### PR TITLE
feat(jobs): add file operation handlers for agent workspace access

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -911,8 +911,12 @@ func runTUIWorker(ctx context.Context, activityFn func(level, msg string)) error
 	// Create worker ID
 	workerID := fmt.Sprintf("citadel-tui-%s", uuid.New().String()[:8])
 
-	// Create handlers with activity callback to route job output through TUI
-	handlers := worker.CreateLegacyHandlers(activity)
+	// Create handlers with activity callback to route job output through TUI.
+	wsDir := resolveWorkspaceDir()
+	handlers := worker.CreateLegacyHandlersWithOpts(worker.LegacyHandlerOpts{
+		LogFn:        activity,
+		WorkspaceDir: wsDir,
+	})
 
 	// Create runner with TUI callbacks
 	runner := worker.NewRunner(source, handlers, worker.RunnerConfig{

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -73,6 +73,9 @@ var (
 
 	// Concurrency flag
 	workMaxConcurrency int
+
+	// Workspace directory for file-operation handlers
+	workWorkspaceDir string
 )
 
 var workCmd = &cobra.Command{
@@ -719,8 +722,11 @@ func runWork(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	// Create handlers (use legacy adapters for now)
-	handlers := worker.CreateLegacyHandlers()
+	// Create handlers with optional workspace for file-operation jobs.
+	wsDir := resolveWorkspaceDir()
+	handlers := worker.CreateLegacyHandlersWithOpts(worker.LegacyHandlerOpts{
+		WorkspaceDir: wsDir,
+	})
 
 	// Build job record function for usage tracking
 	var jobRecordFn func(record usage.UsageRecord)
@@ -830,6 +836,34 @@ func getRedisURLFromConfig() string {
 		return ""
 	}
 	return config.RedisURL
+}
+
+// resolveWorkspaceDir returns the sandbox directory for file-operation handlers.
+// Priority: --workspace flag > CITADEL_WORKSPACE env > ~/citadel-node/workspace default.
+// Returns empty string if the directory cannot be resolved or created.
+func resolveWorkspaceDir() string {
+	dir := workWorkspaceDir
+	if dir == "" {
+		dir = os.Getenv("CITADEL_WORKSPACE")
+	}
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		dir = filepath.Join(home, "citadel-node", "workspace")
+	}
+	// Ensure the directory exists.
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		fmt.Fprintf(os.Stderr, "   - Warning: cannot create workspace dir %s: %v\n", dir, err)
+		return ""
+	}
+	// Resolve to absolute path (handles relative flag values).
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return dir
+	}
+	return abs
 }
 
 // DeviceConfig holds device authentication configuration from the global config file.
@@ -1019,4 +1053,7 @@ func init() {
 
 	// Concurrency flags
 	workCmd.Flags().IntVar(&workMaxConcurrency, "max-concurrency", 0, "Maximum concurrent jobs (0 = auto-detect from GPU count)")
+
+	// Workspace flags
+	workCmd.Flags().StringVar(&workWorkspaceDir, "workspace", "", "Workspace directory for file-operation jobs (or set CITADEL_WORKSPACE env)")
 }

--- a/internal/jobs/file_edit.go
+++ b/internal/jobs/file_edit.go
@@ -1,0 +1,153 @@
+// internal/jobs/file_edit.go
+package jobs
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+// FileEditHandler handles FILE_EDIT jobs.
+// It performs exact string replacement within a file, similar to Claude Code's
+// Edit tool. By default the old_string must appear exactly once; set
+// replace_all to replace every occurrence.
+type FileEditHandler struct {
+	WorkspaceDir string
+}
+
+// NewFileEditHandler creates a new FileEditHandler rooted at workspace.
+func NewFileEditHandler(workspace string) *FileEditHandler {
+	return &FileEditHandler{WorkspaceDir: workspace}
+}
+
+// Execute performs string replacement in the requested file.
+//
+// Payload fields (all strings via nexus.Job):
+//   - path: absolute or workspace-relative path to edit
+//   - old_string: the exact text to find
+//   - new_string: the replacement text
+//   - replace_all: "true" to replace all occurrences (default "false")
+func (h *FileEditHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	path, ok := job.Payload["path"]
+	if !ok || path == "" {
+		return nil, fmt.Errorf("job payload missing 'path' field")
+	}
+
+	oldStr, ok := job.Payload["old_string"]
+	if !ok {
+		return nil, fmt.Errorf("job payload missing 'old_string' field")
+	}
+	if oldStr == "" {
+		return nil, fmt.Errorf("old_string must not be empty")
+	}
+
+	newStr := job.Payload["new_string"] // May be empty (deletion).
+
+	replaceAll := false
+	if v, ok := job.Payload["replace_all"]; ok && v != "" {
+		replaceAll, _ = strconv.ParseBool(v)
+	}
+
+	validated, err := ValidatePath(h.WorkspaceDir, path)
+	if err != nil {
+		return nil, fmt.Errorf("path validation failed: %w", err)
+	}
+
+	ctx.Log("info", "     - [Job %s] FILE_EDIT %s (replace_all=%v)", job.ID, validated, replaceAll)
+
+	data, err := os.ReadFile(validated)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	content := string(data)
+	count := strings.Count(content, oldStr)
+
+	if count == 0 {
+		return nil, fmt.Errorf("old_string not found in file")
+	}
+	if count > 1 && !replaceAll {
+		return nil, fmt.Errorf("old_string found %d times; use replace_all=true or provide more context to make it unique", count)
+	}
+
+	var newContent string
+	if replaceAll {
+		newContent = strings.ReplaceAll(content, oldStr, newStr)
+	} else {
+		newContent = strings.Replace(content, oldStr, newStr, 1)
+	}
+
+	if err := os.WriteFile(validated, []byte(newContent), 0644); err != nil {
+		return nil, fmt.Errorf("failed to write file: %w", err)
+	}
+
+	// Provide context around the edit: find the line range of the replacement.
+	lines := strings.Split(newContent, "\n")
+	editStart, editEnd := findEditContext(lines, newStr, 3)
+
+	var sb strings.Builder
+	for i := editStart; i <= editEnd && i < len(lines); i++ {
+		fmt.Fprintf(&sb, "%6d\t%s\n", i+1, lines[i])
+	}
+
+	result := map[string]any{
+		"path":          validated,
+		"replacements":  count,
+		"context":       sb.String(),
+	}
+	return json.Marshal(result)
+}
+
+// findEditContext returns line indices (0-based) that provide context lines
+// around the first occurrence of needle in the given lines.
+func findEditContext(lines []string, needle string, contextLines int) (int, int) {
+	joined := ""
+	lineStarts := make([]int, len(lines))
+	for i, line := range lines {
+		lineStarts[i] = len(joined)
+		joined += line
+		if i < len(lines)-1 {
+			joined += "\n"
+		}
+	}
+
+	idx := strings.Index(joined, needle)
+	if idx < 0 {
+		// Fallback: show first few lines.
+		end := contextLines*2 + 1
+		if end >= len(lines) {
+			end = len(lines) - 1
+		}
+		return 0, end
+	}
+
+	// Find which line the match starts on.
+	matchLine := 0
+	for i, start := range lineStarts {
+		if start > idx {
+			break
+		}
+		matchLine = i
+	}
+
+	start := matchLine - contextLines
+	if start < 0 {
+		start = 0
+	}
+
+	// Estimate the end line from needle length.
+	needleLines := strings.Count(needle, "\n")
+	end := matchLine + needleLines + contextLines
+	if end >= len(lines) {
+		end = len(lines) - 1
+	}
+
+	return start, end
+}
+
+// Ensure FileEditHandler implements JobHandler.
+var _ JobHandler = (*FileEditHandler)(nil)

--- a/internal/jobs/file_list.go
+++ b/internal/jobs/file_list.go
@@ -1,0 +1,120 @@
+// internal/jobs/file_list.go
+package jobs
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+// FileListHandler handles FILE_LIST jobs.
+// It lists directory contents within the configured workspace, optionally
+// filtering by a glob pattern.
+type FileListHandler struct {
+	WorkspaceDir string
+}
+
+// NewFileListHandler creates a new FileListHandler rooted at workspace.
+func NewFileListHandler(workspace string) *FileListHandler {
+	return &FileListHandler{WorkspaceDir: workspace}
+}
+
+// fileEntry represents one item in a directory listing.
+type fileEntry struct {
+	Name  string `json:"name"`
+	Type  string `json:"type"` // "file", "dir", "symlink"
+	Size  int64  `json:"size"`
+	Mode  string `json:"mode"`
+}
+
+// maxListResults caps directory listings to prevent huge responses.
+const maxListResults = 5000
+
+// Execute lists the contents of the requested directory.
+//
+// Payload fields (all strings via nexus.Job):
+//   - path: absolute or workspace-relative directory path
+//   - pattern: optional glob pattern to filter entries (e.g. "*.go")
+func (h *FileListHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	path, ok := job.Payload["path"]
+	if !ok || path == "" {
+		return nil, fmt.Errorf("job payload missing 'path' field")
+	}
+
+	pattern := job.Payload["pattern"] // May be empty.
+
+	validated, err := ValidatePath(h.WorkspaceDir, path)
+	if err != nil {
+		return nil, fmt.Errorf("path validation failed: %w", err)
+	}
+
+	info, err := os.Stat(validated)
+	if err != nil {
+		return nil, fmt.Errorf("cannot stat path: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("path is not a directory: %s", validated)
+	}
+
+	ctx.Log("info", "     - [Job %s] FILE_LIST %s (pattern=%q)", job.ID, validated, pattern)
+
+	entries, err := os.ReadDir(validated)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read directory: %w", err)
+	}
+
+	var results []fileEntry
+	for _, entry := range entries {
+		name := entry.Name()
+
+		// Apply glob filter if provided.
+		if pattern != "" {
+			matched, err := filepath.Match(pattern, name)
+			if err != nil {
+				return nil, fmt.Errorf("invalid glob pattern %q: %w", pattern, err)
+			}
+			if !matched {
+				continue
+			}
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			continue // Skip entries we can't stat.
+		}
+
+		entryType := "file"
+		if entry.IsDir() {
+			entryType = "dir"
+		} else if entry.Type()&os.ModeSymlink != 0 {
+			entryType = "symlink"
+		}
+
+		results = append(results, fileEntry{
+			Name: name,
+			Type: entryType,
+			Size: info.Size(),
+			Mode: info.Mode().String(),
+		})
+
+		if len(results) >= maxListResults {
+			break
+		}
+	}
+
+	out := map[string]any{
+		"path":    validated,
+		"entries": results,
+		"count":   len(results),
+	}
+	if len(results) >= maxListResults {
+		out["truncated"] = true
+	}
+	return json.Marshal(out)
+}
+
+// Ensure FileListHandler implements JobHandler.
+var _ JobHandler = (*FileListHandler)(nil)

--- a/internal/jobs/file_ops_test.go
+++ b/internal/jobs/file_ops_test.go
@@ -1,0 +1,672 @@
+package jobs
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+// --- helpers ---
+
+func setupWorkspace(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	// Resolve the temp dir itself (macOS /var -> /private/var, etc.)
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("resolving temp dir: %v", err)
+	}
+	return resolved
+}
+
+func writeTestFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return p
+}
+
+func makeJob(payload map[string]string) *nexus.Job {
+	return &nexus.Job{ID: "test-1", Type: "TEST", Payload: payload}
+}
+
+// --- ValidatePath tests ---
+
+func TestValidatePath_BasicAccess(t *testing.T) {
+	ws := setupWorkspace(t)
+	writeTestFile(t, ws, "hello.txt", "hello")
+
+	got, err := ValidatePath(ws, filepath.Join(ws, "hello.txt"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasSuffix(got, "hello.txt") {
+		t.Errorf("expected path ending in hello.txt, got %q", got)
+	}
+}
+
+func TestValidatePath_RelativePath(t *testing.T) {
+	ws := setupWorkspace(t)
+	writeTestFile(t, ws, "sub/file.txt", "data")
+
+	got, err := ValidatePath(ws, "sub/file.txt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := filepath.Join(ws, "sub", "file.txt")
+	if got != expected {
+		t.Errorf("got %q, want %q", got, expected)
+	}
+}
+
+func TestValidatePath_DotDotEscape(t *testing.T) {
+	ws := setupWorkspace(t)
+
+	_, err := ValidatePath(ws, filepath.Join(ws, "..", "etc", "passwd"))
+	if err == nil {
+		t.Fatal("expected error for .. traversal, got nil")
+	}
+}
+
+func TestValidatePath_AbsoluteOutside(t *testing.T) {
+	ws := setupWorkspace(t)
+
+	_, err := ValidatePath(ws, "/etc/passwd")
+	if err == nil {
+		t.Fatal("expected error for absolute path outside workspace, got nil")
+	}
+}
+
+func TestValidatePath_SymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks may need admin on Windows")
+	}
+	ws := setupWorkspace(t)
+
+	// Create a symlink inside the workspace that points outside.
+	link := filepath.Join(ws, "escape")
+	if err := os.Symlink("/tmp", link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	_, err := ValidatePath(ws, filepath.Join(ws, "escape", "something"))
+	if err == nil {
+		t.Fatal("expected error for symlink escape, got nil")
+	}
+}
+
+func TestValidatePath_NonExistentTarget(t *testing.T) {
+	ws := setupWorkspace(t)
+
+	// Path doesn't exist but is within workspace — should succeed.
+	got, err := ValidatePath(ws, filepath.Join(ws, "newdir", "newfile.txt"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := filepath.Join(ws, "newdir", "newfile.txt")
+	if got != expected {
+		t.Errorf("got %q, want %q", got, expected)
+	}
+}
+
+func TestValidatePath_EmptyInputs(t *testing.T) {
+	if _, err := ValidatePath("", "foo"); err == nil {
+		t.Error("expected error for empty workspace")
+	}
+	ws := setupWorkspace(t)
+	if _, err := ValidatePath(ws, ""); err == nil {
+		t.Error("expected error for empty path")
+	}
+}
+
+func TestValidatePath_BoundaryPrefix(t *testing.T) {
+	// Ensure /workspace doesn't match /workspaceEVIL
+	ws := setupWorkspace(t)
+	evil := ws + "EVIL"
+	if err := os.MkdirAll(evil, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeTestFile(t, evil, "secret.txt", "secret")
+
+	_, err := ValidatePath(ws, filepath.Join(evil, "secret.txt"))
+	if err == nil {
+		t.Fatal("expected error for boundary prefix attack, got nil")
+	}
+}
+
+// --- FILE_READ tests ---
+
+func TestFileRead_Basic(t *testing.T) {
+	ws := setupWorkspace(t)
+	content := "line one\nline two\nline three\n"
+	path := writeTestFile(t, ws, "test.txt", content)
+
+	h := NewFileReadHandler(ws)
+	out, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path": path,
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("json unmarshal: %v", err)
+	}
+	if result["total_lines"].(float64) != 4 { // trailing newline creates empty 4th line
+		t.Errorf("total_lines = %v, want 4", result["total_lines"])
+	}
+	resultContent := result["content"].(string)
+	if !strings.Contains(resultContent, "line one") {
+		t.Errorf("content missing 'line one': %s", resultContent)
+	}
+}
+
+func TestFileRead_OffsetAndLimit(t *testing.T) {
+	ws := setupWorkspace(t)
+	var lines []string
+	for i := 0; i < 100; i++ {
+		lines = append(lines, strings.Repeat("x", 10))
+	}
+	path := writeTestFile(t, ws, "big.txt", strings.Join(lines, "\n"))
+
+	h := NewFileReadHandler(ws)
+	out, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path":   path,
+		"offset": "10",
+		"limit":  "5",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result map[string]any
+	json.Unmarshal(out, &result)
+
+	// Should start at line 11 (1-based).
+	content := result["content"].(string)
+	if !strings.HasPrefix(content, "    11\t") {
+		t.Errorf("content should start at line 11, got: %s", content[:40])
+	}
+
+	// Should contain exactly 5 lines.
+	outputLines := strings.Split(strings.TrimRight(content, "\n"), "\n")
+	if len(outputLines) != 5 {
+		t.Errorf("expected 5 lines, got %d", len(outputLines))
+	}
+}
+
+func TestFileRead_BinaryFile(t *testing.T) {
+	ws := setupWorkspace(t)
+	// Write a file with NUL bytes.
+	path := filepath.Join(ws, "binary.dat")
+	os.WriteFile(path, []byte{0x89, 0x50, 0x4E, 0x47, 0x00, 0x00, 0x00}, 0644)
+
+	h := NewFileReadHandler(ws)
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path": path,
+	}))
+	if err == nil {
+		t.Fatal("expected error for binary file, got nil")
+	}
+	if !strings.Contains(err.Error(), "binary") {
+		t.Errorf("error should mention binary, got: %v", err)
+	}
+}
+
+func TestFileRead_NonExistent(t *testing.T) {
+	ws := setupWorkspace(t)
+
+	h := NewFileReadHandler(ws)
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path": filepath.Join(ws, "nope.txt"),
+	}))
+	if err == nil {
+		t.Fatal("expected error for non-existent file, got nil")
+	}
+}
+
+func TestFileRead_PathTraversal(t *testing.T) {
+	ws := setupWorkspace(t)
+
+	h := NewFileReadHandler(ws)
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path": "/etc/passwd",
+	}))
+	if err == nil {
+		t.Fatal("expected error for path outside workspace, got nil")
+	}
+	if !strings.Contains(err.Error(), "path validation") {
+		t.Errorf("error should mention path validation, got: %v", err)
+	}
+}
+
+func TestFileRead_MissingPath(t *testing.T) {
+	ws := setupWorkspace(t)
+	h := NewFileReadHandler(ws)
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{}))
+	if err == nil {
+		t.Fatal("expected error for missing path, got nil")
+	}
+}
+
+// --- FILE_WRITE tests ---
+
+func TestFileWrite_Basic(t *testing.T) {
+	ws := setupWorkspace(t)
+	target := filepath.Join(ws, "output.txt")
+
+	h := NewFileWriteHandler(ws)
+	out, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path":    target,
+		"content": "hello world",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result map[string]any
+	json.Unmarshal(out, &result)
+	if result["bytes_written"].(float64) != 11 {
+		t.Errorf("bytes_written = %v, want 11", result["bytes_written"])
+	}
+
+	data, _ := os.ReadFile(target)
+	if string(data) != "hello world" {
+		t.Errorf("file content = %q, want %q", string(data), "hello world")
+	}
+}
+
+func TestFileWrite_CreatesParentDirs(t *testing.T) {
+	ws := setupWorkspace(t)
+	target := filepath.Join(ws, "a", "b", "c", "deep.txt")
+
+	h := NewFileWriteHandler(ws)
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path":    target,
+		"content": "nested",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, _ := os.ReadFile(target)
+	if string(data) != "nested" {
+		t.Errorf("file content = %q, want %q", string(data), "nested")
+	}
+}
+
+func TestFileWrite_PathTraversal(t *testing.T) {
+	ws := setupWorkspace(t)
+
+	h := NewFileWriteHandler(ws)
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path":    "/tmp/evil-write.txt",
+		"content": "pwned",
+	}))
+	if err == nil {
+		t.Fatal("expected error for path outside workspace, got nil")
+	}
+}
+
+func TestFileWrite_MissingContent(t *testing.T) {
+	ws := setupWorkspace(t)
+	h := NewFileWriteHandler(ws)
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path": filepath.Join(ws, "test.txt"),
+	}))
+	if err == nil {
+		t.Fatal("expected error for missing content, got nil")
+	}
+}
+
+// --- FILE_EDIT tests ---
+
+func TestFileEdit_SingleReplacement(t *testing.T) {
+	ws := setupWorkspace(t)
+	path := writeTestFile(t, ws, "edit.txt", "hello world\nfoo bar\n")
+
+	h := NewFileEditHandler(ws)
+	out, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path":       path,
+		"old_string": "foo bar",
+		"new_string": "baz qux",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, _ := os.ReadFile(path)
+	if !strings.Contains(string(data), "baz qux") {
+		t.Errorf("file should contain 'baz qux', got %q", string(data))
+	}
+	if strings.Contains(string(data), "foo bar") {
+		t.Errorf("file should not contain 'foo bar'")
+	}
+
+	var result map[string]any
+	json.Unmarshal(out, &result)
+	if result["replacements"].(float64) != 1 {
+		t.Errorf("replacements = %v, want 1", result["replacements"])
+	}
+}
+
+func TestFileEdit_NotUnique(t *testing.T) {
+	ws := setupWorkspace(t)
+	path := writeTestFile(t, ws, "dup.txt", "aaa\naaa\naaa\n")
+
+	h := NewFileEditHandler(ws)
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path":       path,
+		"old_string": "aaa",
+		"new_string": "bbb",
+	}))
+	if err == nil {
+		t.Fatal("expected error for non-unique old_string, got nil")
+	}
+	if !strings.Contains(err.Error(), "3 times") {
+		t.Errorf("error should mention count, got: %v", err)
+	}
+}
+
+func TestFileEdit_ReplaceAll(t *testing.T) {
+	ws := setupWorkspace(t)
+	path := writeTestFile(t, ws, "all.txt", "aaa\naaa\naaa\n")
+
+	h := NewFileEditHandler(ws)
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path":        path,
+		"old_string":  "aaa",
+		"new_string":  "bbb",
+		"replace_all": "true",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, _ := os.ReadFile(path)
+	if strings.Contains(string(data), "aaa") {
+		t.Errorf("file should not contain 'aaa' after replace_all")
+	}
+}
+
+func TestFileEdit_NotFound(t *testing.T) {
+	ws := setupWorkspace(t)
+	writeTestFile(t, ws, "nope.txt", "hello world")
+
+	h := NewFileEditHandler(ws)
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path":       filepath.Join(ws, "nope.txt"),
+		"old_string": "missing text",
+		"new_string": "replacement",
+	}))
+	if err == nil {
+		t.Fatal("expected error for old_string not found, got nil")
+	}
+}
+
+func TestFileEdit_EmptyOldString(t *testing.T) {
+	ws := setupWorkspace(t)
+	writeTestFile(t, ws, "empty.txt", "content")
+
+	h := NewFileEditHandler(ws)
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path":       filepath.Join(ws, "empty.txt"),
+		"old_string": "",
+		"new_string": "x",
+	}))
+	if err == nil {
+		t.Fatal("expected error for empty old_string, got nil")
+	}
+}
+
+func TestFileEdit_PathTraversal(t *testing.T) {
+	ws := setupWorkspace(t)
+	h := NewFileEditHandler(ws)
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path":       "/etc/passwd",
+		"old_string": "root",
+		"new_string": "pwned",
+	}))
+	if err == nil {
+		t.Fatal("expected error for path outside workspace, got nil")
+	}
+}
+
+// --- FILE_LIST tests ---
+
+func TestFileList_Basic(t *testing.T) {
+	ws := setupWorkspace(t)
+	writeTestFile(t, ws, "a.txt", "a")
+	writeTestFile(t, ws, "b.go", "b")
+	os.Mkdir(filepath.Join(ws, "subdir"), 0755)
+
+	h := NewFileListHandler(ws)
+	out, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path": ws,
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result map[string]any
+	json.Unmarshal(out, &result)
+	count := int(result["count"].(float64))
+	if count != 3 {
+		t.Errorf("count = %d, want 3", count)
+	}
+}
+
+func TestFileList_WithPattern(t *testing.T) {
+	ws := setupWorkspace(t)
+	writeTestFile(t, ws, "a.txt", "a")
+	writeTestFile(t, ws, "b.go", "b")
+	writeTestFile(t, ws, "c.txt", "c")
+
+	h := NewFileListHandler(ws)
+	out, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path":    ws,
+		"pattern": "*.txt",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result map[string]any
+	json.Unmarshal(out, &result)
+	count := int(result["count"].(float64))
+	if count != 2 {
+		t.Errorf("count = %d, want 2 (*.txt only)", count)
+	}
+}
+
+func TestFileList_NotDirectory(t *testing.T) {
+	ws := setupWorkspace(t)
+	path := writeTestFile(t, ws, "file.txt", "data")
+
+	h := NewFileListHandler(ws)
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path": path,
+	}))
+	if err == nil {
+		t.Fatal("expected error for non-directory path, got nil")
+	}
+}
+
+func TestFileList_PathTraversal(t *testing.T) {
+	ws := setupWorkspace(t)
+	h := NewFileListHandler(ws)
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path": "/etc",
+	}))
+	if err == nil {
+		t.Fatal("expected error for path outside workspace, got nil")
+	}
+}
+
+// --- FILE_SEARCH tests ---
+
+func TestFileSearch_Basic(t *testing.T) {
+	ws := setupWorkspace(t)
+	writeTestFile(t, ws, "main.go", "package main\n\nfunc main() {\n\tprintln(\"hello\")\n}\n")
+	writeTestFile(t, ws, "readme.txt", "This is a readme\n")
+
+	h := NewFileSearchHandler(ws)
+	out, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path":  ws,
+		"query": "main",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result map[string]any
+	json.Unmarshal(out, &result)
+	matchCount := int(result["match_count"].(float64))
+	if matchCount < 2 {
+		t.Errorf("match_count = %d, want >= 2 (package main + func main)", matchCount)
+	}
+}
+
+func TestFileSearch_WithFilePattern(t *testing.T) {
+	ws := setupWorkspace(t)
+	writeTestFile(t, ws, "code.go", "func hello() {}\n")
+	writeTestFile(t, ws, "notes.txt", "func hello\n")
+
+	h := NewFileSearchHandler(ws)
+	out, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path":         ws,
+		"query":        "func",
+		"file_pattern": "*.go",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result map[string]any
+	json.Unmarshal(out, &result)
+	matchCount := int(result["match_count"].(float64))
+	if matchCount != 1 {
+		t.Errorf("match_count = %d, want 1 (only .go file)", matchCount)
+	}
+}
+
+func TestFileSearch_NoResults(t *testing.T) {
+	ws := setupWorkspace(t)
+	writeTestFile(t, ws, "file.txt", "hello world\n")
+
+	h := NewFileSearchHandler(ws)
+	out, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path":  ws,
+		"query": "nonexistent_string_xyz",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result map[string]any
+	json.Unmarshal(out, &result)
+	if result["match_count"].(float64) != 0 {
+		t.Errorf("match_count = %v, want 0", result["match_count"])
+	}
+}
+
+func TestFileSearch_SkipsBinaryFiles(t *testing.T) {
+	ws := setupWorkspace(t)
+	writeTestFile(t, ws, "text.txt", "searchterm in text\n")
+	// Write a "binary" file containing the search term but also NUL bytes.
+	binPath := filepath.Join(ws, "binary.dat")
+	os.WriteFile(binPath, append([]byte("searchterm"), 0x00), 0644)
+
+	h := NewFileSearchHandler(ws)
+	out, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path":  ws,
+		"query": "searchterm",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result map[string]any
+	json.Unmarshal(out, &result)
+	if result["match_count"].(float64) != 1 {
+		t.Errorf("match_count = %v, want 1 (binary file should be skipped)", result["match_count"])
+	}
+}
+
+func TestFileSearch_PathTraversal(t *testing.T) {
+	ws := setupWorkspace(t)
+	h := NewFileSearchHandler(ws)
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path":  "/etc",
+		"query": "root",
+	}))
+	if err == nil {
+		t.Fatal("expected error for path outside workspace, got nil")
+	}
+}
+
+func TestFileSearch_MissingQuery(t *testing.T) {
+	ws := setupWorkspace(t)
+	h := NewFileSearchHandler(ws)
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path": ws,
+	}))
+	if err == nil {
+		t.Fatal("expected error for missing query, got nil")
+	}
+}
+
+func TestFileSearch_SkipsGitDir(t *testing.T) {
+	ws := setupWorkspace(t)
+	writeTestFile(t, ws, "real.txt", "target_string\n")
+	writeTestFile(t, ws, ".git/objects/pack/data", "target_string\n")
+
+	h := NewFileSearchHandler(ws)
+	out, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path":  ws,
+		"query": "target_string",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result map[string]any
+	json.Unmarshal(out, &result)
+	if result["match_count"].(float64) != 1 {
+		t.Errorf("match_count = %v, want 1 (.git should be skipped)", result["match_count"])
+	}
+}
+
+// --- isBinaryContent tests ---
+
+func TestIsBinaryContent(t *testing.T) {
+	tests := []struct {
+		name   string
+		data   []byte
+		binary bool
+	}{
+		{"plain text", []byte("hello world"), false},
+		{"empty", []byte{}, false},
+		{"nul byte", []byte{0x00}, true},
+		{"PNG header", []byte{0x89, 0x50, 0x4E, 0x47, 0x00}, true},
+		{"text with newlines", []byte("line1\nline2\r\nline3"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isBinaryContent(tt.data); got != tt.binary {
+				t.Errorf("isBinaryContent = %v, want %v", got, tt.binary)
+			}
+		})
+	}
+}

--- a/internal/jobs/file_path.go
+++ b/internal/jobs/file_path.go
@@ -1,0 +1,124 @@
+// internal/jobs/file_path.go
+package jobs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ValidatePath resolves requestedPath within the workspace sandbox and returns
+// the cleaned absolute path. It rejects any path that escapes the workspace
+// after symlink resolution. For paths that do not yet exist (e.g. write
+// targets), the nearest existing ancestor is resolved and validated instead.
+func ValidatePath(workspace, requestedPath string) (string, error) {
+	if workspace == "" {
+		return "", fmt.Errorf("workspace directory is not configured")
+	}
+	if requestedPath == "" {
+		return "", fmt.Errorf("path is empty")
+	}
+
+	// Resolve the workspace root itself (it may be under a symlinked tmpdir).
+	resolvedWorkspace, err := filepath.EvalSymlinks(workspace)
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve workspace %q: %w", workspace, err)
+	}
+	resolvedWorkspace = filepath.Clean(resolvedWorkspace)
+
+	// If requestedPath is relative, join it to the workspace.
+	target := requestedPath
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(resolvedWorkspace, target)
+	}
+	target = filepath.Clean(target)
+
+	// Try to resolve the full path via symlinks.
+	resolved, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		// Path doesn't exist yet — walk up to find the nearest existing ancestor.
+		resolved, err = resolveNearestAncestor(target)
+		if err != nil {
+			return "", fmt.Errorf("cannot resolve path %q: %w", requestedPath, err)
+		}
+		// The ancestor resolved successfully. Now reconstruct the full target
+		// using the resolved ancestor + the relative remainder.
+		// This ensures that the non-existing suffix is still lexically clean.
+	}
+
+	// Boundary-safe prefix check: use filepath.Rel to avoid /workspace matching
+	// /workspaceEVIL. Rel returns a path starting with ".." if the target is
+	// outside the workspace.
+	rel, err := filepath.Rel(resolvedWorkspace, resolved)
+	if err != nil {
+		return "", fmt.Errorf("path %q is outside workspace: %w", requestedPath, err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %q resolves outside workspace", requestedPath)
+	}
+
+	// Also verify the full (possibly non-existent) target lexically.
+	cleanTarget := filepath.Clean(target)
+	relTarget, err := filepath.Rel(resolvedWorkspace, cleanTarget)
+	if err != nil {
+		return "", fmt.Errorf("path %q is outside workspace: %w", requestedPath, err)
+	}
+	if relTarget == ".." || strings.HasPrefix(relTarget, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %q resolves outside workspace", requestedPath)
+	}
+
+	return cleanTarget, nil
+}
+
+// resolveNearestAncestor walks up from target until it finds a directory that
+// exists, resolves it via EvalSymlinks, then re-appends the tail. Returns the
+// fully resolved path even though the leaf may not exist.
+func resolveNearestAncestor(target string) (string, error) {
+	current := target
+	var tail []string
+
+	for {
+		info, err := os.Lstat(current)
+		if err == nil {
+			// Found an existing path — resolve symlinks on it.
+			if info.Mode()&os.ModeSymlink != 0 || info.IsDir() {
+				resolved, err := filepath.EvalSymlinks(current)
+				if err != nil {
+					return "", err
+				}
+				// Re-attach the tail components.
+				parts := append([]string{resolved}, tail...)
+				return filepath.Join(parts...), nil
+			}
+			// It exists but is a regular file and we still have tail — error.
+			if len(tail) > 0 {
+				return "", fmt.Errorf("path component %q is not a directory", current)
+			}
+			resolved, err := filepath.EvalSymlinks(current)
+			if err != nil {
+				return "", err
+			}
+			return resolved, nil
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			// Reached filesystem root without finding anything — give up.
+			return "", fmt.Errorf("no existing ancestor for %q", target)
+		}
+		tail = append([]string{filepath.Base(current)}, tail...)
+		current = parent
+	}
+}
+
+// isBinaryContent checks the first n bytes for NUL bytes, which indicate
+// binary content.
+func isBinaryContent(data []byte) bool {
+	for _, b := range data {
+		if b == 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/jobs/file_read.go
+++ b/internal/jobs/file_read.go
@@ -1,0 +1,112 @@
+// internal/jobs/file_read.go
+package jobs
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+// FileReadHandler handles FILE_READ jobs.
+// It reads a file within the configured workspace and returns its content
+// with line numbers (similar to cat -n).
+type FileReadHandler struct {
+	WorkspaceDir string
+}
+
+// NewFileReadHandler creates a new FileReadHandler rooted at workspace.
+func NewFileReadHandler(workspace string) *FileReadHandler {
+	return &FileReadHandler{WorkspaceDir: workspace}
+}
+
+// Execute reads the requested file and returns content with line numbers.
+//
+// Payload fields (all strings via nexus.Job):
+//   - path: absolute or workspace-relative path to read
+//   - offset: starting line number (0-based, default "0")
+//   - limit: max lines to return (default "2000")
+func (h *FileReadHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	path, ok := job.Payload["path"]
+	if !ok || path == "" {
+		return nil, fmt.Errorf("job payload missing 'path' field")
+	}
+
+	validated, err := ValidatePath(h.WorkspaceDir, path)
+	if err != nil {
+		return nil, fmt.Errorf("path validation failed: %w", err)
+	}
+
+	offset := 0
+	if v, ok := job.Payload["offset"]; ok && v != "" {
+		offset, err = strconv.Atoi(v)
+		if err != nil || offset < 0 {
+			return nil, fmt.Errorf("invalid offset: %q", v)
+		}
+	}
+
+	limit := 2000
+	if v, ok := job.Payload["limit"]; ok && v != "" {
+		limit, err = strconv.Atoi(v)
+		if err != nil || limit <= 0 {
+			return nil, fmt.Errorf("invalid limit: %q", v)
+		}
+	}
+
+	ctx.Log("info", "     - [Job %s] FILE_READ %s (offset=%d, limit=%d)", job.ID, validated, offset, limit)
+
+	data, err := os.ReadFile(validated)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	// Check for binary content (first 8KB).
+	checkSize := 8192
+	if len(data) < checkSize {
+		checkSize = len(data)
+	}
+	if isBinaryContent(data[:checkSize]) {
+		return nil, fmt.Errorf("file appears to be binary; use a different tool to inspect it")
+	}
+
+	lines := strings.Split(string(data), "\n")
+	totalLines := len(lines)
+
+	// Apply offset.
+	if offset >= totalLines {
+		result := map[string]any{
+			"content":     "",
+			"total_lines": totalLines,
+			"offset":      offset,
+			"limit":       limit,
+		}
+		return json.Marshal(result)
+	}
+	lines = lines[offset:]
+
+	// Apply limit.
+	if len(lines) > limit {
+		lines = lines[:limit]
+	}
+
+	// Format with line numbers (1-based, matching cat -n).
+	var sb strings.Builder
+	for i, line := range lines {
+		lineNum := offset + i + 1
+		fmt.Fprintf(&sb, "%6d\t%s\n", lineNum, line)
+	}
+
+	result := map[string]any{
+		"content":     sb.String(),
+		"total_lines": totalLines,
+		"offset":      offset,
+		"limit":       limit,
+	}
+	return json.Marshal(result)
+}
+
+// Ensure FileReadHandler implements JobHandler.
+var _ JobHandler = (*FileReadHandler)(nil)

--- a/internal/jobs/file_search.go
+++ b/internal/jobs/file_search.go
@@ -1,0 +1,177 @@
+// internal/jobs/file_search.go
+package jobs
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+// FileSearchHandler handles FILE_SEARCH jobs.
+// It performs grep-like text search across files in the workspace, returning
+// matches with line numbers and context.
+type FileSearchHandler struct {
+	WorkspaceDir string
+}
+
+// NewFileSearchHandler creates a new FileSearchHandler rooted at workspace.
+func NewFileSearchHandler(workspace string) *FileSearchHandler {
+	return &FileSearchHandler{WorkspaceDir: workspace}
+}
+
+// searchMatch represents one grep-like match.
+type searchMatch struct {
+	File    string `json:"file"`
+	Line    int    `json:"line"`
+	Content string `json:"content"`
+}
+
+// maxSearchResults caps search output to prevent huge responses.
+const maxSearchResults = 500
+
+// maxSearchFiles caps the number of files scanned.
+const maxSearchFiles = 10000
+
+// Execute searches for a text query across files in the given directory.
+//
+// Payload fields (all strings via nexus.Job):
+//   - path: root directory to search (absolute or workspace-relative)
+//   - query: the text to search for (case-sensitive substring match)
+//   - file_pattern: optional glob pattern to filter filenames (e.g. "*.go")
+func (h *FileSearchHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	path, ok := job.Payload["path"]
+	if !ok || path == "" {
+		return nil, fmt.Errorf("job payload missing 'path' field")
+	}
+
+	query, ok := job.Payload["query"]
+	if !ok || query == "" {
+		return nil, fmt.Errorf("job payload missing 'query' field")
+	}
+
+	filePattern := job.Payload["file_pattern"] // May be empty.
+
+	validated, err := ValidatePath(h.WorkspaceDir, path)
+	if err != nil {
+		return nil, fmt.Errorf("path validation failed: %w", err)
+	}
+
+	info, err := os.Stat(validated)
+	if err != nil {
+		return nil, fmt.Errorf("cannot stat path: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("path is not a directory: %s", validated)
+	}
+
+	ctx.Log("info", "     - [Job %s] FILE_SEARCH %s query=%q pattern=%q", job.ID, validated, query, filePattern)
+
+	var matches []searchMatch
+	filesScanned := 0
+	truncated := false
+
+	err = filepath.WalkDir(validated, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil // Skip unreadable entries.
+		}
+		if d.IsDir() {
+			// Skip common noise directories.
+			name := d.Name()
+			if name == ".git" || name == "node_modules" || name == "__pycache__" || name == ".venv" || name == "vendor" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if filesScanned >= maxSearchFiles {
+			truncated = true
+			return filepath.SkipAll
+		}
+
+		// Apply file pattern filter.
+		if filePattern != "" {
+			matched, err := filepath.Match(filePattern, d.Name())
+			if err != nil {
+				return nil // Skip bad pattern silently.
+			}
+			if !matched {
+				return nil
+			}
+		}
+
+		// Skip binary files by checking the first chunk.
+		f, err := os.Open(p)
+		if err != nil {
+			return nil
+		}
+		defer f.Close()
+
+		filesScanned++
+
+		// Read first 512 bytes to detect binary.
+		header := make([]byte, 512)
+		n, _ := f.Read(header)
+		if n > 0 && isBinaryContent(header[:n]) {
+			return nil
+		}
+
+		// Seek back to start for full scan.
+		if _, err := f.Seek(0, 0); err != nil {
+			return nil
+		}
+
+		scanner := bufio.NewScanner(f)
+		lineNum := 0
+		for scanner.Scan() {
+			lineNum++
+			line := scanner.Text()
+			if strings.Contains(line, query) {
+				// Use workspace-relative path for cleaner output.
+				relPath, err := filepath.Rel(h.WorkspaceDir, p)
+				if err != nil {
+					relPath = p
+				}
+				matches = append(matches, searchMatch{
+					File:    relPath,
+					Line:    lineNum,
+					Content: truncateLine(line, 200),
+				})
+				if len(matches) >= maxSearchResults {
+					truncated = true
+					return filepath.SkipAll
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("search failed: %w", err)
+	}
+
+	out := map[string]any{
+		"matches":       matches,
+		"match_count":   len(matches),
+		"files_scanned": filesScanned,
+	}
+	if truncated {
+		out["truncated"] = true
+	}
+	return json.Marshal(out)
+}
+
+// truncateLine shortens a line to maxLen characters, appending "..." if
+// truncated.
+func truncateLine(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}
+
+// Ensure FileSearchHandler implements JobHandler.
+var _ JobHandler = (*FileSearchHandler)(nil)

--- a/internal/jobs/file_write.go
+++ b/internal/jobs/file_write.go
@@ -1,0 +1,66 @@
+// internal/jobs/file_write.go
+package jobs
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+// FileWriteHandler handles FILE_WRITE jobs.
+// It writes content to a file within the configured workspace, creating
+// parent directories as needed.
+type FileWriteHandler struct {
+	WorkspaceDir string
+}
+
+// NewFileWriteHandler creates a new FileWriteHandler rooted at workspace.
+func NewFileWriteHandler(workspace string) *FileWriteHandler {
+	return &FileWriteHandler{WorkspaceDir: workspace}
+}
+
+// Execute writes the provided content to the requested file.
+//
+// Payload fields (all strings via nexus.Job):
+//   - path: absolute or workspace-relative path to write
+//   - content: the text content to write
+func (h *FileWriteHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	path, ok := job.Payload["path"]
+	if !ok || path == "" {
+		return nil, fmt.Errorf("job payload missing 'path' field")
+	}
+
+	content, ok := job.Payload["content"]
+	if !ok {
+		return nil, fmt.Errorf("job payload missing 'content' field")
+	}
+
+	validated, err := ValidatePath(h.WorkspaceDir, path)
+	if err != nil {
+		return nil, fmt.Errorf("path validation failed: %w", err)
+	}
+
+	ctx.Log("info", "     - [Job %s] FILE_WRITE %s (%d bytes)", job.ID, validated, len(content))
+
+	// Create parent directories if they don't exist.
+	dir := filepath.Dir(validated)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create parent directories: %w", err)
+	}
+
+	if err := os.WriteFile(validated, []byte(content), 0644); err != nil {
+		return nil, fmt.Errorf("failed to write file: %w", err)
+	}
+
+	result := map[string]any{
+		"path":          validated,
+		"bytes_written": len(content),
+	}
+	return json.Marshal(result)
+}
+
+// Ensure FileWriteHandler implements JobHandler.
+var _ JobHandler = (*FileWriteHandler)(nil)

--- a/internal/jobs/queue_types.go
+++ b/internal/jobs/queue_types.go
@@ -11,6 +11,13 @@ const (
 
 	// JobTypeExtraction handles entity/relation extraction
 	JobTypeExtraction = "EXTRACTION"
+
+	// File operation job types for agent workspace access
+	JobTypeFileRead   = "FILE_READ"
+	JobTypeFileWrite  = "FILE_WRITE"
+	JobTypeFileEdit   = "FILE_EDIT"
+	JobTypeFileList   = "FILE_LIST"
+	JobTypeFileSearch = "FILE_SEARCH"
 )
 
 // Queue names following PR #1105 convention

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -84,6 +84,15 @@ func (a *LegacyHandlerAdapter) Execute(ctx context.Context, job *Job, stream Str
 // Ensure LegacyHandlerAdapter implements JobHandler
 var _ JobHandler = (*LegacyHandlerAdapter)(nil)
 
+// LegacyHandlerOpts configures optional behaviour for CreateLegacyHandlers.
+type LegacyHandlerOpts struct {
+	// LogFn routes job log output through a callback instead of stdout.
+	LogFn func(level, msg string)
+	// WorkspaceDir is the sandbox root for file-operation handlers.
+	// If empty, file-operation handlers are not registered.
+	WorkspaceDir string
+}
+
 // CreateLegacyHandlers creates JobHandler adapters for all existing Nexus job handlers.
 // If logFn is provided, job output will be routed through it instead of stdout.
 func CreateLegacyHandlers(logFn ...func(level, msg string)) []JobHandler {
@@ -91,7 +100,13 @@ func CreateLegacyHandlers(logFn ...func(level, msg string)) []JobHandler {
 	if len(logFn) > 0 {
 		fn = logFn[0]
 	}
+	return CreateLegacyHandlersWithOpts(LegacyHandlerOpts{LogFn: fn})
+}
 
+// CreateLegacyHandlersWithOpts is like CreateLegacyHandlers but accepts a
+// structured options value for richer configuration (e.g. workspace directory
+// for file-operation handlers).
+func CreateLegacyHandlersWithOpts(opts LegacyHandlerOpts) []JobHandler {
 	handlers := []*LegacyHandlerAdapter{
 		NewLegacyHandlerAdapter(JobTypeShellCommand, &jobs.ShellCommandHandler{}),
 		NewLegacyHandlerAdapter(JobTypeDownloadModel, &jobs.DownloadModelHandler{}),
@@ -104,14 +119,25 @@ func CreateLegacyHandlers(logFn ...func(level, msg string)) []JobHandler {
 		NewLegacyHandlerAdapter(JobTypeHTTPProxy, &jobs.HTTPProxyHandler{}),
 	}
 
-	// Set log function on all handlers
-	if fn != nil {
+	// Register file-operation handlers when a workspace is configured.
+	if opts.WorkspaceDir != "" {
+		handlers = append(handlers,
+			NewLegacyHandlerAdapter(JobTypeFileRead, jobs.NewFileReadHandler(opts.WorkspaceDir)),
+			NewLegacyHandlerAdapter(JobTypeFileWrite, jobs.NewFileWriteHandler(opts.WorkspaceDir)),
+			NewLegacyHandlerAdapter(JobTypeFileEdit, jobs.NewFileEditHandler(opts.WorkspaceDir)),
+			NewLegacyHandlerAdapter(JobTypeFileList, jobs.NewFileListHandler(opts.WorkspaceDir)),
+			NewLegacyHandlerAdapter(JobTypeFileSearch, jobs.NewFileSearchHandler(opts.WorkspaceDir)),
+		)
+	}
+
+	// Set log function on all handlers.
+	if opts.LogFn != nil {
 		for _, h := range handlers {
-			h.SetLogFn(fn)
+			h.SetLogFn(opts.LogFn)
 		}
 	}
 
-	// Convert to []JobHandler
+	// Convert to []JobHandler.
 	result := make([]JobHandler, len(handlers))
 	for i, h := range handlers {
 		result[i] = h

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/jobs"
@@ -44,12 +45,20 @@ func (a *LegacyHandlerAdapter) Execute(ctx context.Context, job *Job, stream Str
 		Type: job.Type,
 	}
 
-	// Convert payload map[string]any to map[string]string for nexus.Job
+	// Convert payload map[string]any to map[string]string for nexus.Job.
+	// Redis payloads arrive via json.Unmarshal, so numbers are float64 and
+	// booleans are bool. Coerce all values to strings so handlers can parse
+	// them with strconv.
 	if job.Payload != nil {
 		nexusJob.Payload = make(map[string]string)
 		for k, v := range job.Payload {
-			if strVal, ok := v.(string); ok {
-				nexusJob.Payload[k] = strVal
+			switch val := v.(type) {
+			case string:
+				nexusJob.Payload[k] = val
+			case nil:
+				// skip nil values
+			default:
+				nexusJob.Payload[k] = fmt.Sprint(val)
 			}
 		}
 	}

--- a/internal/worker/handler_adapter_test.go
+++ b/internal/worker/handler_adapter_test.go
@@ -11,11 +11,13 @@ import (
 
 // TestLegacyHandler is a mock jobs.JobHandler for testing.
 type TestLegacyHandler struct {
-	shouldFail bool
-	output     string
+	shouldFail      bool
+	output          string
+	capturedPayload map[string]string // captures the payload for inspection
 }
 
 func (h *TestLegacyHandler) Execute(ctx jobs.JobContext, job *nexus.Job) ([]byte, error) {
+	h.capturedPayload = job.Payload
 	if h.shouldFail {
 		return []byte("error output"), errors.New("handler failed")
 	}
@@ -172,6 +174,56 @@ func TestCreateLegacyHandlers(t *testing.T) {
 
 func TestLegacyHandlerAdapterImplementsJobHandler(t *testing.T) {
 	var _ JobHandler = (*LegacyHandlerAdapter)(nil)
+}
+
+func TestLegacyHandlerAdapterPayloadCoercion(t *testing.T) {
+	handler := &TestLegacyHandler{output: "ok"}
+	adapter := NewLegacyHandlerAdapter("TEST_JOB", handler)
+
+	// Simulate a job payload as it arrives from json.Unmarshal (via Redis):
+	// numbers are float64, booleans are bool, strings are string.
+	job := &Job{
+		ID:   "job-coerce",
+		Type: "TEST_JOB",
+		Payload: map[string]any{
+			"path":        "/some/path",
+			"offset":      float64(10),
+			"limit":       float64(100),
+			"replace_all": true,
+			"nil_field":   nil,
+		},
+	}
+
+	ctx := context.Background()
+	stream := &NoOpStreamWriter{}
+
+	_, err := adapter.Execute(ctx, job, stream)
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+
+	// Verify all non-nil values were coerced to strings.
+	checks := map[string]string{
+		"path":        "/some/path",
+		"offset":      "10",
+		"limit":       "100",
+		"replace_all": "true",
+	}
+	for k, want := range checks {
+		got, ok := handler.capturedPayload[k]
+		if !ok {
+			t.Errorf("payload[%q] missing", k)
+			continue
+		}
+		if got != want {
+			t.Errorf("payload[%q] = %q, want %q", k, got, want)
+		}
+	}
+
+	// nil values should be skipped.
+	if _, ok := handler.capturedPayload["nil_field"]; ok {
+		t.Error("nil_field should be skipped in payload")
+	}
 }
 
 func TestCreateLegacyHandlersWithOpts_FileHandlers(t *testing.T) {

--- a/internal/worker/handler_adapter_test.go
+++ b/internal/worker/handler_adapter_test.go
@@ -173,3 +173,40 @@ func TestCreateLegacyHandlers(t *testing.T) {
 func TestLegacyHandlerAdapterImplementsJobHandler(t *testing.T) {
 	var _ JobHandler = (*LegacyHandlerAdapter)(nil)
 }
+
+func TestCreateLegacyHandlersWithOpts_FileHandlers(t *testing.T) {
+	dir := t.TempDir()
+
+	fileTypes := []string{
+		JobTypeFileRead,
+		JobTypeFileWrite,
+		JobTypeFileEdit,
+		JobTypeFileList,
+		JobTypeFileSearch,
+	}
+
+	// Without workspace: file handlers should NOT be registered.
+	noWS := CreateLegacyHandlersWithOpts(LegacyHandlerOpts{})
+	for _, ft := range fileTypes {
+		for _, h := range noWS {
+			if h.CanHandle(ft) {
+				t.Errorf("file handler %s registered without WorkspaceDir", ft)
+			}
+		}
+	}
+
+	// With workspace: file handlers should be registered.
+	withWS := CreateLegacyHandlersWithOpts(LegacyHandlerOpts{WorkspaceDir: dir})
+	for _, ft := range fileTypes {
+		found := false
+		for _, h := range withWS {
+			if h.CanHandle(ft) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("file handler %s not registered with WorkspaceDir", ft)
+		}
+	}
+}

--- a/internal/worker/job.go
+++ b/internal/worker/job.go
@@ -106,4 +106,9 @@ const (
 	JobTypeApplyDeviceConfig = "APPLY_DEVICE_CONFIG" // Device config from onboarding
 	JobTypeExtraction        = "GLINER_EXTRACTION"   // Entity/relation extraction via GLiNER2
 	JobTypeHTTPProxy         = "HTTP_PROXY"          // Proxy HTTP requests through the local node
+	JobTypeFileRead          = "FILE_READ"           // Read a file from the workspace
+	JobTypeFileWrite         = "FILE_WRITE"          // Write a file to the workspace
+	JobTypeFileEdit          = "FILE_EDIT"           // Edit (string replace) a file in the workspace
+	JobTypeFileList          = "FILE_LIST"           // List directory contents in the workspace
+	JobTypeFileSearch        = "FILE_SEARCH"         // Search for text across files in the workspace
 )


### PR DESCRIPTION
## Context

Resolves aceteam-ai/aceteam#3494. This is the Citadel CLI side of enabling AceTeam's coding agent to read, write, and edit files on the user's local machine through the existing Redis job dispatch pipeline. Without these handlers, agents can only execute shell commands — they cannot efficiently interact with files using the structured, sandboxed operations that tools like Claude Code provide.

## Summary

**Path sandboxing** (`file_path.go`) — The security foundation. `ValidatePath()` resolves symlinks via `EvalSymlinks`, walks up to the nearest existing ancestor for write targets that don't exist yet, and uses `filepath.Rel` (not `strings.HasPrefix`) to reject boundary-prefix attacks like `/workspaceEVIL`. Every handler validates paths through this before any I/O.

**Five new job handlers**, all following the existing `jobs.JobHandler` interface pattern:

| Handler | Job Type | Purpose |
|---------|----------|---------|
| `file_read.go` | `FILE_READ` | Returns file content with line numbers (cat -n style), offset/limit pagination, binary detection |
| `file_write.go` | `FILE_WRITE` | Writes content, creates parent directories, returns bytes written |
| `file_edit.go` | `FILE_EDIT` | Exact string replacement — fails if old_string isn't unique (unless `replace_all`), returns context around edit |
| `file_list.go` | `FILE_LIST` | Directory listing with glob filtering, file types and sizes, capped at 5000 entries |
| `file_search.go` | `FILE_SEARCH` | Grep-like recursive search with file pattern filtering, skips .git/node_modules/binary files, capped at 500 matches |

**Registration and wiring** (`handler_adapter.go`, `work.go`, `controlcenter.go`) — New `CreateLegacyHandlersWithOpts(LegacyHandlerOpts)` accepts a `WorkspaceDir` field. File handlers are only registered when a workspace is configured. The existing `CreateLegacyHandlers(logFn)` signature is preserved as a thin wrapper. Both `citadel work` and the TUI control center now resolve the workspace via:
1. `--workspace` flag (highest priority)
2. `CITADEL_WORKSPACE` env var
3. Default `~/citadel-node/workspace` (auto-created)

**Job type constants** — Added to both `internal/jobs/queue_types.go` and `internal/worker/job.go`.

## Test plan

| Group | Tests | Coverage |
|-------|-------|----------|
| Path validation | 8 | Basic access, relative paths, `..` traversal, absolute outside, symlink escape, non-existent targets, empty inputs, boundary prefix attack |
| FILE_READ | 6 | Basic read, offset/limit pagination, binary file rejection, non-existent file, path traversal, missing payload |
| FILE_WRITE | 4 | Basic write, parent directory creation, path traversal, missing content |
| FILE_EDIT | 6 | Single replacement, non-unique rejection, replace_all, not found, empty old_string, path traversal |
| FILE_LIST | 4 | Basic listing, glob pattern, non-directory error, path traversal |
| FILE_SEARCH | 7 | Basic search, file pattern, no results, binary skip, path traversal, missing query, .git skip |
| isBinaryContent | 5 | Plain text, empty, NUL byte, PNG header, text with newlines |
| Handler registration | 1 | WithOpts: file handlers present with workspace, absent without |
| **Total** | **41** | All pass (`go test ./... -count=1` clean, `go vet ./...` clean) |

## Related

- aceteam-ai/aceteam#3494 (parent issue)