### PR TITLE
feat(capabilities): add OS and architecture auto-detection tags

### DIFF
--- a/internal/capabilities/detector.go
+++ b/internal/capabilities/detector.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"os/exec"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -183,6 +184,12 @@ func DetectNodeCapabilities() *NodeCapabilities {
 
 	// Always add cpu:general
 	caps.Tags = append(caps.Tags, "cpu:general")
+
+	// Add OS tag
+	caps.Tags = append(caps.Tags, "os:"+runtime.GOOS)
+
+	// Add architecture tag
+	caps.Tags = append(caps.Tags, "arch:"+runtime.GOARCH)
 
 	return caps
 }


### PR DESCRIPTION
## Summary

- Adds `os:<runtime.GOOS>` tag (e.g., `os:linux`, `os:darwin`, `os:windows`) to `DetectNodeCapabilities()`
- Adds `arch:<runtime.GOARCH>` tag (e.g., `arch:amd64`, `arch:arm64`)
- Tags flow through heartbeat → Redis → SSE → fabric UI for OS-based grouping

## Test plan

- [x] `go build ./...` passes
- [x] Existing tests pass