### PR TITLE
chore: ignore .claude worktree artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ release
 docs-site/node_modules/
 docs-site/build/
 docs-site/.docusaurus/
+.claude/


### PR DESCRIPTION
Adds .claude/ to gitignore so worktree directories from Claude Code sessions don't show as untracked.