### PR TITLE
feat: display account email at citadel work startup

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -731,6 +731,8 @@ func clearSavedConfig() {
 	delete(config, "api_base_url")
 	delete(config, "org_id")
 	delete(config, "redis_url")
+	delete(config, "user_email")
+	delete(config, "user_name")
 
 	// If only node_config_dir remains (or nothing), write it back
 	if hasNodeConfigDir {
@@ -792,6 +794,12 @@ func saveDeviceConfigToFile(token *nexus.TokenResponse) error {
 	}
 	if token.OrgID != "" {
 		config["org_id"] = token.OrgID
+	}
+	if token.UserEmail != "" {
+		config["user_email"] = token.UserEmail
+	}
+	if token.UserName != "" {
+		config["user_name"] = token.UserName
 	}
 	// Remove redis_url - not needed when using API mode
 	delete(config, "redis_url")

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -185,6 +185,13 @@ func runWork(cmd *cobra.Command, args []string) {
 		streamFactory = worker.CreateAPIStreamWriterFactory(ctx, apiSource)
 
 		fmt.Println("   - Mode: Redis API (secure)")
+		if deviceConfig.UserEmail != "" {
+			if deviceConfig.UserName != "" {
+				fmt.Printf("   - Account: %s (%s)\n", deviceConfig.UserEmail, deviceConfig.UserName)
+			} else {
+				fmt.Printf("   - Account: %s\n", deviceConfig.UserEmail)
+			}
+		}
 	} else {
 		// Legacy mode: direct Redis connection
 		Debug("using direct Redis mode")
@@ -619,6 +626,8 @@ type DeviceConfig struct {
 	APIBaseURL     string `yaml:"api_base_url"`
 	OrgID          string `yaml:"org_id"`
 	RedisURL       string `yaml:"redis_url"`
+	UserEmail      string `yaml:"user_email"`
+	UserName       string `yaml:"user_name"`
 }
 
 // getDeviceConfigFromFile reads device authentication config from global config file.

--- a/internal/nexus/deviceauth.go
+++ b/internal/nexus/deviceauth.go
@@ -34,9 +34,11 @@ type TokenResponse struct {
 	ExpiresIn      int    `json:"expires_in"`
 	NexusURL       string `json:"nexus_url,omitempty"`
 	OrgID          string `json:"org_id,omitempty"`
-	RedisURL       string `json:"redis_url,omitempty"`       // Deprecated: use DeviceAPIToken
+	RedisURL       string `json:"redis_url,omitempty"`        // Deprecated: use DeviceAPIToken
 	DeviceAPIToken string `json:"device_api_token,omitempty"` // New secure API token
 	APIBaseURL     string `json:"api_base_url,omitempty"`     // Base URL for API calls
+	UserEmail      string `json:"user_email,omitempty"`       // User email for display
+	UserName       string `json:"user_name,omitempty"`        // User display name
 }
 
 // TokenError represents an error response from the /token endpoint


### PR DESCRIPTION
## Summary
- Add `user_email` and `user_name` fields to device auth token response parsing
- Save user info to config.yaml during `citadel init`
- Display account info at `citadel work` startup

## Expected Output
```
[22:45:29] [CITADEL] === Session started ===
   - Mode: Redis API (secure)
   - Account: user@example.com (John Doe)
   ...
```

## Related
- Backend PR: aceteam-ai/aceteam#1344

## Test plan
- [x] `go build` succeeds
- [x] `go test ./...` passes
- [ ] Manual test after backend PR is merged

🤖 Generated with [Claude Code](https://claude.ai/code)