### PR TITLE
feat: add citadel mcp command (#138)

### DIFF
--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -166,9 +166,6 @@ func (b *mcpBridge) run() error {
 		switch req.Method {
 		case "initialize":
 			b.handleInitialize(&req)
-		case "notifications/initialized":
-			// Client acknowledgment -- no response needed.
-			Debug("MCP: client initialized")
 		case "ping":
 			if !isNotification {
 				b.writeResult(req.ID, json.RawMessage(`{}`))
@@ -184,6 +181,11 @@ func (b *mcpBridge) run() error {
 			if err != nil {
 				Debug("MCP: backend error for %s: %v", req.Method, err)
 				b.writeError(req.ID, -32603, fmt.Sprintf("Backend error: %v", err))
+				continue
+			}
+			if resp == nil {
+				// No body (e.g. 202 Accepted) -- should not happen for requests.
+				Debug("MCP: empty response for %s", req.Method)
 				continue
 			}
 			// Write the raw response directly to stdout.
@@ -271,10 +273,16 @@ func (b *mcpBridge) forwardToBackend(req *jsonRPCRequest) ([]byte, error) {
 		Debug("MCP: session ID: %s", sid)
 	}
 
-	if httpResp.StatusCode != http.StatusOK {
+	// 200 = success with body, 202 = accepted (notifications), both are OK.
+	if httpResp.StatusCode != http.StatusOK && httpResp.StatusCode != http.StatusAccepted {
 		body, _ := io.ReadAll(httpResp.Body)
 		Debug("MCP: backend returned %d: %s", httpResp.StatusCode, string(body))
 		return nil, fmt.Errorf("backend returned HTTP %d: %s", httpResp.StatusCode, truncate(string(body), 200))
+	}
+
+	// 202 Accepted has no body (used for notifications).
+	if httpResp.StatusCode == http.StatusAccepted {
+		return nil, nil
 	}
 
 	contentType := httpResp.Header.Get("Content-Type")

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -1,0 +1,424 @@
+// cmd/mcp.go
+/*
+Copyright © 2025 AceTeam <dev@aceteam.ai>
+*/
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	mcpAPIKey string
+	mcpAPIURL string
+	mcpServer string
+)
+
+var mcpCmd = &cobra.Command{
+	Use:   "mcp",
+	Short: "Start a local MCP server for AI tool integration",
+	Long: `Starts a Model Context Protocol (MCP) server that exposes AceTeam tools
+to Claude Code, Cursor, and other AI development tools.
+
+The MCP server reads JSON-RPC messages from stdin and writes responses to
+stdout, bridging your local AI tools to the AceTeam platform.
+
+Authentication uses an AceTeam API key. Generate one at:
+  https://aceteam.ai/settings/api-keys
+
+The API key is read from (in priority order):
+  1. --api-key flag
+  2. ACETEAM_API_KEY environment variable
+  3. ~/.citadel-cli/config.yaml (device_api_token from 'citadel init')
+
+Usage with Claude Code:
+  claude mcp add aceteam -- citadel mcp
+
+Usage with Cursor (add to .cursor/mcp.json):
+  {"mcpServers": {"aceteam": {"command": "citadel", "args": ["mcp"]}}}
+
+Usage with environment variable:
+  ACETEAM_API_KEY=act_xxx claude mcp add aceteam -- citadel mcp`,
+	RunE: runMCP,
+}
+
+// jsonRPCRequest represents an incoming JSON-RPC 2.0 request or notification.
+type jsonRPCRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+// jsonRPCResponse represents an outgoing JSON-RPC 2.0 response.
+type jsonRPCResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *jsonRPCError   `json:"error,omitempty"`
+}
+
+// jsonRPCError represents a JSON-RPC 2.0 error object.
+type jsonRPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// mcpBridge holds the state for the stdio-to-HTTP MCP bridge.
+type mcpBridge struct {
+	apiKey     string
+	apiURL     string // e.g., "https://aceteam.ai"
+	mcpServer  string // e.g., "aceteam"
+	sessionID  string // Mcp-Session-Id from the backend
+	httpClient *http.Client
+}
+
+func runMCP(cmd *cobra.Command, args []string) error {
+	// Debug output must go to stderr, not stdout — stdout is the JSON-RPC transport.
+	debugToStderr = true
+
+	// Resolve API key
+	apiKey := mcpAPIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("ACETEAM_API_KEY")
+	}
+	if apiKey == "" {
+		apiKey = getAPIKeyFromConfig()
+	}
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "Error: No API key configured.")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Provide an API key using one of:")
+		fmt.Fprintln(os.Stderr, "  1. citadel mcp --api-key <key>")
+		fmt.Fprintln(os.Stderr, "  2. ACETEAM_API_KEY=<key> citadel mcp")
+		fmt.Fprintln(os.Stderr, "  3. citadel init (saves token to config)")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Generate an API key at: https://aceteam.ai/settings/api-keys")
+		return fmt.Errorf("no API key configured")
+	}
+
+	// Resolve API URL
+	apiURL := mcpAPIURL
+	if apiURL == "" {
+		apiURL = os.Getenv("ACETEAM_URL")
+	}
+	if apiURL == "" {
+		apiURL = getAPIURLFromConfig()
+	}
+	if apiURL == "" {
+		apiURL = "https://aceteam.ai"
+	}
+	// Strip trailing slash
+	apiURL = strings.TrimRight(apiURL, "/")
+
+	bridge := &mcpBridge{
+		apiKey:    apiKey,
+		apiURL:    apiURL,
+		mcpServer: mcpServer,
+		httpClient: &http.Client{
+			Timeout: 120 * time.Second,
+		},
+	}
+
+	Debug("MCP bridge starting: server=%s, url=%s", mcpServer, apiURL)
+
+	return bridge.run()
+}
+
+// run starts the stdio JSON-RPC loop.
+func (b *mcpBridge) run() error {
+	scanner := bufio.NewScanner(os.Stdin)
+	// Increase buffer size to handle large tool lists (default 64KB is too small).
+	scanner.Buffer(make([]byte, 1024*1024), 10*1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+
+		var req jsonRPCRequest
+		if err := json.Unmarshal(line, &req); err != nil {
+			Debug("MCP: failed to parse JSON-RPC request: %v", err)
+			// If we can't parse it, and it might have an ID, send a parse error
+			b.writeError(nil, -32700, "Parse error")
+			continue
+		}
+
+		Debug("MCP: received method=%s id=%s", req.Method, string(req.ID))
+
+		// Notifications have no ID and must not receive a response.
+		isNotification := len(req.ID) == 0 || string(req.ID) == "null"
+
+		switch req.Method {
+		case "initialize":
+			b.handleInitialize(&req)
+		case "notifications/initialized":
+			// Client acknowledgment -- no response needed.
+			Debug("MCP: client initialized")
+		case "ping":
+			if !isNotification {
+				b.writeResult(req.ID, json.RawMessage(`{}`))
+			}
+		default:
+			if isNotification {
+				// Forward notifications to the backend but don't write a response.
+				_, _ = b.forwardToBackend(&req)
+				continue
+			}
+			// Forward all other requests to the backend.
+			resp, err := b.forwardToBackend(&req)
+			if err != nil {
+				Debug("MCP: backend error for %s: %v", req.Method, err)
+				b.writeError(req.ID, -32603, fmt.Sprintf("Backend error: %v", err))
+				continue
+			}
+			// Write the raw response directly to stdout.
+			os.Stdout.Write(resp)
+			os.Stdout.Write([]byte("\n"))
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("stdin read error: %w", err)
+	}
+	return nil
+}
+
+// handleInitialize handles the MCP initialize request.
+// We forward to the backend so it creates a session, but we also ensure
+// the response includes the required fields.
+func (b *mcpBridge) handleInitialize(req *jsonRPCRequest) {
+	resp, err := b.forwardToBackend(req)
+	if err != nil {
+		Debug("MCP: initialize backend error: %v, using local fallback", err)
+		// Fallback: return a local initialize response
+		result := map[string]interface{}{
+			"protocolVersion": "2025-03-26",
+			"capabilities": map[string]interface{}{
+				"tools": map[string]interface{}{},
+			},
+			"serverInfo": map[string]interface{}{
+				"name":    "aceteam",
+				"version": Version,
+			},
+		}
+		resultBytes, _ := json.Marshal(result)
+		b.writeResult(req.ID, resultBytes)
+		return
+	}
+
+	// Write the backend's response directly.
+	os.Stdout.Write(resp)
+	os.Stdout.Write([]byte("\n"))
+}
+
+// forwardToBackend sends a JSON-RPC request to the AceTeam MCP backend
+// via HTTP POST and returns the JSON-RPC response bytes.
+//
+// The MCP Streamable HTTP transport may return either:
+//   - application/json: the response is a raw JSON-RPC message
+//   - text/event-stream: the response is an SSE stream containing one or more
+//     "event: message\ndata: {json}\n\n" frames. We parse the data lines and
+//     return the last JSON-RPC response/error message found.
+func (b *mcpBridge) forwardToBackend(req *jsonRPCRequest) ([]byte, error) {
+	// Re-serialize the request to forward.
+	reqBody, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/api/mcp/%s/mcp", b.apiURL, b.mcpServer)
+	Debug("MCP: POST %s (method=%s)", url, req.Method)
+
+	httpReq, err := http.NewRequest("POST", url, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	// MCP Streamable HTTP requires the client to accept both JSON and SSE.
+	httpReq.Header.Set("Accept", "application/json, text/event-stream")
+	httpReq.Header.Set("Authorization", "Bearer "+b.apiKey)
+
+	// Include session ID if we have one from a previous initialize.
+	if b.sessionID != "" {
+		httpReq.Header.Set("Mcp-Session-Id", b.sessionID)
+	}
+
+	httpResp, err := b.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	// Capture session ID from response.
+	if sid := httpResp.Header.Get("Mcp-Session-Id"); sid != "" {
+		b.sessionID = sid
+		Debug("MCP: session ID: %s", sid)
+	}
+
+	if httpResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(httpResp.Body)
+		Debug("MCP: backend returned %d: %s", httpResp.StatusCode, string(body))
+		return nil, fmt.Errorf("backend returned HTTP %d: %s", httpResp.StatusCode, truncate(string(body), 200))
+	}
+
+	contentType := httpResp.Header.Get("Content-Type")
+	Debug("MCP: response Content-Type: %s", contentType)
+
+	if strings.Contains(contentType, "text/event-stream") {
+		return b.parseSSEResponse(httpResp.Body)
+	}
+
+	// Plain JSON response.
+	body, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	return body, nil
+}
+
+// parseSSEResponse reads an SSE stream and extracts JSON-RPC messages from
+// "data:" lines within "event: message" frames. Returns the last JSON-RPC
+// response or error message found (the final result for this request).
+func (b *mcpBridge) parseSSEResponse(body io.Reader) ([]byte, error) {
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 1024*1024), 10*1024*1024)
+
+	var lastResponse []byte
+	inMessageEvent := false
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if strings.HasPrefix(line, "event:") {
+			eventType := strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+			inMessageEvent = (eventType == "message")
+			continue
+		}
+
+		if strings.HasPrefix(line, "data:") && inMessageEvent {
+			data := strings.TrimPrefix(line, "data:")
+			data = strings.TrimSpace(data)
+			if data == "" {
+				continue
+			}
+
+			Debug("MCP: SSE data: %s", truncate(data, 200))
+			lastResponse = []byte(data)
+		}
+
+		// Empty line marks end of an SSE event frame.
+		if line == "" {
+			inMessageEvent = false
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("SSE read error: %w", err)
+	}
+
+	if lastResponse == nil {
+		return nil, fmt.Errorf("no JSON-RPC message found in SSE stream")
+	}
+
+	return lastResponse, nil
+}
+
+// writeResult writes a successful JSON-RPC response to stdout.
+func (b *mcpBridge) writeResult(id json.RawMessage, result json.RawMessage) {
+	resp := jsonRPCResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  result,
+	}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		Debug("MCP: failed to marshal response: %v", err)
+		return
+	}
+	os.Stdout.Write(data)
+	os.Stdout.Write([]byte("\n"))
+}
+
+// writeError writes an error JSON-RPC response to stdout.
+func (b *mcpBridge) writeError(id json.RawMessage, code int, message string) {
+	resp := jsonRPCResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error: &jsonRPCError{
+			Code:    code,
+			Message: message,
+		},
+	}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		Debug("MCP: failed to marshal error response: %v", err)
+		return
+	}
+	os.Stdout.Write(data)
+	os.Stdout.Write([]byte("\n"))
+}
+
+// getAPIKeyFromConfig reads the device API token from the citadel config file.
+func getAPIKeyFromConfig() string {
+	globalConfigFile := filepath.Join(platform.ConfigDir(), "config.yaml")
+	data, err := os.ReadFile(globalConfigFile)
+	if err != nil {
+		return ""
+	}
+
+	var config struct {
+		DeviceAPIToken string `yaml:"device_api_token"`
+	}
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return ""
+	}
+	return config.DeviceAPIToken
+}
+
+// getAPIURLFromConfig reads the API base URL from the citadel config file.
+func getAPIURLFromConfig() string {
+	globalConfigFile := filepath.Join(platform.ConfigDir(), "config.yaml")
+	data, err := os.ReadFile(globalConfigFile)
+	if err != nil {
+		return ""
+	}
+
+	var config struct {
+		APIBaseURL string `yaml:"api_base_url"`
+	}
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return ""
+	}
+	return config.APIBaseURL
+}
+
+// truncate shortens a string to maxLen, appending "..." if truncated.
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}
+
+func init() {
+	rootCmd.AddCommand(mcpCmd)
+	mcpCmd.Flags().StringVar(&mcpAPIKey, "api-key", "", "AceTeam API key (or set ACETEAM_API_KEY env)")
+	mcpCmd.Flags().StringVar(&mcpAPIURL, "api-url", "", "AceTeam API URL (default: https://aceteam.ai)")
+	mcpCmd.Flags().StringVar(&mcpServer, "server", "aceteam", "MCP server name to proxy (default: aceteam)")
+}

--- a/cmd/mcp_test.go
+++ b/cmd/mcp_test.go
@@ -384,6 +384,35 @@ func TestGetAPIKeyFromConfig(t *testing.T) {
 	_ = key
 }
 
+func TestMCPBridgeNotification202(t *testing.T) {
+	// Test that 202 Accepted (for notifications) returns nil body, no error
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Mcp-Session-Id", "test-session-456")
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	bridge := &mcpBridge{
+		apiKey:     "test-key",
+		apiURL:     server.URL,
+		mcpServer:  "aceteam",
+		httpClient: server.Client(),
+	}
+
+	req := &jsonRPCRequest{
+		JSONRPC: "2.0",
+		Method:  "notifications/initialized",
+	}
+
+	resp, err := bridge.forwardToBackend(req)
+	if err != nil {
+		t.Fatalf("notification should not error: %v", err)
+	}
+	if resp != nil {
+		t.Errorf("notification should return nil body, got: %s", string(resp))
+	}
+}
+
 func TestParseSSEResponseEmpty(t *testing.T) {
 	bridge := &mcpBridge{}
 

--- a/cmd/mcp_test.go
+++ b/cmd/mcp_test.go
@@ -1,0 +1,399 @@
+// cmd/mcp_test.go
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		input  string
+		maxLen int
+		want   string
+	}{
+		{"hello", 10, "hello"},
+		{"hello world", 5, "hello..."},
+		{"", 5, ""},
+		{"abc", 3, "abc"},
+		{"abcd", 3, "abc..."},
+	}
+	for _, tc := range tests {
+		got := truncate(tc.input, tc.maxLen)
+		if got != tc.want {
+			t.Errorf("truncate(%q, %d) = %q, want %q", tc.input, tc.maxLen, got, tc.want)
+		}
+	}
+}
+
+// newMockMCPServer creates a mock MCP server that supports both JSON and SSE responses.
+// When useSSE is true, responses are sent as text/event-stream.
+func newMockMCPServer(useSSE bool) (*httptest.Server, *string, *string) {
+	var receivedSessionID string
+	var receivedAuth string
+	var receivedAccept string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		receivedSessionID = r.Header.Get("Mcp-Session-Id")
+		receivedAccept = r.Header.Get("Accept")
+
+		body, _ := io.ReadAll(r.Body)
+		var req jsonRPCRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		// Validate Accept header (like the real MCP SDK does)
+		if !strings.Contains(receivedAccept, "application/json") ||
+			(!useSSE && false) { // Only enforce SSE acceptance when using SSE mode
+			// Real SDK requires both, but we're lenient in JSON mode
+		}
+
+		// Set session ID on initialize
+		if req.Method == "initialize" {
+			w.Header().Set("Mcp-Session-Id", "test-session-123")
+		}
+
+		var respJSON []byte
+		switch req.Method {
+		case "initialize":
+			resp := map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      json.RawMessage(req.ID),
+				"result": map[string]interface{}{
+					"protocolVersion": "2025-03-26",
+					"capabilities":   map[string]interface{}{"tools": map[string]interface{}{}},
+					"serverInfo":     map[string]interface{}{"name": "test", "version": "1.0"},
+				},
+			}
+			respJSON, _ = json.Marshal(resp)
+
+		case "tools/list":
+			resp := map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      json.RawMessage(req.ID),
+				"result": map[string]interface{}{
+					"tools": []map[string]interface{}{
+						{
+							"name":        "whoami",
+							"description": "Returns the current user",
+							"inputSchema": map[string]interface{}{
+								"type":       "object",
+								"properties": map[string]interface{}{},
+							},
+						},
+					},
+				},
+			}
+			respJSON, _ = json.Marshal(resp)
+
+		default:
+			resp := map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      json.RawMessage(req.ID),
+				"error":   map[string]interface{}{"code": -32601, "message": "Method not found"},
+			}
+			respJSON, _ = json.Marshal(resp)
+		}
+
+		if useSSE {
+			// Respond as SSE (text/event-stream) like the real FastMCP server
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Header().Set("Cache-Control", "no-cache, no-transform")
+			w.Header().Set("Connection", "keep-alive")
+			fmt.Fprintf(w, "event: message\ndata: %s\n\n", string(respJSON))
+		} else {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(respJSON)
+			w.Write([]byte("\n"))
+		}
+	}))
+
+	return server, &receivedAuth, &receivedSessionID
+}
+
+func TestMCPBridgeForwardToBackendJSON(t *testing.T) {
+	server, receivedAuth, receivedSessionID := newMockMCPServer(false)
+	defer server.Close()
+
+	bridge := &mcpBridge{
+		apiKey:     "test-key-123",
+		apiURL:     server.URL,
+		mcpServer:  "aceteam",
+		httpClient: server.Client(),
+	}
+
+	// Test initialize
+	initReq := &jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "initialize",
+	}
+
+	resp, err := bridge.forwardToBackend(initReq)
+	if err != nil {
+		t.Fatalf("initialize failed: %v", err)
+	}
+
+	var initResp map[string]interface{}
+	if err := json.Unmarshal(resp, &initResp); err != nil {
+		t.Fatalf("failed to parse initialize response: %v", err)
+	}
+
+	if initResp["jsonrpc"] != "2.0" {
+		t.Errorf("expected jsonrpc 2.0, got %v", initResp["jsonrpc"])
+	}
+
+	// Verify session ID was captured
+	if bridge.sessionID != "test-session-123" {
+		t.Errorf("expected session ID 'test-session-123', got %q", bridge.sessionID)
+	}
+
+	// Verify auth header was sent
+	if *receivedAuth != "Bearer test-key-123" {
+		t.Errorf("expected auth 'Bearer test-key-123', got %q", *receivedAuth)
+	}
+
+	// Test tools/list (should include session ID)
+	listReq := &jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`2`),
+		Method:  "tools/list",
+	}
+
+	resp, err = bridge.forwardToBackend(listReq)
+	if err != nil {
+		t.Fatalf("tools/list failed: %v", err)
+	}
+
+	// Verify session ID was sent
+	if *receivedSessionID != "test-session-123" {
+		t.Errorf("expected session ID in request, got %q", *receivedSessionID)
+	}
+
+	var listResp map[string]interface{}
+	if err := json.Unmarshal(resp, &listResp); err != nil {
+		t.Fatalf("failed to parse tools/list response: %v", err)
+	}
+
+	result, ok := listResp["result"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected result object, got %T", listResp["result"])
+	}
+
+	tools, ok := result["tools"].([]interface{})
+	if !ok || len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %v", result["tools"])
+	}
+}
+
+func TestMCPBridgeForwardToBackendSSE(t *testing.T) {
+	server, _, _ := newMockMCPServer(true)
+	defer server.Close()
+
+	bridge := &mcpBridge{
+		apiKey:     "test-key-123",
+		apiURL:     server.URL,
+		mcpServer:  "aceteam",
+		httpClient: server.Client(),
+	}
+
+	// Test initialize via SSE
+	initReq := &jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "initialize",
+	}
+
+	resp, err := bridge.forwardToBackend(initReq)
+	if err != nil {
+		t.Fatalf("initialize (SSE) failed: %v", err)
+	}
+
+	var initResp map[string]interface{}
+	if err := json.Unmarshal(resp, &initResp); err != nil {
+		t.Fatalf("failed to parse SSE initialize response: %v (raw: %s)", err, string(resp))
+	}
+
+	if initResp["jsonrpc"] != "2.0" {
+		t.Errorf("expected jsonrpc 2.0 from SSE, got %v", initResp["jsonrpc"])
+	}
+
+	// Verify session ID was captured from SSE response headers
+	if bridge.sessionID != "test-session-123" {
+		t.Errorf("expected session ID from SSE response, got %q", bridge.sessionID)
+	}
+
+	// Test tools/list via SSE
+	listReq := &jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`2`),
+		Method:  "tools/list",
+	}
+
+	resp, err = bridge.forwardToBackend(listReq)
+	if err != nil {
+		t.Fatalf("tools/list (SSE) failed: %v", err)
+	}
+
+	var listResp map[string]interface{}
+	if err := json.Unmarshal(resp, &listResp); err != nil {
+		t.Fatalf("failed to parse SSE tools/list response: %v", err)
+	}
+
+	result, ok := listResp["result"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected result object from SSE, got %T", listResp["result"])
+	}
+
+	tools, ok := result["tools"].([]interface{})
+	if !ok || len(tools) != 1 {
+		t.Fatalf("expected 1 tool from SSE, got %v", result["tools"])
+	}
+}
+
+func TestMCPBridgeSSEMultipleEvents(t *testing.T) {
+	// Test SSE with multiple events -- should return the last JSON-RPC response
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		// Simulate a priming event followed by the actual response
+		fmt.Fprint(w, "event: message\ndata: \n\n")
+		fmt.Fprint(w, "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]}}\n\n")
+	}))
+	defer server.Close()
+
+	bridge := &mcpBridge{
+		apiKey:     "test-key",
+		apiURL:     server.URL,
+		mcpServer:  "aceteam",
+		httpClient: server.Client(),
+	}
+
+	req := &jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"test","arguments":{}}`),
+	}
+
+	resp, err := bridge.forwardToBackend(req)
+	if err != nil {
+		t.Fatalf("tools/call (SSE multi-event) failed: %v", err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(resp, &parsed); err != nil {
+		t.Fatalf("failed to parse multi-event SSE response: %v", err)
+	}
+
+	if parsed["jsonrpc"] != "2.0" {
+		t.Errorf("expected jsonrpc 2.0, got %v", parsed["jsonrpc"])
+	}
+
+	result, ok := parsed["result"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected result object, got %T", parsed["result"])
+	}
+
+	content, ok := result["content"].([]interface{})
+	if !ok || len(content) != 1 {
+		t.Fatalf("expected 1 content item, got %v", result["content"])
+	}
+}
+
+func TestMCPBridgeAcceptHeader(t *testing.T) {
+	var receivedAccept string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAccept = r.Header.Get("Accept")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"jsonrpc":"2.0","id":1,"result":{}}`)
+	}))
+	defer server.Close()
+
+	bridge := &mcpBridge{
+		apiKey:     "test-key",
+		apiURL:     server.URL,
+		mcpServer:  "aceteam",
+		httpClient: server.Client(),
+	}
+
+	req := &jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "ping",
+	}
+
+	_, err := bridge.forwardToBackend(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+
+	// Verify Accept header includes both required types
+	if !strings.Contains(receivedAccept, "application/json") {
+		t.Errorf("Accept header missing application/json: %q", receivedAccept)
+	}
+	if !strings.Contains(receivedAccept, "text/event-stream") {
+		t.Errorf("Accept header missing text/event-stream: %q", receivedAccept)
+	}
+}
+
+func TestMCPBridgeBackendError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprint(w, `{"error": "unauthorized"}`)
+	}))
+	defer server.Close()
+
+	bridge := &mcpBridge{
+		apiKey:     "bad-key",
+		apiURL:     server.URL,
+		mcpServer:  "aceteam",
+		httpClient: server.Client(),
+	}
+
+	req := &jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "tools/list",
+	}
+
+	_, err := bridge.forwardToBackend(req)
+	if err == nil {
+		t.Fatal("expected error for 401 response")
+	}
+
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("expected error to contain '401', got: %s", err.Error())
+	}
+}
+
+func TestGetAPIKeyFromConfig(t *testing.T) {
+	// This tests the function exists and returns empty when no config file is present.
+	// We can't easily test the happy path without mocking the filesystem.
+	key := getAPIKeyFromConfig()
+	// Just verify it doesn't panic; the key may or may not be empty depending on the test env.
+	_ = key
+}
+
+func TestParseSSEResponseEmpty(t *testing.T) {
+	bridge := &mcpBridge{}
+
+	// Empty SSE stream should return error
+	_, err := bridge.parseSSEResponse(strings.NewReader(""))
+	if err == nil {
+		t.Fatal("expected error for empty SSE stream")
+	}
+
+	if !strings.Contains(err.Error(), "no JSON-RPC message found") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,6 +34,10 @@ var debugMode bool
 var daemonMode bool
 var noColorGlobal bool
 
+// debugToStderr forces debug console output to stderr instead of stdout.
+// Set by commands that use stdout as a transport (e.g., MCP).
+var debugToStderr bool
+
 // deferredUpdateNotification stores update info when TUI will handle the display
 var deferredUpdateNotification string
 
@@ -95,7 +99,11 @@ func Log(format string, args ...interface{}) {
 
 	// Print to console only if debug mode is enabled
 	if debugMode {
-		fmt.Printf("[%s] [CITADEL] %s\n", timeStr, msg)
+		if debugToStderr {
+			fmt.Fprintf(os.Stderr, "[%s] [CITADEL] %s\n", timeStr, msg)
+		} else {
+			fmt.Printf("[%s] [CITADEL] %s\n", timeStr, msg)
+		}
 	}
 }
 
@@ -129,6 +137,13 @@ Use 'citadel help' to see all available commands.`,
 		}
 	},
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		// MCP command uses stdout as JSON-RPC transport -- any non-protocol
+		// output there corrupts the stream. Redirect debug to stderr early,
+		// before the first Log() call.
+		if cmd.Name() == "mcp" {
+			debugToStderr = true
+		}
+
 		// Handle global --no-color flag and NO_COLOR env var
 		if noColorGlobal || os.Getenv("NO_COLOR") != "" {
 			color.NoColor = true
@@ -167,6 +182,11 @@ Use 'citadel help' to see all available commands.`,
 		// Detect if we're about to launch TUI control center
 		// In this case, suppress stdout printing and defer to TUI activity log
 		isTUIContext := cmdName == "citadel" && len(args) == 0 && !daemonMode && tui.IsTTY()
+
+		// MCP uses stdout as transport -- suppress update print to stdout.
+		if cmdName == "mcp" {
+			isTUIContext = true
+		}
 
 		if !skipUpdateCheck {
 			checkForUpdateOnStartup(isTUIContext)


### PR DESCRIPTION
## Context

Adds `citadel mcp` — a stdio-to-HTTP bridge that lets Claude Code, Cursor, and other MCP clients use AceTeam's 113 MCP tools through the Citadel CLI. Part of Phase 1 of the Railway-thesis roadmap.

## Summary

- **`cmd/mcp.go`** — Stdio-to-HTTP MCP bridge: reads JSON-RPC from stdin, POSTs to `{api}/api/mcp/aceteam/mcp`, writes responses to stdout. Handles SSE response parsing, session management (`Mcp-Session-Id`), notification forwarding (202 Accepted), and local fallback when backend is unreachable
- **`cmd/mcp_test.go`** — 9 unit tests covering JSON/SSE responses, Accept header, notifications, error handling
- **`cmd/root.go`** — Redirects debug output to stderr when running as MCP server (stdout is the transport)

## Test plan

| Check | Status |
|-------|--------|
| `go build` | Passes |
| `go vet` | Passes |
| `go test ./cmd/...` | 9 tests pass |
| `--help` output | Correct |

---
*Generated by Claude*