### PR TITLE
feat: actionable GPU error diagnostics when drivers are broken

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -190,6 +190,16 @@ func gatherStatusData() (dashboard.StatusData, error) {
 				}
 				data.GPUs = append(data.GPUs, gpuInfo)
 			}
+		} else {
+			// nvidia-smi failed but hardware is present — show lspci info
+			hwName := platform.DetectNvidiaHardware()
+			if hwName != "" {
+				errMsg := platform.NvidiaSMIErrorMessage(err)
+				data.GPUs = append(data.GPUs, dashboard.GPUInfo{
+					Name:   hwName + " (drivers not loaded)",
+					Driver: errMsg,
+				})
+			}
 		}
 	}
 
@@ -377,7 +387,16 @@ func printGPUInfo(w *tabwriter.Writer) {
 
 	gpus, err := detector.GetGPUInfo()
 	if err != nil {
-		fmt.Fprintf(w, "  GPU:\t%s\n", warnColor.Sprintf("Hardware detected, but could not get details: %v", err))
+		// Hardware detected via lspci but nvidia-smi failed — show actionable message
+		hwName := platform.DetectNvidiaHardware()
+		if hwName != "" {
+			fmt.Fprintf(w, "  GPU:\t%s\n", warnColor.Sprintf("NVIDIA hardware detected (drivers not working)"))
+			fmt.Fprintf(w, "    %s:\t%s\n", labelColor.Sprint("Hardware"), hwName)
+		} else {
+			fmt.Fprintf(w, "  GPU:\t%s\n", warnColor.Sprint("Hardware detected, but could not get details"))
+		}
+		errMsg := platform.NvidiaSMIErrorMessage(err)
+		fmt.Fprintf(w, "    %s:\t%s\n", labelColor.Sprint("Issue"), warnColor.Sprint(errMsg))
 		return
 	}
 
@@ -415,13 +434,25 @@ func printCapabilities(w *tabwriter.Writer, manifest *CitadelManifest) {
 	nodeCaps := resolveCapabilities(manifest)
 
 	if nodeCaps.GPU != nil && len(nodeCaps.GPU.Devices) > 0 {
-		fmt.Fprintf(w, "  %s:\t%d\n", labelColor.Sprint("GPU Count"), nodeCaps.GPU.Count)
-		for i, dev := range nodeCaps.GPU.Devices {
-			vramStr := ""
-			if dev.VRAMTag != "" {
-				vramStr = fmt.Sprintf(" (%s)", strings.ToUpper(dev.VRAMTag))
+		if nodeCaps.GPU.DriverStatus == "not_loaded" || nodeCaps.GPU.DriverStatus == "error" {
+			// Hardware present but drivers not working — show status without routing tags
+			fmt.Fprintf(w, "  %s:\t%d\n", labelColor.Sprint("GPU Count"), nodeCaps.GPU.Count)
+			for i, dev := range nodeCaps.GPU.Devices {
+				fmt.Fprintf(w, "  %s %d:\t%s %s\n", labelColor.Sprint("GPU"), i, dev.Name,
+					warnColor.Sprint("(drivers not loaded)"))
 			}
-			fmt.Fprintf(w, "  %s %d:\t%s%s\n", labelColor.Sprint("GPU"), i, dev.Name, vramStr)
+			if nodeCaps.GPU.DriverError != "" {
+				fmt.Fprintf(w, "  %s:\t%s\n", labelColor.Sprint("Issue"), warnColor.Sprint(nodeCaps.GPU.DriverError))
+			}
+		} else {
+			fmt.Fprintf(w, "  %s:\t%d\n", labelColor.Sprint("GPU Count"), nodeCaps.GPU.Count)
+			for i, dev := range nodeCaps.GPU.Devices {
+				vramStr := ""
+				if dev.VRAMTag != "" {
+					vramStr = fmt.Sprintf(" (%s)", strings.ToUpper(dev.VRAMTag))
+				}
+				fmt.Fprintf(w, "  %s %d:\t%s%s\n", labelColor.Sprint("GPU"), i, dev.Name, vramStr)
+			}
 		}
 	} else {
 		fmt.Fprintln(w, "  GPU:\tNone detected")

--- a/internal/capabilities/detector.go
+++ b/internal/capabilities/detector.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
 )
 
 const detectionTimeout = 5 * time.Second
@@ -32,8 +34,10 @@ type GPUDevice struct {
 
 // GPUCapabilities holds the full GPU capability summary for a node.
 type GPUCapabilities struct {
-	Devices []GPUDevice `json:"devices,omitempty" yaml:"devices,omitempty"`
-	Count   int         `json:"count" yaml:"count"`
+	Devices      []GPUDevice `json:"devices,omitempty" yaml:"devices,omitempty"`
+	Count        int         `json:"count" yaml:"count"`
+	DriverStatus string      `json:"driver_status,omitempty" yaml:"driver_status,omitempty"` // "ok", "not_loaded", "error", or "" (unknown)
+	DriverError  string      `json:"driver_error,omitempty" yaml:"driver_error,omitempty"`   // human-readable error when drivers fail
 }
 
 // NodeCapabilities aggregates all detected capabilities for a node.
@@ -44,14 +48,31 @@ type NodeCapabilities struct {
 }
 
 // DetectGPUCapabilities runs nvidia-smi and returns structured GPU information.
-// Returns nil if no nvidia-smi or no GPUs detected.
+// When nvidia-smi fails but lspci detects NVIDIA hardware, a GPUCapabilities
+// is still returned with the hardware name but empty Tag/VRAMTag fields so
+// the GPU is visible in status displays without producing routing tags.
+// Returns nil only if no NVIDIA hardware is detected at all.
 func DetectGPUCapabilities() *GPUCapabilities {
 	ctx, cancel := context.WithTimeout(context.Background(), detectionTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "nvidia-smi", "--query-gpu=name,memory.total,count", "--format=csv,noheader,nounits")
 	output, err := cmd.Output()
 	if err != nil {
-		return nil
+		// nvidia-smi failed — check if hardware is physically present via lspci
+		hwName := platform.DetectNvidiaHardware()
+		if hwName == "" {
+			return nil // No NVIDIA hardware at all
+		}
+		// Hardware present but drivers not working — return display-only entry
+		// with empty Tag/VRAMTag so no routing tags are generated.
+		return &GPUCapabilities{
+			Devices: []GPUDevice{
+				{Name: hwName}, // Tag and VRAMTag intentionally empty
+			},
+			Count:        1,
+			DriverStatus: "not_loaded",
+			DriverError:  platform.NvidiaSMIErrorMessage(err),
+		}
 	}
 
 	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
@@ -107,8 +128,9 @@ func DetectGPUCapabilities() *GPUCapabilities {
 	}
 
 	return &GPUCapabilities{
-		Devices: devices,
-		Count:   totalCount,
+		Devices:      devices,
+		Count:        totalCount,
+		DriverStatus: "ok",
 	}
 }
 

--- a/internal/capabilities/detector_test.go
+++ b/internal/capabilities/detector_test.go
@@ -1,6 +1,7 @@
 package capabilities
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -201,6 +202,66 @@ func TestNodeCapabilities(t *testing.T) {
 	}
 	if len(nodeCaps.Tags) != 4 {
 		t.Errorf("len(Tags) = %d, want 4", len(nodeCaps.Tags))
+	}
+}
+
+func TestGPUCapabilities_DriverNotLoaded_NoRoutingTags(t *testing.T) {
+	// Simulate the scenario where lspci detects hardware but nvidia-smi fails.
+	// The device has Name set but Tag/VRAMTag empty, so DetectNodeCapabilities
+	// must NOT produce gpu: or vram: routing tags.
+	gpuCaps := &GPUCapabilities{
+		Devices: []GPUDevice{
+			{Name: "NVIDIA Corporation GA102 [GeForce RTX 3090]"},
+			// Tag and VRAMTag intentionally empty
+		},
+		Count:        1,
+		DriverStatus: "not_loaded",
+		DriverError:  "NVIDIA drivers not loaded. Install drivers with: sudo apt install nvidia-driver-<version>",
+	}
+
+	// Build tags using the same logic as DetectNodeCapabilities
+	caps := &NodeCapabilities{GPU: gpuCaps}
+	seen := make(map[string]bool)
+	for i, dev := range gpuCaps.Devices {
+		if dev.Tag != "" {
+			tag := "gpu:" + dev.Tag
+			if !seen[tag] {
+				seen[tag] = true
+				caps.Tags = append(caps.Tags, tag)
+			}
+		}
+		if dev.VRAMTag != "" {
+			tag := "vram:" + dev.VRAMTag
+			if !seen[tag] {
+				seen[tag] = true
+				caps.Tags = append(caps.Tags, tag)
+			}
+		}
+		if dev.Tag != "" && dev.VRAMTag != "" {
+			indexedTag := fmt.Sprintf("gpu:%d:%s:%s", i, dev.Tag, dev.VRAMTag)
+			if ValidateTag(indexedTag) {
+				caps.Tags = append(caps.Tags, indexedTag)
+			}
+		}
+	}
+	caps.Tags = append(caps.Tags, "cpu:general")
+
+	// Verify: only cpu:general should be present, no gpu: or vram: tags
+	for _, tag := range caps.Tags {
+		if tag != "cpu:general" {
+			t.Errorf("driver-down GPU should not produce routing tag %q", tag)
+		}
+	}
+
+	// Verify the GPU info is still present for display
+	if caps.GPU == nil || len(caps.GPU.Devices) == 0 {
+		t.Error("GPU devices should still be populated for display")
+	}
+	if caps.GPU.DriverStatus != "not_loaded" {
+		t.Errorf("DriverStatus = %q, want %q", caps.GPU.DriverStatus, "not_loaded")
+	}
+	if caps.GPU.DriverError == "" {
+		t.Error("DriverError should contain a helpful message")
 	}
 }
 

--- a/internal/platform/gpu.go
+++ b/internal/platform/gpu.go
@@ -1,9 +1,11 @@
 package platform
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 )
@@ -25,9 +27,79 @@ type GPUDetector interface {
 	GetGPUCount() int
 }
 
+// NvidiaSMIExitHint translates a known nvidia-smi exit code into a
+// user-friendly message with remediation guidance. Returns an empty string
+// for unrecognized codes.
+func NvidiaSMIExitHint(code int) string {
+	switch code {
+	case 6:
+		return "No NVIDIA GPU detected by the driver"
+	case 9:
+		return "GPU hardware error — may need reseating or a power cycle"
+	case 15:
+		return "Driver version mismatch. Reboot required after driver update"
+	case 18:
+		return "NVIDIA drivers not loaded. Install drivers with: sudo apt install nvidia-driver-<version>"
+	default:
+		return ""
+	}
+}
+
+// NvidiaSMIErrorMessage returns a human-readable message for an nvidia-smi
+// execution error. It distinguishes between "binary not found" and known
+// exit codes, falling back to the raw error for anything else.
+func NvidiaSMIErrorMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	// Binary not found on PATH
+	var pathErr *exec.Error
+	if errors.As(err, &pathErr) {
+		return "nvidia-smi not found — NVIDIA drivers are not installed"
+	}
+
+	// Binary ran but returned a non-zero exit code
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		code := exitErr.ExitCode()
+		if hint := NvidiaSMIExitHint(code); hint != "" {
+			return hint
+		}
+		return fmt.Sprintf("nvidia-smi exited with code %d", code)
+	}
+
+	return fmt.Sprintf("nvidia-smi error: %v", err)
+}
+
+// DetectNvidiaHardware checks via lspci whether any NVIDIA GPU hardware is
+// physically present, regardless of driver status. Returns the GPU name
+// (e.g. "NVIDIA Corporation GA102 [GeForce RTX 3090]") or an empty string.
+// This covers both VGA and 3D controller entries (headless/datacenter GPUs
+// like A100/H100 enumerate as "3D controller").
+func DetectNvidiaHardware() string {
+	cmd := exec.Command("sh", "-c", "lspci 2>/dev/null | grep -iE '(VGA compatible controller|3D controller).*NVIDIA'")
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	line := strings.TrimSpace(string(output))
+	// lspci output example: "01:00.0 VGA compatible controller: NVIDIA Corporation GA104 [GeForce RTX 3060 Ti] (rev a1)"
+	// Extract the part after the controller type.
+	for _, prefix := range []string{"VGA compatible controller: ", "3D controller: "} {
+		if idx := strings.Index(line, prefix); idx >= 0 {
+			return strings.TrimSpace(line[idx+len(prefix):])
+		}
+	}
+	if line != "" {
+		return line
+	}
+	return ""
+}
+
 // GetGPUDetector returns the appropriate GPU detector for the current OS
 func GetGPUDetector() (GPUDetector, error) {
-	switch OS() {
+	switch runtime.GOOS {
 	case "linux":
 		return &LinuxGPUDetector{}, nil
 	case "darwin":
@@ -35,7 +107,7 @@ func GetGPUDetector() (GPUDetector, error) {
 	case "windows":
 		return &WindowsGPUDetector{}, nil
 	default:
-		return nil, fmt.Errorf("unsupported operating system: %s", OS())
+		return nil, fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
 	}
 }
 
@@ -43,8 +115,8 @@ func GetGPUDetector() (GPUDetector, error) {
 type LinuxGPUDetector struct{}
 
 func (l *LinuxGPUDetector) HasGPU() bool {
-	// Check using lspci
-	cmd := exec.Command("sh", "-c", "lspci | grep -i 'VGA compatible controller.*NVIDIA'")
+	// Check using lspci (matches both VGA and 3D controllers for headless/datacenter GPUs)
+	cmd := exec.Command("sh", "-c", "lspci 2>/dev/null | grep -iE '(VGA compatible controller|3D controller).*NVIDIA'")
 	if err := cmd.Run(); err == nil {
 		return true
 	}

--- a/internal/platform/gpu_test.go
+++ b/internal/platform/gpu_test.go
@@ -1,7 +1,11 @@
 package platform
 
 import (
+	"errors"
+	"fmt"
+	"os/exec"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -46,6 +50,97 @@ func TestWindowsGPUDetectorGetGPUCount(t *testing.T) {
 	count := detector.GetGPUCount()
 	if count < 0 {
 		t.Errorf("WindowsGPUDetector.GetGPUCount() = %d, want >= 0", count)
+	}
+}
+
+func TestNvidiaSMIExitHint(t *testing.T) {
+	tests := []struct {
+		code     int
+		wantHint string
+	}{
+		{6, "No NVIDIA GPU detected by the driver"},
+		{9, "GPU hardware error"},
+		{15, "Driver version mismatch"},
+		{18, "NVIDIA drivers not loaded"},
+		{1, ""},  // unknown code
+		{0, ""},  // success (shouldn't be called, but safe)
+		{42, ""}, // arbitrary unknown code
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("exit_%d", tt.code), func(t *testing.T) {
+			hint := NvidiaSMIExitHint(tt.code)
+			if tt.wantHint == "" {
+				if hint != "" {
+					t.Errorf("NvidiaSMIExitHint(%d) = %q, want empty", tt.code, hint)
+				}
+			} else {
+				if !strings.Contains(hint, tt.wantHint) {
+					t.Errorf("NvidiaSMIExitHint(%d) = %q, want substring %q", tt.code, hint, tt.wantHint)
+				}
+			}
+		})
+	}
+}
+
+func TestNvidiaSMIErrorMessage(t *testing.T) {
+	// nil error
+	if msg := NvidiaSMIErrorMessage(nil); msg != "" {
+		t.Errorf("NvidiaSMIErrorMessage(nil) = %q, want empty", msg)
+	}
+
+	// Binary not found (exec.Error)
+	pathErr := &exec.Error{Name: "nvidia-smi", Err: exec.ErrNotFound}
+	msg := NvidiaSMIErrorMessage(pathErr)
+	if !strings.Contains(msg, "not found") && !strings.Contains(msg, "not installed") {
+		t.Errorf("NvidiaSMIErrorMessage(pathErr) = %q, want 'not found' or 'not installed'", msg)
+	}
+
+	// Known exit code — produce a real *exec.ExitError via sh
+	if runtime.GOOS != "windows" {
+		cmd := exec.Command("sh", "-c", "exit 18")
+		err := cmd.Run()
+		if err == nil {
+			t.Fatal("expected exit 18 to produce an error")
+		}
+		msg = NvidiaSMIErrorMessage(err)
+		if !strings.Contains(msg, "NVIDIA drivers not loaded") {
+			t.Errorf("NvidiaSMIErrorMessage(exit 18) = %q, want 'NVIDIA drivers not loaded'", msg)
+		}
+	}
+
+	// Unknown exit code
+	if runtime.GOOS != "windows" {
+		cmd := exec.Command("sh", "-c", "exit 99")
+		err := cmd.Run()
+		if err == nil {
+			t.Fatal("expected exit 99 to produce an error")
+		}
+		msg = NvidiaSMIErrorMessage(err)
+		if !strings.Contains(msg, "99") {
+			t.Errorf("NvidiaSMIErrorMessage(exit 99) = %q, want to contain '99'", msg)
+		}
+	}
+
+	// Wrapped error — simulates what GetGPUInfo returns: fmt.Errorf("failed to query...: %w", exitErr)
+	if runtime.GOOS != "windows" {
+		cmd := exec.Command("sh", "-c", "exit 18")
+		err := cmd.Run()
+		if err == nil {
+			t.Fatal("expected exit 18 to produce an error")
+		}
+		wrapped := fmt.Errorf("failed to query NVIDIA GPUs: %w", err)
+		msg = NvidiaSMIErrorMessage(wrapped)
+		if !strings.Contains(msg, "NVIDIA drivers not loaded") {
+			t.Errorf("NvidiaSMIErrorMessage(wrapped exit 18) = %q, want 'NVIDIA drivers not loaded'", msg)
+		}
+	}
+
+	// Arbitrary error (neither exec.Error nor exec.ExitError)
+	genericErr := errors.New("something went wrong")
+	msg = NvidiaSMIErrorMessage(genericErr)
+	if !strings.Contains(msg, "something went wrong") {
+		t.Errorf("NvidiaSMIErrorMessage(generic) = %q, want to contain original message", msg)
 	}
 }
 


### PR DESCRIPTION
## Context

When nvidia-smi fails (e.g. exit code 18 = NVML shared library not found), `citadel status` shows a cryptic message:

```
💎 GPU STATUS
  GPU:  Hardware detected, but could not get details: failed to query NVIDIA GPUs: exit status 18

🔧 CAPABILITIES
  GPU:            None detected
  Tags:  cpu:general
```

This gives the user no idea what's wrong or how to fix it.

## Summary

**Exit code translation** (`platform.NvidiaSMIExitHint`) — Maps known nvidia-smi exit codes to actionable messages:
- Exit 6: "No NVIDIA GPU detected by the driver"
- Exit 9: "GPU hardware error — may need reseating or a power cycle"
- Exit 15: "Driver version mismatch. Reboot required after driver update"
- Exit 18: "NVIDIA drivers not loaded. Install drivers with: sudo apt install nvidia-driver-<version>"

**lspci fallback** (`platform.DetectNvidiaHardware`) — Detects GPU hardware via lspci even when drivers aren't loaded. Matches both "VGA compatible controller" and "3D controller" entries (the latter covers headless/datacenter GPUs like A100/H100).

**Display-only GPU entries** — When nvidia-smi fails but hardware exists, capabilities detector returns a `GPUDevice` with empty `Tag`/`VRAMTag` fields. This ensures the GPU appears in status displays but doesn't generate routing tags (preventing the node from subscribing to GPU job queues it can't service).

**Status output** — Now shows:
```
💎 GPU STATUS
  GPU:      NVIDIA hardware detected (drivers not working)
    Hardware:  NVIDIA Corporation GA102 [GeForce RTX 3090] (rev a1)
    Issue:     NVIDIA drivers not loaded. Install drivers with: sudo apt install nvidia-driver-<version>

🔧 CAPABILITIES
  GPU 0:    NVIDIA Corporation GA102 [GeForce RTX 3090] (rev a1) (drivers not loaded)
  Issue:    NVIDIA drivers not loaded. Install drivers with: sudo apt install nvidia-driver-<version>
  Tags:  cpu:general
```

## Test plan

| Area | Tests |
|------|-------|
| `NvidiaSMIExitHint` | 7 subtests — all 4 known codes + 3 edge cases |
| `NvidiaSMIErrorMessage` | 6 cases — nil, binary not found, known exit, unknown exit, wrapped error, generic |
| Routing tag safety | Verifies display-only GPU devices produce no `gpu:` or `vram:` tags |
| Build | `go build ./...` clean |