### PR TITLE
fix(jobs): run shell commands via /bin/sh -c with workspace cwd

### DIFF
--- a/cmd/job_handlers.go
+++ b/cmd/job_handlers.go
@@ -55,7 +55,7 @@ func executeJob(client *nexus.Client, job *nexus.Job) (string, error) {
 func init() {
 	// Register all job handlers for test command
 	jobHandlers = map[string]jobs.JobHandler{
-		"SHELL_COMMAND":      &jobs.ShellCommandHandler{},
+		"SHELL_COMMAND":      jobs.NewShellCommandHandler(""),
 		"DOWNLOAD_MODEL":     &jobs.DownloadModelHandler{},
 		"OLLAMA_PULL":        &jobs.OllamaPullHandler{},
 		"LLAMACPP_INFERENCE": &jobs.LlamaCppInferenceHandler{},

--- a/internal/jobs/shell_command.go
+++ b/internal/jobs/shell_command.go
@@ -11,9 +11,10 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
 )
 
-// standardPATHDirs are directories to search when the process PATH
-// does not include them (e.g. when citadel runs via systemd or nohup
-// with a restricted environment).
+// standardPATHDirs are directories ensured on PATH when the inherited process
+// environment is restricted (e.g. citadel running via systemd or nohup with a
+// minimal PATH). They are merged into the command environment so /bin/sh can
+// resolve common executables.
 var standardPATHDirs = []string{
 	"/usr/local/sbin",
 	"/usr/local/bin",
@@ -23,49 +24,64 @@ var standardPATHDirs = []string{
 	"/bin",
 }
 
-// resolveExecutable finds the absolute path of an executable.
-// It first tries the normal PATH lookup (exec.LookPath). If that fails,
-// it falls back to searching standardPATHDirs for the binary.
-func resolveExecutable(name string) (string, error) {
-	// If the name contains a slash it is already a path; skip lookup.
-	if strings.Contains(name, "/") {
-		return name, nil
-	}
-
-	// Try the current process PATH first (preserves existing behavior).
-	if p, err := exec.LookPath(name); err == nil {
-		return p, nil
-	}
-
-	// Fallback: scan standard directories that may not be in PATH.
-	for _, dir := range standardPATHDirs {
-		candidate := filepath.Join(dir, name)
-		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
-			return candidate, nil
+// augmentedEnv returns os.Environ() with the PATH entry extended to include any
+// standardPATHDirs not already present (no duplicates). If no PATH entry exists,
+// one is added. This preserves the restricted-environment fallback from #154
+// now that commands run through /bin/sh rather than a direct exec lookup.
+func augmentedEnv() []string {
+	env := os.Environ()
+	sep := string(os.PathListSeparator)
+	for i, kv := range env {
+		if !strings.HasPrefix(kv, "PATH=") {
+			continue
 		}
+		current := strings.TrimPrefix(kv, "PATH=")
+		existing := make(map[string]struct{})
+		for _, d := range filepath.SplitList(current) {
+			existing[d] = struct{}{}
+		}
+		var additions []string
+		for _, d := range standardPATHDirs {
+			if _, ok := existing[d]; !ok {
+				additions = append(additions, d)
+			}
+		}
+		if len(additions) > 0 {
+			env[i] = "PATH=" + current + sep + strings.Join(additions, sep)
+		}
+		return env
 	}
-
-	return "", fmt.Errorf("executable %q not found in PATH or standard system directories", name)
+	return append(env, "PATH="+strings.Join(standardPATHDirs, sep))
 }
 
-type ShellCommandHandler struct{}
+// ShellCommandHandler executes a command string through /bin/sh -c, so pipes,
+// redirects, && / ||, quoting, and command substitution behave as expected.
+type ShellCommandHandler struct {
+	// WorkspaceDir, when non-empty, is set as the command's working directory so
+	// relative paths resolve consistently with the file-operation handlers.
+	WorkspaceDir string
+}
+
+// NewShellCommandHandler constructs a handler bound to a workspace directory.
+// A zero-value &ShellCommandHandler{} remains valid (no working directory set).
+func NewShellCommandHandler(workspace string) *ShellCommandHandler {
+	return &ShellCommandHandler{WorkspaceDir: workspace}
+}
 
 func (h *ShellCommandHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
 	cmdString, ok := job.Payload["command"]
 	if !ok {
 		return nil, fmt.Errorf("job payload missing 'command' field")
 	}
-	ctx.Log("info", "     - [Job %s] Running shell command: '%s'", job.ID, cmdString)
-	parts := strings.Fields(cmdString)
-	if len(parts) == 0 {
+	if strings.TrimSpace(cmdString) == "" {
 		return nil, fmt.Errorf("empty command")
 	}
+	ctx.Log("info", "     - [Job %s] Running shell command: '%s'", job.ID, cmdString)
 
-	resolvedPath, err := resolveExecutable(parts[0])
-	if err != nil {
-		return nil, err
+	cmd := exec.Command("/bin/sh", "-c", cmdString)
+	cmd.Env = augmentedEnv()
+	if h.WorkspaceDir != "" {
+		cmd.Dir = h.WorkspaceDir
 	}
-
-	cmd := exec.Command(resolvedPath, parts[1:]...)
 	return cmd.CombinedOutput()
 }

--- a/internal/jobs/shell_command_test.go
+++ b/internal/jobs/shell_command_test.go
@@ -2,10 +2,22 @@ package jobs
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
 )
+
+func runShell(t *testing.T, h *ShellCommandHandler, command string) ([]byte, error) {
+	t.Helper()
+	return h.Execute(JobContext{}, &nexus.Job{
+		ID:   "test",
+		Type: "SHELL_COMMAND",
+		Payload: map[string]string{
+			"command": command,
+		},
+	})
+}
 
 func TestShellCommand_MissingCommand(t *testing.T) {
 	h := &ShellCommandHandler{}
@@ -21,13 +33,8 @@ func TestShellCommand_MissingCommand(t *testing.T) {
 
 func TestShellCommand_EmptyCommand(t *testing.T) {
 	h := &ShellCommandHandler{}
-	_, err := h.Execute(JobContext{}, &nexus.Job{
-		ID:   "test-2",
-		Type: "SHELL_COMMAND",
-		Payload: map[string]string{
-			"command": "   ",
-		},
-	})
+	// Whitespace-only command must be rejected.
+	_, err := runShell(t, h, "   ")
 	if err == nil {
 		t.Fatal("expected error for empty command, got nil")
 	}
@@ -35,13 +42,7 @@ func TestShellCommand_EmptyCommand(t *testing.T) {
 
 func TestShellCommand_BasicExecution(t *testing.T) {
 	h := &ShellCommandHandler{}
-	out, err := h.Execute(JobContext{}, &nexus.Job{
-		ID:   "test-3",
-		Type: "SHELL_COMMAND",
-		Payload: map[string]string{
-			"command": "echo hello",
-		},
-	})
+	out, err := runShell(t, h, "echo hello")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -50,71 +51,87 @@ func TestShellCommand_BasicExecution(t *testing.T) {
 	}
 }
 
-func TestResolveExecutable_NormalPATH(t *testing.T) {
-	// "true" is a standard executable in /usr/bin or /bin.
-	p, err := resolveExecutable("true")
-	if err != nil {
-		t.Fatalf("resolveExecutable(true) failed: %v", err)
-	}
-	if p == "" {
-		t.Error("resolved path should not be empty")
-	}
-}
-
-func TestResolveExecutable_RestrictedPATH(t *testing.T) {
-	// Temporarily set PATH to something that excludes standard dirs.
-	origPATH := os.Getenv("PATH")
-	t.Cleanup(func() { os.Setenv("PATH", origPATH) })
-
-	os.Setenv("PATH", "/nonexistent_dir_only")
-
-	// "true" lives in /usr/bin or /bin, which are in standardPATHDirs.
-	p, err := resolveExecutable("true")
-	if err != nil {
-		t.Fatalf("resolveExecutable(true) with restricted PATH should still find it via fallback, got: %v", err)
-	}
-	if p != "/usr/bin/true" && p != "/bin/true" {
-		t.Errorf("expected /usr/bin/true or /bin/true, got %q", p)
-	}
-}
-
-func TestResolveExecutable_NotFound(t *testing.T) {
-	_, err := resolveExecutable("definitely_not_a_real_binary_xyz123")
-	if err == nil {
-		t.Fatal("expected error for nonexistent binary, got nil")
-	}
-}
-
-func TestResolveExecutable_WithSlash(t *testing.T) {
-	// If the name contains a slash, it should be returned as-is.
-	p, err := resolveExecutable("/some/absolute/path")
+func TestShellCommand_Pipe(t *testing.T) {
+	h := &ShellCommandHandler{}
+	out, err := runShell(t, h, "echo hello | cat")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if p != "/some/absolute/path" {
-		t.Errorf("expected /some/absolute/path, got %q", p)
+	if string(out) != "hello\n" {
+		t.Errorf("output = %q, want %q", string(out), "hello\n")
+	}
+}
+
+func TestShellCommand_AndAnd(t *testing.T) {
+	h := &ShellCommandHandler{}
+	out, err := runShell(t, h, "true && echo ok")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(out) != "ok\n" {
+		t.Errorf("output = %q, want %q", string(out), "ok\n")
+	}
+}
+
+func TestShellCommand_QuotedArgs(t *testing.T) {
+	h := &ShellCommandHandler{}
+	out, err := runShell(t, h, `echo "a b c"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(out) != "a b c\n" {
+		t.Errorf("output = %q, want %q", string(out), "a b c\n")
+	}
+}
+
+func TestShellCommand_MultiLineScript(t *testing.T) {
+	h := &ShellCommandHandler{}
+	out, err := runShell(t, h, "set -e\necho one\necho two")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(out) != "one\ntwo\n" {
+		t.Errorf("output = %q, want %q", string(out), "one\ntwo\n")
+	}
+}
+
+func TestShellCommand_NonZeroExit(t *testing.T) {
+	h := &ShellCommandHandler{}
+	_, err := runShell(t, h, "exit 3")
+	if err == nil {
+		t.Fatal("expected error for non-zero exit, got nil")
+	}
+}
+
+func TestShellCommand_WorkspaceCwd(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "foo.txt"), []byte("bar"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	h := NewShellCommandHandler(dir)
+	// Relative path resolves against the configured workspace directory.
+	out, err := runShell(t, h, "cat foo.txt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(out) != "bar" {
+		t.Errorf("output = %q, want %q", string(out), "bar")
 	}
 }
 
 func TestShellCommand_RestrictedPATH(t *testing.T) {
-	// Verify the full handler works even with a restricted PATH.
+	// With a restricted inherited PATH, augmentedEnv must still let /bin/sh
+	// resolve a non-builtin external binary (uname) via standardPATHDirs.
 	origPATH := os.Getenv("PATH")
 	t.Cleanup(func() { os.Setenv("PATH", origPATH) })
-
 	os.Setenv("PATH", "/nonexistent_dir_only")
 
 	h := &ShellCommandHandler{}
-	out, err := h.Execute(JobContext{}, &nexus.Job{
-		ID:   "test-4",
-		Type: "SHELL_COMMAND",
-		Payload: map[string]string{
-			"command": "echo works",
-		},
-	})
+	out, err := runShell(t, h, "uname")
 	if err != nil {
-		t.Fatalf("shell command with restricted PATH should work via fallback: %v", err)
+		t.Fatalf("shell command with restricted PATH should work via augmented env: %v", err)
 	}
-	if string(out) != "works\n" {
-		t.Errorf("output = %q, want %q", string(out), "works\n")
+	if len(out) == 0 {
+		t.Error("expected uname output, got empty")
 	}
 }

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -120,7 +120,7 @@ func CreateLegacyHandlers(logFn ...func(level, msg string)) []JobHandler {
 // for file-operation handlers).
 func CreateLegacyHandlersWithOpts(opts LegacyHandlerOpts) []JobHandler {
 	handlers := []*LegacyHandlerAdapter{
-		NewLegacyHandlerAdapter(JobTypeShellCommand, &jobs.ShellCommandHandler{}),
+		NewLegacyHandlerAdapter(JobTypeShellCommand, jobs.NewShellCommandHandler(opts.WorkspaceDir)),
 		NewLegacyHandlerAdapter(JobTypeDownloadModel, &jobs.DownloadModelHandler{}),
 		NewLegacyHandlerAdapter(JobTypeOllamaPull, &jobs.OllamaPullHandler{}),
 		NewLegacyHandlerAdapter(JobTypeLlamaCppInference, &jobs.LlamaCppInferenceHandler{}),


### PR DESCRIPTION
## Context

The `ShellCommandHandler` (`internal/jobs/shell_command.go`) split the incoming command on whitespace (`strings.Fields`) and `exec.Command`'d it directly — it **never invoked a shell**. So pipes, `&&`/`||`, redirects, quoting, command substitution, and multi-line scripts could not run.

The AceTeam backend sends commands wrapped as `sh -c '<script>; echo __rc:$?'`. `strings.Fields` shredded that into `["sh","-c","'<script>;",...]`, so it never worked. This is the root cause behind:
- **aceteam-ai/aceteam#3859** — memory sync / transcript sync (multi-line git scripts) never executed.
- **`terminal_exec`** — any command using a pipe, `&&`, quotes, or redirection was silently mangled.

## Summary

- **`Execute` now runs `exec.Command("/bin/sh", "-c", cmdString)`** — full shell semantics.
- **`WorkspaceDir` + `NewShellCommandHandler(workspace)`** — when set, becomes `cmd.Dir` so relative paths resolve consistently with the file-operation handlers (this is what lets AceTeam's now-workspace-relative memory repo paths resolve under the sandbox workspace). Zero-value `&ShellCommandHandler{}` still valid.
- **`augmentedEnv()`** preserves the restricted-environment fallback from #154: it merges `standardPATHDirs` into the subprocess `PATH` (no duplicates) so `/bin/sh` can resolve common executables under systemd/nohup.
- Reject whitespace-only commands; removed the now-dead `resolveExecutable`.
- Wired the workspace through `internal/worker/handler_adapter.go` (uses `opts.WorkspaceDir`). `cmd/job_handlers.go` (test-command registry, no workspace in scope) passes `""` — behavior preserved.

## Test plan

`go build ./...` clean. `go test ./internal/jobs/... ./internal/worker/...` — all pass. New/updated tests in `internal/jobs/shell_command_test.go`:

| Test | Proves |
|------|--------|
| `Pipe` | `echo hello \| cat` → `hello` |
| `AndAnd` | `true && echo ok` → `ok` |
| `QuotedArgs` | `echo "a b c"` → `a b c` |
| `MultiLineScript` | multi-line `set -e` script runs |
| `NonZeroExit` | non-zero exit surfaces an error |
| `WorkspaceCwd` | relative `cat foo.txt` reads a file in `WorkspaceDir` |
| `RestrictedPATH` | `uname` resolves via `augmentedEnv()` with a stripped PATH |
| `Missing/EmptyCommand` | guards preserved (whitespace-only rejected) |

## Security / human review

**Intended behavior change:** commands now run through `/bin/sh -c`, so shell metacharacters are interpreted (the whole point — the backend already wraps as `sh -c`). Any caller able to enqueue a `SHELL_COMMAND` / `terminal_exec` job therefore has full shell semantics on the node, where `strings.Fields` previously neutered metacharacters. This is gated upstream: `SHELL_COMMAND` jobs are dispatched only on org-scoped queues (`jobs:v1:shell:org_{org}`) by org-authenticated MCP/API callers, i.e. the node operator's own org. Backward compatible for simple commands. Worth a sign-off given it unblocks aceteam#3859 and `terminal_exec`.

## Related
- Unblocks aceteam-ai/aceteam#3859 (memory/transcript sync) and the companion PR aceteam-ai/aceteam#3865.