### PR TITLE
feat: add SGLang as inference engine service option

### DIFF
--- a/cmd/manifest.go
+++ b/cmd/manifest.go
@@ -23,7 +23,7 @@ type Service struct {
 // If not declared, capabilities are auto-detected at startup.
 type ManifestCapabilities struct {
 	GPUs    []ManifestGPU `yaml:"gpus,omitempty"`
-	Engines []string      `yaml:"engines,omitempty"` // inference engines: vllm, ollama, llamacpp
+	Engines []string      `yaml:"engines,omitempty"` // inference engines: vllm, sglang, ollama, llamacpp
 }
 
 // ManifestGPU describes a GPU declared in the manifest.

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -33,6 +33,7 @@ func prepareCacheDirectories() error {
 		filepath.Join(cacheBase, "vllm"),
 		filepath.Join(cacheBase, "llamacpp"),
 		filepath.Join(cacheBase, "lmstudio"),
+		filepath.Join(cacheBase, "sglang"),
 		filepath.Join(cacheBase, "huggingface"),
 	}
 
@@ -176,6 +177,8 @@ func macServiceWarning(serviceName string) string {
 		return "LM Studio Docker image is Linux-only. Install the native macOS app from https://lmstudio.ai"
 	case "vllm":
 		return "vLLM requires NVIDIA GPU (Linux only). Consider using Ollama on macOS."
+	case "sglang":
+		return "SGLang requires NVIDIA GPU (Linux only). Consider using Ollama on macOS."
 	case "llamacpp":
 		return "llama.cpp Docker may have limited performance on macOS. Consider native installation."
 	default:

--- a/internal/capabilities/detector.go
+++ b/internal/capabilities/detector.go
@@ -202,6 +202,7 @@ func matchEngines(names []string) []string {
 		}
 		rules := []rule{
 			{"vllm", "vllm"},
+			{"sglang", "sglang"},
 			{"ollama", "ollama"},
 			{"llamacpp", "llamacpp"},
 			{"lmstudio", "lmstudio"},

--- a/internal/capabilities/detector_test.go
+++ b/internal/capabilities/detector_test.go
@@ -249,9 +249,15 @@ func TestMatchEngines(t *testing.T) {
 			notWant:    nil,
 		},
 		{
+			name:       "sglang container detected",
+			containers: []string{"citadel-sglang"},
+			want:       []string{"sglang"},
+			notWant:    []string{"vllm", "ollama", "llamacpp"},
+		},
+		{
 			name:       "multiple engines detected independently",
-			containers: []string{"citadel-vllm", "citadel-ollama"},
-			want:       []string{"vllm", "ollama"},
+			containers: []string{"citadel-vllm", "citadel-ollama", "citadel-sglang"},
+			want:       []string{"vllm", "ollama", "sglang"},
 			notWant:    []string{"llamacpp"},
 		},
 		{

--- a/internal/jobs/llm_inference.go
+++ b/internal/jobs/llm_inference.go
@@ -38,6 +38,8 @@ func (h *LLMInferenceHandler) Execute(ctx context.Context, client *redisclient.C
 	switch payload.Backend {
 	case "vllm":
 		return h.executeVLLM(ctx, client, job.JobID, rayID, payload)
+	case "sglang":
+		return h.executeSGLang(ctx, client, job.JobID, rayID, payload)
 	case "ollama":
 		return h.executeOllama(ctx, client, job.JobID, rayID, payload)
 	case "llamacpp":
@@ -256,6 +258,85 @@ func (h *LLMInferenceHandler) waitForVLLMReady(ctx context.Context) error {
 		time.Sleep(pollInterval)
 	}
 	return fmt.Errorf("vLLM did not become ready within %v", maxWait)
+}
+
+// executeSGLang handles inference via SGLang's OpenAI-compatible API.
+// SGLang runs on port 30000 and exposes the same /v1/completions endpoint as vLLM.
+func (h *LLMInferenceHandler) executeSGLang(ctx context.Context, client *redisclient.Client, jobID, rayID string, payload *LLMInferencePayload) error {
+	// Wait for SGLang to be ready
+	if err := h.waitForSGLangReady(ctx); err != nil {
+		return err
+	}
+
+	sglangURL := "http://localhost:30000/v1/completions"
+
+	reqPayload := map[string]any{
+		"model":       payload.Model,
+		"prompt":      payload.Prompt,
+		"max_tokens":  payload.MaxTokens,
+		"temperature": payload.Temperature,
+		"stream":      payload.Stream,
+	}
+
+	if payload.MaxTokens == 0 {
+		reqPayload["max_tokens"] = 512
+	}
+	if len(payload.Stop) > 0 {
+		reqPayload["stop"] = payload.Stop
+	}
+
+	reqBody, _ := json.Marshal(reqPayload)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", sglangURL, bytes.NewBuffer(reqBody))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to connect to SGLang: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("SGLang returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// SGLang uses the same OpenAI-compatible response format as vLLM
+	if payload.Stream {
+		return h.handleVLLMStream(ctx, client, jobID, rayID, resp.Body)
+	}
+
+	return h.handleVLLMNonStream(ctx, client, jobID, rayID, resp.Body)
+}
+
+func (h *LLMInferenceHandler) waitForSGLangReady(ctx context.Context) error {
+	healthURL := "http://localhost:30000/health"
+	maxWait := 60 * time.Second
+	pollInterval := 1 * time.Second
+	startTime := time.Now()
+
+	for time.Since(startTime) < maxWait {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		req, _ := http.NewRequestWithContext(ctx, "GET", healthURL, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil && resp.StatusCode == http.StatusOK {
+			resp.Body.Close()
+			return nil
+		}
+		if resp != nil {
+			resp.Body.Close()
+		}
+		time.Sleep(pollInterval)
+	}
+	return fmt.Errorf("SGLang did not become ready within %v", maxWait)
 }
 
 // executeOllama handles inference via Ollama's API.

--- a/internal/jobs/queue_types.go
+++ b/internal/jobs/queue_types.go
@@ -54,7 +54,7 @@ type LLMInferencePayload struct {
 	Stream bool `json:"stream"`
 
 	// Backend specifies which inference engine to use
-	Backend string `json:"backend"` // "vllm", "ollama", "llamacpp"
+	Backend string `json:"backend"` // "vllm", "sglang", "ollama", "llamacpp"
 
 	// Stop sequences to end generation
 	Stop []string `json:"stop,omitempty"`

--- a/services/compose/sglang.yml
+++ b/services/compose/sglang.yml
@@ -1,0 +1,24 @@
+# services/compose/sglang.yml
+
+services:
+  sglang:
+    image: lmsysorg/sglang:latest
+    container_name: citadel-sglang
+    ports:
+      - "30000:30000"
+    volumes:
+      # Mount a user-accessible directory to cache Hugging Face models
+      - ~/citadel-cache/huggingface:/root/.cache/huggingface
+    # Use an environment variable for the command.
+    # The part after the colon is the default if the variable isn't set.
+    # Users MUST set SGLANG_MODEL to their desired model path.
+    command: ${SGLANG_COMMAND:-python3 -m sglang.launch_server --host 0.0.0.0 --port 30000}
+    ipc: host
+    shm_size: "32g"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/services/compose/sglang.yml
+++ b/services/compose/sglang.yml
@@ -11,7 +11,8 @@ services:
       - ~/citadel-cache/huggingface:/root/.cache/huggingface
     # Use an environment variable for the command.
     # The part after the colon is the default if the variable isn't set.
-    # Users MUST set SGLANG_MODEL to their desired model path.
+    # Users should set SGLANG_COMMAND to include --model-path, e.g.:
+    # SGLANG_COMMAND="python3 -m sglang.launch_server --model-path meta-llama/Llama-3.1-8B-Instruct --host 0.0.0.0 --port 30000"
     command: ${SGLANG_COMMAND:-python3 -m sglang.launch_server --host 0.0.0.0 --port 30000}
     ipc: host
     shm_size: "32g"

--- a/services/embed.go
+++ b/services/embed.go
@@ -18,6 +18,9 @@ var LlamacppCompose string
 //go:embed compose/lmstudio.yml
 var LMStudioCompose string
 
+//go:embed compose/sglang.yml
+var SGLangCompose string
+
 //go:embed compose/extraction.yml
 var ExtractionCompose string
 
@@ -27,6 +30,7 @@ var ServiceMap = map[string]string{
 	"vllm":       VLLMCompose,
 	"llamacpp":   LlamacppCompose,
 	"lmstudio":   LMStudioCompose,
+	"sglang":     SGLangCompose,
 	"extraction": ExtractionCompose,
 }
 

--- a/services/embed_test.go
+++ b/services/embed_test.go
@@ -1,0 +1,48 @@
+package services
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestComposeFilesAreValidYAML verifies that all embedded compose files
+// parse as valid YAML. This catches syntax errors at test time rather
+// than at runtime when a user runs `citadel run <service>`.
+func TestComposeFilesAreValidYAML(t *testing.T) {
+	for name, content := range ServiceMap {
+		t.Run(name, func(t *testing.T) {
+			var parsed map[string]any
+			if err := yaml.Unmarshal([]byte(content), &parsed); err != nil {
+				t.Errorf("compose file for %q is not valid YAML: %v", name, err)
+			}
+			// Every compose file should have a top-level "services" key
+			if _, ok := parsed["services"]; !ok {
+				t.Errorf("compose file for %q missing top-level 'services' key", name)
+			}
+		})
+	}
+}
+
+// TestSGLangComposeRegistered ensures the sglang service is in the ServiceMap.
+func TestSGLangComposeRegistered(t *testing.T) {
+	if _, ok := ServiceMap["sglang"]; !ok {
+		t.Fatal("sglang not found in ServiceMap")
+	}
+}
+
+// TestGetAvailableServicesIncludesSGLang ensures sglang appears in the
+// sorted available services list.
+func TestGetAvailableServicesIncludesSGLang(t *testing.T) {
+	available := GetAvailableServices()
+	found := false
+	for _, s := range available {
+		if s == "sglang" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("GetAvailableServices() = %v, want sglang to be included", available)
+	}
+}


### PR DESCRIPTION
## Context

Part of aceteam-ai/aceteam#3617 -- adding SGLang as a supported inference engine in the Citadel compute fabric. SGLang is a high-performance serving framework for LLMs that competes with vLLM, offering potentially better throughput and lower latency for certain workloads. This PR makes it a first-class citizen alongside vLLM, Ollama, and llama.cpp.

## Summary

**Docker Compose service** (`services/compose/sglang.yml`):
- Uses `lmsysorg/sglang:latest` Docker image on port 30000
- Configurable launch command via `SGLANG_COMMAND` env var (mirrors llama.cpp pattern)
- GPU reservation, IPC host mode, and 32GB shared memory for optimal performance
- Mounts `~/citadel-cache/huggingface` for model caching

**Service registration** (`services/embed.go`):
- Embedded compose file and registered in `ServiceMap` so `citadel run sglang` works out of the box

**Inference backend** (`internal/jobs/llm_inference.go`):
- Added `sglang` as a valid `backend` value in `LLMInferencePayload`
- `executeSGLang()` method routes to port 30000 and reuses vLLM's OpenAI-compatible response handlers (SGLang uses the same wire format)
- Health check polling with 60s timeout

**Capability detection** (`internal/capabilities/detector.go`):
- `matchEngines()` now detects running `citadel-sglang` containers and emits `engine:sglang` tags for capability-based routing

**Supporting changes**:
- Cache directory (`~/citadel-cache/sglang`) created on startup
- macOS warning (GPU required, Linux only)
- Engine list comments updated in `queue_types.go` and `manifest.go`

## Test plan

| Area | Tests | Coverage |
|------|-------|----------|
| Compose YAML | 1 | All embedded compose files parse as valid YAML with `services` key |
| Service registration | 2 | `sglang` in `ServiceMap` and `GetAvailableServices()` |
| Engine detection | 2 | `citadel-sglang` container detected; multi-engine detection includes sglang |
| Existing tests | All | `go test ./...` passes with zero regressions |

## Related

- Parent issue: aceteam-ai/aceteam#3617
- Companion PR (benchmark harness): aceteam-ai/aceteam (feat/sglang-benchmark)

---
*Generated by Claude*