### PR TITLE
fix: VNC cleanup on citadel uninstall

### DIFF
--- a/cmd/service_cmd.go
+++ b/cmd/service_cmd.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
 	"github.com/spf13/cobra"
 )
 
@@ -144,16 +145,28 @@ func runSvcInstall(cmd *cobra.Command, args []string) error {
 }
 
 func runSvcUninstall(cmd *cobra.Command, args []string) error {
+	var err error
 	switch runtime.GOOS {
 	case "linux":
-		return uninstallLinuxSvc()
+		err = uninstallLinuxSvc()
 	case "darwin":
-		return uninstallDarwinSvc()
+		err = uninstallDarwinSvc()
 	case "windows":
-		return uninstallWindowsSvc()
+		err = uninstallWindowsSvc()
 	default:
 		return fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
 	}
+
+	// Clean up VNC if installed
+	vncMgr := platform.GetVNCManager()
+	if vncMgr.IsInstalled() {
+		fmt.Println("Removing VNC server...")
+		if vncErr := vncMgr.Uninstall(); vncErr != nil {
+			fmt.Printf("Warning: VNC removal failed: %v\n", vncErr)
+		}
+	}
+
+	return err
 }
 
 func runSvcStart(cmd *cobra.Command, args []string) error {

--- a/cmd/vnc.go
+++ b/cmd/vnc.go
@@ -10,8 +10,9 @@ import (
 )
 
 var (
-	vncPassword string
-	vncPort     int
+	vncPassword  string
+	vncPort      int
+	vncUninstall bool
 )
 
 var vncCmd = &cobra.Command{
@@ -42,8 +43,9 @@ and printed to stdout.`,
 var vncDisableCmd = &cobra.Command{
 	Use:   "disable",
 	Short: "Stop VNC server",
-	Long:  `Stops the VNC server service. Does not uninstall it.`,
-	RunE:  runVNCDisable,
+	Long: `Stops the VNC server service. Use --uninstall to also remove the
+VNC server software, firewall rules, and registry keys.`,
+	RunE: runVNCDisable,
 }
 
 var vncStatusCmd = &cobra.Command{
@@ -61,6 +63,8 @@ func init() {
 
 	vncEnableCmd.Flags().StringVar(&vncPassword, "password", "", "VNC password (auto-generated if not specified)")
 	vncEnableCmd.Flags().IntVar(&vncPort, "port", platform.DefaultVNCPort, "VNC port number")
+
+	vncDisableCmd.Flags().BoolVar(&vncUninstall, "uninstall", false, "Also uninstall VNC server software")
 }
 
 func runVNCEnable(cmd *cobra.Command, args []string) error {
@@ -125,17 +129,28 @@ func runVNCEnable(cmd *cobra.Command, args []string) error {
 func runVNCDisable(cmd *cobra.Command, args []string) error {
 	mgr := platform.GetVNCManager()
 
-	if !mgr.IsRunning() {
+	if mgr.IsRunning() {
+		fmt.Println("Stopping VNC server...")
+		if err := mgr.Stop(); err != nil {
+			return fmt.Errorf("failed to stop VNC server: %w", err)
+		}
+		fmt.Println("VNC server stopped.")
+	} else {
 		fmt.Println("VNC server is not running.")
-		return nil
 	}
 
-	fmt.Println("Stopping VNC server...")
-	if err := mgr.Stop(); err != nil {
-		return fmt.Errorf("failed to stop VNC server: %w", err)
+	if vncUninstall {
+		if !mgr.IsInstalled() {
+			fmt.Println("VNC server is not installed, nothing to uninstall.")
+			return nil
+		}
+		fmt.Println("Uninstalling VNC server...")
+		if err := mgr.Uninstall(); err != nil {
+			return fmt.Errorf("failed to uninstall VNC server: %w", err)
+		}
+		fmt.Println("VNC server uninstalled.")
 	}
 
-	fmt.Println("VNC server stopped.")
 	return nil
 }
 

--- a/cmd/vnc_test.go
+++ b/cmd/vnc_test.go
@@ -61,6 +61,16 @@ func TestVNCEnableFlags(t *testing.T) {
 	}
 }
 
+func TestVNCDisableUninstallFlag(t *testing.T) {
+	flag := vncDisableCmd.Flags().Lookup("uninstall")
+	if flag == nil {
+		t.Fatal("--uninstall flag not found on vnc disable")
+	}
+	if flag.DefValue != "false" {
+		t.Errorf("--uninstall default = %q, want %q", flag.DefValue, "false")
+	}
+}
+
 func TestVNCEnablePortDefault(t *testing.T) {
 	if platform.DefaultVNCPort != 5900 {
 		t.Errorf("DefaultVNCPort = %d, want 5900", platform.DefaultVNCPort)

--- a/internal/platform/vnc.go
+++ b/internal/platform/vnc.go
@@ -25,6 +25,7 @@ var vncDESKey = []byte{0x17, 0x52, 0x6b, 0x06, 0x23, 0x4e, 0x58, 0x07}
 type VNCManager interface {
 	IsInstalled() bool
 	Install() error
+	Uninstall() error
 	Configure(password string, port int) error
 	Start() error
 	Stop() error
@@ -163,6 +164,58 @@ func (w *WindowsVNCManager) Install() error {
 	}
 
 	fmt.Println("TightVNC installed via MSI.")
+	return nil
+}
+
+func (w *WindowsVNCManager) Uninstall() error {
+	// Stop the service first (best-effort)
+	if err := w.Stop(); err != nil {
+		fmt.Printf("Warning: failed to stop VNC service: %v\n", err)
+	}
+
+	// Find the MSI product GUID for TightVNC
+	cmd := exec.Command("wmic", "product", "where", "name like '%TightVNC%'",
+		"get", "IdentifyingNumber", "/format:list")
+	output, err := cmd.Output()
+	if err != nil {
+		fmt.Printf("Warning: could not query TightVNC product GUID: %v\n", err)
+	}
+
+	// Parse GUID from "IdentifyingNumber={GUID}" output
+	guid := ""
+	for _, line := range strings.Split(string(output), "\n") {
+		line = strings.TrimSpace(strings.TrimRight(line, "\r"))
+		if strings.HasPrefix(line, "IdentifyingNumber=") {
+			guid = strings.TrimPrefix(line, "IdentifyingNumber=")
+			guid = strings.TrimSpace(guid)
+			break
+		}
+	}
+
+	// Run msiexec to uninstall if we found a GUID
+	if guid != "" {
+		uninstallCmd := exec.Command("msiexec", "/x", guid, "/quiet", "/norestart")
+		if err := uninstallCmd.Run(); err != nil {
+			return fmt.Errorf("failed to uninstall TightVNC (GUID %s): %w", guid, err)
+		}
+		fmt.Println("TightVNC uninstalled via MSI.")
+	} else {
+		fmt.Println("Warning: TightVNC MSI product not found, skipping MSI removal.")
+	}
+
+	// Delete firewall rule (best-effort)
+	fwCmd := exec.Command("netsh", "advfirewall", "firewall", "delete", "rule",
+		"name=TightVNC Server (Port 5900)")
+	if err := fwCmd.Run(); err != nil {
+		fmt.Printf("Warning: failed to remove firewall rule: %v\n", err)
+	}
+
+	// Clean registry (best-effort, may already be gone)
+	regCmd := exec.Command("reg", "delete", `HKLM\SOFTWARE\TightVNC`, "/f")
+	if err := regCmd.Run(); err != nil {
+		fmt.Printf("Warning: failed to clean TightVNC registry keys: %v\n", err)
+	}
+
 	return nil
 }
 
@@ -354,6 +407,11 @@ func (l *LinuxVNCManager) Install() error {
 	return fmt.Errorf("no supported package manager found (tried apt-get, yum, pacman)")
 }
 
+func (l *LinuxVNCManager) Uninstall() error {
+	fmt.Println("VNC server uninstall not yet supported on Linux.")
+	return nil
+}
+
 func (l *LinuxVNCManager) Configure(password string, port int) error {
 	if err := ValidateVNCPort(port); err != nil {
 		return err
@@ -477,6 +535,11 @@ func (d *DarwinVNCManager) IsInstalled() bool {
 
 func (d *DarwinVNCManager) Install() error {
 	fmt.Println("VNC server provisioning not yet supported on macOS (use built-in Screen Sharing)")
+	return nil
+}
+
+func (d *DarwinVNCManager) Uninstall() error {
+	fmt.Println("VNC server uninstall not yet supported on macOS.")
 	return nil
 }
 

--- a/internal/platform/vnc_test.go
+++ b/internal/platform/vnc_test.go
@@ -192,6 +192,15 @@ func TestWindowsVNCManagerIsRunning(t *testing.T) {
 	_ = mgr.Port()
 }
 
+func TestVNCManagerUninstallNoPanic(t *testing.T) {
+	mgr := GetVNCManager()
+	// Uninstall() should not panic on any platform, even if nothing is installed
+	err := mgr.Uninstall()
+	if err != nil {
+		t.Logf("Uninstall() returned error (expected on some platforms): %v", err)
+	}
+}
+
 func TestDefaultVNCPort(t *testing.T) {
 	if DefaultVNCPort != 5900 {
 		t.Errorf("DefaultVNCPort = %d, want 5900", DefaultVNCPort)

--- a/internal/platform/vnc_test.go
+++ b/internal/platform/vnc_test.go
@@ -193,6 +193,9 @@ func TestWindowsVNCManagerIsRunning(t *testing.T) {
 }
 
 func TestVNCManagerUninstallNoPanic(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Uninstall is destructive on Windows; no-panic test is Linux-only")
+	}
 	mgr := GetVNCManager()
 	// Uninstall() should not panic on any platform, even if nothing is installed
 	err := mgr.Uninstall()


### PR DESCRIPTION
Closes #120

## Summary

- Add `Uninstall()` to `VNCManager` interface with Windows implementation (stop service, find MSI GUID via wmic, msiexec /x, delete firewall rule, clean registry)
- Linux/macOS stubs print "not yet supported"
- `citadel vnc disable --uninstall` flag triggers full removal
- `citadel service uninstall` now cleans up VNC if installed
- Tests for interface compliance, no-panic on Uninstall(), flag registration

## Notes

- Firewall rule deletion hardcodes port 5900; custom-port rules need manual cleanup (matches the task spec)
- `uninstall.sh` not touched (Linux VNC is stubbed, low priority per issue)

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go vet ./...`