### PR TITLE
feat: make terminal server network-accessible and curl-friendly

### DIFF
--- a/cmd/work.go
+++ b/cmd/work.go
@@ -50,6 +50,7 @@ var (
 
 	// Terminal server flags
 	workTerminal      bool
+	workTerminalHost  string
 	workTerminalPort  int
 	workTerminalDebug bool
 
@@ -505,6 +506,10 @@ func runWork(cmd *cobra.Command, args []string) {
 				termConfig := terminal.DefaultConfig()
 				termConfig.OrgID = orgID
 				termConfig.AuthServiceURL = baseURL
+				termConfig.Version = Version
+				if workTerminalHost != "" {
+					termConfig.Host = workTerminalHost
+				}
 				if workTerminalPort > 0 {
 					termConfig.Port = workTerminalPort
 				}
@@ -527,7 +532,7 @@ func runWork(cmd *cobra.Command, args []string) {
 						fmt.Fprintf(os.Stderr, "   - ⚠️ Token cache error: %v\n", err)
 					}
 
-					fmt.Printf("   - Terminal server: ws://localhost:%d/terminal\n", termConfig.Port)
+					fmt.Printf("   - Terminal server: ws://%s:%d/terminal\n", termConfig.Host, termConfig.Port)
 					if err := termServer.Start(); err != nil {
 						fmt.Fprintf(os.Stderr, "   - ⚠️ Terminal server error: %v\n", err)
 					}
@@ -682,6 +687,7 @@ func init() {
 
 	// Terminal server flags
 	workCmd.Flags().BoolVar(&workTerminal, "terminal", false, "Enable terminal WebSocket server for remote access")
+	workCmd.Flags().StringVar(&workTerminalHost, "terminal-host", "", "Terminal server bind address (default: 0.0.0.0)")
 	workCmd.Flags().IntVar(&workTerminalPort, "terminal-port", 7860, "Terminal server port (default: 7860)")
 	workCmd.Flags().BoolVar(&workTerminalDebug, "terminal-debug", false, "Enable verbose debug logging for terminal server")
 

--- a/internal/terminal/config.go
+++ b/internal/terminal/config.go
@@ -10,8 +10,14 @@ import (
 
 // Config holds the terminal server configuration
 type Config struct {
+	// Host is the address the WebSocket server binds to (default: 0.0.0.0)
+	Host string
+
 	// Port is the port the WebSocket server listens on
 	Port int
+
+	// Version is the server version string (passed from cmd package)
+	Version string
 
 	// Enabled determines whether the terminal service is active
 	Enabled bool
@@ -47,7 +53,9 @@ type Config struct {
 // DefaultConfig returns a Config with sensible defaults
 func DefaultConfig() *Config {
 	return &Config{
+		Host:                 getEnvOrDefault("CITADEL_TERMINAL_HOST", "0.0.0.0"),
 		Port:                 getEnvInt("CITADEL_TERMINAL_PORT", 7860),
+		Version:              "dev",
 		Enabled:              getEnvBool("CITADEL_TERMINAL_ENABLED", true),
 		IdleTimeout:          time.Duration(getEnvInt("CITADEL_TERMINAL_IDLE_TIMEOUT", 30)) * time.Minute,
 		MaxConnections:       getEnvInt("CITADEL_TERMINAL_MAX_CONNECTIONS", 10),


### PR DESCRIPTION
## Summary
- Add `Host` config field with `CITADEL_TERMINAL_HOST` env var (default: `0.0.0.0`)
- Add `Version` config field passed from cmd package for API responses
- Add root `/` endpoint returning JSON server info with version
- Convert all HTTP error responses to JSON format with status codes
- Add `--terminal-host` flag to work command
- Update console output to show actual bind address instead of localhost

## Test plan
- [ ] Start terminal server: `citadel work --terminal --terminal-port 7860`
- [ ] Test root endpoint: `curl http://localhost:7860/` → `{"service":"citadel-terminal","version":"...","endpoints":["/terminal","/health","/stats"]}`
- [ ] Test health endpoint: `curl http://localhost:7860/health` → `{"status":"ok","sessions":0}`
- [ ] Test error response: `curl http://localhost:7860/terminal` → `{"error":"missing token parameter","status":401}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)