### PR TITLE
fix: version comparison + nvidia-smi stderr parsing

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -204,14 +204,17 @@ func checkForUpdateOnStartup(silent bool) {
 		return
 	}
 
-	// Show cached update notification immediately (no network call)
-	if state.AvailableUpdate != "" && state.AvailableUpdate != Version {
-		if silent {
-			// Store for TUI to display via activity log
-			deferredUpdateNotification = state.AvailableUpdate
-		} else {
-			// Print to stdout for non-TUI commands
-			fmt.Printf("\n📦 Update available: %s → %s (run 'citadel update install')\n\n", Version, state.AvailableUpdate)
+	// Show cached update notification only if the cached version is strictly newer (semver).
+	// A simple != check would incorrectly suggest a downgrade when the cached value is older
+	// than the running binary (e.g. binary updated but cached state is stale).
+	if state.AvailableUpdate != "" {
+		newer, err := update.IsNewerVersion(Version, state.AvailableUpdate)
+		if err == nil && newer {
+			if silent {
+				deferredUpdateNotification = state.AvailableUpdate
+			} else {
+				fmt.Printf("\n📦 Update available: %s → %s (run 'citadel update install')\n\n", Version, state.AvailableUpdate)
+			}
 		}
 	}
 

--- a/internal/platform/gpu.go
+++ b/internal/platform/gpu.go
@@ -59,9 +59,22 @@ func NvidiaSMIErrorMessage(err error) string {
 		return "nvidia-smi not found — NVIDIA drivers are not installed"
 	}
 
-	// Binary ran but returned a non-zero exit code
+	// Binary ran but returned a non-zero exit code.
+	// Check stderr first — it is more specific than the exit code alone.
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {
+		if stderr := strings.TrimSpace(string(exitErr.Stderr)); stderr != "" {
+			if strings.Contains(stderr, "Driver/library version mismatch") {
+				return "Driver/library version mismatch — reboot required after driver update"
+			}
+			if strings.Contains(stderr, "NVML Shared Library Not Found") {
+				return "nvidia-smi not found — NVIDIA drivers are not installed"
+			}
+			// Unknown stderr content — surface it directly
+			return fmt.Sprintf("nvidia-smi: %s", stderr)
+		}
+
+		// No stderr captured — fall back to exit-code heuristic
 		code := exitErr.ExitCode()
 		if hint := NvidiaSMIExitHint(code); hint != "" {
 			return hint

--- a/internal/platform/gpu_test.go
+++ b/internal/platform/gpu_test.go
@@ -144,6 +144,68 @@ func TestNvidiaSMIErrorMessage(t *testing.T) {
 	}
 }
 
+func TestNvidiaSMIErrorMessageStderr(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows")
+	}
+
+	// Driver/library version mismatch in stderr → reboot message
+	t.Run("driver_library_mismatch", func(t *testing.T) {
+		_, err := exec.Command("sh", "-c",
+			"echo 'Failed to initialize NVML: Driver/library version mismatch' >&2; exit 18").Output()
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		msg := NvidiaSMIErrorMessage(err)
+		if !strings.Contains(msg, "Driver/library version mismatch") {
+			t.Errorf("want 'Driver/library version mismatch', got %q", msg)
+		}
+		if !strings.Contains(msg, "reboot required") {
+			t.Errorf("want 'reboot required', got %q", msg)
+		}
+	})
+
+	// NVML Shared Library Not Found → drivers not installed
+	t.Run("nvml_not_found", func(t *testing.T) {
+		_, err := exec.Command("sh", "-c",
+			"echo 'NVML Shared Library Not Found' >&2; exit 1").Output()
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		msg := NvidiaSMIErrorMessage(err)
+		if !strings.Contains(msg, "not installed") {
+			t.Errorf("want 'not installed', got %q", msg)
+		}
+	})
+
+	// Unknown stderr → surface stderr text
+	t.Run("unknown_stderr", func(t *testing.T) {
+		_, err := exec.Command("sh", "-c",
+			"echo 'Some unexpected NVML error' >&2; exit 42").Output()
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		msg := NvidiaSMIErrorMessage(err)
+		if !strings.Contains(msg, "Some unexpected NVML error") {
+			t.Errorf("want stderr text in message, got %q", msg)
+		}
+	})
+
+	// Wrapped error with stderr (simulates GetGPUInfo path)
+	t.Run("wrapped_with_stderr", func(t *testing.T) {
+		_, err := exec.Command("sh", "-c",
+			"echo 'Failed to initialize NVML: Driver/library version mismatch' >&2; exit 18").Output()
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		wrapped := fmt.Errorf("failed to query NVIDIA GPUs: %w", err)
+		msg := NvidiaSMIErrorMessage(wrapped)
+		if !strings.Contains(msg, "reboot required") {
+			t.Errorf("want 'reboot required' through wrapper, got %q", msg)
+		}
+	})
+}
+
 func TestFormatGPUInfo(t *testing.T) {
 	// Test with empty slice
 	result := FormatGPUInfo([]GPUInfo{})

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -291,28 +291,33 @@ func (c *Client) fetchLatestRelease() (*Release, error) {
 	return &release, nil
 }
 
-// isNewerVersion compares versions
-func (c *Client) isNewerVersion(newVersion string) (bool, error) {
-	// Strip leading 'v' if present
-	currentStr := strings.TrimPrefix(c.CurrentVersion, "v")
-	newStr := strings.TrimPrefix(newVersion, "v")
+// IsNewerVersion reports whether candidate is a strictly newer semver than
+// current. Both values may optionally carry a leading "v" prefix. The "dev"
+// and empty current versions are always considered outdated (returns true).
+func IsNewerVersion(current, candidate string) (bool, error) {
+	currentStr := strings.TrimPrefix(current, "v")
+	newStr := strings.TrimPrefix(candidate, "v")
 
-	// Handle "dev" version
 	if currentStr == "dev" || currentStr == "" {
 		return true, nil
 	}
 
-	current, err := version.NewVersion(currentStr)
+	cur, err := version.NewVersion(currentStr)
 	if err != nil {
-		return false, fmt.Errorf("invalid current version %s: %w", c.CurrentVersion, err)
+		return false, fmt.Errorf("invalid current version %s: %w", current, err)
 	}
 
-	latest, err := version.NewVersion(newStr)
+	lat, err := version.NewVersion(newStr)
 	if err != nil {
-		return false, fmt.Errorf("invalid new version %s: %w", newVersion, err)
+		return false, fmt.Errorf("invalid new version %s: %w", candidate, err)
 	}
 
-	return latest.GreaterThan(current), nil
+	return lat.GreaterThan(cur), nil
+}
+
+// isNewerVersion compares the client's current version against newVersion.
+func (c *Client) isNewerVersion(newVersion string) (bool, error) {
+	return IsNewerVersion(c.CurrentVersion, newVersion)
 }
 
 // getDownloadURL constructs the download URL for the current platform

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -113,6 +113,34 @@ func TestIsNewerVersion(t *testing.T) {
 	}
 }
 
+func TestIsNewerVersionExported(t *testing.T) {
+	tests := []struct {
+		name      string
+		current   string
+		candidate string
+		want      bool
+		wantErr   bool
+	}{
+		{"upgrade", "v2.21.0", "v2.22.0", true, false},
+		{"downgrade rejected", "v2.22.0", "v2.21.0", false, false},
+		{"same version", "v2.22.0", "v2.22.0", false, false},
+		{"dev always updates", "dev", "v1.0.0", true, false},
+		{"empty always updates", "", "v1.0.0", true, false},
+		{"without v prefix", "2.21.0", "2.22.0", true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := IsNewerVersion(tt.current, tt.candidate)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("IsNewerVersion(%q, %q) error = %v, wantErr %v", tt.current, tt.candidate, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("IsNewerVersion(%q, %q) = %v, want %v", tt.current, tt.candidate, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetBinaryArchiveName(t *testing.T) {
 	client := NewClient("v1.0.0")
 	release := &Release{TagName: "v1.2.3"}


### PR DESCRIPTION
## Context

Two bugs in citadel-cli's diagnostic output: the startup version check suggests downgrades, and nvidia-smi error messages are less specific than they could be.

## Summary

**Bug 1 — Version check suggests downgrade (#188)**

`citadel login` and `citadel status` showed "Update available: v2.22.0 → v2.21.0" when a stale cached version was present. The startup check in `checkForUpdateOnStartup` used `state.AvailableUpdate != Version` (string inequality) instead of semver comparison. When the binary was updated to v2.22.0 but the cache still held v2.21.0 from a previous check, the inequality was true and the notification fired — suggesting a downgrade.

Fix: Extract `IsNewerVersion(current, candidate)` as an exported package-level function in `internal/update` and use it at the startup check site. The `update install` command already used proper semver via `client.CheckForUpdate()` → `isNewerVersion()`, which now delegates to the same exported function.

**Bug 2 — nvidia-smi stderr not parsed (#189)**

Exit code 18 mapped to "NVIDIA drivers not loaded. Install drivers with: sudo apt install nvidia-driver-\<version\>" but the actual nvidia-smi stderr said "Driver/library version mismatch" — the driver IS installed, it just needs a reboot after an update.

Fix: `NvidiaSMIErrorMessage` now inspects `exec.ExitError.Stderr` before falling back to exit-code mapping:
- `"Driver/library version mismatch"` → "Driver/library version mismatch — reboot required after driver update"
- `"NVML Shared Library Not Found"` → "nvidia-smi not found — NVIDIA drivers are not installed"
- Unknown stderr → surface the stderr text directly (more specific than exit code alone)
- Empty stderr → fall back to existing exit-code heuristic (preserves backward compat for `.Run()` callers)

Both `GetGPUInfo()` and `DetectGPUCapabilities()` use `cmd.Output()`, which populates `ExitError.Stderr`, so the fix is effective at all call sites.

## Test plan

| Area | Tests | Coverage |
|------|-------|----------|
| `TestIsNewerVersionExported` | 6 cases | upgrade, downgrade rejected, same version, dev, empty, no-v-prefix |
| `TestNvidiaSMIErrorMessageStderr` | 4 subtests | driver mismatch → reboot, NVML not found → not installed, unknown stderr → surfaced, wrapped error |
| Existing `TestIsNewerVersion` | 7 cases | Unchanged, validates method still delegates correctly |
| Existing `TestNvidiaSMIErrorMessage` | 6 paths | Unchanged, validates exit-code fallback when stderr is empty |

All tests pass. `go test ./...` green (e2e excluded — requires running Redis/server).

Closes #188, closes #189