### PR TITLE
fix(gateway): restrict TLS ALPN to HTTP/1.1 only (#3831)

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -144,6 +144,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		tlsConfig = &tls.Config{
 			Certificates: []tls.Certificate{cert},
 			MinVersion:   tls.VersionTLS12,
+			NextProtos:   []string{"http/1.1"},
 		}
 
 		fmt.Printf("   - TLS: self-signed (cert: %s)\n", tlscert.CertPath(serveCertDir))

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -956,6 +956,7 @@ func runWork(cmd *cobra.Command, args []string) {
 			gwTLSConfig = &tls.Config{
 				Certificates: []tls.Certificate{cert},
 				MinVersion:   tls.VersionTLS12,
+				NextProtos:   []string{"http/1.1"},
 			}
 			fmt.Printf("   - Gateway TLS: self-signed (cert: %s)\n", tlscert.CertPath(workGatewayCertDir))
 		}


### PR DESCRIPTION
## Context

Go's crypto/tls defaults NextProtos to ["h2", "http/1.1"] when empty, advertising HTTP/2 support. But the gateway uses raw http.Server without http2.ConfigureServer(), so clients negotiating h2 get broken connections.

## Summary

One-liner in two places: add `NextProtos: []string{"http/1.1"}` to the TLS config in `serve.go` and `work.go`.

Closes aceteam-ai/aceteam#3831

## Test plan

- `go build ./...` passes
- curl to gateway no longer attempts h2 negotiation

---
*Generated by Claude*