### PR TITLE
fix(desktop): fix phantom right-clicks and color swap in VNC

### DIFF
--- a/internal/desktop/input_windows.go
+++ b/internal/desktop/input_windows.go
@@ -78,33 +78,41 @@ func sendKeyEvent(keysym uint32, down bool) {
 	procSendInput.Call(1, uintptr(unsafe.Pointer(&input)), unsafe.Sizeof(input))
 }
 
+var lastButtonMask byte
+
 // sendPointerEvent sends a mouse move + optional button press via SendInput.
 // buttonMask follows the RFB spec: bit0=left, bit1=middle, bit2=right,
 // bit3=scroll-up, bit4=scroll-down.
 func sendPointerEvent(x, y int, buttonMask byte) {
-	// Move cursor to absolute position
 	procSetCursorPos.Call(uintptr(x), uintptr(y))
 
-	// Determine button events from mask
-	// We track last button state to generate down/up transitions.
-	// For simplicity in this minimal server, we send the current state directly.
+	// Only send button down/up on state transitions to avoid phantom clicks.
+	changed := buttonMask ^ lastButtonMask
+	lastButtonMask = buttonMask
+
 	var flags uint32
 	var mouseData uint32
 
-	if buttonMask&0x01 != 0 {
-		flags |= mouseEventFLeftDown
-	} else {
-		flags |= mouseEventFLeftUp
+	if changed&0x01 != 0 {
+		if buttonMask&0x01 != 0 {
+			flags |= mouseEventFLeftDown
+		} else {
+			flags |= mouseEventFLeftUp
+		}
 	}
-	if buttonMask&0x02 != 0 {
-		flags |= mouseEventFMiddleDown
-	} else {
-		flags |= mouseEventFMiddleUp
+	if changed&0x02 != 0 {
+		if buttonMask&0x02 != 0 {
+			flags |= mouseEventFMiddleDown
+		} else {
+			flags |= mouseEventFMiddleUp
+		}
 	}
-	if buttonMask&0x04 != 0 {
-		flags |= mouseEventFRightDown
-	} else {
-		flags |= mouseEventFRightUp
+	if changed&0x04 != 0 {
+		if buttonMask&0x04 != 0 {
+			flags |= mouseEventFRightDown
+		} else {
+			flags |= mouseEventFRightUp
+		}
 	}
 	if buttonMask&0x08 != 0 {
 		flags |= mouseEventFWheel
@@ -112,8 +120,7 @@ func sendPointerEvent(x, y int, buttonMask byte) {
 	}
 	if buttonMask&0x10 != 0 {
 		flags |= mouseEventFWheel
-		// -120 in two's complement uint32 = 0xFFFFFF88
-		mouseData = ^uint32(wheelDelta) + 1 // scroll down
+		mouseData = ^uint32(wheelDelta) + 1
 	}
 
 	if flags != 0 {

--- a/internal/desktop/vnc_server.go
+++ b/internal/desktop/vnc_server.go
@@ -254,10 +254,11 @@ func (s *VNCServer) rfbHandshake(conn net.Conn) error {
 	return nil
 }
 
-// ServerInit pixel format: 32bpp BGRX, matching GDI/DXGI native byte order.
+// ServerInit pixel format: 32bpp RGBX, matching what noVNC requests.
+// GDI captures in BGRX, we swap B↔R before sending (see writeFramebufferUpdate).
 // bpp=32, depth=24, big-endian=0, true-color=1
 // red-max=255, green-max=255, blue-max=255
-// red-shift=16, green-shift=8, blue-shift=0
+// red-shift=0, green-shift=8, blue-shift=16
 var serverPixelFormat = [16]byte{
 	32,   // bits-per-pixel
 	24,   // depth
@@ -266,9 +267,9 @@ var serverPixelFormat = [16]byte{
 	0, 255, // red-max (big-endian u16)
 	0, 255, // green-max
 	0, 255, // blue-max
-	16,  // red-shift
+	0,   // red-shift
 	8,   // green-shift
-	0,   // blue-shift
+	16,  // blue-shift
 	0, 0, 0, // padding (3 bytes)
 }
 
@@ -458,8 +459,12 @@ func writeFramebufferUpdate(w io.Writer, frame *CaptureResult) error {
 		return err
 	}
 
-	// Pixel data (raw BGRX, matches our advertised pixel format)
-	if _, err := w.Write(frame.Pix); err != nil {
+	// Convert BGRX (GDI native) to RGBX (our advertised format) by swapping B↔R.
+	pix := frame.Pix
+	for i := 0; i < len(pix)-2; i += 4 {
+		pix[i], pix[i+2] = pix[i+2], pix[i]
+	}
+	if _, err := w.Write(pix); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Context

Two bugs in the embedded VNC server cause poor desktop experience:
1. Every mouse movement triggers a right-click context menu on the remote Windows desktop
2. Colors are swapped — orange icons appear blue (R↔B channels reversed)

## Summary

**Phantom right-clicks** (`input_windows.go`): `sendPointerEvent` unconditionally sent button-up events (`MOUSEEVENTF_RIGHTUP`, `MOUSEEVENTF_LEFTUP`, `MOUSEEVENTF_MIDDLEUP`) for ALL unpressed buttons on EVERY pointer event, including plain mouse moves with `buttonMask=0`. Windows interprets receiving `MOUSEEVENTF_RIGHTUP` as completing a right-click (WM_RBUTTONUP), which opens context menus. Fix: track `lastButtonMask` and only send down/up on actual state transitions.

**Color swap** (`vnc_server.go`): The server advertised BGRX pixel format (red-shift=16, blue-shift=0) matching GDI's native byte order, but noVNC sends `SetPixelFormat` requesting RGBX (red-shift=0, blue-shift=16) to match its HTML canvas. The server ignored this request and kept sending BGRX bytes, which noVNC copied directly as RGBX — swapping red and blue channels. Fix: advertise RGBX format and swap B↔R bytes in frame data before sending.

## Test plan

- [ ] Build for Windows, deploy to test node
- [ ] Verify mouse movement no longer triggers right-click context menus
- [ ] Verify colors match real desktop (orange icons appear orange, not blue)
- [ ] Verify left-click, right-click, middle-click work correctly
- [ ] Verify click-and-drag works
- [ ] Verify scroll wheel works