### PR TITLE
feat: add config queue consumer for device configuration jobs

### DIFF
--- a/internal/heartbeat/config_consumer.go
+++ b/internal/heartbeat/config_consumer.go
@@ -1,0 +1,234 @@
+// Package heartbeat provides periodic status reporting to the AceTeam control plane.
+//
+// This file implements the config queue consumer for receiving device configuration
+// jobs from the Python worker via Redis Streams.
+package heartbeat
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/jobs"
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	// ConfigQueueName is the Redis stream for config jobs
+	ConfigQueueName = "jobs:v1:config"
+
+	// ConfigConsumerGroup is the consumer group for config jobs
+	ConfigConsumerGroup = "citadel-config-consumers"
+)
+
+// ConfigConsumer consumes device configuration jobs from Redis Streams.
+// It runs in parallel with the main job worker to apply device configs
+// received from the onboarding wizard.
+type ConfigConsumer struct {
+	client        *redis.Client
+	workerID      string
+	queueName     string
+	consumerGroup string
+	blockMs       int
+	configHandler *jobs.ConfigHandler
+}
+
+// ConfigConsumerConfig holds configuration for the ConfigConsumer.
+type ConfigConsumerConfig struct {
+	// RedisURL is the Redis connection URL
+	RedisURL string
+
+	// RedisPassword is the Redis password (optional)
+	RedisPassword string
+
+	// ConfigDir is where citadel config is stored (optional, defaults to ~/citadel-node)
+	ConfigDir string
+
+	// BlockMs is how long to wait for a job before returning (default: 5000)
+	BlockMs int
+}
+
+// NewConfigConsumer creates a new config queue consumer.
+func NewConfigConsumer(cfg ConfigConsumerConfig) (*ConfigConsumer, error) {
+	if cfg.BlockMs == 0 {
+		cfg.BlockMs = 5000
+	}
+
+	// Parse Redis URL
+	opts, err := redis.ParseURL(cfg.RedisURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse Redis URL: %w", err)
+	}
+
+	if cfg.RedisPassword != "" {
+		opts.Password = cfg.RedisPassword
+	}
+
+	client := redis.NewClient(opts)
+
+	return &ConfigConsumer{
+		client:        client,
+		workerID:      fmt.Sprintf("citadel-config-%s", uuid.New().String()[:8]),
+		queueName:     ConfigQueueName,
+		consumerGroup: ConfigConsumerGroup,
+		blockMs:       cfg.BlockMs,
+		configHandler: jobs.NewConfigHandler(cfg.ConfigDir),
+	}, nil
+}
+
+// Start begins consuming config jobs from Redis.
+// This method blocks until the context is cancelled.
+func (c *ConfigConsumer) Start(ctx context.Context) error {
+	// Verify connection
+	if err := c.client.Ping(ctx).Err(); err != nil {
+		return fmt.Errorf("failed to connect to Redis: %w", err)
+	}
+
+	// Create consumer group if it doesn't exist
+	err := c.client.XGroupCreateMkStream(ctx, c.queueName, c.consumerGroup, "0").Err()
+	if err != nil && !strings.Contains(err.Error(), "BUSYGROUP") {
+		return fmt.Errorf("failed to create consumer group: %w", err)
+	}
+
+	// Main consumption loop
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			job, msgID, err := c.readJob(ctx)
+			if err != nil {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				fmt.Printf("   - ⚠️ Config consumer read error: %v\n", err)
+				continue
+			}
+
+			if job == nil {
+				continue // No job available
+			}
+
+			// Process the config job
+			c.processJob(ctx, job, msgID)
+		}
+	}
+}
+
+// readJob reads the next config job from the stream.
+func (c *ConfigConsumer) readJob(ctx context.Context) (*nexus.Job, string, error) {
+	streams, err := c.client.XReadGroup(ctx, &redis.XReadGroupArgs{
+		Group:    c.consumerGroup,
+		Consumer: c.workerID,
+		Streams:  []string{c.queueName, ">"},
+		Count:    1,
+		Block:    time.Duration(c.blockMs) * time.Millisecond,
+	}).Result()
+
+	if err != nil {
+		if err == redis.Nil {
+			return nil, "", nil // No message available
+		}
+		return nil, "", fmt.Errorf("failed to read from config stream: %w", err)
+	}
+
+	if len(streams) == 0 || len(streams[0].Messages) == 0 {
+		return nil, "", nil
+	}
+
+	msg := streams[0].Messages[0]
+	job, err := c.parseMessage(msg)
+	return job, msg.ID, err
+}
+
+// parseMessage converts a Redis stream message to a nexus.Job.
+func (c *ConfigConsumer) parseMessage(msg redis.XMessage) (*nexus.Job, error) {
+	job := &nexus.Job{
+		Payload: make(map[string]string),
+	}
+
+	// Extract jobId
+	if jobID, ok := msg.Values["jobId"].(string); ok {
+		job.ID = jobID
+	}
+
+	// Extract type
+	if jobType, ok := msg.Values["type"].(string); ok {
+		job.Type = jobType
+	}
+
+	// Parse payload - it could be a JSON string or individual fields
+	if payloadStr, ok := msg.Values["payload"].(string); ok {
+		// Try to parse as JSON object containing config
+		var payload map[string]interface{}
+		if err := json.Unmarshal([]byte(payloadStr), &payload); err == nil {
+			// Extract config from payload and serialize it back for the handler
+			if configData, ok := payload["config"]; ok {
+				configJSON, _ := json.Marshal(configData)
+				job.Payload["config"] = string(configJSON)
+			} else {
+				// The entire payload might be the config
+				job.Payload["config"] = payloadStr
+			}
+		} else {
+			// Use as-is
+			job.Payload["config"] = payloadStr
+		}
+	}
+
+	// Also check for top-level config field
+	if configStr, ok := msg.Values["config"].(string); ok {
+		job.Payload["config"] = configStr
+	}
+
+	return job, nil
+}
+
+// processJob applies the device configuration.
+func (c *ConfigConsumer) processJob(ctx context.Context, job *nexus.Job, msgID string) {
+	fmt.Printf("   - 📥 Config job received: %s (type: %s)\n", job.ID, job.Type)
+
+	// Only process APPLY_DEVICE_CONFIG jobs
+	if job.Type != "APPLY_DEVICE_CONFIG" {
+		fmt.Printf("   - ⚠️ Ignoring unknown config job type: %s\n", job.Type)
+		c.ackJob(ctx, msgID)
+		return
+	}
+
+	// Execute the config handler
+	jobCtx := jobs.JobContext{}
+	output, err := c.configHandler.Execute(jobCtx, job)
+
+	if err != nil {
+		fmt.Printf("   - ❌ Config job failed: %v\n", err)
+		// Don't ACK - let it retry
+		return
+	}
+
+	fmt.Printf("   - ✅ Config applied: %s\n", string(output))
+	c.ackJob(ctx, msgID)
+}
+
+// ackJob acknowledges a processed message.
+func (c *ConfigConsumer) ackJob(ctx context.Context, msgID string) {
+	if err := c.client.XAck(ctx, c.queueName, c.consumerGroup, msgID).Err(); err != nil {
+		fmt.Printf("   - ⚠️ Failed to ACK config job: %v\n", err)
+	}
+}
+
+// Close closes the Redis connection.
+func (c *ConfigConsumer) Close() error {
+	if c.client != nil {
+		return c.client.Close()
+	}
+	return nil
+}
+
+// QueueName returns the config queue name.
+func (c *ConfigConsumer) QueueName() string {
+	return c.queueName
+}

--- a/internal/heartbeat/config_consumer_test.go
+++ b/internal/heartbeat/config_consumer_test.go
@@ -1,0 +1,194 @@
+package heartbeat
+
+import (
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+)
+
+func TestNewConfigConsumer(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  ConfigConsumerConfig
+		wantErr bool
+	}{
+		{
+			name: "valid config",
+			config: ConfigConsumerConfig{
+				RedisURL: "redis://localhost:6379",
+			},
+			wantErr: false,
+		},
+		{
+			name: "with password",
+			config: ConfigConsumerConfig{
+				RedisURL:      "redis://localhost:6379",
+				RedisPassword: "secret",
+			},
+			wantErr: false,
+		},
+		{
+			name: "with custom config dir",
+			config: ConfigConsumerConfig{
+				RedisURL:  "redis://localhost:6379",
+				ConfigDir: "/custom/path",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid redis URL",
+			config: ConfigConsumerConfig{
+				RedisURL: "not-a-valid-url",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			consumer, err := NewConfigConsumer(tt.config)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("NewConfigConsumer() should return error")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("NewConfigConsumer() error = %v, want nil", err)
+				return
+			}
+
+			if consumer == nil {
+				t.Fatal("NewConfigConsumer() returned nil")
+			}
+
+			// Verify queue name
+			if consumer.QueueName() != ConfigQueueName {
+				t.Errorf("QueueName() = %v, want %v", consumer.QueueName(), ConfigQueueName)
+			}
+
+			// Verify consumer group
+			if consumer.consumerGroup != ConfigConsumerGroup {
+				t.Errorf("consumerGroup = %v, want %v", consumer.consumerGroup, ConfigConsumerGroup)
+			}
+
+			// Verify worker ID has correct prefix
+			if len(consumer.workerID) == 0 {
+				t.Error("workerID should not be empty")
+			}
+
+			// Clean up
+			consumer.Close()
+		})
+	}
+}
+
+func TestConfigConsumerParseMessage(t *testing.T) {
+	consumer, err := NewConfigConsumer(ConfigConsumerConfig{
+		RedisURL: "redis://localhost:6379",
+	})
+	if err != nil {
+		t.Fatalf("Failed to create consumer: %v", err)
+	}
+	defer consumer.Close()
+
+	tests := []struct {
+		name        string
+		msg         redis.XMessage
+		wantJobID   string
+		wantJobType string
+		wantConfig  bool
+	}{
+		{
+			name: "job with payload containing config",
+			msg: redis.XMessage{
+				ID: "1234-0",
+				Values: map[string]interface{}{
+					"jobId":   "job-123",
+					"type":    "APPLY_DEVICE_CONFIG",
+					"payload": `{"config":{"deviceName":"test-node","services":["ollama"]}}`,
+				},
+			},
+			wantJobID:   "job-123",
+			wantJobType: "APPLY_DEVICE_CONFIG",
+			wantConfig:  true,
+		},
+		{
+			name: "job with top-level config",
+			msg: redis.XMessage{
+				ID: "1235-0",
+				Values: map[string]interface{}{
+					"jobId":  "job-456",
+					"type":   "APPLY_DEVICE_CONFIG",
+					"config": `{"deviceName":"another-node","services":["vllm"]}`,
+				},
+			},
+			wantJobID:   "job-456",
+			wantJobType: "APPLY_DEVICE_CONFIG",
+			wantConfig:  true,
+		},
+		{
+			name: "job with raw payload",
+			msg: redis.XMessage{
+				ID: "1236-0",
+				Values: map[string]interface{}{
+					"jobId":   "job-789",
+					"type":    "APPLY_DEVICE_CONFIG",
+					"payload": `{"deviceName":"raw-node","services":["llamacpp"]}`,
+				},
+			},
+			wantJobID:   "job-789",
+			wantJobType: "APPLY_DEVICE_CONFIG",
+			wantConfig:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job, err := consumer.parseMessage(tt.msg)
+			if err != nil {
+				t.Fatalf("parseMessage() error = %v", err)
+			}
+
+			if job.ID != tt.wantJobID {
+				t.Errorf("job.ID = %v, want %v", job.ID, tt.wantJobID)
+			}
+			if job.Type != tt.wantJobType {
+				t.Errorf("job.Type = %v, want %v", job.Type, tt.wantJobType)
+			}
+			if tt.wantConfig {
+				if _, ok := job.Payload["config"]; !ok {
+					t.Error("job.Payload should contain 'config' field")
+				}
+			}
+		})
+	}
+}
+
+func TestConfigConsumerConstants(t *testing.T) {
+	// Verify constants are set correctly
+	if ConfigQueueName != "jobs:v1:config" {
+		t.Errorf("ConfigQueueName = %v, want 'jobs:v1:config'", ConfigQueueName)
+	}
+
+	if ConfigConsumerGroup != "citadel-config-consumers" {
+		t.Errorf("ConfigConsumerGroup = %v, want 'citadel-config-consumers'", ConfigConsumerGroup)
+	}
+}
+
+func TestConfigConsumerClose(t *testing.T) {
+	consumer, err := NewConfigConsumer(ConfigConsumerConfig{
+		RedisURL: "redis://localhost:6379",
+	})
+	if err != nil {
+		t.Fatalf("Failed to create consumer: %v", err)
+	}
+
+	// Close should not error
+	err = consumer.Close()
+	if err != nil {
+		t.Errorf("Close() error = %v, want nil", err)
+	}
+}


### PR DESCRIPTION
## Summary

Implements issue #39: consume from `jobs:v1:config` Redis stream for device configuration from the onboarding wizard.

- Add `ConfigConsumer` in `internal/heartbeat/config_consumer.go`
  - Consumes from `jobs:v1:config` stream
  - Uses `citadel-config-consumers` consumer group
  - Delegates `APPLY_DEVICE_CONFIG` jobs to `ConfigHandler`
- Update `cmd/work.go` to start config consumer when `--redis-status` enabled
- Add tests for config consumer
- Update `docs/redis-status-publishing.md` with config consumer documentation

The config consumer runs in parallel with the status publisher to receive and apply device configurations pushed by the Python worker after a user completes the onboarding wizard.

## Architecture

```
┌─────────────────┐                      ┌─────────────────┐
│   Citadel CLI   │                      │  Python Worker  │
│                 │                      │  (DB access)    │
└────────┬────────┘                      └────────┬────────┘
         │                                        │
         │  1. Publish status (with device_code)  │
         │ ─────────────────────────────────────▶ │
         │    (Pub/Sub + Streams)                 │
         │                                        │
         │                                        │  2. Lookup device config
         │                                        │
         │  3. Push APPLY_DEVICE_CONFIG job       │
         │ ◀───────────────────────────────────── │
         │    (jobs:v1:config stream)             │
         │                                        │
         │  4. Apply config (start services)      │
         │                                        │
```

## Test plan

- [x] Unit tests for `ConfigConsumer` pass
- [x] Tests for message parsing pass
- [x] Build succeeds
- [ ] Manual test: Push config job to `jobs:v1:config` stream, verify config applied

```bash
# Start worker with Redis status
citadel work --mode=redis --redis-url=redis://localhost:6379 --redis-status

# Push a test config job
redis-cli XADD jobs:v1:config '*' \
  jobId "test-$(date +%s)" \
  type "APPLY_DEVICE_CONFIG" \
  payload '{"config":{"deviceName":"test-node","services":["ollama"],"autoStartServices":true}}'

# Verify manifest updated
cat ~/citadel-node/citadel.yaml
```

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)