### PR TITLE
feat: add network UX improvements with peer commands

### DIFF
--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -1,0 +1,237 @@
+// cmd/connect.go
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/network"
+	"github.com/aceteam-ai/citadel-cli/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+var (
+	connectTimeout int
+)
+
+var connectCmd = &cobra.Command{
+	Use:   "connect [peer:port]",
+	Short: "Connect to a service on another node",
+	Long: `Establishes a raw TCP connection to a service on another node and pipes
+stdin/stdout to it.
+
+This is useful for:
+  - Testing connectivity to services
+  - Piping data through the network
+  - Using as SSH ProxyCommand (used internally by 'citadel ssh')
+
+PEER IDENTIFICATION:
+  You can specify the peer in multiple ways:
+  - By hostname:  citadel connect gpu-node-1:5432
+  - By IP:        citadel connect 100.64.0.25:5432
+  - Interactive:  citadel connect  (prompts for peer and port)
+
+The connection uses the tsnet userspace network, so it can reach peers
+that system networking cannot.`,
+	Example: `  # Interactive mode - select peer and port
+  citadel connect
+
+  # Connect to a PostgreSQL server
+  citadel connect gpu-node-1:5432
+
+  # Connect to Redis
+  citadel connect gpu-node-1:6379
+
+  # Connect by IP address
+  citadel connect 100.64.0.25:11434
+
+  # Connect with timeout
+  citadel connect gpu-node-1:11434 --timeout 30`,
+	Args: cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		// Ensure network connection
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		if err := ensureNetworkConnected(ctx); err != nil {
+			cancel()
+			badColor.Println(err)
+			os.Exit(1)
+		}
+		cancel()
+
+		var peer, port string
+		var err error
+
+		// Interactive mode if no args
+		if len(args) == 0 {
+			peer, port, err = setupConnectInteractive()
+			if err != nil {
+				badColor.Printf("Error: %v\n", err)
+				os.Exit(1)
+			}
+		} else {
+			// Parse peer:port
+			peer, port, err = parsePeerPort(args[0])
+			if err != nil {
+				badColor.Printf("Invalid target: %v\n", err)
+				fmt.Println("Usage: citadel connect <peer>:<port>")
+				os.Exit(1)
+			}
+		}
+
+		// Resolve peer to IP
+		ip, hostname, err := resolvePeer(peer)
+		if err != nil {
+			badColor.Printf("Could not resolve peer '%s': %v\n", peer, err)
+			suggestAvailablePeers()
+			os.Exit(1)
+		}
+
+		// Display connection info
+		addr := fmt.Sprintf("%s:%s", ip, port)
+		if hostname != "" {
+			fmt.Fprintf(os.Stderr, "Connecting to %s (%s)...\n", hostname, addr)
+		} else {
+			fmt.Fprintf(os.Stderr, "Connecting to %s...\n", addr)
+		}
+
+		// Set up connection context with timeout
+		connectCtx := context.Background()
+		var connectCancel context.CancelFunc
+		if connectTimeout > 0 {
+			connectCtx, connectCancel = context.WithTimeout(connectCtx, time.Duration(connectTimeout)*time.Second)
+			defer connectCancel()
+		}
+
+		// Dial through the network
+		conn, err := network.Dial(connectCtx, "tcp", addr)
+		if err != nil {
+			badColor.Printf("Connection failed: %v\n", err)
+			os.Exit(1)
+		}
+		defer conn.Close()
+
+		fmt.Fprintf(os.Stderr, "Connected.\n")
+
+		// Handle interrupt
+		sigChan := make(chan os.Signal, 1)
+		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+		go func() {
+			<-sigChan
+			conn.Close()
+		}()
+
+		// Bidirectional copy
+		done := make(chan struct{})
+
+		// Copy from connection to stdout
+		go func() {
+			io.Copy(os.Stdout, conn)
+			done <- struct{}{}
+		}()
+
+		// Copy from stdin to connection
+		go func() {
+			io.Copy(conn, os.Stdin)
+			// When stdin is closed, close the write side of the connection
+			if tcpConn, ok := conn.(interface{ CloseWrite() error }); ok {
+				tcpConn.CloseWrite()
+			}
+			done <- struct{}{}
+		}()
+
+		// Wait for either direction to complete
+		<-done
+	},
+}
+
+// setupConnectInteractive guides the user through setting up a connection interactively.
+func setupConnectInteractive() (peer string, port string, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Get our own IP to filter ourselves out
+	myIP, _ := network.GetGlobalIPv4()
+
+	// Get peers
+	peers, err := network.GetGlobalPeers(ctx)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to get peers: %w", err)
+	}
+
+	// Filter to online peers (excluding ourselves)
+	var choices []string
+	var peerMap = make(map[string]string) // display -> hostname
+
+	for _, p := range peers {
+		if p.IP != "" && p.IP != myIP && p.Online {
+			display := fmt.Sprintf("%s (%s)", p.Hostname, p.IP)
+			if p.OS != "" {
+				display = fmt.Sprintf("%s (%s) [%s]", p.Hostname, p.IP, p.OS)
+			}
+			choices = append(choices, display)
+			peerMap[display] = p.Hostname
+		}
+	}
+
+	if len(choices) == 0 {
+		return "", "", fmt.Errorf("no online peers found on the network")
+	}
+
+	// Select peer
+	fmt.Println("Select a peer to connect to:")
+	fmt.Println()
+	selected, err := ui.AskSelect("Available peers:", choices)
+	if err != nil {
+		return "", "", err
+	}
+	peer = peerMap[selected]
+
+	// Select service/port
+	fmt.Println()
+	serviceChoices := []string{
+		"SSH (22)",
+		"Ollama (11434)",
+		"vLLM (8000)",
+		"llama.cpp (8080)",
+		"PostgreSQL (5432)",
+		"Redis (6379)",
+		"Custom port...",
+	}
+	serviceSelected, err := ui.AskSelect("Which service/port?", serviceChoices)
+	if err != nil {
+		return "", "", err
+	}
+
+	// Map service to port
+	servicePorts := map[string]string{
+		"SSH (22)":          "22",
+		"Ollama (11434)":    "11434",
+		"vLLM (8000)":       "8000",
+		"llama.cpp (8080)":  "8080",
+		"PostgreSQL (5432)": "5432",
+		"Redis (6379)":      "6379",
+	}
+
+	if p, ok := servicePorts[serviceSelected]; ok {
+		port = p
+	} else {
+		// Custom port
+		fmt.Println()
+		port, err = ui.AskInput("Enter port:", "8080", "")
+		if err != nil {
+			return "", "", err
+		}
+	}
+
+	return peer, port, nil
+}
+
+func init() {
+	rootCmd.AddCommand(connectCmd)
+	connectCmd.Flags().IntVar(&connectTimeout, "timeout", 0, "Connection timeout in seconds (0 = no timeout)")
+}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
 	"github.com/aceteam-ai/citadel-cli/internal/ui"
+	"github.com/fatih/color"
 )
 
 // DeviceAuthResult contains the result of a device authorization flow.
@@ -74,4 +75,39 @@ func runDeviceAuthFlow(authServiceURL string, forceNew bool) (*DeviceAuthResult,
 		// If UI exited but no result yet, user likely canceled
 		return nil, fmt.Errorf("device authorization was canceled")
 	}
+}
+
+// printNetworkSuccessInfo displays helpful post-connection info explaining
+// userspace networking limitations and available peer commands.
+func printNetworkSuccessInfo(nodeName, ip string) {
+	successColor := color.New(color.FgGreen, color.Bold)
+	dimColor := color.New(color.Faint)
+
+	fmt.Println()
+	successColor.Println("✅ Successfully connected to the AceTeam Network!")
+	fmt.Println()
+
+	// Display node info
+	if nodeName != "" {
+		fmt.Printf("   Node:    %s\n", nodeName)
+	}
+	if ip != "" {
+		fmt.Printf("   IP:      %s\n", ip)
+	}
+	fmt.Println()
+
+	// Explain userspace networking limitation
+	dimColor.Println("   This IP is for AceTeam network traffic only.")
+	dimColor.Println("   System tools (ping, curl) cannot reach it directly.")
+	fmt.Println()
+
+	// Available commands
+	fmt.Println("   Next steps:")
+	fmt.Println("     citadel status    - View network status and peers")
+	fmt.Println("     citadel ssh       - SSH to other nodes")
+	fmt.Println("     citadel proxy     - Forward local ports to peers")
+	fmt.Println()
+
+	// System-wide option hint
+	dimColor.Println("   For system-wide network access, use: sudo citadel init --system")
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -173,7 +173,8 @@ and system user configuration (requires sudo).`,
 				fmt.Fprintf(os.Stderr, "❌ Failed to connect to network: %v\n", err)
 				os.Exit(1)
 			}
-			fmt.Println("✅ Successfully connected to the AceTeam Network!")
+			ip, _ := network.GetGlobalIPv4()
+			printNetworkSuccessInfo(nodeName, ip)
 			earlyNetworkConnected = true
 
 			fmt.Println("\n--- Continuing with node setup ---")
@@ -194,7 +195,8 @@ and system user configuration (requires sudo).`,
 				fmt.Fprintf(os.Stderr, "❌ Failed to connect to network: %v\n", err)
 				os.Exit(1)
 			}
-			fmt.Println("✅ Successfully connected to the AceTeam Network!")
+			ip, _ := network.GetGlobalIPv4()
+			printNetworkSuccessInfo(nodeName, ip)
 			earlyNetworkConnected = true
 
 			fmt.Println("\n--- Continuing with node setup ---")
@@ -239,11 +241,13 @@ and system user configuration (requires sudo).`,
 				// Get IP address
 				ip, _ := network.GetGlobalIPv4()
 
+				// Already connected - show brief info
 				fmt.Printf("✅ Connected as %s\n", nodeName)
 				if ip != "" {
 					fmt.Printf("   IP: %s\n", ip)
 				}
-				fmt.Println("\nTo switch accounts: citadel logout && citadel init")
+				fmt.Println("\n   Run 'citadel status' to see network details and peers.")
+				fmt.Println("   To switch accounts: citadel logout && citadel init")
 				return
 			}
 
@@ -270,7 +274,8 @@ and system user configuration (requires sudo).`,
 					fmt.Fprintf(os.Stderr, "❌ Failed to connect to network: %v\n", err)
 					os.Exit(1)
 				}
-				fmt.Println("\n✅ Successfully connected to the AceTeam Network!")
+				ip, _ := network.GetGlobalIPv4()
+				printNetworkSuccessInfo(nodeName, ip)
 			} else if choice != nexus.NetChoiceSkip {
 				fmt.Println("⚠️  No authkey available. Run 'citadel login' to complete network setup.")
 			}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -82,11 +82,7 @@ func runNonInteractiveLogin() {
 	}
 
 	ip, _ := srv.GetIPv4()
-	fmt.Println("\n✅ Successfully connected to the AceTeam Network!")
-	fmt.Printf("   Node: %s\n", nodeName)
-	if ip != "" {
-		fmt.Printf("   IP: %s\n", ip)
-	}
+	printNetworkSuccessInfo(nodeName, ip)
 }
 
 // runInteractiveLogin handles the interactive login flow
@@ -151,10 +147,7 @@ func runInteractiveLogin() {
 	}
 
 	ip, _ := srv.GetIPv4()
-	fmt.Println("\n✅ Authentication successful! This machine is now connected to the AceTeam Network.")
-	if ip != "" {
-		fmt.Printf("   IP: %s\n", ip)
-	}
+	printNetworkSuccessInfo(nodeName, ip)
 }
 
 func init() {

--- a/cmd/peer_helpers.go
+++ b/cmd/peer_helpers.go
@@ -1,0 +1,144 @@
+// cmd/peer_helpers.go
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"strings"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/network"
+)
+
+// resolvePeer resolves a peer identifier (hostname or IP) to its network IP.
+// Returns the resolved IP, the hostname (if resolved from hostname), and any error.
+func resolvePeer(peer string) (ip string, hostname string, err error) {
+	// Check if it's already an IP address
+	if isValidIP(peer) {
+		return peer, "", nil
+	}
+
+	// Resolve hostname to IP from network peers
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	peers, err := network.GetGlobalPeers(ctx)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to get peers: %w", err)
+	}
+
+	// Try exact match first
+	for _, p := range peers {
+		if p.Hostname == peer && p.IP != "" {
+			return p.IP, p.Hostname, nil
+		}
+	}
+
+	// Try case-insensitive match
+	peerLower := strings.ToLower(peer)
+	for _, p := range peers {
+		if strings.ToLower(p.Hostname) == peerLower && p.IP != "" {
+			return p.IP, p.Hostname, nil
+		}
+	}
+
+	// Try partial match (prefix match)
+	for _, p := range peers {
+		if strings.HasPrefix(strings.ToLower(p.Hostname), peerLower) && p.IP != "" {
+			return p.IP, p.Hostname, nil
+		}
+	}
+
+	return "", "", fmt.Errorf("peer '%s' not found on network", peer)
+}
+
+// isValidIP checks if the string is a valid IP address.
+func isValidIP(s string) bool {
+	_, err := netip.ParseAddr(s)
+	return err == nil
+}
+
+// ensureNetworkConnected verifies the network connection and reconnects if needed.
+// Returns an error if the network cannot be established.
+func ensureNetworkConnected(ctx context.Context) error {
+	if !network.HasState() {
+		return fmt.Errorf("not connected to AceTeam Network - run 'citadel login' first")
+	}
+
+	connected, err := network.VerifyOrReconnect(ctx)
+	if !connected {
+		if err != nil {
+			return fmt.Errorf("failed to connect to network: %w", err)
+		}
+		return fmt.Errorf("not connected to AceTeam Network")
+	}
+
+	return nil
+}
+
+// suggestAvailablePeers prints a list of available peers that can be connected to.
+func suggestAvailablePeers() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	peers, err := network.GetGlobalPeers(ctx)
+	if err != nil {
+		return
+	}
+
+	// Filter to online peers
+	var onlinePeers []network.PeerInfo
+	myIP, _ := network.GetGlobalIPv4()
+	for _, p := range peers {
+		if p.Online && p.IP != "" && p.IP != myIP {
+			onlinePeers = append(onlinePeers, p)
+		}
+	}
+
+	if len(onlinePeers) == 0 {
+		fmt.Println("\nNo other peers are currently online.")
+		return
+	}
+
+	fmt.Println("\nAvailable peers:")
+	for _, p := range onlinePeers {
+		fmt.Printf("  - %s (%s)\n", p.Hostname, p.IP)
+	}
+}
+
+// parsePeerPort parses a "peer:port" string and returns the peer and port.
+func parsePeerPort(s string) (peer string, port string, err error) {
+	// Handle IPv6 addresses in brackets: [::1]:8080
+	if strings.HasPrefix(s, "[") {
+		end := strings.Index(s, "]")
+		if end == -1 {
+			return "", "", fmt.Errorf("invalid address format: unclosed bracket")
+		}
+		peer = s[1:end]
+		rest := s[end+1:]
+		if !strings.HasPrefix(rest, ":") {
+			return "", "", fmt.Errorf("invalid address format: missing port")
+		}
+		port = rest[1:]
+		return peer, port, nil
+	}
+
+	// Simple hostname:port or ip:port
+	lastColon := strings.LastIndex(s, ":")
+	if lastColon == -1 {
+		return "", "", fmt.Errorf("invalid address format: missing port (use peer:port)")
+	}
+
+	peer = s[:lastColon]
+	port = s[lastColon+1:]
+
+	if peer == "" {
+		return "", "", fmt.Errorf("invalid address format: missing peer")
+	}
+	if port == "" {
+		return "", "", fmt.Errorf("invalid address format: missing port")
+	}
+
+	return peer, port, nil
+}

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -1,0 +1,336 @@
+// cmd/proxy.go
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/signal"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/network"
+	"github.com/aceteam-ai/citadel-cli/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+var (
+	proxyBind     string
+	proxyVerbose  bool
+	proxyMaxConns int
+)
+
+var proxyCmd = &cobra.Command{
+	Use:   "proxy [local-port] [peer:port]",
+	Short: "Forward a local port to a service on another node",
+	Long: `Creates a local TCP proxy that forwards connections to a service on another node.
+
+This allows you to access services on remote peers using localhost. Any connection
+to the local port will be forwarded through the AceTeam Network to the remote peer.
+
+PEER IDENTIFICATION:
+  You can specify the peer in multiple ways:
+  - By hostname:  citadel proxy 8080 gpu-node-1:11434
+  - By IP:        citadel proxy 8080 100.64.0.25:11434
+  - Interactive:  citadel proxy  (prompts for peer and ports)
+
+COMMON SERVICES:
+  - Ollama:    port 11434
+  - vLLM:      port 8000
+  - llama.cpp: port 8080
+  - PostgreSQL: port 5432
+  - Redis:     port 6379
+
+The proxy runs until interrupted (Ctrl+C).`,
+	Example: `  # Interactive mode - guided setup
+  citadel proxy
+
+  # Forward localhost:8080 to Ollama on gpu-node-1
+  citadel proxy 8080 gpu-node-1:11434
+  # Then access via: curl http://localhost:8080/v1/models
+
+  # Forward localhost:5432 to PostgreSQL
+  citadel proxy 5432 db-server:5432
+
+  # Forward with verbose logging
+  citadel proxy 8080 gpu-node-1:11434 --verbose
+
+  # Bind to all interfaces (not just localhost)
+  citadel proxy 8080 gpu-node-1:11434 --bind 0.0.0.0`,
+	Args: cobra.MaximumNArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		// Ensure network connection
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		if err := ensureNetworkConnected(ctx); err != nil {
+			cancel()
+			badColor.Println(err)
+			os.Exit(1)
+		}
+		cancel()
+
+		var localPort int
+		var peer, remotePort string
+		var err error
+
+		// Interactive mode if not enough args
+		if len(args) < 2 {
+			localPort, peer, remotePort, err = setupProxyInteractive()
+			if err != nil {
+				badColor.Printf("Error: %v\n", err)
+				os.Exit(1)
+			}
+		} else {
+			// Parse arguments
+			localPort, err = strconv.Atoi(args[0])
+			if err != nil || localPort < 1 || localPort > 65535 {
+				badColor.Printf("Invalid local port: %s\n", args[0])
+				os.Exit(1)
+			}
+
+			peer, remotePort, err = parsePeerPort(args[1])
+			if err != nil {
+				badColor.Printf("Invalid target: %v\n", err)
+				fmt.Println("Usage: citadel proxy <local-port> <peer>:<port>")
+				os.Exit(1)
+			}
+		}
+
+		// Resolve peer to IP
+		ip, hostname, err := resolvePeer(peer)
+		if err != nil {
+			badColor.Printf("Could not resolve peer '%s': %v\n", peer, err)
+			suggestAvailablePeers()
+			os.Exit(1)
+		}
+
+		remoteAddr := fmt.Sprintf("%s:%s", ip, remotePort)
+		localAddr := fmt.Sprintf("%s:%d", proxyBind, localPort)
+
+		// Start local listener
+		listener, err := net.Listen("tcp", localAddr)
+		if err != nil {
+			badColor.Printf("Failed to listen on %s: %v\n", localAddr, err)
+			os.Exit(1)
+		}
+		defer listener.Close()
+
+		// Display info
+		fmt.Println()
+		goodColor.Println("Proxy started!")
+		fmt.Printf("  Local:  %s\n", localAddr)
+		if hostname != "" {
+			fmt.Printf("  Remote: %s (%s)\n", hostname, remoteAddr)
+		} else {
+			fmt.Printf("  Remote: %s\n", remoteAddr)
+		}
+		fmt.Println()
+		fmt.Println("Press Ctrl+C to stop.")
+		fmt.Println()
+
+		// Track active connections
+		var activeConns int64
+		var wg sync.WaitGroup
+
+		// Handle interrupt
+		sigChan := make(chan os.Signal, 1)
+		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+		go func() {
+			<-sigChan
+			fmt.Println("\nShutting down...")
+			listener.Close()
+		}()
+
+		// Accept connections
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				// Check if listener was closed
+				select {
+				case <-sigChan:
+					// Normal shutdown
+				default:
+					if proxyVerbose {
+						badColor.Printf("Accept error: %v\n", err)
+					}
+				}
+				break
+			}
+
+			// Check max connections limit
+			if proxyMaxConns > 0 && atomic.LoadInt64(&activeConns) >= int64(proxyMaxConns) {
+				if proxyVerbose {
+					warnColor.Printf("Max connections (%d) reached, rejecting %s\n", proxyMaxConns, conn.RemoteAddr())
+				}
+				conn.Close()
+				continue
+			}
+
+			atomic.AddInt64(&activeConns, 1)
+			wg.Add(1)
+
+			go func(localConn net.Conn) {
+				defer func() {
+					localConn.Close()
+					atomic.AddInt64(&activeConns, -1)
+					wg.Done()
+				}()
+
+				if proxyVerbose {
+					fmt.Printf("New connection from %s\n", localConn.RemoteAddr())
+				}
+
+				// Connect to remote
+				dialCtx, dialCancel := context.WithTimeout(context.Background(), 30*time.Second)
+				remoteConn, err := network.Dial(dialCtx, "tcp", remoteAddr)
+				dialCancel()
+				if err != nil {
+					if proxyVerbose {
+						badColor.Printf("Failed to connect to %s: %v\n", remoteAddr, err)
+					}
+					return
+				}
+				defer remoteConn.Close()
+
+				if proxyVerbose {
+					goodColor.Printf("Connected to %s\n", remoteAddr)
+				}
+
+				// Bidirectional copy
+				done := make(chan struct{}, 2)
+
+				go func() {
+					io.Copy(remoteConn, localConn)
+					if tcpConn, ok := remoteConn.(interface{ CloseWrite() error }); ok {
+						tcpConn.CloseWrite()
+					}
+					done <- struct{}{}
+				}()
+
+				go func() {
+					io.Copy(localConn, remoteConn)
+					if tcpConn, ok := localConn.(interface{ CloseWrite() error }); ok {
+						tcpConn.CloseWrite()
+					}
+					done <- struct{}{}
+				}()
+
+				// Wait for both directions to complete
+				<-done
+				<-done
+
+				if proxyVerbose {
+					fmt.Printf("Connection from %s closed\n", localConn.RemoteAddr())
+				}
+			}(conn)
+		}
+
+		// Wait for all connections to finish
+		wg.Wait()
+		fmt.Println("Proxy stopped.")
+	},
+}
+
+// setupProxyInteractive guides the user through setting up a proxy interactively.
+func setupProxyInteractive() (localPort int, peer string, remotePort string, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Get our own IP to filter ourselves out
+	myIP, _ := network.GetGlobalIPv4()
+
+	// Get peers
+	peers, err := network.GetGlobalPeers(ctx)
+	if err != nil {
+		return 0, "", "", fmt.Errorf("failed to get peers: %w", err)
+	}
+
+	// Filter to online peers (excluding ourselves)
+	var choices []string
+	var peerMap = make(map[string]string) // display -> hostname
+
+	for _, p := range peers {
+		if p.IP != "" && p.IP != myIP && p.Online {
+			display := fmt.Sprintf("%s (%s)", p.Hostname, p.IP)
+			if p.OS != "" {
+				display = fmt.Sprintf("%s (%s) [%s]", p.Hostname, p.IP, p.OS)
+			}
+			choices = append(choices, display)
+			peerMap[display] = p.Hostname
+		}
+	}
+
+	if len(choices) == 0 {
+		return 0, "", "", fmt.Errorf("no online peers found on the network")
+	}
+
+	// Select peer
+	fmt.Println("Select a peer to forward to:")
+	fmt.Println()
+	selected, err := ui.AskSelect("Available peers:", choices)
+	if err != nil {
+		return 0, "", "", err
+	}
+	peer = peerMap[selected]
+
+	// Select service/port
+	fmt.Println()
+	serviceChoices := []string{
+		"Ollama (11434)",
+		"vLLM (8000)",
+		"llama.cpp (8080)",
+		"PostgreSQL (5432)",
+		"Redis (6379)",
+		"Custom port...",
+	}
+	serviceSelected, err := ui.AskSelect("Which service?", serviceChoices)
+	if err != nil {
+		return 0, "", "", err
+	}
+
+	// Map service to port
+	servicePorts := map[string]string{
+		"Ollama (11434)":    "11434",
+		"vLLM (8000)":       "8000",
+		"llama.cpp (8080)":  "8080",
+		"PostgreSQL (5432)": "5432",
+		"Redis (6379)":      "6379",
+	}
+
+	if port, ok := servicePorts[serviceSelected]; ok {
+		remotePort = port
+	} else {
+		// Custom port
+		fmt.Println()
+		portStr, err := ui.AskInput("Enter remote port:", "8080", "")
+		if err != nil {
+			return 0, "", "", err
+		}
+		remotePort = portStr
+	}
+
+	// Ask for local port (default to same as remote)
+	fmt.Println()
+	localPortStr, err := ui.AskInput("Enter local port:", remotePort, remotePort)
+	if err != nil {
+		return 0, "", "", err
+	}
+
+	localPort, err = strconv.Atoi(localPortStr)
+	if err != nil || localPort < 1 || localPort > 65535 {
+		return 0, "", "", fmt.Errorf("invalid local port: %s", localPortStr)
+	}
+
+	return localPort, peer, remotePort, nil
+}
+
+func init() {
+	rootCmd.AddCommand(proxyCmd)
+	proxyCmd.Flags().StringVar(&proxyBind, "bind", "127.0.0.1", "Address to bind to (default localhost only)")
+	proxyCmd.Flags().BoolVarP(&proxyVerbose, "verbose", "v", false, "Show connection activity")
+	proxyCmd.Flags().IntVar(&proxyMaxConns, "max-conns", 0, "Maximum concurrent connections (0 = unlimited)")
+}

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -1,0 +1,212 @@
+// cmd/ssh.go
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/network"
+	"github.com/aceteam-ai/citadel-cli/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+var (
+	sshUser    string
+	sshPort    string
+	sshVerbose bool
+)
+
+var sshCmd = &cobra.Command{
+	Use:   "ssh [peer]",
+	Short: "SSH to another node on the AceTeam Network",
+	Long: `Establishes an SSH connection to another node on the AceTeam Network.
+
+PEER IDENTIFICATION:
+  You can specify the peer in multiple ways:
+  - By hostname:  citadel ssh gpu-node-1
+  - By IP:        citadel ssh 100.64.0.25
+  - Interactive:  citadel ssh  (shows a list of online peers to choose from)
+
+HOW IT WORKS:
+  This command tunnels SSH through the AceTeam Network's secure mesh.
+  It works even when system tools (ping, ssh) can't reach the peer directly,
+  because it uses the internal tsnet userspace network.
+
+REQUIREMENTS:
+  - Both machines must be registered to the same AceTeam Network
+  - The target peer must have SSH enabled (port 22 or custom port)
+  - You must have valid SSH credentials for the target machine`,
+	Example: `  # Interactive mode - select from available peers
+  citadel ssh
+
+  # Connect by hostname
+  citadel ssh gpu-node-1
+
+  # Connect by network IP address
+  citadel ssh 100.64.0.25
+
+  # Specify SSH username
+  citadel ssh gpu-node-1 -u ubuntu
+
+  # Specify custom SSH port
+  citadel ssh gpu-node-1 -p 2222
+
+  # Combine options
+  citadel ssh gpu-node-1 -u admin -p 2222 -v`,
+	Args: cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		// Ensure network connection
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		if err := ensureNetworkConnected(ctx); err != nil {
+			badColor.Println(err)
+			os.Exit(1)
+		}
+
+		var peer string
+
+		// Interactive mode if no peer specified
+		if len(args) == 0 {
+			selectedPeer, err := selectPeerInteractive(ctx)
+			if err != nil {
+				badColor.Printf("Error: %v\n", err)
+				os.Exit(1)
+			}
+			peer = selectedPeer
+		} else {
+			peer = args[0]
+		}
+
+		// Resolve peer to IP
+		ip, hostname, err := resolvePeer(peer)
+		if err != nil {
+			badColor.Printf("Could not resolve peer '%s': %v\n", peer, err)
+			suggestAvailablePeers()
+			os.Exit(1)
+		}
+
+		// Determine SSH port
+		port := "22"
+		if sshPort != "" {
+			port = sshPort
+		}
+
+		// Get the path to the current citadel executable for ProxyCommand
+		citadelPath, err := os.Executable()
+		if err != nil {
+			badColor.Printf("Could not determine citadel path: %v\n", err)
+			os.Exit(1)
+		}
+
+		// Build SSH command arguments
+		// Use ProxyCommand to tunnel through tsnet via 'citadel connect'
+		proxyCmd := fmt.Sprintf("%s connect %s:%s", citadelPath, ip, port)
+		sshArgs := []string{
+			"-o", fmt.Sprintf("ProxyCommand=%s", proxyCmd),
+			"-o", "StrictHostKeyChecking=accept-new", // Auto-accept new host keys (user can override)
+		}
+
+		// Add verbose flag if requested
+		if sshVerbose {
+			sshArgs = append(sshArgs, "-v")
+		}
+
+		// Build target - use a placeholder hostname since ProxyCommand handles the actual connection
+		// SSH needs a target but ProxyCommand bypasses normal resolution
+		target := ip
+		if sshUser != "" {
+			target = sshUser + "@" + ip
+		}
+		sshArgs = append(sshArgs, target)
+
+		// Display connection info
+		displayName := hostname
+		if displayName == "" {
+			displayName = ip
+		}
+		fmt.Printf("Connecting to %s via AceTeam Network...\n", displayName)
+		if hostname != "" && hostname != ip {
+			fmt.Printf("  Peer: %s (%s)\n", hostname, ip)
+		}
+		if sshUser != "" {
+			fmt.Printf("  User: %s\n", sshUser)
+		}
+		if port != "22" {
+			fmt.Printf("  Port: %s\n", port)
+		}
+		fmt.Println()
+
+		// Execute SSH
+		sshPath, err := exec.LookPath("ssh")
+		if err != nil {
+			badColor.Println("Error: ssh command not found. Please install OpenSSH.")
+			os.Exit(1)
+		}
+
+		sshExec := exec.Command(sshPath, sshArgs...)
+		sshExec.Stdin = os.Stdin
+		sshExec.Stdout = os.Stdout
+		sshExec.Stderr = os.Stderr
+
+		if err := sshExec.Run(); err != nil {
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				os.Exit(exitErr.ExitCode())
+			}
+			badColor.Printf("SSH error: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+// selectPeerInteractive shows a list of online peers and lets the user select one.
+func selectPeerInteractive(ctx context.Context) (string, error) {
+	// Get our own IP to filter ourselves out
+	myIP, _ := network.GetGlobalIPv4()
+
+	// Get peers
+	peers, err := network.GetGlobalPeers(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get peers: %w", err)
+	}
+
+	// Filter to online peers (excluding ourselves)
+	var choices []string
+	var peerMap = make(map[string]string) // display -> hostname
+
+	for _, peer := range peers {
+		if peer.IP != "" && peer.IP != myIP && peer.Online {
+			display := fmt.Sprintf("%s (%s)", peer.Hostname, peer.IP)
+			if peer.OS != "" {
+				display = fmt.Sprintf("%s (%s) [%s]", peer.Hostname, peer.IP, peer.OS)
+			}
+			choices = append(choices, display)
+			peerMap[display] = peer.Hostname
+		}
+	}
+
+	if len(choices) == 0 {
+		return "", fmt.Errorf("no online peers found on the network")
+	}
+
+	// Show interactive selection
+	fmt.Println("Select a peer to connect to:")
+	fmt.Println()
+
+	selected, err := ui.AskSelect("Available peers:", choices)
+	if err != nil {
+		return "", err
+	}
+
+	return peerMap[selected], nil
+}
+
+func init() {
+	rootCmd.AddCommand(sshCmd)
+	sshCmd.Flags().StringVarP(&sshUser, "user", "u", "", "SSH username (defaults to current user)")
+	sshCmd.Flags().StringVarP(&sshPort, "port", "p", "", "SSH port (defaults to 22)")
+	sshCmd.Flags().BoolVarP(&sshVerbose, "verbose", "v", false, "Enable verbose SSH output")
+}

--- a/internal/network/singleton.go
+++ b/internal/network/singleton.go
@@ -5,6 +5,7 @@ package network
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -156,6 +157,24 @@ func PingPeer(ctx context.Context, ip string) (latencyMs float64, connType strin
 		return 0, "", "", fmt.Errorf("not connected")
 	}
 	return s.PingPeer(ctx, ip)
+}
+
+// Dial connects to a remote address through the global server's network.
+func Dial(ctx context.Context, network, addr string) (net.Conn, error) {
+	s := Global()
+	if s == nil {
+		return nil, fmt.Errorf("not connected to AceTeam Network")
+	}
+	return s.Dial(ctx, network, addr)
+}
+
+// Listen creates a listener on the network for the given address via the global server.
+func Listen(network, addr string) (net.Listener, error) {
+	s := Global()
+	if s == nil {
+		return nil, fmt.Errorf("not connected to AceTeam Network")
+	}
+	return s.Listen(network, addr)
 }
 
 // VerifyOrReconnect checks connection and reconnects if state exists but not connected.


### PR DESCRIPTION
## Summary

- Add post-init messaging explaining userspace networking limitations and available commands
- Add `citadel ssh <peer>` command for SSH connections to network peers (uses ProxyCommand to tunnel through tsnet)
- Add `citadel connect <peer>:<port>` for raw TCP connections piped to stdin/stdout
- Add `citadel proxy <local-port> <peer>:<port>` for local port forwarding to remote services
- Enhance `citadel expose` with `--peers` and `--check` flags for peer discovery and connectivity testing

## How It Works

The peer commands work through the tsnet userspace network, which means they can connect to peers even though system tools (ping, curl, ssh) cannot reach the 100.64.x.x IPs directly.

- **`citadel ssh`**: Uses SSH's `ProxyCommand` to tunnel through `citadel connect`
- **`citadel connect`**: Uses `network.Dial()` to establish TCP connections through tsnet
- **`citadel proxy`**: Listens on localhost and forwards connections through tsnet

## Testing Instructions

### Prerequisites
You need two machines registered to the same AceTeam Network:
- **Machine A**: The machine you're testing from
- **Machine B**: A peer with SSH enabled (port 22 open)

### Test 1: SSH from one Citadel node to another

```bash
# On Machine A - ensure you're connected
citadel status

# See available peers
citadel expose --peers

# SSH to a peer (by hostname)
citadel ssh <peer-hostname>

# SSH to a peer (by IP)
citadel ssh 100.64.0.x

# SSH with specific user
citadel ssh <peer-hostname> -u ubuntu
```

### Test 2: Port forwarding with proxy

```bash
# On Machine A - forward local port 8080 to Ollama on Machine B
citadel proxy 8080 <peer-hostname>:11434

# In another terminal, test the forwarded port
curl http://localhost:8080/api/tags
```

### Test 3: Raw TCP connection

```bash
# Connect to a service and interact via stdin/stdout
citadel connect <peer-hostname>:11434

# (Send HTTP request manually)
# GET /api/tags HTTP/1.1
# Host: localhost
# <blank line>
```

### Test 4: Verify peer discovery

```bash
# Show all peers on the network
citadel expose --peers

# Check which services are reachable
citadel expose --peers --check
```

### Test 5: Post-init messaging

```bash
# Logout and re-login to see new messaging
citadel logout
citadel init

# Should show:
# ✅ Successfully connected to the AceTeam Network!
#    Node:    my-server
#    IP:      100.64.0.15
#    This IP is for AceTeam network traffic only.
#    System tools (ping, curl) cannot reach it directly.
#    Next steps:
#      citadel status    - View network status and peers
#      citadel ssh       - SSH to other nodes
#      citadel proxy     - Forward local ports to peers
```

## Web-to-Client SSH (Future)

For SSH from the web interface to a Citadel node, the terminal service (`citadel work --terminal`) already provides WebSocket-based terminal access. The web frontend connects to the terminal WebSocket endpoint.

## New Commands Reference

### `citadel ssh`
```bash
citadel ssh gpu-node-1              # SSH by hostname
citadel ssh 100.64.0.25 -u admin    # SSH with specific user
citadel ssh gpu-node-1 -p 2222      # SSH with custom port
```

### `citadel connect`
```bash
citadel connect gpu-node-1:5432     # Connect to PostgreSQL
citadel connect gpu-node-1:6379     # Connect to Redis
```

### `citadel proxy`
```bash
citadel proxy 8080 gpu-node-1:11434 # Forward localhost:8080 to Ollama
citadel proxy 5432 db-server:5432   # Forward PostgreSQL
citadel proxy 8080 peer:80 --verbose # With connection logging
```

### Enhanced `citadel expose`
```bash
citadel expose --peers              # Show services on all peers
citadel expose --check              # Verify service reachability
citadel expose --peers --check      # Both
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)