### PR TITLE
refactor: Rename gliner2 to generic extraction service

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -526,7 +526,7 @@ func getSelectedService() (string, error) {
 			"vllm (High-throughput OpenAI-compatible API)",
 			"ollama (General purpose, easy to use)",
 			"llamacpp (Versatile GGUF server)",
-			"gliner2 (Entity/relation extraction, CPU-only)",
+			"extraction (Entity/relation extraction, CPU-only)",
 		},
 	)
 	if err != nil {

--- a/cmd/manifest.go
+++ b/cmd/manifest.go
@@ -221,7 +221,7 @@ func addServiceToManifest(configDir, serviceName string) error {
 
 	// Auto-add capability tags for specific services
 	serviceTags := map[string][]string{
-		"gliner2": {"extraction:gliner2", "model:gliner2-base-v1"},
+		"extraction": {"extraction:gliner2", "model:gliner2-base-v1"},
 	}
 	if tags, ok := serviceTags[serviceName]; ok {
 		for _, tag := range tags {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -25,7 +25,7 @@ by 'init --test'.`,
 			"llamacpp": {"DOWNLOAD_MODEL", "LLAMACPP_INFERENCE"},
 			"ollama":   {"OLLAMA_PULL", "OLLAMA_INFERENCE"},
 			"vllm":     {"VLLM_INFERENCE"},
-			"gliner2":  {"GLINER_EXTRACTION"},
+			"extraction": {"EXTRACTION"},
 			"none":     {},
 		}
 

--- a/internal/jobs/extraction_handler.go
+++ b/internal/jobs/extraction_handler.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
 )
 
-// ExtractionHandler proxies extraction requests to the local GLiNER2 service.
+// ExtractionHandler proxies extraction requests to the local extraction service.
 type ExtractionHandler struct{}
 
 func (h *ExtractionHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
@@ -22,11 +22,11 @@ func (h *ExtractionHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, err
 		return nil, fmt.Errorf("job payload missing 'text' field")
 	}
 
-	ctx.Log("info", "     - [Job %s] Waiting for GLiNER2 service to become ready...", job.ID)
+	ctx.Log("info", "     - [Job %s] Waiting for extraction service to become ready...", job.ID)
 	if err := h.waitForReady(); err != nil {
 		return nil, err
 	}
-	ctx.Log("info", "     - [Job %s] GLiNER2 service is ready. Running extraction.", job.ID)
+	ctx.Log("info", "     - [Job %s] Extraction service is ready. Running extraction.", job.ID)
 
 	// Build request payload
 	requestPayload := map[string]any{
@@ -48,13 +48,13 @@ func (h *ExtractionHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, err
 
 	resp, err := http.Post("http://localhost:8100/extract", "application/json", bytes.NewBuffer(reqBody))
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to GLiNER2 service: %w", err)
+		return nil, fmt.Errorf("failed to connect to extraction service: %w", err)
 	}
 	defer resp.Body.Close()
 
 	bodyBytes, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
-		return bodyBytes, fmt.Errorf("GLiNER2 API returned non-200 status: %s", resp.Status)
+		return bodyBytes, fmt.Errorf("extraction API returned non-200 status: %s", resp.Status)
 	}
 
 	return bodyBytes, nil
@@ -77,5 +77,5 @@ func (h *ExtractionHandler) waitForReady() error {
 		}
 		time.Sleep(pollInterval)
 	}
-	return fmt.Errorf("GLiNER2 service did not become ready within %v", maxWait)
+	return fmt.Errorf("extraction service did not become ready within %v", maxWait)
 }

--- a/internal/jobs/queue_types.go
+++ b/internal/jobs/queue_types.go
@@ -9,8 +9,8 @@ const (
 	// JobTypeEmbedding handles local embedding generation (future)
 	JobTypeEmbedding = "embedding"
 
-	// JobTypeExtraction handles entity/relation extraction via GLiNER2
-	JobTypeExtraction = "GLINER_EXTRACTION"
+	// JobTypeExtraction handles entity/relation extraction
+	JobTypeExtraction = "EXTRACTION"
 )
 
 // Queue names following PR #1105 convention

--- a/services/compose/extraction.yml
+++ b/services/compose/extraction.yml
@@ -1,7 +1,7 @@
 services:
-  gliner2:
+  extraction:
     image: ghcr.io/aceteam-ai/gliner2-service:latest
-    container_name: citadel-gliner2
+    container_name: citadel-extraction
     ports:
       - "8100:8100"
     volumes:

--- a/services/embed.go
+++ b/services/embed.go
@@ -18,16 +18,16 @@ var LlamacppCompose string
 //go:embed compose/lmstudio.yml
 var LMStudioCompose string
 
-//go:embed compose/gliner2.yml
-var GlinerCompose string
+//go:embed compose/extraction.yml
+var ExtractionCompose string
 
 // ServiceMap provides a lookup for pre-packaged service compose files.
 var ServiceMap = map[string]string{
-	"ollama":   OllamaCompose,
-	"vllm":     VLLMCompose,
-	"llamacpp": LlamacppCompose,
-	"lmstudio": LMStudioCompose,
-	"gliner2":  GlinerCompose,
+	"ollama":     OllamaCompose,
+	"vllm":       VLLMCompose,
+	"llamacpp":   LlamacppCompose,
+	"lmstudio":   LMStudioCompose,
+	"extraction": ExtractionCompose,
 }
 
 // GetAvailableServices returns a sorted list of service names.


### PR DESCRIPTION
## Summary

- Renamed all user-facing "gliner2"/"GLiNER2" references to model-agnostic "extraction" naming
- Internal backend identifier `gliner2` preserved as one backend option in the Python worker

### Changes

| File | Change |
|------|--------|
| `services/compose/gliner2.yml` → `extraction.yml` | Renamed compose file, service, and container name |
| `services/embed.go` | `GlinerCompose` → `ExtractionCompose`, service map key `"gliner2"` → `"extraction"` |
| `internal/jobs/queue_types.go` | `"GLINER_EXTRACTION"` → `"EXTRACTION"` |
| `internal/jobs/extraction_handler.go` | Updated log messages to say "extraction service" |
| `cmd/init.go` | Updated CLI prompt option |
| `cmd/manifest.go` | Updated service tags key |
| `cmd/test.go` | Updated service-job mapping |
| `CLAUDE.md` | Updated service references |

### Related

- aceteam-ai/aceteam#1578 (merged) — corresponding platform changes

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)