### PR TITLE
feat: add GLiNER2 as a supported Citadel service

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -526,6 +526,7 @@ func getSelectedService() (string, error) {
 			"vllm (High-throughput OpenAI-compatible API)",
 			"ollama (General purpose, easy to use)",
 			"llamacpp (Versatile GGUF server)",
+			"gliner2 (Entity/relation extraction, CPU-only)",
 		},
 	)
 	if err != nil {

--- a/cmd/manifest.go
+++ b/cmd/manifest.go
@@ -219,8 +219,30 @@ func addServiceToManifest(configDir, serviceName string) error {
 		ComposeFile: filepath.Join("./services", serviceName+".yml"),
 	})
 
+	// Auto-add capability tags for specific services
+	serviceTags := map[string][]string{
+		"gliner2": {"extraction:gliner2", "model:gliner2-base-v1"},
+	}
+	if tags, ok := serviceTags[serviceName]; ok {
+		for _, tag := range tags {
+			if !containsTag(manifest.Node.Tags, tag) {
+				manifest.Node.Tags = append(manifest.Node.Tags, tag)
+			}
+		}
+	}
+
 	// Write back
 	return writeManifest(manifestPath, manifest)
+}
+
+// containsTag checks if a tag is already in the tags slice.
+func containsTag(tags []string, tag string) bool {
+	for _, t := range tags {
+		if t == tag {
+			return true
+		}
+	}
+	return false
 }
 
 // ensureComposeFile ensures the compose file exists in the services directory.

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -25,6 +25,7 @@ by 'init --test'.`,
 			"llamacpp": {"DOWNLOAD_MODEL", "LLAMACPP_INFERENCE"},
 			"ollama":   {"OLLAMA_PULL", "OLLAMA_INFERENCE"},
 			"vllm":     {"VLLM_INFERENCE"},
+			"gliner2":  {"GLINER_EXTRACTION"},
 			"none":     {},
 		}
 

--- a/internal/jobs/extraction_handler.go
+++ b/internal/jobs/extraction_handler.go
@@ -1,0 +1,81 @@
+// internal/jobs/extraction_handler.go
+package jobs
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+// ExtractionHandler proxies extraction requests to the local GLiNER2 service.
+type ExtractionHandler struct{}
+
+func (h *ExtractionHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	text, textOk := job.Payload["text"]
+	schema, schemaOk := job.Payload["schema"]
+	if !textOk {
+		return nil, fmt.Errorf("job payload missing 'text' field")
+	}
+
+	ctx.Log("info", "     - [Job %s] Waiting for GLiNER2 service to become ready...", job.ID)
+	if err := h.waitForReady(); err != nil {
+		return nil, err
+	}
+	ctx.Log("info", "     - [Job %s] GLiNER2 service is ready. Running extraction.", job.ID)
+
+	// Build request payload
+	requestPayload := map[string]any{
+		"text": text,
+	}
+	if schemaOk && schema != "" {
+		// Schema is JSON-encoded in the string payload
+		var schemaObj any
+		if err := json.Unmarshal([]byte(schema), &schemaObj); err != nil {
+			return nil, fmt.Errorf("failed to parse 'schema' as JSON: %w", err)
+		}
+		requestPayload["schema"] = schemaObj
+	}
+
+	reqBody, err := json.Marshal(requestPayload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	resp, err := http.Post("http://localhost:8100/extract", "application/json", bytes.NewBuffer(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to GLiNER2 service: %w", err)
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return bodyBytes, fmt.Errorf("GLiNER2 API returned non-200 status: %s", resp.Status)
+	}
+
+	return bodyBytes, nil
+}
+
+func (h *ExtractionHandler) waitForReady() error {
+	healthURL := "http://localhost:8100/health"
+	maxWait := 60 * time.Second
+	pollInterval := 1 * time.Second
+	startTime := time.Now()
+
+	for time.Since(startTime) < maxWait {
+		resp, err := http.Get(healthURL)
+		if err == nil && resp.StatusCode == http.StatusOK {
+			resp.Body.Close()
+			return nil
+		}
+		if resp != nil {
+			resp.Body.Close()
+		}
+		time.Sleep(pollInterval)
+	}
+	return fmt.Errorf("GLiNER2 service did not become ready within %v", maxWait)
+}

--- a/internal/jobs/queue_types.go
+++ b/internal/jobs/queue_types.go
@@ -8,6 +8,9 @@ const (
 
 	// JobTypeEmbedding handles local embedding generation (future)
 	JobTypeEmbedding = "embedding"
+
+	// JobTypeExtraction handles entity/relation extraction via GLiNER2
+	JobTypeExtraction = "GLINER_EXTRACTION"
 )
 
 // Queue names following PR #1105 convention

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -100,6 +100,7 @@ func CreateLegacyHandlers(logFn ...func(level, msg string)) []JobHandler {
 		NewLegacyHandlerAdapter(JobTypeVLLMInference, &jobs.VLLMInferenceHandler{}),
 		NewLegacyHandlerAdapter(JobTypeOllamaInference, &jobs.OllamaInferenceHandler{}),
 		NewLegacyHandlerAdapter(JobTypeApplyDeviceConfig, jobs.NewConfigHandler("")),
+		NewLegacyHandlerAdapter(JobTypeExtraction, &jobs.ExtractionHandler{}),
 	}
 
 	// Set log function on all handlers

--- a/internal/worker/job.go
+++ b/internal/worker/job.go
@@ -98,4 +98,5 @@ const (
 	JobTypeLLMInference      = "llm_inference"       // Redis worker format
 	JobTypeEmbedding         = "embedding"           // Redis worker format
 	JobTypeApplyDeviceConfig = "APPLY_DEVICE_CONFIG" // Device config from onboarding
+	JobTypeExtraction        = "GLINER_EXTRACTION"   // Entity/relation extraction via GLiNER2
 )

--- a/services/compose/gliner2.yml
+++ b/services/compose/gliner2.yml
@@ -1,0 +1,12 @@
+services:
+  gliner2:
+    image: ghcr.io/aceteam-ai/gliner2-service:latest
+    container_name: citadel-gliner2
+    ports:
+      - "8100:8100"
+    volumes:
+      - ~/citadel-cache/huggingface:/root/.cache/huggingface
+    environment:
+      - MODEL_NAME=fastino/gliner2-base-v1
+      - PORT=8100
+    restart: unless-stopped

--- a/services/embed.go
+++ b/services/embed.go
@@ -18,12 +18,16 @@ var LlamacppCompose string
 //go:embed compose/lmstudio.yml
 var LMStudioCompose string
 
+//go:embed compose/gliner2.yml
+var GlinerCompose string
+
 // ServiceMap provides a lookup for pre-packaged service compose files.
 var ServiceMap = map[string]string{
 	"ollama":   OllamaCompose,
 	"vllm":     VLLMCompose,
 	"llamacpp": LlamacppCompose,
 	"lmstudio": LMStudioCompose,
+	"gliner2":  GlinerCompose,
 }
 
 // GetAvailableServices returns a sorted list of service names.


### PR DESCRIPTION
## Summary
- Adds GLiNER2 entity/relation extraction as a supported Citadel service (CPU-only, port 8100)
- New `GLINER_EXTRACTION` job type with handler that proxies to the local `gliner2-service` container
- Nodes running gliner2 are auto-tagged with `extraction:gliner2` and `model:gliner2-base-v1`
- Docker image sourced from `ghcr.io/aceteam-ai/gliner2-service` (new repo: aceteam-ai/gliner2-service)

## Changes
- `services/compose/gliner2.yml` — Docker Compose definition (CPU-only, HuggingFace cache mount)
- `services/embed.go` — Embed + register in ServiceMap
- `cmd/init.go` — Add to interactive service picker
- `cmd/manifest.go` — Auto-add extraction capability tags
- `cmd/test.go` — Add test job mapping
- `internal/jobs/extraction_handler.go` — HTTP proxy handler with health check polling
- `internal/jobs/queue_types.go` + `internal/worker/job.go` — `GLINER_EXTRACTION` constant
- `internal/worker/handler_adapter.go` — Register handler

## Security Review
- Handler only calls hardcoded `localhost:8100` — no SSRF risk
- Job payload comes from trusted internal sources (Nexus/Redis), not user HTTP
- Schema field is JSON-parsed then re-marshaled — no injection vector
- Compose file: no privileged mode, no host networking, no secrets
- Follows identical pattern to existing VLLMInferenceHandler

## Cross-Repo
- New repo: https://github.com/aceteam-ai/gliner2-service (scaffold + implementation issue filed)
- Parent epic: aceteam-ai/aceteam#1506
- Closes #82

## Test Plan
- [x] `go build ./...` compiles successfully
- [x] `go test ./...` all tests pass
- [ ] `go run . init` — verify "gliner2" appears in service picker
- [ ] Manual: `docker compose -f services/compose/gliner2.yml up` once image is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)