### PR TITLE
fix: prevent stdout output from corrupting TUI rendering

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -98,6 +98,11 @@ func runControlCenter() {
 
 	cc := controlcenter.New(cfg)
 
+	// Show deferred update notification in TUI activity log (if any)
+	if deferredUpdateNotification != "" {
+		cc.AddActivity("info", fmt.Sprintf("Update available: %s -> %s (run 'citadel update install')", Version, deferredUpdateNotification))
+	}
+
 	// Set heartbeat callback so worker can update TUI
 	ccHeartbeatFn = cc.UpdateHeartbeat
 
@@ -789,6 +794,7 @@ func runTUIWorker(ctx context.Context, activityFn func(level, msg string)) error
 			ConsumerGroup: "",
 			BlockMs:       5000,
 			MaxAttempts:   3,
+			LogFn:         activity, // Route logs through TUI
 		})
 
 		if err := apiSource.Connect(ctx); err != nil {
@@ -817,6 +823,7 @@ func runTUIWorker(ctx context.Context, activityFn func(level, msg string)) error
 			ConsumerGroup: "",
 			BlockMs:       5000,
 			MaxAttempts:   3,
+			LogFn:         activity, // Route logs through TUI
 		})
 		source = redisSource
 		streamFactory = worker.CreateRedisStreamWriterFactory(ctx, redisSource)
@@ -861,6 +868,7 @@ func runTUIWorker(ctx context.Context, activityFn func(level, msg string)) error
 					NodeID:    nodeName,
 					OrgID:     orgID,
 					DebugFunc: nil,
+					LogFn:     activity, // Route logs through TUI
 				}, collector)
 				if err == nil {
 					go func() {

--- a/internal/heartbeat/config_consumer.go
+++ b/internal/heartbeat/config_consumer.go
@@ -223,11 +223,11 @@ func (c *ConfigConsumer) parseMessage(msg redis.XMessage) (*nexus.Job, error) {
 
 // processJob applies the device configuration.
 func (c *ConfigConsumer) processJob(ctx context.Context, job *nexus.Job, msgID string) {
-	fmt.Printf("   - 📥 Config job received: %s (type: %s)\n", job.ID, job.Type)
+	c.log("info", "   - 📥 Config job received: %s (type: %s)", job.ID, job.Type)
 
 	// Only process APPLY_DEVICE_CONFIG jobs
 	if job.Type != "APPLY_DEVICE_CONFIG" {
-		fmt.Printf("   - ⚠️ Ignoring unknown config job type: %s\n", job.Type)
+		c.log("warning", "   - ⚠️ Ignoring unknown config job type: %s", job.Type)
 		c.ackJob(ctx, msgID)
 		return
 	}
@@ -237,19 +237,19 @@ func (c *ConfigConsumer) processJob(ctx context.Context, job *nexus.Job, msgID s
 	output, err := c.configHandler.Execute(jobCtx, job)
 
 	if err != nil {
-		fmt.Printf("   - ❌ Config job failed: %v\n", err)
+		c.log("error", "   - ❌ Config job failed: %v", err)
 		// Don't ACK - let it retry
 		return
 	}
 
-	fmt.Printf("   - ✅ Config applied: %s\n", string(output))
+	c.log("success", "   - ✅ Config applied: %s", string(output))
 	c.ackJob(ctx, msgID)
 }
 
 // ackJob acknowledges a processed message.
 func (c *ConfigConsumer) ackJob(ctx context.Context, msgID string) {
 	if err := c.client.XAck(ctx, c.queueName, c.consumerGroup, msgID).Err(); err != nil {
-		fmt.Printf("   - ⚠️ Failed to ACK config job: %v\n", err)
+		c.log("warning", "   - ⚠️ Failed to ACK config job: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `LogFn` callback pattern to internal components to route log output through TUI activity panel
- Defer update notification to TUI activity log instead of printing to stdout before TUI starts
- Update worker sources (Redis, API) and heartbeat publishers to use `LogFn` callback

## Problem

When launching `citadel` (TUI mode), various components printed directly to stdout via `fmt.Printf()`:
- Update check notification in `PersistentPreRun`
- Worker source connection info
- Heartbeat publisher warnings

This caused terminal corruption requiring ESC to force repaint.

## Solution

Added `LogFn func(level, msg string)` callback to all internal components that output to stdout:
- `internal/worker/redis_source.go`
- `internal/worker/api_source.go`
- `internal/heartbeat/api.go`
- `internal/heartbeat/client.go`
- `internal/heartbeat/redis.go`
- `internal/heartbeat/config_subscriber.go`
- `internal/heartbeat/config_consumer.go`

When `LogFn` is set (TUI mode), output routes to activity log.
When `LogFn` is nil (non-TUI commands like `citadel status`), output prints to stdout as before.

## Test plan

- [ ] Build: `go build -o citadel ./cmd/citadel`
- [ ] Run tests: `go test ./...`
- [ ] Test TUI mode: `./citadel` - should render cleanly without update notification corrupting display
- [ ] Test non-TUI: `./citadel status` - should still show update notification on stdout

🤖 Generated with [Claude Code](https://claude.com/claude-code)