### PR TITLE
fix: restrict Group Policy locks on Windows for non-interactive sessions

### DIFF
--- a/internal/network/syspolicy_other.go
+++ b/internal/network/syspolicy_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package network
+
+func restrictPolicyLocks() (removeRestriction func()) {
+	return func() {}
+}

--- a/internal/network/syspolicy_windows.go
+++ b/internal/network/syspolicy_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package network
+
+import "tailscale.com/util/winutil/gp"
+
+// restrictPolicyLocks prevents Group Policy lock acquisition during tsnet startup.
+// On Windows, syspolicy tries to acquire a GP read lock which fails with
+// ERROR_ACCESS_DENIED in non-interactive sessions (WinRM, services).
+// Returns a function to lift the restriction after startup completes.
+func restrictPolicyLocks() (removeRestriction func()) {
+	return gp.RestrictPolicyLocks()
+}


### PR DESCRIPTION
## Summary

- Fixes `citadel init` failing on Windows in non-interactive sessions (WinRM, services) with `ERROR_ACCESS_DENIED`
- Root cause: tsnet's `syspolicy` package calls `EnterCriticalPolicySection()`, which requires an interactive logon session
- Fix calls `gp.RestrictPolicyLocks()` before `tsnet.Server.Start()` and lifts the restriction after startup, following Tailscale's own pattern from `tailscaled_windows.go`

## Changes

| File | Description |
|------|-------------|
| `internal/network/server.go` | Call `restrictPolicyLocks()` before tsnet startup, release after |
| `internal/network/syspolicy_windows.go` | Windows implementation: calls `gp.RestrictPolicyLocks()` |
| `internal/network/syspolicy_other.go` | Non-Windows no-op implementation |

## Test plan

- [x] `go build ./cmd/citadel/` succeeds
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (excluding e2e which requires Redis/server infrastructure)
- [ ] Run Windows E2E test to verify fix end-to-end

Fixes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)