### PR TITLE
feat: add MODEL_CACHE_PULL and MODEL_CACHE_EVICT job handlers

### DIFF
--- a/cmd/job_handlers.go
+++ b/cmd/job_handlers.go
@@ -61,5 +61,7 @@ func init() {
 		"LLAMACPP_INFERENCE": &jobs.LlamaCppInferenceHandler{},
 		"VLLM_INFERENCE":     &jobs.VLLMInferenceHandler{},
 		"OLLAMA_INFERENCE":   &jobs.OllamaInferenceHandler{},
+		"MODEL_CACHE_PULL":   &jobs.ModelCachePullHandler{},
+		"MODEL_CACHE_EVICT":  &jobs.ModelCacheEvictHandler{},
 	}
 }

--- a/internal/jobs/model_cache_evict.go
+++ b/internal/jobs/model_cache_evict.go
@@ -1,0 +1,92 @@
+// internal/jobs/model_cache_evict.go
+package jobs
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+// ModelCacheEvictHandler handles MODEL_CACHE_EVICT jobs.
+// It removes cached model weights for the specified engine.
+type ModelCacheEvictHandler struct{}
+
+// modelCacheEvictResult is the JSON result returned on success.
+type modelCacheEvictResult struct {
+	Status    string `json:"status"`
+	ModelName string `json:"model_name"`
+	Engine    string `json:"engine"`
+}
+
+func (h *ModelCacheEvictHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	modelName, ok := job.Payload["model_name"]
+	if !ok || modelName == "" {
+		return nil, fmt.Errorf("job payload missing 'model_name' field")
+	}
+	engine, ok := job.Payload["engine"]
+	if !ok || engine == "" {
+		return nil, fmt.Errorf("job payload missing 'engine' field")
+	}
+
+	engine = strings.ToLower(engine)
+
+	switch engine {
+	case "ollama":
+		return h.evictOllama(ctx, job.ID, modelName)
+	case "vllm", "llamacpp":
+		return h.evictHuggingFace(ctx, job.ID, modelName, engine)
+	default:
+		return nil, fmt.Errorf("unsupported engine %q: must be ollama, vllm, or llamacpp", engine)
+	}
+}
+
+// evictOllama runs `ollama rm <model>` to remove the model from the local cache.
+func (h *ModelCacheEvictHandler) evictOllama(ctx JobContext, jobID, modelName string) ([]byte, error) {
+	ctx.Log("info", "     - [Job %s] Evicting model '%s' from ollama cache", jobID, modelName)
+
+	cmd := exec.Command("ollama", "rm", modelName)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return output, fmt.Errorf("ollama rm failed: %w", err)
+	}
+
+	result := modelCacheEvictResult{
+		Status:    "evicted",
+		ModelName: modelName,
+		Engine:    "ollama",
+	}
+	return json.Marshal(result)
+}
+
+// evictHuggingFace removes the model from the HuggingFace cache directory.
+func (h *ModelCacheEvictHandler) evictHuggingFace(ctx JobContext, jobID, modelName, engine string) ([]byte, error) {
+	ctx.Log("info", "     - [Job %s] Evicting model '%s' from HuggingFace cache for %s", jobID, modelName, engine)
+
+	cacheDir := hfCacheDir(modelName)
+	if cacheDir == "" {
+		return nil, fmt.Errorf("model %q not found in HuggingFace cache", modelName)
+	}
+
+	if err := os.RemoveAll(cacheDir); err != nil {
+		return nil, fmt.Errorf("failed to remove cache directory %s: %w", cacheDir, err)
+	}
+
+	ctx.Log("info", "     - [Job %s] Removed cache directory: %s", jobID, cacheDir)
+
+	result := modelCacheEvictResult{
+		Status:    "evicted",
+		ModelName: modelName,
+		Engine:    engine,
+	}
+	return json.Marshal(result)
+}
+
+// BuildOllamaRmCommand returns the exec.Cmd for removing a model via ollama.
+// Exported for testing command construction.
+func BuildOllamaRmCommand(modelName string) *exec.Cmd {
+	return exec.Command("ollama", "rm", modelName)
+}

--- a/internal/jobs/model_cache_pull.go
+++ b/internal/jobs/model_cache_pull.go
@@ -1,0 +1,194 @@
+// internal/jobs/model_cache_pull.go
+package jobs
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+// ModelCachePullHandler handles MODEL_CACHE_PULL jobs.
+// It pulls model weights into the local cache for the specified engine.
+type ModelCachePullHandler struct{}
+
+// modelCachePullResult is the JSON result returned on success.
+type modelCachePullResult struct {
+	Status    string `json:"status"`
+	ModelName string `json:"model_name"`
+	SizeBytes int64  `json:"size_bytes"`
+	Engine    string `json:"engine"`
+}
+
+func (h *ModelCachePullHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	modelName, ok := job.Payload["model_name"]
+	if !ok || modelName == "" {
+		return nil, fmt.Errorf("job payload missing 'model_name' field")
+	}
+	engine, ok := job.Payload["engine"]
+	if !ok || engine == "" {
+		return nil, fmt.Errorf("job payload missing 'engine' field")
+	}
+
+	engine = strings.ToLower(engine)
+
+	switch engine {
+	case "ollama":
+		return h.pullOllama(ctx, job.ID, modelName)
+	case "vllm", "llamacpp":
+		return h.pullHuggingFace(ctx, job.ID, modelName, engine)
+	default:
+		return nil, fmt.Errorf("unsupported engine %q: must be ollama, vllm, or llamacpp", engine)
+	}
+}
+
+// pullOllama runs `ollama pull <model>` to cache the model locally.
+func (h *ModelCachePullHandler) pullOllama(ctx JobContext, jobID, modelName string) ([]byte, error) {
+	ctx.Log("info", "     - [Job %s] Pulling model '%s' via ollama", jobID, modelName)
+
+	cmd := exec.Command("ollama", "pull", modelName)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return output, fmt.Errorf("ollama pull failed: %w", err)
+	}
+
+	// Query model size via `ollama list`
+	sizeBytes := ollamaModelSize(modelName)
+
+	result := modelCachePullResult{
+		Status:    "cached",
+		ModelName: modelName,
+		SizeBytes: sizeBytes,
+		Engine:    "ollama",
+	}
+	return json.Marshal(result)
+}
+
+// ollamaModelSize attempts to get the model size from `ollama list`.
+// Returns 0 if the size cannot be determined.
+func ollamaModelSize(modelName string) int64 {
+	cmd := exec.Command("ollama", "list")
+	output, err := cmd.Output()
+	if err != nil {
+		return 0
+	}
+	// Parse lines looking for model name. Each line is:
+	// NAME  ID  SIZE  MODIFIED
+	for _, line := range strings.Split(string(output), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		// Match model name (first field may include :tag)
+		name := fields[0]
+		if name == modelName || strings.HasPrefix(name, modelName+":") {
+			// SIZE field is at index 2, with unit at index 3
+			// e.g. "4.1 GB"
+			if len(fields) >= 4 {
+				return parseHumanSize(fields[2], fields[3])
+			}
+		}
+	}
+	return 0
+}
+
+// parseHumanSize converts human-readable size (e.g. "4.1" "GB") to bytes.
+func parseHumanSize(numStr, unit string) int64 {
+	var num float64
+	if _, err := fmt.Sscanf(numStr, "%f", &num); err != nil {
+		return 0
+	}
+	switch strings.ToUpper(unit) {
+	case "B":
+		return int64(num)
+	case "KB":
+		return int64(num * 1024)
+	case "MB":
+		return int64(num * 1024 * 1024)
+	case "GB":
+		return int64(num * 1024 * 1024 * 1024)
+	case "TB":
+		return int64(num * 1024 * 1024 * 1024 * 1024)
+	default:
+		return 0
+	}
+}
+
+// pullHuggingFace runs `huggingface-cli download <model>` for vllm/llamacpp engines.
+func (h *ModelCachePullHandler) pullHuggingFace(ctx JobContext, jobID, modelName, engine string) ([]byte, error) {
+	ctx.Log("info", "     - [Job %s] Pulling model '%s' via huggingface-cli for %s", jobID, modelName, engine)
+
+	cmd := exec.Command("huggingface-cli", "download", modelName)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return output, fmt.Errorf("huggingface-cli download failed: %w", err)
+	}
+
+	// Attempt to determine cache size from HuggingFace cache directory.
+	sizeBytes := hfCacheModelSize(modelName)
+
+	result := modelCachePullResult{
+		Status:    "cached",
+		ModelName: modelName,
+		SizeBytes: sizeBytes,
+		Engine:    engine,
+	}
+	return json.Marshal(result)
+}
+
+// hfCacheModelSize walks the HuggingFace cache directory for the model and
+// sums file sizes. Returns 0 if the cache directory cannot be found.
+func hfCacheModelSize(modelName string) int64 {
+	cacheDir := hfCacheDir(modelName)
+	if cacheDir == "" {
+		return 0
+	}
+
+	var total int64
+	filepath.Walk(cacheDir, func(_ string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		total += info.Size()
+		return nil
+	})
+	return total
+}
+
+// hfCacheDir returns the HuggingFace cache directory for a model, or empty
+// string if it cannot be determined.
+func hfCacheDir(modelName string) string {
+	// HuggingFace cache follows: ~/.cache/huggingface/hub/models--{org}--{model}/
+	base := os.Getenv("HF_HOME")
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		base = filepath.Join(home, ".cache", "huggingface")
+	}
+
+	// Convert "org/model" to "models--org--model"
+	sanitized := "models--" + strings.ReplaceAll(modelName, "/", "--")
+	dir := filepath.Join(base, "hub", sanitized)
+	if _, err := os.Stat(dir); err != nil {
+		return ""
+	}
+	return dir
+}
+
+// BuildOllamaPullCommand returns the exec.Cmd for pulling a model via ollama.
+// Exported for testing command construction.
+func BuildOllamaPullCommand(modelName string) *exec.Cmd {
+	return exec.Command("ollama", "pull", modelName)
+}
+
+// BuildHuggingFaceDownloadCommand returns the exec.Cmd for downloading a model
+// via huggingface-cli. Exported for testing command construction.
+func BuildHuggingFaceDownloadCommand(modelName string) *exec.Cmd {
+	return exec.Command("huggingface-cli", "download", modelName)
+}

--- a/internal/jobs/model_cache_test.go
+++ b/internal/jobs/model_cache_test.go
@@ -1,0 +1,345 @@
+package jobs
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+// --- MODEL_CACHE_PULL payload parsing tests ---
+
+func TestModelCachePull_MissingModelName(t *testing.T) {
+	h := &ModelCachePullHandler{}
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"engine": "ollama",
+	}))
+	if err == nil {
+		t.Fatal("expected error for missing model_name, got nil")
+	}
+	if !strings.Contains(err.Error(), "model_name") {
+		t.Errorf("error should mention model_name, got: %v", err)
+	}
+}
+
+func TestModelCachePull_EmptyModelName(t *testing.T) {
+	h := &ModelCachePullHandler{}
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"model_name": "",
+		"engine":     "ollama",
+	}))
+	if err == nil {
+		t.Fatal("expected error for empty model_name, got nil")
+	}
+}
+
+func TestModelCachePull_MissingEngine(t *testing.T) {
+	h := &ModelCachePullHandler{}
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"model_name": "llama3.2",
+	}))
+	if err == nil {
+		t.Fatal("expected error for missing engine, got nil")
+	}
+	if !strings.Contains(err.Error(), "engine") {
+		t.Errorf("error should mention engine, got: %v", err)
+	}
+}
+
+func TestModelCachePull_EmptyEngine(t *testing.T) {
+	h := &ModelCachePullHandler{}
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"model_name": "llama3.2",
+		"engine":     "",
+	}))
+	if err == nil {
+		t.Fatal("expected error for empty engine, got nil")
+	}
+}
+
+func TestModelCachePull_UnsupportedEngine(t *testing.T) {
+	h := &ModelCachePullHandler{}
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"model_name": "llama3.2",
+		"engine":     "tensorrt",
+	}))
+	if err == nil {
+		t.Fatal("expected error for unsupported engine, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported engine") {
+		t.Errorf("error should mention unsupported engine, got: %v", err)
+	}
+}
+
+func TestModelCachePull_EngineNormalization(t *testing.T) {
+	h := &ModelCachePullHandler{}
+	// "OLLAMA" should be normalized to "ollama" and attempt the pull.
+	// It will fail because ollama isn't installed in the test env,
+	// but the error should be about the pull failing, not about
+	// an unsupported engine.
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"model_name": "llama3.2",
+		"engine":     "OLLAMA",
+	}))
+	if err == nil {
+		// If ollama happens to be installed, that's fine too.
+		return
+	}
+	if strings.Contains(err.Error(), "unsupported engine") {
+		t.Errorf("OLLAMA should be normalized to ollama, got: %v", err)
+	}
+}
+
+// --- MODEL_CACHE_EVICT payload parsing tests ---
+
+func TestModelCacheEvict_MissingModelName(t *testing.T) {
+	h := &ModelCacheEvictHandler{}
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"engine": "ollama",
+	}))
+	if err == nil {
+		t.Fatal("expected error for missing model_name, got nil")
+	}
+	if !strings.Contains(err.Error(), "model_name") {
+		t.Errorf("error should mention model_name, got: %v", err)
+	}
+}
+
+func TestModelCacheEvict_EmptyModelName(t *testing.T) {
+	h := &ModelCacheEvictHandler{}
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"model_name": "",
+		"engine":     "ollama",
+	}))
+	if err == nil {
+		t.Fatal("expected error for empty model_name, got nil")
+	}
+}
+
+func TestModelCacheEvict_MissingEngine(t *testing.T) {
+	h := &ModelCacheEvictHandler{}
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"model_name": "llama3.2",
+	}))
+	if err == nil {
+		t.Fatal("expected error for missing engine, got nil")
+	}
+	if !strings.Contains(err.Error(), "engine") {
+		t.Errorf("error should mention engine, got: %v", err)
+	}
+}
+
+func TestModelCacheEvict_EmptyEngine(t *testing.T) {
+	h := &ModelCacheEvictHandler{}
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"model_name": "llama3.2",
+		"engine":     "",
+	}))
+	if err == nil {
+		t.Fatal("expected error for empty engine, got nil")
+	}
+}
+
+func TestModelCacheEvict_UnsupportedEngine(t *testing.T) {
+	h := &ModelCacheEvictHandler{}
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"model_name": "llama3.2",
+		"engine":     "tensorrt",
+	}))
+	if err == nil {
+		t.Fatal("expected error for unsupported engine, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported engine") {
+		t.Errorf("error should mention unsupported engine, got: %v", err)
+	}
+}
+
+func TestModelCacheEvict_EngineNormalization(t *testing.T) {
+	h := &ModelCacheEvictHandler{}
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"model_name": "llama3.2",
+		"engine":     "OLLAMA",
+	}))
+	if err == nil {
+		return
+	}
+	if strings.Contains(err.Error(), "unsupported engine") {
+		t.Errorf("OLLAMA should be normalized to ollama, got: %v", err)
+	}
+}
+
+func TestModelCacheEvict_HuggingFaceNotCached(t *testing.T) {
+	h := &ModelCacheEvictHandler{}
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"model_name": "nonexistent-org/nonexistent-model-xyz",
+		"engine":     "vllm",
+	}))
+	if err == nil {
+		t.Fatal("expected error for model not in cache, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention not found, got: %v", err)
+	}
+}
+
+// --- Command construction tests ---
+
+func TestBuildOllamaPullCommand(t *testing.T) {
+	cmd := BuildOllamaPullCommand("llama3.2:7b")
+	args := cmd.Args
+	if len(args) != 3 {
+		t.Fatalf("expected 3 args, got %d: %v", len(args), args)
+	}
+	if args[1] != "pull" {
+		t.Errorf("args[1] = %q, want 'pull'", args[1])
+	}
+	if args[2] != "llama3.2:7b" {
+		t.Errorf("args[2] = %q, want 'llama3.2:7b'", args[2])
+	}
+}
+
+func TestBuildOllamaRmCommand(t *testing.T) {
+	cmd := BuildOllamaRmCommand("llama3.2:7b")
+	args := cmd.Args
+	if len(args) != 3 {
+		t.Fatalf("expected 3 args, got %d: %v", len(args), args)
+	}
+	if args[1] != "rm" {
+		t.Errorf("args[1] = %q, want 'rm'", args[1])
+	}
+	if args[2] != "llama3.2:7b" {
+		t.Errorf("args[2] = %q, want 'llama3.2:7b'", args[2])
+	}
+}
+
+func TestBuildHuggingFaceDownloadCommand(t *testing.T) {
+	cmd := BuildHuggingFaceDownloadCommand("meta-llama/Llama-2-7b-chat-hf")
+	args := cmd.Args
+	if len(args) != 3 {
+		t.Fatalf("expected 3 args, got %d: %v", len(args), args)
+	}
+	if args[1] != "download" {
+		t.Errorf("args[1] = %q, want 'download'", args[1])
+	}
+	if args[2] != "meta-llama/Llama-2-7b-chat-hf" {
+		t.Errorf("args[2] = %q, want 'meta-llama/Llama-2-7b-chat-hf'", args[2])
+	}
+}
+
+// --- parseHumanSize tests ---
+
+func TestParseHumanSize(t *testing.T) {
+	tests := []struct {
+		numStr string
+		unit   string
+		want   int64
+	}{
+		{"4.1", "GB", 4402341478},  // ~4.1 * 1024^3
+		{"512", "MB", 536870912},   // 512 * 1024^2
+		{"1", "TB", 1099511627776}, // 1 * 1024^4
+		{"100", "KB", 102400},      // 100 * 1024
+		{"42", "B", 42},
+		{"bad", "GB", 0},
+		{"4.1", "XB", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.numStr+"_"+tt.unit, func(t *testing.T) {
+			got := parseHumanSize(tt.numStr, tt.unit)
+			if got != tt.want {
+				t.Errorf("parseHumanSize(%q, %q) = %d, want %d", tt.numStr, tt.unit, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- hfCacheDir tests ---
+
+func TestHfCacheDir_NonexistentModel(t *testing.T) {
+	dir := hfCacheDir("nonexistent-org/nonexistent-model-xyz")
+	if dir != "" {
+		t.Errorf("expected empty string for nonexistent model, got %q", dir)
+	}
+}
+
+// --- Result JSON structure tests ---
+
+func TestModelCachePullResult_JSONFields(t *testing.T) {
+	result := modelCachePullResult{
+		Status:    "cached",
+		ModelName: "llama3.2",
+		SizeBytes: 4402341478,
+		Engine:    "ollama",
+	}
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("json marshal: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("json unmarshal: %v", err)
+	}
+
+	if parsed["status"] != "cached" {
+		t.Errorf("status = %v, want 'cached'", parsed["status"])
+	}
+	if parsed["model_name"] != "llama3.2" {
+		t.Errorf("model_name = %v, want 'llama3.2'", parsed["model_name"])
+	}
+	if parsed["engine"] != "ollama" {
+		t.Errorf("engine = %v, want 'ollama'", parsed["engine"])
+	}
+	if _, ok := parsed["size_bytes"]; !ok {
+		t.Error("missing size_bytes field")
+	}
+}
+
+func TestModelCacheEvictResult_JSONFields(t *testing.T) {
+	result := modelCacheEvictResult{
+		Status:    "evicted",
+		ModelName: "llama3.2",
+		Engine:    "vllm",
+	}
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("json marshal: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("json unmarshal: %v", err)
+	}
+
+	if parsed["status"] != "evicted" {
+		t.Errorf("status = %v, want 'evicted'", parsed["status"])
+	}
+	if parsed["model_name"] != "llama3.2" {
+		t.Errorf("model_name = %v, want 'llama3.2'", parsed["model_name"])
+	}
+	if parsed["engine"] != "vllm" {
+		t.Errorf("engine = %v, want 'vllm'", parsed["engine"])
+	}
+}
+
+// --- Interface compliance ---
+
+func TestModelCachePullHandler_ImplementsJobHandler(t *testing.T) {
+	var _ JobHandler = (*ModelCachePullHandler)(nil)
+}
+
+func TestModelCacheEvictHandler_ImplementsJobHandler(t *testing.T) {
+	var _ JobHandler = (*ModelCacheEvictHandler)(nil)
+}
+
+// makeModelCacheJob is a helper for creating model cache jobs.
+func makeModelCacheJob(jobType, modelName, engine string) *nexus.Job {
+	return &nexus.Job{
+		ID:   "test-cache-1",
+		Type: jobType,
+		Payload: map[string]string{
+			"model_name": modelName,
+			"engine":     engine,
+		},
+	}
+}

--- a/internal/jobs/queue_types.go
+++ b/internal/jobs/queue_types.go
@@ -18,6 +18,10 @@ const (
 	JobTypeFileEdit   = "FILE_EDIT"
 	JobTypeFileList   = "FILE_LIST"
 	JobTypeFileSearch = "FILE_SEARCH"
+
+	// Model cache management job types
+	JobTypeModelCachePull  = "MODEL_CACHE_PULL"
+	JobTypeModelCacheEvict = "MODEL_CACHE_EVICT"
 )
 
 // Queue names following PR #1105 convention

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -129,6 +129,8 @@ func CreateLegacyHandlersWithOpts(opts LegacyHandlerOpts) []JobHandler {
 		NewLegacyHandlerAdapter(JobTypeApplyDeviceConfig, jobs.NewConfigHandler("")),
 		NewLegacyHandlerAdapter(JobTypeExtraction, &jobs.ExtractionHandler{}),
 		NewLegacyHandlerAdapter(JobTypeHTTPProxy, &jobs.HTTPProxyHandler{}),
+		NewLegacyHandlerAdapter(JobTypeModelCachePull, &jobs.ModelCachePullHandler{}),
+		NewLegacyHandlerAdapter(JobTypeModelCacheEvict, &jobs.ModelCacheEvictHandler{}),
 	}
 
 	// Register file-operation handlers when a workspace is configured.

--- a/internal/worker/job.go
+++ b/internal/worker/job.go
@@ -114,4 +114,6 @@ const (
 	JobTypeServiceStart      = "SERVICE_START"       // Start a service on the node
 	JobTypeServiceStop       = "SERVICE_STOP"        // Stop a service on the node
 	JobTypeServiceStatus     = "SERVICE_STATUS"      // Check if a service is running
+	JobTypeModelCachePull    = "MODEL_CACHE_PULL"    // Pull model weights into local cache
+	JobTypeModelCacheEvict   = "MODEL_CACHE_EVICT"   // Evict model weights from local cache
 )


### PR DESCRIPTION
## Context

Implements #146. The Sovereign Compute Fabric needs the ability to manage model weight caches on Citadel nodes remotely. When dispatching inference jobs, the platform should be able to pre-pull models or evict unused models to manage disk space on user hardware.

## Summary

Two new job handlers for model weight cache management, following the established handler pattern (`JobHandler` interface, `LegacyHandlerAdapter` registration):

- **`MODEL_CACHE_PULL`** (`internal/jobs/model_cache_pull.go`):
  - Ollama engine: runs `ollama pull <model>`, queries model size via `ollama list`
  - vLLM/llama.cpp engines: runs `huggingface-cli download <model>`, computes cache size by walking the HF cache directory
  - Returns `{ "status": "cached", "model_name": "...", "size_bytes": ..., "engine": "..." }`

- **`MODEL_CACHE_EVICT`** (`internal/jobs/model_cache_evict.go`):
  - Ollama engine: runs `ollama rm <model>`
  - vLLM/llama.cpp engines: removes the model's HuggingFace cache directory (`~/.cache/huggingface/hub/models--org--model/`)
  - Returns `{ "status": "evicted", "model_name": "...", "engine": "..." }`

Both handlers validate required fields, normalize engine names to lowercase, and reject unsupported engines. Registered in both `cmd/job_handlers.go` (test command) and `internal/worker/handler_adapter.go` (Redis worker).

## Test plan

| Group | Tests | Coverage |
|-------|-------|----------|
| Pull payload validation | 6 | missing/empty model_name, missing/empty engine, unsupported engine, case normalization |
| Evict payload validation | 7 | missing/empty model_name, missing/empty engine, unsupported engine, case normalization, HF not cached |
| Command construction | 3 | ollama pull, ollama rm, huggingface-cli download arg verification |
| Size parsing | 7 | GB, MB, TB, KB, B, invalid number, unknown unit |
| HF cache dir | 1 | nonexistent model returns empty |
| JSON result structure | 2 | pull result fields, evict result fields |
| Interface compliance | 2 | both handlers implement JobHandler |

Closes #146

---
*Generated by Claude*