### PR TITLE
fix: filebrowser container crash on /database permission denied

### DIFF
--- a/internal/apps/catalog.go
+++ b/internal/apps/catalog.go
@@ -102,11 +102,12 @@ var builtinCatalog = map[string]AppManifest{
 		Ports:       map[int]int{80: 8102},
 		Volumes: []VolumeMount{
 			{HostPath: "data", ContainerPath: "/srv"},
-			{HostPath: "database", ContainerPath: "/database"},
 		},
-		Env: map[string]string{},
+		Env: map[string]string{
+			"FB_DATABASE": "/srv/filebrowser.db",
+		},
 		HealthCheck: &HealthCheck{
-			HTTPPath:        "/health",
+			HTTPPath:        "/",
 			IntervalSeconds: 2,
 			TimeoutSeconds:  30,
 		},


### PR DESCRIPTION
## Context

Fixes aceteam-ai/aceteam#3482. When running `citadel app install filebrowser`, the container enters a restart loop with:

```
Error: open /database/filebrowser.db: permission denied
```

The root cause is that the bind-mounted `/database` directory is owned by the host UID, but filebrowser inside the container runs as a different UID and cannot write to it.

## Summary

- **Relocate database to writable volume**: Set `FB_DATABASE=/srv/filebrowser.db` so the SQLite database lives inside the already-writable `/srv` volume mount. This eliminates the separate `/database` volume entirely -- no extra directory to manage, no UID mismatch.
- **Fix health check path**: Changed from `/health` (which does not exist in filebrowser) to `/` (the app root, which returns 200 when the server is ready).

## Test plan

- [x] `go test ./internal/apps/ -v` -- all 22 tests pass
- [x] `go test ./...` -- full suite passes (all packages OK)
- [x] `go vet ./internal/apps/` -- clean
- [x] `GOOS=linux GOARCH=amd64 go build -o /tmp/citadel-test ./cmd/citadel/` -- builds successfully
- [ ] Manual: `citadel app install filebrowser` on a Linux node -- container should start without restart loop

---
*Generated by Claude*