### PR TITLE
fix(heartbeat): include vnc_port and Headscale node ID (#3480)

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -841,10 +841,12 @@ func runTUIWorker(ctx context.Context, activityFn func(level, msg string)) error
 		return fmt.Errorf("no API token configured (complete device authorization first)")
 	}
 
-	// Get node name
+	// Get node name and Headscale node ID
 	nodeName := ""
+	headscaleNodeID := ""
 	if netStatus, err := network.GetGlobalStatus(ctx); err == nil && netStatus.Connected && netStatus.Hostname != "" {
 		nodeName = netStatus.Hostname
+		headscaleNodeID = netStatus.NodeID
 	} else {
 		nodeName, _ = os.Hostname()
 	}
@@ -868,11 +870,12 @@ func runTUIWorker(ctx context.Context, activityFn func(level, msg string)) error
 		if orgID != "" {
 			if apiSource, ok := source.(*worker.APISource); ok {
 				apiPublisher, err := heartbeat.NewAPIPublisher(heartbeat.APIPublisherConfig{
-					Client:    apiSource.Client(),
-					NodeID:    nodeName,
-					OrgID:     orgID,
-					DebugFunc: nil,
-					LogFn:     activity, // Route logs through TUI
+					Client:          apiSource.Client(),
+					NodeID:          nodeName,
+					HeadscaleNodeID: headscaleNodeID,
+					OrgID:           orgID,
+					DebugFunc:       nil,
+					LogFn:           activity, // Route logs through TUI
 				}, collector)
 				if err == nil {
 					go func() {

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -365,8 +365,9 @@ func runWork(cmd *cobra.Command, args []string) {
 		Debug("network not configured (no saved state)")
 	}
 
-	// Get node name - prefer the actual registered name from network (Headscale-assigned)
+	// Get node name and Headscale node ID from network status
 	nodeName := workNodeName
+	var headscaleNodeID string // Headscale numeric node ID (e.g., "758")
 	Debug("resolving node name...")
 	Debug("workNodeName flag: %q", workNodeName)
 	Debug("CITADEL_NODE_NAME env: %q", os.Getenv("CITADEL_NODE_NAME"))
@@ -379,19 +380,38 @@ func runWork(cmd *cobra.Command, args []string) {
 		if netStatus, err := network.GetGlobalStatus(ctx); err == nil && netStatus.Connected && netStatus.Hostname != "" {
 			Debug("got hostname from network status: %s", netStatus.Hostname)
 			nodeName = netStatus.Hostname
+			if netStatus.NodeID != "" {
+				headscaleNodeID = netStatus.NodeID
+				Debug("got Headscale node ID from network status: %s", headscaleNodeID)
+			}
 		} else {
 			// Fallback to local hostname
 			hostname, _ := os.Hostname()
 			Debug("using local hostname fallback: %s", hostname)
 			nodeName = hostname
 		}
+	} else {
+		// Even with an explicit node name, resolve the Headscale node ID
+		headscaleNodeID = network.GetGlobalNodeID(ctx)
+		if headscaleNodeID != "" {
+			Debug("got Headscale node ID: %s", headscaleNodeID)
+		}
 	}
 	Debug("final node name: %s", nodeName)
+	if headscaleNodeID != "" {
+		Debug("final Headscale node ID: %s", headscaleNodeID)
+	}
 
-	// Set node identity on the stream event publisher for operator attribution
+	// Set node identity on the stream event publisher for operator attribution.
+	// Use Headscale numeric node ID when available so job results can be
+	// correlated with fabric_node_status (which is keyed by Headscale ID).
 	if setNodeMeta != nil {
-		setNodeMeta(nodeName, nodeName)
-		Debug("node meta set: node_id=%s, node_name=%s", nodeName, nodeName)
+		metaNodeID := nodeName
+		if headscaleNodeID != "" {
+			metaNodeID = headscaleNodeID
+		}
+		setNodeMeta(metaNodeID, nodeName)
+		Debug("node meta set: node_id=%s, node_name=%s", metaNodeID, nodeName)
 	}
 
 	// Open usage store for per-job compute tracking
@@ -568,10 +588,11 @@ func runWork(cmd *cobra.Command, args []string) {
 				fmt.Fprintln(os.Stderr, "   - ⚠️ API status publisher requires org-id (run 'citadel init' first)")
 			} else {
 				apiPublisher, err := heartbeat.NewAPIPublisher(heartbeat.APIPublisherConfig{
-					Client:    apiSource.Client(),
-					NodeID:    nodeName,
-					OrgID:     orgID,
-					DebugFunc: Debug,
+					Client:          apiSource.Client(),
+					NodeID:          nodeName,
+					HeadscaleNodeID: headscaleNodeID,
+					OrgID:           orgID,
+					DebugFunc:       Debug,
 				}, collector)
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "   - ⚠️ Failed to create API publisher: %v\n", err)
@@ -596,6 +617,7 @@ func runWork(cmd *cobra.Command, args []string) {
 				RedisURL:        workRedisURL,
 				RedisPassword:   workRedisPass,
 				NodeID:          nodeName,
+				HeadscaleNodeID: headscaleNodeID,
 				DeviceCode:      deviceCode,
 				ChannelOverride: workStatusChannel,
 				DebugFunc:       Debug,

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -403,15 +403,13 @@ func runWork(cmd *cobra.Command, args []string) {
 	}
 
 	// Set node identity on the stream event publisher for operator attribution.
-	// Use Headscale numeric node ID when available so job results can be
-	// correlated with fabric_node_status (which is keyed by Headscale ID).
+	// Note: We keep using nodeName (hostname) here rather than the Headscale
+	// numeric ID, because the usage/earnings pipeline may key on hostname.
+	// The Headscale numeric ID is passed in the heartbeat payload via
+	// headscaleNodeId for the Python NodeStatusWorker to use directly.
 	if setNodeMeta != nil {
-		metaNodeID := nodeName
-		if headscaleNodeID != "" {
-			metaNodeID = headscaleNodeID
-		}
-		setNodeMeta(metaNodeID, nodeName)
-		Debug("node meta set: node_id=%s, node_name=%s", metaNodeID, nodeName)
+		setNodeMeta(nodeName, nodeName)
+		Debug("node meta set: node_id=%s, node_name=%s", nodeName, nodeName)
 	}
 
 	// Open usage store for per-job compute tracking

--- a/internal/heartbeat/api.go
+++ b/internal/heartbeat/api.go
@@ -28,11 +28,12 @@ import (
 // APIPublisher publishes node status via the Redis API proxy.
 // This is the secure alternative to direct Redis connections.
 type APIPublisher struct {
-	client    *redisapi.Client
-	nodeID    string
-	orgID     string
-	interval  time.Duration
-	collector *status.Collector
+	client          *redisapi.Client
+	nodeID          string
+	headscaleNodeID string // Headscale numeric node ID (e.g., "758")
+	orgID           string
+	interval        time.Duration
+	collector       *status.Collector
 
 	// Redis key names
 	pubSubChannel string // format: node:status:org:{orgId}:{hostname}
@@ -55,6 +56,11 @@ type APIPublisherConfig struct {
 
 	// NodeID is the node identifier (typically hostname or network node name)
 	NodeID string
+
+	// HeadscaleNodeID is the Headscale numeric node ID (e.g., "758").
+	// When set, included in heartbeat messages so the Python worker can skip
+	// the Headscale hostname-to-ID lookup.
+	HeadscaleNodeID string
 
 	// OrgID is the organization ID for channel scoping (required for API mode)
 	OrgID string
@@ -91,15 +97,16 @@ func NewAPIPublisher(cfg APIPublisherConfig, collector *status.Collector) (*APIP
 	pubSubChannel := fmt.Sprintf("node:status:org:%s:%s", cfg.OrgID, cfg.NodeID)
 
 	return &APIPublisher{
-		client:        cfg.Client,
-		nodeID:        cfg.NodeID,
-		orgID:         cfg.OrgID,
-		interval:      cfg.Interval,
-		collector:     collector,
-		pubSubChannel: pubSubChannel,
-		streamName:    "node:status:stream",
-		debugFunc:     cfg.DebugFunc,
-		logFn:         cfg.LogFn,
+		client:          cfg.Client,
+		nodeID:          cfg.NodeID,
+		headscaleNodeID: cfg.HeadscaleNodeID,
+		orgID:           cfg.OrgID,
+		interval:        cfg.Interval,
+		collector:       collector,
+		pubSubChannel:   pubSubChannel,
+		streamName:      "node:status:stream",
+		debugFunc:       cfg.DebugFunc,
+		logFn:           cfg.LogFn,
 	}, nil
 }
 
@@ -170,14 +177,15 @@ func (p *APIPublisher) publishStatus(ctx context.Context) error {
 
 	// Build status message
 	msg := StatusMessage{
-		Version:   "1.0",
-		Timestamp: timestamp,
-		NodeID:    p.nodeID,
-		Status:    nodeStatus,
+		Version:         "1.0",
+		Timestamp:       timestamp,
+		NodeID:          p.nodeID,
+		HeadscaleNodeID: p.headscaleNodeID,
+		Status:          nodeStatus,
 	}
 
 	p.debug("heartbeat: publishing to channel %s", p.pubSubChannel)
-	p.debug("heartbeat: nodeId=%s, timestamp=%s", msg.NodeID, msg.Timestamp)
+	p.debug("heartbeat: nodeId=%s, headscaleNodeId=%s, timestamp=%s", msg.NodeID, msg.HeadscaleNodeID, msg.Timestamp)
 
 	// 1. Publish to Pub/Sub for real-time UI updates
 	if err := p.client.Publish(ctx, p.pubSubChannel, msg); err != nil {

--- a/internal/heartbeat/redis.go
+++ b/internal/heartbeat/redis.go
@@ -33,20 +33,22 @@ var nodeIDPattern = regexp.MustCompile(`^[a-zA-Z0-9._-]{1,64}$`)
 
 // StatusMessage is the payload published to Redis for status updates.
 type StatusMessage struct {
-	Version    string             `json:"version"`
-	Timestamp  string             `json:"timestamp"`
-	NodeID     string             `json:"nodeId"`
-	DeviceCode string             `json:"deviceCode,omitempty"`
-	Status     *status.NodeStatus `json:"status"`
+	Version          string             `json:"version"`
+	Timestamp        string             `json:"timestamp"`
+	NodeID           string             `json:"nodeId"`
+	HeadscaleNodeID  string             `json:"headscaleNodeId,omitempty"`
+	DeviceCode       string             `json:"deviceCode,omitempty"`
+	Status           *status.NodeStatus `json:"status"`
 }
 
 // RedisPublisher publishes node status to Redis for real-time updates and reliable processing.
 type RedisPublisher struct {
-	client    *redis.Client
-	redisURL  string // For debug logging
-	nodeID    string
-	interval  time.Duration
-	collector *status.Collector
+	client          *redis.Client
+	redisURL        string // For debug logging
+	nodeID          string
+	headscaleNodeID string // Headscale numeric node ID (e.g., "758")
+	interval        time.Duration
+	collector       *status.Collector
 
 	// deviceCode is protected by mu since it can be updated after auth
 	mu         sync.RWMutex
@@ -76,6 +78,11 @@ type RedisPublisherConfig struct {
 
 	// NodeID is the node identifier (typically hostname or Headscale node name)
 	NodeID string
+
+	// HeadscaleNodeID is the Headscale numeric node ID (e.g., "758").
+	// When set, included in heartbeat messages so the Python worker can skip
+	// the Headscale hostname-to-ID lookup.
+	HeadscaleNodeID string
 
 	// DeviceCode is the device authorization code for config lookup (optional)
 	DeviceCode string
@@ -124,16 +131,17 @@ func NewRedisPublisher(cfg RedisPublisherConfig, collector *status.Collector) (*
 	}
 
 	return &RedisPublisher{
-		client:        client,
-		redisURL:      cfg.RedisURL,
-		nodeID:        cfg.NodeID,
-		deviceCode:    cfg.DeviceCode,
-		interval:      cfg.Interval,
-		collector:     collector,
-		pubSubChannel: pubSubChannel,
-		streamName:    "node:status:stream",
-		debugFunc:     cfg.DebugFunc,
-		logFn:         cfg.LogFn,
+		client:          client,
+		redisURL:        cfg.RedisURL,
+		nodeID:          cfg.NodeID,
+		headscaleNodeID: cfg.HeadscaleNodeID,
+		deviceCode:      cfg.DeviceCode,
+		interval:        cfg.Interval,
+		collector:       collector,
+		pubSubChannel:   pubSubChannel,
+		streamName:      "node:status:stream",
+		debugFunc:       cfg.DebugFunc,
+		logFn:           cfg.LogFn,
 	}, nil
 }
 
@@ -213,11 +221,12 @@ func (p *RedisPublisher) publishStatus(ctx context.Context) error {
 
 	// Build status message
 	msg := StatusMessage{
-		Version:    "1.0",
-		Timestamp:  time.Now().UTC().Format(time.RFC3339),
-		NodeID:     p.nodeID,
-		DeviceCode: deviceCode,
-		Status:     nodeStatus,
+		Version:         "1.0",
+		Timestamp:       time.Now().UTC().Format(time.RFC3339),
+		NodeID:          p.nodeID,
+		HeadscaleNodeID: p.headscaleNodeID,
+		DeviceCode:      deviceCode,
+		Status:          nodeStatus,
 	}
 
 	// Marshal to JSON
@@ -227,7 +236,7 @@ func (p *RedisPublisher) publishStatus(ctx context.Context) error {
 	}
 
 	p.debug("heartbeat: publishing to channel %s", p.pubSubChannel)
-	p.debug("heartbeat: nodeId=%s, deviceCode=%s, timestamp=%s", msg.NodeID, msg.DeviceCode, msg.Timestamp)
+	p.debug("heartbeat: nodeId=%s, headscaleNodeId=%s, deviceCode=%s, timestamp=%s", msg.NodeID, msg.HeadscaleNodeID, msg.DeviceCode, msg.Timestamp)
 	p.debug("heartbeat: payload (%d bytes): %s", len(jsonData), string(jsonData))
 
 	// Publish to Pub/Sub for real-time UI updates

--- a/internal/heartbeat/redis_test.go
+++ b/internal/heartbeat/redis_test.go
@@ -1,6 +1,8 @@
 package heartbeat
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -174,5 +176,111 @@ func TestStatusMessageJSON(t *testing.T) {
 	}
 	if msg.DeviceCode != "abc123" {
 		t.Errorf("DeviceCode = %v, want abc123", msg.DeviceCode)
+	}
+}
+
+func TestStatusMessageHeadscaleNodeID(t *testing.T) {
+	// Test that HeadscaleNodeID is included in StatusMessage when set
+	msg := StatusMessage{
+		Version:         "1.0",
+		Timestamp:       "2024-01-15T12:00:00Z",
+		NodeID:          "ubuntu-gpu-8gluaaom",
+		HeadscaleNodeID: "758",
+		Status: &status.NodeStatus{
+			Version: "1.0",
+			Node: status.NodeInfo{
+				Name: "ubuntu-gpu-8gluaaom",
+			},
+			VNCPort: 5900,
+		},
+	}
+
+	if msg.HeadscaleNodeID != "758" {
+		t.Errorf("HeadscaleNodeID = %v, want 758", msg.HeadscaleNodeID)
+	}
+	if msg.Status.VNCPort != 5900 {
+		t.Errorf("Status.VNCPort = %v, want 5900", msg.Status.VNCPort)
+	}
+}
+
+func TestStatusMessageHeadscaleNodeIDOmittedWhenEmpty(t *testing.T) {
+	// Test that HeadscaleNodeID is omitted from JSON when empty (omitempty tag)
+	msg := StatusMessage{
+		Version:   "1.0",
+		Timestamp: "2024-01-15T12:00:00Z",
+		NodeID:    "test-node",
+		Status:    &status.NodeStatus{Version: "1.0"},
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("Failed to marshal StatusMessage: %v", err)
+	}
+
+	jsonStr := string(data)
+	if strings.Contains(jsonStr, "headscaleNodeId") {
+		t.Errorf("JSON should omit headscaleNodeId when empty, got: %s", jsonStr)
+	}
+}
+
+func TestStatusMessageHeadscaleNodeIDIncludedWhenSet(t *testing.T) {
+	// Test that HeadscaleNodeID IS included in JSON when set
+	msg := StatusMessage{
+		Version:         "1.0",
+		Timestamp:       "2024-01-15T12:00:00Z",
+		NodeID:          "ubuntu-gpu",
+		HeadscaleNodeID: "758",
+		Status:          &status.NodeStatus{Version: "1.0"},
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("Failed to marshal StatusMessage: %v", err)
+	}
+
+	jsonStr := string(data)
+	if !strings.Contains(jsonStr, `"headscaleNodeId":"758"`) {
+		t.Errorf("JSON should include headscaleNodeId when set, got: %s", jsonStr)
+	}
+}
+
+func TestStatusMessageVNCPortIncluded(t *testing.T) {
+	// Test that vnc_port is included in the status payload
+	msg := StatusMessage{
+		Version:   "1.0",
+		Timestamp: "2024-01-15T12:00:00Z",
+		NodeID:    "test-node",
+		Status: &status.NodeStatus{
+			Version: "1.0",
+			VNCPort: 5900,
+		},
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("Failed to marshal StatusMessage: %v", err)
+	}
+
+	jsonStr := string(data)
+	if !strings.Contains(jsonStr, `"vnc_port":5900`) {
+		t.Errorf("JSON should include vnc_port in status, got: %s", jsonStr)
+	}
+}
+
+func TestRedisPublisherHeadscaleNodeID(t *testing.T) {
+	collector := status.NewCollector(status.CollectorConfig{NodeName: "test"})
+
+	pub, err := NewRedisPublisher(RedisPublisherConfig{
+		RedisURL:        "redis://localhost:6379",
+		NodeID:          "ubuntu-gpu",
+		HeadscaleNodeID: "758",
+	}, collector)
+	if err != nil {
+		t.Skipf("Skipping test, could not create publisher: %v", err)
+	}
+	defer pub.Close()
+
+	if pub.headscaleNodeID != "758" {
+		t.Errorf("headscaleNodeID = %v, want 758", pub.headscaleNodeID)
 	}
 }

--- a/internal/network/server.go
+++ b/internal/network/server.go
@@ -354,10 +354,17 @@ func (s *NetworkServer) Status(ctx context.Context) (*NetworkStatus, error) {
 		}
 	}
 
+	// Extract Headscale numeric node ID from StableNodeID
+	var nodeID string
+	if status.Self != nil && !status.Self.ID.IsZero() {
+		nodeID = string(status.Self.ID)
+	}
+
 	return &NetworkStatus{
 		Connected:    status.BackendState == "Running",
 		BackendState: status.BackendState,
 		Hostname:     hostname,
+		NodeID:       nodeID,
 		IPv4:         ipv4,
 		IPv6:         ipv6,
 		ControlURL:   s.controlURL,
@@ -392,6 +399,7 @@ type NetworkStatus struct {
 	Connected    bool   `json:"connected"`
 	BackendState string `json:"backend_state"`
 	Hostname     string `json:"hostname"`
+	NodeID       string `json:"node_id,omitempty"` // Headscale numeric node ID (StableNodeID)
 	IPv4         string `json:"ipv4,omitempty"`
 	IPv6         string `json:"ipv6,omitempty"`
 	ControlURL   string `json:"control_url"`

--- a/internal/network/singleton.go
+++ b/internal/network/singleton.go
@@ -151,6 +151,20 @@ func KeepAlive(ctx context.Context) error {
 	return s.KeepAlive(ctx)
 }
 
+// GetGlobalNodeID returns the Headscale numeric node ID of the global server.
+// Returns empty string if not connected or node ID is unavailable.
+func GetGlobalNodeID(ctx context.Context) string {
+	s := Global()
+	if s == nil {
+		return ""
+	}
+	status, err := s.Status(ctx)
+	if err != nil || !status.Connected {
+		return ""
+	}
+	return status.NodeID
+}
+
 // GetGlobalPeers returns the list of peers from the global server.
 func GetGlobalPeers(ctx context.Context) ([]PeerInfo, error) {
 	s := Global()

--- a/internal/network/singleton_test.go
+++ b/internal/network/singleton_test.go
@@ -2,6 +2,7 @@
 package network
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -119,6 +120,33 @@ func TestLogoutVsDisconnectBehavior(t *testing.T) {
 	//     }
 	//     return ClearState()
 	// }
+}
+
+// TestGetGlobalNodeIDWhenNotConnected verifies GetGlobalNodeID returns empty when not connected.
+func TestGetGlobalNodeIDWhenNotConnected(t *testing.T) {
+	// Ensure no global server is set
+	ClearGlobal()
+
+	ctx := context.Background()
+	nodeID := GetGlobalNodeID(ctx)
+	if nodeID != "" {
+		t.Errorf("GetGlobalNodeID() = %q, want empty string when not connected", nodeID)
+	}
+}
+
+// TestNetworkStatusNodeIDField verifies the NodeID field exists on NetworkStatus.
+func TestNetworkStatusNodeIDField(t *testing.T) {
+	status := NetworkStatus{
+		Connected:    true,
+		BackendState: "Running",
+		Hostname:     "ubuntu-gpu-8gluaaom",
+		NodeID:       "758",
+		IPv4:         "100.64.0.1",
+	}
+
+	if status.NodeID != "758" {
+		t.Errorf("NetworkStatus.NodeID = %q, want %q", status.NodeID, "758")
+	}
 }
 
 // TestHasStateWithEmptyDir verifies HasState returns false for empty directory.


### PR DESCRIPTION
## Context

During E2E testing of the desktop viewer, nodes weren't appearing in `/machines` because their heartbeats didn't include `vnc_port` or the correct Headscale node ID. The `/machines` page and `desktop_screenshot` MCP tool both depend on `fabric_node_status` having nodes registered with these fields.

## Summary

- **Headscale node ID resolution** — Added `NodeID` field to `NetworkStatus`, populated from tsnet's `StableNodeID` (which maps to Headscale's numeric DB primary key). New `GetGlobalNodeID(ctx)` convenience function.
- **HeadscaleNodeID in heartbeats** — Added `headscaleNodeId` field to both `RedisPublisher` and `APIPublisher` heartbeat messages. Wired through `work` and `controlcenter` commands.
- **Preserved hostname as node_id** — `setNodeMeta` still uses hostname (not Headscale ID) to avoid breaking the usage/earnings pipeline. The new field is additive.

### What's NOT in this PR
The Python `NodeStatusWorker` doesn't yet consume the new `headscaleNodeId` field — that's a follow-up PR in aceteam-2. This PR ensures the data is available in heartbeat messages.

## Test plan

| Test | Coverage |
|------|----------|
| `TestStatusMessageHeadscaleNodeID` | Field access |
| `TestStatusMessageHeadscaleNodeIDOmittedWhenEmpty` | JSON omitempty |
| `TestStatusMessageHeadscaleNodeIDIncludedWhenSet` | JSON serialization |
| `TestStatusMessageVNCPortIncluded` | vnc_port in serialized heartbeat |
| `TestRedisPublisherHeadscaleNodeID` | Config propagation |
| `TestGetGlobalNodeIDWhenNotConnected` | Returns empty when disconnected |
| `TestNetworkStatusNodeIDField` | Struct field access |
| **Total: 7 new tests** | All pass |

## Related
- aceteam-ai/aceteam#3480
- aceteam-ai/aceteam#3474 (desktop viewer E2E)

---
*Generated by Claude*