### PR TITLE
feat: include node_id in job result events for operator attribution

### DIFF
--- a/cmd/work.go
+++ b/cmd/work.go
@@ -189,6 +189,7 @@ func runWork(cmd *cobra.Command, args []string) {
 	var streamFactory func(job *worker.Job) worker.StreamWriter
 	var useAPIMode bool
 	var apiSource *worker.APISource // Keep reference for heartbeat
+	var setNodeMeta func(nodeID, nodeName string) // Set after node identity is resolved
 
 	if !workForceDirectRedis && deviceConfig != nil && deviceConfig.DeviceAPIToken != "" {
 		// API mode: use secure HTTP API instead of direct Redis.
@@ -237,6 +238,9 @@ func runWork(cmd *cobra.Command, args []string) {
 
 		source = apiSource
 		streamFactory = worker.CreateAPIStreamWriterFactory(ctx, apiSource)
+		setNodeMeta = func(nodeID, nodeName string) {
+			apiSource.Client().SetNodeMeta(nodeID, nodeName)
+		}
 
 		fmt.Println("   - Mode: Redis API (secure)")
 		if deviceConfig.UserEmail != "" {
@@ -331,6 +335,9 @@ func runWork(cmd *cobra.Command, args []string) {
 		})
 		source = redisSource
 		streamFactory = worker.CreateRedisStreamWriterFactory(ctx, redisSource)
+		setNodeMeta = func(nodeID, nodeName string) {
+			redisSource.Client().SetNodeMeta(nodeID, nodeName)
+		}
 
 		fmt.Println("   - Mode: Direct Redis (legacy)")
 	}
@@ -374,6 +381,12 @@ func runWork(cmd *cobra.Command, args []string) {
 		}
 	}
 	Debug("final node name: %s", nodeName)
+
+	// Set node identity on the stream event publisher for operator attribution
+	if setNodeMeta != nil {
+		setNodeMeta(nodeName, nodeName)
+		Debug("node meta set: node_id=%s, node_name=%s", nodeName, nodeName)
+	}
 
 	// Open usage store for per-job compute tracking
 	var usageStore *usage.Store

--- a/internal/redis/client.go
+++ b/internal/redis/client.go
@@ -44,6 +44,12 @@ type Job struct {
 	EnqueuedAt string // JQS-Core: original enqueue timestamp, preserved for DLQ
 }
 
+// NodeMeta holds node identity metadata injected into every stream event.
+type NodeMeta struct {
+	NodeID   string `json:"node_id"`
+	NodeName string `json:"node_name"`
+}
+
 // Client wraps Redis operations for the job queue system.
 type Client struct {
 	client        *redis.Client
@@ -52,6 +58,7 @@ type Client struct {
 	consumerGroup string
 	blockMs       int
 	maxAttempts   int
+	nodeMeta      *NodeMeta
 }
 
 // ClientConfig holds configuration for the Redis client.
@@ -380,6 +387,14 @@ func (c *Client) getDLQName() string {
 func (c *Client) PublishStreamEvent(ctx context.Context, jobID, rayID, eventType string, data map[string]interface{}) error {
 	streamName := fmt.Sprintf("stream:v1:%s", jobID)
 
+	// Inject node identity metadata into every event for operator attribution
+	if c.nodeMeta != nil {
+		if data == nil {
+			data = make(map[string]interface{})
+		}
+		data["meta"] = c.nodeMeta
+	}
+
 	event := StreamEvent{
 		Version:   "1.0",
 		Type:      eventType,
@@ -483,4 +498,9 @@ func (c *Client) QueueName() string {
 // MaxAttempts returns the maximum retry attempts before DLQ.
 func (c *Client) MaxAttempts() int {
 	return c.maxAttempts
+}
+
+// SetNodeMeta sets the node identity metadata that will be included in all stream events.
+func (c *Client) SetNodeMeta(nodeID, nodeName string) {
+	c.nodeMeta = &NodeMeta{NodeID: nodeID, NodeName: nodeName}
 }

--- a/internal/redis/client_test.go
+++ b/internal/redis/client_test.go
@@ -223,3 +223,92 @@ func TestJob(t *testing.T) {
 		t.Errorf("Payload[prompt] = %v, want Hello", job.Payload["prompt"])
 	}
 }
+
+func TestNodeMeta(t *testing.T) {
+	meta := NodeMeta{
+		NodeID:   "758",
+		NodeName: "desktop-6ukhjan",
+	}
+
+	data, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	jsonStr := string(data)
+	if !strings.Contains(jsonStr, `"node_id":"758"`) {
+		t.Errorf("Expected node_id in JSON, got: %s", jsonStr)
+	}
+	if !strings.Contains(jsonStr, `"node_name":"desktop-6ukhjan"`) {
+		t.Errorf("Expected node_name in JSON, got: %s", jsonStr)
+	}
+}
+
+func TestSetNodeMeta(t *testing.T) {
+	client := NewClient(ClientConfig{})
+
+	// Initially nil
+	if client.nodeMeta != nil {
+		t.Error("nodeMeta should be nil initially")
+	}
+
+	// Set meta
+	client.SetNodeMeta("758", "desktop-6ukhjan")
+
+	if client.nodeMeta == nil {
+		t.Fatal("nodeMeta should not be nil after SetNodeMeta")
+	}
+	if client.nodeMeta.NodeID != "758" {
+		t.Errorf("NodeID = %s, want 758", client.nodeMeta.NodeID)
+	}
+	if client.nodeMeta.NodeName != "desktop-6ukhjan" {
+		t.Errorf("NodeName = %s, want desktop-6ukhjan", client.nodeMeta.NodeName)
+	}
+}
+
+func TestStreamEventIncludesNodeMeta(t *testing.T) {
+	// Verify that StreamEvent data can contain meta and it serializes correctly
+	meta := &NodeMeta{
+		NodeID:   "758",
+		NodeName: "desktop-6ukhjan",
+	}
+
+	event := StreamEvent{
+		Version:   "1.0",
+		Type:      "end",
+		JobID:     "job-123",
+		Timestamp: "2026-06-01T00:00:00Z",
+		Data: map[string]interface{}{
+			"result": map[string]interface{}{"output": "hello"},
+			"meta":   meta,
+		},
+	}
+
+	data, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	// Verify the structure round-trips correctly
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	dataField, ok := parsed["data"].(map[string]interface{})
+	if !ok {
+		t.Fatal("Expected data to be a map")
+	}
+
+	metaField, ok := dataField["meta"].(map[string]interface{})
+	if !ok {
+		t.Fatal("Expected data.meta to be a map")
+	}
+
+	if metaField["node_id"] != "758" {
+		t.Errorf("data.meta.node_id = %v, want 758", metaField["node_id"])
+	}
+	if metaField["node_name"] != "desktop-6ukhjan" {
+		t.Errorf("data.meta.node_name = %v, want desktop-6ukhjan", metaField["node_name"])
+	}
+}

--- a/internal/redisapi/client.go
+++ b/internal/redisapi/client.go
@@ -24,6 +24,9 @@ type Client struct {
 
 	// Debug callback (optional)
 	debugFunc func(format string, args ...any)
+
+	// Node identity metadata injected into stream events
+	nodeMeta *NodeMeta
 }
 
 // ClientConfig holds configuration for the API client.
@@ -132,6 +135,11 @@ func (c *Client) WebSocket() *WSClient {
 // IsWebSocketConnected returns whether the WebSocket is currently connected.
 func (c *Client) IsWebSocketConnected() bool {
 	return c.wsClient != nil && c.wsClient.IsConnected()
+}
+
+// SetNodeMeta sets the node identity metadata that will be included in all stream events.
+func (c *Client) SetNodeMeta(nodeID, nodeName string) {
+	c.nodeMeta = &NodeMeta{NodeID: nodeID, NodeName: nodeName}
 }
 
 // doRequest performs an HTTP request with authentication and JSON handling.

--- a/internal/redisapi/pubsub.go
+++ b/internal/redisapi/pubsub.go
@@ -49,6 +49,14 @@ func (c *Client) Publish(ctx context.Context, channel string, message any) error
 func (c *Client) PublishStreamEvent(ctx context.Context, jobID, rayID, eventType string, data map[string]any) error {
 	streamName := fmt.Sprintf("stream:v1:%s", jobID)
 
+	// Inject node identity metadata into every event for operator attribution
+	if c.nodeMeta != nil {
+		if data == nil {
+			data = make(map[string]any)
+		}
+		data["meta"] = c.nodeMeta
+	}
+
 	event := StreamEvent{
 		Version:   "1.0",
 		Type:      eventType,

--- a/internal/redisapi/types.go
+++ b/internal/redisapi/types.go
@@ -137,3 +137,9 @@ type StreamEvent struct {
 	Timestamp string         `json:"timestamp"`
 	Data      map[string]any `json:"data,omitempty"`
 }
+
+// NodeMeta holds node identity metadata injected into every stream event.
+type NodeMeta struct {
+	NodeID   string `json:"node_id"`
+	NodeName string `json:"node_name"`
+}


### PR DESCRIPTION
## Context

When a Citadel worker completes an inference job, the result event published to Redis doesn't include node identity. The Python consumer (`gateway_citadel.py`) needs this to credit the operator org via `settle_inference_job()`. Without it, earnings fall back to the platform org (aceteam#3392).

## Changes

**Choke-point injection** -- both Redis direct and API mode clients now inject `meta` into the `data` field of every stream event:

- `internal/redis/client.go` -- added `NodeMeta` struct, `SetNodeMeta()` method, and meta injection in `PublishStreamEvent()`
- `internal/redisapi/client.go` + `pubsub.go` + `types.go` -- same pattern for the API proxy client
- `cmd/work.go` -- resolves node hostname from Headscale network status, then calls `SetNodeMeta()` on the active client

All event types (start, chunk, end, error, cancelled) get the meta automatically because the injection happens at `PublishStreamEvent`, the single method through which all events flow.

**Event structure after this change:**
```json
{
  "type": "end",
  "data": {
    "result": {"output": "..."},
    "meta": {"node_id": "desktop-6ukhjan", "node_name": "desktop-6ukhjan"}
  }
}
```

**Why hostname works for attribution:** The `node:capabilities:{nodeId}` Redis keys are created by the `resolve-queues` route (`app/api/fabric/nodes/resolve-queues/route.ts`) using the Citadel hostname as the key, and include `orgId`. So `_resolve_operator_org(hostname)` does `hget("node:capabilities:{hostname}", "orgId")` and resolves correctly.

The numeric Headscale ID is a server-side artifact not available to the Citadel binary. The heartbeat status worker refreshes TTL on `node:capabilities:{numeric_id}`, but the primary writer (resolve-queues) uses hostname.

## Test plan

| Test | Coverage |
|------|----------|
| `TestNodeMeta` | Verifies JSON serialization of `NodeMeta` struct |
| `TestSetNodeMeta` | Verifies setter on Redis client |
| `TestStreamEventIncludesNodeMeta` | Verifies meta round-trips through `StreamEvent` data field |
| `go build ./...` | Compiles cleanly |
| `go test ./...` | All existing + new tests pass |

## Related

- aceteam-ai/aceteam#3392 (gateway fallback to platform org when operator unknown)
- aceteam-ai/aceteam#3426 (gateway_citadel.py)

Closes #121

---
*Generated by Claude*