### PR TITLE
feat: enable go install support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 build
 release
-citadel
-citadel-cli
+/citadel
+/citadel-cli
 
 # direnv
 .direnv/

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ Or as a one-liner:
 brew install aceteam-ai/tap/citadel
 ```
 
+#### Go Install
+
+If you have Go 1.21+ installed:
+
+```bash
+go install github.com/aceteam-ai/citadel-cli/cmd/citadel@latest
+```
+
+This installs the `citadel` binary to your `$GOPATH/bin` or `$GOBIN`.
+
 ### Manual Installation
 
 #### Linux / macOS
@@ -131,7 +141,7 @@ See [**WINDOWS_QUICKSTART.md**](WINDOWS_QUICKSTART.md) for a 5-minute getting st
 .\build.ps1 -All
 
 # Quick development build
-go build -o citadel.exe .
+go build -o citadel.exe ./cmd/citadel
 ```
 
 See [**WINDOWS_DEVELOPMENT.md**](WINDOWS_DEVELOPMENT.md) for detailed Windows development setup instructions.

--- a/build.ps1
+++ b/build.ps1
@@ -35,7 +35,7 @@ if (-not $VERSION) {
 $BUILD_DIR = "build"
 $RELEASE_DIR = "release"
 $MODULE_PATH = (go list -m)
-$VERSION_VAR_PATH = "${MODULE_PATH}/cmd.Version"
+$VERSION_VAR_PATH = "${MODULE_PATH}/cmd.version"
 
 # --- Clean Up ---
 if (Test-Path $BUILD_DIR) {
@@ -95,7 +95,7 @@ foreach ($OS in $PLATFORMS) {
         $env:CGO_ENABLED = "0"
 
         $ldflags = "-X '$VERSION_VAR_PATH=$VERSION'"
-        go build -ldflags $ldflags -o $BINARY_PATH .
+        go build -ldflags $ldflags -o $BINARY_PATH ./cmd/citadel
 
         if ($LASTEXITCODE -ne 0) {
             Write-Error "Build failed for $OS/$ARCH"

--- a/build.sh
+++ b/build.sh
@@ -35,7 +35,7 @@ VERSION=$(git describe --tags --always --dirty || echo "dev")
 BUILD_DIR="build"
 RELEASE_DIR="release"
 MODULE_PATH=$(go list -m)
-VERSION_VAR_PATH="${MODULE_PATH}/cmd.Version"
+VERSION_VAR_PATH="${MODULE_PATH}/cmd.version"
 
 # --- Man Page Generation ---
 MAN_DIR="docs/man"
@@ -104,7 +104,7 @@ for OS in "${PLATFORMS[@]}"; do
 
         # 1. Build the binary
         echo "Building binary..."
-        CGO_ENABLED=0 GOOS=$OS GOARCH=$ARCH go build -ldflags="-X '${VERSION_VAR_PATH}=${VERSION}'" -o "$BINARY_PATH" .
+        CGO_ENABLED=0 GOOS=$OS GOARCH=$ARCH go build -ldflags="-X '${VERSION_VAR_PATH}=${VERSION}'" -o "$BINARY_PATH" ./cmd/citadel
 
         # 2. Copy man page if available (not for Windows)
         if [[ "$OS" != "windows" ]] && [[ -f "$MAN_DIR/citadel.1" ]]; then

--- a/cmd/citadel/main.go
+++ b/cmd/citadel/main.go
@@ -1,4 +1,4 @@
-// main.go
+// cmd/citadel/main.go
 /*
 Copyright © 2025 AceTeam <dev@aceteam.ai>
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,12 +3,26 @@ package cmd
 
 import (
 	"fmt"
+	"runtime/debug"
 
 	"github.com/spf13/cobra"
 )
 
-// Version will be set at build time
-var Version = "dev"
+// version is set via ldflags at build time
+var version = ""
+
+// Version returns the CLI version, preferring ldflags, then build info, then "dev"
+var Version = func() string {
+	if version != "" {
+		return version
+	}
+	if info, ok := debug.ReadBuildInfo(); ok {
+		if info.Main.Version != "" && info.Main.Version != "(devel)" {
+			return info.Main.Version
+		}
+	}
+	return "dev"
+}()
 
 var versionCmd = &cobra.Command{
 	Use:   "version",


### PR DESCRIPTION
## Summary

- Move entry point to `cmd/citadel/main.go` so `go install` produces a binary named `citadel`
- Add `debug.ReadBuildInfo()` for automatic version detection when installed via `go install @version`
- Update build scripts to use new entry point path

## Installation

Users can now install via:

```bash
go install github.com/aceteam-ai/citadel-cli/cmd/citadel@latest
```

## Test plan

- [x] `go build -o citadel ./cmd/citadel` - builds successfully
- [x] `./citadel version` - shows version from build info
- [x] `go install ./cmd/citadel` - creates binary named `citadel`
- [x] `./build.sh` - release build works with version injection
- [x] `go test ./...` - all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)