### PR TITLE
fix: nil-guard setNodeMeta + deprecate direct Redis mode

### DIFF
--- a/cmd/work.go
+++ b/cmd/work.go
@@ -252,6 +252,7 @@ func runWork(cmd *cobra.Command, args []string) {
 		}
 	} else {
 		// Legacy mode: direct Redis connection
+		fmt.Fprintln(os.Stderr, "WARNING: Direct Redis mode is deprecated. Run 'citadel init' to set up API mode.")
 		Debug("using direct Redis mode")
 
 		// Resolve Redis URL: flag > env > config

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -336,7 +336,9 @@ func runWork(cmd *cobra.Command, args []string) {
 		source = redisSource
 		streamFactory = worker.CreateRedisStreamWriterFactory(ctx, redisSource)
 		setNodeMeta = func(nodeID, nodeName string) {
-			redisSource.Client().SetNodeMeta(nodeID, nodeName)
+			if c := redisSource.Client(); c != nil {
+				c.SetNodeMeta(nodeID, nodeName)
+			}
 		}
 
 		fmt.Println("   - Mode: Direct Redis (legacy)")


### PR DESCRIPTION
## Context

The node_id attribution feature (PR #124, v2.5.1) added `setNodeMeta` to inject node identity into job result events. It was wired for both API mode and direct Redis mode, but the direct Redis path calls `redisSource.Client()` before `Connect()` runs, causing a nil pointer crash.

Found during production MCP testing — `citadel work --redis-url ...` panics immediately on startup.

## Changes

- **Nil-guard in setNodeMeta closure** — check `Client()` != nil before calling `SetNodeMeta`. In direct Redis mode, the client isn't initialized until the worker's internal `Connect()` during the run loop, but the closure is invoked earlier during node identity resolution.
- **Deprecation warning for direct Redis mode** — prints a stderr warning when falling back to legacy direct Redis. API mode (via device auth) is the proper path: it's secure, auto-resolves queues (including the new shell queue for terminal MCP), and doesn't expose Redis credentials.

## Test plan

- [x] `go test ./cmd/...` passes
- [x] Manual: `citadel work --redis-url <url> --queue <queue>` no longer crashes
- [x] Manual: worker receives and executes SHELL_COMMAND jobs via terminal MCP

---
*Generated by Claude*