### PR TITLE
feat: create citadel symlink to current platform binary after build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -98,6 +98,14 @@ for OS in "${PLATFORMS[@]}"; do
     done
 done
 
+# --- Create Symlink for Current Platform ---
+CURRENT_BINARY="$BUILD_DIR/${CURRENT_OS}-${CURRENT_ARCH}/citadel"
+if [[ -f "$CURRENT_BINARY" ]]; then
+    ln -sf "$CURRENT_BINARY" citadel
+    echo ""
+    echo "--- Created symlink: citadel -> $CURRENT_BINARY ---"
+fi
+
 # --- Generate Checksums ---
 echo ""
 echo "--- Generating Checksums ---"

--- a/citadel
+++ b/citadel
@@ -1,1 +1,0 @@
-build/linux-amd64/citadel


### PR DESCRIPTION
## Summary
- Build script now creates a `./citadel` symlink pointing to the current platform's binary (e.g., `build/darwin-arm64/citadel`)
- Removes previously tracked `citadel` binary from git (it was already in `.gitignore`)
- Symlink always points to current platform even when building with `--all` flag

## Test plan
- [x] Ran `./build.sh` - symlink created correctly
- [x] Ran `./build.sh --all` - symlink still points to current platform
- [x] Verified `./citadel version` works through symlink

🤖 Generated with [Claude Code](https://claude.com/claude-code)