### PR TITLE
feat: Add Redis Streams worker for private GPU cloud

### DIFF
--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -1,0 +1,228 @@
+// cmd/worker.go
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/aceboss/citadel-cli/internal/jobs"
+	redisclient "github.com/aceboss/citadel-cli/internal/redis"
+	"github.com/spf13/cobra"
+)
+
+var (
+	redisURL      string
+	redisPassword string
+	workerQueue   string
+	consumerGroup string
+)
+
+// WorkerJobHandler is the interface for Redis-based job handlers.
+type WorkerJobHandler interface {
+	Execute(ctx context.Context, client *redisclient.Client, job *redisclient.Job) error
+	CanHandle(jobType string) bool
+}
+
+// workerHandlers holds all registered handlers for the worker
+var workerHandlers []WorkerJobHandler
+
+var workerCmd = &cobra.Command{
+	Use:   "worker",
+	Short: "Run as a high-performance Redis Streams worker for AceTeam's private GPU cloud",
+	Long: `High-performance job queue worker for AceTeam's private GPU infrastructure.
+
+Written in Go for maximum concurrency and throughput, this worker:
+- Consumes jobs from Redis Streams using consumer groups
+- Routes inference requests to private vLLM/Ollama/llama.cpp clusters
+- Streams responses back via Redis Pub/Sub
+- Scales horizontally across GPU nodes
+
+This is the Citadel Worker - designed for AceTeam's private cloud.
+For external API calls (OpenAI, Anthropic), use the Python Worker instead.`,
+	Run: runWorker,
+}
+
+func runWorker(cmd *cobra.Command, args []string) {
+	fmt.Println("--- 🚀 Starting Citadel Worker ---")
+
+	// Validate configuration
+	if redisURL == "" {
+		redisURL = os.Getenv("REDIS_URL")
+	}
+	if redisURL == "" {
+		fmt.Fprintln(os.Stderr, "Error: Redis URL is required. Set --redis-url or REDIS_URL env var.")
+		os.Exit(1)
+	}
+
+	if workerQueue == "" {
+		workerQueue = os.Getenv("WORKER_QUEUE")
+	}
+	if workerQueue == "" {
+		workerQueue = "jobs:v1:gpu-general" // Default queue
+	}
+
+	if redisPassword == "" {
+		redisPassword = os.Getenv("REDIS_PASSWORD")
+	}
+
+	if consumerGroup == "" {
+		consumerGroup = os.Getenv("CONSUMER_GROUP")
+	}
+
+	// Create Redis client
+	client := redisclient.NewClient(redisclient.ClientConfig{
+		URL:           redisURL,
+		Password:      redisPassword,
+		QueueName:     workerQueue,
+		ConsumerGroup: consumerGroup,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Connect to Redis
+	fmt.Printf("   - Connecting to Redis...\n")
+	if err := client.Connect(ctx, redisURL, redisPassword); err != nil {
+		fmt.Fprintf(os.Stderr, "   - ❌ Failed to connect to Redis: %v\n", err)
+		os.Exit(1)
+	}
+	defer client.Close()
+
+	fmt.Printf("   - ✅ Connected to Redis\n")
+	fmt.Printf("   - Worker ID: %s\n", client.WorkerID())
+	fmt.Printf("   - Queue: %s\n", client.QueueName())
+
+	// Ensure consumer group exists
+	if err := client.EnsureConsumerGroup(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "   - ❌ Failed to create consumer group: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Setup signal handling for graceful shutdown
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+	fmt.Println("   - ✅ Worker started. Listening for jobs...")
+
+	// Main worker loop
+workerLoop:
+	for {
+		select {
+		case sig := <-sigs:
+			fmt.Printf("\n   - Received signal %v, initiating graceful shutdown...\n", sig)
+			cancel()
+			break workerLoop
+		default:
+			// Read next job from queue
+			job, err := client.ReadJob(ctx)
+			if err != nil {
+				if ctx.Err() != nil {
+					break workerLoop // Context cancelled
+				}
+				fmt.Fprintf(os.Stderr, "   - ⚠️ Error reading job: %v\n", err)
+				continue
+			}
+
+			if job == nil {
+				continue // No job available, loop again
+			}
+
+			// Process the job
+			processWorkerJob(ctx, client, job)
+		}
+	}
+
+	fmt.Println("--- 🛑 Worker shutdown complete ---")
+}
+
+func processWorkerJob(ctx context.Context, client *redisclient.Client, job *redisclient.Job) {
+	fmt.Printf("   - 📥 Received job %s (type: %s)\n", job.JobID, job.Type)
+
+	// Check delivery count for DLQ handling
+	deliveryCount, _ := client.GetDeliveryCount(ctx, job.MessageID)
+	if int(deliveryCount) >= client.MaxAttempts() {
+		fmt.Printf("   - ⚠️ Job %s exceeded max attempts (%d), moving to DLQ\n", job.JobID, client.MaxAttempts())
+		if err := client.MoveToDLQ(ctx, job, "Exceeded max retry attempts"); err != nil {
+			fmt.Fprintf(os.Stderr, "   - ❌ Failed to move job to DLQ: %v\n", err)
+		}
+		client.AckJob(ctx, job.MessageID)
+		return
+	}
+
+	// Update status to processing
+	client.SetJobStatus(ctx, job.JobID, "processing", nil)
+
+	// Publish start event
+	client.PublishStart(ctx, job.JobID, "Job processing started")
+
+	// Find handler for this job type
+	var handler WorkerJobHandler
+	for _, h := range workerHandlers {
+		if h.CanHandle(job.Type) {
+			handler = h
+			break
+		}
+	}
+
+	if handler == nil {
+		errMsg := fmt.Sprintf("No handler for job type: %s", job.Type)
+		fmt.Printf("   - ❌ %s\n", errMsg)
+		client.PublishError(ctx, job.JobID, errMsg, false)
+		client.SetJobStatus(ctx, job.JobID, "failed", map[string]interface{}{"error": errMsg})
+		// Don't ACK - let it retry or go to DLQ
+		return
+	}
+
+	// Execute the handler
+	err := handler.Execute(ctx, client, job)
+
+	if err != nil {
+		fmt.Printf("   - ❌ Job %s failed: %v\n", job.JobID, err)
+		client.PublishError(ctx, job.JobID, err.Error(), false)
+		client.SetJobStatus(ctx, job.JobID, "failed", map[string]interface{}{"error": err.Error()})
+		// Don't ACK - let it retry or go to DLQ
+		return
+	}
+
+	// Success - ACK the message
+	fmt.Printf("   - ✅ Job %s completed successfully\n", job.JobID)
+	client.SetJobStatus(ctx, job.JobID, "completed", nil)
+	if err := client.AckJob(ctx, job.MessageID); err != nil {
+		fmt.Fprintf(os.Stderr, "   - ⚠️ Failed to ACK job: %v\n", err)
+	}
+}
+
+// RegisterWorkerHandler adds a handler to the worker's handler list.
+func RegisterWorkerHandler(handler WorkerJobHandler) {
+	workerHandlers = append(workerHandlers, handler)
+}
+
+// LLMInferenceWorkerHandler wraps jobs.LLMInferenceHandler for the worker interface.
+type LLMInferenceWorkerHandler struct {
+	handler jobs.LLMInferenceHandler
+}
+
+// CanHandle returns true if this handler can process the given job type.
+func (h *LLMInferenceWorkerHandler) CanHandle(jobType string) bool {
+	return h.handler.CanHandle(jobType)
+}
+
+// Execute processes an llm_inference job.
+func (h *LLMInferenceWorkerHandler) Execute(ctx context.Context, client *redisclient.Client, job *redisclient.Job) error {
+	return h.handler.Execute(ctx, client, job)
+}
+
+func init() {
+	rootCmd.AddCommand(workerCmd)
+
+	workerCmd.Flags().StringVar(&redisURL, "redis-url", "", "Redis connection URL (or set REDIS_URL env)")
+	workerCmd.Flags().StringVar(&redisPassword, "redis-password", "", "Redis password (or set REDIS_PASSWORD env)")
+	workerCmd.Flags().StringVar(&workerQueue, "queue", "", "Queue name to consume from (default: jobs:v1:gpu-general)")
+	workerCmd.Flags().StringVar(&consumerGroup, "consumer-group", "", "Consumer group name (default: citadel-workers)")
+
+	// Register job handlers
+	RegisterWorkerHandler(&LLMInferenceWorkerHandler{})
+}

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
@@ -40,6 +41,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
+	github.com/redis/go-redis/v9 v9.17.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect

--- a/internal/jobs/llm_inference.go
+++ b/internal/jobs/llm_inference.go
@@ -1,0 +1,457 @@
+// internal/jobs/llm_inference.go
+package jobs
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	redisclient "github.com/aceboss/citadel-cli/internal/redis"
+)
+
+// LLMInferenceHandler handles llm_inference jobs from the Redis queue.
+type LLMInferenceHandler struct{}
+
+// CanHandle returns true if this handler can process the given job type.
+func (h *LLMInferenceHandler) CanHandle(jobType string) bool {
+	return jobType == JobTypeLLMInference
+}
+
+// Execute processes an llm_inference job.
+func (h *LLMInferenceHandler) Execute(ctx context.Context, client *redisclient.Client, job *redisclient.Job) error {
+	// Parse payload
+	payload, err := h.parsePayload(job.Payload)
+	if err != nil {
+		return fmt.Errorf("invalid payload: %w", err)
+	}
+
+	// Route to appropriate backend
+	switch payload.Backend {
+	case "vllm":
+		return h.executeVLLM(ctx, client, job.JobID, payload)
+	case "ollama":
+		return h.executeOllama(ctx, client, job.JobID, payload)
+	case "llamacpp":
+		return h.executeLlamaCpp(ctx, client, job.JobID, payload)
+	default:
+		return fmt.Errorf("unsupported backend: %s", payload.Backend)
+	}
+}
+
+func (h *LLMInferenceHandler) parsePayload(data map[string]any) (*LLMInferencePayload, error) {
+	// Convert map to JSON then unmarshal to struct
+	jsonBytes, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+
+	var payload LLMInferencePayload
+	if err := json.Unmarshal(jsonBytes, &payload); err != nil {
+		return nil, err
+	}
+
+	// Validate required fields
+	if payload.Model == "" {
+		return nil, fmt.Errorf("model is required")
+	}
+	if payload.Prompt == "" && len(payload.Messages) == 0 {
+		return nil, fmt.Errorf("prompt or messages is required")
+	}
+	if payload.Backend == "" {
+		payload.Backend = "vllm" // Default to vLLM
+	}
+
+	return &payload, nil
+}
+
+// executeVLLM handles inference via vLLM's OpenAI-compatible API.
+func (h *LLMInferenceHandler) executeVLLM(ctx context.Context, client *redisclient.Client, jobID string, payload *LLMInferencePayload) error {
+	// Wait for vLLM to be ready
+	if err := h.waitForVLLMReady(ctx); err != nil {
+		return err
+	}
+
+	vllmURL := "http://localhost:8000/v1/completions"
+
+	reqPayload := map[string]any{
+		"model":       payload.Model,
+		"prompt":      payload.Prompt,
+		"max_tokens":  payload.MaxTokens,
+		"temperature": payload.Temperature,
+		"stream":      payload.Stream,
+	}
+
+	if payload.MaxTokens == 0 {
+		reqPayload["max_tokens"] = 512
+	}
+	if len(payload.Stop) > 0 {
+		reqPayload["stop"] = payload.Stop
+	}
+
+	reqBody, _ := json.Marshal(reqPayload)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", vllmURL, bytes.NewBuffer(reqBody))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to connect to vLLM: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("vLLM returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	if payload.Stream {
+		return h.handleVLLMStream(ctx, client, jobID, resp.Body)
+	}
+
+	return h.handleVLLMNonStream(ctx, client, jobID, resp.Body)
+}
+
+func (h *LLMInferenceHandler) handleVLLMStream(ctx context.Context, client *redisclient.Client, jobID string, body io.Reader) error {
+	scanner := bufio.NewScanner(body)
+	chunkIndex := 0
+	var fullContent strings.Builder
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// SSE format: "data: {...}"
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+
+		data := strings.TrimPrefix(line, "data: ")
+		if data == "[DONE]" {
+			break
+		}
+
+		var chunk struct {
+			Choices []struct {
+				Text         string `json:"text"`
+				FinishReason string `json:"finish_reason"`
+			} `json:"choices"`
+		}
+
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			continue
+		}
+
+		if len(chunk.Choices) > 0 {
+			text := chunk.Choices[0].Text
+			fullContent.WriteString(text)
+
+			// Publish chunk to Redis
+			client.PublishChunk(ctx, jobID, text, chunkIndex)
+			chunkIndex++
+
+			if chunk.Choices[0].FinishReason != "" {
+				break
+			}
+		}
+	}
+
+	// Publish end event
+	client.PublishEnd(ctx, jobID, map[string]any{
+		"content":       fullContent.String(),
+		"finish_reason": "stop",
+	})
+
+	return scanner.Err()
+}
+
+func (h *LLMInferenceHandler) handleVLLMNonStream(ctx context.Context, client *redisclient.Client, jobID string, body io.Reader) error {
+	bodyBytes, err := io.ReadAll(body)
+	if err != nil {
+		return err
+	}
+
+	var response struct {
+		Choices []struct {
+			Text         string `json:"text"`
+			FinishReason string `json:"finish_reason"`
+		} `json:"choices"`
+		Usage struct {
+			PromptTokens     int `json:"prompt_tokens"`
+			CompletionTokens int `json:"completion_tokens"`
+			TotalTokens      int `json:"total_tokens"`
+		} `json:"usage"`
+	}
+
+	if err := json.Unmarshal(bodyBytes, &response); err != nil {
+		return fmt.Errorf("failed to parse vLLM response: %w", err)
+	}
+
+	if len(response.Choices) == 0 {
+		return fmt.Errorf("vLLM returned no choices")
+	}
+
+	content := strings.TrimSpace(response.Choices[0].Text)
+
+	// Publish single chunk then end
+	client.PublishChunk(ctx, jobID, content, 0)
+	client.PublishEnd(ctx, jobID, map[string]any{
+		"content":       content,
+		"finish_reason": response.Choices[0].FinishReason,
+		"usage": map[string]any{
+			"prompt_tokens":     response.Usage.PromptTokens,
+			"completion_tokens": response.Usage.CompletionTokens,
+			"total_tokens":      response.Usage.TotalTokens,
+		},
+	})
+
+	return nil
+}
+
+func (h *LLMInferenceHandler) waitForVLLMReady(ctx context.Context) error {
+	healthURL := "http://localhost:8000/health"
+	maxWait := 60 * time.Second
+	pollInterval := 1 * time.Second
+	startTime := time.Now()
+
+	for time.Since(startTime) < maxWait {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		req, _ := http.NewRequestWithContext(ctx, "GET", healthURL, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil && resp.StatusCode == http.StatusOK {
+			resp.Body.Close()
+			return nil
+		}
+		if resp != nil {
+			resp.Body.Close()
+		}
+		time.Sleep(pollInterval)
+	}
+	return fmt.Errorf("vLLM did not become ready within %v", maxWait)
+}
+
+// executeOllama handles inference via Ollama's API.
+func (h *LLMInferenceHandler) executeOllama(ctx context.Context, client *redisclient.Client, jobID string, payload *LLMInferencePayload) error {
+	ollamaURL := "http://localhost:11434/api/generate"
+
+	reqPayload := map[string]any{
+		"model":  payload.Model,
+		"prompt": payload.Prompt,
+		"stream": payload.Stream,
+	}
+
+	if payload.MaxTokens > 0 {
+		reqPayload["options"] = map[string]any{
+			"num_predict": payload.MaxTokens,
+		}
+	}
+
+	reqBody, _ := json.Marshal(reqPayload)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", ollamaURL, bytes.NewBuffer(reqBody))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to connect to Ollama: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("Ollama returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	if payload.Stream {
+		return h.handleOllamaStream(ctx, client, jobID, resp.Body)
+	}
+
+	return h.handleOllamaNonStream(ctx, client, jobID, resp.Body)
+}
+
+func (h *LLMInferenceHandler) handleOllamaStream(ctx context.Context, client *redisclient.Client, jobID string, body io.Reader) error {
+	scanner := bufio.NewScanner(body)
+	chunkIndex := 0
+	var fullContent strings.Builder
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		var chunk struct {
+			Response string `json:"response"`
+			Done     bool   `json:"done"`
+		}
+
+		if err := json.Unmarshal([]byte(line), &chunk); err != nil {
+			continue
+		}
+
+		if chunk.Response != "" {
+			fullContent.WriteString(chunk.Response)
+			client.PublishChunk(ctx, jobID, chunk.Response, chunkIndex)
+			chunkIndex++
+		}
+
+		if chunk.Done {
+			break
+		}
+	}
+
+	client.PublishEnd(ctx, jobID, map[string]any{
+		"content":       fullContent.String(),
+		"finish_reason": "stop",
+	})
+
+	return scanner.Err()
+}
+
+func (h *LLMInferenceHandler) handleOllamaNonStream(ctx context.Context, client *redisclient.Client, jobID string, body io.Reader) error {
+	bodyBytes, err := io.ReadAll(body)
+	if err != nil {
+		return err
+	}
+
+	var response struct {
+		Response string `json:"response"`
+	}
+
+	if err := json.Unmarshal(bodyBytes, &response); err != nil {
+		return fmt.Errorf("failed to parse Ollama response: %w", err)
+	}
+
+	client.PublishChunk(ctx, jobID, response.Response, 0)
+	client.PublishEnd(ctx, jobID, map[string]any{
+		"content":       response.Response,
+		"finish_reason": "stop",
+	})
+
+	return nil
+}
+
+// executeLlamaCpp handles inference via llama.cpp server API.
+func (h *LLMInferenceHandler) executeLlamaCpp(ctx context.Context, client *redisclient.Client, jobID string, payload *LLMInferencePayload) error {
+	llamaCppURL := "http://localhost:8080/completion"
+
+	reqPayload := map[string]any{
+		"prompt":      payload.Prompt,
+		"n_predict":   payload.MaxTokens,
+		"temperature": payload.Temperature,
+		"stream":      payload.Stream,
+	}
+
+	if payload.MaxTokens == 0 {
+		reqPayload["n_predict"] = 512
+	}
+	if len(payload.Stop) > 0 {
+		reqPayload["stop"] = payload.Stop
+	}
+
+	reqBody, _ := json.Marshal(reqPayload)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", llamaCppURL, bytes.NewBuffer(reqBody))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to connect to llama.cpp: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("llama.cpp returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	if payload.Stream {
+		return h.handleLlamaCppStream(ctx, client, jobID, resp.Body)
+	}
+
+	return h.handleLlamaCppNonStream(ctx, client, jobID, resp.Body)
+}
+
+func (h *LLMInferenceHandler) handleLlamaCppStream(ctx context.Context, client *redisclient.Client, jobID string, body io.Reader) error {
+	scanner := bufio.NewScanner(body)
+	chunkIndex := 0
+	var fullContent strings.Builder
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// SSE format: "data: {...}"
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+
+		data := strings.TrimPrefix(line, "data: ")
+
+		var chunk struct {
+			Content string `json:"content"`
+			Stop    bool   `json:"stop"`
+		}
+
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			continue
+		}
+
+		if chunk.Content != "" {
+			fullContent.WriteString(chunk.Content)
+			client.PublishChunk(ctx, jobID, chunk.Content, chunkIndex)
+			chunkIndex++
+		}
+
+		if chunk.Stop {
+			break
+		}
+	}
+
+	client.PublishEnd(ctx, jobID, map[string]any{
+		"content":       fullContent.String(),
+		"finish_reason": "stop",
+	})
+
+	return scanner.Err()
+}
+
+func (h *LLMInferenceHandler) handleLlamaCppNonStream(ctx context.Context, client *redisclient.Client, jobID string, body io.Reader) error {
+	bodyBytes, err := io.ReadAll(body)
+	if err != nil {
+		return err
+	}
+
+	var response struct {
+		Content string `json:"content"`
+	}
+
+	if err := json.Unmarshal(bodyBytes, &response); err != nil {
+		return fmt.Errorf("failed to parse llama.cpp response: %w", err)
+	}
+
+	client.PublishChunk(ctx, jobID, response.Content, 0)
+	client.PublishEnd(ctx, jobID, map[string]any{
+		"content":       response.Content,
+		"finish_reason": "stop",
+	})
+
+	return nil
+}

--- a/internal/jobs/queue_types.go
+++ b/internal/jobs/queue_types.go
@@ -1,0 +1,106 @@
+// Package jobs contains job type definitions and handlers for the Redis queue system.
+package jobs
+
+// Job types that citadel can handle
+const (
+	// JobTypeLLMInference handles local LLM completion requests
+	JobTypeLLMInference = "llm_inference"
+
+	// JobTypeEmbedding handles local embedding generation (future)
+	JobTypeEmbedding = "embedding"
+)
+
+// Queue names following PR #1105 convention
+const (
+	QueueGPUGeneral = "jobs:v1:gpu-general"
+	QueueCPUGeneral = "jobs:v1:cpu-general"
+)
+
+// LLMInferencePayload represents the payload for llm_inference jobs.
+type LLMInferencePayload struct {
+	// Model is the model identifier (e.g., "meta-llama/Llama-2-7b-chat-hf")
+	Model string `json:"model"`
+
+	// Prompt is the input text to send to the model
+	Prompt string `json:"prompt"`
+
+	// Messages is an alternative to Prompt for chat-style APIs
+	Messages []ChatMessage `json:"messages,omitempty"`
+
+	// MaxTokens is the maximum number of tokens to generate
+	MaxTokens int `json:"max_tokens"`
+
+	// Temperature controls randomness (0.0-2.0)
+	Temperature float64 `json:"temperature"`
+
+	// TopP is nucleus sampling parameter
+	TopP float64 `json:"top_p,omitempty"`
+
+	// Stream indicates whether to stream the response
+	Stream bool `json:"stream"`
+
+	// Backend specifies which inference engine to use
+	Backend string `json:"backend"` // "vllm", "ollama", "llamacpp"
+
+	// Stop sequences to end generation
+	Stop []string `json:"stop,omitempty"`
+}
+
+// ChatMessage represents a message in chat-style APIs.
+type ChatMessage struct {
+	Role    string `json:"role"`    // "system", "user", "assistant"
+	Content string `json:"content"`
+}
+
+// LLMInferenceResult represents the result of an llm_inference job.
+type LLMInferenceResult struct {
+	// Content is the generated text
+	Content string `json:"content"`
+
+	// FinishReason indicates why generation stopped
+	FinishReason string `json:"finish_reason"` // "stop", "length", "error"
+
+	// Usage contains token counts
+	Usage UsageInfo `json:"usage"`
+
+	// Model is the model that was used
+	Model string `json:"model"`
+}
+
+// UsageInfo contains token usage information.
+type UsageInfo struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+// StreamChunk represents a single chunk in a streaming response.
+type StreamChunk struct {
+	Content      string `json:"content"`
+	Index        int    `json:"index"`
+	FinishReason string `json:"finish_reason,omitempty"`
+}
+
+// BaseJobPayload contains common fields for all job types (matches PR #1105).
+type BaseJobPayload struct {
+	Version        string `json:"version"`
+	Type           string `json:"type"`
+	JobID          string `json:"jobId"`
+	UserID         string `json:"userId"`
+	OrganizationID string `json:"organizationId"`
+	CreatedAt      string `json:"createdAt"`
+	Priority       int    `json:"priority"`
+	MaxAttempts    int    `json:"maxAttempts"`
+	TimeoutSeconds int    `json:"timeoutSeconds"`
+}
+
+// JobStatus represents the status of a job.
+type JobStatus string
+
+const (
+	StatusEnqueued   JobStatus = "enqueued"
+	StatusClaimed    JobStatus = "claimed"
+	StatusProcessing JobStatus = "processing"
+	StatusCompleted  JobStatus = "completed"
+	StatusFailed     JobStatus = "failed"
+)


### PR DESCRIPTION
## Summary

- Adds `citadel worker` command - high-performance Redis Streams consumer for AceTeam's private GPU infrastructure
- Supports vLLM, Ollama, and llama.cpp backends with streaming responses
- Written in Go for maximum concurrency and throughput

## Architecture

```
                         Redis Streams
                              │
          ┌───────────────────┴───────────────────┐
          │                                       │
          ▼                                       ▼
┌─────────────────────┐               ┌─────────────────────┐
│   Python Worker     │               │   Citadel Worker    │
│   (lightweight)     │               │   (high-perf Go)    │
│                     │               │                     │
│   → OpenAI API      │               │   → Private vLLM    │
│   → Anthropic API   │               │   → Private Ollama  │
│   → Google API      │               │   → GPU clusters    │
└─────────────────────┘               └─────────────────────┘
      Superscalers                     AceTeam Private Cloud
```

## New Files

| File | Purpose |
|------|---------|
| `cmd/worker.go` | Worker command with Redis consumer loop |
| `internal/redis/client.go` | Redis Streams + Pub/Sub client |
| `internal/jobs/queue_types.go` | Job type definitions (compatible with PR #1105) |
| `internal/jobs/llm_inference.go` | LLM handler with streaming for vLLM/Ollama/llama.cpp |

## Usage

```bash
citadel worker --redis-url redis://localhost:6379 --queue jobs:v1:gpu-general
```

## Tested

- [x] Worker connects to Redis and creates consumer group
- [x] Jobs received from Redis Streams (XREADGROUP)
- [x] Job status tracked in Redis hash
- [x] Error handling for vLLM timeout
- [x] Error handling for unknown job types
- [x] Error handling for unsupported backends
- [x] Graceful shutdown on SIGTERM

🤖 Generated with [Claude Code](https://claude.ai/code)