### PR TITLE
feat: add citadel logs and deploy commands (#139)

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -137,7 +137,8 @@ func runLocalDeploy(image, containerName string) error {
 	Debug("docker %s", strings.Join(runArgs, " "))
 
 	runCmd := exec.Command("docker", runArgs...)
-	output, err := runCmd.CombinedOutput()
+	runCmd.Stderr = os.Stderr // Show warnings (GPU, runtime) directly
+	output, err := runCmd.Output()
 	if err != nil {
 		return fmt.Errorf("failed to start container: %s", strings.TrimSpace(string(output)))
 	}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -1,0 +1,284 @@
+// cmd/deploy.go
+/*
+Copyright © 2025 Jason Sun <jason@aceteam.ai>
+*/
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+var (
+	deployName    string
+	deployPorts   []string
+	deployEnv     []string
+	deployGPU     bool
+	deployRestart string
+	deployNode    string
+)
+
+// validImageNameRe allows typical Docker image references:
+// registry/repo:tag, repo:tag, repo@sha256:..., etc.
+var validImageNameRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._/:@-]*$`)
+
+var deployCmd = &cobra.Command{
+	Use:   "deploy [image]",
+	Short: "Deploy a Docker container to a Citadel node",
+	Long: `Pull a Docker image and run it as a managed container on this node or a remote node.
+
+Local mode (default):
+  1. Pulls the specified Docker image.
+  2. Stops and removes any existing container with the same name.
+  3. Starts a new container with the configured ports, env vars, and restart policy.
+
+Remote mode (--node):
+  Dispatches the deploy request to a remote node via the AceTeam API.`,
+	Example: `  # Deploy nginx locally
+  citadel deploy nginx:latest --port 8080:80
+
+  # Deploy with GPU access and environment variables
+  citadel deploy ghcr.io/my-org/my-model:v1 --gpu --env MODEL=llama3 --port 8000:8000
+
+  # Deploy with a custom container name
+  citadel deploy ollama/ollama --name my-ollama --port 11434:11434
+
+  # Deploy to a remote node
+  citadel deploy nginx:latest --node my-gpu-server --port 8080:80`,
+	Args: cobra.ExactArgs(1),
+	RunE: runDeploy,
+}
+
+func runDeploy(cmd *cobra.Command, args []string) error {
+	image := args[0]
+
+	// Validate image name
+	if !validImageNameRe.MatchString(image) {
+		return fmt.Errorf("invalid image name %q", image)
+	}
+
+	// Derive container name from image if not specified
+	containerName := deployName
+	if containerName == "" {
+		containerName = deriveContainerName(image)
+	}
+
+	// Remote mode
+	if deployNode != "" {
+		return runRemoteDeploy(image, containerName)
+	}
+
+	// Local mode
+	return runLocalDeploy(image, containerName)
+}
+
+// runLocalDeploy pulls an image and runs a container locally.
+func runLocalDeploy(image, containerName string) error {
+	stepColor := color.New(color.FgCyan)
+
+	// Step 1: Pull the image
+	stepColor.Printf("--- Pulling image: %s ---\n", image)
+	pullCmd := exec.Command("docker", "pull", image)
+	pullCmd.Stdout = os.Stdout
+	pullCmd.Stderr = os.Stderr
+	if err := pullCmd.Run(); err != nil {
+		return fmt.Errorf("failed to pull image %q: %w", image, err)
+	}
+	fmt.Println()
+
+	// Step 2: Stop and remove existing container (if any)
+	inspectCmd := exec.Command("docker", "inspect", "--format", "{{.State.Status}}", containerName)
+	if output, err := inspectCmd.Output(); err == nil {
+		status := strings.TrimSpace(string(output))
+		stepColor.Printf("--- Stopping existing container '%s' (status: %s) ---\n", containerName, status)
+
+		stopCmd := exec.Command("docker", "stop", containerName)
+		stopCmd.Stdout = os.Stdout
+		stopCmd.Stderr = os.Stderr
+		_ = stopCmd.Run() // Ignore error if already stopped
+
+		rmCmd := exec.Command("docker", "rm", containerName)
+		rmCmd.Stdout = os.Stdout
+		rmCmd.Stderr = os.Stderr
+		_ = rmCmd.Run() // Ignore error if already removed
+		fmt.Println()
+	}
+
+	// Step 3: Build docker run arguments
+	runArgs := []string{"run", "-d", "--name", containerName, "--restart", deployRestart}
+
+	// Port mappings
+	for _, port := range deployPorts {
+		runArgs = append(runArgs, "-p", port)
+	}
+
+	// Environment variables
+	for _, env := range deployEnv {
+		runArgs = append(runArgs, "-e", env)
+	}
+
+	// GPU access
+	if deployGPU {
+		runArgs = append(runArgs, "--runtime=nvidia", "--gpus", "all")
+	}
+
+	runArgs = append(runArgs, image)
+
+	stepColor.Printf("--- Starting container '%s' ---\n", containerName)
+	Debug("docker %s", strings.Join(runArgs, " "))
+
+	runCmd := exec.Command("docker", runArgs...)
+	output, err := runCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to start container: %s", strings.TrimSpace(string(output)))
+	}
+
+	containerID := strings.TrimSpace(string(output))
+	if len(containerID) > 12 {
+		containerID = containerID[:12]
+	}
+
+	fmt.Println()
+	color.New(color.FgGreen, color.Bold).Printf("Container '%s' is running (ID: %s)\n", containerName, containerID)
+
+	// Print port mappings
+	if len(deployPorts) > 0 {
+		fmt.Println()
+		fmt.Println("Port mappings:")
+		for _, port := range deployPorts {
+			fmt.Printf("  %s\n", port)
+		}
+	}
+
+	fmt.Println()
+	fmt.Println("Useful commands:")
+	fmt.Printf("  citadel logs %s -f    - Follow container logs\n", containerName)
+	fmt.Printf("  docker stop %s        - Stop the container\n", containerName)
+	fmt.Printf("  docker rm %s          - Remove the container\n", containerName)
+
+	return nil
+}
+
+// runRemoteDeploy dispatches a deploy request to a remote node via the AceTeam API.
+func runRemoteDeploy(image, containerName string) error {
+	deviceConfig := getDeviceConfigFromFile()
+	if deviceConfig == nil || deviceConfig.DeviceAPIToken == "" {
+		return fmt.Errorf("remote deploy requires device authentication; run 'citadel init' or 'citadel login' first")
+	}
+
+	apiBaseURL := deviceConfig.APIBaseURL
+	if apiBaseURL == "" {
+		apiBaseURL = authServiceURL
+	}
+
+	// Build the deploy payload
+	payload := map[string]interface{}{
+		"image":          image,
+		"container_name": containerName,
+		"restart_policy": deployRestart,
+		"gpu":            deployGPU,
+	}
+	if len(deployPorts) > 0 {
+		payload["ports"] = deployPorts
+	}
+	if len(deployEnv) > 0 {
+		payload["env"] = deployEnv
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to build request payload: %w", err)
+	}
+
+	endpoint := fmt.Sprintf("%s/api/machines/%s/manage/deploy", apiBaseURL, deployNode)
+	req, err := http.NewRequest(http.MethodPost, endpoint, strings.NewReader(string(body)))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+deviceConfig.DeviceAPIToken)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Fabric-Source", "citadel-cli")
+
+	fmt.Printf("--- Deploying '%s' to node '%s' ---\n", image, deployNode)
+
+	httpClient := &http.Client{Timeout: 120 * time.Second}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send deploy request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		respBody := make([]byte, 1024)
+		n, _ := resp.Body.Read(respBody)
+		return fmt.Errorf("remote deploy failed (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(respBody[:n])))
+	}
+
+	color.New(color.FgGreen, color.Bold).Printf("Deploy request sent to node '%s' successfully.\n", deployNode)
+	fmt.Printf("  Image:     %s\n", image)
+	fmt.Printf("  Container: %s\n", containerName)
+	if len(deployPorts) > 0 {
+		fmt.Printf("  Ports:     %s\n", strings.Join(deployPorts, ", "))
+	}
+	fmt.Println()
+	fmt.Printf("Check status: citadel logs %s --node %s\n", containerName, deployNode)
+
+	return nil
+}
+
+// deriveContainerName extracts a reasonable container name from a Docker image reference.
+// Examples:
+//
+//	"nginx:latest"                  -> "citadel-nginx"
+//	"ghcr.io/my-org/my-app:v1"     -> "citadel-my-app"
+//	"ollama/ollama"                 -> "citadel-ollama"
+func deriveContainerName(image string) string {
+	// Strip tag or digest
+	name := image
+	if at := strings.Index(name, "@"); at != -1 {
+		name = name[:at]
+	}
+	if colon := strings.LastIndex(name, ":"); colon != -1 {
+		name = name[:colon]
+	}
+
+	// Take the last path component
+	if slash := strings.LastIndex(name, "/"); slash != -1 {
+		name = name[slash+1:]
+	}
+
+	// Sanitize: replace anything not alphanumeric/hyphen/dot with hyphens
+	sanitized := strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '.' {
+			return r
+		}
+		return '-'
+	}, name)
+
+	if sanitized == "" {
+		sanitized = "container"
+	}
+
+	return "citadel-" + sanitized
+}
+
+func init() {
+	rootCmd.AddCommand(deployCmd)
+
+	deployCmd.Flags().StringVar(&deployName, "name", "", "Container name (default: derived from image)")
+	deployCmd.Flags().StringSliceVarP(&deployPorts, "port", "p", nil, "Port mappings (e.g. \"8080:80\")")
+	deployCmd.Flags().StringSliceVarP(&deployEnv, "env", "e", nil, "Environment variables (e.g. \"KEY=value\")")
+	deployCmd.Flags().BoolVar(&deployGPU, "gpu", false, "Enable GPU access (--runtime=nvidia --gpus all)")
+	deployCmd.Flags().StringVar(&deployRestart, "restart", "unless-stopped", "Restart policy (no, always, unless-stopped, on-failure)")
+	deployCmd.Flags().StringVar(&deployNode, "node", "", "Deploy to a remote node (node ID or hostname)")
+}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aceteam-ai/citadel-cli/internal/redisapi"
 	"github.com/aceteam-ai/citadel-cli/services"
 	"github.com/spf13/cobra"
 )
@@ -202,12 +201,6 @@ func runRemoteLogs(serviceName, tailLines string) error {
 		apiBaseURL = authServiceURL
 	}
 
-	client := redisapi.NewClient(redisapi.ClientConfig{
-		BaseURL:   apiBaseURL,
-		Token:     deviceConfig.DeviceAPIToken,
-		DebugFunc: Debug,
-	})
-
 	// Build the request URL for the remote logs endpoint
 	endpoint := fmt.Sprintf("%s/api/machines/%s/manage/logs", apiBaseURL, logsNode)
 	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
@@ -227,10 +220,6 @@ func runRemoteLogs(serviceName, tailLines string) error {
 
 	req.Header.Set("Authorization", "Bearer "+deviceConfig.DeviceAPIToken)
 	req.Header.Set("X-Fabric-Source", "citadel-cli")
-
-	// Suppress unused variable — the client is created for future use when
-	// the remote logs endpoint supports WebSocket streaming.
-	_ = client
 
 	fmt.Printf("--- Fetching logs for service '%s' from node '%s' ---\n", serviceName, logsNode)
 

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -5,124 +5,346 @@ Copyright © 2025 Jason Sun <jason@aceteam.ai>
 package cmd
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
+	"time"
 
+	"github.com/aceteam-ai/citadel-cli/internal/redisapi"
 	"github.com/aceteam-ai/citadel-cli/services"
 	"github.com/spf13/cobra"
 )
 
-var follow bool
-var tail string
+var (
+	logsFollow bool
+	logsTail   string
+	logsLines  int
+	logsSince  string
+	logsNode   string
+)
+
+// validServiceNameRe restricts service names to safe characters (alphanumeric, hyphens, dots, underscores).
+// This prevents argument injection when passing the name to journalctl or docker commands.
+var validServiceNameRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
 
 // logsCmd represents the logs command
 var logsCmd = &cobra.Command{
-	Use:   "logs <service-name>",
-	Short: "Fetch the logs of a running service",
-	Long: fmt.Sprintf(`Streams the logs for a service started with 'citadel run' or defined in citadel.yaml.
-Available services: %s`, strings.Join(services.GetAvailableServices(), ", ")),
-	Example: `  # View last 100 lines of vllm logs
+	Use:   "logs [service]",
+	Short: "View service logs from a Citadel node",
+	Long: fmt.Sprintf(`View logs from Docker services, systemd units, or remote nodes.
+
+Resolution order:
+  1. If --node is set, fetch logs from a remote node via the AceTeam API.
+  2. If the service is found in the citadel.yaml manifest, use docker compose logs.
+  3. If a citadel-<service> Docker container exists, use docker logs.
+  4. Otherwise, fall back to journalctl -u <service>.
+
+If no service is specified, defaults to "citadel" (the systemd unit).
+
+Available managed services: %s`, strings.Join(services.GetAvailableServices(), ", ")),
+	Example: `  # View the citadel systemd service logs
+  citadel logs
+
+  # View last 100 lines of vllm logs (Docker)
   citadel logs vllm
 
   # Follow ollama logs in real-time
   citadel logs ollama -f
 
   # View last 50 lines and follow
-  citadel logs llamacpp -f -t 50`,
-	Args: cobra.ExactArgs(1), // Requires exactly one argument: the service name
-	Run: func(cmd *cobra.Command, args []string) {
-		serviceName := args[0]
+  citadel logs llamacpp -f -t 50
 
-		// First, try to find service in manifest
-		var fullComposePath string
-		manifest, configDir, err := findAndReadManifest()
-		if err == nil {
-			for _, s := range manifest.Services {
-				if s.Name == serviceName {
-					fullComposePath = filepath.Join(configDir, s.ComposeFile)
-					break
-				}
-			}
-		}
+  # View systemd logs since 1 hour ago
+  citadel logs citadel --since 1h -n 200
 
-		// If found in manifest, use docker compose logs
-		if fullComposePath != "" {
-			dockerArgs := []string{"compose", "-f", fullComposePath, "logs"}
-			if follow {
-				dockerArgs = append(dockerArgs, "--follow")
-			}
-			if tail != "" {
-				dockerArgs = append(dockerArgs, "--tail", tail)
-			}
-
-			logCmd := exec.Command("docker", dockerArgs...)
-			logCmd.Stdout = os.Stdout
-			logCmd.Stderr = os.Stderr
-
-			fmt.Printf("--- Streaming logs for service '%s' (Ctrl+C to stop) ---\n", serviceName)
-			if err := logCmd.Run(); err != nil {
-				if exitError, ok := err.(*exec.ExitError); ok {
-					if exitError.ExitCode() != 130 {
-						fmt.Fprintf(os.Stderr, "  ❌ Error: %v\n", err)
-					}
-				} else {
-					fmt.Fprintf(os.Stderr, "  ❌ Error executing docker logs: %v\n", err)
-				}
-			}
-			return
-		}
-
-		// Fallback: try direct container access (for 'citadel run' services)
-		containerName := fmt.Sprintf("citadel-%s", serviceName)
-
-		// Check if container exists
-		inspectCmd := exec.Command("docker", "inspect", "--format", "{{.State.Status}}", containerName)
-		if _, err := inspectCmd.Output(); err != nil {
-			// Validate service name before giving error
-			if _, ok := services.ServiceMap[serviceName]; !ok {
-				fmt.Fprintf(os.Stderr, "❌ Unknown service '%s'.\n", serviceName)
-				fmt.Printf("Available services: %s\n", strings.Join(services.GetAvailableServices(), ", "))
-			} else {
-				fmt.Fprintf(os.Stderr, "❌ Container '%s' not found. Is the service running?\n", containerName)
-			}
-			os.Exit(1)
-		}
-
-		// Use docker logs directly
-		dockerArgs := []string{"logs"}
-		if follow {
-			dockerArgs = append(dockerArgs, "-f")
-		}
-		if tail != "" {
-			dockerArgs = append(dockerArgs, "--tail", tail)
-		}
-		dockerArgs = append(dockerArgs, containerName)
-
-		logCmd := exec.Command("docker", dockerArgs...)
-		logCmd.Stdout = os.Stdout
-		logCmd.Stderr = os.Stderr
-
-		fmt.Printf("--- Streaming logs for service '%s' (Ctrl+C to stop) ---\n", serviceName)
-		if err := logCmd.Run(); err != nil {
-			if exitError, ok := err.(*exec.ExitError); ok {
-				if exitError.ExitCode() != 130 {
-					fmt.Fprintf(os.Stderr, "  ❌ Error: %v\n", err)
-				}
-			} else {
-				fmt.Fprintf(os.Stderr, "  ❌ Error executing docker logs: %v\n", err)
-			}
-		}
-	},
+  # Fetch logs from a remote node
+  citadel logs citadel --node my-gpu-server`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runLogs,
 }
 
-// NOTE: The init() function remains the same.
+func runLogs(cmd *cobra.Command, args []string) error {
+	serviceName := "citadel"
+	if len(args) > 0 {
+		serviceName = args[0]
+	}
+
+	// Validate the service name to prevent argument injection
+	if !validServiceNameRe.MatchString(serviceName) {
+		return fmt.Errorf("invalid service name %q: must be alphanumeric with hyphens, dots, or underscores", serviceName)
+	}
+
+	// Resolve the effective line count: --lines/-n takes precedence over --tail/-t
+	effectiveTail := logsTail
+	if cmd.Flags().Changed("lines") {
+		effectiveTail = fmt.Sprintf("%d", logsLines)
+	}
+
+	// Remote mode: fetch logs from a remote node via AceTeam API
+	if logsNode != "" {
+		return runRemoteLogs(serviceName, effectiveTail)
+	}
+
+	// Local mode: try manifest -> container -> journalctl
+
+	// 1. Try to find the service in the manifest (docker compose)
+	var fullComposePath string
+	manifest, configDir, err := findAndReadManifest()
+	if err == nil {
+		for _, s := range manifest.Services {
+			if s.Name == serviceName {
+				fullComposePath = filepath.Join(configDir, s.ComposeFile)
+				break
+			}
+		}
+	}
+
+	if fullComposePath != "" {
+		return runDockerComposeLogs(serviceName, fullComposePath, effectiveTail)
+	}
+
+	// 2. Try direct container access (for 'citadel run' services)
+	containerName := fmt.Sprintf("citadel-%s", serviceName)
+	inspectCmd := exec.Command("docker", "inspect", "--format", "{{.State.Status}}", containerName)
+	if _, err := inspectCmd.Output(); err == nil {
+		return runDockerLogs(serviceName, containerName, effectiveTail)
+	}
+
+	// 3. Fall back to journalctl (systemd)
+	return runJournalctlLogs(serviceName, effectiveTail)
+}
+
+// runDockerComposeLogs streams logs from a docker compose service.
+func runDockerComposeLogs(serviceName, composePath, tailLines string) error {
+	dockerArgs := []string{"compose", "-f", composePath, "logs"}
+	if logsFollow {
+		dockerArgs = append(dockerArgs, "--follow")
+	}
+	if tailLines != "" {
+		dockerArgs = append(dockerArgs, "--tail", tailLines)
+	}
+	if logsSince != "" {
+		dockerArgs = append(dockerArgs, "--since", logsSince)
+	}
+
+	logCmd := exec.Command("docker", dockerArgs...)
+	logCmd.Stdout = os.Stdout
+	logCmd.Stderr = os.Stderr
+
+	fmt.Printf("--- Streaming logs for service '%s' (Ctrl+C to stop) ---\n", serviceName)
+	return handleLogCmdError(logCmd.Run())
+}
+
+// runDockerLogs streams logs from a standalone Docker container.
+func runDockerLogs(serviceName, containerName, tailLines string) error {
+	dockerArgs := []string{"logs"}
+	if logsFollow {
+		dockerArgs = append(dockerArgs, "-f")
+	}
+	if tailLines != "" {
+		dockerArgs = append(dockerArgs, "--tail", tailLines)
+	}
+	if logsSince != "" {
+		dockerArgs = append(dockerArgs, "--since", logsSince)
+	}
+	dockerArgs = append(dockerArgs, containerName)
+
+	logCmd := exec.Command("docker", dockerArgs...)
+	logCmd.Stdout = os.Stdout
+	logCmd.Stderr = os.Stderr
+
+	fmt.Printf("--- Streaming logs for service '%s' (Ctrl+C to stop) ---\n", serviceName)
+	return handleLogCmdError(logCmd.Run())
+}
+
+// runJournalctlLogs streams logs from a systemd unit via journalctl.
+func runJournalctlLogs(serviceName, tailLines string) error {
+	journalArgs := []string{"-u", serviceName, "--no-pager"}
+
+	if tailLines != "" {
+		journalArgs = append(journalArgs, "-n", tailLines)
+	} else {
+		journalArgs = append(journalArgs, "-n", "100")
+	}
+
+	if logsSince != "" {
+		journalArgs = append(journalArgs, "--since", parseRelativeDuration(logsSince))
+	}
+
+	if logsFollow {
+		journalArgs = append(journalArgs, "-f")
+	}
+
+	logCmd := exec.Command("journalctl", journalArgs...)
+	logCmd.Stdout = os.Stdout
+	logCmd.Stderr = os.Stderr
+
+	fmt.Printf("--- Streaming logs for service '%s' via journalctl (Ctrl+C to stop) ---\n", serviceName)
+	return handleLogCmdError(logCmd.Run())
+}
+
+// runRemoteLogs fetches logs from a remote node via the AceTeam API.
+func runRemoteLogs(serviceName, tailLines string) error {
+	deviceConfig := getDeviceConfigFromFile()
+	if deviceConfig == nil || deviceConfig.DeviceAPIToken == "" {
+		return fmt.Errorf("remote logs require device authentication; run 'citadel init' or 'citadel login' first")
+	}
+
+	apiBaseURL := deviceConfig.APIBaseURL
+	if apiBaseURL == "" {
+		apiBaseURL = authServiceURL
+	}
+
+	client := redisapi.NewClient(redisapi.ClientConfig{
+		BaseURL:   apiBaseURL,
+		Token:     deviceConfig.DeviceAPIToken,
+		DebugFunc: Debug,
+	})
+
+	// Build the request URL for the remote logs endpoint
+	endpoint := fmt.Sprintf("%s/api/machines/%s/manage/logs", apiBaseURL, logsNode)
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	q := req.URL.Query()
+	q.Set("service", serviceName)
+	if tailLines != "" {
+		q.Set("lines", tailLines)
+	}
+	if logsSince != "" {
+		q.Set("since", logsSince)
+	}
+	req.URL.RawQuery = q.Encode()
+
+	req.Header.Set("Authorization", "Bearer "+deviceConfig.DeviceAPIToken)
+	req.Header.Set("X-Fabric-Source", "citadel-cli")
+
+	// Suppress unused variable — the client is created for future use when
+	// the remote logs endpoint supports WebSocket streaming.
+	_ = client
+
+	fmt.Printf("--- Fetching logs for service '%s' from node '%s' ---\n", serviceName, logsNode)
+
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+
+	if logsFollow {
+		return pollRemoteLogs(httpClient, req, serviceName)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to fetch remote logs: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("remote logs request failed (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	// Try to parse as JSON (API may return structured response)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response: %w", err)
+	}
+
+	var logResp struct {
+		Logs string `json:"logs"`
+	}
+	if json.Unmarshal(body, &logResp) == nil && logResp.Logs != "" {
+		fmt.Print(logResp.Logs)
+	} else {
+		fmt.Print(string(body))
+	}
+
+	return nil
+}
+
+// pollRemoteLogs polls the remote logs endpoint every 2 seconds for new lines.
+func pollRemoteLogs(httpClient *http.Client, baseReq *http.Request, serviceName string) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var lastLineCount int
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	fmt.Printf("--- Following logs for service '%s' from node '%s' (Ctrl+C to stop) ---\n", serviceName, logsNode)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			req := baseReq.Clone(ctx)
+			resp, err := httpClient.Do(req)
+			if err != nil {
+				Debug("remote log poll error: %v", err)
+				continue
+			}
+			body, err := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if err != nil || resp.StatusCode != http.StatusOK {
+				Debug("remote log poll error: status=%d", resp.StatusCode)
+				continue
+			}
+
+			lines := strings.Split(strings.TrimRight(string(body), "\n"), "\n")
+			if len(lines) > lastLineCount {
+				// Print only new lines
+				for _, line := range lines[lastLineCount:] {
+					fmt.Println(line)
+				}
+				lastLineCount = len(lines)
+			}
+		}
+	}
+}
+
+// parseRelativeDuration converts a simple relative duration string (e.g. "5m", "1h", "24h")
+// into a journalctl-compatible --since value (e.g. "5 minutes ago").
+func parseRelativeDuration(s string) string {
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		// Not a Go duration; pass through as-is (let journalctl validate)
+		return s
+	}
+
+	since := time.Now().Add(-d)
+	return since.Format("2006-01-02 15:04:05")
+}
+
+// handleLogCmdError handles errors from log streaming commands,
+// suppressing expected exit codes (e.g. SIGINT / Ctrl+C).
+func handleLogCmdError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if exitError, ok := err.(*exec.ExitError); ok {
+		// Exit code 130 = SIGINT (Ctrl+C) — expected when following logs
+		if exitError.ExitCode() == 130 {
+			return nil
+		}
+	}
+	return err
+}
+
 func init() {
 	rootCmd.AddCommand(logsCmd)
 
-	// Add flags for 'follow' and 'tail' to mimic 'docker logs'
-	logsCmd.Flags().BoolVarP(&follow, "follow", "f", false, "Follow log output.")
-	logsCmd.Flags().StringVarP(&tail, "tail", "t", "100", "Number of lines to show from the end of the logs.")
+	// Flags for controlling log output
+	logsCmd.Flags().BoolVarP(&logsFollow, "follow", "f", false, "Follow log output")
+	logsCmd.Flags().StringVarP(&logsTail, "tail", "t", "100", "Number of lines to show from the end of the logs")
+	logsCmd.Flags().IntVarP(&logsLines, "lines", "n", 100, "Number of log lines to show")
+	logsCmd.Flags().StringVar(&logsSince, "since", "", "Show logs since duration (e.g. \"5m\", \"1h\", \"24h\")")
+	logsCmd.Flags().StringVar(&logsNode, "node", "", "Fetch logs from a remote node (node ID or hostname)")
 }


### PR DESCRIPTION
## Context

CLI parity with Railway — operators can view service logs and deploy containers to Citadel nodes without SSH. Part of Phase 1 of the Railway-thesis roadmap.

## Summary

- **`citadel logs`** — Extended existing command: service arg now optional (defaults to `citadel` systemd unit), new `--lines/-n`, `--since`, `--node` flags. Remote mode fetches logs via AceTeam API. Service name validated against regex to prevent injection
- **`citadel deploy`** — New command: `docker pull` → `docker stop/rm` → `docker run -d` with `--name`, `--port/-p`, `--env/-e`, `--gpu`, `--restart`, `--node` flags. Auto-derives container name from image path. Remote mode dispatches via API

## Test plan

| Check | Status |
|-------|--------|
| `go build` | Passes |
| `go vet` | Passes |
| `go test ./cmd/...` | Passes |
| `--help` output | Correct for both commands |
| Service name injection rejected | `citadel logs 'foo;rm -rf /'` → error |
| Journalctl fallback | `citadel logs citadel --lines 5` works locally |

---
*Generated by Claude*