### PR TITLE
fix: send device API token for terminal hash endpoint

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -243,9 +243,14 @@ func startTerminalServer(orgID string) error {
 	config.Port = ccTerminalPort
 
 	// Create the caching token validator
+	ccAPIToken := ""
+	if cfg := getDeviceConfigFromFile(); cfg != nil {
+		ccAPIToken = cfg.DeviceAPIToken
+	}
 	ccTerminalAuth = terminal.NewCachingTokenValidator(
 		config.AuthServiceURL,
 		config.OrgID,
+		ccAPIToken,
 		config.TokenRefreshInterval,
 	)
 

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -487,6 +487,9 @@ func runWork(cmd *cobra.Command, args []string) {
 	if baseURL == "" {
 		baseURL = os.Getenv("HEARTBEAT_URL") // backward compat
 	}
+	if baseURL == "" && deviceConfig != nil && deviceConfig.APIBaseURL != "" {
+		baseURL = deviceConfig.APIBaseURL
+	}
 	if baseURL == "" {
 		baseURL = "https://aceteam.ai"
 	}
@@ -528,7 +531,11 @@ func runWork(cmd *cobra.Command, args []string) {
 			}
 		}
 		if statusOrgID != "" && baseURL != "" {
-			serverCfg.TokenValidator = terminal.NewCachingTokenValidator(baseURL, statusOrgID, 30*time.Second)
+			statusAPIToken := ""
+			if deviceConfig != nil {
+				statusAPIToken = deviceConfig.DeviceAPIToken
+			}
+			serverCfg.TokenValidator = terminal.NewCachingTokenValidator(baseURL, statusOrgID, statusAPIToken, 30*time.Second)
 			serverCfg.OrgID = statusOrgID
 		}
 
@@ -773,9 +780,14 @@ func runWork(cmd *cobra.Command, args []string) {
 				}
 
 				// Use CachingTokenValidator for production
+				termAPIToken := ""
+				if deviceConfig != nil {
+					termAPIToken = deviceConfig.DeviceAPIToken
+				}
 				cachingAuth := terminal.NewCachingTokenValidator(
 					baseURL,
 					orgID,
+					termAPIToken,
 					termConfig.TokenRefreshInterval,
 				)
 

--- a/internal/terminal/auth.go
+++ b/internal/terminal/auth.go
@@ -112,6 +112,7 @@ type CachedTokenEntry struct {
 type CachingTokenValidator struct {
 	baseURL         string
 	orgID           string
+	apiToken        string // Device API token (act_*) for authenticating with the platform
 	httpClient      *http.Client
 	cache           map[string]*CachedTokenEntry // SHA-256 hash -> entry
 	cacheMu         sync.RWMutex
@@ -131,10 +132,11 @@ type CachingTokenValidator struct {
 }
 
 // NewCachingTokenValidator creates a new caching token validator
-func NewCachingTokenValidator(baseURL, orgID string, refreshInterval time.Duration) *CachingTokenValidator {
+func NewCachingTokenValidator(baseURL, orgID, apiToken string, refreshInterval time.Duration) *CachingTokenValidator {
 	return &CachingTokenValidator{
 		baseURL:          baseURL,
 		orgID:            orgID,
+		apiToken:         apiToken,
 		httpClient:       &http.Client{Timeout: 10 * time.Second},
 		cache:            make(map[string]*CachedTokenEntry),
 		refreshInterval:  refreshInterval,
@@ -224,6 +226,9 @@ func (v *CachingTokenValidator) fetchAndCacheTokens() error {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Set("Accept", "application/json")
+	if v.apiToken != "" {
+		req.Header.Set("Authorization", "Bearer "+v.apiToken)
+	}
 
 	resp, err := v.httpClient.Do(req)
 	if err != nil {

--- a/internal/terminal/auth_test.go
+++ b/internal/terminal/auth_test.go
@@ -192,7 +192,7 @@ func TestCachingTokenValidator(t *testing.T) {
 	mock.AddValidToken(validToken, tokenInfo)
 
 	// Create caching validator
-	validator := NewCachingTokenValidator(mock.URL(), "org-456", time.Hour)
+	validator := NewCachingTokenValidator(mock.URL(), "org-456", "", time.Hour)
 
 	t.Run("initial fetch populates cache", func(t *testing.T) {
 		mock.ResetRequestCount()
@@ -260,7 +260,7 @@ func TestCachingTokenValidatorExpiredToken(t *testing.T) {
 		ExpiresAt: time.Now().Add(-time.Hour), // Expired
 	})
 
-	validator := NewCachingTokenValidator(mock.URL(), "org-456", time.Hour)
+	validator := NewCachingTokenValidator(mock.URL(), "org-456", "", time.Hour)
 	validator.Start()
 	defer validator.Stop()
 
@@ -302,7 +302,7 @@ func TestCachingTokenValidatorRateLimiting(t *testing.T) {
 	})
 
 	// Create validator with short rate limit for testing
-	validator := NewCachingTokenValidator(mock.URL(), "org-456", time.Hour)
+	validator := NewCachingTokenValidator(mock.URL(), "org-456", "", time.Hour)
 	validator.refreshRateLimit = 100 * time.Millisecond // Short for testing
 	validator.Start()
 	defer validator.Stop()
@@ -355,7 +355,7 @@ func TestCachingTokenValidatorOrgIsolation(t *testing.T) {
 	})
 
 	// Create validator for org-B
-	validator := NewCachingTokenValidator(mock.URL(), "org-B", time.Hour)
+	validator := NewCachingTokenValidator(mock.URL(), "org-B", "", time.Hour)
 	validator.Start()
 	defer validator.Stop()
 


### PR DESCRIPTION
## Context

The terminal token hash endpoint (`/hashes`) was restricted to VPN-IP-only access, but Citadel nodes reach the platform via the public URL (aceteam.ai), not through the VPN mesh. This meant the `CachingTokenValidator` always got 403, and the terminal auth chain was broken.

## Summary

- **`internal/terminal/auth.go`**: Add `apiToken` field to `CachingTokenValidator`. Include `Authorization: Bearer {token}` header in hash fetch requests.
- **`cmd/work.go`**: Pass `deviceConfig.DeviceAPIToken` to both status server and terminal server validators. Derive `baseURL` from `deviceConfig.APIBaseURL` so services use the configured API endpoint instead of hardcoded default.
- **`cmd/controlcenter.go`**: Pass device API token to the TUI terminal validator.
- **Tests updated**: All 4 test call sites updated for new constructor signature.

## Test plan

- [x] `go build ./cmd/citadel` succeeds
- [x] `go test ./internal/terminal/ -run TestCaching` — all 4 subtests pass
- [x] `go vet ./...` clean
- [x] E2E on hardware: laptop running `citadel work --gateway --terminal` against dev server successfully fetches token hashes, browser terminal connects and authenticates through the full proxy chain

## Related

- Platform-side counterpart: aceteam-ai/aceteam#3795 (accepts device token on /hashes endpoint)
- Closes citadel-cli#170 (was previously partially fixed by #171)

---
*Generated by Claude*