### PR TITLE
fix: windows non-interactive and error handling (#111)

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -133,6 +133,6 @@ func printNetworkSuccessInfo(nodeName, ip string) {
 	fmt.Println("     citadel proxy     - Forward local ports to peers")
 	fmt.Println()
 
-	// System-wide option hint
-	dimColor.Println("   For system-wide network access, use: sudo citadel init --system")
+	// Note: system-wide access is handled by the embedded tsnet library.
+	// No separate system-level command is needed.
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/network"
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
+	"github.com/aceteam-ai/citadel-cli/internal/tui"
 	"github.com/aceteam-ai/citadel-cli/internal/ui"
 	"github.com/aceteam-ai/citadel-cli/services"
 	"github.com/spf13/cobra"
@@ -402,6 +403,8 @@ and system user configuration (requires sudo).`,
 						if initVerbose {
 							fmt.Fprintf(os.Stderr, "     ⚠️  WARNING: Could not install %s. This is expected on non-GPU systems. Error: %v\n", step.name, err)
 						}
+					} else if platform.IsWindows() && !isCommandAvailable("winget") {
+						fmt.Fprintf(os.Stderr, "     ⚠️  WARNING: Could not install %s (winget not available). Install manually.\n", step.name)
 					} else {
 						fmt.Fprintf(os.Stderr, "     ❌ FAILED: %s\n        Error: %v\n", step.name, err)
 						os.Exit(1)
@@ -519,6 +522,15 @@ func getSelectedService() (string, error) {
 		}
 		return "", fmt.Errorf("invalid service '%s' specified", initService)
 	}
+
+	// In non-interactive sessions (SSH, CI), default to "none" instead of
+	// showing an arrow-key menu that would hang forever.
+	if !tui.IsTTY() {
+		fmt.Fprintln(os.Stderr, "⚠️  No TTY detected, defaulting to service=none.")
+		fmt.Fprintln(os.Stderr, "   Use --service flag to specify a service in non-interactive sessions.")
+		return "none", nil
+	}
+
 	selection, err := ui.AskSelect(
 		"Which primary service should this node run?",
 		[]string{
@@ -987,7 +999,8 @@ func ensureCoreDependencies() error {
 	// On Windows, check for winget availability
 	if platform.IsWindows() {
 		if _, err := exec.LookPath("winget"); err != nil {
-			return fmt.Errorf("winget not found - please upgrade to Windows 10 1809+ or Windows 11")
+			fmt.Fprintln(os.Stderr, "⚠️  winget not found. Package installation will be skipped.")
+			fmt.Fprintln(os.Stderr, "   Install software manually or upgrade to Windows 10 1809+ / Windows 11.")
 		}
 		// curl is built-in on Windows 10 1803+, no additional packages needed
 		if initVerbose {

--- a/internal/network/server.go
+++ b/internal/network/server.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net"
 	"net/netip"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -107,6 +108,12 @@ func (s *NetworkServer) Connect(ctx context.Context, authKey string) error {
 	// Start the server (this initiates the connection)
 	if err := s.srv.Start(); err != nil {
 		removeRestriction()
+		// On Windows, wrap cryptic syspolicy errors with actionable guidance.
+		if runtime.GOOS == "windows" && strings.Contains(err.Error(), "syspolicy") {
+			return fmt.Errorf("Windows requires SYSTEM privileges for network access.\n"+
+				"   Run via a scheduled task with /ru SYSTEM, or install as a service.\n"+
+				"   Original error: %w", err)
+		}
 		return fmt.Errorf("failed to start network: %w", err)
 	}
 	removeRestriction()


### PR DESCRIPTION
## Summary

Addresses 4 code-fixable items from #111:

- **Service selector TTY guard**: `getSelectedService()` now checks `tui.IsTTY()` and defaults to `"none"` with a stderr warning when no terminal is attached (SSH, CI). Prevents the interactive arrow-key menu from hanging in non-interactive sessions.
- **Remove `--system` flag reference**: The success message previously referenced `sudo citadel init --system` which doesn't exist. Removed the misleading output since embedded tsnet handles networking without a separate system-level command.
- **Syspolicy error wrapping**: When `tsnet.Server.Start()` fails with a `syspolicy` error on Windows, the error is now wrapped with actionable guidance ("Run via scheduled task with /ru SYSTEM, or install as a service") instead of showing the raw "Access is denied" message.
- **Winget-dependent steps non-fatal**: `ensureCoreDependencies()` no longer fatally errors when winget is missing on Windows. Instead it warns and continues. Docker and other winget-dependent provisioning steps also degrade gracefully with a warning when winget is absent.

Closes #111 (code-fixable items; documentation items deferred).

## Test plan

- [ ] Verify `citadel init --provision` without `--service` in a non-TTY session defaults to `"none"`
- [ ] Verify success message no longer mentions `--system` flag
- [ ] Verify Windows syspolicy errors show the wrapped message
- [ ] Verify `citadel init --provision` on Windows without winget warns but doesn't exit