### PR TITLE
fix: keep Headscale lastSeen fresh with periodic keep-alive

### DIFF
--- a/internal/network/singleton.go
+++ b/internal/network/singleton.go
@@ -141,6 +141,16 @@ func GetGlobalStatus(ctx context.Context) (*NetworkStatus, error) {
 	return s.Status(ctx)
 }
 
+// KeepAlive triggers network activity to keep Headscale's lastSeen fresh.
+// Safe to call even if not connected (returns nil).
+func KeepAlive(ctx context.Context) error {
+	s := Global()
+	if s == nil {
+		return nil
+	}
+	return s.KeepAlive(ctx)
+}
+
 // GetGlobalPeers returns the list of peers from the global server.
 func GetGlobalPeers(ctx context.Context) ([]PeerInfo, error) {
 	s := Global()


### PR DESCRIPTION
## Summary

- Add periodic network keep-alive (every 60s) to prevent Headscale's `lastSeen` from becoming stale
- Citadel heartbeats use Redis pub/sub, independent of Headscale/Tailscale, causing `lastSeen` to not update
- Uses tsnet's LocalClient.Status() to trigger control plane communication

## Changes

- `internal/network/server.go`: Add `KeepAlive()` method to NetworkServer
- `internal/network/singleton.go`: Add global `KeepAlive()` function
- `internal/heartbeat/redis.go`: Call keep-alive every 60s (every 2nd heartbeat)
- `internal/heartbeat/api.go`: Call keep-alive every 60s (every 2nd heartbeat)

## Test plan

- [ ] Run `go test ./internal/network/... ./internal/heartbeat/...` - all tests pass
- [ ] Run `citadel work --verbose` on a connected node - verify Headscale `lastSeen` updates every ~60s
- [ ] Verify KeepAlive() is safe when not connected (returns nil)

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)