### PR TITLE
fix(windows): reject SYSTEM profile paths in state directory resolution

### DIFF
--- a/internal/network/state.go
+++ b/internal/network/state.go
@@ -9,8 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
-
-	"gopkg.in/yaml.v3"
+	"strings"
 )
 
 // GetStateDir returns the state directory path for network state.
@@ -24,11 +23,24 @@ import (
 func GetStateDir() string {
 	// First, try to get state dir from global config (follows config location)
 	if nodeDir := getNodeConfigDirFromGlobalConfig(); nodeDir != "" {
-		return filepath.Join(nodeDir, "network")
+		// On Windows, reject paths under SYSTEM profile — these are written by a
+		// service running as LocalSystem and are inaccessible to interactive users.
+		if runtime.GOOS == "windows" && isSystemProfilePath(nodeDir) {
+			// Fall through to user home directory
+		} else {
+			return filepath.Join(nodeDir, "network")
+		}
 	}
 
 	// Fallback to user home directory
 	return filepath.Join(getUserHomeDir(), "citadel-node", "network")
+}
+
+// isSystemProfilePath returns true if the path is under the Windows SYSTEM
+// profile directory, which happens when a service running as LocalSystem
+// writes config with its own home directory.
+func isSystemProfilePath(p string) bool {
+	return strings.Contains(strings.ToLower(p), `\systemprofile`)
 }
 
 // getUserHomeDir returns the user's home directory.
@@ -55,23 +67,26 @@ func getUserHomeDir() string {
 	return baseDir
 }
 
-// getNodeConfigDirFromGlobalConfig reads node_config_dir from global config
+// getNodeConfigDirFromGlobalConfig reads node_config_dir from global config.
+// On Windows, checks both ProgramData (system-wide, written by services) and
+// LOCALAPPDATA (user-local, written by interactive init) locations.
 func getNodeConfigDirFromGlobalConfig() string {
-	globalConfigFile := filepath.Join(getGlobalConfigDirForState(), "config.yaml")
-
-	data, err := os.ReadFile(globalConfigFile)
-	if err != nil {
-		return ""
+	candidates := []string{
+		filepath.Join(getGlobalConfigDirForState(), "config.yaml"),
+	}
+	// On Windows, platform.ConfigDir() writes to LOCALAPPDATA\Citadel — also check there.
+	if runtime.GOOS == "windows" {
+		if v := os.Getenv("LOCALAPPDATA"); v != "" {
+			candidates = append(candidates, filepath.Join(v, "Citadel", "config.yaml"))
+		}
 	}
 
-	var config struct {
-		NodeConfigDir string `yaml:"node_config_dir"`
+	for _, path := range candidates {
+		if dir := readNodeConfigDir(path); dir != "" {
+			return dir
+		}
 	}
-	if err := yaml.Unmarshal(data, &config); err != nil {
-		return ""
-	}
-
-	return config.NodeConfigDir
+	return ""
 }
 
 // getGlobalConfigDirForState returns the global config directory path

--- a/internal/network/state_test.go
+++ b/internal/network/state_test.go
@@ -170,6 +170,26 @@ func TestEnsureStateDirCreatesDirectory(t *testing.T) {
 	}
 }
 
+// TestIsSystemProfilePath verifies detection of SYSTEM profile paths on Windows.
+func TestIsSystemProfilePath(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{`C:\Windows\system32\config\systemprofile\citadel-node`, true},
+		{`C:\WINDOWS\System32\config\SystemProfile\data`, true},
+		{`C:\Users\acewin\citadel-node`, false},
+		{`C:\Users\acewin\AppData\Local\citadel-node`, false},
+		{`/home/citadel/citadel-node`, false},
+	}
+	for _, tt := range tests {
+		got := isSystemProfilePath(tt.path)
+		if got != tt.want {
+			t.Errorf("isSystemProfilePath(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}
+
 // TestFixStatePermissions_NoOpWhenNotRoot verifies FixStatePermissions is safe to call as non-root.
 func TestFixStatePermissions_NoOpWhenNotRoot(t *testing.T) {
 	if os.Getuid() == 0 {


### PR DESCRIPTION
## Context

When citadel is installed as a Windows service (LocalSystem), `citadel init` writes `node_config_dir: C:\Windows\system32\config\systemprofile\citadel-node` to `C:\ProgramData\Citadel\config.yaml`. When an interactive user later runs citadel (via bat file or cmd), `GetStateDir()` reads that config and tries to `mkdir` under the SYSTEM profile directory, which fails with "Cannot create a file when that file already exists."

Root cause confirmed via diagnostic binary: `getUserHomeDir()` returned the correct `LOCALAPPDATA` path, but `getNodeConfigDirFromGlobalConfig()` returned the SYSTEM profile path from the ProgramData config, overriding the fallback.

## Summary

- **`isSystemProfilePath()` guard** — rejects any `node_config_dir` containing `\systemprofile` on Windows, falling through to the user's home directory
- **Multi-location config search** — `getNodeConfigDirFromGlobalConfig()` now checks both `ProgramData\Citadel` (system-wide, written by services) and `LOCALAPPDATA\Citadel` (user-local, written by interactive init), fixing the path mismatch between where `platform.ConfigDir()` writes and where `GetStateDir()` reads
- **Removed `yaml` import** from `state.go` — reuses `readNodeConfigDir()` from `singleton.go`

## Test plan

| Test | Status |
|------|--------|
| `TestIsSystemProfilePath` — 5 cases (system paths, user paths, Linux paths) | Pass |
| All existing `internal/network` tests | Pass |
| Verified on Windows VM: bad ProgramData config present → fixed binary resolves state dir correctly | Pass |
| Deleted broken LocalSystem service + cleaned ProgramData config on test machine | Done |

## Related

- Commit a4d6c72 (v2.27.1): original LOCALAPPDATA fix for `getUserHomeDir()`
- The broken Windows service was installed via `citadel service install` running as admin, creating the stale ProgramData config