### PR TITLE
feat: simplify init with --network-only flag and hostname default

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -20,11 +20,12 @@ import (
 )
 
 var (
-	authkey               string
-	initService           string
-	initNodeName          string
-	initTest              bool
-	initVerbose           bool
+	authkey                string
+	initService            string
+	initNodeName           string
+	initTest               bool
+	initVerbose            bool
+	initNetworkOnly        bool
 	userAddedToDockerGroup bool // Track if we added user to docker group in this run
 )
 
@@ -37,17 +38,17 @@ interactively or with flags for automation.`,
 	Example: `  # Interactive setup (recommended for first-time setup)
   sudo citadel init
 
+  # Network-only setup (no services, no Docker)
+  sudo citadel init --network-only
+
   # Automated setup with specific service
-  sudo citadel init --service vllm --node-name gpu-server-1
+  sudo citadel init --service vllm
 
   # Setup with pre-generated authkey (for CI/CD)
   sudo citadel init --authkey <your-key> --service ollama
 
   # Setup with verbose output (for debugging)
-  sudo citadel init --verbose
-
-  # Setup without running tests
-  sudo citadel init --test=false`,
+  sudo citadel init --verbose`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if !isRoot() {
 			if platform.IsWindows() {
@@ -87,6 +88,43 @@ interactively or with flags for automation.`,
 				os.Exit(1)
 			}
 			fmt.Println("\n--- Continuing with node setup ---")
+		}
+
+		// Handle --network-only: just join network and exit
+		if initNetworkOnly {
+			nodeName, err := getNodeName()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "❌ Error getting node name: %v\n", err)
+				os.Exit(1)
+			}
+
+			// Install Tailscale if needed
+			if err := ensureTailscaleInstalled(); err != nil {
+				fmt.Fprintf(os.Stderr, "❌ Failed to install Tailscale: %v\n", err)
+				os.Exit(1)
+			}
+
+			// Determine authkey to use
+			var authkeyToUse string
+			if choice == nexus.NetChoiceDevice && deviceAuthToken != nil {
+				authkeyToUse = deviceAuthToken.Authkey
+			} else if key != "" {
+				authkeyToUse = key
+			}
+
+			if authkeyToUse != "" {
+				fmt.Printf("Joining network as '%s'...\n", nodeName)
+				if err := joinTailscaleNetwork(nodeName, authkeyToUse); err != nil {
+					fmt.Fprintf(os.Stderr, "❌ Failed to join network: %v\n", err)
+					os.Exit(1)
+				}
+				fmt.Println("\n✅ Successfully joined the AceTeam network!")
+			} else if choice != nexus.NetChoiceSkip {
+				fmt.Println("⚠️  No authkey available. Run 'citadel join' to complete network setup.")
+			}
+
+			fmt.Printf("Node name: %s\n", nodeName)
+			return
 		}
 
 		selectedService, err := getSelectedService()
@@ -334,8 +372,12 @@ func getNodeName() (string, error) {
 	if initNodeName != "" {
 		return initNodeName, nil
 	}
-	defaultName, _ := os.Hostname()
-	return ui.AskInput("Enter a name for this node:", "e.g., gpu-node-1", defaultName)
+	// Use hostname by default without prompting
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "", fmt.Errorf("could not determine hostname: %w", err)
+	}
+	return hostname, nil
 }
 
 func checkForRunningServicesQuiet(serviceToStart string) error {
@@ -910,4 +952,5 @@ func init() {
 	initCmd.Flags().StringVar(&initNodeName, "node-name", "", "Set the node name (defaults to hostname)")
 	initCmd.Flags().BoolVar(&initTest, "test", true, "Run a diagnostic test after provisioning")
 	initCmd.Flags().BoolVar(&initVerbose, "verbose", false, "Show detailed output during provisioning")
+	initCmd.Flags().BoolVar(&initNetworkOnly, "network-only", false, "Only join the network, skip service provisioning")
 }

--- a/cmd/join.go
+++ b/cmd/join.go
@@ -1,0 +1,172 @@
+// cmd/join.go
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/aceboss/citadel-cli/internal/nexus"
+	"github.com/aceboss/citadel-cli/internal/platform"
+	"github.com/spf13/cobra"
+)
+
+var (
+	joinAuthkey  string
+	joinNodeName string
+)
+
+var joinCmd = &cobra.Command{
+	Use:   "join",
+	Short: "Join the AceTeam network (lightweight, no services)",
+	Long: `Connects this machine to the AceTeam network using Tailscale.
+This is a lightweight command that only handles network connectivity.
+No Docker installation, no services, no manifest generation.
+
+By default, uses the system hostname as the node name and device
+authorization for authentication.`,
+	Example: `  # Join with defaults (hostname, device auth)
+  sudo citadel join
+
+  # Join with authkey (for automation)
+  sudo citadel join --authkey tskey-auth-xxx
+
+  # Override the node name
+  sudo citadel join --node-name my-gpu-server`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// Check for root/admin privileges
+		if !platform.IsRoot() {
+			if platform.IsWindows() {
+				fmt.Fprintln(os.Stderr, "Error: join command must be run as Administrator.")
+			} else {
+				fmt.Fprintln(os.Stderr, "Error: join command must be run with sudo.")
+			}
+			os.Exit(1)
+		}
+
+		// Check if already connected
+		if nexus.IsTailscaleConnected() {
+			fmt.Println("Already connected to the AceTeam network.")
+			return
+		}
+
+		// Ensure Tailscale is installed
+		if err := ensureTailscaleInstalled(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error installing Tailscale: %v\n", err)
+			os.Exit(1)
+		}
+
+		// Get node name (default to hostname)
+		nodeName := joinNodeName
+		if nodeName == "" {
+			hostname, err := os.Hostname()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: could not determine hostname: %v\n", err)
+				os.Exit(1)
+			}
+			nodeName = hostname
+		}
+
+		// Get authkey (device auth if not provided)
+		authkeyToUse := joinAuthkey
+		if authkeyToUse == "" {
+			// Run device authorization flow
+			token, err := runDeviceAuthFlow(authServiceURL)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				fmt.Fprintf(os.Stderr, "\nAlternative: Get an authkey at %s/fabric\n", authServiceURL)
+				fmt.Fprintln(os.Stderr, "Then run: sudo citadel join --authkey <your-key>")
+				os.Exit(1)
+			}
+			authkeyToUse = token.Authkey
+		}
+
+		// Join the network
+		fmt.Printf("Joining network as '%s'...\n", nodeName)
+		if err := joinTailscaleNetwork(nodeName, authkeyToUse); err != nil {
+			fmt.Fprintf(os.Stderr, "Error joining network: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Println("\nSuccessfully joined the AceTeam network!")
+		fmt.Printf("Node name: %s\n", nodeName)
+	},
+}
+
+// ensureTailscaleInstalled checks if Tailscale is installed and installs it if not
+func ensureTailscaleInstalled() error {
+	// Check if tailscale command exists
+	if _, err := exec.LookPath("tailscale"); err == nil {
+		return nil // Already installed
+	}
+
+	fmt.Println("Installing Tailscale...")
+
+	if platform.IsWindows() {
+		cmd := exec.Command("winget", "install", "--id", "Tailscale.Tailscale", "--silent", "--accept-package-agreements", "--accept-source-agreements")
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			outputStr := string(output)
+			if strings.Contains(outputStr, "already installed") ||
+				strings.Contains(outputStr, "No applicable upgrade found") ||
+				strings.Contains(outputStr, "No available upgrade found") {
+				return nil // Already installed
+			}
+			return fmt.Errorf("winget install failed: %w", err)
+		}
+
+		// Start the Tailscale service
+		exec.Command("net", "start", "Tailscale").Run()
+		return nil
+	}
+
+	// Linux/macOS: Use the official install script
+	script := "curl -fsSL https://tailscale.com/install.sh | sh"
+	cmd := exec.Command("sh", "-c", script)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// joinTailscaleNetwork connects to the Tailscale network with the given credentials
+func joinTailscaleNetwork(nodeName, authkey string) error {
+	// Logout first (ignore errors)
+	if platform.IsWindows() {
+		exec.Command("tailscale", "logout").Run()
+	} else {
+		exec.Command("sudo", "tailscale", "logout").Run()
+	}
+
+	// Build the tailscale up command
+	var tsCmd *exec.Cmd
+	if platform.IsWindows() {
+		tsCmd = exec.Command("tailscale", "up",
+			"--login-server="+nexusURL,
+			"--authkey="+authkey,
+			"--hostname="+nodeName,
+			"--accept-routes",
+			"--accept-dns",
+		)
+	} else {
+		tsCmd = exec.Command("sudo", "tailscale", "up",
+			"--login-server="+nexusURL,
+			"--authkey="+authkey,
+			"--hostname="+nodeName,
+			"--accept-routes",
+			"--accept-dns",
+		)
+	}
+
+	output, err := tsCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("tailscale up failed: %s", string(output))
+	}
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(joinCmd)
+	joinCmd.Flags().StringVar(&joinAuthkey, "authkey", "", "Pre-generated authkey for non-interactive join")
+	joinCmd.Flags().StringVar(&joinNodeName, "node-name", "", "Override the node name (defaults to hostname)")
+}


### PR DESCRIPTION
## Summary

- Add `--network-only` flag to skip service provisioning
- Use hostname as node name by default (no prompting)
- Include `citadel join` command for reusable network logic

## Dependencies

This PR includes the `citadel join` command from PR #15. Once PR #15 is merged, this can be rebased to remove the duplicate.

## Changes

### New `--network-only` flag
Skip Docker, services, and config generation - just join the network:
```bash
sudo citadel init --network-only
```

### Hostname default
Node name now defaults to system hostname without prompting. Use `--node-name` to override.

### New `citadel join` command
Lightweight command for network-only joining (see PR #15 for details).

## Test plan

- [x] Run `sudo citadel init --network-only` - verify it joins network and exits
- [x] Run `sudo citadel init` - verify it uses hostname without prompting
- [ ] Run `sudo citadel init --node-name custom` - verify custom name is used
- [ ] Run `sudo citadel init --service vllm` - verify full provisioning still works
- [ ] Verify `go build` and `go test ./...` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)