### PR TITLE
feat: add --gateway flag to citadel work

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -28,9 +28,16 @@ var (
 
 var serveCmd = &cobra.Command{
 	Use:   "serve",
-	Short: "Start the HTTPS gateway for this node",
+	Short: "Start the HTTPS gateway for this node (standalone)",
 	Long: `Starts an HTTPS reverse proxy that consolidates all Citadel node services
 behind a single TLS endpoint.
+
+RECOMMENDED: Use 'citadel work --gateway' instead, which runs the gateway
+in-process alongside the worker. This avoids competing tsnet instances and
+is the preferred way to expose the gateway on the VPN.
+
+This standalone command is still useful when you need to run the gateway
+separately from the worker (e.g., on a different machine or for testing).
 
 The gateway proxies to the local status server (started by 'citadel work
 --status-port'), terminal server, and optionally a websockify instance
@@ -57,7 +64,10 @@ certificate provisioning API, so automatic Let's Encrypt certs via the VPN
 are not available. The self-signed certificate approach is the default.
 When Headscale adds cert support, the gateway can be upgraded to use
 tsnet.ListenTLS for automatic public certs.`,
-	Example: `  # Start gateway with default settings (HTTPS on port 8443)
+	Example: `  # PREFERRED: Run gateway in-process with the worker
+  citadel work --gateway
+
+  # Start standalone gateway with default settings (HTTPS on port 8443)
   citadel serve
 
   # Start on a custom port

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -3,8 +3,10 @@ package cmd
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -14,6 +16,7 @@ import (
 	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/capabilities"
+	"github.com/aceteam-ai/citadel-cli/internal/gateway"
 	"github.com/aceteam-ai/citadel-cli/internal/heartbeat"
 	"github.com/aceteam-ai/citadel-cli/internal/network"
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
@@ -22,6 +25,7 @@ import (
 	internalServices "github.com/aceteam-ai/citadel-cli/internal/services"
 	"github.com/aceteam-ai/citadel-cli/internal/status"
 	"github.com/aceteam-ai/citadel-cli/internal/terminal"
+	"github.com/aceteam-ai/citadel-cli/internal/tlscert"
 	"github.com/aceteam-ai/citadel-cli/internal/usage"
 	"github.com/aceteam-ai/citadel-cli/internal/worker"
 	"github.com/google/uuid"
@@ -74,6 +78,14 @@ var (
 
 	// Workspace directory for file-operation handlers
 	workWorkspaceDir string
+
+	// Gateway flags
+	workGateway        bool
+	workGatewayPort    int
+	workGatewayBind    string
+	workGatewayVNC     int
+	workGatewayNoTLS   bool
+	workGatewayCertDir string
 )
 
 var workCmd = &cobra.Command{
@@ -92,6 +104,12 @@ Run 'citadel init' first to authenticate and configure the node.
 Examples:
   # Run after citadel init (recommended)
   citadel work
+
+  # Run with HTTPS gateway (exposes all services on one port)
+  citadel work --gateway
+
+  # Gateway with terminal access
+  citadel work --gateway --terminal
 
   # Disable status publishing
   citadel work --redis-status=false
@@ -185,7 +203,7 @@ func runWork(cmd *cobra.Command, args []string) {
 	var source worker.JobSource
 	var streamFactory func(job *worker.Job) worker.StreamWriter
 	var useAPIMode bool
-	var apiSource *worker.APISource // Keep reference for heartbeat
+	var apiSource *worker.APISource               // Keep reference for heartbeat
 	var setNodeMeta func(nodeID, nodeName string) // Set after node identity is resolved
 
 	if workRedisURL == "" && deviceConfig != nil && deviceConfig.DeviceAPIToken != "" {
@@ -471,6 +489,14 @@ func runWork(cmd *cobra.Command, args []string) {
 	}
 	if baseURL == "" {
 		baseURL = "https://aceteam.ai"
+	}
+
+	// When --gateway is set, auto-enable the status server on port 8080 so the
+	// gateway has a working upstream. This must happen before the status server
+	// block below so that the full status server (with token cache, VPN listener,
+	// desktop API, etc.) is started correctly.
+	if workGateway && workStatusPort == 0 {
+		workStatusPort = 8080
 	}
 
 	// Create status collector (used by status server and Redis status publisher)
@@ -771,6 +797,129 @@ func runWork(cmd *cobra.Command, args []string) {
 				}()
 			}
 		}
+	}
+
+	// Start in-process HTTPS gateway if enabled
+	if workGateway {
+		// Validate that gateway port does not collide with upstream ports
+		upstreamPorts := map[int]string{
+			workStatusPort:   "status-port",
+			workTerminalPort: "terminal-port",
+			workGatewayVNC:   "gateway-vnc-port",
+		}
+		if name, collision := upstreamPorts[workGatewayPort]; collision {
+			fmt.Fprintf(os.Stderr, "Error: gateway port %d collides with --%s; choose a different --gateway-port\n", workGatewayPort, name)
+			os.Exit(1)
+		}
+
+		// Fetch VPN IPs for TLS certificate SANs
+		var vpnIPs []net.IP
+		if network.IsGlobalConnected() {
+			if netStatus, err := network.GetGlobalStatus(ctx); err == nil && netStatus.Connected {
+				if netStatus.IPv4 != "" {
+					if ip := net.ParseIP(netStatus.IPv4); ip != nil {
+						vpnIPs = append(vpnIPs, ip)
+					}
+				}
+				if netStatus.IPv6 != "" {
+					if ip := net.ParseIP(netStatus.IPv6); ip != nil {
+						vpnIPs = append(vpnIPs, ip)
+					}
+				}
+			}
+		}
+
+		// Set up TLS (unless --gateway-no-tls)
+		var gwTLSConfig *tls.Config
+		if !workGatewayNoTLS {
+			cert, err := tlscert.EnsureCert(tlscert.Config{
+				Hostname:    nodeName,
+				IPAddresses: vpnIPs,
+				CertDir:     workGatewayCertDir,
+			})
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: TLS certificate error: %v\n", err)
+				os.Exit(1)
+			}
+			gwTLSConfig = &tls.Config{
+				Certificates: []tls.Certificate{cert},
+				MinVersion:   tls.VersionTLS12,
+			}
+			fmt.Printf("   - Gateway TLS: self-signed (cert: %s)\n", tlscert.CertPath(workGatewayCertDir))
+		}
+
+		// Build upstream addresses
+		statusAddr := fmt.Sprintf("127.0.0.1:%d", workStatusPort)
+		termAddr := fmt.Sprintf("127.0.0.1:%d", workTerminalPort)
+		vncAddr := fmt.Sprintf("127.0.0.1:%d", workGatewayVNC)
+
+		// Create gateway server
+		gw := gateway.NewServer(gateway.Config{
+			Port:          workGatewayPort,
+			ListenAddress: fmt.Sprintf("%s:%d", workGatewayBind, workGatewayPort),
+			TLSConfig:     gwTLSConfig,
+			NodeName:      nodeName,
+		})
+
+		// Register upstreams (same routes as cmd/serve.go)
+		gw.AddUpstream("/health", &gateway.Upstream{Address: statusAddr})
+		gw.AddUpstream("/status", &gateway.Upstream{Address: statusAddr})
+		gw.AddUpstream("/ping", &gateway.Upstream{Address: statusAddr})
+		gw.AddUpstream("/services", &gateway.Upstream{Address: statusAddr})
+		gw.AddUpstream("/api/screenshot", &gateway.Upstream{Address: statusAddr})
+		gw.AddUpstream("/api/actions", &gateway.Upstream{Address: statusAddr})
+
+		gw.AddUpstream("/vnc", &gateway.Upstream{
+			Address:     vncAddr,
+			StripPrefix: true,
+			WebSocket:   true,
+		})
+
+		gw.AddUpstream("/terminal", &gateway.Upstream{
+			Address:     termAddr,
+			StripPrefix: false,
+			WebSocket:   true,
+		})
+
+		// Add VPN listener (TLS-wrapped) so the gateway is reachable over tsnet
+		if network.IsGlobalConnected() {
+			vpnAddr := fmt.Sprintf(":%d", workGatewayPort)
+			rawLn, err := network.Listen("tcp", vpnAddr)
+			if err != nil {
+				Debug("gateway VPN listener failed (LAN-only): %v", err)
+			} else {
+				var vpnGwLn net.Listener
+				if gwTLSConfig != nil {
+					vpnGwLn = tls.NewListener(rawLn, gwTLSConfig)
+				} else {
+					vpnGwLn = rawLn
+				}
+				gw.AddListener(vpnGwLn)
+			}
+		}
+
+		// Print route table
+		scheme := "https"
+		if workGatewayNoTLS {
+			scheme = "http"
+		}
+		listenAddr := fmt.Sprintf("%s:%d", workGatewayBind, workGatewayPort)
+		fmt.Printf("   - Gateway: %s://%s\n", scheme, listenAddr)
+		fmt.Println("   - Routes:")
+		fmt.Printf("     /health, /status, /ping  -> %s (status server)\n", statusAddr)
+		fmt.Printf("     /api/screenshot, /api/actions -> %s\n", statusAddr)
+		fmt.Printf("     /vnc/...                 -> %s (websockify)\n", vncAddr)
+		fmt.Printf("     /terminal/...            -> %s (terminal)\n", termAddr)
+
+		if len(vpnIPs) > 0 {
+			fmt.Printf("   - Gateway VPN: %s://%s:%d\n", scheme, vpnIPs[0], workGatewayPort)
+		}
+
+		go func() {
+			if err := gw.Start(ctx); err != nil && err != context.Canceled {
+				fmt.Fprintf(os.Stderr, "   - Warning: Gateway error: %v\n", err)
+			}
+		}()
 	}
 
 	// Start usage syncer if store is available
@@ -1137,4 +1286,13 @@ func init() {
 
 	// Workspace flags
 	workCmd.Flags().StringVar(&workWorkspaceDir, "workspace", "", "Workspace directory for file-operation jobs (or set CITADEL_WORKSPACE env)")
+
+	// Gateway flags
+	workCmd.Flags().BoolVar(&workGateway, "gateway", false, "Start the HTTPS gateway in-process (replaces 'citadel serve')")
+	workCmd.Flags().IntVar(&workGatewayPort, "gateway-port", 8443, "HTTPS gateway port (default: 8443)")
+	workCmd.Flags().StringVar(&workGatewayBind, "gateway-bind", "0.0.0.0", "Gateway bind address")
+	workCmd.Flags().IntVar(&workGatewayVNC, "gateway-vnc-port", 6080, "VNC websockify port for gateway proxy")
+	workCmd.Flags().BoolVar(&workGatewayNoTLS, "gateway-no-tls", false, "Disable TLS on the gateway (for testing only)")
+	workCmd.Flags().StringVar(&workGatewayCertDir, "gateway-cert-dir", "", "Custom directory for gateway TLS certificates")
+	workCmd.Flags().MarkHidden("gateway-no-tls")
 }


### PR DESCRIPTION
## Context

Running `citadel work` and `citadel serve` as separate processes creates two competing tsnet instances — only the first process can bind VPN listeners, so the gateway started by `citadel serve` is unreachable over the VPN mesh. This was identified in #166 as a fundamental architectural issue with the two-process model.

## Summary

Adds a `--gateway` flag to `citadel work` that starts the HTTPS gateway **in-process** alongside the worker, terminal, and status servers. This reuses the single tsnet connection established by `citadel work`, so all services — including the gateway — are reachable over the VPN.

**`cmd/work.go`** — When `--gateway` is passed:
- **Auto-enables the status server** on port 8080 if `--status-port` was not explicitly set, ensuring the gateway has a working upstream. The port default is hoisted above the existing status server block so that the full status server startup path runs (token cache, VPN listener, desktop API) — avoiding a subtle auth bug that would occur if the status server were re-created in a separate code path.
- **Generates self-signed TLS certificates** via `tlscert.EnsureCert()` with VPN IPs as SANs (fetched from the global network status), matching `cmd/serve.go`'s cert approach.
- **Registers the same upstream routes** as `citadel serve`: `/health`, `/status`, `/ping`, `/services`, `/api/screenshot`, `/api/actions`, `/vnc/...`, `/terminal/...`.
- **Adds a TLS-wrapped tsnet VPN listener** via `network.Listen()` + `tls.NewListener()`, so the gateway is reachable at `https://<vpn-ip>:8443`.
- **Validates port collisions** — the gateway port must not equal the status, terminal, or VNC websockify port.

**`cmd/serve.go`** — Updated help text to recommend `citadel work --gateway` as the preferred approach. The standalone command is preserved for cases where the gateway needs to run on a different machine.

**New flags:**
| Flag | Default | Purpose |
|------|---------|---------|
| `--gateway` | `false` | Enable in-process HTTPS gateway |
| `--gateway-port` | `8443` | Gateway listen port |
| `--gateway-bind` | `0.0.0.0` | Gateway bind address |
| `--gateway-vnc-port` | `6080` | VNC websockify upstream port |
| `--gateway-cert-dir` | (platform default) | Custom TLS cert directory |
| `--gateway-no-tls` | `false` | Disable TLS (hidden, testing only) |

## Test plan

- [x] `CGO_ENABLED=0 go build ./cmd/citadel` — static binary builds cleanly
- [x] `go test ./cmd/...` — cmd package tests pass
- [x] `go test ./internal/gateway/... ./internal/tlscert/...` — gateway and TLS tests pass
- [x] `go vet ./cmd/...` — no issues
- [x] `gofmt` — formatted
- [x] `citadel work --help` shows gateway flags and examples
- [x] `citadel serve --help` shows recommendation to use `--gateway`
- [x] Pre-existing test failure (`TestServerStartAndShutdown` port 8080 bind) confirmed unrelated

## Related

- Closes #166
- Builds on #165 (tsnet VPN dual-listen)

---
*Generated by Claude*