### PR TITLE
feat: modular app catalog (citadel app install)

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -1,0 +1,369 @@
+// cmd/app.go
+// Modular app catalog commands for deploying developer tools on Citadel nodes.
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/apps"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+var appCmd = &cobra.Command{
+	Use:     "app",
+	Aliases: []string{"apps"},
+	Short:   "Manage developer tool apps on this node",
+	Long: `Install, manage, and remove developer tool applications on your Citadel node.
+
+Apps run as Docker containers and are accessible via your browser. Data is
+persisted in ~/.citadel/apps/<name>/data/ so it survives restarts.
+
+Available apps: code-server, jupyter, filebrowser, ollama-webui`,
+}
+
+var appListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Show available apps with install status",
+	RunE:  runAppList,
+}
+
+var appInstallCmd = &cobra.Command{
+	Use:   "install <name>",
+	Short: "Deploy an app on this node",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runAppInstall,
+}
+
+var appStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show running apps and their ports",
+	RunE:  runAppStatus,
+}
+
+var appStopCmd = &cobra.Command{
+	Use:   "stop <name>",
+	Short: "Stop a running app",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runAppStop,
+}
+
+var appStartCmd = &cobra.Command{
+	Use:   "start <name>",
+	Short: "Start a previously stopped app",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runAppStart,
+}
+
+var appUninstallKeepData bool
+
+var appUninstallCmd = &cobra.Command{
+	Use:   "uninstall <name>",
+	Short: "Remove an app, its container, and data",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runAppUninstall,
+}
+
+func init() {
+	rootCmd.AddCommand(appCmd)
+	appCmd.AddCommand(appListCmd)
+	appCmd.AddCommand(appInstallCmd)
+	appCmd.AddCommand(appStatusCmd)
+	appCmd.AddCommand(appStopCmd)
+	appCmd.AddCommand(appStartCmd)
+	appCmd.AddCommand(appUninstallCmd)
+
+	appUninstallCmd.Flags().BoolVar(&appUninstallKeepData, "keep-data", false,
+		"Preserve the app's data directory instead of deleting it")
+}
+
+// runAppList shows the catalog with install status.
+func runAppList(cmd *cobra.Command, args []string) error {
+	state, err := apps.LoadState()
+	if err != nil {
+		return fmt.Errorf("failed to load app state: %w", err)
+	}
+
+	ctx := context.Background()
+	runner := apps.ExecRunner{}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	defer w.Flush()
+
+	bold := color.New(color.Bold)
+	bold.Fprintf(w, "NAME\tDESCRIPTION\tSTATUS\tPORT\n")
+
+	for _, name := range apps.List() {
+		manifest, _ := apps.Lookup(name)
+		installed, isInstalled := state.Get(name)
+
+		statusStr := color.New(color.FgWhite).Sprint("available")
+		portStr := "-"
+
+		if isInstalled {
+			dockerStatus := apps.ContainerStatus(ctx, runner, name)
+			switch dockerStatus {
+			case "running":
+				statusStr = color.New(color.FgGreen).Sprint("running")
+			case "exited":
+				statusStr = color.New(color.FgYellow).Sprint("stopped")
+			default:
+				statusStr = color.New(color.FgRed).Sprint(dockerStatus)
+			}
+			portStr = fmt.Sprintf("%d", installed.HostPort)
+		}
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", name, manifest.Description, statusStr, portStr)
+	}
+
+	return nil
+}
+
+// runAppInstall deploys an app.
+func runAppInstall(cmd *cobra.Command, args []string) error {
+	appName := args[0]
+
+	manifest, ok := apps.Lookup(appName)
+	if !ok {
+		return fmt.Errorf("unknown app: %s\nRun 'citadel app list' to see available apps", appName)
+	}
+
+	ctx := context.Background()
+	runner := apps.ExecRunner{}
+
+	// Check Docker availability.
+	if err := apps.DockerAvailable(ctx, runner); err != nil {
+		return err
+	}
+
+	// Load state.
+	state, err := apps.LoadState()
+	if err != nil {
+		return fmt.Errorf("failed to load app state: %w", err)
+	}
+
+	// Check if already installed.
+	if _, installed := state.Get(appName); installed {
+		status := apps.ContainerStatus(ctx, runner, appName)
+		if status == "running" {
+			fmt.Printf("App %s is already installed and running.\n", appName)
+			return nil
+		}
+		// Exists but not running — start it.
+		fmt.Printf("App %s is installed but not running. Starting...\n", appName)
+		if err := apps.Start(ctx, runner, appName); err != nil {
+			return fmt.Errorf("failed to start app: %w", err)
+		}
+		fmt.Printf("Started %s.\n", appName)
+		return nil
+	}
+
+	// Allocate a host port.
+	hostPort, err := state.AllocatePort()
+	if err != nil {
+		return fmt.Errorf("failed to allocate port: %w", err)
+	}
+
+	// Create data directory.
+	dataDir, err := apps.AppDataDir(appName)
+	if err != nil {
+		return fmt.Errorf("failed to determine data directory: %w", err)
+	}
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		return fmt.Errorf("failed to create data directory: %w", err)
+	}
+
+	// Create sub-directories for volumes.
+	for _, vol := range manifest.Volumes {
+		if vol.HostPath != "" {
+			subDir := dataDir + "/" + vol.HostPath
+			if err := os.MkdirAll(subDir, 0755); err != nil {
+				return fmt.Errorf("failed to create volume directory %s: %w", subDir, err)
+			}
+		}
+	}
+
+	fmt.Printf("Installing %s...\n", appName)
+	fmt.Printf("  Image: %s\n", manifest.Image)
+	fmt.Printf("  Port:  localhost:%d\n", hostPort)
+	fmt.Printf("  Data:  %s\n", dataDir)
+
+	// Pull image first for better UX (shows download progress).
+	fmt.Printf("  Pulling image...\n")
+	if _, err := runner.Run(ctx, "docker", "pull", manifest.Image); err != nil {
+		return fmt.Errorf("failed to pull image %s: %w", manifest.Image, err)
+	}
+
+	// Start the container.
+	containerID, err := apps.Install(ctx, runner, manifest, hostPort, dataDir)
+	if err != nil {
+		return fmt.Errorf("failed to start container: %w", err)
+	}
+
+	// Record in state.
+	state.Set(apps.InstalledApp{
+		Name:        appName,
+		Image:       manifest.Image,
+		ContainerID: containerID,
+		HostPort:    hostPort,
+	})
+	if err := state.Save(); err != nil {
+		return fmt.Errorf("failed to save state: %w", err)
+	}
+
+	// Wait for health check.
+	fmt.Printf("  Waiting for app to be ready...")
+	healthCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
+	defer cancel()
+
+	if err := apps.WaitHealthy(healthCtx, manifest, hostPort); err != nil {
+		fmt.Printf(" timeout\n")
+		fmt.Printf("  Warning: %v\n", err)
+		fmt.Printf("  The app may still be starting. Check with 'citadel app status'.\n")
+	} else {
+		fmt.Printf(" ready!\n")
+	}
+
+	fmt.Printf("\nApp %s is now available at http://localhost:%d\n", appName, hostPort)
+	return nil
+}
+
+// runAppStatus shows running apps and their ports.
+func runAppStatus(cmd *cobra.Command, args []string) error {
+	state, err := apps.LoadState()
+	if err != nil {
+		return fmt.Errorf("failed to load app state: %w", err)
+	}
+
+	if len(state.Apps) == 0 {
+		fmt.Println("No apps installed. Run 'citadel app list' to see available apps.")
+		return nil
+	}
+
+	ctx := context.Background()
+	runner := apps.ExecRunner{}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	defer w.Flush()
+
+	bold := color.New(color.Bold)
+	bold.Fprintf(w, "NAME\tSTATUS\tPORT\tURL\n")
+
+	for _, name := range apps.List() {
+		installed, ok := state.Get(name)
+		if !ok {
+			continue
+		}
+
+		dockerStatus := apps.ContainerStatus(ctx, runner, name)
+		var statusStr string
+		switch dockerStatus {
+		case "running":
+			statusStr = color.New(color.FgGreen).Sprint("running")
+		case "exited":
+			statusStr = color.New(color.FgYellow).Sprint("stopped")
+		default:
+			statusStr = color.New(color.FgRed).Sprint(dockerStatus)
+		}
+
+		url := fmt.Sprintf("http://localhost:%d", installed.HostPort)
+		fmt.Fprintf(w, "%s\t%s\t%d\t%s\n", name, statusStr, installed.HostPort, url)
+	}
+
+	return nil
+}
+
+// runAppStop stops a running app.
+func runAppStop(cmd *cobra.Command, args []string) error {
+	appName := args[0]
+
+	state, err := apps.LoadState()
+	if err != nil {
+		return fmt.Errorf("failed to load app state: %w", err)
+	}
+
+	if _, ok := state.Get(appName); !ok {
+		return fmt.Errorf("app %s is not installed", appName)
+	}
+
+	ctx := context.Background()
+	runner := apps.ExecRunner{}
+
+	fmt.Printf("Stopping %s...\n", appName)
+	if err := apps.Stop(ctx, runner, appName); err != nil {
+		return fmt.Errorf("failed to stop app: %w", err)
+	}
+
+	fmt.Printf("Stopped %s.\n", appName)
+	return nil
+}
+
+// runAppStart starts a previously stopped app.
+func runAppStart(cmd *cobra.Command, args []string) error {
+	appName := args[0]
+
+	state, err := apps.LoadState()
+	if err != nil {
+		return fmt.Errorf("failed to load app state: %w", err)
+	}
+
+	if _, ok := state.Get(appName); !ok {
+		return fmt.Errorf("app %s is not installed. Run 'citadel app install %s' first", appName, appName)
+	}
+
+	ctx := context.Background()
+	runner := apps.ExecRunner{}
+
+	fmt.Printf("Starting %s...\n", appName)
+	if err := apps.Start(ctx, runner, appName); err != nil {
+		return fmt.Errorf("failed to start app: %w", err)
+	}
+
+	fmt.Printf("Started %s.\n", appName)
+	return nil
+}
+
+// runAppUninstall removes an app container, state, and data.
+func runAppUninstall(cmd *cobra.Command, args []string) error {
+	appName := args[0]
+
+	state, err := apps.LoadState()
+	if err != nil {
+		return fmt.Errorf("failed to load app state: %w", err)
+	}
+
+	if _, ok := state.Get(appName); !ok {
+		return fmt.Errorf("app %s is not installed", appName)
+	}
+
+	ctx := context.Background()
+	runner := apps.ExecRunner{}
+
+	fmt.Printf("Uninstalling %s...\n", appName)
+	if err := apps.Uninstall(ctx, runner, appName); err != nil {
+		return fmt.Errorf("failed to remove container: %w", err)
+	}
+
+	// Remove from state.
+	state.Remove(appName)
+	if err := state.Save(); err != nil {
+		return fmt.Errorf("failed to save state: %w", err)
+	}
+
+	// Remove data directory unless --keep-data is set.
+	appDir, _ := apps.AppDir(appName)
+	if appUninstallKeepData {
+		fmt.Printf("Uninstalled %s. Data preserved at %s.\n", appName, appDir)
+	} else {
+		if err := os.RemoveAll(appDir); err != nil {
+			fmt.Printf("Warning: failed to remove data directory %s: %v\n", appDir, err)
+		} else {
+			fmt.Printf("Uninstalled %s and removed data at %s.\n", appName, appDir)
+		}
+	}
+	return nil
+}

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -187,14 +187,33 @@ func runAppInstall(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Generate and inject auth password for apps that need it.
+	generatedPassword := ""
+	if apps.NeedsPassword(appName) {
+		pw, err := apps.GeneratePassword(16)
+		if err != nil {
+			return fmt.Errorf("failed to generate password: %w", err)
+		}
+		generatedPassword = pw
+		switch appName {
+		case "code-server":
+			manifest.Env["PASSWORD"] = pw
+		case "filebrowser":
+			manifest.Env["FB_PASSWORD"] = pw
+			manifest.Env["FB_USERNAME"] = "admin"
+		}
+	}
+
 	fmt.Printf("Installing %s...\n", appName)
 	fmt.Printf("  Image: %s\n", manifest.Image)
 	fmt.Printf("  Port:  localhost:%d\n", hostPort)
 	fmt.Printf("  Data:  %s\n", dataDir)
 
-	// Pull image first for better UX (shows download progress).
+	// Pull image with a timeout.
 	fmt.Printf("  Pulling image...\n")
-	if _, err := runner.Run(ctx, "docker", "pull", manifest.Image); err != nil {
+	pullCtx, pullCancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer pullCancel()
+	if _, err := runner.Run(pullCtx, "docker", "pull", manifest.Image); err != nil {
 		return fmt.Errorf("failed to pull image %s: %w", manifest.Image, err)
 	}
 
@@ -204,7 +223,7 @@ func runAppInstall(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to start container: %w", err)
 	}
 
-	// Record in state.
+	// Record in state. On failure, clean up the orphaned container.
 	state.Set(apps.InstalledApp{
 		Name:        appName,
 		Image:       manifest.Image,
@@ -212,7 +231,9 @@ func runAppInstall(cmd *cobra.Command, args []string) error {
 		HostPort:    hostPort,
 	})
 	if err := state.Save(); err != nil {
-		return fmt.Errorf("failed to save state: %w", err)
+		_ = apps.Stop(ctx, runner, appName)
+		_, _ = runner.Run(ctx, "docker", "rm", "-f", apps.ContainerName(appName))
+		return fmt.Errorf("failed to save state (container cleaned up): %w", err)
 	}
 
 	// Wait for health check.
@@ -229,6 +250,9 @@ func runAppInstall(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("\nApp %s is now available at http://localhost:%d\n", appName, hostPort)
+	if generatedPassword != "" {
+		fmt.Printf("  Password: %s\n", generatedPassword)
+	}
 	return nil
 }
 

--- a/cmd/app_test.go
+++ b/cmd/app_test.go
@@ -1,0 +1,70 @@
+package cmd
+
+import "testing"
+
+func TestAppListCommand(t *testing.T) {
+	// Use a temp home so state file is empty (no Docker calls needed).
+	t.Setenv("HOME", t.TempDir())
+
+	// runAppList writes to os.Stdout via tabwriter; we just verify it
+	// runs without error. The tabwriter output is visible in -v mode.
+	err := runAppList(appListCmd, nil)
+	if err != nil {
+		t.Fatalf("runAppList() error = %v", err)
+	}
+}
+
+func TestAppStopNotInstalled(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	err := runAppStop(appStopCmd, []string{"code-server"})
+	if err == nil {
+		t.Fatal("runAppStop() expected error for not-installed app")
+	}
+	if err.Error() != "app code-server is not installed" {
+		t.Errorf("runAppStop() error = %q, want %q", err.Error(), "app code-server is not installed")
+	}
+}
+
+func TestAppStartNotInstalled(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	err := runAppStart(appStartCmd, []string{"jupyter"})
+	if err == nil {
+		t.Fatal("runAppStart() expected error for not-installed app")
+	}
+	if err.Error() != "app jupyter is not installed. Run 'citadel app install jupyter' first" {
+		t.Errorf("unexpected error: %q", err.Error())
+	}
+}
+
+func TestAppUninstallNotInstalled(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	err := runAppUninstall(appUninstallCmd, []string{"filebrowser"})
+	if err == nil {
+		t.Fatal("runAppUninstall() expected error for not-installed app")
+	}
+	if err.Error() != "app filebrowser is not installed" {
+		t.Errorf("unexpected error: %q", err.Error())
+	}
+}
+
+func TestAppInstallUnknownApp(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	err := runAppInstall(appInstallCmd, []string{"nonexistent-app"})
+	if err == nil {
+		t.Fatal("runAppInstall() expected error for unknown app")
+	}
+}
+
+func TestAppStatusEmpty(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	// Should print "no apps installed" message and not error.
+	err := runAppStatus(appStatusCmd, nil)
+	if err != nil {
+		t.Fatalf("runAppStatus() error = %v", err)
+	}
+}

--- a/internal/apps/catalog.go
+++ b/internal/apps/catalog.go
@@ -1,0 +1,134 @@
+// Package apps provides a modular app catalog for deploying developer tools
+// on Citadel nodes using Docker containers.
+package apps
+
+import "sort"
+
+// AppManifest describes a deployable application in the catalog.
+type AppManifest struct {
+	Name        string            // Unique identifier (e.g., "code-server")
+	Description string            // Human-readable description
+	Image       string            // Docker image reference
+	Ports       map[int]int       // Container port -> suggested host port
+	Volumes     []VolumeMount     // Data volumes to persist
+	Env         map[string]string // Default environment variables
+	HealthCheck *HealthCheck      // Optional health check configuration
+}
+
+// VolumeMount describes a bind-mount from the host into the container.
+type VolumeMount struct {
+	// HostPath is relative to the app's data directory (~/.citadel/apps/<name>/data/).
+	// An empty string means the data directory root.
+	HostPath      string
+	ContainerPath string
+}
+
+// HealthCheck describes how to verify an app is ready after starting.
+type HealthCheck struct {
+	// HTTPPath is a path to GET on the app's first exposed port.
+	// A 2xx or 3xx response indicates healthy.
+	HTTPPath string
+	// IntervalSeconds is the time between retries.
+	IntervalSeconds int
+	// TimeoutSeconds is the maximum time to wait for the app to become healthy.
+	TimeoutSeconds int
+}
+
+// builtinCatalog defines the apps available out of the box.
+var builtinCatalog = map[string]AppManifest{
+	"code-server": {
+		Name:        "code-server",
+		Description: "VS Code in the browser (code-server)",
+		Image:       "linuxserver/code-server:latest",
+		Ports:       map[int]int{8443: 8100},
+		Volumes: []VolumeMount{
+			{HostPath: "config", ContainerPath: "/config"},
+		},
+		Env: map[string]string{
+			"PUID": "1000",
+			"PGID": "1000",
+			"TZ":   "UTC",
+		},
+		HealthCheck: &HealthCheck{
+			HTTPPath:        "/",
+			IntervalSeconds: 2,
+			TimeoutSeconds:  60,
+		},
+	},
+	"jupyter": {
+		Name:        "jupyter",
+		Description: "Jupyter Notebook for Python development",
+		Image:       "jupyter/minimal-notebook:latest",
+		Ports:       map[int]int{8888: 8101},
+		Volumes: []VolumeMount{
+			{HostPath: "work", ContainerPath: "/home/jovyan/work"},
+		},
+		Env: map[string]string{
+			"JUPYTER_ENABLE_LAB": "yes",
+		},
+		HealthCheck: &HealthCheck{
+			HTTPPath:        "/api",
+			IntervalSeconds: 2,
+			TimeoutSeconds:  60,
+		},
+	},
+	"filebrowser": {
+		Name:        "filebrowser",
+		Description: "Web-based file manager",
+		Image:       "filebrowser/filebrowser:latest",
+		Ports:       map[int]int{80: 8102},
+		Volumes: []VolumeMount{
+			{HostPath: "data", ContainerPath: "/srv"},
+			{HostPath: "database", ContainerPath: "/database"},
+		},
+		Env: map[string]string{},
+		HealthCheck: &HealthCheck{
+			HTTPPath:        "/health",
+			IntervalSeconds: 2,
+			TimeoutSeconds:  30,
+		},
+	},
+	"ollama-webui": {
+		Name:        "ollama-webui",
+		Description: "Open WebUI for local LLM chat (connects to Ollama)",
+		Image:       "ghcr.io/open-webui/open-webui:main",
+		Ports:       map[int]int{8080: 8103},
+		Volumes: []VolumeMount{
+			{HostPath: "data", ContainerPath: "/app/backend/data"},
+		},
+		Env: map[string]string{
+			"OLLAMA_BASE_URL": "http://host.docker.internal:11434",
+		},
+		HealthCheck: &HealthCheck{
+			HTTPPath:        "/",
+			IntervalSeconds: 3,
+			TimeoutSeconds:  90,
+		},
+	},
+}
+
+// Lookup returns the AppManifest for the given name, or false if not found.
+func Lookup(name string) (AppManifest, bool) {
+	m, ok := builtinCatalog[name]
+	return m, ok
+}
+
+// List returns all app names in sorted order.
+func List() []string {
+	names := make([]string, 0, len(builtinCatalog))
+	for k := range builtinCatalog {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// All returns all app manifests keyed by name.
+func All() map[string]AppManifest {
+	// Return a copy to prevent mutation.
+	out := make(map[string]AppManifest, len(builtinCatalog))
+	for k, v := range builtinCatalog {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/apps/catalog.go
+++ b/internal/apps/catalog.go
@@ -2,7 +2,30 @@
 // on Citadel nodes using Docker containers.
 package apps
 
-import "sort"
+import (
+	"crypto/rand"
+	"math/big"
+	"sort"
+)
+
+// GeneratePassword generates a random alphanumeric password.
+func GeneratePassword(length int) (string, error) {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	result := make([]byte, length)
+	for i := range result {
+		idx, err := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
+		if err != nil {
+			return "", err
+		}
+		result[i] = charset[idx.Int64()]
+	}
+	return string(result), nil
+}
+
+// NeedsPassword returns true if the app needs a generated password at install time.
+func NeedsPassword(name string) bool {
+	return name == "code-server" || name == "filebrowser"
+}
 
 // AppManifest describes a deployable application in the catalog.
 type AppManifest struct {

--- a/internal/apps/catalog_test.go
+++ b/internal/apps/catalog_test.go
@@ -1,0 +1,93 @@
+package apps
+
+import "testing"
+
+func TestLookup(t *testing.T) {
+	tests := []struct {
+		name  string
+		found bool
+	}{
+		{"code-server", true},
+		{"jupyter", true},
+		{"filebrowser", true},
+		{"ollama-webui", true},
+		{"nonexistent", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, ok := Lookup(tt.name)
+			if ok != tt.found {
+				t.Errorf("Lookup(%q) found = %v, want %v", tt.name, ok, tt.found)
+			}
+			if ok && m.Name != tt.name {
+				t.Errorf("Lookup(%q).Name = %q, want %q", tt.name, m.Name, tt.name)
+			}
+		})
+	}
+}
+
+func TestLookupManifestFields(t *testing.T) {
+	m, ok := Lookup("code-server")
+	if !ok {
+		t.Fatal("code-server not found in catalog")
+	}
+
+	if m.Image == "" {
+		t.Error("code-server image is empty")
+	}
+	if m.Description == "" {
+		t.Error("code-server description is empty")
+	}
+	if len(m.Ports) == 0 {
+		t.Error("code-server has no port mappings")
+	}
+	if len(m.Volumes) == 0 {
+		t.Error("code-server has no volume mounts")
+	}
+	if m.HealthCheck == nil {
+		t.Error("code-server has no health check")
+	}
+}
+
+func TestList(t *testing.T) {
+	names := List()
+	if len(names) != 4 {
+		t.Errorf("List() returned %d apps, want 4", len(names))
+	}
+
+	// Verify sorted order.
+	for i := 1; i < len(names); i++ {
+		if names[i] < names[i-1] {
+			t.Errorf("List() not sorted: %q comes after %q", names[i], names[i-1])
+		}
+	}
+}
+
+func TestAll(t *testing.T) {
+	all := All()
+	if len(all) != 4 {
+		t.Errorf("All() returned %d apps, want 4", len(all))
+	}
+
+	// Verify that mutating the returned map doesn't affect the catalog.
+	delete(all, "code-server")
+	if _, ok := Lookup("code-server"); !ok {
+		t.Error("deleting from All() result affected the builtin catalog")
+	}
+}
+
+func TestAllAppsHaveRequiredFields(t *testing.T) {
+	for _, name := range List() {
+		m, _ := Lookup(name)
+		if m.Image == "" {
+			t.Errorf("app %q has empty Image", name)
+		}
+		if m.Description == "" {
+			t.Errorf("app %q has empty Description", name)
+		}
+		if len(m.Ports) == 0 {
+			t.Errorf("app %q has no port mappings", name)
+		}
+	}
+}

--- a/internal/apps/docker.go
+++ b/internal/apps/docker.go
@@ -1,0 +1,180 @@
+package apps
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// CommandRunner abstracts command execution for testability.
+type CommandRunner interface {
+	// Run executes a command and returns combined stdout+stderr and error.
+	Run(ctx context.Context, name string, args ...string) (string, error)
+}
+
+// ExecRunner is the default CommandRunner that shells out to the OS.
+type ExecRunner struct{}
+
+// Run executes a command and returns combined output.
+func (ExecRunner) Run(ctx context.Context, name string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+// DockerAvailable checks whether Docker is installed and the daemon is responsive.
+func DockerAvailable(ctx context.Context, runner CommandRunner) error {
+	_, err := runner.Run(ctx, "docker", "info")
+	if err != nil {
+		return fmt.Errorf("Docker is not available (is Docker installed and running?): %w", err)
+	}
+	return nil
+}
+
+// ContainerName returns the standardised container name for an app.
+func ContainerName(appName string) string {
+	return "citadel-app-" + appName
+}
+
+// Install pulls the image and starts a container for the given app manifest.
+// It returns the container ID on success.
+func Install(ctx context.Context, runner CommandRunner, manifest AppManifest, hostPort int, dataDir string) (string, error) {
+	containerName := ContainerName(manifest.Name)
+
+	// Build docker run arguments.
+	args := []string{
+		"run", "-d",
+		"--name", containerName,
+		"--restart", "unless-stopped",
+	}
+
+	// Port mapping: use a single host port mapped to the first container port.
+	for containerPort := range manifest.Ports {
+		args = append(args, "-p", fmt.Sprintf("%d:%d", hostPort, containerPort))
+		break // only map the first port
+	}
+
+	// Volume mounts.
+	for _, vol := range manifest.Volumes {
+		hostPath := dataDir
+		if vol.HostPath != "" {
+			hostPath = dataDir + "/" + vol.HostPath
+		}
+		args = append(args, "-v", fmt.Sprintf("%s:%s", hostPath, vol.ContainerPath))
+	}
+
+	// Environment variables.
+	for k, v := range manifest.Env {
+		args = append(args, "-e", fmt.Sprintf("%s=%s", k, v))
+	}
+
+	// Add --add-host for host.docker.internal on Linux.
+	args = append(args, "--add-host", "host.docker.internal:host-gateway")
+
+	args = append(args, manifest.Image)
+
+	output, err := runner.Run(ctx, "docker", args...)
+	if err != nil {
+		return "", fmt.Errorf("docker run failed: %s: %w", output, err)
+	}
+
+	// output is the container ID (first 12 chars from docker).
+	containerID := output
+	if len(containerID) > 12 {
+		containerID = containerID[:12]
+	}
+	return containerID, nil
+}
+
+// Stop stops a running app container.
+func Stop(ctx context.Context, runner CommandRunner, appName string) error {
+	containerName := ContainerName(appName)
+	output, err := runner.Run(ctx, "docker", "stop", containerName)
+	if err != nil {
+		return fmt.Errorf("docker stop failed: %s: %w", output, err)
+	}
+	return nil
+}
+
+// Start starts a previously stopped app container.
+func Start(ctx context.Context, runner CommandRunner, appName string) error {
+	containerName := ContainerName(appName)
+	output, err := runner.Run(ctx, "docker", "start", containerName)
+	if err != nil {
+		return fmt.Errorf("docker start failed: %s: %w", output, err)
+	}
+	return nil
+}
+
+// Uninstall stops and removes the container, then optionally removes data.
+func Uninstall(ctx context.Context, runner CommandRunner, appName string) error {
+	containerName := ContainerName(appName)
+	// Force remove (handles both running and stopped containers).
+	output, err := runner.Run(ctx, "docker", "rm", "-f", containerName)
+	if err != nil {
+		// Ignore "no such container" errors.
+		if !strings.Contains(output, "No such container") &&
+			!strings.Contains(strings.ToLower(output), "no such container") {
+			return fmt.Errorf("docker rm failed: %s: %w", output, err)
+		}
+	}
+	return nil
+}
+
+// ContainerStatus returns "running", "exited", or "not_found" for a container.
+func ContainerStatus(ctx context.Context, runner CommandRunner, appName string) string {
+	containerName := ContainerName(appName)
+	output, err := runner.Run(ctx, "docker", "inspect",
+		"--format", "{{.State.Status}}", containerName)
+	if err != nil {
+		return "not_found"
+	}
+	status := strings.TrimSpace(output)
+	if status == "" {
+		return "not_found"
+	}
+	return status
+}
+
+// WaitHealthy polls the app's health check endpoint until it responds or times out.
+func WaitHealthy(ctx context.Context, manifest AppManifest, hostPort int) error {
+	if manifest.HealthCheck == nil {
+		// No health check configured; wait a fixed 3 seconds.
+		select {
+		case <-time.After(3 * time.Second):
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	hc := manifest.HealthCheck
+	interval := time.Duration(hc.IntervalSeconds) * time.Second
+	timeout := time.Duration(hc.TimeoutSeconds) * time.Second
+
+	deadline := time.Now().Add(timeout)
+	url := fmt.Sprintf("http://localhost:%d%s", hostPort, hc.HTTPPath)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(url)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode >= 200 && resp.StatusCode < 400 {
+				return nil
+			}
+		}
+
+		select {
+		case <-time.After(interval):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	return fmt.Errorf("app %s did not become healthy within %s", manifest.Name, timeout)
+}

--- a/internal/apps/docker.go
+++ b/internal/apps/docker.go
@@ -53,7 +53,7 @@ func Install(ctx context.Context, runner CommandRunner, manifest AppManifest, ho
 
 	// Port mapping: use a single host port mapped to the first container port.
 	for containerPort := range manifest.Ports {
-		args = append(args, "-p", fmt.Sprintf("%d:%d", hostPort, containerPort))
+		args = append(args, "-p", fmt.Sprintf("127.0.0.1:%d:%d", hostPort, containerPort))
 		break // only map the first port
 	}
 

--- a/internal/apps/docker_test.go
+++ b/internal/apps/docker_test.go
@@ -1,0 +1,238 @@
+package apps
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// mockRunner records commands and returns pre-configured responses.
+type mockRunner struct {
+	calls   []string
+	results map[string]mockResult
+}
+
+type mockResult struct {
+	output string
+	err    error
+}
+
+func newMockRunner() *mockRunner {
+	return &mockRunner{
+		results: make(map[string]mockResult),
+	}
+}
+
+func (m *mockRunner) Run(_ context.Context, name string, args ...string) (string, error) {
+	cmd := name + " " + strings.Join(args, " ")
+	m.calls = append(m.calls, cmd)
+
+	// Match by prefix for flexible assertions.
+	for prefix, result := range m.results {
+		if strings.HasPrefix(cmd, prefix) {
+			return result.output, result.err
+		}
+	}
+	return "", nil
+}
+
+func (m *mockRunner) setResult(prefix, output string, err error) {
+	m.results[prefix] = mockResult{output: output, err: err}
+}
+
+func (m *mockRunner) lastCall() string {
+	if len(m.calls) == 0 {
+		return ""
+	}
+	return m.calls[len(m.calls)-1]
+}
+
+func (m *mockRunner) callCount() int {
+	return len(m.calls)
+}
+
+func TestDockerAvailable(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("docker available", func(t *testing.T) {
+		runner := newMockRunner()
+		runner.setResult("docker info", "ok", nil)
+		if err := DockerAvailable(ctx, runner); err != nil {
+			t.Errorf("DockerAvailable() error = %v, want nil", err)
+		}
+	})
+
+	t.Run("docker not available", func(t *testing.T) {
+		runner := newMockRunner()
+		runner.setResult("docker info", "", fmt.Errorf("not found"))
+		if err := DockerAvailable(ctx, runner); err == nil {
+			t.Error("DockerAvailable() expected error when docker is missing")
+		}
+	})
+}
+
+func TestInstall(t *testing.T) {
+	ctx := context.Background()
+	runner := newMockRunner()
+	runner.setResult("docker run", "abc123def456", nil)
+
+	manifest := AppManifest{
+		Name:  "test-app",
+		Image: "test/image:latest",
+		Ports: map[int]int{8080: 8100},
+		Volumes: []VolumeMount{
+			{HostPath: "data", ContainerPath: "/data"},
+		},
+		Env: map[string]string{"FOO": "bar"},
+	}
+
+	containerID, err := Install(ctx, runner, manifest, 8100, "/tmp/test-data")
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+
+	if containerID != "abc123def456" {
+		t.Errorf("Install() containerID = %q, want %q", containerID, "abc123def456")
+	}
+
+	// Verify the docker run command was called.
+	if runner.callCount() != 1 {
+		t.Fatalf("expected 1 call, got %d", runner.callCount())
+	}
+
+	call := runner.calls[0]
+	if !strings.Contains(call, "docker run") {
+		t.Error("expected docker run command")
+	}
+	if !strings.Contains(call, "--name citadel-app-test-app") {
+		t.Errorf("expected container name in call: %s", call)
+	}
+	if !strings.Contains(call, "test/image:latest") {
+		t.Errorf("expected image in call: %s", call)
+	}
+	if !strings.Contains(call, "-e FOO=bar") {
+		t.Errorf("expected env var in call: %s", call)
+	}
+}
+
+func TestInstallError(t *testing.T) {
+	ctx := context.Background()
+	runner := newMockRunner()
+	runner.setResult("docker run", "error: something failed", fmt.Errorf("exit 1"))
+
+	manifest := AppManifest{
+		Name:  "test-app",
+		Image: "test/image:latest",
+		Ports: map[int]int{8080: 8100},
+	}
+
+	_, err := Install(ctx, runner, manifest, 8100, "/tmp/test-data")
+	if err == nil {
+		t.Fatal("Install() expected error")
+	}
+}
+
+func TestStop(t *testing.T) {
+	ctx := context.Background()
+	runner := newMockRunner()
+	runner.setResult("docker stop", "", nil)
+
+	if err := Stop(ctx, runner, "test-app"); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+
+	if !strings.Contains(runner.lastCall(), "docker stop citadel-app-test-app") {
+		t.Errorf("unexpected command: %s", runner.lastCall())
+	}
+}
+
+func TestStart(t *testing.T) {
+	ctx := context.Background()
+	runner := newMockRunner()
+	runner.setResult("docker start", "", nil)
+
+	if err := Start(ctx, runner, "test-app"); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	if !strings.Contains(runner.lastCall(), "docker start citadel-app-test-app") {
+		t.Errorf("unexpected command: %s", runner.lastCall())
+	}
+}
+
+func TestUninstall(t *testing.T) {
+	ctx := context.Background()
+	runner := newMockRunner()
+	runner.setResult("docker rm", "", nil)
+
+	if err := Uninstall(ctx, runner, "test-app"); err != nil {
+		t.Fatalf("Uninstall() error = %v", err)
+	}
+
+	call := runner.lastCall()
+	if !strings.Contains(call, "docker rm -f citadel-app-test-app") {
+		t.Errorf("unexpected command: %s", call)
+	}
+}
+
+func TestUninstallIgnoresNoSuchContainer(t *testing.T) {
+	ctx := context.Background()
+	runner := newMockRunner()
+	runner.setResult("docker rm", "Error: No such container: citadel-app-test-app", fmt.Errorf("exit 1"))
+
+	// Should not return error for "no such container".
+	if err := Uninstall(ctx, runner, "test-app"); err != nil {
+		t.Fatalf("Uninstall() should not error for missing container: %v", err)
+	}
+}
+
+func TestContainerStatus(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("running", func(t *testing.T) {
+		runner := newMockRunner()
+		runner.setResult("docker inspect", "running", nil)
+		status := ContainerStatus(ctx, runner, "test-app")
+		if status != "running" {
+			t.Errorf("ContainerStatus() = %q, want %q", status, "running")
+		}
+	})
+
+	t.Run("exited", func(t *testing.T) {
+		runner := newMockRunner()
+		runner.setResult("docker inspect", "exited", nil)
+		status := ContainerStatus(ctx, runner, "test-app")
+		if status != "exited" {
+			t.Errorf("ContainerStatus() = %q, want %q", status, "exited")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		runner := newMockRunner()
+		runner.setResult("docker inspect", "", fmt.Errorf("not found"))
+		status := ContainerStatus(ctx, runner, "test-app")
+		if status != "not_found" {
+			t.Errorf("ContainerStatus() = %q, want %q", status, "not_found")
+		}
+	})
+}
+
+func TestContainerNameFormat(t *testing.T) {
+	tests := []struct {
+		app  string
+		want string
+	}{
+		{"code-server", "citadel-app-code-server"},
+		{"jupyter", "citadel-app-jupyter"},
+		{"filebrowser", "citadel-app-filebrowser"},
+		{"ollama-webui", "citadel-app-ollama-webui"},
+	}
+
+	for _, tt := range tests {
+		got := ContainerName(tt.app)
+		if got != tt.want {
+			t.Errorf("ContainerName(%q) = %q, want %q", tt.app, got, tt.want)
+		}
+	}
+}

--- a/internal/apps/state.go
+++ b/internal/apps/state.go
@@ -1,0 +1,174 @@
+package apps
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// InstalledApp records the runtime state of a deployed app.
+type InstalledApp struct {
+	Name        string `json:"name"`
+	Image       string `json:"image"`
+	ContainerID string `json:"container_id"`
+	HostPort    int    `json:"host_port"`
+}
+
+// State persists the set of installed apps and their port assignments.
+type State struct {
+	Apps map[string]InstalledApp `json:"apps"`
+
+	mu   sync.RWMutex
+	path string
+}
+
+// appsBaseDir returns ~/.citadel/apps.
+func appsBaseDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+	return filepath.Join(home, ".citadel", "apps"), nil
+}
+
+// statePath returns the path to the state file.
+func statePath() (string, error) {
+	base, err := appsBaseDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "state.json"), nil
+}
+
+// AppDir returns the root directory for a specific app (~/.citadel/apps/<name>/).
+func AppDir(appName string) (string, error) {
+	base, err := appsBaseDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, appName), nil
+}
+
+// AppDataDir returns the data directory for a specific app.
+func AppDataDir(appName string) (string, error) {
+	appDir, err := AppDir(appName)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(appDir, "data"), nil
+}
+
+// LoadState reads the state file from disk. If the file does not exist,
+// an empty state is returned.
+func LoadState() (*State, error) {
+	p, err := statePath()
+	if err != nil {
+		return nil, err
+	}
+
+	s := &State{
+		Apps: make(map[string]InstalledApp),
+		path: p,
+	}
+
+	data, err := os.ReadFile(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return s, nil
+		}
+		return nil, fmt.Errorf("failed to read state file: %w", err)
+	}
+
+	if err := json.Unmarshal(data, &s.Apps); err != nil {
+		return nil, fmt.Errorf("failed to parse state file: %w", err)
+	}
+	return s, nil
+}
+
+// Save writes the state to disk atomically.
+func (s *State) Save() error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	dir := filepath.Dir(s.path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create state directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(s.Apps, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal state: %w", err)
+	}
+
+	// Write to temp file then rename for atomicity.
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return fmt.Errorf("failed to write state file: %w", err)
+	}
+	if err := os.Rename(tmp, s.path); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("failed to finalize state file: %w", err)
+	}
+	return nil
+}
+
+// Get returns the InstalledApp for the given name, or false if not installed.
+func (s *State) Get(name string) (InstalledApp, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	app, ok := s.Apps[name]
+	return app, ok
+}
+
+// Set records an installed app.
+func (s *State) Set(app InstalledApp) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Apps[app.Name] = app
+}
+
+// Remove deletes an app from the state.
+func (s *State) Remove(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.Apps, name)
+}
+
+// InstalledNames returns the names of all installed apps in no particular order.
+func (s *State) InstalledNames() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	names := make([]string, 0, len(s.Apps))
+	for k := range s.Apps {
+		names = append(names, k)
+	}
+	return names
+}
+
+// portRange defines the auto-allocation range for app host ports.
+const (
+	portRangeStart = 8100
+	portRangeEnd   = 8199
+)
+
+// AllocatePort returns the next available port in the 8100-8199 range
+// that is not already used by an installed app. It returns an error
+// if the range is exhausted.
+func (s *State) AllocatePort() (int, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	used := make(map[int]bool, len(s.Apps))
+	for _, app := range s.Apps {
+		used[app.HostPort] = true
+	}
+
+	for port := portRangeStart; port <= portRangeEnd; port++ {
+		if !used[port] {
+			return port, nil
+		}
+	}
+	return 0, fmt.Errorf("no available ports in range %d-%d", portRangeStart, portRangeEnd)
+}

--- a/internal/apps/state_test.go
+++ b/internal/apps/state_test.go
@@ -1,0 +1,164 @@
+package apps
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStateRoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	stateFile := filepath.Join(tmpDir, "state.json")
+
+	s := &State{
+		Apps: make(map[string]InstalledApp),
+		path: stateFile,
+	}
+
+	// Set an app.
+	s.Set(InstalledApp{
+		Name:        "code-server",
+		Image:       "linuxserver/code-server:latest",
+		ContainerID: "abc123",
+		HostPort:    8100,
+	})
+
+	if err := s.Save(); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	// Verify the file exists.
+	if _, err := os.Stat(stateFile); err != nil {
+		t.Fatalf("state file does not exist after Save: %v", err)
+	}
+
+	// Load it back by reading the file manually (simulating LoadState).
+	s2 := &State{
+		Apps: make(map[string]InstalledApp),
+		path: stateFile,
+	}
+	data, err := os.ReadFile(stateFile)
+	if err != nil {
+		t.Fatalf("failed to read state file: %v", err)
+	}
+
+	if len(data) == 0 {
+		t.Fatal("state file is empty")
+	}
+
+	// Verify the Get method.
+	app, ok := s.Get("code-server")
+	if !ok {
+		t.Fatal("Get(code-server) returned false")
+	}
+	if app.HostPort != 8100 {
+		t.Errorf("Get(code-server).HostPort = %d, want 8100", app.HostPort)
+	}
+	if app.ContainerID != "abc123" {
+		t.Errorf("Get(code-server).ContainerID = %q, want %q", app.ContainerID, "abc123")
+	}
+
+	// Verify Get for non-existent.
+	_, ok = s2.Get("nonexistent")
+	if ok {
+		t.Error("Get(nonexistent) should return false")
+	}
+}
+
+func TestStateRemove(t *testing.T) {
+	s := &State{
+		Apps: make(map[string]InstalledApp),
+		path: filepath.Join(t.TempDir(), "state.json"),
+	}
+
+	s.Set(InstalledApp{Name: "test-app", HostPort: 8100})
+	s.Remove("test-app")
+
+	if _, ok := s.Get("test-app"); ok {
+		t.Error("app should be removed after Remove()")
+	}
+}
+
+func TestStateInstalledNames(t *testing.T) {
+	s := &State{
+		Apps: make(map[string]InstalledApp),
+		path: filepath.Join(t.TempDir(), "state.json"),
+	}
+
+	s.Set(InstalledApp{Name: "app1", HostPort: 8100})
+	s.Set(InstalledApp{Name: "app2", HostPort: 8101})
+
+	names := s.InstalledNames()
+	if len(names) != 2 {
+		t.Errorf("InstalledNames() returned %d, want 2", len(names))
+	}
+}
+
+func TestAllocatePort(t *testing.T) {
+	s := &State{
+		Apps: make(map[string]InstalledApp),
+		path: filepath.Join(t.TempDir(), "state.json"),
+	}
+
+	// First allocation should return portRangeStart.
+	port, err := s.AllocatePort()
+	if err != nil {
+		t.Fatalf("AllocatePort() error: %v", err)
+	}
+	if port != portRangeStart {
+		t.Errorf("AllocatePort() = %d, want %d", port, portRangeStart)
+	}
+
+	// After setting an app on portRangeStart, next should be portRangeStart+1.
+	s.Set(InstalledApp{Name: "app1", HostPort: portRangeStart})
+	port, err = s.AllocatePort()
+	if err != nil {
+		t.Fatalf("AllocatePort() error: %v", err)
+	}
+	if port != portRangeStart+1 {
+		t.Errorf("AllocatePort() = %d, want %d", port, portRangeStart+1)
+	}
+}
+
+func TestAllocatePortExhausted(t *testing.T) {
+	s := &State{
+		Apps: make(map[string]InstalledApp),
+		path: filepath.Join(t.TempDir(), "state.json"),
+	}
+
+	// Fill the entire port range.
+	for i := portRangeStart; i <= portRangeEnd; i++ {
+		s.Set(InstalledApp{
+			Name:     "app" + string(rune('a'+i-portRangeStart)),
+			HostPort: i,
+		})
+	}
+
+	_, err := s.AllocatePort()
+	if err == nil {
+		t.Error("AllocatePort() should return error when range is exhausted")
+	}
+}
+
+func TestLoadStateEmpty(t *testing.T) {
+	// Override home dir to a temp dir so LoadState creates a fresh state.
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	state, err := LoadState()
+	if err != nil {
+		t.Fatalf("LoadState() error: %v", err)
+	}
+
+	if len(state.Apps) != 0 {
+		t.Errorf("LoadState() returned %d apps, want 0", len(state.Apps))
+	}
+}
+
+func TestContainerName(t *testing.T) {
+	name := ContainerName("code-server")
+	expected := "citadel-app-code-server"
+	if name != expected {
+		t.Errorf("ContainerName() = %q, want %q", name, expected)
+	}
+}

--- a/internal/status/collector.go
+++ b/internal/status/collector.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aceteam-ai/citadel-cli/internal/apps"
 	"github.com/aceteam-ai/citadel-cli/internal/desktop"
 	"github.com/aceteam-ai/citadel-cli/internal/network"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
@@ -78,6 +79,9 @@ func (c *Collector) Collect() (*NodeStatus, error) {
 
 	// Collect service status
 	status.Services = c.collectServiceStatus()
+
+	// Collect installed app status
+	status.Apps = c.collectAppStatus()
 
 	// Include cached capabilities if available
 	status.Capabilities = c.capabilities
@@ -322,6 +326,33 @@ func InferServiceType(serviceName string) string {
 	}
 
 	return ServiceTypeOther
+}
+
+// collectAppStatus queries installed catalog apps for their Docker container status.
+func (c *Collector) collectAppStatus() []AppInfo {
+	state, err := apps.LoadState()
+	if err != nil {
+		return nil
+	}
+
+	if len(state.Apps) == 0 {
+		return nil
+	}
+
+	ctx := context.Background()
+	runner := apps.ExecRunner{}
+	result := make([]AppInfo, 0, len(state.Apps))
+
+	for _, installed := range state.Apps {
+		dockerStatus := apps.ContainerStatus(ctx, runner, installed.Name)
+		result = append(result, AppInfo{
+			Name:   installed.Name,
+			Status: dockerStatus,
+			Port:   installed.HostPort,
+		})
+	}
+
+	return result
 }
 
 // InferServicePort attempts to determine port from service name.

--- a/internal/status/types.go
+++ b/internal/status/types.go
@@ -24,9 +24,17 @@ type NodeStatus struct {
 	System       SystemMetrics         `json:"system"`
 	GPU          []GPUMetrics          `json:"gpu,omitempty"`
 	Services     []ServiceInfo         `json:"services,omitempty"`
+	Apps         []AppInfo             `json:"apps,omitempty"`
 	Capabilities *NodeCapabilities     `json:"capabilities,omitempty"`
 	Desktop      *desktop.Capabilities `json:"desktop,omitempty"`
 	VNCPort      int                   `json:"vnc_port"`
+}
+
+// AppInfo contains information about an installed catalog app.
+type AppInfo struct {
+	Name   string `json:"name"`
+	Status string `json:"status"` // "running", "stopped", "not_found"
+	Port   int    `json:"port,omitempty"`
 }
 
 // NodeCapabilities describes the GPU and inference engine capabilities of a node.


### PR DESCRIPTION
## Summary

Users want to deploy common developer tools on their Citadel nodes. This PR adds a modular app catalog that uses Docker containers under the hood, giving users one-command access to:

- **code-server** -- VS Code in the browser (linuxserver/code-server)
- **jupyter** -- Jupyter Notebook for Python development (jupyter/minimal-notebook)  
- **filebrowser** -- web-based file manager (filebrowser/filebrowser)
- **ollama-webui** -- Open WebUI for local LLM chat (ghcr.io/open-webui/open-webui)

### New CLI commands

```
citadel app list                    # Show available apps with status
citadel app install <name>          # Deploy an app
citadel app status                  # Show running apps and their ports
citadel app start <name>            # Start a previously stopped app
citadel app stop <name>             # Stop a running app
citadel app uninstall <name>        # Remove app, container, and data
citadel app uninstall <name> --keep-data  # Remove app but preserve data
```

### Architecture

- **`internal/apps/catalog.go`** -- `AppManifest` struct and built-in catalog (4 apps with image, ports, volumes, env, health check)
- **`internal/apps/state.go`** -- `State` struct persisted to `~/.citadel/apps/state.json` tracking installed apps, container IDs, and port assignments
- **`internal/apps/docker.go`** -- Docker integration via `CommandRunner` interface (abstracts `docker run/stop/start/rm/inspect` for testability)
- **`cmd/app.go`** -- Cobra command tree (`app list|install|status|start|stop|uninstall`)
- **`internal/status/types.go`** -- New `AppInfo` type and `Apps` field on `NodeStatus` for heartbeat reporting
- **`internal/status/collector.go`** -- `collectAppStatus()` queries installed apps' Docker container status

### Key design decisions

- **`docker run` over Docker Compose** -- simpler, no compose file management; each app is a single container
- **Port auto-allocation (8100-8199)** -- avoids conflicts between apps; ports are tracked in state.json
- **`CommandRunner` interface** -- all Docker CLI calls go through an interface so tests use a mock runner (no Docker required in CI)
- **Heartbeat integration** -- installed apps automatically appear in the `apps` field of the NodeStatus payload so the platform can show them on the Fabric page

## Test plan

| Area | Tests | Coverage |
|------|-------|----------|
| Catalog lookup | 5 apps (4 found + 1 not-found), field validation, sorted list | `catalog_test.go` |
| State management | Round-trip save/load, remove, installed names, port allocation, exhaustion | `state_test.go` |
| Docker commands | Install, stop, start, uninstall, container status, error cases, mock runner | `docker_test.go` |
| Full suite | `go test ./...` passes (all existing + new tests) | All packages |
| Build verification | `go build -o /tmp/citadel ./cmd/citadel/` compiles cleanly | Binary |
| Manual verification needed | `citadel app list` and `citadel app install code-server` on a machine with Docker | User |

> **Note:** The `jupyter/minimal-notebook` image boots with a login token. Users need to check `docker logs citadel-app-jupyter` to get the token URL. This is standard Jupyter behavior and not something we should suppress.

## Related

- Closes #3473