### PR TITLE
feat: add Homebrew tap support for macOS installation

### DIFF
--- a/.homebrew/README.md
+++ b/.homebrew/README.md
@@ -1,0 +1,149 @@
+# Homebrew Tap for Citadel CLI
+
+This directory contains the Homebrew formula template for Citadel CLI.
+
+## Installation (for users)
+
+Install Citadel via our Homebrew tap:
+
+```bash
+brew tap aceteam-ai/tap
+brew install citadel
+```
+
+Or as a one-liner:
+
+```bash
+brew install aceteam-ai/tap/citadel
+```
+
+Upgrade to the latest version:
+
+```bash
+brew upgrade citadel
+```
+
+## Publishing to Homebrew Tap (for maintainers)
+
+### Repository Structure
+
+The actual Homebrew tap lives in a separate repository: `aceteam-ai/homebrew-tap`
+
+```
+homebrew-tap/
+├── README.md           # User-facing tap documentation
+└── Formula/
+    └── citadel.rb      # Actual formula (copy from template, fill in version/hashes)
+```
+
+### Updating the Formula
+
+After creating a new release with `release.sh`, update the Homebrew tap:
+
+1. **Get the SHA256 checksums** from the release output or `release/checksums.txt`:
+
+   ```bash
+   # From checksums.txt
+   grep darwin release/checksums.txt
+   ```
+
+2. **Update the formula** in `aceteam-ai/homebrew-tap`:
+
+   ```ruby
+   # In Formula/citadel.rb, update:
+   version "X.Y.Z"  # New version (without 'v' prefix)
+
+   # For Apple Silicon (arm64)
+   url "https://github.com/aceteam-ai/citadel-cli/releases/download/vX.Y.Z/citadel_vX.Y.Z_darwin_arm64.tar.gz"
+   sha256 "ARM64_SHA256_HERE"
+
+   # For Intel Macs (amd64)
+   url "https://github.com/aceteam-ai/citadel-cli/releases/download/vX.Y.Z/citadel_vX.Y.Z_darwin_amd64.tar.gz"
+   sha256 "AMD64_SHA256_HERE"
+   ```
+
+3. **Commit and push** the formula update:
+
+   ```bash
+   cd /path/to/homebrew-tap
+   git add Formula/citadel.rb
+   git commit -m "citadel X.Y.Z"
+   git push origin main
+   ```
+
+4. **Verify the update**:
+
+   ```bash
+   brew update
+   brew upgrade citadel
+   citadel version
+   ```
+
+### First-Time Tap Setup
+
+To create the `aceteam-ai/homebrew-tap` repository:
+
+1. **Create the repository** on GitHub:
+   - Repository name: `homebrew-tap` (must start with `homebrew-`)
+   - Make it public
+
+2. **Initialize the structure**:
+
+   ```bash
+   mkdir -p Formula
+   cp /path/to/citadel-cli/.homebrew/citadel.rb.template Formula/citadel.rb
+   # Edit Formula/citadel.rb with actual version and SHA256 values
+   ```
+
+3. **Add a README.md**:
+
+   ```markdown
+   # AceTeam Homebrew Tap
+
+   Homebrew formulae for AceTeam tools.
+
+   ## Installation
+
+   ```bash
+   brew tap aceteam-ai/tap
+   brew install citadel
+   ```
+
+   ## Available Formulae
+
+   - `citadel` - On-premise agent for the AceTeam Sovereign Compute Fabric
+   ```
+
+4. **Commit and push**:
+
+   ```bash
+   git add .
+   git commit -m "Initial tap setup with citadel formula"
+   git push origin main
+   ```
+
+### Validating the Formula
+
+Before publishing, validate the formula locally:
+
+```bash
+# Audit the formula
+brew audit --strict Formula/citadel.rb
+
+# Test installation
+brew install --build-from-source Formula/citadel.rb
+citadel version
+
+# Clean up
+brew uninstall citadel
+```
+
+## Formula Template
+
+See `citadel.rb.template` in this directory for the formula structure with VERSION placeholders.
+
+## Resources
+
+- [Homebrew Formula Cookbook](https://docs.brew.sh/Formula-Cookbook)
+- [Homebrew Tap Documentation](https://docs.brew.sh/Taps)
+- [Formula API Documentation](https://rubydoc.brew.sh/Formula)

--- a/.homebrew/citadel.rb.template
+++ b/.homebrew/citadel.rb.template
@@ -1,0 +1,32 @@
+# Homebrew formula for Citadel CLI
+#
+# This is a template file with VERSION placeholders.
+# Copy to aceteam-ai/homebrew-tap/Formula/citadel.rb and replace:
+#   - VERSION with the actual version (e.g., 1.3.0)
+#   - ARM64_SHA256 with the SHA256 of darwin_arm64.tar.gz
+#   - AMD64_SHA256 with the SHA256 of darwin_amd64.tar.gz
+
+class Citadel < Formula
+  desc "On-premise agent for the AceTeam Sovereign Compute Fabric"
+  homepage "https://github.com/aceteam-ai/citadel-cli"
+  version "VERSION"
+  license "Apache-2.0"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/aceteam-ai/citadel-cli/releases/download/vVERSION/citadel_vVERSION_darwin_arm64.tar.gz"
+      sha256 "ARM64_SHA256"
+    elsif Hardware::CPU.intel?
+      url "https://github.com/aceteam-ai/citadel-cli/releases/download/vVERSION/citadel_vVERSION_darwin_amd64.tar.gz"
+      sha256 "AMD64_SHA256"
+    end
+  end
+
+  def install
+    bin.install "citadel"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/citadel version")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ curl -fsSL https://get.aceteam.ai/citadel.sh | bash
 
 This installs to `~/.local/bin` and automatically configures your PATH. For system-wide install, use `sudo bash` instead.
 
+#### macOS (Homebrew)
+
+```bash
+brew tap aceteam-ai/tap
+brew install citadel
+```
+
+Or as a one-liner:
+
+```bash
+brew install aceteam-ai/tap/citadel
+```
+
 ### Manual Installation
 
 #### Linux / macOS

--- a/release.sh
+++ b/release.sh
@@ -332,13 +332,29 @@ if [[ "$DRY_RUN" == true ]]; then
 else
     RELEASE_URL=$(gh release view "$VERSION" --json url -q .url)
 
+    # Extract macOS SHA256 values for Homebrew tap update
+    DARWIN_AMD64_SHA=$(grep "darwin_amd64" release/checksums.txt | awk '{print $1}')
+    DARWIN_ARM64_SHA=$(grep "darwin_arm64" release/checksums.txt | awk '{print $1}')
+    VERSION_NUM=${VERSION#v}  # Remove 'v' prefix for Homebrew
+
     echo ""
     echo -e "${GREEN}✅ Release $VERSION published successfully!${NC}"
     echo ""
     echo "📦 Release URL: $RELEASE_URL"
     echo ""
+    echo -e "${YELLOW}🍺 Homebrew Tap Update${NC}"
+    echo "   Update aceteam-ai/homebrew-tap/Formula/citadel.rb with:"
+    echo ""
+    echo "   version \"$VERSION_NUM\""
+    echo ""
+    echo "   # Apple Silicon (arm64)"
+    echo "   sha256 \"$DARWIN_ARM64_SHA\""
+    echo ""
+    echo "   # Intel Mac (amd64)"
+    echo "   sha256 \"$DARWIN_AMD64_SHA\""
+    echo ""
     echo "Next steps:"
     echo "  1. Review the release notes and edit if needed"
-    echo "  2. Announce the release to your team"
-    echo "  3. Update any documentation that references version numbers"
+    echo "  2. Update the Homebrew tap: aceteam-ai/homebrew-tap"
+    echo "  3. Announce the release to your team"
 fi


### PR DESCRIPTION
## Summary

- Add `.homebrew/README.md` with maintainer documentation for updating the tap
- Add `.homebrew/citadel.rb.template` formula template with VERSION placeholders
- Update `README.md` with Homebrew installation instructions
- Update `release.sh` to display SHA256 values after release for easy tap updates

## Installation (after tap is created)

```bash
brew tap aceteam-ai/tap
brew install citadel
```

Or as a one-liner:

```bash
brew install aceteam-ai/tap/citadel
```

## Test plan

- [ ] Verify `.homebrew/citadel.rb.template` has correct formula structure
- [ ] Verify `README.md` shows Homebrew section under Installation
- [ ] Run `./release.sh --dry-run -v v1.0.0` to verify SHA256 output format
- [ ] Create `aceteam-ai/homebrew-tap` repository with the formula (manual step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)