### PR TITLE
docs: update quick start to single citadel command

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,12 @@ gh release create v1.2.0 \
 
 ## Command Reference
 
+### Interactive Mode
+
+| Command | Description |
+| :------ | :---------- |
+| `citadel` | **(Recommended)** Launch the interactive control center. Handles login, network, services, and job processing in one place. |
+
 ### Node Setup & Provisioning
 
 | Command                                                                   | Description                                                                                                                                                                                            |
@@ -347,17 +353,14 @@ The status server runs when using `citadel work --status-port=8080`.
 
 This workflow shows how to take a fresh server and turn it into a fully operational Citadel node.
 
-### Quick Start (2 Commands)
+### Quick Start (1 Command)
 
 ```bash
-# 1. Join the AceTeam Network (interactive - opens browser for auth)
-./citadel init
-
-# 2. Start services and run the worker
-./citadel work
+# Launch the interactive control center
+./citadel
 ```
 
-That's it! Your node is now online and accepting jobs.
+That's it! The control center handles login, network connection, service startup, and job processing -- all interactively.
 
 ### Full Provisioning (with system setup)
 

--- a/docs-site/docs/getting-started/quick-start.md
+++ b/docs-site/docs/getting-started/quick-start.md
@@ -5,72 +5,46 @@ title: Quick Start
 
 # Quick Start
 
-Get your node online in 2 commands.
+Get your node online in 1 command.
 
-## Step 1: Join the AceTeam Network
-
-```bash
-citadel init
-```
-
-This starts the device authorization flow:
-
-1. The CLI displays a one-time code and a URL.
-2. Open [aceteam.ai/device](https://aceteam.ai/device) in your browser.
-3. Enter the code shown in your terminal.
-4. Once approved, your node joins the AceTeam Network automatically.
-
-```
-Your device code is: ABCD-1234
-
-Open https://aceteam.ai/device in your browser and enter the code above.
-Waiting for authorization...
-
-Connected! Node registered as "gpu-server-01"
-```
-
-No sudo required. The CLI uses userspace networking -- no system-level VPN or driver installation needed.
-
-## Step 2: Start the worker
+## Run Citadel
 
 ```bash
-citadel work
+citadel
 ```
 
-This starts your node's services (defined in `citadel.yaml`) and begins accepting AI workloads from the job queue. The worker runs continuously, polling for new jobs and reporting status back to the control plane.
+The interactive control center launches and walks you through everything:
+
+1. **Login** -- If this is your first time, Citadel displays a one-time code and prompts you to open [aceteam.ai/device](https://aceteam.ai/device) in your browser. Enter the code to authorize your node.
+2. **Connect** -- Once authorized, your node joins the AceTeam Network automatically. No sudo required -- the CLI uses userspace networking with no system-level VPN or driver installation.
+3. **Work** -- The worker starts automatically, accepting AI workloads from the job queue.
+
+The control center shows a live dashboard with system vitals, GPU status, network connectivity, running services, and worker activity -- all in one place.
 
 ```
-Starting services...
-  vllm: running
-Worker connected to job queue
-Listening for jobs...
+ ╭─────────────────────────────────────────╮
+ │  CITADEL CONTROL CENTER                 │
+ │                                         │
+ │  Node:     gpu-server-01                │
+ │  Network:  Connected (100.64.0.12)      │
+ │  Worker:   Running                      │
+ │                                         │
+ │  CPU: 8%    MEM: 4.2/32 GiB    GPU: 3%  │
+ │                                         │
+ │  Services:                              │
+ │    vllm     running   port 8000         │
+ │                                         │
+ │  Activity:                              │
+ │    Connected to AceTeam Network         │
+ │    Worker started, listening for jobs... │
+ ╰─────────────────────────────────────────╯
 ```
 
-## Step 3: Verify
-
-```bash
-citadel status
-```
-
-This displays a health dashboard showing system vitals, GPU status, network connectivity, and running services:
-
-```
-Node:       gpu-server-01
-Status:     Online
-Network:    Connected (100.64.0.12)
-Uptime:     2m 34s
-
-CPU:        12 cores, 8% usage
-Memory:     32 GiB total, 4.2 GiB used
-GPU:        NVIDIA RTX 4090 (24 GiB VRAM)
-
-Services:
-  vllm      running   port 8000
-```
+No subcommands to memorize. Everything is managed interactively from the control center.
 
 ## What just happened?
 
-In those two commands, your node:
+By running `citadel`, your node:
 
 1. **Joined the AceTeam Network** -- an encrypted secure mesh network connecting your hardware to the AceTeam control plane. All traffic is end-to-end encrypted.
 2. **Announced its capabilities** -- CPU, memory, GPU, and available services are reported to the platform so workloads can be routed to the right hardware.

--- a/docs-site/docs/intro.md
+++ b/docs-site/docs/intro.md
@@ -12,18 +12,17 @@ Citadel is the on-premise agent that connects your hardware to the AceTeam Sover
 
 **Sovereign.** Your data never leaves your hardware. AI inference runs locally on your machines, not in someone else's data center. Meet compliance requirements without sacrificing capability.
 
-**Simple.** Two commands to go from bare metal to production-ready AI node. No complex networking configuration, no cloud console, no Kubernetes expertise required.
+**Simple.** One command to go from bare metal to production-ready AI node. No complex networking configuration, no cloud console, no Kubernetes expertise required.
 
 **Secure.** Every connection is encrypted end-to-end through a secure mesh network. No inbound ports to open, no VPN appliances to manage, no attack surface to worry about.
 
-## Get Started in 2 Commands
+## Get Started in 1 Command
 
 ```bash
-citadel init
-citadel work
+citadel
 ```
 
-That is all it takes to connect your hardware and start accepting AI workloads from the AceTeam platform.
+That's it. The interactive control center handles everything: login, network connection, service management, and accepting AI workloads. No subcommands to memorize.
 
 ## Documentation Guide
 

--- a/docs-site/docs/reference/commands.md
+++ b/docs-site/docs/reference/commands.md
@@ -7,6 +7,14 @@ title: Command Reference
 
 All Citadel CLI commands organized by category. Run `citadel <command> --help` for full flag documentation, or `man citadel-<command>` if man pages are installed.
 
+## Interactive Mode
+
+Running `citadel` with no subcommand launches the interactive control center. This is the recommended way to use Citadel -- it handles login, network connection, service management, and job processing in a single unified TUI.
+
+```bash
+citadel
+```
+
 ## Setup and Provisioning
 
 | Command | Description | Key Flags |


### PR DESCRIPTION
## Summary
- Updated "Get Started in 2 Commands" to "Get Started in 1 Command" across all docs
- Rewrote quick start guide to show the interactive control center TUI as the primary entry point
- Added "Interactive Mode" section to command reference and README command table

## Test plan
- [ ] Verify docs-site builds: `cd docs-site && npm run build`
- [ ] Review rendered quick-start page for clarity
- [ ] Confirm no broken internal links

🤖 Generated with [Claude Code](https://claude.com/claude-code)