### PR TITLE
fix: install script unbound variable and silent 404 errors

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -389,12 +389,12 @@ install_citadel_binary() {
     tmp_dir=$(mktemp -d)
 
     msg "Downloading ${archive}..."
-    if ! curl -sSL -o "${tmp_dir}/${archive}" "${base_url}/${archive}"; then
+    if ! curl -fsSL -o "${tmp_dir}/${archive}" "${base_url}/${archive}"; then
         rm -rf "$tmp_dir"
         die "Failed to download ${archive}"
     fi
 
-    if ! curl -sSL -o "${tmp_dir}/${checksum_file}" "${base_url}/${checksum_file}"; then
+    if ! curl -fsSL -o "${tmp_dir}/${checksum_file}" "${base_url}/${checksum_file}"; then
         rm -rf "$tmp_dir"
         die "Failed to download checksums"
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -196,15 +196,15 @@ install_citadel() {
 
   local tmp_dir
   tmp_dir=$(mktemp -d)
-  trap 'rm -rf "$tmp_dir"' EXIT # Ensure cleanup on exit/error
+  trap 'rm -rf "${tmp_dir:-}"' EXIT # Ensure cleanup on exit/error
 
   msg "Downloading Citadel CLI ${version} for ${arch}..."
 
   # Download the archive and checksums
-  if ! curl -sSL -o "${tmp_dir}/${binary_archive}" "${download_url_base}/${binary_archive}"; then
+  if ! curl -fsSL -o "${tmp_dir}/${binary_archive}" "${download_url_base}/${binary_archive}"; then
     err "Failed to download binary archive. Check version and architecture."
   fi
-  if ! curl -sSL -o "${tmp_dir}/${checksum_file}" "${download_url_base}/${checksum_file}"; then
+  if ! curl -fsSL -o "${tmp_dir}/${checksum_file}" "${download_url_base}/${checksum_file}"; then
     err "Failed to download checksums file."
   fi
 


### PR DESCRIPTION
## Context

Running `curl -fsSL https://get.aceteam.ai/citadel.sh | bash` fails with `tmp_dir: unbound variable` when release assets are missing or download fails.

## Summary

- **Trap handler**: `${tmp_dir:-}` prevents `set -u` from erroring when the EXIT trap fires before `tmp_dir` is assigned (e.g., early failure)
- **Download commands**: `-f` flag added to `curl` so HTTP 404s cause non-zero exit instead of silently writing HTML error pages to the output file — the `if ! curl` guard now actually catches download failures

Affects both `scripts/install.sh` (get.aceteam.ai) and `install.sh` (full node installer).

## Test plan

- Verified install script completes successfully with v2.21.0 assets present
- Verified install script fails gracefully with proper error message on 404