### PR TITLE
fix: authenticate deregister requests with Bearer token

### DIFF
--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -88,13 +88,12 @@ func runLogout(cmd *cobra.Command, args []string) {
 // deregisterFromBackend attempts to deregister the node from Headscale via the backend API.
 // This is a best-effort operation - errors are logged but don't block logout.
 func deregisterFromBackend(ctx context.Context) {
-	var orgID, nodeName string
+	var nodeName string
 
 	// Try to get node identity from manifest
 	if manifest, _, err := findAndReadManifest(); err == nil {
-		orgID = manifest.Node.OrgID
 		nodeName = manifest.Node.Name
-		Debug("from manifest: orgID=%s, nodeName=%s", orgID, nodeName)
+		Debug("from manifest: nodeName=%s", nodeName)
 	}
 
 	// Try to get more accurate hostname from network status (if connected)
@@ -106,16 +105,23 @@ func deregisterFromBackend(ctx context.Context) {
 	}
 
 	// Skip if we have no identity information
-	if orgID == "" && nodeName == "" {
+	if nodeName == "" {
 		Debug("no node identity found, skipping deregistration")
 		return
 	}
 
+	// Resolve API key for authentication
+	apiKey := os.Getenv("CITADEL_API_KEY")
+	if apiKey == "" {
+		Debug("no API key configured, skipping deregistration")
+		fmt.Println("   - Warning: CITADEL_API_KEY not set, cannot deregister from backend")
+		return
+	}
+
 	// Call backend to deregister
-	Debug("deregistering from backend: orgID=%s, nodeName=%s", orgID, nodeName)
-	client := nexus.NewDeregisterClient(authServiceURL)
+	Debug("deregistering from backend: nodeName=%s", nodeName)
+	client := nexus.NewDeregisterClient(authServiceURL, apiKey)
 	req := nexus.DeregisterRequest{
-		OrgID:    orgID,
 		NodeName: nodeName,
 	}
 

--- a/internal/nexus/deregister.go
+++ b/internal/nexus/deregister.go
@@ -13,18 +13,18 @@ import (
 // DeregisterClient handles node deregistration from Headscale
 type DeregisterClient struct {
 	baseURL    string
+	apiToken   string
 	httpClient *http.Client
 }
 
 // DeregisterRequest represents the request body for the /deregister endpoint
 type DeregisterRequest struct {
-	OrgID    string `json:"org_id,omitempty"`
-	NodeName string `json:"node_name,omitempty"`
+	NodeName string `json:"node_name"`
 }
 
 // DeregisterResponse represents a successful deregister response
 type DeregisterResponse struct {
-	Status  string `json:"status"`
+	Success bool   `json:"success"`
 	Message string `json:"message,omitempty"`
 }
 
@@ -41,10 +41,12 @@ func (e *DeregisterError) Error() string {
 	return e.ErrorCode
 }
 
-// NewDeregisterClient creates a new deregister client
-func NewDeregisterClient(baseURL string) *DeregisterClient {
+// NewDeregisterClient creates a new deregister client.
+// apiToken is the Bearer token for authentication (e.g. CITADEL_API_KEY).
+func NewDeregisterClient(baseURL, apiToken string) *DeregisterClient {
 	return &DeregisterClient{
-		baseURL: baseURL,
+		baseURL:  baseURL,
+		apiToken: apiToken,
 		httpClient: &http.Client{
 			Timeout: 15 * time.Second,
 		},
@@ -68,6 +70,9 @@ func (c *DeregisterClient) Deregister(ctx context.Context, req DeregisterRequest
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
+	if c.apiToken != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+c.apiToken)
+	}
 
 	// Send request
 	resp, err := c.httpClient.Do(httpReq)


### PR DESCRIPTION
## Context

**Why:** The backend deregister endpoint (`POST /api/fabric/device-auth/deregister`) was unauthenticated — anyone who knew an org ID could deregister arbitrary devices. A [review comment on aceteam#2233](https://github.com/aceteam-ai/aceteam/pull/2233) flagged this as a security vulnerability.

**What:** Update the CLI to authenticate deregister requests and stop sending `org_id` in the body (the backend now derives it from the session).

**How:** The `DeregisterClient` now accepts an API token and sends it as a `Bearer` header. `logout.go` reads `CITADEL_API_KEY` and passes it to the client, warning the user if it's not set.

## Summary

| Component | Change | Rationale |
|-----------|--------|-----------|
| `internal/nexus/deregister.go` | Add `apiToken` field, send `Authorization` header | Backend now requires auth |
| `internal/nexus/deregister.go` | Remove `OrgID` from `DeregisterRequest` | Backend derives org from session |
| `internal/nexus/deregister.go` | Fix `DeregisterResponse.Status` → `Success` | Match actual server response shape |
| `internal/nexus/deregister.go` | Remove `omitempty` from `NodeName` | Clearer server-side validation errors |
| `cmd/logout.go` | Read `CITADEL_API_KEY`, pass to client | Provide auth credentials |

## Test plan

- [ ] `go build ./...` passes
- [ ] `citadel logout` with `CITADEL_API_KEY` set sends auth header and deregisters
- [ ] `citadel logout` without `CITADEL_API_KEY` warns and skips deregistration
- [ ] `citadel logout --keep-registration` skips deregistration entirely

## Related

- Backend PR: https://github.com/aceteam-ai/aceteam/pull/2389
- Review comment: https://github.com/aceteam-ai/aceteam/pull/2233

🤖 Generated with [Claude Code](https://claude.com/claude-code)