### PR TITLE
fix: use /hashes endpoint for CachingTokenValidator

### DIFF
--- a/internal/terminal/auth.go
+++ b/internal/terminal/auth.go
@@ -217,7 +217,7 @@ type TokenHashEntry struct {
 
 // fetchAndCacheTokens fetches token hashes from the API and updates the cache
 func (v *CachingTokenValidator) fetchAndCacheTokens() error {
-	url := fmt.Sprintf("%s/api/fabric/terminal/tokens/%s", v.baseURL, v.orgID)
+	url := fmt.Sprintf("%s/api/fabric/terminal/tokens/%s/hashes", v.baseURL, v.orgID)
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {


### PR DESCRIPTION
## Context

The `CachingTokenValidator` in the terminal auth module fetches token hashes from the platform API to validate WebSocket connections. The API endpoint was updated to serve hashes at `/api/fabric/terminal/tokens/{orgId}/hashes` instead of `/api/fabric/terminal/tokens/{orgId}`, but the client was never updated to match.

Closes #170

## Summary

- Updated `fetchAndCacheTokens()` URL from `/api/fabric/terminal/tokens/{orgId}` to `/api/fabric/terminal/tokens/{orgId}/hashes` to match the server-side endpoint

## Test plan

- [x] `CGO_ENABLED=0 go build ./cmd/citadel` — builds clean
- [x] `go test ./internal/terminal/...` — all tests pass
- [x] `go vet ./...` — no issues

---
*Generated by Claude*