### PR TITLE
feat: multi-GPU concurrent execution and per-GPU targeting

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,68 @@
+// cmd/completion.go
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var completionCmd = &cobra.Command{
+	Use:   "completion [bash|zsh|fish|powershell]",
+	Short: "Generate shell completion scripts",
+	Long: `Generate shell completion scripts for Citadel CLI.
+
+To load completions:
+
+Bash:
+  $ source <(citadel completion bash)
+
+  # To load completions for each session, execute once:
+  # Linux:
+  $ citadel completion bash > /etc/bash_completion.d/citadel
+  # macOS:
+  $ citadel completion bash > $(brew --prefix)/etc/bash_completion.d/citadel
+
+Zsh:
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it. You can execute the following once:
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  $ citadel completion zsh > "${fpath[1]}/_citadel"
+
+  # You will need to start a new shell for this setup to take effect.
+
+Fish:
+  $ citadel completion fish | source
+
+  # To load completions for each session, execute once:
+  $ citadel completion fish > ~/.config/fish/completions/citadel.fish
+
+PowerShell:
+  PS> citadel completion powershell | Out-String | Invoke-Expression
+
+  # To load completions for every new session, add the output to your profile:
+  PS> citadel completion powershell > citadel.ps1
+  # and source this file from your PowerShell profile.
+`,
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+	Run: func(cmd *cobra.Command, args []string) {
+		switch args[0] {
+		case "bash":
+			rootCmd.GenBashCompletionV2(os.Stdout, true)
+		case "zsh":
+			rootCmd.GenZshCompletion(os.Stdout)
+		case "fish":
+			rootCmd.GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			rootCmd.GenPowerShellCompletionWithDesc(os.Stdout)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+}

--- a/cmd/manifest.go
+++ b/cmd/manifest.go
@@ -89,7 +89,7 @@ func findAndReadManifest() (*CitadelManifest, string, error) {
 	manifestData, err := os.ReadFile(manifestPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, "", fmt.Errorf("manifest not found at %s. The configuration is incomplete or corrupt", manifestPath)
+			return nil, "", fmt.Errorf("manifest not found at %s. Run 'citadel init' to regenerate the configuration", manifestPath)
 		}
 		return nil, "", fmt.Errorf("could not read manifest from global path %s: %w", manifestPath, err)
 	}

--- a/cmd/nodes.go
+++ b/cmd/nodes.go
@@ -5,6 +5,7 @@ Copyright © 2025 Jason Sun <jason@aceteam.ai>
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"text/tabwriter"
@@ -13,6 +14,8 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
 	"github.com/spf13/cobra"
 )
+
+var nodesJSON bool
 
 // nodesCmd represents the nodes command
 var nodesCmd = &cobra.Command{
@@ -33,7 +36,21 @@ registered compute nodes, showing their status, IP address, and last-seen time.`
 		}
 
 		if len(nodes) == 0 {
-			fmt.Println("🤷 No nodes found in your fabric.")
+			if nodesJSON {
+				fmt.Println("[]")
+			} else {
+				fmt.Println("🤷 No nodes found in your fabric.")
+			}
+			return
+		}
+
+		if nodesJSON {
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			if err := enc.Encode(nodes); err != nil {
+				fmt.Fprintf(os.Stderr, "❌ Failed to encode JSON: %v\n", err)
+				os.Exit(1)
+			}
 			return
 		}
 
@@ -58,4 +75,5 @@ registered compute nodes, showing their status, IP address, and last-seen time.`
 
 func init() {
 	rootCmd.AddCommand(nodesCmd)
+	nodesCmd.Flags().BoolVar(&nodesJSON, "json", false, "Output in JSON format")
 }

--- a/cmd/peers.go
+++ b/cmd/peers.go
@@ -3,6 +3,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -18,6 +19,7 @@ var (
 	peersCapability   string
 	peersOnlineOnly   bool
 	peersIncludeStats bool
+	peersJSON         bool
 )
 
 var peersCmd = &cobra.Command{
@@ -76,10 +78,22 @@ func runPeers(cmd *cobra.Command, args []string) {
 	}
 
 	if len(nodes) == 0 {
-		if len(capabilities) > 0 {
+		if peersJSON {
+			fmt.Println("[]")
+		} else if len(capabilities) > 0 {
 			fmt.Printf("No peers found matching capabilities: %s\n", strings.Join(capabilities, ", "))
 		} else {
 			fmt.Println("No peers found in your organization.")
+		}
+		return
+	}
+
+	if peersJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(nodes); err != nil {
+			fmt.Fprintf(os.Stderr, "❌ Failed to encode JSON: %v\n", err)
+			os.Exit(1)
 		}
 		return
 	}
@@ -159,4 +173,5 @@ func init() {
 	peersCmd.Flags().StringVar(&peersCapability, "capability", "", "Filter by capability tags (comma-separated, e.g., gpu:a100,llm:llama3)")
 	peersCmd.Flags().BoolVar(&peersOnlineOnly, "online-only", false, "Only show online peers")
 	peersCmd.Flags().BoolVar(&peersIncludeStats, "stats", false, "Include hardware stats (CPU, memory, GPU usage)")
+	peersCmd.Flags().BoolVar(&peersJSON, "json", false, "Output in JSON format")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/aceteam-ai/citadel-cli/internal/tui"
 	"github.com/aceteam-ai/citadel-cli/internal/update"
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -31,6 +32,7 @@ var nexusURL string
 var authServiceURL string
 var debugMode bool
 var daemonMode bool
+var noColorGlobal bool
 
 // deferredUpdateNotification stores update info when TUI will handle the display
 var deferredUpdateNotification string
@@ -127,6 +129,11 @@ Use 'citadel help' to see all available commands.`,
 		}
 	},
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		// Handle global --no-color flag and NO_COLOR env var
+		if noColorGlobal || os.Getenv("NO_COLOR") != "" {
+			color.NoColor = true
+		}
+
 		// Always log the command (Log() handles console output based on --debug)
 		fullCmd := "citadel"
 		if cmd.Name() != "citadel" {
@@ -229,6 +236,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&nexusURL, "nexus", "https://nexus.aceteam.ai", "The URL of the AceTeam Nexus server")
 	rootCmd.PersistentFlags().StringVar(&authServiceURL, "auth-service", getEnvOrDefault("CITADEL_AUTH_HOST", "https://aceteam.ai"), "The URL of the authentication service")
 	rootCmd.PersistentFlags().BoolVar(&debugMode, "debug", false, "Enable debug output")
+	rootCmd.PersistentFlags().BoolVar(&noColorGlobal, "no-color", false, "Disable colorized output")
 	rootCmd.Flags().BoolVar(&daemonMode, "daemon", false, "Run in background daemon mode (no TUI)")
 
 	// Cobra also supports local flags, which will only run

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -93,6 +93,7 @@ func runAllServices() {
 			fmt.Printf("🚀 Starting service: %s (native)\n", service.Name)
 			if err := startNativeService(service.Name, configDir); err != nil {
 				fmt.Fprintf(os.Stderr, "   ❌ Failed to start service %s: %v\n", service.Name, err)
+				fmt.Fprintf(os.Stderr, "   Hint: Run 'citadel logs %s' to see detailed output.\n", service.Name)
 				os.Exit(1)
 			}
 		} else {
@@ -105,6 +106,7 @@ func runAllServices() {
 			fmt.Printf("🚀 Starting service: %s\n", service.Name)
 			if err := startService(service.Name, fullComposePath); err != nil {
 				fmt.Fprintf(os.Stderr, "   ❌ Failed to start service %s: %v\n", service.Name, err)
+				fmt.Fprintf(os.Stderr, "   Hint: Run 'citadel logs %s' to see detailed output.\n", service.Name)
 				os.Exit(1)
 			}
 		}

--- a/internal/platform/gpu.go
+++ b/internal/platform/gpu.go
@@ -12,6 +12,7 @@ import (
 type GPUInfo struct {
 	Name        string
 	Memory      string
+	MemoryUsed  string
 	Temperature string
 	Utilization string
 	Driver      string
@@ -67,7 +68,7 @@ func (l *LinuxGPUDetector) GetGPUCount() int {
 func (l *LinuxGPUDetector) GetGPUInfo() ([]GPUInfo, error) {
 	cmd := exec.Command(
 		"nvidia-smi",
-		"--query-gpu=name,memory.total,temperature.gpu,utilization.gpu,driver_version",
+		"--query-gpu=name,memory.total,memory.used,temperature.gpu,utilization.gpu,driver_version",
 		"--format=csv,noheader,nounits",
 	)
 
@@ -81,16 +82,17 @@ func (l *LinuxGPUDetector) GetGPUInfo() ([]GPUInfo, error) {
 
 	for _, line := range lines {
 		parts := strings.Split(line, ",")
-		if len(parts) < 5 {
+		if len(parts) < 6 {
 			continue
 		}
 
 		gpu := GPUInfo{
 			Name:        strings.TrimSpace(parts[0]),
 			Memory:      strings.TrimSpace(parts[1]) + " MB",
-			Temperature: strings.TrimSpace(parts[2]) + "°C",
-			Utilization: strings.TrimSpace(parts[3]) + "%",
-			Driver:      strings.TrimSpace(parts[4]),
+			MemoryUsed:  strings.TrimSpace(parts[2]) + " MB",
+			Temperature: strings.TrimSpace(parts[3]) + "°C",
+			Utilization: strings.TrimSpace(parts[4]) + "%",
+			Driver:      strings.TrimSpace(parts[5]),
 		}
 		gpus = append(gpus, gpu)
 	}
@@ -278,7 +280,7 @@ func (w *WindowsGPUDetector) GetGPUCount() int {
 
 func (w *WindowsGPUDetector) GetGPUInfo() ([]GPUInfo, error) {
 	cmd := w.nvidiaSmiCommand(
-		"--query-gpu=name,memory.total,temperature.gpu,utilization.gpu,driver_version",
+		"--query-gpu=name,memory.total,memory.used,temperature.gpu,utilization.gpu,driver_version",
 		"--format=csv,noheader,nounits",
 	)
 
@@ -292,16 +294,17 @@ func (w *WindowsGPUDetector) GetGPUInfo() ([]GPUInfo, error) {
 
 	for _, line := range lines {
 		parts := strings.Split(line, ",")
-		if len(parts) < 5 {
+		if len(parts) < 6 {
 			continue
 		}
 
 		gpu := GPUInfo{
 			Name:        strings.TrimSpace(parts[0]),
 			Memory:      strings.TrimSpace(parts[1]) + " MB",
-			Temperature: strings.TrimSpace(parts[2]) + "°C",
-			Utilization: strings.TrimSpace(parts[3]) + "%",
-			Driver:      strings.TrimSpace(parts[4]),
+			MemoryUsed:  strings.TrimSpace(parts[2]) + " MB",
+			Temperature: strings.TrimSpace(parts[3]) + "°C",
+			Utilization: strings.TrimSpace(parts[4]) + "%",
+			Driver:      strings.TrimSpace(parts[5]),
 		}
 		gpus = append(gpus, gpu)
 	}

--- a/internal/status/collector.go
+++ b/internal/status/collector.go
@@ -148,12 +148,21 @@ func (c *Collector) collectGPUMetrics() []GPUMetrics {
 			Driver: gpu.Driver,
 		}
 
-		// Parse memory (e.g., "24576 MB" or "24 GB")
+		// Parse total memory (e.g., "24576 MB" or "24 GB")
 		if gpu.Memory != "" {
 			memStr := strings.TrimSuffix(gpu.Memory, " MB")
 			memStr = strings.TrimSuffix(memStr, "MB")
 			if mb, err := strconv.Atoi(strings.TrimSpace(memStr)); err == nil {
 				metrics.MemoryTotalMB = mb
+			}
+		}
+
+		// Parse used memory (e.g., "8192 MB")
+		if gpu.MemoryUsed != "" {
+			memStr := strings.TrimSuffix(gpu.MemoryUsed, " MB")
+			memStr = strings.TrimSuffix(memStr, "MB")
+			if mb, err := strconv.Atoi(strings.TrimSpace(memStr)); err == nil {
+				metrics.MemoryUsedMB = mb
 			}
 		}
 

--- a/internal/tui/dashboard/panels.go
+++ b/internal/tui/dashboard/panels.go
@@ -154,9 +154,9 @@ type ServicePanel struct {
 
 // ServiceStatus represents a service's status
 type ServiceStatus struct {
-	Name   string
-	Status string // "running", "stopped", "error"
-	Uptime string // e.g., "2d 14h"
+	Name   string `json:"name"`
+	Status string `json:"status"` // "running", "stopped", "error"
+	Uptime string `json:"uptime,omitempty"` // e.g., "2d 14h"
 }
 
 // Render renders the service panel
@@ -209,11 +209,11 @@ type PeerPanel struct {
 
 // PeerInfo represents a network peer
 type PeerInfo struct {
-	Hostname  string
-	IP        string
-	Online    bool
-	Latency   string // e.g., "12ms"
-	ConnType  string // "direct" or "relay"
+	Hostname string `json:"hostname"`
+	IP       string `json:"ip"`
+	Online   bool   `json:"online"`
+	Latency  string `json:"latency,omitempty"` // e.g., "12ms"
+	ConnType string `json:"connType,omitempty"` // "direct" or "relay"
 }
 
 // Render renders the peer panel

--- a/internal/tui/dashboard/status.go
+++ b/internal/tui/dashboard/status.go
@@ -14,47 +14,47 @@ import (
 
 // StatusData holds all the data for the status dashboard
 type StatusData struct {
-	NodeName   string
-	NodeIP     string
-	OrgID      string
-	Tags       []string
-	Connected  bool
-	Version    string
-	LastUpdate time.Time
+	NodeName   string    `json:"nodeName"`
+	NodeIP     string    `json:"nodeIP"`
+	OrgID      string    `json:"orgID,omitempty"`
+	Tags       []string  `json:"tags,omitempty"`
+	Connected  bool      `json:"connected"`
+	Version    string    `json:"version"`
+	LastUpdate time.Time `json:"lastUpdate"`
 
 	// System vitals
-	CPUPercent    float64
-	MemoryPercent float64
-	MemoryUsed    string
-	MemoryTotal   string
-	DiskPercent   float64
-	DiskUsed      string
-	DiskTotal     string
+	CPUPercent    float64 `json:"cpuPercent"`
+	MemoryPercent float64 `json:"memoryPercent"`
+	MemoryUsed    string  `json:"memoryUsed"`
+	MemoryTotal   string  `json:"memoryTotal"`
+	DiskPercent   float64 `json:"diskPercent"`
+	DiskUsed      string  `json:"diskUsed"`
+	DiskTotal     string  `json:"diskTotal"`
 
 	// GPU info
-	GPUs []GPUInfo
+	GPUs []GPUInfo `json:"gpus,omitempty"`
 
 	// Services
-	Services []ServiceStatus
+	Services []ServiceStatus `json:"services,omitempty"`
 
 	// Peers
-	Peers []PeerInfo
+	Peers []PeerInfo `json:"peers,omitempty"`
 
 	// Job queue (optional)
-	JobQueueEnabled bool
-	JobChannel      string
-	PendingJobs     int64
-	InProgressJobs  int64
-	FailedJobs      int64
+	JobQueueEnabled bool   `json:"jobQueueEnabled,omitempty"`
+	JobChannel      string `json:"jobChannel,omitempty"`
+	PendingJobs     int64  `json:"pendingJobs,omitempty"`
+	InProgressJobs  int64  `json:"inProgressJobs,omitempty"`
+	FailedJobs      int64  `json:"failedJobs,omitempty"`
 }
 
 // GPUInfo holds GPU information
 type GPUInfo struct {
-	Name        string
-	Memory      string
-	Temperature string
-	Utilization float64
-	Driver      string
+	Name        string  `json:"name"`
+	Memory      string  `json:"memory"`
+	Temperature string  `json:"temperature,omitempty"`
+	Utilization float64 `json:"utilization"`
+	Driver      string  `json:"driver,omitempty"`
 }
 
 // StatusModel is the BubbleTea model for the interactive status dashboard

--- a/internal/worker/gpu_tracker.go
+++ b/internal/worker/gpu_tracker.go
@@ -1,0 +1,67 @@
+package worker
+
+import "sync"
+
+// GPUTracker manages GPU slot allocation for concurrent job execution.
+// Thread-safe via mutex.
+type GPUTracker struct {
+	mu    sync.Mutex
+	slots []bool // true = in use
+}
+
+// NewGPUTracker creates a tracker for the given number of GPUs.
+func NewGPUTracker(gpuCount int) *GPUTracker {
+	return &GPUTracker{slots: make([]bool, gpuCount)}
+}
+
+// Acquire returns the index of the first available GPU slot, or -1 if all are busy.
+func (t *GPUTracker) Acquire() (int, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for i, inUse := range t.slots {
+		if !inUse {
+			t.slots[i] = true
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+// AcquireSpecific attempts to acquire a specific GPU index.
+// Returns false if the index is invalid or already in use.
+func (t *GPUTracker) AcquireSpecific(index int) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if index < 0 || index >= len(t.slots) || t.slots[index] {
+		return false
+	}
+	t.slots[index] = true
+	return true
+}
+
+// Release marks a GPU slot as available.
+func (t *GPUTracker) Release(index int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if index >= 0 && index < len(t.slots) {
+		t.slots[index] = false
+	}
+}
+
+// AvailableCount returns the number of free GPU slots.
+func (t *GPUTracker) AvailableCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	count := 0
+	for _, inUse := range t.slots {
+		if !inUse {
+			count++
+		}
+	}
+	return count
+}
+
+// Total returns the total number of GPU slots.
+func (t *GPUTracker) Total() int {
+	return len(t.slots)
+}

--- a/internal/worker/gpu_tracker_test.go
+++ b/internal/worker/gpu_tracker_test.go
@@ -1,0 +1,119 @@
+package worker
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestGPUTracker_Acquire(t *testing.T) {
+	tracker := NewGPUTracker(2)
+
+	idx, ok := tracker.Acquire()
+	if !ok || idx != 0 {
+		t.Fatalf("expected GPU 0, got %d (ok=%v)", idx, ok)
+	}
+
+	idx, ok = tracker.Acquire()
+	if !ok || idx != 1 {
+		t.Fatalf("expected GPU 1, got %d (ok=%v)", idx, ok)
+	}
+
+	// All slots taken
+	_, ok = tracker.Acquire()
+	if ok {
+		t.Fatal("expected Acquire to fail when all slots taken")
+	}
+}
+
+func TestGPUTracker_Release(t *testing.T) {
+	tracker := NewGPUTracker(1)
+
+	idx, _ := tracker.Acquire()
+	tracker.Release(idx)
+
+	idx2, ok := tracker.Acquire()
+	if !ok || idx2 != 0 {
+		t.Fatalf("expected GPU 0 after release, got %d (ok=%v)", idx2, ok)
+	}
+}
+
+func TestGPUTracker_AcquireSpecific(t *testing.T) {
+	tracker := NewGPUTracker(3)
+
+	if !tracker.AcquireSpecific(1) {
+		t.Fatal("expected AcquireSpecific(1) to succeed")
+	}
+	if tracker.AcquireSpecific(1) {
+		t.Fatal("expected AcquireSpecific(1) to fail (already acquired)")
+	}
+	if tracker.AcquireSpecific(5) {
+		t.Fatal("expected AcquireSpecific(5) to fail (out of range)")
+	}
+}
+
+func TestGPUTracker_AvailableCount(t *testing.T) {
+	tracker := NewGPUTracker(4)
+	if tracker.AvailableCount() != 4 {
+		t.Fatalf("expected 4 available, got %d", tracker.AvailableCount())
+	}
+
+	tracker.Acquire()
+	tracker.Acquire()
+	if tracker.AvailableCount() != 2 {
+		t.Fatalf("expected 2 available, got %d", tracker.AvailableCount())
+	}
+}
+
+func TestGPUTracker_Total(t *testing.T) {
+	tracker := NewGPUTracker(6)
+	if tracker.Total() != 6 {
+		t.Fatalf("expected total 6, got %d", tracker.Total())
+	}
+}
+
+func TestGPUTracker_Concurrent(t *testing.T) {
+	tracker := NewGPUTracker(4)
+	var wg sync.WaitGroup
+	acquired := make(chan int, 100)
+
+	// 10 goroutines competing for 4 slots
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			idx, ok := tracker.Acquire()
+			if ok {
+				acquired <- idx
+			}
+		}()
+	}
+	wg.Wait()
+	close(acquired)
+
+	count := 0
+	seen := make(map[int]bool)
+	for idx := range acquired {
+		count++
+		if seen[idx] {
+			t.Fatalf("GPU %d acquired twice", idx)
+		}
+		seen[idx] = true
+	}
+	if count != 4 {
+		t.Fatalf("expected exactly 4 acquisitions, got %d", count)
+	}
+}
+
+func TestGPUTracker_ReleaseInvalidIndex(t *testing.T) {
+	tracker := NewGPUTracker(2)
+
+	// Should not panic
+	tracker.Release(-1)
+	tracker.Release(5)
+	tracker.Release(2)
+
+	// All slots should still be available
+	if tracker.AvailableCount() != 2 {
+		t.Fatalf("expected 2 available after invalid releases, got %d", tracker.AvailableCount())
+	}
+}


### PR DESCRIPTION
## Summary

- **Concurrent job execution**: Semaphore-based goroutine pool in Runner with configurable `--max-concurrency` (auto-detects GPU count)
- **GPU slot tracker**: Thread-safe `GPUTracker` with `Acquire()`, `AcquireSpecific()`, and `Release()` for managing GPU assignments across concurrent jobs
- **Per-GPU targeting**: Indexed capability tags (`gpu:0:rtx4090:24gb`), `targetGpu` payload field support, and `CUDA_VISIBLE_DEVICES` injection via `_gpuIndex`
- **Memory metrics**: Collect `memory.used` from nvidia-smi for per-GPU VRAM reporting

## Companion PR

Platform side (metrics pipeline, routing, UI): https://github.com/aceteam-ai/aceteam/pull/1939

## Test plan

- [ ] `go test ./internal/worker/...` — GPUTracker unit tests (7 tests including concurrency)
- [ ] `go build .` — verify compilation
- [ ] Manual: run `citadel work --max-concurrency 2` on multi-GPU node, verify concurrent job processing
- [ ] Manual: submit job with `targetGpu: 1`, verify `CUDA_VISIBLE_DEVICES=1` in subprocess env
- [ ] Manual: `citadel capabilities` shows indexed tags like `gpu:0:rtx4090:24gb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)