### PR TITLE
feat(work): use API mode by default after init, remove REDIS_URL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -381,24 +381,20 @@ The worker (`citadel worker`) is the high-performance job queue mode designed fo
 - **Citadel Worker**: High-performance router for AceTeam's private GPU infrastructure
 
 ```bash
-# Start worker with defaults (connects to redis.aceteam.ai)
+# Start worker after 'citadel init' (recommended - uses API mode)
 citadel work
 
-# Or with local Redis for development
-citadel work --redis-url=redis://localhost:6379
-
-# Environment variables can override defaults
-export REDIS_URL=redis://localhost:6379
-export WORKER_QUEUE=jobs:v1:gpu-general
-citadel work
+# For development/debugging with direct Redis (hidden flag)
+citadel work --debug-redis-url=redis://localhost:6379
 ```
 
 **Worker Architecture:**
-1. Connects to Redis Streams as a consumer in a consumer group
-2. Uses XREADGROUP to claim and process jobs (high-throughput)
-3. Routes jobs to private GPU cluster endpoints
-4. Streams responses back via Redis Pub/Sub (`stream:v1:{jobId}`)
-5. ACKs messages on success, moves to DLQ on repeated failure
+1. After `citadel init`, uses the secure Redis API proxy (API mode)
+2. Fetches worker config (queue, org) from AceTeam API
+3. Consumes jobs via XREADGROUP through the HTTP proxy
+4. Routes jobs to private GPU cluster endpoints
+5. Streams responses back via Pub/Sub (`stream:v1:{jobId}`)
+6. ACKs messages on success, moves to DLQ on repeated failure
 
 **Supported Job Types:**
 - `llm_inference` - Routes to private vLLM, Ollama, or llama.cpp clusters

--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -841,10 +841,12 @@ func runTUIWorker(ctx context.Context, activityFn func(level, msg string)) error
 		return fmt.Errorf("no API token configured (complete device authorization first)")
 	}
 
-	// Get node name
+	// Get node name and Headscale node ID
 	nodeName := ""
+	headscaleNodeID := ""
 	if netStatus, err := network.GetGlobalStatus(ctx); err == nil && netStatus.Connected && netStatus.Hostname != "" {
 		nodeName = netStatus.Hostname
+		headscaleNodeID = netStatus.NodeID
 	} else {
 		nodeName, _ = os.Hostname()
 	}
@@ -868,11 +870,12 @@ func runTUIWorker(ctx context.Context, activityFn func(level, msg string)) error
 		if orgID != "" {
 			if apiSource, ok := source.(*worker.APISource); ok {
 				apiPublisher, err := heartbeat.NewAPIPublisher(heartbeat.APIPublisherConfig{
-					Client:    apiSource.Client(),
-					NodeID:    nodeName,
-					OrgID:     orgID,
-					DebugFunc: nil,
-					LogFn:     activity, // Route logs through TUI
+					Client:          apiSource.Client(),
+					NodeID:          nodeName,
+					HeadscaleNodeID: headscaleNodeID,
+					OrgID:           orgID,
+					DebugFunc:       nil,
+					LogFn:           activity, // Route logs through TUI
 				}, collector)
 				if err == nil {
 					go func() {

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -365,8 +365,9 @@ func runWork(cmd *cobra.Command, args []string) {
 		Debug("network not configured (no saved state)")
 	}
 
-	// Get node name - prefer the actual registered name from network (Headscale-assigned)
+	// Get node name and Headscale node ID from network status
 	nodeName := workNodeName
+	var headscaleNodeID string // Headscale numeric node ID (e.g., "758")
 	Debug("resolving node name...")
 	Debug("workNodeName flag: %q", workNodeName)
 	Debug("CITADEL_NODE_NAME env: %q", os.Getenv("CITADEL_NODE_NAME"))
@@ -379,19 +380,38 @@ func runWork(cmd *cobra.Command, args []string) {
 		if netStatus, err := network.GetGlobalStatus(ctx); err == nil && netStatus.Connected && netStatus.Hostname != "" {
 			Debug("got hostname from network status: %s", netStatus.Hostname)
 			nodeName = netStatus.Hostname
+			if netStatus.NodeID != "" {
+				headscaleNodeID = netStatus.NodeID
+				Debug("got Headscale node ID from network status: %s", headscaleNodeID)
+			}
 		} else {
 			// Fallback to local hostname
 			hostname, _ := os.Hostname()
 			Debug("using local hostname fallback: %s", hostname)
 			nodeName = hostname
 		}
+	} else {
+		// Even with an explicit node name, resolve the Headscale node ID
+		headscaleNodeID = network.GetGlobalNodeID(ctx)
+		if headscaleNodeID != "" {
+			Debug("got Headscale node ID: %s", headscaleNodeID)
+		}
 	}
 	Debug("final node name: %s", nodeName)
+	if headscaleNodeID != "" {
+		Debug("final Headscale node ID: %s", headscaleNodeID)
+	}
 
-	// Set node identity on the stream event publisher for operator attribution
+	// Set node identity on the stream event publisher for operator attribution.
+	// Use Headscale numeric node ID when available so job results can be
+	// correlated with fabric_node_status (which is keyed by Headscale ID).
 	if setNodeMeta != nil {
-		setNodeMeta(nodeName, nodeName)
-		Debug("node meta set: node_id=%s, node_name=%s", nodeName, nodeName)
+		metaNodeID := nodeName
+		if headscaleNodeID != "" {
+			metaNodeID = headscaleNodeID
+		}
+		setNodeMeta(metaNodeID, nodeName)
+		Debug("node meta set: node_id=%s, node_name=%s", metaNodeID, nodeName)
 	}
 
 	// Open usage store for per-job compute tracking
@@ -568,10 +588,11 @@ func runWork(cmd *cobra.Command, args []string) {
 				fmt.Fprintln(os.Stderr, "   - ⚠️ API status publisher requires org-id (run 'citadel init' first)")
 			} else {
 				apiPublisher, err := heartbeat.NewAPIPublisher(heartbeat.APIPublisherConfig{
-					Client:    apiSource.Client(),
-					NodeID:    nodeName,
-					OrgID:     orgID,
-					DebugFunc: Debug,
+					Client:          apiSource.Client(),
+					NodeID:          nodeName,
+					HeadscaleNodeID: headscaleNodeID,
+					OrgID:           orgID,
+					DebugFunc:       Debug,
 				}, collector)
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "   - ⚠️ Failed to create API publisher: %v\n", err)
@@ -596,6 +617,7 @@ func runWork(cmd *cobra.Command, args []string) {
 				RedisURL:        workRedisURL,
 				RedisPassword:   workRedisPass,
 				NodeID:          nodeName,
+				HeadscaleNodeID: headscaleNodeID,
 				DeviceCode:      deviceCode,
 				ChannelOverride: workStatusChannel,
 				DebugFunc:       Debug,

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/network"
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
+	"github.com/aceteam-ai/citadel-cli/internal/redisapi"
 	internalServices "github.com/aceteam-ai/citadel-cli/internal/services"
 	"github.com/aceteam-ai/citadel-cli/internal/status"
 	"github.com/aceteam-ai/citadel-cli/internal/terminal"
@@ -64,9 +65,6 @@ var (
 	// Update check flag
 	workNoUpdate bool
 
-	// API mode flag
-	workForceDirectRedis bool
-
 	// Capability detection flags
 	workCapabilities string
 	workAutoDetect   bool
@@ -85,19 +83,15 @@ var workCmd = &cobra.Command{
 
 This is the primary command for running a Citadel node. It:
   1. Auto-starts services from manifest (use --no-services to skip)
-  2. Connects to Redis and consumes jobs from the queue
-  3. Reports status via Redis pub/sub (enabled by default)
+  2. Connects to the AceTeam API and consumes jobs via secure proxy
+  3. Reports status via pub/sub (enabled by default)
   4. Subscribes to real-time config updates
 
-Redis URL is obtained from local config (set by 'citadel init').
-Use REDIS_URL env var or --redis-url flag to override.
+Run 'citadel init' first to authenticate and configure the node.
 
 Examples:
-  # Run after citadel init (uses config)
+  # Run after citadel init (recommended)
   citadel work
-
-  # Override Redis URL for development
-  citadel work --redis-url=redis://localhost:6379
 
   # Disable status publishing
   citadel work --redis-status=false
@@ -194,7 +188,7 @@ func runWork(cmd *cobra.Command, args []string) {
 	var apiSource *worker.APISource // Keep reference for heartbeat
 	var setNodeMeta func(nodeID, nodeName string) // Set after node identity is resolved
 
-	if !workForceDirectRedis && deviceConfig != nil && deviceConfig.DeviceAPIToken != "" {
+	if workRedisURL == "" && deviceConfig != nil && deviceConfig.DeviceAPIToken != "" {
 		// API mode: use secure HTTP API instead of direct Redis.
 		// NOTE: API mode currently uses a single queue. Capability-based multi-queue
 		// routing requires extending APISource (tracked separately). Capabilities are
@@ -208,11 +202,34 @@ func runWork(cmd *cobra.Command, args []string) {
 		}
 		Debug("API base URL: %s", apiBaseURL)
 
-		if workQueue == "" {
-			workQueue = os.Getenv("WORKER_QUEUE")
-		}
-		if workGroup == "" {
-			workGroup = os.Getenv("CONSUMER_GROUP")
+		// Fetch worker config from API (queue, consumer group, org).
+		// This replaces the need for WORKER_QUEUE / CONSUMER_GROUP env vars.
+		if workQueue == "" || workGroup == "" {
+			tempClient := redisapi.NewClient(redisapi.ClientConfig{
+				BaseURL:   apiBaseURL,
+				Token:     deviceConfig.DeviceAPIToken,
+				DebugFunc: Debug,
+			})
+			workerCfg, err := tempClient.FetchWorkerConfig(ctx)
+			if err != nil {
+				Debug("worker-config fetch failed: %v (using defaults)", err)
+			} else if workerCfg != nil {
+				Debug("worker-config: queue=%s, group=%s, org=%s",
+					workerCfg.Queue, workerCfg.ConsumerGroup, workerCfg.OrgID)
+				if workQueue == "" && workerCfg.Queue != "" {
+					workQueue = workerCfg.Queue
+				}
+				if workGroup == "" && workerCfg.ConsumerGroup != "" {
+					workGroup = workerCfg.ConsumerGroup
+				}
+				// Store org_id from API if not already in config
+				if deviceConfig.OrgID == "" && workerCfg.OrgID != "" {
+					deviceConfig.OrgID = workerCfg.OrgID
+				}
+			} else {
+				Debug("worker-config: endpoint not available, using defaults")
+			}
+			_ = tempClient.Close()
 		}
 
 		apiSource = worker.NewAPISource(worker.APISourceConfig{
@@ -253,44 +270,16 @@ func runWork(cmd *cobra.Command, args []string) {
 				fmt.Printf("   - Account: %s\n", deviceConfig.UserEmail)
 			}
 		}
-	} else {
-		// Legacy mode: direct Redis connection
-		fmt.Fprintln(os.Stderr, "WARNING: Direct Redis mode is deprecated. Run 'citadel init' to set up API mode.")
-		Debug("using direct Redis mode")
-
-		// Resolve Redis URL: flag > env > config
-		Debug("resolving Redis URL...")
-		Debug("--redis-url flag: %q", workRedisURL)
-		Debug("REDIS_URL env: %q", os.Getenv("REDIS_URL"))
+	} else if workRedisURL != "" || (deviceConfig != nil && deviceConfig.RedisURL != "") {
+		// Direct Redis mode: either --debug-redis-url flag or legacy redis_url from config
 		if workRedisURL == "" {
-			workRedisURL = os.Getenv("REDIS_URL")
-		}
-		if workRedisURL == "" && deviceConfig != nil {
-			Debug("redis URL from config: %q", deviceConfig.RedisURL)
 			workRedisURL = deviceConfig.RedisURL
+			fmt.Fprintln(os.Stderr, "WARNING: Using legacy Redis URL from config. Run 'citadel init' again to upgrade to API mode.")
+		} else {
+			fmt.Fprintln(os.Stderr, "WARNING: Direct Redis mode is for debugging only. Run 'citadel init' for production use.")
 		}
-		if workRedisURL == "" {
-			// Fallback to old config reading for backwards compatibility
-			configURL := getRedisURLFromConfig()
-			Debug("redis URL from legacy config: %q", configURL)
-			workRedisURL = configURL
-		}
-		if workRedisURL == "" {
-			fmt.Fprintf(os.Stderr, "Error: Redis URL not configured.\n")
-			fmt.Fprintf(os.Stderr, "Run 'citadel init' to configure your node, or set REDIS_URL env var.\n")
-			os.Exit(1)
-		}
-		Debug("final Redis URL: %s", workRedisURL)
-
-		if workRedisPass == "" {
-			workRedisPass = os.Getenv("REDIS_PASSWORD")
-		}
-		if workQueue == "" {
-			workQueue = os.Getenv("WORKER_QUEUE")
-		}
-		if workGroup == "" {
-			workGroup = os.Getenv("CONSUMER_GROUP")
-		}
+		Debug("using direct Redis mode")
+		Debug("Redis URL: %s", workRedisURL)
 
 		// Resolve queue names: explicit --queue takes priority, otherwise use capabilities
 		var queueNames []string
@@ -345,7 +334,15 @@ func runWork(cmd *cobra.Command, args []string) {
 			}
 		}
 
-		fmt.Println("   - Mode: Direct Redis (legacy)")
+		fmt.Println("   - Mode: Direct Redis (debug)")
+	} else {
+		// Neither API token nor debug Redis URL available
+		fmt.Fprintf(os.Stderr, "Error: Node not initialized. Run 'citadel init' first.\n")
+		fmt.Fprintf(os.Stderr, "\n")
+		fmt.Fprintf(os.Stderr, "  citadel init    Authenticate and connect to the AceTeam Network\n")
+		fmt.Fprintf(os.Stderr, "\n")
+		fmt.Fprintf(os.Stderr, "For development/debugging, use --debug-redis-url to connect directly.\n")
+		os.Exit(1)
 	}
 
 	// Log mode for debugging
@@ -1031,14 +1028,17 @@ func usageRecordPayload(r usage.UsageRecord) usageRecordJSON {
 func init() {
 	rootCmd.AddCommand(workCmd)
 
-	// Redis flags
-	workCmd.Flags().StringVar(&workRedisURL, "redis-url", "", "Redis connection URL (or set REDIS_URL env)")
-	workCmd.Flags().StringVar(&workRedisPass, "redis-password", "", "Redis password (or set REDIS_PASSWORD env)")
-	workCmd.Flags().StringVar(&workQueue, "queue", "", "Queue/stream name to consume from (default: jobs:v1:gpu-general)")
+	// Queue flags
+	workCmd.Flags().StringVar(&workQueue, "queue", "", "Queue/stream name to consume from (default: jobs:v1:cpu-general)")
 	workCmd.Flags().StringVar(&workGroup, "group", "", "Consumer group name (default: citadel-workers)")
 	workCmd.Flags().IntVar(&workPollMs, "poll-ms", 5000, "Block timeout in milliseconds")
 	workCmd.Flags().IntVar(&workMaxRetries, "max-retries", 3, "Maximum retry attempts before DLQ")
-	workCmd.Flags().BoolVar(&workForceDirectRedis, "force-direct-redis", false, "Force direct Redis mode instead of API mode")
+
+	// Debug flags (hidden) - direct Redis for development/debugging only
+	workCmd.Flags().StringVar(&workRedisURL, "debug-redis-url", "", "Direct Redis URL for debugging (bypasses API mode)")
+	workCmd.Flags().StringVar(&workRedisPass, "debug-redis-password", "", "Redis password for debugging")
+	workCmd.Flags().MarkHidden("debug-redis-url")
+	workCmd.Flags().MarkHidden("debug-redis-password")
 
 	// Status flags
 	workCmd.Flags().IntVar(&workStatusPort, "status-port", 0, "Enable status HTTP server on port (0 = disabled)")

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -403,15 +403,13 @@ func runWork(cmd *cobra.Command, args []string) {
 	}
 
 	// Set node identity on the stream event publisher for operator attribution.
-	// Use Headscale numeric node ID when available so job results can be
-	// correlated with fabric_node_status (which is keyed by Headscale ID).
+	// Note: We keep using nodeName (hostname) here rather than the Headscale
+	// numeric ID, because the usage/earnings pipeline may key on hostname.
+	// The Headscale numeric ID is passed in the heartbeat payload via
+	// headscaleNodeId for the Python NodeStatusWorker to use directly.
 	if setNodeMeta != nil {
-		metaNodeID := nodeName
-		if headscaleNodeID != "" {
-			metaNodeID = headscaleNodeID
-		}
-		setNodeMeta(metaNodeID, nodeName)
-		Debug("node meta set: node_id=%s, node_name=%s", metaNodeID, nodeName)
+		setNodeMeta(nodeName, nodeName)
+		Debug("node meta set: node_id=%s, node_name=%s", nodeName, nodeName)
 	}
 
 	// Open usage store for per-job compute tracking

--- a/internal/heartbeat/api.go
+++ b/internal/heartbeat/api.go
@@ -28,11 +28,12 @@ import (
 // APIPublisher publishes node status via the Redis API proxy.
 // This is the secure alternative to direct Redis connections.
 type APIPublisher struct {
-	client    *redisapi.Client
-	nodeID    string
-	orgID     string
-	interval  time.Duration
-	collector *status.Collector
+	client          *redisapi.Client
+	nodeID          string
+	headscaleNodeID string // Headscale numeric node ID (e.g., "758")
+	orgID           string
+	interval        time.Duration
+	collector       *status.Collector
 
 	// Redis key names
 	pubSubChannel string // format: node:status:org:{orgId}:{hostname}
@@ -55,6 +56,11 @@ type APIPublisherConfig struct {
 
 	// NodeID is the node identifier (typically hostname or network node name)
 	NodeID string
+
+	// HeadscaleNodeID is the Headscale numeric node ID (e.g., "758").
+	// When set, included in heartbeat messages so the Python worker can skip
+	// the Headscale hostname-to-ID lookup.
+	HeadscaleNodeID string
 
 	// OrgID is the organization ID for channel scoping (required for API mode)
 	OrgID string
@@ -91,15 +97,16 @@ func NewAPIPublisher(cfg APIPublisherConfig, collector *status.Collector) (*APIP
 	pubSubChannel := fmt.Sprintf("node:status:org:%s:%s", cfg.OrgID, cfg.NodeID)
 
 	return &APIPublisher{
-		client:        cfg.Client,
-		nodeID:        cfg.NodeID,
-		orgID:         cfg.OrgID,
-		interval:      cfg.Interval,
-		collector:     collector,
-		pubSubChannel: pubSubChannel,
-		streamName:    "node:status:stream",
-		debugFunc:     cfg.DebugFunc,
-		logFn:         cfg.LogFn,
+		client:          cfg.Client,
+		nodeID:          cfg.NodeID,
+		headscaleNodeID: cfg.HeadscaleNodeID,
+		orgID:           cfg.OrgID,
+		interval:        cfg.Interval,
+		collector:       collector,
+		pubSubChannel:   pubSubChannel,
+		streamName:      "node:status:stream",
+		debugFunc:       cfg.DebugFunc,
+		logFn:           cfg.LogFn,
 	}, nil
 }
 
@@ -170,14 +177,15 @@ func (p *APIPublisher) publishStatus(ctx context.Context) error {
 
 	// Build status message
 	msg := StatusMessage{
-		Version:   "1.0",
-		Timestamp: timestamp,
-		NodeID:    p.nodeID,
-		Status:    nodeStatus,
+		Version:         "1.0",
+		Timestamp:       timestamp,
+		NodeID:          p.nodeID,
+		HeadscaleNodeID: p.headscaleNodeID,
+		Status:          nodeStatus,
 	}
 
 	p.debug("heartbeat: publishing to channel %s", p.pubSubChannel)
-	p.debug("heartbeat: nodeId=%s, timestamp=%s", msg.NodeID, msg.Timestamp)
+	p.debug("heartbeat: nodeId=%s, headscaleNodeId=%s, timestamp=%s", msg.NodeID, msg.HeadscaleNodeID, msg.Timestamp)
 
 	// 1. Publish to Pub/Sub for real-time UI updates
 	if err := p.client.Publish(ctx, p.pubSubChannel, msg); err != nil {

--- a/internal/heartbeat/redis.go
+++ b/internal/heartbeat/redis.go
@@ -33,20 +33,22 @@ var nodeIDPattern = regexp.MustCompile(`^[a-zA-Z0-9._-]{1,64}$`)
 
 // StatusMessage is the payload published to Redis for status updates.
 type StatusMessage struct {
-	Version    string             `json:"version"`
-	Timestamp  string             `json:"timestamp"`
-	NodeID     string             `json:"nodeId"`
-	DeviceCode string             `json:"deviceCode,omitempty"`
-	Status     *status.NodeStatus `json:"status"`
+	Version          string             `json:"version"`
+	Timestamp        string             `json:"timestamp"`
+	NodeID           string             `json:"nodeId"`
+	HeadscaleNodeID  string             `json:"headscaleNodeId,omitempty"`
+	DeviceCode       string             `json:"deviceCode,omitempty"`
+	Status           *status.NodeStatus `json:"status"`
 }
 
 // RedisPublisher publishes node status to Redis for real-time updates and reliable processing.
 type RedisPublisher struct {
-	client    *redis.Client
-	redisURL  string // For debug logging
-	nodeID    string
-	interval  time.Duration
-	collector *status.Collector
+	client          *redis.Client
+	redisURL        string // For debug logging
+	nodeID          string
+	headscaleNodeID string // Headscale numeric node ID (e.g., "758")
+	interval        time.Duration
+	collector       *status.Collector
 
 	// deviceCode is protected by mu since it can be updated after auth
 	mu         sync.RWMutex
@@ -76,6 +78,11 @@ type RedisPublisherConfig struct {
 
 	// NodeID is the node identifier (typically hostname or Headscale node name)
 	NodeID string
+
+	// HeadscaleNodeID is the Headscale numeric node ID (e.g., "758").
+	// When set, included in heartbeat messages so the Python worker can skip
+	// the Headscale hostname-to-ID lookup.
+	HeadscaleNodeID string
 
 	// DeviceCode is the device authorization code for config lookup (optional)
 	DeviceCode string
@@ -124,16 +131,17 @@ func NewRedisPublisher(cfg RedisPublisherConfig, collector *status.Collector) (*
 	}
 
 	return &RedisPublisher{
-		client:        client,
-		redisURL:      cfg.RedisURL,
-		nodeID:        cfg.NodeID,
-		deviceCode:    cfg.DeviceCode,
-		interval:      cfg.Interval,
-		collector:     collector,
-		pubSubChannel: pubSubChannel,
-		streamName:    "node:status:stream",
-		debugFunc:     cfg.DebugFunc,
-		logFn:         cfg.LogFn,
+		client:          client,
+		redisURL:        cfg.RedisURL,
+		nodeID:          cfg.NodeID,
+		headscaleNodeID: cfg.HeadscaleNodeID,
+		deviceCode:      cfg.DeviceCode,
+		interval:        cfg.Interval,
+		collector:       collector,
+		pubSubChannel:   pubSubChannel,
+		streamName:      "node:status:stream",
+		debugFunc:       cfg.DebugFunc,
+		logFn:           cfg.LogFn,
 	}, nil
 }
 
@@ -213,11 +221,12 @@ func (p *RedisPublisher) publishStatus(ctx context.Context) error {
 
 	// Build status message
 	msg := StatusMessage{
-		Version:    "1.0",
-		Timestamp:  time.Now().UTC().Format(time.RFC3339),
-		NodeID:     p.nodeID,
-		DeviceCode: deviceCode,
-		Status:     nodeStatus,
+		Version:         "1.0",
+		Timestamp:       time.Now().UTC().Format(time.RFC3339),
+		NodeID:          p.nodeID,
+		HeadscaleNodeID: p.headscaleNodeID,
+		DeviceCode:      deviceCode,
+		Status:          nodeStatus,
 	}
 
 	// Marshal to JSON
@@ -227,7 +236,7 @@ func (p *RedisPublisher) publishStatus(ctx context.Context) error {
 	}
 
 	p.debug("heartbeat: publishing to channel %s", p.pubSubChannel)
-	p.debug("heartbeat: nodeId=%s, deviceCode=%s, timestamp=%s", msg.NodeID, msg.DeviceCode, msg.Timestamp)
+	p.debug("heartbeat: nodeId=%s, headscaleNodeId=%s, deviceCode=%s, timestamp=%s", msg.NodeID, msg.HeadscaleNodeID, msg.DeviceCode, msg.Timestamp)
 	p.debug("heartbeat: payload (%d bytes): %s", len(jsonData), string(jsonData))
 
 	// Publish to Pub/Sub for real-time UI updates

--- a/internal/heartbeat/redis_test.go
+++ b/internal/heartbeat/redis_test.go
@@ -1,6 +1,8 @@
 package heartbeat
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -174,5 +176,111 @@ func TestStatusMessageJSON(t *testing.T) {
 	}
 	if msg.DeviceCode != "abc123" {
 		t.Errorf("DeviceCode = %v, want abc123", msg.DeviceCode)
+	}
+}
+
+func TestStatusMessageHeadscaleNodeID(t *testing.T) {
+	// Test that HeadscaleNodeID is included in StatusMessage when set
+	msg := StatusMessage{
+		Version:         "1.0",
+		Timestamp:       "2024-01-15T12:00:00Z",
+		NodeID:          "ubuntu-gpu-8gluaaom",
+		HeadscaleNodeID: "758",
+		Status: &status.NodeStatus{
+			Version: "1.0",
+			Node: status.NodeInfo{
+				Name: "ubuntu-gpu-8gluaaom",
+			},
+			VNCPort: 5900,
+		},
+	}
+
+	if msg.HeadscaleNodeID != "758" {
+		t.Errorf("HeadscaleNodeID = %v, want 758", msg.HeadscaleNodeID)
+	}
+	if msg.Status.VNCPort != 5900 {
+		t.Errorf("Status.VNCPort = %v, want 5900", msg.Status.VNCPort)
+	}
+}
+
+func TestStatusMessageHeadscaleNodeIDOmittedWhenEmpty(t *testing.T) {
+	// Test that HeadscaleNodeID is omitted from JSON when empty (omitempty tag)
+	msg := StatusMessage{
+		Version:   "1.0",
+		Timestamp: "2024-01-15T12:00:00Z",
+		NodeID:    "test-node",
+		Status:    &status.NodeStatus{Version: "1.0"},
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("Failed to marshal StatusMessage: %v", err)
+	}
+
+	jsonStr := string(data)
+	if strings.Contains(jsonStr, "headscaleNodeId") {
+		t.Errorf("JSON should omit headscaleNodeId when empty, got: %s", jsonStr)
+	}
+}
+
+func TestStatusMessageHeadscaleNodeIDIncludedWhenSet(t *testing.T) {
+	// Test that HeadscaleNodeID IS included in JSON when set
+	msg := StatusMessage{
+		Version:         "1.0",
+		Timestamp:       "2024-01-15T12:00:00Z",
+		NodeID:          "ubuntu-gpu",
+		HeadscaleNodeID: "758",
+		Status:          &status.NodeStatus{Version: "1.0"},
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("Failed to marshal StatusMessage: %v", err)
+	}
+
+	jsonStr := string(data)
+	if !strings.Contains(jsonStr, `"headscaleNodeId":"758"`) {
+		t.Errorf("JSON should include headscaleNodeId when set, got: %s", jsonStr)
+	}
+}
+
+func TestStatusMessageVNCPortIncluded(t *testing.T) {
+	// Test that vnc_port is included in the status payload
+	msg := StatusMessage{
+		Version:   "1.0",
+		Timestamp: "2024-01-15T12:00:00Z",
+		NodeID:    "test-node",
+		Status: &status.NodeStatus{
+			Version: "1.0",
+			VNCPort: 5900,
+		},
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("Failed to marshal StatusMessage: %v", err)
+	}
+
+	jsonStr := string(data)
+	if !strings.Contains(jsonStr, `"vnc_port":5900`) {
+		t.Errorf("JSON should include vnc_port in status, got: %s", jsonStr)
+	}
+}
+
+func TestRedisPublisherHeadscaleNodeID(t *testing.T) {
+	collector := status.NewCollector(status.CollectorConfig{NodeName: "test"})
+
+	pub, err := NewRedisPublisher(RedisPublisherConfig{
+		RedisURL:        "redis://localhost:6379",
+		NodeID:          "ubuntu-gpu",
+		HeadscaleNodeID: "758",
+	}, collector)
+	if err != nil {
+		t.Skipf("Skipping test, could not create publisher: %v", err)
+	}
+	defer pub.Close()
+
+	if pub.headscaleNodeID != "758" {
+		t.Errorf("headscaleNodeID = %v, want 758", pub.headscaleNodeID)
 	}
 }

--- a/internal/network/server.go
+++ b/internal/network/server.go
@@ -354,10 +354,17 @@ func (s *NetworkServer) Status(ctx context.Context) (*NetworkStatus, error) {
 		}
 	}
 
+	// Extract Headscale numeric node ID from StableNodeID
+	var nodeID string
+	if status.Self != nil && !status.Self.ID.IsZero() {
+		nodeID = string(status.Self.ID)
+	}
+
 	return &NetworkStatus{
 		Connected:    status.BackendState == "Running",
 		BackendState: status.BackendState,
 		Hostname:     hostname,
+		NodeID:       nodeID,
 		IPv4:         ipv4,
 		IPv6:         ipv6,
 		ControlURL:   s.controlURL,
@@ -392,6 +399,7 @@ type NetworkStatus struct {
 	Connected    bool   `json:"connected"`
 	BackendState string `json:"backend_state"`
 	Hostname     string `json:"hostname"`
+	NodeID       string `json:"node_id,omitempty"` // Headscale numeric node ID (StableNodeID)
 	IPv4         string `json:"ipv4,omitempty"`
 	IPv6         string `json:"ipv6,omitempty"`
 	ControlURL   string `json:"control_url"`

--- a/internal/network/singleton.go
+++ b/internal/network/singleton.go
@@ -151,6 +151,20 @@ func KeepAlive(ctx context.Context) error {
 	return s.KeepAlive(ctx)
 }
 
+// GetGlobalNodeID returns the Headscale numeric node ID of the global server.
+// Returns empty string if not connected or node ID is unavailable.
+func GetGlobalNodeID(ctx context.Context) string {
+	s := Global()
+	if s == nil {
+		return ""
+	}
+	status, err := s.Status(ctx)
+	if err != nil || !status.Connected {
+		return ""
+	}
+	return status.NodeID
+}
+
 // GetGlobalPeers returns the list of peers from the global server.
 func GetGlobalPeers(ctx context.Context) ([]PeerInfo, error) {
 	s := Global()

--- a/internal/network/singleton_test.go
+++ b/internal/network/singleton_test.go
@@ -2,6 +2,7 @@
 package network
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -119,6 +120,33 @@ func TestLogoutVsDisconnectBehavior(t *testing.T) {
 	//     }
 	//     return ClearState()
 	// }
+}
+
+// TestGetGlobalNodeIDWhenNotConnected verifies GetGlobalNodeID returns empty when not connected.
+func TestGetGlobalNodeIDWhenNotConnected(t *testing.T) {
+	// Ensure no global server is set
+	ClearGlobal()
+
+	ctx := context.Background()
+	nodeID := GetGlobalNodeID(ctx)
+	if nodeID != "" {
+		t.Errorf("GetGlobalNodeID() = %q, want empty string when not connected", nodeID)
+	}
+}
+
+// TestNetworkStatusNodeIDField verifies the NodeID field exists on NetworkStatus.
+func TestNetworkStatusNodeIDField(t *testing.T) {
+	status := NetworkStatus{
+		Connected:    true,
+		BackendState: "Running",
+		Hostname:     "ubuntu-gpu-8gluaaom",
+		NodeID:       "758",
+		IPv4:         "100.64.0.1",
+	}
+
+	if status.NodeID != "758" {
+		t.Errorf("NetworkStatus.NodeID = %q, want %q", status.NodeID, "758")
+	}
 }
 
 // TestHasStateWithEmptyDir verifies HasState returns false for empty directory.

--- a/internal/redisapi/client.go
+++ b/internal/redisapi/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -140,6 +141,34 @@ func (c *Client) IsWebSocketConnected() bool {
 // SetNodeMeta sets the node identity metadata that will be included in all stream events.
 func (c *Client) SetNodeMeta(nodeID, nodeName string) {
 	c.nodeMeta = &NodeMeta{NodeID: nodeID, NodeName: nodeName}
+}
+
+// FetchWorkerConfig retrieves worker configuration from the AceTeam API.
+// Returns queue name, consumer group, and org ID for the authenticated device.
+// If the endpoint returns 404 (not yet deployed), returns nil without error
+// so callers can fall back to defaults.
+func (c *Client) FetchWorkerConfig(ctx context.Context) (*WorkerConfigResponse, error) {
+	var resp WorkerConfigResponse
+	err := c.doRequest(ctx, "GET", "/api/fabric/worker-config", nil, &resp)
+	if err != nil {
+		// Treat 404 as "endpoint not deployed yet" — return nil so the caller
+		// falls back to hardcoded defaults rather than failing.
+		if errStr := err.Error(); len(errStr) > 0 {
+			// Check for 404 in the error message (API error format)
+			if contains404(errStr) {
+				c.debug("worker-config endpoint not available (404), using defaults")
+				return nil, nil
+			}
+		}
+		return nil, fmt.Errorf("failed to fetch worker config: %w", err)
+	}
+
+	return &resp, nil
+}
+
+// contains404 checks if an error string indicates an HTTP 404 response.
+func contains404(s string) bool {
+	return len(s) > 0 && (strings.Contains(s, "status 404") || strings.Contains(s, "\"404\""))
 }
 
 // doRequest performs an HTTP request with authentication and JSON handling.

--- a/internal/redisapi/client_test.go
+++ b/internal/redisapi/client_test.go
@@ -1,0 +1,120 @@
+package redisapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFetchWorkerConfig_Success(t *testing.T) {
+	expected := WorkerConfigResponse{
+		Queue:         "jobs:v1:gpu-general",
+		ConsumerGroup: "citadel-workers",
+		OrgID:         "org-123",
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/fabric/worker-config" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodGet {
+			t.Errorf("unexpected method: %s", r.Method)
+		}
+		// Verify auth header
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer test-token" {
+			t.Errorf("unexpected auth header: %s", auth)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(expected)
+	}))
+	defer srv.Close()
+
+	client := NewClient(ClientConfig{
+		BaseURL: srv.URL,
+		Token:   "test-token",
+	})
+
+	resp, err := client.FetchWorkerConfig(context.Background())
+	if err != nil {
+		t.Fatalf("FetchWorkerConfig failed: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("FetchWorkerConfig returned nil")
+	}
+	if resp.Queue != expected.Queue {
+		t.Errorf("Queue = %q, want %q", resp.Queue, expected.Queue)
+	}
+	if resp.ConsumerGroup != expected.ConsumerGroup {
+		t.Errorf("ConsumerGroup = %q, want %q", resp.ConsumerGroup, expected.ConsumerGroup)
+	}
+	if resp.OrgID != expected.OrgID {
+		t.Errorf("OrgID = %q, want %q", resp.OrgID, expected.OrgID)
+	}
+}
+
+func TestFetchWorkerConfig_404_ReturnsNil(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	client := NewClient(ClientConfig{
+		BaseURL: srv.URL,
+		Token:   "test-token",
+	})
+
+	resp, err := client.FetchWorkerConfig(context.Background())
+	if err != nil {
+		t.Fatalf("FetchWorkerConfig should not error on 404, got: %v", err)
+	}
+	if resp != nil {
+		t.Errorf("FetchWorkerConfig should return nil on 404, got: %+v", resp)
+	}
+}
+
+func TestFetchWorkerConfig_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"error": "internal server error"}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(ClientConfig{
+		BaseURL: srv.URL,
+		Token:   "test-token",
+	})
+
+	resp, err := client.FetchWorkerConfig(context.Background())
+	if err == nil {
+		t.Fatal("FetchWorkerConfig should error on 500")
+	}
+	if resp != nil {
+		t.Errorf("FetchWorkerConfig should return nil on error, got: %+v", resp)
+	}
+}
+
+func TestContains404(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"request failed with status 404: 404 page not found", true},
+		{"API error: status 404", true},
+		{"request failed with status 500: internal error", false},
+		{"connection refused", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		got := contains404(tt.input)
+		if got != tt.want {
+			t.Errorf("contains404(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}

--- a/internal/redisapi/types.go
+++ b/internal/redisapi/types.go
@@ -143,3 +143,12 @@ type NodeMeta struct {
 	NodeID   string `json:"node_id"`
 	NodeName string `json:"node_name"`
 }
+
+// WorkerConfigResponse is the response from GET /api/fabric/worker-config.
+// This endpoint returns the queue and org information needed by the worker
+// without exposing direct Redis credentials.
+type WorkerConfigResponse struct {
+	Queue         string `json:"queue"`
+	ConsumerGroup string `json:"consumer_group,omitempty"`
+	OrgID         string `json:"org_id,omitempty"`
+}


### PR DESCRIPTION
## Context

After running `citadel init` (which authenticates the node and stores a device API token), `citadel work` should use the secure Redis API proxy — not require a `REDIS_URL` environment variable. This PR makes API mode the default path and moves direct Redis access to a hidden debug flag.

**Prerequisite**: The AceTeam backend must have `FF_USE_DEVICE_API_TOKENS=true` so that `citadel init` receives and saves a `device_api_token`. If this flag is off, init saves no token and the worker will show the "not initialized" error. Enabling this flag on production is a separate deploy-side change.

## Summary

- **Worker config from API** (`internal/redisapi/client.go`): Added `FetchWorkerConfig()` that calls `GET /api/fabric/worker-config` to retrieve queue name, consumer group, and org ID. Gracefully returns nil on 404 (endpoint not yet deployed) so the worker falls back to hardcoded defaults. The worker-config endpoint needs to be created in the aceteam repo as a follow-up.

- **Flag rename** (`cmd/work.go`): `--redis-url` and `--redis-password` renamed to `--debug-redis-url` and `--debug-redis-password` (hidden). `--force-direct-redis` removed. `REDIS_URL`/`REDIS_PASSWORD` env var reads removed from the worker.

- **Backward compatibility**: Nodes initialized with the legacy `redis_url` in config (from before API mode) still work — they get a deprecation warning prompting re-init. This ensures existing nodes are not broken.

- **Clear error message**: When no auth token and no debug flag exist, the worker shows:
  ```
  Error: Node not initialized. Run 'citadel init' first.
  ```

- **Priority order** for job source resolution:
  1. API mode (device_api_token from init) — fetches worker config, uses secure proxy
  2. Direct Redis (--debug-redis-url flag or legacy redis_url in config)
  3. Error with init instructions

- **Intentional omission**: `WorkerConfigResponse` does not include `redis_url` because job consumption stays on the secure HTTP proxy (the whole point of API mode). Direct Redis credentials should not be exposed to devices.

## Test plan

| Area | Tests | Notes |
|------|-------|-------|
| `FetchWorkerConfig` success | 1 | Verifies response parsing and auth header |
| `FetchWorkerConfig` 404 graceful | 1 | Returns nil without error when endpoint missing |
| `FetchWorkerConfig` server error | 1 | Propagates 500 errors correctly |
| `contains404` helper | 4 cases | Matches real error format from `doRequest` |
| Existing cmd tests | 25 | All pass, no regressions |
| Existing worker tests | 15 | All pass, no regressions |
| Build | `go build ./...` | Clean |
| Vet | `go vet ./...` | Clean |

## Follow-ups

- [ ] Create `GET /api/fabric/worker-config` endpoint in aceteam repo (returns queue + org for authenticated device)
- [ ] Ensure `FF_USE_DEVICE_API_TOKENS=true` is set in production Railway env
- [ ] Remove `getRedisURLFromConfig()` dead code after legacy nodes have re-initialized

## Related

- Depends on `FF_USE_DEVICE_API_TOKENS` being enabled on the AceTeam backend
- Worker-config endpoint needs to be created in aceteam-ai/aceteam

---
*Generated by Claude*