### PR TITLE
feat: service catalog commands (browse, search, install)

### DIFF
--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -1,0 +1,313 @@
+// cmd/catalog.go
+// Service catalog commands: browse, search, and install services from the catalog repository.
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/aceteam-ai/citadel-cli/internal/catalog"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+var catalogCmd = &cobra.Command{
+	Use:   "catalog",
+	Short: "Browse and install services from the catalog",
+	Long: `Manage the service catalog — a curated repository of containerized services
+that can be installed on your Citadel node.
+
+Run 'citadel service catalog update' to download or refresh the catalog,
+then use list, search, and info to discover services.`,
+}
+
+var catalogUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Download or refresh the local service catalog",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Println("Updating service catalog...")
+		if err := catalog.Update(); err != nil {
+			return fmt.Errorf("failed to update catalog: %w", err)
+		}
+		fmt.Println("Catalog updated successfully.")
+		return nil
+	},
+}
+
+var catalogListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List available services in the catalog",
+	RunE:  runCatalogList,
+}
+
+var catalogSearchCmd = &cobra.Command{
+	Use:   "search <query>",
+	Short: "Search for services by name, tag, or category",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runCatalogSearch,
+}
+
+var catalogInfoCmd = &cobra.Command{
+	Use:   "info <name>",
+	Short: "Show full details about a catalog service",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runCatalogInfo,
+}
+
+var catalogInstallConfigFlags []string
+
+var catalogInstallCmd = &cobra.Command{
+	Use:   "install <name>",
+	Short: "Install a service from the catalog onto this node",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runCatalogInstall,
+}
+
+func init() {
+	svcCmd.AddCommand(catalogCmd)
+	catalogCmd.AddCommand(catalogUpdateCmd)
+	catalogCmd.AddCommand(catalogListCmd)
+	catalogCmd.AddCommand(catalogSearchCmd)
+	catalogCmd.AddCommand(catalogInfoCmd)
+	catalogCmd.AddCommand(catalogInstallCmd)
+
+	catalogInstallCmd.Flags().StringArrayVar(&catalogInstallConfigFlags, "set", nil,
+		"Set a config value (e.g. --set MODEL=Qwen/Qwen3-8B)")
+}
+
+// runCatalogList prints all catalog services in a table with install status.
+func runCatalogList(cmd *cobra.Command, args []string) error {
+	reg, err := catalog.LoadRegistry()
+	if err != nil {
+		return err
+	}
+
+	if len(reg.Services) == 0 {
+		fmt.Println("No services found in catalog.")
+		return nil
+	}
+
+	// Determine which services are already installed by checking the node's services dir.
+	installed := installedServiceSet()
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	defer w.Flush()
+
+	bold := color.New(color.Bold)
+	bold.Fprintf(w, "SERVICE\tVERSION\tCATEGORY\tGPU\tSTATUS\tDESCRIPTION\n")
+
+	for _, s := range reg.Services {
+		statusStr := color.New(color.FgWhite).Sprint("available")
+		if installed[s.Name] {
+			statusStr = color.New(color.FgGreen).Sprint("installed")
+		}
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			s.Name, s.Version, s.Category, s.GPU, statusStr, truncate(s.Description, 50))
+	}
+	return nil
+}
+
+// runCatalogSearch prints services matching the query.
+func runCatalogSearch(cmd *cobra.Command, args []string) error {
+	results, err := catalog.Search(args[0])
+	if err != nil {
+		return err
+	}
+
+	if len(results) == 0 {
+		fmt.Printf("No services matching '%s'.\n", args[0])
+		return nil
+	}
+
+	installed := installedServiceSet()
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	defer w.Flush()
+
+	bold := color.New(color.Bold)
+	bold.Fprintf(w, "SERVICE\tVERSION\tCATEGORY\tGPU\tSTATUS\tDESCRIPTION\n")
+
+	for _, s := range results {
+		statusStr := color.New(color.FgWhite).Sprint("available")
+		if installed[s.Name] {
+			statusStr = color.New(color.FgGreen).Sprint("installed")
+		}
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			s.Name, s.Version, s.Category, s.GPU, statusStr, truncate(s.Description, 50))
+	}
+	return nil
+}
+
+// runCatalogInfo prints the full manifest details for a service.
+func runCatalogInfo(cmd *cobra.Command, args []string) error {
+	manifest, err := catalog.LoadServiceManifest(args[0])
+	if err != nil {
+		return err
+	}
+
+	bold := color.New(color.Bold)
+
+	bold.Print("Name:        ")
+	fmt.Println(manifest.Name)
+	bold.Print("Version:     ")
+	fmt.Println(manifest.Version)
+	bold.Print("Description: ")
+	fmt.Println(manifest.Description)
+	bold.Print("Category:    ")
+	fmt.Println(manifest.Category)
+	if manifest.Author != "" {
+		bold.Print("Author:      ")
+		fmt.Println(manifest.Author)
+	}
+	if manifest.License != "" {
+		bold.Print("License:     ")
+		fmt.Println(manifest.License)
+	}
+	if manifest.Homepage != "" {
+		bold.Print("Homepage:    ")
+		fmt.Println(manifest.Homepage)
+	}
+
+	// Requirements
+	fmt.Println()
+	bold.Println("Requirements:")
+	if manifest.Requires.GPU {
+		fmt.Println("  GPU:       required")
+	} else {
+		fmt.Println("  GPU:       no")
+	}
+	if manifest.Requires.VRAMMinGB > 0 {
+		fmt.Printf("  Min VRAM:  %.0f GB\n", manifest.Requires.VRAMMinGB)
+	}
+	if len(manifest.Requires.Arch) > 0 {
+		fmt.Printf("  Arch:      %s\n", strings.Join(manifest.Requires.Arch, ", "))
+	}
+
+	// Ports
+	if len(manifest.Ports) > 0 {
+		fmt.Println()
+		bold.Println("Ports:")
+		for _, p := range manifest.Ports {
+			proto := p.Protocol
+			if proto == "" {
+				proto = "tcp"
+			}
+			desc := ""
+			if p.Description != "" {
+				desc = "  " + p.Description
+			}
+			fmt.Printf("  %d -> %d/%s%s\n", p.Host, p.Container, proto, desc)
+		}
+	}
+
+	// Config
+	if len(manifest.Config) > 0 {
+		fmt.Println()
+		bold.Println("Configuration:")
+
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		for _, cv := range manifest.Config {
+			def := ""
+			if cv.Default != "" {
+				def = fmt.Sprintf("[default: %s]", cv.Default)
+			} else if cv.Required {
+				def = color.New(color.FgRed).Sprint("[required]")
+			}
+			fmt.Fprintf(w, "  %s\t%s\t%s\n", cv.Name, cv.Description, def)
+		}
+		w.Flush()
+	}
+
+	// Volumes
+	if len(manifest.Volumes) > 0 {
+		fmt.Println()
+		bold.Println("Volumes:")
+		for _, v := range manifest.Volumes {
+			desc := ""
+			if v.Description != "" {
+				desc = "  " + v.Description
+			}
+			fmt.Printf("  %s -> %s%s\n", v.Host, v.Container, desc)
+		}
+	}
+
+	// Tags
+	if len(manifest.Tags) > 0 {
+		fmt.Println()
+		bold.Print("Tags: ")
+		fmt.Println(strings.Join(manifest.Tags, ", "))
+	}
+
+	return nil
+}
+
+// runCatalogInstall installs a service from the catalog and registers it in the manifest.
+func runCatalogInstall(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	// Parse --set flags into a map.
+	overrides := make(map[string]string)
+	for _, kv := range catalogInstallConfigFlags {
+		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid --set value '%s': expected KEY=VALUE", kv)
+		}
+		overrides[parts[0]] = parts[1]
+	}
+
+	// Find or create the node manifest to get the services directory.
+	manifest, configDir, err := findOrCreateManifest()
+	if err != nil {
+		return fmt.Errorf("failed to initialize configuration: %w", err)
+	}
+
+	// Check if already installed.
+	if hasService(manifest, name) {
+		fmt.Printf("Service '%s' is already in the node manifest.\n", name)
+		return nil
+	}
+
+	servicesDir := filepath.Join(configDir, "services")
+
+	fmt.Printf("Installing %s from catalog...\n", name)
+
+	result, err := catalog.Install(name, servicesDir, overrides)
+	if err != nil {
+		return fmt.Errorf("install failed: %w", err)
+	}
+
+	// Register in the node manifest using existing helpers.
+	if err := addServiceToManifest(configDir, result.Name); err != nil {
+		return fmt.Errorf("failed to update manifest: %w", err)
+	}
+
+	fmt.Printf("\nInstalled %s successfully.\n", result.Name)
+	fmt.Printf("  Compose: %s\n", result.ComposeDestPath)
+	if result.EnvDestPath != "" {
+		fmt.Printf("  Config:  %s\n", result.EnvDestPath)
+	}
+	fmt.Printf("\nTo start the service:\n")
+	fmt.Printf("  citadel run %s\n", result.Name)
+
+	return nil
+}
+
+// installedServiceSet returns a set of service names that are in the current node manifest.
+func installedServiceSet() map[string]bool {
+	installed := make(map[string]bool)
+	manifest, _, err := findAndReadManifest()
+	if err != nil {
+		return installed
+	}
+	for _, s := range manifest.Services {
+		installed[s.Name] = true
+	}
+	return installed
+}
+
+// truncate is defined in mcp.go and reused here.

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -1,0 +1,342 @@
+// Package catalog manages the local cache of the citadel-services catalog repository
+// and provides functions for reading service manifests and registry entries.
+package catalog
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// DefaultCatalogURL is the git URL for the official service catalog.
+	DefaultCatalogURL = "https://github.com/aceteam-ai/citadel-services.git"
+	// catalogSubdir is the subdirectory within the config dir for the catalog cache.
+	catalogSubdir = "catalog"
+)
+
+// Registry is the top-level index of available services (registry.yaml).
+type Registry struct {
+	Version  int             `yaml:"version"`
+	Services []RegistryEntry `yaml:"services"`
+}
+
+// RegistryEntry is a summary of a single service in the registry index.
+type RegistryEntry struct {
+	Name        string   `yaml:"name"`
+	Version     string   `yaml:"version"`
+	Category    string   `yaml:"category"`
+	GPU         string   `yaml:"gpu"` // "required", "optional", "no"
+	Description string   `yaml:"description"`
+	Tags        []string `yaml:"tags,omitempty"`
+}
+
+// ServiceManifest is the full definition of a service (service.yaml inside a service dir).
+type ServiceManifest struct {
+	Name        string        `yaml:"name"`
+	Version     string        `yaml:"version"`
+	Description string        `yaml:"description"`
+	Category    string        `yaml:"category"`
+	Author      string        `yaml:"author"`
+	License     string        `yaml:"license"`
+	Homepage    string        `yaml:"homepage"`
+	Requires    Requirements  `yaml:"requires"`
+	Ports       []PortMapping `yaml:"ports"`
+	Config      []ConfigVar   `yaml:"config"`
+	HealthCheck HealthCheck   `yaml:"health_check"`
+	Volumes     []VolumeMount `yaml:"volumes"`
+	Tags        []string      `yaml:"tags"`
+}
+
+// Requirements describes what a service needs from the host.
+type Requirements struct {
+	GPU       bool     `yaml:"gpu"`
+	VRAMMinGB float64  `yaml:"vram_min_gb"`
+	Arch      []string `yaml:"arch"`
+}
+
+// PortMapping describes a port exposed by the service container.
+type PortMapping struct {
+	Host        int    `yaml:"host"`
+	Container   int    `yaml:"container"`
+	Protocol    string `yaml:"protocol"`
+	Description string `yaml:"description"`
+}
+
+// ConfigVar describes a user-configurable environment variable.
+type ConfigVar struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+	Default     string `yaml:"default"`
+	Required    bool   `yaml:"required"`
+}
+
+// HealthCheck describes how to probe the service for readiness.
+type HealthCheck struct {
+	Endpoint string `yaml:"endpoint"`
+	Port     int    `yaml:"port"`
+	Interval string `yaml:"interval"`
+	Timeout  string `yaml:"timeout"`
+	Retries  int    `yaml:"retries"`
+}
+
+// VolumeMount describes a bind mount from host to container.
+type VolumeMount struct {
+	Name        string `yaml:"name"`
+	Host        string `yaml:"host"`
+	Container   string `yaml:"container"`
+	Description string `yaml:"description"`
+}
+
+// GetCatalogPath returns the local catalog cache directory.
+// It uses platform.ConfigDir() so that root/sudo/Windows are handled correctly.
+func GetCatalogPath() string {
+	return filepath.Join(platform.ConfigDir(), catalogSubdir)
+}
+
+// IsAvailable returns true if the catalog has been cloned locally.
+func IsAvailable() bool {
+	info, err := os.Stat(GetCatalogPath())
+	return err == nil && info.IsDir()
+}
+
+// Update clones or pulls the catalog repository into the local cache.
+func Update() error {
+	catalogPath := GetCatalogPath()
+
+	// Ensure parent directory exists.
+	if err := os.MkdirAll(filepath.Dir(catalogPath), 0755); err != nil {
+		return fmt.Errorf("failed to create catalog parent directory: %w", err)
+	}
+
+	if isGitRepo(catalogPath) {
+		// Pull latest changes.
+		cmd := exec.Command("git", "-C", catalogPath, "pull", "--ff-only")
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("git pull failed: %s", strings.TrimSpace(string(output)))
+		}
+		return nil
+	}
+
+	// Fresh clone. Remove any leftover non-git directory first.
+	if err := os.RemoveAll(catalogPath); err != nil {
+		return fmt.Errorf("failed to clean catalog directory: %w", err)
+	}
+
+	cmd := exec.Command("git", "clone", "--depth", "1", DefaultCatalogURL, catalogPath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git clone failed: %s", strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// LoadRegistry reads the registry.yaml index file.
+// If registry.yaml is absent, it falls back to scanning service subdirectories.
+func LoadRegistry() (*Registry, error) {
+	catalogPath := GetCatalogPath()
+	if !IsAvailable() {
+		return nil, fmt.Errorf("catalog not found. Run 'citadel service catalog update' first")
+	}
+
+	registryPath := filepath.Join(catalogPath, "registry.yaml")
+	data, err := os.ReadFile(registryPath)
+	if err == nil {
+		var reg Registry
+		if err := yaml.Unmarshal(data, &reg); err != nil {
+			return nil, fmt.Errorf("failed to parse registry.yaml: %w", err)
+		}
+		return &reg, nil
+	}
+
+	// Fallback: scan subdirectories for service.yaml files.
+	return scanForServices(catalogPath)
+}
+
+// LoadServiceManifest reads a specific service's service.yaml.
+func LoadServiceManifest(name string) (*ServiceManifest, error) {
+	catalogPath := GetCatalogPath()
+	manifestPath := filepath.Join(catalogPath, name, "service.yaml")
+
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("service '%s' not found in catalog", name)
+		}
+		return nil, fmt.Errorf("failed to read service manifest: %w", err)
+	}
+
+	var manifest ServiceManifest
+	if err := yaml.Unmarshal(data, &manifest); err != nil {
+		return nil, fmt.Errorf("failed to parse service manifest for '%s': %w", name, err)
+	}
+	return &manifest, nil
+}
+
+// GetComposeFile returns the path to a service's compose.yml inside the catalog.
+func GetComposeFile(name string) (string, error) {
+	catalogPath := GetCatalogPath()
+	composePath := filepath.Join(catalogPath, name, "compose.yml")
+
+	if _, err := os.Stat(composePath); err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("compose.yml not found for service '%s'", name)
+		}
+		return "", fmt.Errorf("failed to access compose file: %w", err)
+	}
+	return composePath, nil
+}
+
+// Search filters services by a query string, matching against name, tags, category,
+// and description (case-insensitive).
+func Search(query string) ([]RegistryEntry, error) {
+	reg, err := LoadRegistry()
+	if err != nil {
+		return nil, err
+	}
+
+	q := strings.ToLower(query)
+	var results []RegistryEntry
+
+	for _, entry := range reg.Services {
+		if matchesQuery(entry, q) {
+			results = append(results, entry)
+		}
+	}
+	return results, nil
+}
+
+// CheckGPU checks whether an NVIDIA GPU is available and returns VRAM in GB.
+func CheckGPU() (hasGPU bool, vramGB float64, err error) {
+	cmd := exec.Command("nvidia-smi", "--query-gpu=memory.total", "--format=csv,noheader,nounits")
+	output, err := cmd.Output()
+	if err != nil {
+		return false, 0, nil // nvidia-smi not found or failed -- no GPU
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	if len(lines) == 0 {
+		return false, 0, nil
+	}
+
+	// Sum VRAM across all GPUs.
+	var totalMB float64
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var mb float64
+		if _, err := fmt.Sscanf(line, "%f", &mb); err == nil {
+			totalMB += mb
+		}
+	}
+
+	if totalMB > 0 {
+		return true, totalMB / 1024.0, nil
+	}
+	return false, 0, nil
+}
+
+// CheckPortConflict returns true if the given port is already in use.
+func CheckPortConflict(port int) bool {
+	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		return true // port is in use
+	}
+	ln.Close()
+	return false
+}
+
+// CheckArchCompatible returns true if the current architecture matches any in the list.
+// An empty list means any architecture is acceptable.
+func CheckArchCompatible(archList []string) bool {
+	if len(archList) == 0 {
+		return true
+	}
+	current := runtime.GOARCH
+	for _, a := range archList {
+		if a == current {
+			return true
+		}
+	}
+	return false
+}
+
+// --- internal helpers ---
+
+func isGitRepo(path string) bool {
+	info, err := os.Stat(filepath.Join(path, ".git"))
+	return err == nil && info.IsDir()
+}
+
+func matchesQuery(entry RegistryEntry, query string) bool {
+	if strings.Contains(strings.ToLower(entry.Name), query) {
+		return true
+	}
+	if strings.Contains(strings.ToLower(entry.Category), query) {
+		return true
+	}
+	if strings.Contains(strings.ToLower(entry.Description), query) {
+		return true
+	}
+	for _, tag := range entry.Tags {
+		if strings.Contains(strings.ToLower(tag), query) {
+			return true
+		}
+	}
+	return false
+}
+
+// scanForServices scans the catalog directory for service.yaml files when registry.yaml
+// is absent. Each immediate subdirectory containing a service.yaml becomes an entry.
+func scanForServices(catalogPath string) (*Registry, error) {
+	entries, err := os.ReadDir(catalogPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan catalog directory: %w", err)
+	}
+
+	var reg Registry
+	reg.Version = 1
+
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+
+		manifestPath := filepath.Join(catalogPath, entry.Name(), "service.yaml")
+		data, err := os.ReadFile(manifestPath)
+		if err != nil {
+			continue // skip directories without service.yaml
+		}
+
+		var manifest ServiceManifest
+		if err := yaml.Unmarshal(data, &manifest); err != nil {
+			continue // skip malformed manifests
+		}
+
+		gpuStr := "no"
+		if manifest.Requires.GPU {
+			gpuStr = "required"
+		}
+
+		reg.Services = append(reg.Services, RegistryEntry{
+			Name:        manifest.Name,
+			Version:     manifest.Version,
+			Category:    manifest.Category,
+			GPU:         gpuStr,
+			Description: manifest.Description,
+			Tags:        manifest.Tags,
+		})
+	}
+
+	return &reg, nil
+}

--- a/internal/catalog/install.go
+++ b/internal/catalog/install.go
@@ -1,0 +1,165 @@
+package catalog
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// InstallResult holds the artifacts produced by a catalog install so the caller
+// (cmd layer) can register the service in the node manifest.
+type InstallResult struct {
+	// Name is the canonical service name.
+	Name string
+	// ComposeDestPath is the absolute path where compose.yml was written.
+	ComposeDestPath string
+	// EnvDestPath is the absolute path where the .env file was written, or empty.
+	EnvDestPath string
+}
+
+// Install copies a catalog service's compose.yml (and optional .env) into the
+// node's services directory. It checks requirements and port conflicts before
+// copying. Manifest registration is the caller's responsibility (cmd layer).
+//
+// servicesDir is the absolute path to the node's services directory
+// (e.g. ~/citadel-node/services). configOverrides are key=value pairs that
+// override config defaults.
+func Install(name string, servicesDir string, configOverrides map[string]string) (*InstallResult, error) {
+	// 1. Load service manifest from catalog.
+	manifest, err := LoadServiceManifest(name)
+	if err != nil {
+		return nil, err
+	}
+
+	// 2. Check architecture compatibility.
+	if !CheckArchCompatible(manifest.Requires.Arch) {
+		return nil, fmt.Errorf("service '%s' requires architecture %v, but this machine is %s",
+			name, manifest.Requires.Arch, runtime.GOARCH)
+	}
+
+	// 3. Check GPU requirements.
+	if manifest.Requires.GPU {
+		hasGPU, vramGB, err := CheckGPU()
+		if err != nil {
+			return nil, fmt.Errorf("failed to check GPU: %w", err)
+		}
+		if !hasGPU {
+			return nil, fmt.Errorf("service '%s' requires a GPU, but none was detected", name)
+		}
+		if manifest.Requires.VRAMMinGB > 0 && vramGB < manifest.Requires.VRAMMinGB {
+			return nil, fmt.Errorf("service '%s' requires %.1f GB VRAM, but only %.1f GB available",
+				name, manifest.Requires.VRAMMinGB, vramGB)
+		}
+	}
+
+	// 4. Check port conflicts.
+	var conflicts []int
+	for _, p := range manifest.Ports {
+		if CheckPortConflict(p.Host) {
+			conflicts = append(conflicts, p.Host)
+		}
+	}
+	if len(conflicts) > 0 {
+		return nil, fmt.Errorf("port conflict: port(s) %v already in use", conflicts)
+	}
+
+	// 5. Resolve config values (prompt for required ones without defaults).
+	configValues, err := resolveConfig(manifest.Config, configOverrides)
+	if err != nil {
+		return nil, err
+	}
+
+	// 6. Copy compose.yml to services directory.
+	composeSrc, err := GetComposeFile(name)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := os.MkdirAll(servicesDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create services directory: %w", err)
+	}
+
+	composeDest := filepath.Join(servicesDir, name+".yml")
+	if err := copyFile(composeSrc, composeDest); err != nil {
+		return nil, fmt.Errorf("failed to copy compose file: %w", err)
+	}
+
+	result := &InstallResult{
+		Name:            name,
+		ComposeDestPath: composeDest,
+	}
+
+	// 7. Write .env file if there are config values.
+	if len(configValues) > 0 {
+		envDest := filepath.Join(servicesDir, name+".env")
+		if err := writeEnvFile(envDest, configValues); err != nil {
+			return nil, fmt.Errorf("failed to write env file: %w", err)
+		}
+		result.EnvDestPath = envDest
+	}
+
+	return result, nil
+}
+
+// resolveConfig merges overrides with defaults, prompting the user for any
+// required config vars that have no default and no override.
+func resolveConfig(configVars []ConfigVar, overrides map[string]string) (map[string]string, error) {
+	values := make(map[string]string)
+
+	for _, cv := range configVars {
+		// Check override first.
+		if v, ok := overrides[cv.Name]; ok {
+			values[cv.Name] = v
+			continue
+		}
+
+		// Use default if available.
+		if cv.Default != "" {
+			values[cv.Name] = cv.Default
+			continue
+		}
+
+		// Required without default -- prompt the user.
+		if cv.Required {
+			fmt.Printf("  %s", cv.Name)
+			if cv.Description != "" {
+				fmt.Printf(" (%s)", cv.Description)
+			}
+			fmt.Print(": ")
+
+			scanner := bufio.NewScanner(os.Stdin)
+			if !scanner.Scan() {
+				return nil, fmt.Errorf("aborted: no value provided for required config '%s'", cv.Name)
+			}
+			val := strings.TrimSpace(scanner.Text())
+			if val == "" {
+				return nil, fmt.Errorf("required config '%s' cannot be empty", cv.Name)
+			}
+			values[cv.Name] = val
+		}
+	}
+
+	return values, nil
+}
+
+// copyFile copies src to dst, preserving content but using 0600 permissions.
+func copyFile(src, dst string) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dst, data, 0600)
+}
+
+// writeEnvFile writes key=value pairs to a file, one per line.
+func writeEnvFile(path string, values map[string]string) error {
+	var lines []string
+	for k, v := range values {
+		lines = append(lines, fmt.Sprintf("%s=%s", k, v))
+	}
+	content := strings.Join(lines, "\n") + "\n"
+	return os.WriteFile(path, []byte(content), 0600)
+}


### PR DESCRIPTION
## Context
Phase 1 of the Service Marketplace (#196). Citadel nodes can now browse and install services from the [citadel-services](https://github.com/aceteam-ai/citadel-services) catalog repo.

## Summary

### New commands
```
citadel service catalog update          # git clone/pull catalog
citadel service catalog list            # tabular view with install status
citadel service catalog search <query>  # filter by name/tag/category
citadel service catalog info <name>     # full manifest details
citadel service catalog install <name>  # install to node
```

### New package: `internal/catalog/`
- **catalog.go** (342 lines) — registry/manifest YAML parsing, git clone/pull, search across name/tags/category/description
- **install.go** (165 lines) — GPU detection via nvidia-smi, port conflict check, arch compatibility, compose file copy, env file generation from config vars

### CLI wiring: `cmd/catalog.go`
- Registers under existing `svcCmd` (`citadel service`)
- Pretty output with tabwriter + fatih/color
- `--set KEY=VALUE` flags for config overrides on install
- Install integrates with existing manifest helpers (`findOrCreateManifest`, `addServiceToManifest`)

## Catalog repo
https://github.com/aceteam-ai/citadel-services — initialized with ollama, vllm, llamacpp + schema + templates.

Closes #196