### PR TITLE
feat: add SANDBOX_SUSPEND and SANDBOX_RESUME job handlers

### DIFF
--- a/cmd/job_handlers.go
+++ b/cmd/job_handlers.go
@@ -61,5 +61,7 @@ func init() {
 		"LLAMACPP_INFERENCE": &jobs.LlamaCppInferenceHandler{},
 		"VLLM_INFERENCE":     &jobs.VLLMInferenceHandler{},
 		"OLLAMA_INFERENCE":   &jobs.OllamaInferenceHandler{},
+		"SANDBOX_SUSPEND":    &jobs.SandboxSuspendHandler{},
+		"SANDBOX_RESUME":     &jobs.SandboxResumeHandler{},
 	}
 }

--- a/internal/jobs/sandbox_resume.go
+++ b/internal/jobs/sandbox_resume.go
@@ -1,0 +1,56 @@
+// internal/jobs/sandbox_resume.go
+package jobs
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+// SandboxResumeHandler unpauses a Docker container for sandbox resumption.
+type SandboxResumeHandler struct{}
+
+// Execute unpauses the Docker container identified by container_id.
+//
+// Payload fields:
+//   - sandbox_id: logical sandbox identifier
+//   - container_id: Docker container ID or name to unpause
+func (h *SandboxResumeHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	sandboxID := job.Payload["sandbox_id"]
+	if sandboxID == "" {
+		return nil, fmt.Errorf("job payload missing 'sandbox_id' field")
+	}
+
+	containerID := job.Payload["container_id"]
+	if containerID == "" {
+		return nil, fmt.Errorf("job payload missing 'container_id' field")
+	}
+
+	ctx.Log("info", "     - [Job %s] SANDBOX_RESUME sandbox=%s container=%s", job.ID, sandboxID, containerID)
+
+	cmd := exec.Command("docker", "unpause", containerID)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		errMsg := fmt.Sprintf("docker unpause failed: %s", strings.TrimSpace(string(output)))
+		return json.Marshal(sandboxResult{
+			SandboxID:   sandboxID,
+			ContainerID: containerID,
+			Action:      "resume",
+			Success:     false,
+			Error:       errMsg,
+		})
+	}
+
+	return json.Marshal(sandboxResult{
+		SandboxID:   sandboxID,
+		ContainerID: containerID,
+		Action:      "resume",
+		Success:     true,
+	})
+}
+
+// Ensure SandboxResumeHandler implements JobHandler.
+var _ JobHandler = (*SandboxResumeHandler)(nil)

--- a/internal/jobs/sandbox_suspend.go
+++ b/internal/jobs/sandbox_suspend.go
@@ -1,0 +1,65 @@
+// internal/jobs/sandbox_suspend.go
+package jobs
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+// SandboxSuspendHandler pauses a Docker container for sandbox suspension.
+type SandboxSuspendHandler struct{}
+
+// sandboxResult is the JSON structure returned for sandbox operations.
+type sandboxResult struct {
+	SandboxID   string `json:"sandbox_id"`
+	ContainerID string `json:"container_id"`
+	Action      string `json:"action"`
+	Success     bool   `json:"success"`
+	Error       string `json:"error,omitempty"`
+}
+
+// Execute pauses the Docker container identified by container_id.
+//
+// Payload fields:
+//   - sandbox_id: logical sandbox identifier
+//   - container_id: Docker container ID or name to pause
+func (h *SandboxSuspendHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	sandboxID := job.Payload["sandbox_id"]
+	if sandboxID == "" {
+		return nil, fmt.Errorf("job payload missing 'sandbox_id' field")
+	}
+
+	containerID := job.Payload["container_id"]
+	if containerID == "" {
+		return nil, fmt.Errorf("job payload missing 'container_id' field")
+	}
+
+	ctx.Log("info", "     - [Job %s] SANDBOX_SUSPEND sandbox=%s container=%s", job.ID, sandboxID, containerID)
+
+	cmd := exec.Command("docker", "pause", containerID)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		errMsg := fmt.Sprintf("docker pause failed: %s", strings.TrimSpace(string(output)))
+		return json.Marshal(sandboxResult{
+			SandboxID:   sandboxID,
+			ContainerID: containerID,
+			Action:      "suspend",
+			Success:     false,
+			Error:       errMsg,
+		})
+	}
+
+	return json.Marshal(sandboxResult{
+		SandboxID:   sandboxID,
+		ContainerID: containerID,
+		Action:      "suspend",
+		Success:     true,
+	})
+}
+
+// Ensure SandboxSuspendHandler implements JobHandler.
+var _ JobHandler = (*SandboxSuspendHandler)(nil)

--- a/internal/jobs/sandbox_test.go
+++ b/internal/jobs/sandbox_test.go
@@ -1,0 +1,172 @@
+package jobs
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+// --- SANDBOX_SUSPEND tests ---
+
+func TestSandboxSuspend_MissingSandboxID(t *testing.T) {
+	h := &SandboxSuspendHandler{}
+	_, err := h.Execute(JobContext{}, &nexus.Job{
+		ID:   "test-1",
+		Type: "SANDBOX_SUSPEND",
+		Payload: map[string]string{
+			"container_id": "abc123",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing sandbox_id, got nil")
+	}
+}
+
+func TestSandboxSuspend_MissingContainerID(t *testing.T) {
+	h := &SandboxSuspendHandler{}
+	_, err := h.Execute(JobContext{}, &nexus.Job{
+		ID:   "test-2",
+		Type: "SANDBOX_SUSPEND",
+		Payload: map[string]string{
+			"sandbox_id": "sb-1",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing container_id, got nil")
+	}
+}
+
+func TestSandboxSuspend_EmptyPayload(t *testing.T) {
+	h := &SandboxSuspendHandler{}
+	_, err := h.Execute(JobContext{}, &nexus.Job{
+		ID:      "test-3",
+		Type:    "SANDBOX_SUSPEND",
+		Payload: map[string]string{},
+	})
+	if err == nil {
+		t.Fatal("expected error for empty payload, got nil")
+	}
+}
+
+func TestSandboxSuspend_DockerNotAvailable(t *testing.T) {
+	h := &SandboxSuspendHandler{}
+	out, err := h.Execute(JobContext{}, &nexus.Job{
+		ID:   "test-4",
+		Type: "SANDBOX_SUSPEND",
+		Payload: map[string]string{
+			"sandbox_id":   "sb-1",
+			"container_id": "nonexistent-container-xyz",
+		},
+	})
+	// When docker is not available or container doesn't exist, the handler
+	// returns a result with Success=false (not an error), because it
+	// marshals the failure into a sandboxResult.
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result sandboxResult
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("json unmarshal: %v", err)
+	}
+	if result.Success {
+		t.Error("expected Success=false for nonexistent container")
+	}
+	if result.Action != "suspend" {
+		t.Errorf("action = %q, want %q", result.Action, "suspend")
+	}
+	if result.SandboxID != "sb-1" {
+		t.Errorf("sandbox_id = %q, want %q", result.SandboxID, "sb-1")
+	}
+	if result.ContainerID != "nonexistent-container-xyz" {
+		t.Errorf("container_id = %q, want %q", result.ContainerID, "nonexistent-container-xyz")
+	}
+	if result.Error == "" {
+		t.Error("expected non-empty error message")
+	}
+}
+
+// --- SANDBOX_RESUME tests ---
+
+func TestSandboxResume_MissingSandboxID(t *testing.T) {
+	h := &SandboxResumeHandler{}
+	_, err := h.Execute(JobContext{}, &nexus.Job{
+		ID:   "test-5",
+		Type: "SANDBOX_RESUME",
+		Payload: map[string]string{
+			"container_id": "abc123",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing sandbox_id, got nil")
+	}
+}
+
+func TestSandboxResume_MissingContainerID(t *testing.T) {
+	h := &SandboxResumeHandler{}
+	_, err := h.Execute(JobContext{}, &nexus.Job{
+		ID:   "test-6",
+		Type: "SANDBOX_RESUME",
+		Payload: map[string]string{
+			"sandbox_id": "sb-2",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing container_id, got nil")
+	}
+}
+
+func TestSandboxResume_EmptyPayload(t *testing.T) {
+	h := &SandboxResumeHandler{}
+	_, err := h.Execute(JobContext{}, &nexus.Job{
+		ID:      "test-7",
+		Type:    "SANDBOX_RESUME",
+		Payload: map[string]string{},
+	})
+	if err == nil {
+		t.Fatal("expected error for empty payload, got nil")
+	}
+}
+
+func TestSandboxResume_DockerNotAvailable(t *testing.T) {
+	h := &SandboxResumeHandler{}
+	out, err := h.Execute(JobContext{}, &nexus.Job{
+		ID:   "test-8",
+		Type: "SANDBOX_RESUME",
+		Payload: map[string]string{
+			"sandbox_id":   "sb-2",
+			"container_id": "nonexistent-container-xyz",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result sandboxResult
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("json unmarshal: %v", err)
+	}
+	if result.Success {
+		t.Error("expected Success=false for nonexistent container")
+	}
+	if result.Action != "resume" {
+		t.Errorf("action = %q, want %q", result.Action, "resume")
+	}
+	if result.SandboxID != "sb-2" {
+		t.Errorf("sandbox_id = %q, want %q", result.SandboxID, "sb-2")
+	}
+	if result.ContainerID != "nonexistent-container-xyz" {
+		t.Errorf("container_id = %q, want %q", result.ContainerID, "nonexistent-container-xyz")
+	}
+	if result.Error == "" {
+		t.Error("expected non-empty error message")
+	}
+}
+
+// --- Interface compliance ---
+
+func TestSandboxHandlersImplementJobHandler(t *testing.T) {
+	var _ JobHandler = (*SandboxSuspendHandler)(nil)
+	var _ JobHandler = (*SandboxResumeHandler)(nil)
+}

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -129,6 +129,8 @@ func CreateLegacyHandlersWithOpts(opts LegacyHandlerOpts) []JobHandler {
 		NewLegacyHandlerAdapter(JobTypeApplyDeviceConfig, jobs.NewConfigHandler("")),
 		NewLegacyHandlerAdapter(JobTypeExtraction, &jobs.ExtractionHandler{}),
 		NewLegacyHandlerAdapter(JobTypeHTTPProxy, &jobs.HTTPProxyHandler{}),
+		NewLegacyHandlerAdapter(JobTypeSandboxSuspend, &jobs.SandboxSuspendHandler{}),
+		NewLegacyHandlerAdapter(JobTypeSandboxResume, &jobs.SandboxResumeHandler{}),
 	}
 
 	// Register file-operation handlers when a workspace is configured.

--- a/internal/worker/handler_adapter_test.go
+++ b/internal/worker/handler_adapter_test.go
@@ -156,6 +156,8 @@ func TestCreateLegacyHandlers(t *testing.T) {
 		JobTypeLlamaCppInference,
 		JobTypeVLLMInference,
 		JobTypeOllamaInference,
+		JobTypeSandboxSuspend,
+		JobTypeSandboxResume,
 	}
 
 	for _, jobType := range expectedTypes {

--- a/internal/worker/job.go
+++ b/internal/worker/job.go
@@ -114,4 +114,6 @@ const (
 	JobTypeServiceStart      = "SERVICE_START"       // Start a service on the node
 	JobTypeServiceStop       = "SERVICE_STOP"        // Stop a service on the node
 	JobTypeServiceStatus     = "SERVICE_STATUS"      // Check if a service is running
+	JobTypeSandboxSuspend    = "SANDBOX_SUSPEND"     // Pause a Docker container (sandbox suspend)
+	JobTypeSandboxResume     = "SANDBOX_RESUME"      // Unpause a Docker container (sandbox resume)
 )


### PR DESCRIPTION
## Context

Closes #145. The agent workspace infrastructure needs the ability to suspend and resume Docker containers for sandbox lifecycle management. When a sandbox is idle, suspending the container (via `docker pause`) frees CPU cycles without losing container state. Resuming (via `docker unpause`) brings it back instantly.

## Summary

Two new job handlers following the established `jobs.JobHandler` pattern:

- **`SandboxSuspendHandler`** (`internal/jobs/sandbox_suspend.go`) — Receives `sandbox_id` + `container_id`, runs `docker pause`, returns structured JSON result with success/failure and error details
- **`SandboxResumeHandler`** (`internal/jobs/sandbox_resume.go`) — Same payload contract, runs `docker unpause`
- **Handler registration** — Both handlers registered in `CreateLegacyHandlersWithOpts` (worker adapter) and `cmd/job_handlers.go` (legacy test path)
- **Job type constants** — `SANDBOX_SUSPEND` and `SANDBOX_RESUME` added to `internal/worker/job.go`

Design decisions:
- Docker failures return a structured `sandboxResult` JSON (not a Go error) so the caller gets actionable context (sandbox_id, container_id, error message) instead of a raw failure
- Payload validation returns Go errors for missing fields, matching the pattern used by `ShellCommandHandler` and `FileReadHandler`

## Test plan

| Group | Tests | Coverage |
|-------|-------|----------|
| Payload validation | 6 | Missing sandbox_id, missing container_id, empty payload (x2 handlers) |
| Docker failure | 2 | Nonexistent container returns Success=false with error message |
| Interface compliance | 1 | Compile-time `var _ JobHandler` check |
| Handler registration | 1 | `TestCreateLegacyHandlers` updated to verify both types |

```
go test ./internal/jobs/ -run Sandbox -v    # 9/9 PASS
go test ./internal/worker/ -v               # all PASS
go test ./cmd/ -v                           # all PASS
go build ./...                              # clean build
```

---
*Generated by Claude*