### PR TITLE
feat(tui): view device page shortcut (V key) after auth

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -197,8 +197,16 @@ func runControlCenter() {
 		// Gather initial data after network check
 		if data, err := gatherControlCenterData(); err == nil {
 			cc.UpdateData(data)
-			// Update networkConnected based on actual status
 			networkConnected = data.Connected
+		}
+
+		// Set device URL for "V" key shortcut if connected
+		if networkConnected {
+			deviceURL := authServiceURL + "/fabric"
+			if d, err := gatherControlCenterData(); err == nil && d.HeadscaleNodeID != "" {
+				deviceURL = authServiceURL + "/fabric/machines/" + d.HeadscaleNodeID
+			}
+			cc.SetDeviceURL(deviceURL)
 		}
 
 		// Auto-start servers and worker after network is connected
@@ -509,6 +517,7 @@ func gatherControlCenterData() (controlcenter.StatusData, error) {
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			if status, err := network.GetGlobalStatus(ctx); err == nil {
 				data.NodeIP = status.IPv4
+				data.HeadscaleNodeID = status.NodeID
 				if data.NodeName == "" {
 					data.NodeName = status.Hostname
 				}

--- a/internal/tui/controlcenter/actions.go
+++ b/internal/tui/controlcenter/actions.go
@@ -1420,6 +1420,11 @@ func (cc *ControlCenter) showDeviceAuthModal(config *DeviceAuthConfig) {
 						if cc.onConnect != nil {
 							cc.onConnect(cc.AddActivity)
 						}
+
+						// Set device URL for the "V" key shortcut
+						cc.deviceURL = cc.authServiceURL + "/fabric"
+						cc.AddActivity("info", fmt.Sprintf("View your device: %s", cc.deviceURL))
+						cc.AddActivity("info", "Press [V] to open in browser")
 					}
 				}
 

--- a/internal/tui/controlcenter/controlcenter.go
+++ b/internal/tui/controlcenter/controlcenter.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/aceteam-ai/citadel-cli/internal/config"
 	"github.com/aceteam-ai/citadel-cli/internal/network"
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
@@ -53,12 +54,13 @@ type JobRecord struct {
 
 // StatusData holds all the data for the control center
 type StatusData struct {
-	NodeName   string
-	NodeIP     string
-	OrgID      string
-	OrgName    string // Human-readable org name (if available from API)
-	Connected  bool
-	Version    string
+	NodeName        string
+	NodeIP          string
+	HeadscaleNodeID string // Numeric Headscale node ID (for fabric URLs)
+	OrgID           string
+	OrgName         string // Human-readable org name (if available from API)
+	Connected       bool
+	Version         string
 
 	// User info (from device auth)
 	UserEmail string
@@ -349,6 +351,9 @@ type ControlCenter struct {
 	// Service state overrides (transitional states: starting/stopping/failed)
 	serviceOverrides   map[string]*serviceStateOverride
 	serviceOverridesMu sync.Mutex
+
+	// Device URL set after successful device auth + connect
+	deviceURL string
 }
 
 // Pane focus constants
@@ -467,6 +472,11 @@ func (cc *ControlCenter) AddActivity(level, message string) {
 			})
 		}()
 	}
+}
+
+// SetDeviceURL sets the URL for the "V" key shortcut to open the device page.
+func (cc *ControlCenter) SetDeviceURL(url string) {
+	cc.deviceURL = url
 }
 
 // Run starts the control center
@@ -751,6 +761,16 @@ func (cc *ControlCenter) handleInput(event *tcell.EventKey) *tcell.EventKey {
 		case 'z', 'Z':
 			// Zoom toggle on focused pane
 			cc.toggleZoom()
+			return nil
+		case 'v', 'V':
+			// Open device page in browser (available after device auth)
+			if cc.deviceURL != "" {
+				if err := platform.OpenURL(cc.deviceURL); err != nil {
+					cc.AddActivity("warning", fmt.Sprintf("Failed to open browser: %v", err))
+				} else {
+					cc.AddActivity("info", "Opened device page in browser")
+				}
+			}
 			return nil
 		}
 	}
@@ -1250,6 +1270,7 @@ func (cc *ControlCenter) showHelpModal() {
 
 [yellow]General:[-]
   [white::b]r[-:-:-]             Refresh status
+  [white::b]v[-:-:-]             View device in browser (after auth)
   [white::b]z[-:-:-]             Zoom focused pane (full screen toggle)
   [white::b]c[-:-:-]             Copy focused panel to clipboard
   [white::b]C[-:-:-]             Copy all panels to clipboard


### PR DESCRIPTION
## Context

After device authorization, users want to quickly view their device on the web UI. Currently there's no way to navigate to the device page from the TUI.

## Summary

- **V key binding**: Opens the device's fabric page in the default browser
- **Deep link**: Uses `/fabric/machines/{headscaleNodeID}` when available, falls back to `/fabric`
- **Activity log messages**: Shows URL and "Press [V] to open in browser" after auth success
- **Works on reconnect too**: V key is enabled on auto-reconnect at startup, not just fresh auth
- **Help modal**: V key documented in the `?` help screen
- **HeadscaleNodeID**: Added to `StatusData`, populated from network status

## Test plan

- [ ] Fresh device auth → activity log shows URL + V key hint
- [ ] Press V → opens browser to fabric page
- [ ] Restart citadel (auto-reconnect) → V key still works
- [ ] `?` help shows V key entry
- [ ] V key does nothing when not connected (no deviceURL set)