### PR TITLE
fix: add citadel user to systemd-journal and adm groups

### DIFF
--- a/packer/deploy-to-proxmox.sh
+++ b/packer/deploy-to-proxmox.sh
@@ -209,9 +209,9 @@ write_files:
     owner: root:root
     permissions: '0600'
 
-# Ensure the citadel user has docker group access
+# Ensure the citadel user has required group access
 runcmd:
-  - usermod -aG docker citadel || true
+  - usermod -aG docker,systemd-journal,adm citadel || true
 CIEOF
 )
 

--- a/packer/scripts/04-citadel.sh
+++ b/packer/scripts/04-citadel.sh
@@ -79,6 +79,12 @@ install -m 755 "${TMP_DIR}/${BINARY_NAME}" "${INSTALL_DIR}/${BINARY_NAME}"
 echo "==> Citadel CLI installed: $(${INSTALL_DIR}/${BINARY_NAME} version)"
 
 # ---------------------------------------------------------------------------
+# Add citadel user to log-reading groups so journalctl returns entries
+# ---------------------------------------------------------------------------
+
+usermod -aG systemd-journal,adm citadel
+
+# ---------------------------------------------------------------------------
 # Create directories
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Context

The Logs tab on the AceTeam fabric device page shows "No entries" with a hint that the user needs to be in the `systemd-journal` group. The `citadel` user in the Packer-built Proxmox VM images was missing this group membership, so `journalctl` returned no entries when the log API endpoint queried system logs.

The primary fix is in the live-build configuration (aceteam-ai/citadel repo). This PR applies the same fix to the Packer build path for Proxmox VMs.

## Summary

- **`packer/scripts/04-citadel.sh`**: Added `usermod -aG systemd-journal,adm citadel` after binary install so the groups are baked into the Packer image
- **`packer/deploy-to-proxmox.sh`**: Updated the cloud-init runcmd to also add `systemd-journal` and `adm` groups alongside `docker`

## Test plan

- [ ] Build Packer image: `cd packer && packer build citadel-node.pkr.hcl`
- [ ] Deploy VM and verify `groups citadel` includes `systemd-journal` and `adm`
- [ ] Verify `journalctl` returns entries when run as the citadel user

## Related

- Fixes #179
- See also: aceteam-ai/citadel PR (live-build fix)

---
*Generated by Claude*