### PR TITLE
fix: suppress all log output that could corrupt TUI display

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -253,6 +253,10 @@ func startTerminalServer(orgID string) error {
 
 	// Create and start the server
 	ccTerminalServer = terminal.NewServer(config, ccTerminalAuth)
+
+	// Suppress terminal server logging in TUI mode to prevent display corruption
+	ccTerminalServer.SetSilent()
+
 	if err := ccTerminalServer.Start(); err != nil {
 		ccTerminalAuth.Stop()
 		return fmt.Errorf("failed to start terminal server: %w", err)
@@ -914,8 +918,8 @@ func runTUIWorker(ctx context.Context, activityFn func(level, msg string)) error
 	// Create worker ID
 	workerID := fmt.Sprintf("citadel-tui-%s", uuid.New().String()[:8])
 
-	// Create handlers
-	handlers := worker.CreateLegacyHandlers()
+	// Create handlers with activity callback to route job output through TUI
+	handlers := worker.CreateLegacyHandlers(activity)
 
 	// Create runner with TUI callbacks
 	runner := worker.NewRunner(source, handlers, worker.RunnerConfig{

--- a/internal/jobs/download_model.go
+++ b/internal/jobs/download_model.go
@@ -30,18 +30,18 @@ func (h *DownloadModelHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, 
 	destDir := filepath.Join(homeDir, "citadel-cache", modelType)
 	destPath := filepath.Join(destDir, fileName)
 
-	fmt.Printf("     - [Job %s] Preparing to download model to %s\n", job.ID, destPath)
+	ctx.Log("info", "     - [Job %s] Preparing to download model to %s", job.ID, destPath)
 
 	if err := os.MkdirAll(destDir, 0755); err != nil {
 		return nil, fmt.Errorf("failed to create destination directory %s: %w", destDir, err)
 	}
 
 	if _, statErr := os.Stat(destPath); statErr == nil {
-		fmt.Printf("     - [Job %s] Model already exists. Skipping download.\n", job.ID)
+		ctx.Log("info", "     - [Job %s] Model already exists. Skipping download.", job.ID)
 		return []byte(fmt.Sprintf("Model '%s' already exists at %s", fileName, destPath)), nil
 	}
 
-	fmt.Printf("     - [Job %s] Starting download...\n", job.ID)
+	ctx.Log("info", "     - [Job %s] Starting download...", job.ID)
 	cmd := exec.Command("curl", "-L", "--create-dirs", "-o", destPath, fullURL)
 	return cmd.CombinedOutput()
 }

--- a/internal/jobs/handler.go
+++ b/internal/jobs/handler.go
@@ -1,11 +1,26 @@
 // internal/jobs/handler.go
 package jobs
 
-import "github.com/aceteam-ai/citadel-cli/internal/nexus"
+import (
+	"fmt"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
 
 // JobContext can hold shared resources like a logger, config, etc.
 type JobContext struct {
-	// For now, it's empty, but we can add things later.
+	// LogFn is an optional callback for logging (if nil, prints to stdout)
+	LogFn func(level, msg string)
+}
+
+// Log outputs a message - uses LogFn callback if set, otherwise prints to stdout.
+func (c *JobContext) Log(level, format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	if c.LogFn != nil {
+		c.LogFn(level, msg)
+	} else {
+		fmt.Printf("%s\n", msg)
+	}
 }
 
 // JobHandler is the interface that all job executors must implement.

--- a/internal/jobs/llamacpp_inference.go
+++ b/internal/jobs/llamacpp_inference.go
@@ -31,7 +31,7 @@ func (h *LlamaCppInferenceHandler) Execute(ctx JobContext, job *nexus.Job) ([]by
 	}
 
 	// --- Step 1: Restart the llama.cpp container with the correct model ---
-	fmt.Printf("     - [Job %s] Configuring llama.cpp to use model '%s'\n", job.ID, modelFile)
+	ctx.Log("info", "     - [Job %s] Configuring llama.cpp to use model '%s'", job.ID, modelFile)
 	homeDir := getUserHomeDir()
 	composeFile := filepath.Join(homeDir, "citadel-node/services/llamacpp.yml") // Assuming standard path
 	newCommand := fmt.Sprintf("--model /models/%s --host 0.0.0.0 --port 8080 --n-gpu-layers -1", modelFile)
@@ -43,13 +43,13 @@ func (h *LlamaCppInferenceHandler) Execute(ctx JobContext, job *nexus.Job) ([]by
 	}
 
 	// --- Step 2: Wait for the server to become ready ---
-	fmt.Printf("     - [Job %s] Waiting for llama.cpp server to initialize...\n", job.ID)
+	ctx.Log("info", "     - [Job %s] Waiting for llama.cpp server to initialize...", job.ID)
 	if err := h.waitForLlamaCppReady(); err != nil {
 		return nil, err
 	}
 
 	// --- Step 3: Perform the inference ---
-	fmt.Printf("     - [Job %s] Running Llama.cpp inference\n", job.ID)
+	ctx.Log("info", "     - [Job %s] Running Llama.cpp inference", job.ID)
 	return h.performInference(prompt)
 }
 

--- a/internal/jobs/ollama_inference.go
+++ b/internal/jobs/ollama_inference.go
@@ -34,7 +34,7 @@ func (h *OllamaInferenceHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte
 		return nil, fmt.Errorf("job payload missing 'model' or 'prompt' field")
 	}
 
-	fmt.Printf("     - [Job %s] Running Ollama inference on model '%s'\n", job.ID, model)
+	ctx.Log("info", "     - [Job %s] Running Ollama inference on model '%s'", job.ID, model)
 
 	ollamaURL := "http://localhost:11434/api/generate"
 	reqPayload := ollamaRequest{

--- a/internal/jobs/ollama_pull.go
+++ b/internal/jobs/ollama_pull.go
@@ -15,7 +15,7 @@ func (h *OllamaPullHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, err
 	if !modelOk {
 		return nil, fmt.Errorf("job payload missing 'model' field")
 	}
-	fmt.Printf("     - [Job %s] Pulling Ollama model '%s'\n", job.ID, model)
+	ctx.Log("info", "     - [Job %s] Pulling Ollama model '%s'", job.ID, model)
 	cmd := exec.Command("docker", "exec", "citadel-ollama", "ollama", "pull", model)
 	return cmd.CombinedOutput()
 }

--- a/internal/jobs/shell_command.go
+++ b/internal/jobs/shell_command.go
@@ -16,7 +16,7 @@ func (h *ShellCommandHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, e
 	if !ok {
 		return nil, fmt.Errorf("job payload missing 'command' field")
 	}
-	fmt.Printf("     - [Job %s] Running shell command: '%s'\n", job.ID, cmdString)
+	ctx.Log("info", "     - [Job %s] Running shell command: '%s'", job.ID, cmdString)
 	parts := strings.Fields(cmdString)
 	cmd := exec.Command(parts[0], parts[1:]...)
 	return cmd.CombinedOutput()

--- a/internal/jobs/vllm_inference.go
+++ b/internal/jobs/vllm_inference.go
@@ -23,11 +23,11 @@ func (h *VLLMInferenceHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, 
 	}
 
 	// --- HEALTH CHECK BLOCK (Preserved as requested) ---
-	fmt.Printf("     - [Job %s] Waiting for vLLM service to become ready...\n", job.ID)
+	ctx.Log("info", "     - [Job %s] Waiting for vLLM service to become ready...", job.ID)
 	if err := h.waitForVLLMReady(); err != nil {
 		return nil, err
 	}
-	fmt.Printf("     - [Job %s] vLLM service is ready. Running inference on model '%s'\n", job.ID, model)
+	ctx.Log("info", "     - [Job %s] vLLM service is ready. Running inference on model '%s'", job.ID, model)
 
 	// --- INFERENCE LOGIC ---
 	vllmCompletionsURL := "http://localhost:8000/v1/completions"


### PR DESCRIPTION
## Summary
Multiple components were printing directly to stdout/stderr which corrupted the TUI display when the control center was running.

## Changes
- Add `LogFn` to `jobs.JobContext` for routing job handler output through TUI
- Update all job handlers to use `ctx.Log()` instead of `fmt.Printf`
- Add `SetSilent()` to terminal server to switch to a no-op logger
- Update `CreateLegacyHandlers()` to accept optional log callback
- Update `controlcenter.go` to silence terminal server and pass activity callback to job handlers

## Files changed
- `internal/jobs/handler.go` - Add LogFn and Log() method to JobContext
- `internal/jobs/*.go` - Replace fmt.Printf with ctx.Log()
- `internal/terminal/server.go` - Add noOpLogger and SetSilent() method
- `internal/worker/handler_adapter.go` - Pass logFn to job context
- `cmd/controlcenter.go` - Call SetSilent() and pass activity callback

## Root cause
- Terminal server was using its own logger (`log.New(os.Stderr, ...)`) which bypassed `network.SuppressLogs()`
- Job handlers were printing directly to stdout without checking for TUI mode

## Test plan
- [ ] Start `citadel` (TUI mode)
- [ ] Verify no log messages corrupt the display
- [ ] Verify terminal server can still be accessed remotely
- [ ] Verify job execution still logs to TUI activity panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)