### PR TITLE
fix: chown tsnet state files when login runs as root

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1324,6 +1324,11 @@ func connectToNetwork(nodeName, authKey string) error {
 		fmt.Printf("   IP: %s\n", ip)
 	}
 
+	// Disconnect cleanly so tsnet flushes its state files, then the
+	// post-Close chown in Disconnect() fixes ownership for the non-root
+	// worker process. The work command re-establishes its own connection.
+	_ = network.Disconnect()
+
 	return nil
 }
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -86,6 +86,11 @@ func runNonInteractiveLogin() {
 	ip, _ := srv.GetIPv4()
 	spinner.StopWithSuccess(fmt.Sprintf("Connected as '%s'", nodeName))
 	printNetworkSuccessInfo(nodeName, ip)
+
+	// Disconnect cleanly so tsnet flushes its state files, then the
+	// post-Close chown in Disconnect() fixes ownership for the non-root
+	// worker process. The work command re-establishes its own connection.
+	_ = network.Disconnect()
 }
 
 // runInteractiveLogin handles the interactive login flow
@@ -164,6 +169,11 @@ func runInteractiveLogin() {
 	ip, _ := srv.GetIPv4()
 	spinner.StopWithSuccess(fmt.Sprintf("Connected as '%s'", nodeName))
 	printNetworkSuccessInfo(nodeName, ip)
+
+	// Disconnect cleanly so tsnet flushes its state files, then the
+	// post-Close chown in Disconnect() fixes ownership for the non-root
+	// worker process. The work command re-establishes its own connection.
+	_ = network.Disconnect()
 }
 
 func init() {

--- a/internal/network/server.go
+++ b/internal/network/server.go
@@ -125,6 +125,12 @@ func (s *NetworkServer) Connect(ctx context.Context, authKey string) error {
 		return err
 	}
 
+	// Fix state file ownership after tsnet has written its initial state.
+	// When login runs as root (sudo or systemd), tsnet creates state files
+	// owned by root. The worker process runs as a non-root user and needs
+	// to read these files. See issue #176.
+	FixStatePermissions()
+
 	s.connected = true
 	return nil
 }
@@ -172,6 +178,14 @@ func (s *NetworkServer) Disconnect() error {
 	err := s.srv.Close()
 	s.srv = nil
 	s.connected = false
+
+	// Fix state file ownership after tsnet has finished writing.
+	// tsnet rewrites tailscaled.state atomically (temp file + rename),
+	// so new root-owned files may have been created since Connect().
+	// This ensures the final on-disk state is accessible to the
+	// non-root worker process. See issue #176.
+	FixStatePermissions()
+
 	return err
 }
 

--- a/internal/network/state.go
+++ b/internal/network/state.go
@@ -3,9 +3,12 @@
 package network
 
 import (
+	"fmt"
 	"os"
+	"os/user"
 	"path/filepath"
 	"runtime"
+	"strconv"
 
 	"gopkg.in/yaml.v3"
 )
@@ -77,12 +80,17 @@ func getGlobalConfigDirForState() string {
 }
 
 // EnsureStateDir creates the state directory if it doesn't exist.
+// If running as root, fixes ownership so the intended non-root user
+// (detected via $SUDO_USER or defaulting to "citadel") can access the state.
 // Returns the state directory path.
 func EnsureStateDir() (string, error) {
 	stateDir := GetStateDir()
 	if err := os.MkdirAll(stateDir, 0700); err != nil {
 		return "", err
 	}
+	// Fix ownership of the state directory and parent node config dir
+	// when running as root (e.g. sudo login, systemd pairing).
+	fixStateDirOwnership(stateDir)
 	return stateDir, nil
 }
 
@@ -115,4 +123,94 @@ func HasState() bool {
 // GetStatePath returns the full path for a state file.
 func GetStatePath(filename string) string {
 	return filepath.Join(GetStateDir(), filename)
+}
+
+// FixStatePermissions fixes ownership of the state directory and all contents
+// so the intended non-root user can access tsnet state files.
+// This should be called after tsnet has finished writing state (e.g. after
+// Connect succeeds or after Disconnect). No-op if not running as root.
+func FixStatePermissions() {
+	fixStateDirOwnership(GetStateDir())
+}
+
+// resolveChownTarget determines the UID/GID to chown state files to.
+// Returns (uid, gid, true) if running as root and a target user is found,
+// or (0, 0, false) if not running as root or lookup fails.
+func resolveChownTarget() (uid int, gid int, ok bool) {
+	return resolveChownTargetWith(os.Getuid(), os.Getenv("SUDO_USER"), user.Lookup)
+}
+
+// resolveChownTargetWith is the testable core of resolveChownTarget.
+// It accepts injected values instead of reading from the OS directly.
+func resolveChownTargetWith(currentUID int, sudoUser string, lookupFn func(string) (*user.User, error)) (uid int, gid int, ok bool) {
+	if currentUID != 0 {
+		return 0, 0, false // Not root, nothing to fix
+	}
+
+	targetUser := sudoUser
+	if targetUser == "" {
+		targetUser = "citadel" // Default Citadel OS user
+	}
+
+	u, err := lookupFn(targetUser)
+	if err != nil {
+		return 0, 0, false // User not found, can't fix
+	}
+
+	parsedUID, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		return 0, 0, false
+	}
+	parsedGID, err := strconv.Atoi(u.Gid)
+	if err != nil {
+		return 0, 0, false
+	}
+
+	return parsedUID, parsedGID, true
+}
+
+// fixStateDirOwnership chowns the state directory, its parent node config dir,
+// and all contents to the target non-root user. No-op if not running as root
+// or the target user cannot be resolved.
+//
+// We chown from the parent (node_config_dir) down, not just the network/ dir,
+// because the parent may also have been created by root and the non-root user
+// needs traverse permission (the dir is mode 0700).
+func fixStateDirOwnership(stateDir string) {
+	uid, gid, ok := resolveChownTarget()
+	if !ok {
+		return
+	}
+
+	// stateDir is typically <node_config_dir>/network/
+	// Chown from the parent (node_config_dir) to cover traverse permissions.
+	parentDir := filepath.Dir(stateDir)
+
+	// Safety: only chown if parentDir looks like a citadel node dir,
+	// not a system path like /home or /etc.
+	parentBase := filepath.Base(parentDir)
+	if parentBase != "citadel-node" && parentBase != filepath.Base(getNodeConfigDirFromGlobalConfig()) {
+		// If we can't verify the parent is a citadel dir, chown only stateDir
+		chownRecursive(stateDir, uid, gid)
+		return
+	}
+
+	chownRecursive(parentDir, uid, gid)
+}
+
+// chownRecursive changes ownership of a directory and all its contents.
+// Errors are logged to stderr but do not cause failure — this is best-effort.
+func chownRecursive(root string, uid, gid int) {
+	if err := os.Chown(root, uid, gid); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not chown %s: %v\n", root, err)
+	}
+	filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil // Skip inaccessible entries
+		}
+		if chownErr := os.Chown(path, uid, gid); chownErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not chown %s: %v\n", path, chownErr)
+		}
+		return nil
+	})
 }

--- a/internal/network/state_test.go
+++ b/internal/network/state_test.go
@@ -1,0 +1,181 @@
+// internal/network/state_test.go
+package network
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"testing"
+)
+
+// TestResolveChownTarget_NotRoot verifies no chown when not running as root.
+func TestResolveChownTarget_NotRoot(t *testing.T) {
+	uid, gid, ok := resolveChownTargetWith(1000, "someuser", user.Lookup)
+	if ok {
+		t.Errorf("expected ok=false for non-root (uid=1000), got uid=%d gid=%d", uid, gid)
+	}
+}
+
+// TestResolveChownTarget_RootWithSudoUser verifies chown target uses $SUDO_USER.
+func TestResolveChownTarget_RootWithSudoUser(t *testing.T) {
+	// Use a lookup function that returns a known user
+	fakeLookup := func(username string) (*user.User, error) {
+		if username == "citadel" {
+			return &user.User{Uid: "1000", Gid: "1000", Username: "citadel"}, nil
+		}
+		if username == "testuser" {
+			return &user.User{Uid: "1001", Gid: "1001", Username: "testuser"}, nil
+		}
+		return nil, fmt.Errorf("user not found: %s", username)
+	}
+
+	// Root with SUDO_USER set
+	uid, gid, ok := resolveChownTargetWith(0, "testuser", fakeLookup)
+	if !ok {
+		t.Fatal("expected ok=true for root with SUDO_USER=testuser")
+	}
+	if uid != 1001 || gid != 1001 {
+		t.Errorf("expected uid=1001 gid=1001, got uid=%d gid=%d", uid, gid)
+	}
+}
+
+// TestResolveChownTarget_RootNoSudoUser verifies chown target defaults to "citadel".
+func TestResolveChownTarget_RootNoSudoUser(t *testing.T) {
+	fakeLookup := func(username string) (*user.User, error) {
+		if username == "citadel" {
+			return &user.User{Uid: "1000", Gid: "1000", Username: "citadel"}, nil
+		}
+		return nil, fmt.Errorf("user not found: %s", username)
+	}
+
+	// Root with no SUDO_USER (e.g., systemd running as root)
+	uid, gid, ok := resolveChownTargetWith(0, "", fakeLookup)
+	if !ok {
+		t.Fatal("expected ok=true for root with empty SUDO_USER (falls back to citadel)")
+	}
+	if uid != 1000 || gid != 1000 {
+		t.Errorf("expected uid=1000 gid=1000, got uid=%d gid=%d", uid, gid)
+	}
+}
+
+// TestResolveChownTarget_RootUserNotFound verifies graceful handling when user doesn't exist.
+func TestResolveChownTarget_RootUserNotFound(t *testing.T) {
+	fakeLookup := func(username string) (*user.User, error) {
+		return nil, fmt.Errorf("user not found: %s", username)
+	}
+
+	uid, gid, ok := resolveChownTargetWith(0, "nonexistent", fakeLookup)
+	if ok {
+		t.Errorf("expected ok=false when user lookup fails, got uid=%d gid=%d", uid, gid)
+	}
+}
+
+// TestResolveChownTarget_RootBadUID verifies graceful handling of non-numeric UID.
+func TestResolveChownTarget_RootBadUID(t *testing.T) {
+	fakeLookup := func(username string) (*user.User, error) {
+		return &user.User{Uid: "notanumber", Gid: "1000", Username: username}, nil
+	}
+
+	_, _, ok := resolveChownTargetWith(0, "citadel", fakeLookup)
+	if ok {
+		t.Error("expected ok=false when UID is not numeric")
+	}
+}
+
+// TestResolveChownTarget_RootBadGID verifies graceful handling of non-numeric GID.
+func TestResolveChownTarget_RootBadGID(t *testing.T) {
+	fakeLookup := func(username string) (*user.User, error) {
+		return &user.User{Uid: "1000", Gid: "notanumber", Username: username}, nil
+	}
+
+	_, _, ok := resolveChownTargetWith(0, "citadel", fakeLookup)
+	if ok {
+		t.Error("expected ok=false when GID is not numeric")
+	}
+}
+
+// TestChownRecursive_CreatesCorrectPermissions verifies the recursive chown walks all files.
+// This test can only verify the walk logic since os.Chown requires root for real ownership changes.
+func TestChownRecursive_CreatesCorrectPermissions(t *testing.T) {
+	// Create a temp directory tree
+	tmpDir, err := os.MkdirTemp("", "citadel-chown-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create nested structure mimicking the real state dir
+	networkDir := filepath.Join(tmpDir, "network")
+	if err := os.MkdirAll(networkDir, 0700); err != nil {
+		t.Fatalf("Failed to create network dir: %v", err)
+	}
+
+	stateFile := filepath.Join(networkDir, "tailscaled.state")
+	if err := os.WriteFile(stateFile, []byte("fake-state"), 0600); err != nil {
+		t.Fatalf("Failed to create state file: %v", err)
+	}
+
+	machineKey := filepath.Join(networkDir, "machine-key")
+	if err := os.WriteFile(machineKey, []byte("fake-key"), 0600); err != nil {
+		t.Fatalf("Failed to create machine-key file: %v", err)
+	}
+
+	// chownRecursive with current user's UID/GID (should succeed without root)
+	currentUID := os.Getuid()
+	currentGID := os.Getgid()
+	chownRecursive(tmpDir, currentUID, currentGID)
+
+	// Verify all files still exist and are accessible
+	entries, err := os.ReadDir(networkDir)
+	if err != nil {
+		t.Fatalf("Failed to read network dir after chown: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Errorf("Expected 2 files in network dir, got %d", len(entries))
+	}
+
+	// Verify files are readable
+	data, err := os.ReadFile(stateFile)
+	if err != nil {
+		t.Errorf("State file not readable after chown: %v", err)
+	}
+	if string(data) != "fake-state" {
+		t.Errorf("State file content changed: %q", data)
+	}
+}
+
+// TestEnsureStateDirCreatesDirectory verifies EnsureStateDir creates the directory.
+func TestEnsureStateDirCreatesDirectory(t *testing.T) {
+	// This test exercises the real EnsureStateDir. Since we're not root,
+	// fixStateDirOwnership will be a no-op, but the directory creation
+	// should still work.
+	stateDir := GetStateDir()
+
+	// If the state dir doesn't exist, EnsureStateDir should create it
+	dir, err := EnsureStateDir()
+	if err != nil {
+		t.Fatalf("EnsureStateDir() error: %v", err)
+	}
+	if dir != stateDir {
+		t.Errorf("EnsureStateDir() returned %q, want %q", dir, stateDir)
+	}
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("State dir not accessible after EnsureStateDir: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("State dir path is not a directory")
+	}
+}
+
+// TestFixStatePermissions_NoOpWhenNotRoot verifies FixStatePermissions is safe to call as non-root.
+func TestFixStatePermissions_NoOpWhenNotRoot(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("Test only meaningful when not running as root")
+	}
+
+	// Should not panic or error
+	FixStatePermissions()
+}


### PR DESCRIPTION
## Context

Closes #176. On Citadel OS, the pairing/login flow runs as root (via sudo or systemd), creating tsnet state files at `/home/citadel/citadel-node/network/` owned by `root:root`. When `citadel work` later starts as the `citadel` user, it fails with:

```
permission denied: open /home/citadel/citadel-node/network/tailscaled.state
```

This is a regression from the QR pairing flow where login runs as root to write to `/etc/citadel/config.yaml`.

## Summary

- **`resolveChownTarget()` / `resolveChownTargetWith()`** in `state.go` — Determines the target UID/GID for ownership fix. Detects root via `os.Getuid() == 0`, resolves user from `$SUDO_USER` (set by sudo) or falls back to `"citadel"` (the standard Citadel OS user). The `With` variant accepts injected values for testability without mocking OS calls.

- **`fixStateDirOwnership()`** — Recursively chowns the state directory and its parent `node_config_dir`. Chowning from the parent is necessary because the `0700` permission on a root-owned parent blocks traverse access for the non-root user. Includes a safety check to only chown the parent if it looks like a citadel node dir (not `/home` or `/etc`).

- **`FixStatePermissions()`** — Public entry point, called at three points:
  1. `EnsureStateDir()` — fixes ownership of the directory and any pre-existing files
  2. `Connect()` after `waitForConnection` — fixes files tsnet just created during `Start()`
  3. `Disconnect()` after `Close()` — catches files tsnet may have rewritten atomically (temp file + rename) during the session

- All functions are no-ops when not running as root, so there is zero impact on normal (non-sudo) usage.

## Test plan

| Test | What it covers |
|------|----------------|
| `TestResolveChownTarget_NotRoot` | Non-root returns `ok=false` |
| `TestResolveChownTarget_RootWithSudoUser` | Root + `$SUDO_USER` resolves correct user |
| `TestResolveChownTarget_RootNoSudoUser` | Root + empty `$SUDO_USER` falls back to "citadel" |
| `TestResolveChownTarget_RootUserNotFound` | Graceful failure when user doesn't exist |
| `TestResolveChownTarget_RootBadUID` | Graceful failure on non-numeric UID |
| `TestResolveChownTarget_RootBadGID` | Graceful failure on non-numeric GID |
| `TestChownRecursive_CreatesCorrectPermissions` | Walk covers nested files, no data corruption |
| `TestEnsureStateDirCreatesDirectory` | Directory creation still works with new ownership fix |
| `TestFixStatePermissions_NoOpWhenNotRoot` | Safe to call as non-root (no panic/error) |

All 15 network tests pass. `go vet ./...` clean.

## Related

- #175 — VPN reconnect with stale tsnet state (closely related)
- #176 — This issue

---
*Generated by Claude*