### PR TITLE
feat: add sudo-free installation option for Linux/macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,17 @@ The `citadel` CLI is the on-premise agent and administrator's toolkit for the Ac
 
 ## Installation
 
-### From a Release (Recommended)
+### One-Line Installer (Recommended)
+
+#### Linux / macOS
+
+```bash
+curl -fsSL https://get.aceteam.ai/citadel.sh | bash
+```
+
+This installs to `~/.local/bin` and automatically configures your PATH. For system-wide install, use `sudo bash` instead.
+
+### Manual Installation
 
 #### Linux / macOS
 
@@ -21,7 +31,8 @@ The `citadel` CLI is the on-premise agent and administrator's toolkit for the Ac
 
     ```bash
     tar -xvf citadel_vX.Y.Z_linux_amd64.tar.gz
-    sudo mv citadel /usr/local/bin/
+    mv citadel ~/.local/bin/    # User-local (no sudo)
+    # or: sudo mv citadel /usr/local/bin/  # System-wide
     ```
 
 #### Windows

--- a/release.sh
+++ b/release.sh
@@ -251,34 +251,46 @@ $SUMMARY_SECTION
 
 ## Installation
 
+### One-Line Installer (Recommended)
+
+\`\`\`bash
+# User-local install (no sudo required)
+curl -fsSL https://get.aceteam.ai/citadel.sh | bash
+
+# Or system-wide install
+curl -fsSL https://get.aceteam.ai/citadel.sh | sudo bash
+\`\`\`
+
+### Manual Installation
+
 Download the appropriate binary for your platform and architecture:
 
-### Linux
+#### Linux
 
 \`\`\`bash
 # For amd64
 curl -LO https://github.com/aceteam-ai/citadel-cli/releases/download/$VERSION/citadel_${VERSION}_linux_amd64.tar.gz
 tar -xzf citadel_${VERSION}_linux_amd64.tar.gz
-sudo mv citadel /usr/local/bin/
+mv citadel ~/.local/bin/  # or: sudo mv citadel /usr/local/bin/
 
 # For arm64
 curl -LO https://github.com/aceteam-ai/citadel-cli/releases/download/$VERSION/citadel_${VERSION}_linux_arm64.tar.gz
 tar -xzf citadel_${VERSION}_linux_arm64.tar.gz
-sudo mv citadel /usr/local/bin/
+mv citadel ~/.local/bin/  # or: sudo mv citadel /usr/local/bin/
 \`\`\`
 
-### macOS
+#### macOS
 
 \`\`\`bash
 # For Intel Macs (amd64)
 curl -LO https://github.com/aceteam-ai/citadel-cli/releases/download/$VERSION/citadel_${VERSION}_darwin_amd64.tar.gz
 tar -xzf citadel_${VERSION}_darwin_amd64.tar.gz
-sudo mv citadel /usr/local/bin/
+mv citadel ~/.local/bin/  # or: sudo mv citadel /usr/local/bin/
 
 # For Apple Silicon (arm64)
 curl -LO https://github.com/aceteam-ai/citadel-cli/releases/download/$VERSION/citadel_${VERSION}_darwin_arm64.tar.gz
 tar -xzf citadel_${VERSION}_darwin_arm64.tar.gz
-sudo mv citadel /usr/local/bin/
+mv citadel ~/.local/bin/  # or: sudo mv citadel /usr/local/bin/
 \`\`\`
 
 ## SHA256 Checksums


### PR DESCRIPTION
## Summary

- Add user-local installation option (no sudo required)
- Installer now detects root status and chooses appropriate directory
- Automatically configures PATH for user shells (bash, zsh, fish)

## Changes

| File | Change |
|------|--------|
| `scripts/install.sh` | Dual-mode installation, PATH configuration, updated messaging |
| `release.sh` | Updated release notes template |
| `README.md` | Added one-line installer documentation |

## New Installation Command

```bash
# User-local install (no sudo required)
curl -fsSL https://get.aceteam.ai/citadel.sh | bash

# Or system-wide install
curl -fsSL https://get.aceteam.ai/citadel.sh | sudo bash
```

## Behavior

| Scenario | Install Location | PATH | Auto-init |
|----------|------------------|------|-----------|
| Without sudo | `~/.local/bin` | Auto-added to shell profile | No |
| With sudo | `/usr/local/bin` | Usually in PATH | Yes (interactive) |

## Test plan

- [ ] Test user-local install on Linux (bash)
- [ ] Test user-local install on macOS (zsh)
- [ ] Test system-wide install preserves existing behavior
- [ ] Verify PATH export added to correct shell profile
- [ ] Verify fish shell support works

🤖 Generated with [Claude Code](https://claude.ai/code)