### PR TITLE
fix: prevent terminal auth warnings from corrupting TUI

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -239,6 +239,13 @@ func startTerminalServer(orgID string) error {
 		config.TokenRefreshInterval,
 	)
 
+	// Set log callback to suppress stdout output in TUI mode
+	// Warnings will be silently ignored to prevent TUI corruption
+	ccTerminalAuth.SetLogFn(func(level, msg string) {
+		// In TUI mode, terminal server warnings are suppressed
+		// since they would corrupt the display
+	})
+
 	// Start the validator's background refresh
 	if err := ccTerminalAuth.Start(); err != nil {
 		return fmt.Errorf("failed to start token cache: %w", err)


### PR DESCRIPTION
## Summary
- Add `LogFn` callback to `CachingTokenValidator` for routing log output
- Add `SetLogFn` method to configure logging behavior
- Replace `fmt.Printf` calls with `log()` method that uses callback
- Update `controlcenter.go` to suppress terminal auth warnings in TUI mode

## Problem
When the terminal server's `CachingTokenValidator` failed to fetch tokens (e.g., due to network issues or missing API endpoint), it printed warnings directly to stdout:
```
Warning: initial token fetch failed: ...
Warning: token refresh failed (will retry in ...): ...
```

These prints corrupted the TUI display, causing lines to become messed up.

## Solution
Follow the same `LogFn` callback pattern used in other packages (worker, heartbeat) to route log output through a callback instead of printing directly. In TUI mode, the callback silently discards warnings to prevent display corruption.

## Test plan
- [ ] Start `citadel` (TUI mode) when token fetch will fail (no auth configured)
- [ ] Verify TUI display is not corrupted
- [ ] Verify normal operation still works when tokens are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)