### PR TITLE
fix: macOS Tailscale PATH resolution and SSH key sync infrastructure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,37 @@ This ensures:
 - Reviewable progress with context for each change
 - Easy rollback if needed
 
+### Bug Fix and Issue-Driven Development
+
+When fixing bugs or implementing changes based on user feedback/issues:
+
+1. **Document the problem**: In the PR description, include:
+   - **Context**: Why this change is needed (link to issue, user feedback, onboarding problems)
+   - **Root Cause Analysis**: What was causing the issue
+   - **Solution**: What changes were made and why
+
+2. **Include verification steps**: Always document how to test the changes:
+   - Manual testing commands
+   - Expected behavior before/after
+   - Edge cases to verify
+
+3. **Update CLAUDE.md**: If the fix reveals architectural patterns or important implementation details that future developers should know, add them to this file.
+
+**Example PR structure:**
+```markdown
+## Context
+[Link to issue or description of the problem encountered]
+
+## Root Cause
+[Technical explanation of what was wrong]
+
+## Changes
+- [List of changes with file paths]
+
+## Testing
+[Commands and steps to verify the fix]
+```
+
 ## Architecture
 
 ### Command Structure
@@ -94,6 +125,8 @@ Built with Cobra. Main command files are in `cmd/`:
 
 **Tailscale Integration**: Network connectivity uses Tailscale for secure mesh networking between nodes and Nexus. Commands check Tailscale status via `tailscale status --json` and authenticate using device authorization or authkeys.
 
+**IMPORTANT**: All Tailscale CLI path resolution MUST use `platform.GetTailscaleCLI()` from `internal/platform/tailscale.go`. This function handles cross-platform path resolution (Windows, macOS Homebrew, macOS App Store, Linux). Never hardcode `"tailscale"` or create local path resolution functions.
+
 **Job Handler Pattern**: The agent uses a pluggable handler system for remote job execution:
 ```go
 type JobHandler interface {
@@ -109,7 +142,8 @@ Handlers in `internal/jobs/` implement specific job types (shell commands, model
 ### Key Packages
 
 - **`cmd/`**: Cobra command implementations
-- **`internal/nexus/`**: HTTP client for Nexus API, network helpers for Tailscale operations
+- **`internal/nexus/`**: HTTP client for Nexus API, SSH key sync, device authentication
+- **`internal/platform/`**: Cross-platform utilities (OS detection, package managers, Docker, GPU, Tailscale CLI resolution)
 - **`internal/jobs/`**: Job handler implementations (shell, inference, model download)
 - **`internal/ui/`**: Interactive prompts using survey library
 - **`services/`**: Embedded Docker Compose files and service registry

--- a/cmd/expose.go
+++ b/cmd/expose.go
@@ -259,15 +259,11 @@ func listExposedPorts() {
 	fmt.Println(string(output))
 }
 
-// getTailscaleCLIPath returns the path to the tailscale CLI
+// getTailscaleCLIPath returns the path to the tailscale CLI.
+// Delegates to the centralized platform.GetTailscaleCLI() which handles
+// PATH lookup and platform-specific fallback locations for Windows, macOS, and Linux.
 func getTailscaleCLIPath() string {
-	if platform.IsWindows() {
-		fullPath := `C:\Program Files\Tailscale\tailscale.exe`
-		if _, err := os.Stat(fullPath); err == nil {
-			return fullPath
-		}
-	}
-	return "tailscale"
+	return platform.GetTailscaleCLI()
 }
 
 func init() {

--- a/cmd/tailscale.go
+++ b/cmd/tailscale.go
@@ -3,22 +3,12 @@
 package cmd
 
 import (
-	"os"
-
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
 )
 
 // getTailscaleCLI returns the path to the tailscale CLI executable.
-// On Windows, we need to use the full path because the PATH might not be updated
-// in child processes (especially when launched via cmd /c from init).
+// Delegates to the centralized platform.GetTailscaleCLI() which handles
+// PATH lookup and platform-specific fallback locations for Windows, macOS, and Linux.
 func getTailscaleCLI() string {
-	if platform.IsWindows() {
-		// Standard installation path for Tailscale on Windows
-		fullPath := `C:\Program Files\Tailscale\tailscale.exe`
-		if _, err := os.Stat(fullPath); err == nil {
-			return fullPath
-		}
-		// Fall back to PATH if the standard location doesn't exist
-	}
-	return "tailscale"
+	return platform.GetTailscaleCLI()
 }

--- a/internal/nexus/network_helpers.go
+++ b/internal/nexus/network_helpers.go
@@ -4,47 +4,18 @@ package nexus
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
-	"runtime"
 	"strings"
 
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
 	"github.com/aceteam-ai/citadel-cli/internal/ui"
 )
 
 // getTailscaleCLI returns the path to the tailscale CLI executable.
-// Checks PATH first, then platform-specific locations:
-// - Windows: C:\Program Files\Tailscale\tailscale.exe
-// - macOS: Homebrew paths and App Store location
+// Delegates to the centralized platform.GetTailscaleCLI() which handles
+// PATH lookup and platform-specific fallback locations for Windows, macOS, and Linux.
 func getTailscaleCLI() string {
-	// First check if tailscale is in PATH
-	if path, err := exec.LookPath("tailscale"); err == nil {
-		return path
-	}
-
-	// Windows: Check standard installation path
-	if runtime.GOOS == "windows" {
-		fullPath := `C:\Program Files\Tailscale\tailscale.exe`
-		if _, err := os.Stat(fullPath); err == nil {
-			return fullPath
-		}
-	}
-
-	// macOS: Check Homebrew and App Store locations
-	if runtime.GOOS == "darwin" {
-		macPaths := []string{
-			"/opt/homebrew/bin/tailscale",                          // Homebrew (Apple Silicon)
-			"/usr/local/bin/tailscale",                             // Homebrew (Intel)
-			"/Applications/Tailscale.app/Contents/MacOS/Tailscale", // App Store
-		}
-		for _, p := range macPaths {
-			if _, err := os.Stat(p); err == nil {
-				return p
-			}
-		}
-	}
-
-	return "tailscale" // Fallback
+	return platform.GetTailscaleCLI()
 }
 
 // NetworkChoice represents the user's selected method for network connection.

--- a/internal/nexus/sshkeys.go
+++ b/internal/nexus/sshkeys.go
@@ -1,0 +1,298 @@
+// internal/nexus/sshkeys.go
+// SSH key synchronization from AceTeam platform
+package nexus
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	// Markers for the managed section of authorized_keys
+	ManagedKeysStart = "# === AceTeam Managed Keys (DO NOT EDIT) ==="
+	ManagedKeysEnd   = "# === End AceTeam Managed Keys ==="
+)
+
+// SSHKeysClient handles SSH key synchronization with the AceTeam platform
+type SSHKeysClient struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// AuthorizedKeysResponse represents the response from the authorized-keys endpoint
+type AuthorizedKeysResponse struct {
+	Keys []SSHKeyInfo `json:"keys"`
+	// AuthorizedKeys is the pre-formatted string ready to write to authorized_keys file
+	AuthorizedKeys string `json:"authorized_keys"`
+	Count          int    `json:"count"`
+}
+
+// SSHKeyInfo represents a single SSH key with metadata
+type SSHKeyInfo struct {
+	PublicKey string `json:"public_key"`
+	Name      string `json:"name"`
+	KeyType   string `json:"key_type"`
+	UserEmail string `json:"user_email"`
+	UserName  string `json:"user_name"`
+}
+
+// SSHSyncConfig holds configuration for SSH key synchronization
+type SSHSyncConfig struct {
+	APIToken string // Bearer token for AceTeam API
+	NodeID   string // Node ID in AceTeam platform
+	BaseURL  string // API base URL (default: https://aceteam.ai)
+}
+
+// NewSSHKeysClient creates a new SSH keys synchronization client
+func NewSSHKeysClient(baseURL string) *SSHKeysClient {
+	return &SSHKeysClient{
+		baseURL: baseURL,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// FetchAuthorizedKeys retrieves the authorized SSH keys for a node from the AceTeam API
+func (c *SSHKeysClient) FetchAuthorizedKeys(nodeID, apiToken string) (*AuthorizedKeysResponse, error) {
+	url := fmt.Sprintf("%s/api/fabric/nodes/%s/authorized-keys", c.baseURL, nodeID)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+apiToken)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to AceTeam API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return nil, fmt.Errorf("authentication failed (status %d): re-authenticate with 'citadel login'", resp.StatusCode)
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("node not found in AceTeam platform")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var response AuthorizedKeysResponse
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &response, nil
+}
+
+// SyncAuthorizedKeys fetches SSH keys from AceTeam and writes them to the authorized_keys file.
+// It preserves any existing user keys that are not in the managed section.
+func SyncAuthorizedKeys(config SSHSyncConfig) error {
+	if config.APIToken == "" || config.NodeID == "" {
+		return fmt.Errorf("SSH sync not configured: missing API token or node ID")
+	}
+
+	baseURL := config.BaseURL
+	if baseURL == "" {
+		baseURL = "https://aceteam.ai"
+	}
+
+	client := NewSSHKeysClient(baseURL)
+
+	// Fetch keys from AceTeam
+	response, err := client.FetchAuthorizedKeys(config.NodeID, config.APIToken)
+	if err != nil {
+		return fmt.Errorf("failed to fetch SSH keys: %w", err)
+	}
+
+	// Determine authorized_keys path
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	sshDir := filepath.Join(homeDir, ".ssh")
+	authKeysPath := filepath.Join(sshDir, "authorized_keys")
+
+	// Ensure .ssh directory exists with correct permissions
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		return fmt.Errorf("failed to create .ssh directory: %w", err)
+	}
+
+	// Read existing authorized_keys (if exists)
+	existingKeys, err := readExistingKeys(authKeysPath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to read existing authorized_keys: %w", err)
+	}
+
+	// Build new authorized_keys content
+	var newContent strings.Builder
+
+	// Write non-managed keys first
+	for _, key := range existingKeys {
+		newContent.WriteString(key)
+		newContent.WriteString("\n")
+	}
+
+	// Add blank line before managed section if there are existing keys
+	if len(existingKeys) > 0 {
+		newContent.WriteString("\n")
+	}
+
+	// Write managed section
+	newContent.WriteString(ManagedKeysStart)
+	newContent.WriteString("\n")
+	if response.AuthorizedKeys != "" {
+		// Ensure each key is on its own line
+		keys := strings.Split(strings.TrimSpace(response.AuthorizedKeys), "\n")
+		for _, key := range keys {
+			if key = strings.TrimSpace(key); key != "" {
+				newContent.WriteString(key)
+				newContent.WriteString("\n")
+			}
+		}
+	}
+	newContent.WriteString(ManagedKeysEnd)
+	newContent.WriteString("\n")
+
+	// Write to file atomically
+	tmpPath := authKeysPath + ".tmp"
+	if err := os.WriteFile(tmpPath, []byte(newContent.String()), 0600); err != nil {
+		return fmt.Errorf("failed to write temporary file: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, authKeysPath); err != nil {
+		os.Remove(tmpPath) // Clean up on failure
+		return fmt.Errorf("failed to update authorized_keys: %w", err)
+	}
+
+	return nil
+}
+
+// readExistingKeys reads the authorized_keys file and returns keys that are NOT in the managed section
+func readExistingKeys(path string) ([]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var keys []string
+	inManagedSection := false
+	scanner := bufio.NewScanner(file)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Track managed section
+		if strings.TrimSpace(line) == ManagedKeysStart {
+			inManagedSection = true
+			continue
+		}
+		if strings.TrimSpace(line) == ManagedKeysEnd {
+			inManagedSection = false
+			continue
+		}
+
+		// Skip lines in managed section
+		if inManagedSection {
+			continue
+		}
+
+		// Skip empty lines and comments for cleaner output
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		keys = append(keys, line)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return keys, nil
+}
+
+// LoadSSHSyncConfig loads SSH sync configuration from the config directory.
+// Returns nil config if not configured (not an error - just means sync is disabled).
+func LoadSSHSyncConfig(configDir string) (*SSHSyncConfig, error) {
+	configPath := filepath.Join(configDir, "ssh_sync.yaml")
+
+	data, err := os.ReadFile(configPath)
+	if os.IsNotExist(err) {
+		// Not configured - return nil, no error
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read SSH sync config: %w", err)
+	}
+
+	// Simple YAML parsing (avoid adding dependency for just 3 fields)
+	config := &SSHSyncConfig{}
+	lines := strings.Split(string(data), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+		// Remove quotes if present
+		value = strings.Trim(value, "\"'")
+
+		switch key {
+		case "api_token":
+			config.APIToken = value
+		case "node_id":
+			config.NodeID = value
+		case "base_url":
+			config.BaseURL = value
+		}
+	}
+
+	if config.APIToken == "" || config.NodeID == "" {
+		// Partially configured - treat as not configured
+		return nil, nil
+	}
+
+	return config, nil
+}
+
+// SaveSSHSyncConfig saves the SSH sync configuration to the config directory.
+func SaveSSHSyncConfig(configDir string, config *SSHSyncConfig) error {
+	configPath := filepath.Join(configDir, "ssh_sync.yaml")
+
+	content := fmt.Sprintf(`# AceTeam SSH Key Sync Configuration
+# This file is auto-generated. Manual edits may be overwritten.
+
+api_token: "%s"
+node_id: "%s"
+base_url: "%s"
+`, config.APIToken, config.NodeID, config.BaseURL)
+
+	if err := os.WriteFile(configPath, []byte(content), 0600); err != nil {
+		return fmt.Errorf("failed to save SSH sync config: %w", err)
+	}
+
+	return nil
+}

--- a/internal/platform/tailscale.go
+++ b/internal/platform/tailscale.go
@@ -1,0 +1,95 @@
+package platform
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// GetTailscaleCLI returns the path to the tailscale CLI executable.
+// It checks PATH first, then platform-specific locations:
+// - Windows: C:\Program Files\Tailscale\tailscale.exe
+// - macOS: Homebrew paths (Apple Silicon and Intel) and App Store location
+// - Linux: Usually in PATH, no special handling needed
+func GetTailscaleCLI() string {
+	// Check PATH first
+	if path, err := exec.LookPath("tailscale"); err == nil {
+		return path
+	}
+
+	// Windows: Check standard installation path
+	if IsWindows() {
+		paths := []string{
+			`C:\Program Files\Tailscale\tailscale.exe`,
+		}
+		for _, p := range paths {
+			if _, err := os.Stat(p); err == nil {
+				return p
+			}
+		}
+	}
+
+	// macOS: Check Homebrew and App Store locations
+	if IsDarwin() {
+		paths := []string{
+			"/opt/homebrew/bin/tailscale",                          // Homebrew (Apple Silicon)
+			"/usr/local/bin/tailscale",                             // Homebrew (Intel)
+			"/Applications/Tailscale.app/Contents/MacOS/Tailscale", // App Store
+		}
+		for _, p := range paths {
+			if _, err := os.Stat(p); err == nil {
+				return p
+			}
+		}
+	}
+
+	return "tailscale" // Fallback (Linux usually has it in PATH)
+}
+
+// IsTailscaleInstalled checks if Tailscale is installed on the system.
+// Returns true if the tailscale binary is found in PATH or at known platform-specific locations.
+func IsTailscaleInstalled() bool {
+	// Check PATH first
+	if _, err := exec.LookPath("tailscale"); err == nil {
+		return true
+	}
+
+	// Windows: Check standard installation path
+	if IsWindows() {
+		if _, err := os.Stat(`C:\Program Files\Tailscale\tailscale.exe`); err == nil {
+			return true
+		}
+	}
+
+	// macOS: Check Homebrew and App Store locations
+	if IsDarwin() {
+		paths := []string{
+			"/opt/homebrew/bin/tailscale",
+			"/usr/local/bin/tailscale",
+			"/Applications/Tailscale.app/Contents/MacOS/Tailscale",
+		}
+		for _, p := range paths {
+			if _, err := os.Stat(p); err == nil {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// CheckTailscaleCLIEnabled verifies the Tailscale CLI is functional.
+// On macOS with App Store installation, CLI must be manually enabled in
+// Tailscale > Settings > CLI.
+func CheckTailscaleCLIEnabled() error {
+	cli := GetTailscaleCLI()
+	cmd := exec.Command(cli, "version")
+	if err := cmd.Run(); err != nil {
+		if IsDarwin() {
+			return fmt.Errorf("Tailscale CLI not available. If you installed Tailscale from the App Store, " +
+				"please open Tailscale > Settings and enable 'Use Tailscale CLI'")
+		}
+		return fmt.Errorf("Tailscale CLI not functional: %w", err)
+	}
+	return nil
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -164,28 +164,37 @@ install_citadel() {
 # --- Execution ---
 main() {
   msg "Starting Citadel CLI installation..."
-  
+
   check_root
   check_deps
-  
+
   local arch
   arch=$(get_arch)
-  
+
   local version
   version=$(get_latest_version)
-  
+
   install_citadel "$arch" "$version"
-  
+
   msg "Citadel CLI installed successfully to ${INSTALL_DIR}/${BINARY_NAME}"
-  
+
   local installed_version
   installed_version=$(${INSTALL_DIR}/${BINARY_NAME} version)
-  
+
   echo "" >&2
   msg "Installation complete!"
   echo "  Version: ${installed_version}" >&2
-  echo "  Run 'citadel --help' to get started." >&2
-  echo "  To provision this node, run: sudo citadel init" >&2
+
+  # Auto-run citadel init if running interactively
+  if [ -t 0 ] && [ -t 1 ]; then
+    echo "" >&2
+    msg "Starting device provisioning..."
+    echo "" >&2
+    ${INSTALL_DIR}/${BINARY_NAME} init
+  else
+    echo "  Run 'citadel --help' to get started." >&2
+    echo "  To provision this node, run: sudo citadel init" >&2
+  fi
 }
 
 main


### PR DESCRIPTION
## Context

During a new user's onboarding session, several critical issues were discovered that prevented new Mac users from successfully using Citadel CLI:

1. **Tailscale CLI "command not found"** - After `citadel init` succeeded, subsequent commands like `citadel logout`, `citadel status`, and `citadel expose` failed on macOS
2. **macOS App Store Tailscale CLI not enabled** - Users who install Tailscale from the App Store need to manually enable CLI integration in Settings
3. **SSH key provisioning was manual** - No automated way to sync SSH keys from the AceTeam platform
4. **Two-step installation** - Users had to run both the install script AND `citadel init` separately

See: [aceteam-ai/aceteam#1203](https://github.com/aceteam-ai/aceteam/pull/1203) for related SSH key API implementation.

## Root Cause Analysis

### Tailscale PATH Issue
The codebase had **4 different implementations** of Tailscale CLI path resolution:

| File | macOS Support | Used By |
|------|---------------|---------|
| `internal/nexus/network_helpers.go` | ✅ Correct | init, login |
| `cmd/login.go` | ✅ Correct | login |
| `cmd/tailscale.go` | ❌ Windows only | logout, status |
| `cmd/expose.go` | ❌ Windows only | expose |

This meant `citadel init` worked (used correct implementation) but `citadel logout/status/expose` failed on macOS.

## Changes

### 1. Centralized Tailscale CLI Resolution
- **NEW** `internal/platform/tailscale.go` - Single source of truth for Tailscale path resolution
  - `GetTailscaleCLI()` - Checks PATH, then platform-specific locations
  - `IsTailscaleInstalled()` - Boolean check for installation
  - `CheckTailscaleCLIEnabled()` - Verifies CLI is functional (catches App Store CLI-not-enabled issue)

- **UPDATED** All files to use `platform.GetTailscaleCLI()`:
  - `cmd/tailscale.go`
  - `cmd/expose.go`
  - `cmd/login.go`
  - `internal/nexus/network_helpers.go`

### 2. SSH Key Sync Infrastructure
- **NEW** `internal/nexus/sshkeys.go` - SSH key synchronization client
  - `FetchAuthorizedKeys()` - Fetches keys from AceTeam API
  - `SyncAuthorizedKeys()` - Writes to `~/.ssh/authorized_keys` with managed section markers
  - Preserves existing user keys outside the managed section

- **UPDATED** `cmd/work.go` - Added `--ssh-sync` and `--ssh-sync-interval` flags
- **UPDATED** `cmd/run.go` - Auto-syncs SSH keys when starting all services (if configured)

### 3. Installer Auto-Init
- **UPDATED** `scripts/install.sh` - Detects TTY and auto-runs `citadel init` for interactive installations

### 4. Documentation
- **UPDATED** `CLAUDE.md` - Added bug fix workflow guidelines and documented the centralized Tailscale pattern

## Testing

### Test Tailscale PATH Fix (macOS)
```bash
# Build locally
go build -o citadel .

# These should all work without "command not found":
./citadel status          # Should show status (may fail if not connected, but should not error on CLI path)
./citadel expose --help   # Should show help
./citadel logout          # Should attempt logout (may fail if not connected)
```

### Test Tailscale CLI Check (macOS App Store)
```bash
# If Tailscale installed from App Store with CLI disabled:
./citadel login
# Should show: "Tailscale CLI not available. If you installed Tailscale from the App Store,
#              please open Tailscale > Settings and enable 'Use Tailscale CLI'"
```

### Test SSH Key Sync (requires API configuration)
```bash
# Create SSH sync config (manual for now, until backend integration complete)
mkdir -p ~/citadel-node
cat > ~/citadel-node/ssh_sync.yaml << 'EOF'
api_token: "your-api-token"
node_id: "your-node-id"
base_url: "https://aceteam.ai"
EOF

# Run with SSH sync enabled
./citadel work --mode=nexus --ssh-sync --api-key=your-key
# Should see: "SSH key sync: enabled (every 5m)"
```

### Test Installer Auto-Init
```bash
# Interactive install (TTY present) - should auto-run citadel init
curl -fsSL https://get.aceteam.ai/citadel.sh | sudo bash

# Non-interactive install - should just show instructions
curl -fsSL https://get.aceteam.ai/citadel.sh | sudo bash < /dev/null
```

### Run Unit Tests
```bash
go test ./cmd/... ./internal/nexus/... ./internal/platform/... -v
```

## Files Changed

| File | Change |
|------|--------|
| `internal/platform/tailscale.go` | NEW - Centralized Tailscale utilities |
| `internal/nexus/sshkeys.go` | NEW - SSH key sync client |
| `cmd/tailscale.go` | MODIFIED - Use platform.GetTailscaleCLI() |
| `cmd/expose.go` | MODIFIED - Use platform.GetTailscaleCLI() |
| `cmd/login.go` | MODIFIED - Use platform functions, add CLI check |
| `cmd/work.go` | MODIFIED - Add SSH sync flags and goroutine |
| `cmd/run.go` | MODIFIED - Add SSH sync on service start |
| `internal/nexus/network_helpers.go` | MODIFIED - Use platform.GetTailscaleCLI() |
| `scripts/install.sh` | MODIFIED - Add auto-init for interactive mode |
| `CLAUDE.md` | MODIFIED - Add workflow docs and architecture notes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)