### PR TITLE
fix: windows config path, login persistence, device auth TTY guard

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+	"github.com/aceteam-ai/citadel-cli/internal/tui"
 	"github.com/aceteam-ai/citadel-cli/internal/ui"
 	"github.com/fatih/color"
 )
@@ -21,6 +22,9 @@ type DeviceAuthResult struct {
 // The device code is returned for use in status publishing to enable config lookup.
 // If forceNew is true, the backend will ignore existing machine mappings and
 // create a fresh device registration.
+//
+// When no TTY is available (e.g. SSH without -t, CI, pipes), the device code
+// and URL are printed as plain text and the flow polls without bubbletea.
 func runDeviceAuthFlow(authServiceURL string, forceNew bool) (*DeviceAuthResult, error) {
 	client := nexus.NewDeviceAuthClient(authServiceURL)
 
@@ -31,8 +35,29 @@ func runDeviceAuthFlow(authServiceURL string, forceNew bool) (*DeviceAuthResult,
 		return nil, fmt.Errorf("failed to start device authorization: %w", err)
 	}
 
-	// Create UI program with device code display
-	// The UI shows clickable links and keyboard shortcuts for browser/clipboard
+	// Non-TTY path: print plain text and poll without bubbletea
+	if !tui.IsTTY() {
+		completeURL := resp.VerificationURI + "?code=" + resp.UserCode
+		fmt.Println()
+		fmt.Println("Device authorization required.")
+		fmt.Printf("Open this URL to sign in: %s\n", completeURL)
+		fmt.Printf("Or enter code manually:   %s\n", resp.UserCode)
+		fmt.Println()
+		fmt.Println("Waiting for authorization...")
+
+		token, err := client.PollForToken(resp.DeviceCode, resp.Interval)
+		if err != nil {
+			return nil, fmt.Errorf("device authorization failed: %w", err)
+		}
+
+		fmt.Println("Authorization successful!")
+		return &DeviceAuthResult{
+			Token:      token,
+			DeviceCode: resp.DeviceCode,
+		}, nil
+	}
+
+	// TTY path: interactive bubbletea UI
 	model := ui.NewDeviceCodeModel(resp.UserCode, resp.VerificationURI, resp.ExpiresIn)
 	program := ui.NewDeviceCodeProgram(model)
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -116,6 +116,17 @@ func runInteractiveLogin() {
 		}
 		authKey = authResult.Token.Authkey
 
+		// Persist device config so the token survives across sessions
+		if authResult.Token.DeviceAPIToken != "" {
+			if err := saveDeviceConfigToFile(authResult.Token); err != nil {
+				fmt.Fprintf(os.Stderr, "⚠️  Warning: Could not save device config: %v\n", err)
+			}
+		} else if authResult.Token.RedisURL != "" {
+			if err := saveRedisURLToConfig(authResult.Token.RedisURL); err != nil {
+				fmt.Fprintf(os.Stderr, "⚠️  Warning: Could not save Redis URL to config: %v\n", err)
+			}
+		}
+
 	case nexus.NetChoiceAuthkey:
 		fmt.Println("--- Authenticating with authkey ---")
 		authKey = key

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -88,13 +88,12 @@ func runLogout(cmd *cobra.Command, args []string) {
 // deregisterFromBackend attempts to deregister the node from Headscale via the backend API.
 // This is a best-effort operation - errors are logged but don't block logout.
 func deregisterFromBackend(ctx context.Context) {
-	var orgID, nodeName string
+	var nodeName string
 
 	// Try to get node identity from manifest
 	if manifest, _, err := findAndReadManifest(); err == nil {
-		orgID = manifest.Node.OrgID
 		nodeName = manifest.Node.Name
-		Debug("from manifest: orgID=%s, nodeName=%s", orgID, nodeName)
+		Debug("from manifest: nodeName=%s", nodeName)
 	}
 
 	// Try to get more accurate hostname from network status (if connected)
@@ -106,16 +105,23 @@ func deregisterFromBackend(ctx context.Context) {
 	}
 
 	// Skip if we have no identity information
-	if orgID == "" && nodeName == "" {
+	if nodeName == "" {
 		Debug("no node identity found, skipping deregistration")
 		return
 	}
 
+	// Resolve API key for authentication
+	apiKey := os.Getenv("CITADEL_API_KEY")
+	if apiKey == "" {
+		Debug("no API key configured, skipping deregistration")
+		fmt.Println("   - Warning: CITADEL_API_KEY not set, cannot deregister from backend")
+		return
+	}
+
 	// Call backend to deregister
-	Debug("deregistering from backend: orgID=%s, nodeName=%s", orgID, nodeName)
-	client := nexus.NewDeregisterClient(authServiceURL)
+	Debug("deregistering from backend: nodeName=%s", nodeName)
+	client := nexus.NewDeregisterClient(authServiceURL, apiKey)
 	req := nexus.DeregisterRequest{
-		OrgID:    orgID,
 		NodeName: nodeName,
 	}
 

--- a/internal/nexus/deregister.go
+++ b/internal/nexus/deregister.go
@@ -13,18 +13,18 @@ import (
 // DeregisterClient handles node deregistration from Headscale
 type DeregisterClient struct {
 	baseURL    string
+	apiToken   string
 	httpClient *http.Client
 }
 
 // DeregisterRequest represents the request body for the /deregister endpoint
 type DeregisterRequest struct {
-	OrgID    string `json:"org_id,omitempty"`
-	NodeName string `json:"node_name,omitempty"`
+	NodeName string `json:"node_name"`
 }
 
 // DeregisterResponse represents a successful deregister response
 type DeregisterResponse struct {
-	Status  string `json:"status"`
+	Success bool   `json:"success"`
 	Message string `json:"message,omitempty"`
 }
 
@@ -41,10 +41,12 @@ func (e *DeregisterError) Error() string {
 	return e.ErrorCode
 }
 
-// NewDeregisterClient creates a new deregister client
-func NewDeregisterClient(baseURL string) *DeregisterClient {
+// NewDeregisterClient creates a new deregister client.
+// apiToken is the Bearer token for authentication (e.g. CITADEL_API_KEY).
+func NewDeregisterClient(baseURL, apiToken string) *DeregisterClient {
 	return &DeregisterClient{
-		baseURL: baseURL,
+		baseURL:  baseURL,
+		apiToken: apiToken,
 		httpClient: &http.Client{
 			Timeout: 15 * time.Second,
 		},
@@ -68,6 +70,9 @@ func (c *DeregisterClient) Deregister(ctx context.Context, req DeregisterRequest
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
+	if c.apiToken != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+c.apiToken)
+	}
 
 	// Send request
 	resp, err := c.httpClient.Do(httpReq)

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -120,8 +120,27 @@ func ChownR(path, owner string) error {
 
 // ConfigDir returns the appropriate config directory for the OS.
 // Uses system-wide paths when running as root, user-local paths otherwise.
+// On Windows, always uses a user-local path (%LOCALAPPDATA%\Citadel) to
+// match the install location and avoid requiring admin privileges.
 func ConfigDir() string {
-	// If not running as root/admin, use user-local config
+	// Windows: always use user-local path regardless of elevation.
+	// The installer places the binary in %LOCALAPPDATA%\Citadel, so config
+	// should live there too. Using ProgramData would silently fail without
+	// admin and diverge from the install path.
+	if IsWindows() {
+		if v := os.Getenv("LOCALAPPDATA"); v != "" {
+			return filepath.Join(v, "Citadel")
+		}
+		if v := os.Getenv("APPDATA"); v != "" {
+			return filepath.Join(v, "Citadel")
+		}
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, "AppData", "Local", "Citadel")
+		}
+		return `C:\ProgramData\Citadel`
+	}
+
+	// Linux/macOS: use user-local config when not root
 	if !IsRoot() {
 		home, err := os.UserHomeDir()
 		if err == nil {
@@ -137,8 +156,7 @@ func ConfigDir() string {
 		// On macOS, use /usr/local/etc for consistency with Homebrew conventions
 		return "/usr/local/etc/citadel"
 	}
-	// Windows: Use ProgramData for system-wide config
-	return `C:\ProgramData\Citadel`
+	return "/etc/citadel"
 }
 
 // DefaultNodeDir returns the default directory for node configuration


### PR DESCRIPTION
## Summary

Fixes three bugs reported in #109:

- **Windows config path**: `ConfigDir()` now returns `%LOCALAPPDATA%\Citadel` on Windows regardless of elevation, matching the install path from `install.ps1`. Previously it resolved to `C:\ProgramData\Citadel` when running as admin, which could silently fail without admin and diverged from where the binary lives. Falls back through `%APPDATA%` and `UserHomeDir` before last-resort `ProgramData`.

- **Login device config persistence**: `citadel login`'s `NetChoiceDevice` branch extracted the authkey but never called `saveDeviceConfigToFile` or `saveRedisURLToConfig`, making the device API token ephemeral. Now mirrors the same save logic from `citadel init`.

- **Device auth TTY guard**: `runDeviceAuthFlow` now checks `tui.IsTTY()` before creating a bubbletea `tea.Program`. When no TTY is available (CI, piped input, SSH without `-t`), it prints the device code and verification URL as plain text and polls with `PollForToken` directly.

**Note**: Existing Windows installs that wrote config to `C:\ProgramData\Citadel` will need to move their `config.yaml` to `%LOCALAPPDATA%\Citadel\config.yaml` or re-run `citadel init`.

## Files changed

- `internal/platform/platform.go` -- `ConfigDir()` Windows path fix
- `cmd/login.go` -- persist device config in login flow
- `cmd/helpers.go` -- TTY guard for device auth TUI

Fixes #109