### PR TITLE
feat: HTTP_PROXY job handler

### DIFF
--- a/internal/jobs/http_proxy.go
+++ b/internal/jobs/http_proxy.go
@@ -1,0 +1,70 @@
+// internal/jobs/http_proxy.go
+package jobs
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+type HTTPProxyHandler struct{}
+
+func (h *HTTPProxyHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	url, ok := job.Payload["url"]
+	if !ok {
+		return nil, fmt.Errorf("job payload missing 'url' field")
+	}
+	method := job.Payload["method"]
+	if method == "" {
+		method = "GET"
+	}
+
+	ctx.Log("info", "     - [Job %s] HTTP %s %s", job.ID, method, url)
+
+	var bodyReader io.Reader
+	if body, ok := job.Payload["body"]; ok && body != "" {
+		bodyReader = bytes.NewBufferString(body)
+	}
+
+	req, err := http.NewRequest(method, url, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	if headersJSON, ok := job.Payload["headers"]; ok && headersJSON != "" {
+		var headers map[string]string
+		if err := json.Unmarshal([]byte(headersJSON), &headers); err != nil {
+			return nil, fmt.Errorf("failed to parse headers: %w", err)
+		}
+		for k, v := range headers {
+			req.Header.Set(k, v)
+		}
+	}
+
+	if req.Header.Get("Content-Type") == "" && bodyReader != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	result := map[string]any{
+		"status_code": resp.StatusCode,
+		"body":        string(respBody),
+	}
+	return json.Marshal(result)
+}

--- a/internal/jobs/http_proxy.go
+++ b/internal/jobs/http_proxy.go
@@ -57,7 +57,7 @@ func (h *HTTPProxyHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, erro
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -101,6 +101,7 @@ func CreateLegacyHandlers(logFn ...func(level, msg string)) []JobHandler {
 		NewLegacyHandlerAdapter(JobTypeOllamaInference, &jobs.OllamaInferenceHandler{}),
 		NewLegacyHandlerAdapter(JobTypeApplyDeviceConfig, jobs.NewConfigHandler("")),
 		NewLegacyHandlerAdapter(JobTypeExtraction, &jobs.ExtractionHandler{}),
+		NewLegacyHandlerAdapter(JobTypeHTTPProxy, &jobs.HTTPProxyHandler{}),
 	}
 
 	// Set log function on all handlers

--- a/internal/worker/job.go
+++ b/internal/worker/job.go
@@ -105,4 +105,5 @@ const (
 	JobTypeEmbedding         = "embedding"           // Redis worker format
 	JobTypeApplyDeviceConfig = "APPLY_DEVICE_CONFIG" // Device config from onboarding
 	JobTypeExtraction        = "GLINER_EXTRACTION"   // Entity/relation extraction via GLiNER2
+	JobTypeHTTPProxy         = "HTTP_PROXY"          // Proxy HTTP requests through the local node
 )


### PR DESCRIPTION
## Summary
- New `HTTP_PROXY` job type for proxying HTTP requests through local Citadel nodes
- Handler takes `url`, `method`, `headers` (JSON), `body` from job payload
- Returns `{status_code, body}` JSON via the standard job result path
- 10MB response body limit via `io.LimitReader`

## Why
Railway MCP services can't reach the WeChat API (or other local services) directly -- DERP relay TCP times out. Citadel on the same LAN can make the request and return results through the Redis queue.

## Test plan
- [x] `go build` passes
- [ ] Deploy to aceteamvm, test `wechat_health` via MCP

---
*Generated by Claude*