### PR TITLE
feat: add backend deregistration to citadel logout

### DIFF
--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -2,39 +2,117 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/network"
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
 	"github.com/spf13/cobra"
+)
+
+var (
+	logoutKeepRegistration bool
 )
 
 var logoutCmd = &cobra.Command{
 	Use:   "logout",
-	Short: "Disconnect this machine from the AceTeam Network",
-	Long: `Disconnects this machine from your AceTeam network. This command will stop
-the node from receiving jobs and remove it from the network until you run
-'citadel login' again.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("--- Disconnecting from the AceTeam Network ---")
+	Short: "Disconnect and deregister this machine from the AceTeam Network",
+	Long: `Disconnects this machine from your AceTeam network and deregisters it from
+the coordination server. This allows the node to be re-registered under a
+different organization when running 'citadel init' again.
 
-		// Check if connected
-		if !network.IsGlobalConnected() && !network.HasState() {
-			fmt.Println("Not connected to any network.")
-			return
+By default, logout will:
+  1. Deregister the node from Headscale (allows re-registration to different org)
+  2. Disconnect from the network
+  3. Clear local network state
+
+Use --keep-registration to only disconnect locally without deregistering from
+Headscale. This is useful for temporary disconnects where you want to reconnect
+to the same organization later.`,
+	Run: runLogout,
+}
+
+func runLogout(cmd *cobra.Command, args []string) {
+	fmt.Println("--- Disconnecting from the AceTeam Network ---")
+
+	// Check if connected or has state
+	if !network.IsGlobalConnected() && !network.HasState() {
+		fmt.Println("Not connected to any network.")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Try to deregister from backend (unless --keep-registration is set)
+	if !logoutKeepRegistration {
+		deregisterFromBackend(ctx)
+	} else {
+		Debug("skipping backend deregistration (--keep-registration)")
+	}
+
+	// Logout (disconnect and clear state)
+	if err := network.Logout(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error logging out: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("✅ Successfully disconnected from the AceTeam Network.")
+	if logoutKeepRegistration {
+		fmt.Println("   Node registration preserved. To reconnect, run 'citadel login'")
+	} else {
+		fmt.Println("   To register again, run 'citadel init'")
+	}
+}
+
+// deregisterFromBackend attempts to deregister the node from Headscale via the backend API.
+// This is a best-effort operation - errors are logged but don't block logout.
+func deregisterFromBackend(ctx context.Context) {
+	var orgID, nodeName string
+
+	// Try to get node identity from manifest
+	if manifest, _, err := findAndReadManifest(); err == nil {
+		orgID = manifest.Node.OrgID
+		nodeName = manifest.Node.Name
+		Debug("from manifest: orgID=%s, nodeName=%s", orgID, nodeName)
+	}
+
+	// Try to get more accurate hostname from network status (if connected)
+	if status, err := network.GetGlobalStatus(ctx); err == nil && status.Connected {
+		if status.Hostname != "" {
+			Debug("from network status: hostname=%s (overriding manifest)", status.Hostname)
+			nodeName = status.Hostname
 		}
+	}
 
-		// Logout (disconnect and clear state)
-		if err := network.Logout(); err != nil {
-			fmt.Fprintf(os.Stderr, "❌ Error logging out: %v\n", err)
-			os.Exit(1)
-		}
+	// Skip if we have no identity information
+	if orgID == "" && nodeName == "" {
+		Debug("no node identity found, skipping deregistration")
+		return
+	}
 
-		fmt.Println("✅ Successfully disconnected from the AceTeam Network.")
-		fmt.Println("   To reconnect, run 'citadel login' or 'citadel login --authkey <key>'")
-	},
+	// Call backend to deregister
+	Debug("deregistering from backend: orgID=%s, nodeName=%s", orgID, nodeName)
+	client := nexus.NewDeregisterClient(authServiceURL)
+	req := nexus.DeregisterRequest{
+		OrgID:    orgID,
+		NodeName: nodeName,
+	}
+
+	if err := client.Deregister(ctx, req); err != nil {
+		// Warning only - continue with local logout
+		fmt.Printf("   - Warning: Could not deregister from backend: %v\n", err)
+		fmt.Println("   - Node may still be registered in Headscale")
+	} else {
+		fmt.Println("   - Deregistered from coordination server")
+	}
 }
 
 func init() {
 	rootCmd.AddCommand(logoutCmd)
+
+	logoutCmd.Flags().BoolVar(&logoutKeepRegistration, "keep-registration", false,
+		"Only disconnect locally, keep node registered in Headscale (for temporary disconnects)")
 }

--- a/internal/nexus/deregister.go
+++ b/internal/nexus/deregister.go
@@ -1,0 +1,100 @@
+// internal/nexus/deregister.go
+package nexus
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// DeregisterClient handles node deregistration from Headscale
+type DeregisterClient struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// DeregisterRequest represents the request body for the /deregister endpoint
+type DeregisterRequest struct {
+	OrgID    string `json:"org_id,omitempty"`
+	NodeName string `json:"node_name,omitempty"`
+}
+
+// DeregisterResponse represents a successful deregister response
+type DeregisterResponse struct {
+	Status  string `json:"status"`
+	Message string `json:"message,omitempty"`
+}
+
+// DeregisterError represents an error response from the /deregister endpoint
+type DeregisterError struct {
+	ErrorCode   string `json:"error"`
+	Description string `json:"error_description,omitempty"`
+}
+
+func (e *DeregisterError) Error() string {
+	if e.Description != "" {
+		return fmt.Sprintf("%s: %s", e.ErrorCode, e.Description)
+	}
+	return e.ErrorCode
+}
+
+// NewDeregisterClient creates a new deregister client
+func NewDeregisterClient(baseURL string) *DeregisterClient {
+	return &DeregisterClient{
+		baseURL: baseURL,
+		httpClient: &http.Client{
+			Timeout: 15 * time.Second,
+		},
+	}
+}
+
+// Deregister removes the node from Headscale via the backend API.
+// This is a best-effort operation - errors should be logged but not block logout.
+func (c *DeregisterClient) Deregister(ctx context.Context, req DeregisterRequest) error {
+	url := c.baseURL + "/api/fabric/device-auth/deregister"
+
+	// Create request body
+	body, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	// Create HTTP request
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	// Send request
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Handle response based on status code
+	switch {
+	case resp.StatusCode == http.StatusOK:
+		// Success
+		return nil
+
+	case resp.StatusCode == http.StatusNotFound:
+		// Node not found is also success (already deregistered)
+		return nil
+
+	case resp.StatusCode >= 400:
+		// Try to parse error response
+		var errResp DeregisterError
+		if err := json.NewDecoder(resp.Body).Decode(&errResp); err == nil && errResp.ErrorCode != "" {
+			return &errResp
+		}
+		return fmt.Errorf("server returned status %d", resp.StatusCode)
+
+	default:
+		return nil
+	}
+}


### PR DESCRIPTION
## Summary

Enhances `citadel logout` to call a backend API endpoint that deregisters the node from Headscale. This allows users to re-register under a different organization by running `citadel logout && citadel init`.

**Related Issue**: https://github.com/aceteam-ai/aceteam/issues/1300

### Problem

When a machine is registered in Headscale under one user/org and then goes through device auth with a different organization, Headscale doesn't change the node's user (by design - prevents machine stealing). This causes issues when users want to move nodes between organizations.

### Solution

Make `citadel logout` call a backend API to deregister the node from Headscale before clearing local state.

## Changes

- **`internal/nexus/deregister.go`** (new) - Client for `/api/fabric/device-auth/deregister` endpoint
- **`cmd/logout.go`** - Call deregister before `network.Logout()`, add `--keep-registration` flag

## New Logout Flow

```
citadel logout
    │
    ├─→ 1. Read org_id + node_name from manifest
    ├─→ 2. Get hostname from network status (if connected)
    ├─→ 3. POST /api/fabric/device-auth/deregister (best-effort)
    ├─→ 4. network.Logout() - disconnect + clear local state
    └─→ 5. Print success message
```

## Usage

```bash
# Full logout with deregistration (allows re-init to different org)
citadel logout

# Temporary disconnect (keeps registration for same org)
citadel logout --keep-registration

# Debug to see what's happening
citadel logout --debug
```

## Backend Requirements

The backend (aceteam repo) needs to implement:

```
POST /api/fabric/device-auth/deregister
Content-Type: application/json

{
  "org_id": "f0b8c095-...",
  "node_name": "ubuntu-gpu"
}
```

## Test plan

- [ ] Build: `go build -o citadel .`
- [ ] Run tests: `go test ./...`
- [ ] Test logout without backend (should warn but succeed)
- [ ] Test `--keep-registration` flag
- [ ] Test with `--debug` to see deregistration flow

🤖 Generated with [Claude Code](https://claude.ai/code)