### PR TITLE
fix: expose services on tsnet VPN via dual-listen

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -547,16 +547,6 @@ func getSelectedService() (string, error) {
 	return strings.Fields(selection)[0], nil
 }
 
-// genericHostnames are OS default hostnames that provide no useful identity.
-// When the OS hostname matches one of these, we generate a citadel-<id> name instead.
-var genericHostnames = map[string]bool{
-	"debian":    true,
-	"ubuntu":    true,
-	"localhost": true,
-	"linux":     true,
-	"host":      true,
-}
-
 func getNodeName() (string, error) {
 	// 1. Explicit --node-name flag always wins
 	if initNodeName != "" {
@@ -569,14 +559,9 @@ func getNodeName() (string, error) {
 		return saved, nil
 	}
 
-	// 3. Use OS hostname if it's meaningful (not a generic live-ISO default)
-	hostname, err := os.Hostname()
-	if err == nil && hostname != "" && !genericHostnames[strings.ToLower(hostname)] {
-		return hostname, nil
-	}
-
-	// 4. Generate a citadel-<short_id> hostname
-	Debug("OS hostname %q is generic or unavailable, generating citadel hostname", hostname)
+	// 3. Always generate a citadel-<short_id> hostname instead of inheriting
+	//    the OS hostname, which is often useless on live ISOs (e.g., "debian").
+	//    Users who want a custom name can use --node-name.
 	generated, err := platform.GenerateCitadelHostname()
 	if err != nil {
 		return "", fmt.Errorf("could not generate hostname: %w", err)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -547,16 +547,90 @@ func getSelectedService() (string, error) {
 	return strings.Fields(selection)[0], nil
 }
 
+// genericHostnames are OS default hostnames that provide no useful identity.
+// When the OS hostname matches one of these, we generate a citadel-<id> name instead.
+var genericHostnames = map[string]bool{
+	"debian":    true,
+	"ubuntu":    true,
+	"localhost": true,
+	"linux":     true,
+	"host":      true,
+}
+
 func getNodeName() (string, error) {
+	// 1. Explicit --node-name flag always wins
 	if initNodeName != "" {
 		return initNodeName, nil
 	}
-	// Use hostname by default without prompting
-	hostname, err := os.Hostname()
-	if err != nil {
-		return "", fmt.Errorf("could not determine hostname: %w", err)
+
+	// 2. Check if a hostname was previously saved to config (for re-run stability)
+	if saved := getSavedHostname(); saved != "" {
+		Debug("using saved hostname from config: %s", saved)
+		return saved, nil
 	}
-	return hostname, nil
+
+	// 3. Use OS hostname if it's meaningful (not a generic live-ISO default)
+	hostname, err := os.Hostname()
+	if err == nil && hostname != "" && !genericHostnames[strings.ToLower(hostname)] {
+		return hostname, nil
+	}
+
+	// 4. Generate a citadel-<short_id> hostname
+	Debug("OS hostname %q is generic or unavailable, generating citadel hostname", hostname)
+	generated, err := platform.GenerateCitadelHostname()
+	if err != nil {
+		return "", fmt.Errorf("could not generate hostname: %w", err)
+	}
+
+	Debug("generated hostname: %s", generated)
+	return generated, nil
+}
+
+// getSavedHostname reads a previously saved hostname from the global config file.
+func getSavedHostname() string {
+	globalConfigFile := filepath.Join(platform.ConfigDir(), "config.yaml")
+	data, err := os.ReadFile(globalConfigFile)
+	if err != nil {
+		return ""
+	}
+
+	var config struct {
+		Hostname string `yaml:"hostname"`
+	}
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return ""
+	}
+	return config.Hostname
+}
+
+// saveHostnameToConfig persists the generated hostname to the global config file
+// so that re-runs of 'citadel init' produce the same name.
+func saveHostnameToConfig(hostname string) error {
+	globalConfigDir := platform.ConfigDir()
+	globalConfigFile := filepath.Join(globalConfigDir, "config.yaml")
+
+	if err := os.MkdirAll(globalConfigDir, 0755); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	var config map[string]interface{}
+	data, err := os.ReadFile(globalConfigFile)
+	if err == nil {
+		if unmarshalErr := yaml.Unmarshal(data, &config); unmarshalErr != nil {
+			config = nil
+		}
+	}
+	if config == nil {
+		config = make(map[string]interface{})
+	}
+
+	config["hostname"] = hostname
+
+	newData, err := yaml.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+	return os.WriteFile(globalConfigFile, newData, 0600)
 }
 
 func checkForRunningServicesQuiet(serviceToStart string) error {
@@ -1229,7 +1303,23 @@ func configureNvidiaDocker() error {
 
 // connectToNetwork connects to the AceTeam Network using the embedded tsnet library.
 // No external Tailscale installation is required.
+//
+// Before registering with Headscale, it attempts to set the system hostname to
+// match the node name (best-effort, requires root). The node name is always used
+// for Headscale registration regardless of whether the OS hostname update succeeds.
 func connectToNetwork(nodeName, authKey string) error {
+	// Attempt to set the OS hostname to match (best-effort, needs root)
+	if err := platform.SetHostname(nodeName); err != nil {
+		Debug("could not set system hostname (expected without root): %v", err)
+	} else {
+		Debug("system hostname set to %s", nodeName)
+	}
+
+	// Persist the hostname to config so re-runs are stable
+	if err := saveHostnameToConfig(nodeName); err != nil {
+		Debug("warning: could not save hostname to config: %v", err)
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -4,7 +4,6 @@ package cmd
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -163,35 +162,6 @@ func TestInitFlagDescriptions(t *testing.T) {
 
 	if newDeviceFlag.Usage == "" {
 		t.Error("--new-device flag should have a usage description")
-	}
-}
-
-// TestGenericHostnamesDetection verifies that common default hostnames are recognized.
-func TestGenericHostnamesDetection(t *testing.T) {
-	tests := []struct {
-		hostname string
-		generic  bool
-	}{
-		{"debian", true},
-		{"ubuntu", true},
-		{"localhost", true},
-		{"linux", true},
-		{"host", true},
-		{"Debian", true},  // case-insensitive
-		{"UBUNTU", true},  // case-insensitive
-		{"my-gpu-node", false},
-		{"citadel-ab12cd34", false},
-		{"jason-desktop", false},
-		{"", false}, // empty is handled separately
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.hostname, func(t *testing.T) {
-			got := genericHostnames[strings.ToLower(tt.hostname)]
-			if got != tt.generic {
-				t.Errorf("genericHostnames[%q] = %v, want %v", tt.hostname, got, tt.generic)
-			}
-		})
 	}
 }
 

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -4,6 +4,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -162,6 +163,111 @@ func TestInitFlagDescriptions(t *testing.T) {
 
 	if newDeviceFlag.Usage == "" {
 		t.Error("--new-device flag should have a usage description")
+	}
+}
+
+// TestGenericHostnamesDetection verifies that common default hostnames are recognized.
+func TestGenericHostnamesDetection(t *testing.T) {
+	tests := []struct {
+		hostname string
+		generic  bool
+	}{
+		{"debian", true},
+		{"ubuntu", true},
+		{"localhost", true},
+		{"linux", true},
+		{"host", true},
+		{"Debian", true},  // case-insensitive
+		{"UBUNTU", true},  // case-insensitive
+		{"my-gpu-node", false},
+		{"citadel-ab12cd34", false},
+		{"jason-desktop", false},
+		{"", false}, // empty is handled separately
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.hostname, func(t *testing.T) {
+			got := genericHostnames[strings.ToLower(tt.hostname)]
+			if got != tt.generic {
+				t.Errorf("genericHostnames[%q] = %v, want %v", tt.hostname, got, tt.generic)
+			}
+		})
+	}
+}
+
+// TestClearSavedConfigPreservesHostname verifies that clearSavedConfig()
+// does NOT clear the saved hostname (it's stable identity, not device auth).
+func TestClearSavedConfigPreservesHostname(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "citadel-hostname-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	configContent := `hostname: "citadel-ab12cd34"
+node_config_dir: "/home/user/citadel-node"
+device_api_token: "test-token"
+`
+	if err := os.WriteFile(configFile, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write config: %v", err)
+	}
+
+	// Simulate clearSavedConfig logic
+	data, _ := os.ReadFile(configFile)
+	var config map[string]interface{}
+	yaml.Unmarshal(data, &config)
+
+	// clearSavedConfig deletes these fields:
+	delete(config, "device_api_token")
+	delete(config, "api_base_url")
+	delete(config, "org_id")
+	delete(config, "redis_url")
+	delete(config, "user_email")
+	delete(config, "user_name")
+
+	// hostname should NOT be in the delete list (stable identity)
+	if _, exists := config["hostname"]; !exists {
+		t.Error("hostname should survive clearSavedConfig")
+	}
+	if config["hostname"] != "citadel-ab12cd34" {
+		t.Errorf("hostname = %q, want %q", config["hostname"], "citadel-ab12cd34")
+	}
+}
+
+// TestSaveHostnameToConfigRoundTrip verifies hostname save/load via config YAML.
+func TestSaveHostnameToConfigRoundTrip(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "citadel-hostname-rt-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configFile := filepath.Join(tmpDir, "config.yaml")
+
+	// Write a config with hostname
+	config := map[string]interface{}{
+		"hostname":        "citadel-deadbeef",
+		"node_config_dir": "/home/user/citadel-node",
+	}
+	data, _ := yaml.Marshal(config)
+	os.WriteFile(configFile, data, 0600)
+
+	// Read it back
+	readData, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatalf("Failed to read config: %v", err)
+	}
+
+	var readConfig struct {
+		Hostname string `yaml:"hostname"`
+	}
+	if err := yaml.Unmarshal(readData, &readConfig); err != nil {
+		t.Fatalf("Failed to parse config: %v", err)
+	}
+
+	if readConfig.Hostname != "citadel-deadbeef" {
+		t.Errorf("hostname = %q, want %q", readConfig.Hostname, "citadel-deadbeef")
 	}
 }
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -153,6 +153,22 @@ func runServe(cmd *cobra.Command, args []string) error {
 	termAddr := fmt.Sprintf("127.0.0.1:%d", serveTermPort)
 	vncAddr := fmt.Sprintf("127.0.0.1:%d", serveVNCPort)
 
+	// Add VPN listener so the gateway is reachable over the tsnet VPN.
+	// For HTTPS mode, the raw tsnet listener must be TLS-wrapped so that
+	// clients connecting over the VPN get the same TLS termination.
+	var vpnGatewayListener net.Listener
+	if network.IsGlobalConnected() {
+		vpnAddr := fmt.Sprintf(":%d", servePort)
+		rawLn, err := network.Listen("tcp", vpnAddr)
+		if err != nil {
+			Debug("gateway VPN listener failed (LAN-only): %v", err)
+		} else if tlsConfig != nil {
+			vpnGatewayListener = tls.NewListener(rawLn, tlsConfig)
+		} else {
+			vpnGatewayListener = rawLn
+		}
+	}
+
 	// Create gateway
 	gw := gateway.NewServer(gateway.Config{
 		Port:          servePort,
@@ -183,6 +199,11 @@ func runServe(cmd *cobra.Command, args []string) error {
 		StripPrefix: false,
 		WebSocket:   true,
 	})
+
+	// Attach VPN listener if available
+	if vpnGatewayListener != nil {
+		gw.AddListener(vpnGatewayListener)
+	}
 
 	// Print route table
 	scheme := "https"

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -519,6 +519,17 @@ func runWork(cmd *cobra.Command, args []string) {
 
 		statusServer := status.NewServer(serverCfg, collector)
 
+		// Add VPN listener so the status server is reachable over the tsnet VPN
+		if network.IsGlobalConnected() {
+			vpnAddr := fmt.Sprintf(":%d", workStatusPort)
+			if vpnLn, err := network.Listen("tcp", vpnAddr); err != nil {
+				Debug("status server VPN listener failed (LAN-only): %v", err)
+			} else {
+				statusServer.AddListener(vpnLn)
+				fmt.Printf("   - Status server VPN: http://<vpn-ip>:%d\n", workStatusPort)
+			}
+		}
+
 		go func() {
 			if serverCfg.TokenValidator != nil {
 				if cachingVal, ok := serverCfg.TokenValidator.(*terminal.CachingTokenValidator); ok {
@@ -735,6 +746,17 @@ func runWork(cmd *cobra.Command, args []string) {
 				)
 
 				termServer := terminal.NewServer(termConfig, cachingAuth)
+
+				// Add VPN listener so the terminal server is reachable over the tsnet VPN
+				if network.IsGlobalConnected() {
+					vpnAddr := fmt.Sprintf(":%d", termConfig.Port)
+					if vpnLn, err := network.Listen("tcp", vpnAddr); err != nil {
+						Debug("terminal server VPN listener failed (LAN-only): %v", err)
+					} else {
+						termServer.AddListener(vpnLn)
+						fmt.Printf("   - Terminal server VPN: ws://<vpn-ip>:%d/terminal\n", termConfig.Port)
+					}
+				}
 
 				go func() {
 					// Start the token cache

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -69,6 +69,10 @@ type Server struct {
 	mux        *http.ServeMux
 	httpServer *http.Server
 	mu         sync.RWMutex
+
+	// extraListeners are additional net.Listeners the server will also serve on
+	// (e.g., a TLS-wrapped tsnet VPN listener). Added via AddListener before Start.
+	extraListeners []net.Listener
 }
 
 // NewServer creates a new gateway server.
@@ -86,6 +90,15 @@ func NewServer(cfg Config) *Server {
 	}
 
 	return s
+}
+
+// AddListener registers an additional net.Listener that the server will also
+// serve on when Start is called. For HTTPS gateways, the listener should
+// already be TLS-wrapped (e.g., via tls.NewListener). Must be called before Start.
+func (s *Server) AddListener(ln net.Listener) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.extraListeners = append(s.extraListeners, ln)
 }
 
 // AddUpstream registers a backend for the given path prefix.
@@ -138,6 +151,17 @@ func (s *Server) Start(ctx context.Context) error {
 			errCh <- err
 		}
 	}()
+
+	// Serve on any extra listeners (e.g., TLS-wrapped tsnet VPN listener)
+	for _, ln := range s.extraListeners {
+		ln := ln // capture loop variable
+		log.Printf("[Gateway] also listening on %s (VPN)", ln.Addr().String())
+		go func() {
+			if err := s.httpServer.Serve(ln); err != nil && err != http.ErrServerClosed {
+				log.Printf("[Gateway] VPN listener error: %v", err)
+			}
+		}()
+	}
 
 	select {
 	case <-ctx.Done():

--- a/internal/gateway/gateway_test.go
+++ b/internal/gateway/gateway_test.go
@@ -258,6 +258,85 @@ func TestProxyUpstreamDown(t *testing.T) {
 	}
 }
 
+func TestStartAndShutdownDualListen(t *testing.T) {
+	// Find a free port for the primary listener
+	primaryLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := primaryLn.Addr().(*net.TCPAddr).Port
+	primaryLn.Close()
+
+	// Create a second listener to simulate a VPN listener
+	extraLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	extraPort := extraLn.Addr().(*net.TCPAddr).Port
+
+	gw := NewServer(Config{
+		Port:          port,
+		ListenAddress: fmt.Sprintf("127.0.0.1:%d", port),
+		NodeName:      "test-dual-node",
+	})
+	gw.AddListener(extraLn)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- gw.Start(ctx)
+	}()
+
+	// Give it time to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Primary listener should serve /
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/", port))
+	if err != nil {
+		t.Fatalf("primary GET /: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("primary listener: status = %d, want 200", resp.StatusCode)
+	}
+
+	// Extra (VPN) listener should also serve /
+	resp, err = http.Get(fmt.Sprintf("http://127.0.0.1:%d/", extraPort))
+	if err != nil {
+		t.Fatalf("extra GET /: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("extra listener: status = %d, want 200, body: %s", resp.StatusCode, string(body))
+	}
+
+	// Verify the extra listener returns the gateway info
+	var gwResp map[string]interface{}
+	if err := json.Unmarshal(body, &gwResp); err != nil {
+		t.Fatalf("unmarshal extra listener response: %v", err)
+	}
+	if gwResp["gateway"] != "citadel" {
+		t.Errorf("extra listener gateway = %v, want citadel", gwResp["gateway"])
+	}
+	if gwResp["node"] != "test-dual-node" {
+		t.Errorf("extra listener node = %v, want test-dual-node", gwResp["node"])
+	}
+
+	// Shutdown
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("Start() returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Error("Start() did not return after context cancel")
+	}
+}
+
 func TestStartAndShutdown(t *testing.T) {
 	// Find a free port
 	listener, err := net.Listen("tcp", "127.0.0.1:0")

--- a/internal/platform/hostname.go
+++ b/internal/platform/hostname.go
@@ -9,6 +9,9 @@ import (
 	"strings"
 )
 
+// machineIDPath is the path to the machine-id file. Overridable in tests.
+var machineIDPath = "/etc/machine-id"
+
 // GenerateCitadelHostname generates a hostname like "citadel-<short_id>" for use
 // during node initialization. The short_id is derived from /etc/machine-id (first
 // 8 characters) when available, or a random 8-character hex string as fallback.
@@ -26,17 +29,17 @@ func GenerateCitadelHostname() (string, error) {
 	return "citadel-" + shortID, nil
 }
 
-// getShortMachineID reads /etc/machine-id and returns its first 8 characters.
+// getShortMachineID reads the machine-id file and returns its first 8 characters.
 // Returns an error if the file is missing, empty, or shorter than 8 characters.
 func getShortMachineID() (string, error) {
-	data, err := os.ReadFile("/etc/machine-id")
+	data, err := os.ReadFile(machineIDPath)
 	if err != nil {
-		return "", fmt.Errorf("could not read /etc/machine-id: %w", err)
+		return "", fmt.Errorf("could not read %s: %w", machineIDPath, err)
 	}
 
 	id := strings.TrimSpace(string(data))
 	if len(id) < 8 {
-		return "", fmt.Errorf("/etc/machine-id too short: %q", id)
+		return "", fmt.Errorf("%s too short: %q", machineIDPath, id)
 	}
 
 	return id[:8], nil

--- a/internal/platform/hostname.go
+++ b/internal/platform/hostname.go
@@ -1,0 +1,84 @@
+package platform
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// GenerateCitadelHostname generates a hostname like "citadel-<short_id>" for use
+// during node initialization. The short_id is derived from /etc/machine-id (first
+// 8 characters) when available, or a random 8-character hex string as fallback.
+//
+// This ensures nodes get unique, recognizable names instead of inheriting generic
+// OS hostnames like "debian" on live ISOs.
+func GenerateCitadelHostname() (string, error) {
+	shortID, err := getShortMachineID()
+	if err != nil {
+		shortID, err = generateRandomHexID(8)
+		if err != nil {
+			return "", fmt.Errorf("failed to generate hostname: %w", err)
+		}
+	}
+	return "citadel-" + shortID, nil
+}
+
+// getShortMachineID reads /etc/machine-id and returns its first 8 characters.
+// Returns an error if the file is missing, empty, or shorter than 8 characters.
+func getShortMachineID() (string, error) {
+	data, err := os.ReadFile("/etc/machine-id")
+	if err != nil {
+		return "", fmt.Errorf("could not read /etc/machine-id: %w", err)
+	}
+
+	id := strings.TrimSpace(string(data))
+	if len(id) < 8 {
+		return "", fmt.Errorf("/etc/machine-id too short: %q", id)
+	}
+
+	return id[:8], nil
+}
+
+// generateRandomHexID generates a random hex string of the specified length.
+func generateRandomHexID(length int) (string, error) {
+	// We need length/2 bytes (rounded up) to produce `length` hex chars
+	numBytes := (length + 1) / 2
+	b := make([]byte, numBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("failed to generate random bytes: %w", err)
+	}
+	return hex.EncodeToString(b)[:length], nil
+}
+
+// SetHostname attempts to set the system hostname. This is best-effort and will
+// return an error if it fails (e.g., when not running as root). Callers should
+// treat failure as non-fatal — the generated hostname is still used for Headscale
+// registration regardless of whether the OS hostname is updated.
+//
+// On Linux: tries hostnamectl, falls back to writing /etc/hostname + syscall.
+// On other platforms: no-op (returns nil).
+func SetHostname(name string) error {
+	if !IsLinux() {
+		return nil
+	}
+
+	// Try hostnamectl first (sets both transient and static hostname)
+	if err := exec.Command("hostnamectl", "set-hostname", name).Run(); err == nil {
+		return nil
+	}
+
+	// Fallback: write /etc/hostname for persistence across reboots
+	if err := os.WriteFile("/etc/hostname", []byte(name+"\n"), 0644); err != nil {
+		return fmt.Errorf("failed to write /etc/hostname: %w", err)
+	}
+
+	// Also set the transient hostname for the current session
+	if err := exec.Command("hostname", name).Run(); err != nil {
+		return fmt.Errorf("failed to set transient hostname: %w", err)
+	}
+
+	return nil
+}

--- a/internal/platform/hostname_test.go
+++ b/internal/platform/hostname_test.go
@@ -69,17 +69,81 @@ func TestGetShortMachineID(t *testing.T) {
 }
 
 func TestGetShortMachineIDTooShort(t *testing.T) {
-	// Create a temp file with content shorter than 8 chars
 	tmpDir := t.TempDir()
 	tmpFile := filepath.Join(tmpDir, "machine-id")
 	if err := os.WriteFile(tmpFile, []byte("abc\n"), 0644); err != nil {
 		t.Fatalf("failed to write temp file: %v", err)
 	}
 
-	// We can't easily test getShortMachineID with a custom path since it
-	// reads /etc/machine-id directly. This test documents the expected
-	// behavior: strings shorter than 8 chars should cause an error.
-	t.Log("getShortMachineID returns error for machine-id shorter than 8 chars")
+	// Override the machine-id path to test the too-short branch
+	old := machineIDPath
+	machineIDPath = tmpFile
+	defer func() { machineIDPath = old }()
+
+	_, err := getShortMachineID()
+	if err == nil {
+		t.Error("expected error for machine-id shorter than 8 chars, got nil")
+	}
+}
+
+func TestGetShortMachineIDMissing(t *testing.T) {
+	// Override to a non-existent path
+	old := machineIDPath
+	machineIDPath = "/tmp/does-not-exist-citadel-test"
+	defer func() { machineIDPath = old }()
+
+	_, err := getShortMachineID()
+	if err == nil {
+		t.Error("expected error for missing machine-id file, got nil")
+	}
+}
+
+func TestGenerateCitadelHostnameFallbackToRandom(t *testing.T) {
+	// Point machine-id to a non-existent file to force random fallback
+	old := machineIDPath
+	machineIDPath = "/tmp/does-not-exist-citadel-test"
+	defer func() { machineIDPath = old }()
+
+	hostname, err := GenerateCitadelHostname()
+	if err != nil {
+		t.Fatalf("GenerateCitadelHostname() with missing machine-id failed: %v", err)
+	}
+
+	if !strings.HasPrefix(hostname, "citadel-") {
+		t.Errorf("hostname %q does not have citadel- prefix", hostname)
+	}
+
+	if len(hostname) != 16 {
+		t.Errorf("hostname %q has length %d, want 16", hostname, len(hostname))
+	}
+
+	// Random fallback should produce different values each time
+	hostname2, _ := GenerateCitadelHostname()
+	if hostname == hostname2 {
+		t.Errorf("random fallback produced same hostname twice: %q", hostname)
+	}
+}
+
+func TestGenerateCitadelHostnameWithCustomMachineID(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "machine-id")
+	if err := os.WriteFile(tmpFile, []byte("deadbeef12345678abcdef\n"), 0644); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+
+	old := machineIDPath
+	machineIDPath = tmpFile
+	defer func() { machineIDPath = old }()
+
+	hostname, err := GenerateCitadelHostname()
+	if err != nil {
+		t.Fatalf("GenerateCitadelHostname() failed: %v", err)
+	}
+
+	expected := "citadel-deadbeef"
+	if hostname != expected {
+		t.Errorf("hostname = %q, want %q", hostname, expected)
+	}
 }
 
 func TestGenerateRandomHexID(t *testing.T) {

--- a/internal/platform/hostname_test.go
+++ b/internal/platform/hostname_test.go
@@ -1,0 +1,125 @@
+package platform
+
+import (
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGenerateCitadelHostname(t *testing.T) {
+	hostname, err := GenerateCitadelHostname()
+	if err != nil {
+		t.Fatalf("GenerateCitadelHostname() failed: %v", err)
+	}
+
+	// Must have the citadel- prefix
+	if !strings.HasPrefix(hostname, "citadel-") {
+		t.Errorf("hostname %q does not have citadel- prefix", hostname)
+	}
+
+	// Total length should be "citadel-" (8) + short_id (8) = 16
+	if len(hostname) != 16 {
+		t.Errorf("hostname %q has length %d, want 16", hostname, len(hostname))
+	}
+
+	// The suffix should be valid lowercase hex
+	suffix := hostname[len("citadel-"):]
+	if _, err := hex.DecodeString(suffix); err != nil {
+		t.Errorf("hostname suffix %q is not valid hex: %v", suffix, err)
+	}
+}
+
+func TestGenerateCitadelHostnameConsistency(t *testing.T) {
+	// On systems with /etc/machine-id, the hostname should be consistent
+	if _, err := os.ReadFile("/etc/machine-id"); err != nil {
+		t.Skip("no /etc/machine-id on this system, skipping consistency test")
+	}
+
+	h1, err := GenerateCitadelHostname()
+	if err != nil {
+		t.Fatalf("first call failed: %v", err)
+	}
+
+	h2, err := GenerateCitadelHostname()
+	if err != nil {
+		t.Fatalf("second call failed: %v", err)
+	}
+
+	if h1 != h2 {
+		t.Errorf("hostname not consistent across calls: %q vs %q", h1, h2)
+	}
+}
+
+func TestGetShortMachineID(t *testing.T) {
+	id, err := getShortMachineID()
+	if err != nil {
+		t.Skipf("cannot read /etc/machine-id: %v", err)
+	}
+
+	if len(id) != 8 {
+		t.Errorf("short machine ID length = %d, want 8", len(id))
+	}
+
+	// Should be valid hex
+	if _, err := hex.DecodeString(id); err != nil {
+		t.Errorf("short machine ID %q is not valid hex: %v", id, err)
+	}
+}
+
+func TestGetShortMachineIDTooShort(t *testing.T) {
+	// Create a temp file with content shorter than 8 chars
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "machine-id")
+	if err := os.WriteFile(tmpFile, []byte("abc\n"), 0644); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+
+	// We can't easily test getShortMachineID with a custom path since it
+	// reads /etc/machine-id directly. This test documents the expected
+	// behavior: strings shorter than 8 chars should cause an error.
+	t.Log("getShortMachineID returns error for machine-id shorter than 8 chars")
+}
+
+func TestGenerateRandomHexID(t *testing.T) {
+	id, err := generateRandomHexID(8)
+	if err != nil {
+		t.Fatalf("generateRandomHexID(8) failed: %v", err)
+	}
+
+	if len(id) != 8 {
+		t.Errorf("random hex ID length = %d, want 8", len(id))
+	}
+
+	// Should be valid hex
+	if _, err := hex.DecodeString(id); err != nil {
+		t.Errorf("random hex ID %q is not valid hex: %v", id, err)
+	}
+}
+
+func TestGenerateRandomHexIDUniqueness(t *testing.T) {
+	ids := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		id, err := generateRandomHexID(8)
+		if err != nil {
+			t.Fatalf("generateRandomHexID failed on iteration %d: %v", i, err)
+		}
+		if ids[id] {
+			t.Errorf("duplicate random ID %q on iteration %d", id, i)
+		}
+		ids[id] = true
+	}
+}
+
+func TestSetHostnameNonLinux(t *testing.T) {
+	// SetHostname is a no-op on non-Linux platforms
+	if IsLinux() {
+		t.Skip("skipping non-Linux test on Linux")
+	}
+
+	// Should return nil without doing anything
+	if err := SetHostname("test-hostname"); err != nil {
+		t.Errorf("SetHostname on non-Linux returned error: %v", err)
+	}
+}

--- a/internal/status/server.go
+++ b/internal/status/server.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -23,6 +25,10 @@ type Server struct {
 	tokenValidator terminal.TokenValidator
 	orgID          string
 	enableDesktop  bool
+
+	// extraListeners are additional net.Listeners the server will also serve on
+	// (e.g., a tsnet VPN listener). Added via AddListener before Start.
+	extraListeners []net.Listener
 }
 
 // ServerConfig holds configuration for the status server.
@@ -47,6 +53,13 @@ func NewServer(cfg ServerConfig, collector *Collector) *Server {
 		orgID:          cfg.OrgID,
 		enableDesktop:  cfg.EnableDesktop,
 	}
+}
+
+// AddListener registers an additional net.Listener that the server will also
+// serve on when Start is called. This enables dual-listen on both LAN and VPN
+// interfaces. Must be called before Start.
+func (s *Server) AddListener(ln net.Listener) {
+	s.extraListeners = append(s.extraListeners, ln)
 }
 
 // Start begins listening for HTTP requests.
@@ -77,6 +90,17 @@ func (s *Server) Start(ctx context.Context) error {
 			errChan <- err
 		}
 	}()
+
+	// Serve on any extra listeners (e.g., tsnet VPN)
+	for _, ln := range s.extraListeners {
+		ln := ln // capture loop variable
+		log.Printf("[status] also listening on %s (VPN)", ln.Addr().String())
+		go func() {
+			if err := s.httpServer.Serve(ln); err != nil && err != http.ErrServerClosed {
+				log.Printf("[status] VPN listener error: %v", err)
+			}
+		}()
+	}
 
 	// Wait for context cancellation or server error
 	select {

--- a/internal/status/server_test.go
+++ b/internal/status/server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -305,6 +306,49 @@ func TestDesktopEndpointRejectsInvalidToken(t *testing.T) {
 
 	if w.Code != http.StatusUnauthorized {
 		t.Errorf("/api/screenshot with bad token: got %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestServerDualListen(t *testing.T) {
+	collector := NewCollector(CollectorConfig{NodeName: "test-dual"})
+
+	// Create an extra listener to simulate a VPN listener
+	extraLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create extra listener: %v", err)
+	}
+	extraAddr := extraLn.Addr().(*net.TCPAddr)
+
+	server := NewServer(ServerConfig{
+		Port:    0,
+		Version: "test-dual",
+	}, collector)
+	server.AddListener(extraLn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	go server.Start(ctx)
+	time.Sleep(100 * time.Millisecond) // Wait for server to start
+
+	// The extra (VPN) listener should serve /health
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/health", extraAddr.Port))
+	if err != nil {
+		t.Fatalf("extra listener health check failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("extra listener: expected status 200, got %d", resp.StatusCode)
+	}
+
+	// The extra listener should serve /ping
+	resp, err = http.Get(fmt.Sprintf("http://127.0.0.1:%d/ping", extraAddr.Port))
+	if err != nil {
+		t.Fatalf("extra listener ping failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("extra listener: expected ping status 200, got %d", resp.StatusCode)
 	}
 }
 

--- a/internal/terminal/server.go
+++ b/internal/terminal/server.go
@@ -65,6 +65,10 @@ type Server struct {
 	mu      sync.RWMutex
 	running bool
 
+	// extraListeners are additional net.Listeners the server will also serve on
+	// (e.g., a tsnet VPN listener). Added via AddListener before Start.
+	extraListeners []net.Listener
+
 	// stopIdleChecker signals the idle checker to stop
 	stopIdleChecker chan struct{}
 
@@ -100,6 +104,15 @@ func NewServer(config *Config, auth TokenValidator) *Server {
 // Use this in TUI mode to prevent log messages from corrupting the display.
 func (s *Server) SetSilent() {
 	s.logger = &noOpLogger{}
+}
+
+// AddListener registers an additional net.Listener that the server will also
+// serve on when Start is called. This enables dual-listen on both LAN and VPN
+// interfaces. Must be called before Start.
+func (s *Server) AddListener(ln net.Listener) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.extraListeners = append(s.extraListeners, ln)
 }
 
 // NewServerWithDebug creates a new terminal server with debug logging enabled
@@ -180,6 +193,17 @@ func (s *Server) Start() error {
 			s.logger.Printf("server error: %v", err)
 		}
 	}()
+
+	// Serve on any extra listeners (e.g., tsnet VPN)
+	for _, ln := range s.extraListeners {
+		ln := ln // capture loop variable
+		s.logger.Printf("also listening on %s (VPN)", ln.Addr().String())
+		go func() {
+			if err := s.httpServer.Serve(ln); err != nil && err != http.ErrServerClosed {
+				s.logger.Printf("VPN listener error: %v", err)
+			}
+		}()
+	}
 
 	return nil
 }

--- a/internal/terminal/server_test.go
+++ b/internal/terminal/server_test.go
@@ -3,6 +3,8 @@ package terminal
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"net/http"
 	"testing"
 	"time"
@@ -206,6 +208,58 @@ func TestServerWithDebug(t *testing.T) {
 	// Config should have Debug enabled
 	if !config.Debug {
 		t.Error("expected Debug to be true after NewServerWithDebug")
+	}
+}
+
+func TestServerDualListen(t *testing.T) {
+	config := &Config{
+		Port:           17865,
+		MaxConnections: 10,
+		IdleTimeout:    30 * time.Minute,
+		OrgID:          "test-org",
+		Shell:          "/bin/sh",
+		RateLimitRPS:   1.0,
+		RateLimitBurst: 5,
+	}
+
+	auth := NewMockTokenValidator()
+	server := NewServer(config, auth)
+
+	// Create a second listener to simulate a VPN listener
+	extraLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create extra listener: %v", err)
+	}
+	extraAddr := extraLn.Addr().(*net.TCPAddr)
+	server.AddListener(extraLn)
+
+	err = server.Start()
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer server.Stop(context.Background())
+
+	// Give server time to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Test health endpoint via the primary listener
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/health", config.Port))
+	if err != nil {
+		t.Fatalf("primary listener health check failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("primary listener: expected status 200, got %d", resp.StatusCode)
+	}
+
+	// Test health endpoint via the extra (VPN) listener
+	resp, err = http.Get(fmt.Sprintf("http://127.0.0.1:%d/health", extraAddr.Port))
+	if err != nil {
+		t.Fatalf("extra listener health check failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("extra listener: expected status 200, got %d", resp.StatusCode)
 	}
 }
 


### PR DESCRIPTION
## Context

Closes #164. When `citadel work --terminal` runs, it starts the tsnet VPN via userspace networking (no kernel tun device). The terminal server (port 7860), status server (port 8080), and gateway (port 8443) all bind to `0.0.0.0` via `net.Listen()`, which only reaches kernel interfaces. Since the tsnet VPN IP exists solely in the Go process's virtual network stack, these services are unreachable from other nodes on the VPN.

## Summary

- **`internal/terminal/server.go`** -- Added `AddListener(net.Listener)` method and extra-listener serving in `Start()`. The same `*http.Server` serves on both the primary LAN listener and any additional listeners (e.g., tsnet VPN). `Shutdown()` closes all listeners cleanly.
- **`internal/status/server.go`** -- Same `AddListener` + dual-serve pattern. The existing `ListenAndServe` goroutine handles LAN; extra listeners get their own `Serve` goroutines.
- **`internal/gateway/gateway.go`** -- Same pattern. For HTTPS gateways, the caller must TLS-wrap the extra listener before passing it in (documented in the method's godoc).
- **`cmd/work.go`** -- After `network.VerifyOrReconnect()` establishes the VPN, creates tsnet listeners via `network.Listen("tcp", ":port")` for both the status server and terminal server. Guarded by `network.IsGlobalConnected()` so VPN listeners are optional and non-fatal.
- **`cmd/serve.go`** -- Same pattern for the gateway. The raw tsnet listener is wrapped with `tls.NewListener(rawLn, tlsConfig)` to match the gateway's HTTPS primary listener.

Key design decisions:
- **Servers are tsnet-agnostic** -- they accept generic `net.Listener`, keeping the network singleton out of internal packages and preserving unit testability.
- **VPN listeners are optional and non-fatal** -- if the node isn't on the VPN, services continue to work on LAN only. Failures are logged at debug level.
- **Same port, different stacks** -- VPN-IP:7860 and 0.0.0.0:7860 don't collide because they're on different network stacks (userspace vs kernel).

## Test plan

| Test | Package | What it verifies |
|------|---------|-----------------|
| `TestServerDualListen` | `internal/terminal` | Terminal server serves `/health` on both primary and extra listener |
| `TestServerDualListen` | `internal/status` | Status server serves `/health` and `/ping` on extra listener |
| `TestStartAndShutdownDualListen` | `internal/gateway` | Gateway serves `/` on both primary and extra listener, verifies JSON response content, clean shutdown |
| All existing tests | All packages | No regressions (build + test pass with `CGO_ENABLED=0`) |

---
*Generated by Claude*