### PR TITLE
fix: preserve user-chosen hostnames during node registration

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -559,9 +559,14 @@ func getNodeName() (string, error) {
 		return saved, nil
 	}
 
-	// 3. Always generate a citadel-<short_id> hostname instead of inheriting
-	//    the OS hostname, which is often useless on live ISOs (e.g., "debian").
-	//    Users who want a custom name can use --node-name.
+	// 3. Use the current OS hostname if it's meaningful (user-chosen).
+	//    Skip generic names from live ISOs and fresh installs.
+	if current, err := os.Hostname(); err == nil && !platform.IsGenericHostname(current) {
+		Debug("preserving existing OS hostname: %s", current)
+		return current, nil
+	}
+
+	// 4. Generate a citadel-<short_id> hostname for generic/missing hostnames.
 	generated, err := platform.GenerateCitadelHostname()
 	if err != nil {
 		return "", fmt.Errorf("could not generate hostname: %w", err)
@@ -1289,15 +1294,19 @@ func configureNvidiaDocker() error {
 // connectToNetwork connects to the AceTeam Network using the embedded tsnet library.
 // No external Tailscale installation is required.
 //
-// Before registering with Headscale, it attempts to set the system hostname to
-// match the node name (best-effort, requires root). The node name is always used
-// for Headscale registration regardless of whether the OS hostname update succeeds.
+// Only overwrites the OS hostname when the current hostname is generic (live ISO,
+// fresh install). User-chosen hostnames are preserved.
 func connectToNetwork(nodeName, authKey string) error {
-	// Attempt to set the OS hostname to match (best-effort, needs root)
-	if err := platform.SetHostname(nodeName); err != nil {
-		Debug("could not set system hostname (expected without root): %v", err)
+	// Only overwrite the OS hostname if the current one is generic.
+	// Preserves user-chosen hostnames like "aceteamvm" or "gpu-server".
+	if current, err := os.Hostname(); err != nil || platform.IsGenericHostname(current) {
+		if err := platform.SetHostname(nodeName); err != nil {
+			Debug("could not set system hostname (expected without root): %v", err)
+		} else {
+			Debug("system hostname set to %s", nodeName)
+		}
 	} else {
-		Debug("system hostname set to %s", nodeName)
+		Debug("preserving existing OS hostname %q (registering as %q on network)", current, nodeName)
 	}
 
 	// Persist the hostname to config so re-runs are stable

--- a/internal/platform/hostname.go
+++ b/internal/platform/hostname.go
@@ -9,6 +9,31 @@ import (
 	"strings"
 )
 
+// genericHostnames are OS hostnames that indicate a fresh install or live ISO
+// and should be replaced with a citadel-<id> name. Anything not in this list
+// is treated as a user-chosen hostname worth preserving.
+var genericHostnames = map[string]bool{
+	"":          true,
+	"localhost":  true,
+	"debian":     true,
+	"ubuntu":     true,
+	"fedora":     true,
+	"archlinux":  true,
+	"nixos":      true,
+	"raspberrypi": true,
+	"linux":      true,
+	"host":       true,
+	"changeme":   true,
+	"default":    true,
+}
+
+// IsGenericHostname returns true if the hostname looks like a default OS
+// hostname that should be replaced during Citadel registration.
+func IsGenericHostname(name string) bool {
+	lower := strings.ToLower(strings.TrimSpace(name))
+	return genericHostnames[lower]
+}
+
 // machineIDPath is the path to the machine-id file. Overridable in tests.
 var machineIDPath = "/etc/machine-id"
 

--- a/internal/platform/hostname_test.go
+++ b/internal/platform/hostname_test.go
@@ -176,6 +176,30 @@ func TestGenerateRandomHexIDUniqueness(t *testing.T) {
 	}
 }
 
+func TestIsGenericHostname(t *testing.T) {
+	generic := []string{
+		"", "localhost", "debian", "ubuntu", "fedora",
+		"archlinux", "nixos", "raspberrypi", "linux",
+		"host", "changeme", "default",
+		"DEBIAN", "Ubuntu", " debian ", // case/whitespace variants
+	}
+	for _, name := range generic {
+		if !IsGenericHostname(name) {
+			t.Errorf("IsGenericHostname(%q) = false, want true", name)
+		}
+	}
+
+	meaningful := []string{
+		"aceteamvm", "gpu-server", "jason-desktop",
+		"citadel-23bd5f21", "my-workstation", "prod-node-1",
+	}
+	for _, name := range meaningful {
+		if IsGenericHostname(name) {
+			t.Errorf("IsGenericHostname(%q) = true, want false", name)
+		}
+	}
+}
+
 func TestSetHostnameNonLinux(t *testing.T) {
 	// SetHostname is a no-op on non-Linux platforms
 	if IsLinux() {


### PR DESCRIPTION
## Context

When running `citadel init` on a machine with a user-configured hostname like `aceteamvm`, the CLI overwrites it with `citadel-<machine-id>` (e.g., `citadel-23bd5f21`). This was intentional for live ISOs where the default hostname is useless (`debian`, `ubuntu`), but it's surprising on real machines where the user has already set a meaningful name.

## Summary

- **`IsGenericHostname()` blocklist** — new function in `platform/hostname.go` that identifies default OS hostnames (debian, ubuntu, localhost, fedora, archlinux, nixos, raspberrypi, etc.) that should be replaced. Anything not in the list is treated as user-chosen.
- **`getNodeName()` now checks OS hostname first** — priority order is now: `--node-name` flag > saved config > current OS hostname (if meaningful) > generated `citadel-<id>`. Previously it skipped the OS hostname entirely.
- **`connectToNetwork()` only overwrites generic hostnames** — no longer calls `SetHostname()` when the machine already has a meaningful name, preserving the user's prompt and `/etc/hostname`.

## Test plan

| Test | Status |
|------|--------|
| `TestIsGenericHostname` — blocklist entries return true | PASS |
| `TestIsGenericHostname` — meaningful names return false | PASS |
| All existing hostname tests still pass | PASS |
| Full `go test ./...` (excluding E2E) | PASS |

---
*Generated by Claude*