### PR TITLE
feat: service management job handlers (start/stop/status)

### DIFF
--- a/cmd/work.go
+++ b/cmd/work.go
@@ -131,7 +131,7 @@ func runWork(cmd *cobra.Command, args []string) {
 
 	// Resolve node capabilities early (used for queue routing and heartbeat)
 	var nodeCaps *capabilities.NodeCapabilities
-	workManifest, _, _ := findAndReadManifest()
+	workManifest, workConfigDir, _ := findAndReadManifest()
 	if workManifest != nil && workManifest.Capabilities != nil {
 		nodeCaps = manifestToNodeCapabilities(workManifest.Capabilities)
 		fmt.Println("   - Capabilities: loaded from manifest")
@@ -726,6 +726,7 @@ func runWork(cmd *cobra.Command, args []string) {
 	wsDir := resolveWorkspaceDir()
 	handlers := worker.CreateLegacyHandlersWithOpts(worker.LegacyHandlerOpts{
 		WorkspaceDir: wsDir,
+		ConfigDir:    workConfigDir,
 	})
 
 	// Build job record function for usage tracking

--- a/internal/jobs/service_handler.go
+++ b/internal/jobs/service_handler.go
@@ -1,0 +1,277 @@
+// internal/jobs/service_handler.go
+package jobs
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
+	"github.com/aceteam-ai/citadel-cli/internal/services"
+	"gopkg.in/yaml.v3"
+)
+
+// serviceManifest is a minimal subset of the citadel.yaml manifest used by
+// the service handler.  It lives here (not in cmd/) to avoid import cycles.
+type serviceManifest struct {
+	Services []manifestService `yaml:"services"`
+}
+
+type manifestService struct {
+	Name        string `yaml:"name"`
+	Type        string `yaml:"type,omitempty"`
+	ComposeFile string `yaml:"compose_file,omitempty"`
+	Port        int    `yaml:"port,omitempty"`
+}
+
+// ServiceHandler manages start/stop/status of services declared in the node's
+// citadel.yaml manifest.  The job type (SERVICE_START, SERVICE_STOP,
+// SERVICE_STATUS) is read from the incoming job's Type field.
+type ServiceHandler struct {
+	// ConfigDir is the absolute path to the directory containing citadel.yaml.
+	ConfigDir string
+}
+
+// NewServiceHandler creates a ServiceHandler rooted at configDir.
+func NewServiceHandler(configDir string) *ServiceHandler {
+	return &ServiceHandler{ConfigDir: configDir}
+}
+
+// serviceResult is the JSON structure returned for all service operations.
+type serviceResult struct {
+	Name    string `json:"name"`
+	Running bool   `json:"running"`
+	Kind    string `json:"kind"`              // "docker" or "native"
+	Error   string `json:"error,omitempty"`
+	Action  string `json:"action,omitempty"`  // "start", "stop", "status"
+	Message string `json:"message,omitempty"` // human-readable summary
+}
+
+func (h *ServiceHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	svcName := job.Payload["service"]
+	if svcName == "" {
+		return nil, fmt.Errorf("job payload missing 'service' field")
+	}
+
+	ctx.Log("info", "     - [Job %s] Service %s: %s", job.ID, job.Type, svcName)
+
+	// Load manifest and validate service name against it.
+	manifest, err := h.loadManifest()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load manifest: %w", err)
+	}
+
+	svc, ok := h.findService(manifest, svcName)
+	if !ok {
+		return nil, fmt.Errorf("service %q not found in manifest (known: %s)",
+			svcName, h.knownServiceNames(manifest))
+	}
+
+	switch job.Type {
+	case "SERVICE_STATUS":
+		return h.serviceStatus(svc)
+	case "SERVICE_START":
+		return h.serviceStart(ctx, svc)
+	case "SERVICE_STOP":
+		return h.serviceStop(ctx, svc)
+	default:
+		return nil, fmt.Errorf("unknown service job type: %s", job.Type)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Operations
+// ---------------------------------------------------------------------------
+
+func (h *ServiceHandler) serviceStatus(svc manifestService) ([]byte, error) {
+	kind := h.resolveKind(svc)
+	running := false
+
+	switch kind {
+	case "native":
+		running = services.IsNativeServiceRunning(svc.Name)
+	case "docker":
+		running = h.isDockerServiceRunning(svc.Name)
+	}
+
+	return json.Marshal(serviceResult{
+		Name:    svc.Name,
+		Running: running,
+		Kind:    kind,
+		Action:  "status",
+		Message: fmt.Sprintf("%s is %s (%s)", svc.Name, boolToStatus(running), kind),
+	})
+}
+
+func (h *ServiceHandler) serviceStart(ctx JobContext, svc manifestService) ([]byte, error) {
+	kind := h.resolveKind(svc)
+	var err error
+
+	switch kind {
+	case "native":
+		if services.IsNativeServiceRunning(svc.Name) {
+			return json.Marshal(serviceResult{
+				Name: svc.Name, Running: true, Kind: kind,
+				Action: "start", Message: svc.Name + " is already running",
+			})
+		}
+		logDir := filepath.Join(h.ConfigDir, "logs")
+		_, err = services.StartNativeService(svc.Name, logDir)
+
+	case "docker":
+		if h.isDockerServiceRunning(svc.Name) {
+			return json.Marshal(serviceResult{
+				Name: svc.Name, Running: true, Kind: kind,
+				Action: "start", Message: svc.Name + " is already running",
+			})
+		}
+		composePath, pathErr := h.resolveComposePath(svc)
+		if pathErr != nil {
+			return nil, pathErr
+		}
+		cmd := exec.Command("docker", "compose", "-f", composePath, "up", "-d")
+		out, cmdErr := cmd.CombinedOutput()
+		if cmdErr != nil {
+			err = fmt.Errorf("docker compose up failed: %s", strings.TrimSpace(string(out)))
+		}
+	}
+
+	if err != nil {
+		return json.Marshal(serviceResult{
+			Name: svc.Name, Running: false, Kind: kind,
+			Action: "start", Error: err.Error(),
+			Message: fmt.Sprintf("failed to start %s: %s", svc.Name, err),
+		})
+	}
+
+	return json.Marshal(serviceResult{
+		Name: svc.Name, Running: true, Kind: kind,
+		Action: "start", Message: fmt.Sprintf("%s started successfully", svc.Name),
+	})
+}
+
+func (h *ServiceHandler) serviceStop(ctx JobContext, svc manifestService) ([]byte, error) {
+	kind := h.resolveKind(svc)
+	var err error
+
+	switch kind {
+	case "native":
+		if !services.IsNativeServiceRunning(svc.Name) {
+			return json.Marshal(serviceResult{
+				Name: svc.Name, Running: false, Kind: kind,
+				Action: "stop", Message: svc.Name + " is not running",
+			})
+		}
+		err = services.StopNativeService(svc.Name)
+
+	case "docker":
+		if !h.isDockerServiceRunning(svc.Name) {
+			return json.Marshal(serviceResult{
+				Name: svc.Name, Running: false, Kind: kind,
+				Action: "stop", Message: svc.Name + " is not running",
+			})
+		}
+		composePath, pathErr := h.resolveComposePath(svc)
+		if pathErr != nil {
+			return nil, pathErr
+		}
+		cmd := exec.Command("docker", "compose", "-f", composePath, "down")
+		out, cmdErr := cmd.CombinedOutput()
+		if cmdErr != nil {
+			err = fmt.Errorf("docker compose down failed: %s", strings.TrimSpace(string(out)))
+		}
+	}
+
+	if err != nil {
+		return json.Marshal(serviceResult{
+			Name: svc.Name, Running: false, Kind: kind,
+			Action: "stop", Error: err.Error(),
+			Message: fmt.Sprintf("failed to stop %s: %s", svc.Name, err),
+		})
+	}
+
+	return json.Marshal(serviceResult{
+		Name: svc.Name, Running: false, Kind: kind,
+		Action: "stop", Message: fmt.Sprintf("%s stopped successfully", svc.Name),
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func (h *ServiceHandler) loadManifest() (*serviceManifest, error) {
+	path := filepath.Join(h.ConfigDir, "citadel.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var m serviceManifest
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+func (h *ServiceHandler) findService(m *serviceManifest, name string) (manifestService, bool) {
+	for _, s := range m.Services {
+		if s.Name == name {
+			return s, true
+		}
+	}
+	return manifestService{}, false
+}
+
+func (h *ServiceHandler) knownServiceNames(m *serviceManifest) string {
+	names := make([]string, len(m.Services))
+	for i, s := range m.Services {
+		names[i] = s.Name
+	}
+	return strings.Join(names, ", ")
+}
+
+func (h *ServiceHandler) resolveKind(svc manifestService) string {
+	if svc.Type == "native" {
+		return "native"
+	}
+	if svc.Type == "docker" {
+		return "docker"
+	}
+	// Auto-detect: prefer native if available
+	if services.IsNativeAvailable(svc.Name) {
+		return "native"
+	}
+	return "docker"
+}
+
+func (h *ServiceHandler) isDockerServiceRunning(svcName string) bool {
+	containerName := "citadel-" + svcName
+	cmd := exec.Command("docker", "inspect", "--format", "{{.State.Status}}", containerName)
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) == "running"
+}
+
+func (h *ServiceHandler) resolveComposePath(svc manifestService) (string, error) {
+	if svc.ComposeFile == "" {
+		return "", fmt.Errorf("service %s has no compose_file defined", svc.Name)
+	}
+	fullPath, err := platform.ValidatePathWithinDir(h.ConfigDir, svc.ComposeFile)
+	if err != nil {
+		return "", fmt.Errorf("invalid compose file path for %s: %w", svc.Name, err)
+	}
+	return fullPath, nil
+}
+
+func boolToStatus(running bool) string {
+	if running {
+		return "running"
+	}
+	return "stopped"
+}

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -100,6 +100,9 @@ type LegacyHandlerOpts struct {
 	// WorkspaceDir is the sandbox root for file-operation handlers.
 	// If empty, file-operation handlers are not registered.
 	WorkspaceDir string
+	// ConfigDir is the path to the citadel.yaml manifest directory.
+	// If empty, service-management handlers are not registered.
+	ConfigDir string
 }
 
 // CreateLegacyHandlers creates JobHandler adapters for all existing Nexus job handlers.
@@ -136,6 +139,16 @@ func CreateLegacyHandlersWithOpts(opts LegacyHandlerOpts) []JobHandler {
 			NewLegacyHandlerAdapter(JobTypeFileEdit, jobs.NewFileEditHandler(opts.WorkspaceDir)),
 			NewLegacyHandlerAdapter(JobTypeFileList, jobs.NewFileListHandler(opts.WorkspaceDir)),
 			NewLegacyHandlerAdapter(JobTypeFileSearch, jobs.NewFileSearchHandler(opts.WorkspaceDir)),
+		)
+	}
+
+	// Register service-management handlers when a config directory is available.
+	if opts.ConfigDir != "" {
+		svcHandler := jobs.NewServiceHandler(opts.ConfigDir)
+		handlers = append(handlers,
+			NewLegacyHandlerAdapter(JobTypeServiceStart, svcHandler),
+			NewLegacyHandlerAdapter(JobTypeServiceStop, svcHandler),
+			NewLegacyHandlerAdapter(JobTypeServiceStatus, svcHandler),
 		)
 	}
 

--- a/internal/worker/job.go
+++ b/internal/worker/job.go
@@ -111,4 +111,7 @@ const (
 	JobTypeFileEdit          = "FILE_EDIT"           // Edit (string replace) a file in the workspace
 	JobTypeFileList          = "FILE_LIST"           // List directory contents in the workspace
 	JobTypeFileSearch        = "FILE_SEARCH"         // Search for text across files in the workspace
+	JobTypeServiceStart      = "SERVICE_START"       // Start a service on the node
+	JobTypeServiceStop       = "SERVICE_STOP"        // Stop a service on the node
+	JobTypeServiceStatus     = "SERVICE_STATUS"      // Check if a service is running
 )


### PR DESCRIPTION
## Summary
- New `SERVICE_START`, `SERVICE_STOP`, `SERVICE_STATUS` job types
- `ServiceHandler` validates service names against citadel.yaml manifest
- Supports docker (compose up/down) and native (process) service kinds
- Path traversal protection on compose file paths
- Registered via `LegacyHandlerOpts.ConfigDir`

## Why
MCP tools need to start/stop/check services on Citadel nodes without SSH. Enables automated WeChat API restart when it hangs, inference engine management, etc. (#3465)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/worker/ ./internal/jobs/` passes
- [ ] E2E: deploy to aceteamvm, call `service_status` via MCP

---
*Generated by Claude*