### PR TITLE
fix: use LOCALAPPDATA for Windows state directory

### DIFF
--- a/internal/network/state.go
+++ b/internal/network/state.go
@@ -31,14 +31,21 @@ func GetStateDir() string {
 	return filepath.Join(getUserHomeDir(), "citadel-node", "network")
 }
 
-// getUserHomeDir returns the user's home directory
+// getUserHomeDir returns the user's home directory.
+// On Windows, uses LOCALAPPDATA/APPDATA to avoid resolving to
+// C:\Windows\System32\config\systemprofile when running as SYSTEM.
 func getUserHomeDir() string {
 	if runtime.GOOS == "windows" {
-		baseDir := os.Getenv("USERPROFILE")
-		if baseDir == "" {
-			baseDir = os.Getenv("HOME")
+		if v := os.Getenv("LOCALAPPDATA"); v != "" {
+			return v
 		}
-		return baseDir
+		if v := os.Getenv("APPDATA"); v != "" {
+			return v
+		}
+		if home, err := os.UserHomeDir(); err == nil {
+			return home
+		}
+		return os.Getenv("USERPROFILE")
 	}
 
 	baseDir, err := os.UserHomeDir()

--- a/internal/update/state.go
+++ b/internal/update/state.go
@@ -120,14 +120,21 @@ func defaultState() *State {
 	}
 }
 
-// getUserHomeDir returns the user's home directory
+// getUserHomeDir returns the user's home directory.
+// On Windows, uses LOCALAPPDATA/APPDATA to avoid resolving to
+// C:\Windows\System32\config\systemprofile when running as SYSTEM.
 func getUserHomeDir() string {
 	if runtime.GOOS == "windows" {
-		baseDir := os.Getenv("USERPROFILE")
-		if baseDir == "" {
-			baseDir = os.Getenv("HOME")
+		if v := os.Getenv("LOCALAPPDATA"); v != "" {
+			return v
 		}
-		return baseDir
+		if v := os.Getenv("APPDATA"); v != "" {
+			return v
+		}
+		if home, err := os.UserHomeDir(); err == nil {
+			return home
+		}
+		return os.Getenv("USERPROFILE")
 	}
 
 	baseDir, err := os.UserHomeDir()


### PR DESCRIPTION
## Context

On Windows, `citadel login` succeeds but `citadel work` fails with:
```
Failed to connect: failed to create state directory: mkdir C:\Windows\System32\config\systemprofile: Cannot create a file when that file already exists.
```

`getUserHomeDir()` in both `internal/network/state.go` and `internal/update/state.go` used `USERPROFILE` as the first choice on Windows, which resolves to `C:\Windows\System32\config\systemprofile` when running as SYSTEM service account.

## Summary

- Use `LOCALAPPDATA` > `APPDATA` > `os.UserHomeDir()` > `USERPROFILE` fallback chain
- Matches the pattern already established in `platform.ConfigDir()` (which correctly uses LOCALAPPDATA)
- Fixed in both `internal/network/state.go` and `internal/update/state.go`

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/network/ ./internal/update/` passes
- [ ] Verify on Windows VM that `citadel work` no longer fails with mkdir error