### PR TITLE
feat: subscribe to per-org shell command queues

### DIFF
--- a/cmd/work.go
+++ b/cmd/work.go
@@ -325,13 +325,19 @@ func runWork(cmd *cobra.Command, args []string) {
 			}
 		}
 
-		// Add per-org shell queue if org_id is known
+		// Add per-org shell queue if org_id is known.
+		// Ensure the default base queue is present when no explicit queue
+		// or capabilities were resolved (otherwise shell-only list would
+		// suppress the default fallback inside NewRedisSource).
 		orgID := ""
 		if deviceConfig != nil {
 			orgID = deviceConfig.OrgID
 		}
 		if orgID != "" {
 			shellQ := shellQueueName(orgID)
+			if len(queueNames) == 0 {
+				queueNames = []string{"jobs:v1:gpu-general"}
+			}
 			queueNames = append(queueNames, shellQ)
 			Debug("shell queue: %s", shellQ)
 		}

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -190,9 +190,6 @@ func runWork(cmd *cobra.Command, args []string) {
 
 	if workRedisURL == "" && deviceConfig != nil && deviceConfig.DeviceAPIToken != "" {
 		// API mode: use secure HTTP API instead of direct Redis.
-		// NOTE: API mode currently uses a single queue. Capability-based multi-queue
-		// routing requires extending APISource (tracked separately). Capabilities are
-		// still published in the heartbeat so the control plane can route upstream.
 		Debug("using API mode (device_api_token found)")
 		useAPIMode = true
 
@@ -232,10 +229,22 @@ func runWork(cmd *cobra.Command, args []string) {
 			_ = tempClient.Close()
 		}
 
+		// Build queue list: primary queue + per-org shell queue
+		var apiQueueNames []string
+		if workQueue != "" {
+			apiQueueNames = append(apiQueueNames, workQueue)
+		}
+		orgID := deviceConfig.OrgID
+		if orgID != "" {
+			shellQueue := shellQueueName(orgID)
+			apiQueueNames = append(apiQueueNames, shellQueue)
+			Debug("shell queue: %s", shellQueue)
+		}
+
 		apiSource = worker.NewAPISource(worker.APISourceConfig{
 			BaseURL:       apiBaseURL,
 			Token:         deviceConfig.DeviceAPIToken,
-			QueueName:     workQueue,
+			QueueNames:    apiQueueNames,
 			ConsumerGroup: workGroup,
 			BlockMs:       workPollMs,
 			MaxAttempts:   workMaxRetries,
@@ -314,6 +323,17 @@ func runWork(cmd *cobra.Command, args []string) {
 				baseQueue := "jobs:v1:gpu-general"
 				queueNames = capabilities.ResolveQueues(allCaps, baseQueue)
 			}
+		}
+
+		// Add per-org shell queue if org_id is known
+		orgID := ""
+		if deviceConfig != nil {
+			orgID = deviceConfig.OrgID
+		}
+		if orgID != "" {
+			shellQ := shellQueueName(orgID)
+			queueNames = append(queueNames, shellQ)
+			Debug("shell queue: %s", shellQ)
 		}
 
 		// Create Redis job source
@@ -836,6 +856,13 @@ func autoStartServices() error {
 
 	fmt.Println("--- Services started ---")
 	return nil
+}
+
+// shellQueueName returns the per-org shell command queue name.
+// Jobs dispatched by platform MCP tools (terminal_exec, code_read, etc.)
+// are enqueued to this queue using the pattern jobs:v1:shell:org_{org_id}.
+func shellQueueName(orgID string) string {
+	return fmt.Sprintf("jobs:v1:shell:org_%s", orgID)
 }
 
 // getRedisURLFromConfig reads Redis URL from global config file.

--- a/cmd/work_test.go
+++ b/cmd/work_test.go
@@ -1,0 +1,30 @@
+package cmd
+
+import "testing"
+
+func TestShellQueueName(t *testing.T) {
+	tests := []struct {
+		orgID string
+		want  string
+	}{
+		{
+			orgID: "550e8400-e29b-41d4-a716-446655440000",
+			want:  "jobs:v1:shell:org_550e8400-e29b-41d4-a716-446655440000",
+		},
+		{
+			orgID: "test-org-id",
+			want:  "jobs:v1:shell:org_test-org-id",
+		},
+		{
+			orgID: "",
+			want:  "jobs:v1:shell:org_",
+		},
+	}
+
+	for _, tt := range tests {
+		got := shellQueueName(tt.orgID)
+		if got != tt.want {
+			t.Errorf("shellQueueName(%q) = %q, want %q", tt.orgID, got, tt.want)
+		}
+	}
+}

--- a/internal/redisapi/jobs.go
+++ b/internal/redisapi/jobs.go
@@ -39,6 +39,7 @@ func parseStreamMessage(msg StreamMessage) (*Job, error) {
 	job := &Job{
 		MessageID: msg.ID,
 		JobID:     msg.Data.JobID,
+		Type:      msg.Data.Type, // Top-level stream field (e.g., SHELL_COMMAND)
 		RawData:   make(map[string]any),
 	}
 
@@ -58,9 +59,11 @@ func parseStreamMessage(msg StreamMessage) (*Job, error) {
 		}
 		job.Payload = payload
 
-		// Extract type from payload if present
-		if jobType, ok := payload["type"].(string); ok {
-			job.Type = jobType
+		// Fall back to type from payload if not at top level
+		if job.Type == "" {
+			if jobType, ok := payload["type"].(string); ok {
+				job.Type = jobType
+			}
 		}
 	}
 

--- a/internal/redisapi/jobs_test.go
+++ b/internal/redisapi/jobs_test.go
@@ -1,0 +1,136 @@
+package redisapi
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseStreamMessage_TopLevelType(t *testing.T) {
+	// Simulate a stream message from the Python backend's xadd:
+	//   xadd(queue, { "jobId": ..., "type": "SHELL_COMMAND", "payload": json.dumps({"command": "ls"}) })
+	msg := StreamMessage{
+		ID: "1234567890-0",
+		Data: StreamMessageData{
+			JobID:   "job-uuid-123",
+			Type:    "SHELL_COMMAND",
+			Payload: `{"command":"ls -la"}`,
+		},
+	}
+
+	job, err := parseStreamMessage(msg)
+	if err != nil {
+		t.Fatalf("parseStreamMessage error: %v", err)
+	}
+	if job.Type != "SHELL_COMMAND" {
+		t.Errorf("Type = %q, want %q", job.Type, "SHELL_COMMAND")
+	}
+	if job.JobID != "job-uuid-123" {
+		t.Errorf("JobID = %q, want %q", job.JobID, "job-uuid-123")
+	}
+	if cmd, ok := job.Payload["command"].(string); !ok || cmd != "ls -la" {
+		t.Errorf("Payload[command] = %v, want %q", job.Payload["command"], "ls -la")
+	}
+}
+
+func TestParseStreamMessage_PayloadFallbackType(t *testing.T) {
+	// When type is only in the payload (legacy format), it should still be extracted.
+	payload := map[string]any{"type": "llm_inference", "model": "llama3"}
+	payloadJSON, _ := json.Marshal(payload)
+
+	msg := StreamMessage{
+		ID: "1234567890-1",
+		Data: StreamMessageData{
+			JobID:   "job-uuid-456",
+			Type:    "", // Empty top-level type
+			Payload: string(payloadJSON),
+		},
+	}
+
+	job, err := parseStreamMessage(msg)
+	if err != nil {
+		t.Fatalf("parseStreamMessage error: %v", err)
+	}
+	if job.Type != "llm_inference" {
+		t.Errorf("Type = %q, want %q", job.Type, "llm_inference")
+	}
+}
+
+func TestParseStreamMessage_TopLevelTypeWins(t *testing.T) {
+	// Top-level type should take precedence over payload type.
+	payload := map[string]any{"type": "wrong_type", "data": "test"}
+	payloadJSON, _ := json.Marshal(payload)
+
+	msg := StreamMessage{
+		ID: "1234567890-2",
+		Data: StreamMessageData{
+			JobID:   "job-uuid-789",
+			Type:    "FILE_READ",
+			Payload: string(payloadJSON),
+		},
+	}
+
+	job, err := parseStreamMessage(msg)
+	if err != nil {
+		t.Fatalf("parseStreamMessage error: %v", err)
+	}
+	if job.Type != "FILE_READ" {
+		t.Errorf("Type = %q, want %q (top-level should win)", job.Type, "FILE_READ")
+	}
+}
+
+func TestParseStreamMessage_RayID(t *testing.T) {
+	msg := StreamMessage{
+		ID: "1234567890-3",
+		Data: StreamMessageData{
+			JobID:   "job-uuid-aaa",
+			Type:    "SHELL_COMMAND",
+			Payload: `{"command":"echo hello"}`,
+			RayID:   "ray-test-123",
+		},
+	}
+
+	job, err := parseStreamMessage(msg)
+	if err != nil {
+		t.Fatalf("parseStreamMessage error: %v", err)
+	}
+	if job.RawData["rayId"] != "ray-test-123" {
+		t.Errorf("RawData[rayId] = %v, want %q", job.RawData["rayId"], "ray-test-123")
+	}
+}
+
+func TestParseStreamMessage_InvalidPayload(t *testing.T) {
+	msg := StreamMessage{
+		ID: "1234567890-4",
+		Data: StreamMessageData{
+			JobID:   "job-uuid-bbb",
+			Type:    "SHELL_COMMAND",
+			Payload: "not-valid-json{{{",
+		},
+	}
+
+	_, err := parseStreamMessage(msg)
+	if err == nil {
+		t.Error("parseStreamMessage should error on invalid JSON payload")
+	}
+}
+
+func TestParseStreamMessage_EmptyPayload(t *testing.T) {
+	msg := StreamMessage{
+		ID: "1234567890-5",
+		Data: StreamMessageData{
+			JobID: "job-uuid-ccc",
+			Type:  "SHELL_COMMAND",
+		},
+	}
+
+	job, err := parseStreamMessage(msg)
+	if err != nil {
+		t.Fatalf("parseStreamMessage error: %v", err)
+	}
+	if job.Type != "SHELL_COMMAND" {
+		t.Errorf("Type = %q, want %q", job.Type, "SHELL_COMMAND")
+	}
+	if job.Payload != nil {
+		t.Errorf("Payload should be nil for empty payload string, got %v", job.Payload)
+	}
+}

--- a/internal/redisapi/types.go
+++ b/internal/redisapi/types.go
@@ -30,6 +30,7 @@ type StreamMessage struct {
 // StreamMessageData contains the job data within a stream message
 type StreamMessageData struct {
 	JobID      string `json:"jobId"`
+	Type       string `json:"type"`    // Job type (e.g., "SHELL_COMMAND"), top-level stream field
 	Payload    string `json:"payload"` // JSON-encoded job payload
 	EnqueuedAt string `json:"enqueuedAt"`
 	RayID      string `json:"rayId"`
@@ -148,7 +149,8 @@ type NodeMeta struct {
 // This endpoint returns the queue and org information needed by the worker
 // without exposing direct Redis credentials.
 type WorkerConfigResponse struct {
-	Queue         string `json:"queue"`
-	ConsumerGroup string `json:"consumer_group,omitempty"`
-	OrgID         string `json:"org_id,omitempty"`
+	Queue         string   `json:"queue"`
+	QueueNames    []string `json:"queue_names,omitempty"`
+	ConsumerGroup string   `json:"consumer_group,omitempty"`
+	OrgID         string   `json:"org_id,omitempty"`
 }

--- a/internal/worker/api_source.go
+++ b/internal/worker/api_source.go
@@ -157,6 +157,9 @@ func (s *APISource) nextSingle(ctx context.Context) (*Job, error) {
 
 // nextMulti round-robins across queues with a shorter block timeout.
 // Each poll checks one queue; if empty, advances to the next.
+// Individual queue failures (e.g., rejected by server validation) are
+// logged and skipped rather than failing the entire poll cycle. Only
+// when all queues error does the caller see an error (triggering backoff).
 func (s *APISource) nextMulti(ctx context.Context) (*Job, error) {
 	// Use a shorter block per queue so we cycle through them all within
 	// roughly the configured block timeout.
@@ -164,6 +167,9 @@ func (s *APISource) nextMulti(ctx context.Context) (*Job, error) {
 	if perQueueBlockMs < 500 {
 		perQueueBlockMs = 500
 	}
+
+	var lastErr error
+	errCount := 0
 
 	for i := 0; i < len(s.queueNames); i++ {
 		select {
@@ -183,7 +189,11 @@ func (s *APISource) nextMulti(ctx context.Context) (*Job, error) {
 			BlockMs:  perQueueBlockMs,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("failed to consume job from API (%s): %w", queue, err)
+			// Log and skip -- one rejected queue must not block the others.
+			s.log("warning", "consume failed on %s: %v", queue, err)
+			lastErr = err
+			errCount++
+			continue
 		}
 
 		if apiJob != nil {
@@ -191,6 +201,11 @@ func (s *APISource) nextMulti(ctx context.Context) (*Job, error) {
 			job.SourceQueue = queue
 			return job, nil
 		}
+	}
+
+	// Only propagate error (triggering backoff) if ALL queues failed.
+	if errCount == len(s.queueNames) {
+		return nil, fmt.Errorf("all queues failed: %w", lastErr)
 	}
 
 	return nil, nil // No job available on any queue

--- a/internal/worker/api_source.go
+++ b/internal/worker/api_source.go
@@ -9,9 +9,12 @@ import (
 
 // APISource implements JobSource using the AceTeam Redis API proxy.
 // This is the secure alternative to direct Redis connections.
+// Supports consuming from multiple queues by round-robining across them.
 type APISource struct {
-	client *redisapi.Client
-	config APISourceConfig
+	client     *redisapi.Client
+	config     APISourceConfig
+	queueNames []string // resolved list of queues to consume from
+	queueIndex int      // round-robin index for multi-queue polling
 }
 
 // APISourceConfig holds configuration for APISource.
@@ -22,8 +25,12 @@ type APISourceConfig struct {
 	// Token is the device_api_token from device authentication
 	Token string
 
-	// QueueName is the Redis Stream to consume from
+	// QueueName is the Redis Stream to consume from (single queue, backwards compat)
 	QueueName string
+
+	// QueueNames is the list of Redis Streams to consume from (multi-queue mode).
+	// If set, QueueName is ignored.
+	QueueNames []string
 
 	// ConsumerGroup is the consumer group name (default: "citadel-workers")
 	ConsumerGroup string
@@ -43,9 +50,6 @@ type APISourceConfig struct {
 
 // NewAPISource creates a new API-backed job source.
 func NewAPISource(cfg APISourceConfig) *APISource {
-	if cfg.QueueName == "" {
-		cfg.QueueName = "jobs:v1:cpu-general"
-	}
 	if cfg.ConsumerGroup == "" {
 		cfg.ConsumerGroup = "citadel-workers"
 	}
@@ -56,8 +60,19 @@ func NewAPISource(cfg APISourceConfig) *APISource {
 		cfg.MaxAttempts = 3
 	}
 
+	// Resolve queue names: prefer QueueNames, fall back to QueueName
+	var queues []string
+	if len(cfg.QueueNames) > 0 {
+		queues = cfg.QueueNames
+	} else if cfg.QueueName != "" {
+		queues = []string{cfg.QueueName}
+	} else {
+		queues = []string{"jobs:v1:cpu-general"}
+	}
+
 	return &APISource{
-		config: cfg,
+		config:     cfg,
+		queueNames: queues,
 	}
 }
 
@@ -96,15 +111,32 @@ func (s *APISource) Connect(ctx context.Context) error {
 
 	s.log("info", "   - API: %s", s.config.BaseURL)
 	s.log("info", "   - Worker ID: %s", s.client.WorkerID())
-	s.log("info", "   - Queue: %s", s.config.QueueName)
+	if len(s.queueNames) == 1 {
+		s.log("info", "   - Queue: %s", s.queueNames[0])
+	} else {
+		s.log("info", "   - Queues (%d):", len(s.queueNames))
+		for _, q := range s.queueNames {
+			s.log("info", "     - %s", q)
+		}
+	}
 	s.log("info", "   - Consumer group: %s", s.config.ConsumerGroup)
 	return nil
 }
 
 // Next blocks until a job is available or context is cancelled.
+// When consuming from multiple queues, polls each queue in round-robin
+// with a short block timeout to avoid starving any queue.
 func (s *APISource) Next(ctx context.Context) (*Job, error) {
+	if len(s.queueNames) == 1 {
+		return s.nextSingle(ctx)
+	}
+	return s.nextMulti(ctx)
+}
+
+// nextSingle reads from a single queue (original behavior).
+func (s *APISource) nextSingle(ctx context.Context) (*Job, error) {
 	apiJob, err := s.client.ConsumeJob(ctx, redisapi.ConsumeRequest{
-		Queue:    s.config.QueueName,
+		Queue:    s.queueNames[0],
 		Group:    s.config.ConsumerGroup,
 		Consumer: s.client.WorkerID(),
 		Count:    1,
@@ -115,11 +147,53 @@ func (s *APISource) Next(ctx context.Context) (*Job, error) {
 	}
 
 	if apiJob == nil {
-		return nil, nil // No job available
+		return nil, nil
 	}
 
-	// Convert to worker.Job
-	return s.convertJob(apiJob), nil
+	job := s.convertJob(apiJob)
+	job.SourceQueue = s.queueNames[0]
+	return job, nil
+}
+
+// nextMulti round-robins across queues with a shorter block timeout.
+// Each poll checks one queue; if empty, advances to the next.
+func (s *APISource) nextMulti(ctx context.Context) (*Job, error) {
+	// Use a shorter block per queue so we cycle through them all within
+	// roughly the configured block timeout.
+	perQueueBlockMs := s.config.BlockMs / len(s.queueNames)
+	if perQueueBlockMs < 500 {
+		perQueueBlockMs = 500
+	}
+
+	for i := 0; i < len(s.queueNames); i++ {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		queue := s.queueNames[s.queueIndex]
+		s.queueIndex = (s.queueIndex + 1) % len(s.queueNames)
+
+		apiJob, err := s.client.ConsumeJob(ctx, redisapi.ConsumeRequest{
+			Queue:    queue,
+			Group:    s.config.ConsumerGroup,
+			Consumer: s.client.WorkerID(),
+			Count:    1,
+			BlockMs:  perQueueBlockMs,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to consume job from API (%s): %w", queue, err)
+		}
+
+		if apiJob != nil {
+			job := s.convertJob(apiJob)
+			job.SourceQueue = queue
+			return job, nil
+		}
+	}
+
+	return nil, nil // No job available on any queue
 }
 
 // convertJob converts an API job to a worker.Job.
@@ -148,8 +222,12 @@ func (s *APISource) convertJob(aj *redisapi.Job) *Job {
 // Ack acknowledges successful job completion.
 func (s *APISource) Ack(ctx context.Context, job *Job) error {
 	s.client.SetJobStatus(ctx, job.ID, "completed", nil)
+	queue := job.SourceQueue
+	if queue == "" {
+		queue = s.queueNames[0]
+	}
 	return s.client.AcknowledgeJob(ctx, redisapi.AcknowledgeRequest{
-		Queue:     s.config.QueueName,
+		Queue:     queue,
 		Group:     s.config.ConsumerGroup,
 		MessageID: job.MessageID,
 	})
@@ -176,6 +254,11 @@ func (s *APISource) Close() error {
 // Client returns the underlying API client for stream writing.
 func (s *APISource) Client() *redisapi.Client {
 	return s.client
+}
+
+// QueueNames returns the list of queues being consumed.
+func (s *APISource) QueueNames() []string {
+	return s.queueNames
 }
 
 // IsJobCancelled checks whether a job has been cancelled by the producer.

--- a/internal/worker/api_source_test.go
+++ b/internal/worker/api_source_test.go
@@ -1,0 +1,125 @@
+package worker
+
+import (
+	"testing"
+)
+
+func TestNewAPISource_Defaults(t *testing.T) {
+	source := NewAPISource(APISourceConfig{
+		BaseURL: "https://aceteam.ai",
+		Token:   "test-token",
+	})
+
+	if source == nil {
+		t.Fatal("NewAPISource returned nil")
+	}
+	if len(source.queueNames) != 1 || source.queueNames[0] != "jobs:v1:cpu-general" {
+		t.Errorf("queueNames = %v, want [jobs:v1:cpu-general]", source.queueNames)
+	}
+	if source.config.ConsumerGroup != "citadel-workers" {
+		t.Errorf("ConsumerGroup = %v, want citadel-workers", source.config.ConsumerGroup)
+	}
+	if source.config.BlockMs != 5000 {
+		t.Errorf("BlockMs = %v, want 5000", source.config.BlockMs)
+	}
+	if source.config.MaxAttempts != 3 {
+		t.Errorf("MaxAttempts = %v, want 3", source.config.MaxAttempts)
+	}
+}
+
+func TestNewAPISource_SingleQueue(t *testing.T) {
+	source := NewAPISource(APISourceConfig{
+		BaseURL:   "https://aceteam.ai",
+		Token:     "test-token",
+		QueueName: "jobs:v1:gpu-a100",
+	})
+
+	if len(source.queueNames) != 1 || source.queueNames[0] != "jobs:v1:gpu-a100" {
+		t.Errorf("queueNames = %v, want [jobs:v1:gpu-a100]", source.queueNames)
+	}
+}
+
+func TestNewAPISource_MultiQueue(t *testing.T) {
+	queues := []string{
+		"jobs:v1:cpu-general",
+		"jobs:v1:shell:org_550e8400-e29b-41d4-a716-446655440000",
+	}
+	source := NewAPISource(APISourceConfig{
+		BaseURL:    "https://aceteam.ai",
+		Token:      "test-token",
+		QueueNames: queues,
+	})
+
+	if len(source.queueNames) != 2 {
+		t.Fatalf("queueNames length = %d, want 2", len(source.queueNames))
+	}
+	if source.queueNames[0] != queues[0] {
+		t.Errorf("queueNames[0] = %v, want %v", source.queueNames[0], queues[0])
+	}
+	if source.queueNames[1] != queues[1] {
+		t.Errorf("queueNames[1] = %v, want %v", source.queueNames[1], queues[1])
+	}
+}
+
+func TestNewAPISource_QueueNamesPrecedence(t *testing.T) {
+	// QueueNames should take precedence over QueueName
+	source := NewAPISource(APISourceConfig{
+		BaseURL:    "https://aceteam.ai",
+		Token:      "test-token",
+		QueueName:  "should-be-ignored",
+		QueueNames: []string{"queue-a", "queue-b"},
+	})
+
+	if len(source.queueNames) != 2 {
+		t.Fatalf("queueNames length = %d, want 2", len(source.queueNames))
+	}
+	if source.queueNames[0] != "queue-a" {
+		t.Errorf("queueNames[0] = %v, want queue-a", source.queueNames[0])
+	}
+}
+
+func TestAPISourceName(t *testing.T) {
+	source := NewAPISource(APISourceConfig{
+		BaseURL: "https://aceteam.ai",
+		Token:   "test-token",
+	})
+
+	if source.Name() != "redis-api" {
+		t.Errorf("Name() = %v, want redis-api", source.Name())
+	}
+}
+
+func TestAPISourceClose(t *testing.T) {
+	source := NewAPISource(APISourceConfig{
+		BaseURL: "https://aceteam.ai",
+		Token:   "test-token",
+	})
+
+	// Close without connecting should not error
+	if err := source.Close(); err != nil {
+		t.Errorf("Close() error = %v, want nil", err)
+	}
+}
+
+func TestAPISourceImplementsJobSource(t *testing.T) {
+	var _ JobSource = (*APISource)(nil)
+}
+
+func TestAPISourceQueueNames(t *testing.T) {
+	queues := []string{"queue-a", "queue-b", "queue-c"}
+	source := NewAPISource(APISourceConfig{
+		BaseURL:    "https://aceteam.ai",
+		Token:      "test-token",
+		QueueNames: queues,
+	})
+
+	got := source.QueueNames()
+	if len(got) != len(queues) {
+		t.Fatalf("QueueNames() length = %d, want %d", len(got), len(queues))
+	}
+	for i, q := range queues {
+		if got[i] != q {
+			t.Errorf("QueueNames()[%d] = %v, want %v", i, got[i], q)
+		}
+	}
+}

--- a/services/citadel-worker.service
+++ b/services/citadel-worker.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Citadel Worker - AceTeam Sovereign Compute
+After=network-online.target docker.service
+Wants=network-online.target docker.service
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/citadel work
+Restart=on-failure
+RestartSec=10
+Environment=HOME=/root
+WorkingDirectory=/root
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=citadel-worker
+
+# Resource limits
+LimitNOFILE=65535
+LimitNPROC=65535
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Context

Closes #125. The platform's MCP tools (`terminal_exec`, `code_read`, `code_write`, `code_edit`, `code_list`, `code_search`) dispatch jobs to per-org shell queues (`jobs:v1:shell:org_{org_id}`) via Redis Streams. However, the `citadel work` command never subscribed to these queues, so dispatched commands were never consumed. This PR connects the two sides.

## Summary

**Shell queue subscription** (`cmd/work.go`):
- Derives the shell queue name `jobs:v1:shell:org_{org_id}` from the node's org_id (set during `citadel init`)
- Adds the shell queue to both API mode and direct Redis mode queue lists
- Ensures the default base queue is preserved when no capabilities are detected (prevents shell-only consumption)
- The `ShellCommandHandler` (and all FILE_* handlers) already exist and process jobs from any queue -- the only missing piece was subscribing to the right queue

**Multi-queue API source** (`internal/worker/api_source.go`):
- Extended `APISource` to support consuming from multiple queues simultaneously (previously single-queue only)
- Uses round-robin polling: each `Next()` call cycles through queues with a proportionally shorter block timeout per queue
- Individual queue failures are logged and skipped rather than failing the entire poll cycle -- only when ALL queues fail does the runner trigger backoff
- Added `QueueNames` field to `APISourceConfig` (parallel to `RedisSourceConfig`)
- `Ack` now uses the job's `SourceQueue` for correct acknowledgment on the right stream

**Job type extraction fix** (`internal/redisapi/types.go`, `internal/redisapi/jobs.go`):
- Added `Type` field to `StreamMessageData` to capture the top-level `type` stream field
- The Python backend's `xadd` puts `type` at the stream level (e.g., `"type": "SHELL_COMMAND"`), not inside the JSON payload
- Previously in API mode, the type was silently dropped because `StreamMessageData` didn't map it, and the fallback only checked inside the payload JSON
- Now: top-level type takes precedence, with fallback to payload type for backwards compatibility

**Systemd service** (`services/citadel-worker.service`):
- Standalone unit file matching the inline unit in `install.sh`
- Can be enabled by firstboot scripts or `systemctl enable citadel-worker`

## Companion PR

**Required:** [aceteam-ai/aceteam#3646](https://github.com/aceteam-ai/aceteam/pull/3646) -- Adds shell queue validation to `isValidQueueName()` so the API proxy consume endpoint accepts shell queue names. Without this, API-mode workers get 400 errors on the shell queue consume call. The citadel-cli side gracefully skips the failed queue (no regression), but shell commands won't be consumed until the platform change lands.

## Test plan

| Area | Tests | Coverage |
|------|-------|----------|
| Shell queue name | `TestShellQueueName` | Queue name construction from org_id |
| API source multi-queue | `TestNewAPISource_MultiQueue`, `TestNewAPISource_QueueNamesPrecedence` | Multi-queue config, QueueNames > QueueName precedence |
| API source defaults | `TestNewAPISource_Defaults`, `TestNewAPISource_SingleQueue` | Backwards compatibility with single-queue config |
| Job type extraction | `TestParseStreamMessage_TopLevelType`, `TestParseStreamMessage_PayloadFallbackType`, `TestParseStreamMessage_TopLevelTypeWins` | Top-level type, payload fallback, precedence |
| Edge cases | `TestParseStreamMessage_InvalidPayload`, `TestParseStreamMessage_EmptyPayload`, `TestParseStreamMessage_RayID` | Error handling, empty payload, ray ID extraction |
| Existing tests | Full `go test ./...` passes | No regressions |

---
*Generated by Claude*