### PR TITLE
feat: enable gateway and terminal by default in citadel work

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -32,8 +32,8 @@ var serveCmd = &cobra.Command{
 	Long: `Starts an HTTPS reverse proxy that consolidates all Citadel node services
 behind a single TLS endpoint.
 
-RECOMMENDED: Use 'citadel work --gateway' instead, which runs the gateway
-in-process alongside the worker. This avoids competing tsnet instances and
+RECOMMENDED: Use 'citadel work' instead, which runs the gateway in-process
+alongside the worker by default. This avoids competing tsnet instances and
 is the preferred way to expose the gateway on the VPN.
 
 This standalone command is still useful when you need to run the gateway
@@ -64,8 +64,8 @@ certificate provisioning API, so automatic Let's Encrypt certs via the VPN
 are not available. The self-signed certificate approach is the default.
 When Headscale adds cert support, the gateway can be upgraded to use
 tsnet.ListenTLS for automatic public certs.`,
-	Example: `  # PREFERRED: Run gateway in-process with the worker
-  citadel work --gateway
+	Example: `  # PREFERRED: Run gateway in-process with the worker (enabled by default)
+  citadel work
 
   # Start standalone gateway with default settings (HTTPS on port 8443)
   citadel serve

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -59,6 +59,7 @@ var (
 
 	// Terminal server flags
 	workTerminal      bool
+	workNoTerminal    bool
 	workTerminalHost  string
 	workTerminalPort  int
 	workTerminalDebug bool
@@ -81,6 +82,7 @@ var (
 
 	// Gateway flags
 	workGateway        bool
+	workNoGateway      bool
 	workGatewayPort    int
 	workGatewayBind    string
 	workGatewayVNC     int
@@ -98,18 +100,23 @@ This is the primary command for running a Citadel node. It:
   2. Connects to the AceTeam API and consumes jobs via secure proxy
   3. Reports status via pub/sub (enabled by default)
   4. Subscribes to real-time config updates
+  5. Starts HTTPS gateway on port 8443 (use --no-gateway to skip)
+  6. Starts terminal server on port 7860 (use --no-terminal to skip)
 
 Run 'citadel init' first to authenticate and configure the node.
 
 Examples:
-  # Run after citadel init (recommended)
+  # Run after citadel init (recommended — gateway + terminal enabled)
   citadel work
 
-  # Run with HTTPS gateway (exposes all services on one port)
-  citadel work --gateway
+  # Disable the HTTPS gateway
+  citadel work --no-gateway
 
-  # Gateway with terminal access
-  citadel work --gateway --terminal
+  # Disable terminal access
+  citadel work --no-terminal
+
+  # Worker only (no gateway, no terminal)
+  citadel work --no-gateway --no-terminal
 
   # Disable status publishing
   citadel work --redis-status=false
@@ -122,6 +129,14 @@ Examples:
 func runWork(cmd *cobra.Command, args []string) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	// Apply --no-gateway / --no-terminal overrides (take precedence over defaults)
+	if workNoGateway {
+		workGateway = false
+	}
+	if workNoTerminal {
+		workTerminal = false
+	}
 
 	// Setup signal handling
 	sigs := make(chan os.Signal, 1)
@@ -1285,7 +1300,8 @@ func init() {
 	workCmd.Flags().StringVar(&workStatusChannel, "status-channel", "", "Override Redis pub/sub channel for status (default: node:status:{node-name})")
 
 	// Terminal server flags
-	workCmd.Flags().BoolVar(&workTerminal, "terminal", false, "Enable terminal WebSocket server for remote access")
+	workCmd.Flags().BoolVar(&workTerminal, "terminal", true, "Enable terminal WebSocket server (enabled by default; use --no-terminal to disable)")
+	workCmd.Flags().BoolVar(&workNoTerminal, "no-terminal", false, "Disable the terminal WebSocket server")
 	workCmd.Flags().StringVar(&workTerminalHost, "terminal-host", "", "Terminal server bind address (default: 0.0.0.0)")
 	workCmd.Flags().IntVar(&workTerminalPort, "terminal-port", 7860, "Terminal server port (default: 7860)")
 	workCmd.Flags().BoolVar(&workTerminalDebug, "terminal-debug", false, "Enable verbose debug logging for terminal server")
@@ -1308,7 +1324,8 @@ func init() {
 	workCmd.Flags().StringVar(&workWorkspaceDir, "workspace", "", "Workspace directory for file-operation jobs (or set CITADEL_WORKSPACE env)")
 
 	// Gateway flags
-	workCmd.Flags().BoolVar(&workGateway, "gateway", false, "Start the HTTPS gateway in-process (replaces 'citadel serve')")
+	workCmd.Flags().BoolVar(&workGateway, "gateway", true, "Start the HTTPS gateway in-process (enabled by default; use --no-gateway to disable)")
+	workCmd.Flags().BoolVar(&workNoGateway, "no-gateway", false, "Disable the HTTPS gateway")
 	workCmd.Flags().IntVar(&workGatewayPort, "gateway-port", 8443, "HTTPS gateway port (default: 8443)")
 	workCmd.Flags().StringVar(&workGatewayBind, "gateway-bind", "0.0.0.0", "Gateway bind address")
 	workCmd.Flags().IntVar(&workGatewayVNC, "gateway-vnc-port", 6080, "VNC websockify port for gateway proxy")


### PR DESCRIPTION
## Context

Issue [#177](https://github.com/aceteam-ai/citadel-cli/issues/177) — users shouldn't need to remember `--gateway --terminal` flags every time they run `citadel work`. The whole point of Citadel is to be opinionated about defaults.

## Summary

- **`--gateway` and `--terminal` now default to `true`** — plain `citadel work` starts the HTTPS gateway (port 8443), terminal server (port 7860), and the job worker. This matches how every production and systemd deployment already runs.
- **Added `--no-gateway` and `--no-terminal` flags** for users who want to opt out (e.g., headless worker-only nodes).
- **Backwards compatible** — existing scripts passing `--gateway --terminal` still work (true stays true). `--gateway=false` also still works.
- **Updated help text and examples** to reflect the new defaults, including the `serve` command which previously told users to run `citadel work --gateway`.

### Precedence logic

```go
if workNoGateway  { workGateway  = false }
if workNoTerminal { workTerminal = false }
```

Applied at the top of `runWork` before any downstream code reads the flags.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (pre-existing port-collision failure in `internal/status` unrelated)
- [x] `citadel work --help` shows correct defaults and examples
- [x] `citadel serve --help` updated reference

---
*Generated by Claude*