### PR TITLE
feat: Service discovery client and citadel peers command

### DIFF
--- a/cmd/peers.go
+++ b/cmd/peers.go
@@ -1,0 +1,159 @@
+// cmd/peers.go
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/discovery"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+var (
+	peersCapability   string
+	peersOnlineOnly   bool
+	peersIncludeStats bool
+)
+
+var peersCmd = &cobra.Command{
+	Use:   "peers",
+	Short: "Discover peer nodes in your organization",
+	Long: `Queries the AceTeam service discovery API to find peer nodes
+in your organization. Optionally filter by capability tags.
+
+Examples:
+  # List all peers
+  citadel peers
+
+  # Find peers with GPU capabilities
+  citadel peers --capability gpu:a100
+
+  # Find online peers with LLM models, include hardware stats
+  citadel peers --capability llm:llama3 --online-only --stats`,
+	Run: runPeers,
+}
+
+func runPeers(cmd *cobra.Command, args []string) {
+	// Resolve API key and base URL
+	apiKey := os.Getenv("CITADEL_API_KEY")
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "Error: CITADEL_API_KEY environment variable is required.")
+		fmt.Fprintln(os.Stderr, "  Set it to your AceTeam device API key.")
+		os.Exit(1)
+	}
+
+	baseURL := os.Getenv("HEARTBEAT_URL")
+	if baseURL == "" {
+		baseURL = "https://aceteam.ai"
+	}
+
+	client := discovery.NewClient(discovery.ClientConfig{
+		BaseURL: baseURL,
+		APIKey:  apiKey,
+	})
+
+	// Parse capabilities
+	var capabilities []string
+	if peersCapability != "" {
+		capabilities = strings.Split(peersCapability, ",")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	nodes, err := client.DiscoverNodes(ctx, capabilities, peersIncludeStats, peersOnlineOnly)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error discovering peers: %v\n", err)
+		os.Exit(1)
+	}
+
+	if len(nodes) == 0 {
+		if len(capabilities) > 0 {
+			fmt.Printf("No peers found matching capabilities: %s\n", strings.Join(capabilities, ", "))
+		} else {
+			fmt.Println("No peers found in your organization.")
+		}
+		return
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+
+	if peersIncludeStats {
+		fmt.Fprintln(w, "NAME\tSTATUS\tIP\tCAPABILITIES\tCPU\tMEM\tGPU")
+		fmt.Fprintln(w, "----\t------\t--\t------------\t---\t---\t---")
+	} else {
+		fmt.Fprintln(w, "NAME\tSTATUS\tIP\tCAPABILITIES")
+		fmt.Fprintln(w, "----\t------\t--\t------------")
+	}
+
+	goodColor := color.New(color.FgGreen)
+	badColor := color.New(color.FgRed)
+
+	for _, node := range nodes {
+		statusStr := badColor.Sprint("OFFLINE")
+		if node.Online {
+			statusStr = goodColor.Sprint("ONLINE")
+		}
+
+		// Display first IP address
+		ip := "-"
+		if len(node.IPAddresses) > 0 {
+			ip = node.IPAddresses[0]
+		}
+
+		// Format capabilities (show first 3, then +N more)
+		capsStr := formatCapabilities(node.Capabilities, 3)
+
+		if peersIncludeStats && node.Status != nil {
+			cpuStr := "-"
+			memStr := "-"
+			gpuStr := "-"
+
+			if node.Status.CPUUsage != nil {
+				cpuStr = fmt.Sprintf("%.0f%%", *node.Status.CPUUsage)
+			}
+			if node.Status.MemoryUsage != nil {
+				memStr = fmt.Sprintf("%.0f%%", *node.Status.MemoryUsage)
+			}
+			if node.Status.GPUUsage != nil {
+				gpuStr = fmt.Sprintf("%.0f%%", *node.Status.GPUUsage)
+			}
+
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				node.GivenName, statusStr, ip, capsStr, cpuStr, memStr, gpuStr)
+		} else {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+				node.GivenName, statusStr, ip, capsStr)
+		}
+	}
+
+	w.Flush()
+	fmt.Printf("\n%d peer(s) found", len(nodes))
+	if len(capabilities) > 0 {
+		fmt.Printf(" matching: %s", strings.Join(capabilities, ", "))
+	}
+	fmt.Println()
+}
+
+func formatCapabilities(caps []string, maxShow int) string {
+	if len(caps) == 0 {
+		return "(none)"
+	}
+	if len(caps) <= maxShow {
+		return strings.Join(caps, ", ")
+	}
+	shown := strings.Join(caps[:maxShow], ", ")
+	return fmt.Sprintf("%s (+%d more)", shown, len(caps)-maxShow)
+}
+
+func init() {
+	rootCmd.AddCommand(peersCmd)
+	peersCmd.Flags().StringVar(&peersCapability, "capability", "", "Filter by capability tags (comma-separated, e.g., gpu:a100,llm:llama3)")
+	peersCmd.Flags().BoolVar(&peersOnlineOnly, "online-only", false, "Only show online peers")
+	peersCmd.Flags().BoolVar(&peersIncludeStats, "stats", false, "Include hardware stats (CPU, memory, GPU usage)")
+}

--- a/internal/discovery/client.go
+++ b/internal/discovery/client.go
@@ -1,0 +1,193 @@
+// Package discovery provides a client for querying the AceTeam service discovery API.
+//
+// The discovery client queries the platform's /api/fabric/discover/nodes endpoint
+// to find peer nodes by capability tags. This enables nodes to be aware of peers
+// in the same organization and their capabilities.
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Node represents a discovered peer node from the service discovery API.
+type Node struct {
+	ID           string   `json:"id"`
+	Hostname     string   `json:"hostname"`
+	GivenName    string   `json:"givenName"`
+	Online       bool     `json:"online"`
+	LastSeen     string   `json:"lastSeen"`
+	IPAddresses  []string `json:"ipAddresses"`
+	Tags         []string `json:"tags"`
+	Capabilities []string `json:"capabilities"`
+	Status       *Status  `json:"status,omitempty"`
+}
+
+// Status contains hardware metrics for a node.
+type Status struct {
+	CPUUsage       *float64 `json:"cpuUsage"`
+	MemoryUsage    *float64 `json:"memoryUsage"`
+	DiskUsage      *float64 `json:"diskUsage"`
+	GPUUsage       *float64 `json:"gpuUsage"`
+	GPUMemoryUsage *float64 `json:"gpuMemoryUsage"`
+	GPUTemperature *float64 `json:"gpuTemperature"`
+	IsOnline       bool     `json:"isOnline"`
+	ReportedAt     string   `json:"reportedAt"`
+}
+
+// DiscoverResponse is the API response from the discover/nodes endpoint.
+type DiscoverResponse struct {
+	Nodes []Node `json:"nodes"`
+	Total int    `json:"total"`
+}
+
+// Client queries the AceTeam service discovery API.
+type Client struct {
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+
+	// Cached peer list
+	mu         sync.RWMutex
+	peers      []Node
+	lastUpdate time.Time
+	cacheTTL   time.Duration
+}
+
+// ClientConfig holds configuration for the discovery client.
+type ClientConfig struct {
+	// BaseURL is the AceTeam API base URL (e.g., "https://aceteam.ai")
+	BaseURL string
+
+	// APIKey is the authentication token
+	APIKey string
+
+	// CacheTTL is how long to cache the peer list (default: 60s)
+	CacheTTL time.Duration
+
+	// Timeout is the HTTP request timeout (default: 10s)
+	Timeout time.Duration
+}
+
+// NewClient creates a new discovery client.
+func NewClient(cfg ClientConfig) *Client {
+	if cfg.CacheTTL == 0 {
+		cfg.CacheTTL = 60 * time.Second
+	}
+	if cfg.Timeout == 0 {
+		cfg.Timeout = 10 * time.Second
+	}
+
+	return &Client{
+		baseURL: strings.TrimRight(cfg.BaseURL, "/"),
+		apiKey:  cfg.APIKey,
+		httpClient: &http.Client{
+			Timeout: cfg.Timeout,
+		},
+		cacheTTL: cfg.CacheTTL,
+	}
+}
+
+// DiscoverNodes queries the service discovery API for nodes matching the given capabilities.
+// If no capabilities are specified, returns all nodes in the organization.
+func (c *Client) DiscoverNodes(ctx context.Context, capabilities []string, includeStatus bool, onlineOnly bool) ([]Node, error) {
+	u, err := url.Parse(fmt.Sprintf("%s/api/fabric/discover/nodes", c.baseURL))
+	if err != nil {
+		return nil, fmt.Errorf("invalid base URL: %w", err)
+	}
+
+	q := u.Query()
+	for _, cap := range capabilities {
+		q.Add("capability", cap)
+	}
+	if includeStatus {
+		q.Set("includeStatus", "true")
+	}
+	if onlineOnly {
+		q.Set("onlineOnly", "true")
+	}
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.apiKey))
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("discovery request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("discovery API returned status %d", resp.StatusCode)
+	}
+
+	var result DiscoverResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return result.Nodes, nil
+}
+
+// GetPeers returns the cached peer list, refreshing if the cache has expired.
+func (c *Client) GetPeers(ctx context.Context) ([]Node, error) {
+	c.mu.RLock()
+	if time.Since(c.lastUpdate) < c.cacheTTL && c.peers != nil {
+		peers := c.peers
+		c.mu.RUnlock()
+		return peers, nil
+	}
+	c.mu.RUnlock()
+
+	return c.RefreshPeers(ctx)
+}
+
+// RefreshPeers fetches the latest peer list from the discovery API.
+func (c *Client) RefreshPeers(ctx context.Context) ([]Node, error) {
+	nodes, err := c.DiscoverNodes(ctx, nil, false, false)
+	if err != nil {
+		return nil, err
+	}
+
+	c.mu.Lock()
+	c.peers = nodes
+	c.lastUpdate = time.Now()
+	c.mu.Unlock()
+
+	return nodes, nil
+}
+
+// StartPeriodicRefresh begins a background goroutine that refreshes the peer cache.
+// It runs until the context is cancelled.
+func (c *Client) StartPeriodicRefresh(ctx context.Context) {
+	ticker := time.NewTicker(c.cacheTTL)
+	defer ticker.Stop()
+
+	// Initial refresh
+	if _, err := c.RefreshPeers(ctx); err != nil {
+		fmt.Printf("   - Warning: Initial peer discovery failed: %v\n", err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if _, err := c.RefreshPeers(ctx); err != nil {
+				// Log but don't fail — peers are best-effort
+				fmt.Printf("   - Warning: Peer discovery refresh failed: %v\n", err)
+			}
+		}
+	}
+}

--- a/internal/discovery/client_test.go
+++ b/internal/discovery/client_test.go
@@ -1,0 +1,190 @@
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestNewClient(t *testing.T) {
+	c := NewClient(ClientConfig{
+		BaseURL: "https://aceteam.ai",
+		APIKey:  "test-key",
+	})
+
+	if c.baseURL != "https://aceteam.ai" {
+		t.Errorf("baseURL = %v, want https://aceteam.ai", c.baseURL)
+	}
+	if c.cacheTTL != 60*time.Second {
+		t.Errorf("cacheTTL = %v, want 60s", c.cacheTTL)
+	}
+}
+
+func TestNewClientTrailingSlash(t *testing.T) {
+	c := NewClient(ClientConfig{
+		BaseURL: "https://aceteam.ai/",
+		APIKey:  "test-key",
+	})
+
+	if c.baseURL != "https://aceteam.ai" {
+		t.Errorf("baseURL = %v, want https://aceteam.ai (trailing slash stripped)", c.baseURL)
+	}
+}
+
+func TestDiscoverNodes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify auth header
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		// Verify path
+		if r.URL.Path != "/api/fabric/discover/nodes" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		// Verify query params
+		caps := r.URL.Query()["capability"]
+		if len(caps) != 2 || caps[0] != "gpu:a100" || caps[1] != "llm:llama3" {
+			t.Errorf("unexpected capabilities: %v", caps)
+		}
+
+		if r.URL.Query().Get("onlineOnly") != "true" {
+			t.Error("expected onlineOnly=true")
+		}
+
+		resp := DiscoverResponse{
+			Nodes: []Node{
+				{
+					ID:           "1",
+					Hostname:     "gpu-node-1",
+					GivenName:    "gpu-node-1",
+					Online:       true,
+					IPAddresses:  []string{"100.64.0.1"},
+					Tags:         []string{"gpu", "training"},
+					Capabilities: []string{"gpu:a100", "llm:llama3", "vram:80gb"},
+				},
+			},
+			Total: 1,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	c := NewClient(ClientConfig{
+		BaseURL: server.URL,
+		APIKey:  "test-key",
+	})
+
+	nodes, err := c.DiscoverNodes(context.Background(), []string{"gpu:a100", "llm:llama3"}, false, true)
+	if err != nil {
+		t.Fatalf("DiscoverNodes() error = %v", err)
+	}
+
+	if len(nodes) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(nodes))
+	}
+
+	if nodes[0].Hostname != "gpu-node-1" {
+		t.Errorf("hostname = %v, want gpu-node-1", nodes[0].Hostname)
+	}
+
+	if len(nodes[0].Capabilities) != 3 {
+		t.Errorf("capabilities count = %d, want 3", len(nodes[0].Capabilities))
+	}
+}
+
+func TestDiscoverNodesError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	c := NewClient(ClientConfig{
+		BaseURL: server.URL,
+		APIKey:  "test-key",
+	})
+
+	_, err := c.DiscoverNodes(context.Background(), nil, false, false)
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+}
+
+func TestGetPeersCaching(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		resp := DiscoverResponse{
+			Nodes: []Node{{ID: "1", Hostname: "node-1", Online: true}},
+			Total: 1,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	c := NewClient(ClientConfig{
+		BaseURL:  server.URL,
+		APIKey:   "test-key",
+		CacheTTL: 5 * time.Second, // Long cache
+	})
+
+	// First call — fetches from API
+	peers, err := c.GetPeers(context.Background())
+	if err != nil {
+		t.Fatalf("GetPeers() error = %v", err)
+	}
+	if len(peers) != 1 {
+		t.Fatalf("expected 1 peer, got %d", len(peers))
+	}
+
+	// Second call — should use cache
+	peers, err = c.GetPeers(context.Background())
+	if err != nil {
+		t.Fatalf("GetPeers() error = %v", err)
+	}
+	if len(peers) != 1 {
+		t.Fatalf("expected 1 peer, got %d", len(peers))
+	}
+
+	if callCount != 1 {
+		t.Errorf("expected 1 API call (cached), got %d", callCount)
+	}
+}
+
+func TestRefreshPeersInvalidatesCache(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		resp := DiscoverResponse{
+			Nodes: []Node{{ID: "1", Hostname: "node-1", Online: true}},
+			Total: 1,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	c := NewClient(ClientConfig{
+		BaseURL:  server.URL,
+		APIKey:   "test-key",
+		CacheTTL: 5 * time.Second,
+	})
+
+	// First call
+	c.GetPeers(context.Background())
+
+	// Force refresh
+	c.RefreshPeers(context.Background())
+
+	if callCount != 2 {
+		t.Errorf("expected 2 API calls after refresh, got %d", callCount)
+	}
+}


### PR DESCRIPTION
## Summary
- New `internal/discovery` package with HTTP client for querying discovery API
- Caches peer list with configurable TTL (default 60s) and periodic refresh
- New `citadel peers` command to discover peer nodes in the organization
- Supports `--capability`, `--online-only`, and `--stats` flags
- 6 unit tests with httptest mock server

## Related
- Closes aceteam-ai/citadel-cli#86
- Part of aceteam-ai/aceteam#1525 (Sovereign Compute Fabric epic)
- Platform-side: aceteam-ai/aceteam#1519
- Depends on aceteam-ai/citadel-cli#88 (tag-based queue routing)

## Test plan
- [ ] `go test ./internal/discovery/` — all 6 tests pass
- [ ] `go build ./...` — clean build
- [ ] `citadel peers` — lists all peers (requires CITADEL_API_KEY)
- [ ] `citadel peers --capability gpu:a100` — filters by capability
- [ ] `citadel peers --online-only --stats` — shows online peers with metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)