### PR TITLE
feat(jobs): FILE_READ_BYTES binary read handler

### DIFF
--- a/internal/jobs/file_read_bytes.go
+++ b/internal/jobs/file_read_bytes.go
@@ -1,0 +1,96 @@
+// internal/jobs/file_read_bytes.go
+package jobs
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+// defaultMaxReadBytes caps a single FILE_READ_BYTES read at 50 MB, matching the
+// server-side cap. Used when the job payload omits or empties 'max_bytes'.
+const defaultMaxReadBytes int64 = 50 * 1024 * 1024
+
+// FileReadBytesHandler handles FILE_READ_BYTES jobs.
+// Unlike FILE_READ, it reads a file as raw bytes (binary-safe: no line numbers,
+// no binary rejection) and returns the content base64-encoded. This powers
+// file-by-reference email attachments and upload_file ingestion, where the
+// faithful bytes of PDFs/xlsx/CSV-with-NULs must cross the VPN mesh intact.
+type FileReadBytesHandler struct {
+	WorkspaceDir string
+}
+
+// NewFileReadBytesHandler creates a new FileReadBytesHandler rooted at workspace.
+func NewFileReadBytesHandler(workspace string) *FileReadBytesHandler {
+	return &FileReadBytesHandler{WorkspaceDir: workspace}
+}
+
+// Execute reads the requested file as raw bytes and returns it base64-encoded.
+//
+// Payload fields (all strings via nexus.Job):
+//   - path: absolute or workspace-relative path to read
+//   - max_bytes: server's size cap as a decimal string (default 50 MB)
+//
+// Response JSON:
+//   - encoding: always "base64" (the marker the coordinator checks)
+//   - content: standard base64 of the raw file bytes
+//   - size: decoded byte length (raw file size)
+func (h *FileReadBytesHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	path, ok := job.Payload["path"]
+	if !ok || path == "" {
+		return nil, fmt.Errorf("job payload missing 'path' field")
+	}
+
+	validated, err := ValidatePath(h.WorkspaceDir, path)
+	if err != nil {
+		return nil, fmt.Errorf("path validation failed: %w", err)
+	}
+
+	maxBytes := defaultMaxReadBytes
+	if v, ok := job.Payload["max_bytes"]; ok && v != "" {
+		maxBytes, err = strconv.ParseInt(v, 10, 64)
+		if err != nil || maxBytes <= 0 {
+			return nil, fmt.Errorf("invalid max_bytes: %q", v)
+		}
+	}
+
+	info, err := os.Stat(validated)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat file: %w", err)
+	}
+	if info.IsDir() {
+		return nil, fmt.Errorf("path is a directory, not a file")
+	}
+
+	// Enforce the size cap before reading so we never load a huge file just to
+	// reject it. The coordinator independently re-checks the decoded length.
+	if info.Size() > maxBytes {
+		return nil, fmt.Errorf("file size %d exceeds max_bytes %d", info.Size(), maxBytes)
+	}
+
+	ctx.Log("info", "     - [Job %s] FILE_READ_BYTES %s (size=%d, max_bytes=%d)", job.ID, validated, info.Size(), maxBytes)
+
+	data, err := os.ReadFile(validated)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	// Guard against a race where the file grew between Stat and ReadFile.
+	if int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("file size %d exceeds max_bytes %d", len(data), maxBytes)
+	}
+
+	result := map[string]any{
+		"encoding": "base64",
+		"content":  base64.StdEncoding.EncodeToString(data),
+		"size":     len(data),
+	}
+	return json.Marshal(result)
+}
+
+// Ensure FileReadBytesHandler implements JobHandler.
+var _ JobHandler = (*FileReadBytesHandler)(nil)

--- a/internal/jobs/file_read_bytes_test.go
+++ b/internal/jobs/file_read_bytes_test.go
@@ -1,0 +1,175 @@
+package jobs
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fileReadBytesResult mirrors the JSON contract the coordinator decodes.
+type fileReadBytesResult struct {
+	Encoding string `json:"encoding"`
+	Content  string `json:"content"`
+	Size     int    `json:"size"`
+}
+
+func runFileReadBytes(t *testing.T, ws string, payload map[string]string) fileReadBytesResult {
+	t.Helper()
+	h := NewFileReadBytesHandler(ws)
+	out, err := h.Execute(JobContext{}, makeJob(payload))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var result fileReadBytesResult
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("json unmarshal: %v", err)
+	}
+	return result
+}
+
+// TestFileReadBytes_BinaryRoundTrip is the core proof that binary is no longer
+// rejected: a file containing NUL bytes round-trips faithfully through base64.
+func TestFileReadBytes_BinaryRoundTrip(t *testing.T) {
+	ws := setupWorkspace(t)
+	raw := []byte{0x89, 0x50, 0x4E, 0x47, 0x00, 0x0D, 0x0A, 0x00, 0xFF, 0x00}
+	path := filepath.Join(ws, "binary.dat")
+	if err := os.WriteFile(path, raw, 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	result := runFileReadBytes(t, ws, map[string]string{"path": path})
+
+	if result.Encoding != "base64" {
+		t.Errorf("encoding = %q, want \"base64\"", result.Encoding)
+	}
+	if result.Size != len(raw) {
+		t.Errorf("size = %d, want %d", result.Size, len(raw))
+	}
+	decoded, err := base64.StdEncoding.DecodeString(result.Content)
+	if err != nil {
+		t.Fatalf("content is not valid standard base64: %v", err)
+	}
+	if !bytes.Equal(decoded, raw) {
+		t.Errorf("decoded bytes %v != original %v", decoded, raw)
+	}
+}
+
+func TestFileReadBytes_TextRoundTrip(t *testing.T) {
+	ws := setupWorkspace(t)
+	content := "line one\nline two\nline three\n"
+	path := writeTestFile(t, ws, "test.txt", content)
+
+	result := runFileReadBytes(t, ws, map[string]string{"path": path})
+
+	decoded, err := base64.StdEncoding.DecodeString(result.Content)
+	if err != nil {
+		t.Fatalf("content is not valid standard base64: %v", err)
+	}
+	if string(decoded) != content {
+		t.Errorf("decoded = %q, want %q", string(decoded), content)
+	}
+	// Crucially, no cat -n line numbering is applied.
+	if strings.Contains(string(decoded), "\t") {
+		t.Errorf("decoded content unexpectedly contains a tab (line numbering?): %q", string(decoded))
+	}
+}
+
+func TestFileReadBytes_MaxBytesCap(t *testing.T) {
+	ws := setupWorkspace(t)
+	path := writeTestFile(t, ws, "big.bin", strings.Repeat("A", 100))
+
+	h := NewFileReadBytesHandler(ws)
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path":      path,
+		"max_bytes": "10",
+	}))
+	if err == nil {
+		t.Fatal("expected error when file exceeds max_bytes, got nil")
+	}
+	if !strings.Contains(err.Error(), "max_bytes") {
+		t.Errorf("error should mention max_bytes, got: %v", err)
+	}
+}
+
+func TestFileReadBytes_MaxBytesAllowsWithinCap(t *testing.T) {
+	ws := setupWorkspace(t)
+	raw := strings.Repeat("A", 100)
+	path := writeTestFile(t, ws, "ok.bin", raw)
+
+	result := runFileReadBytes(t, ws, map[string]string{
+		"path":      path,
+		"max_bytes": fmt.Sprintf("%d", len(raw)),
+	})
+	if result.Size != len(raw) {
+		t.Errorf("size = %d, want %d", result.Size, len(raw))
+	}
+}
+
+func TestFileReadBytes_InvalidMaxBytes(t *testing.T) {
+	ws := setupWorkspace(t)
+	path := writeTestFile(t, ws, "f.txt", "hi")
+
+	h := NewFileReadBytesHandler(ws)
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path":      path,
+		"max_bytes": "not-a-number",
+	}))
+	if err == nil {
+		t.Fatal("expected error for invalid max_bytes, got nil")
+	}
+}
+
+func TestFileReadBytes_PathTraversal(t *testing.T) {
+	ws := setupWorkspace(t)
+	h := NewFileReadBytesHandler(ws)
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path": "/etc/passwd",
+	}))
+	if err == nil {
+		t.Fatal("expected error for path outside workspace, got nil")
+	}
+	if !strings.Contains(err.Error(), "path validation") {
+		t.Errorf("error should mention path validation, got: %v", err)
+	}
+}
+
+func TestFileReadBytes_RejectsDirectory(t *testing.T) {
+	ws := setupWorkspace(t)
+	sub := filepath.Join(ws, "subdir")
+	if err := os.MkdirAll(sub, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	h := NewFileReadBytesHandler(ws)
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{"path": sub}))
+	if err == nil {
+		t.Fatal("expected error when reading a directory, got nil")
+	}
+	if !strings.Contains(err.Error(), "directory") {
+		t.Errorf("error should mention directory, got: %v", err)
+	}
+}
+
+func TestFileReadBytes_MissingPath(t *testing.T) {
+	ws := setupWorkspace(t)
+	h := NewFileReadBytesHandler(ws)
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{}))
+	if err == nil {
+		t.Fatal("expected error for missing path, got nil")
+	}
+}
+
+func TestFileReadBytes_NonExistent(t *testing.T) {
+	ws := setupWorkspace(t)
+	h := NewFileReadBytesHandler(ws)
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path": filepath.Join(ws, "nope.dat"),
+	}))
+	if err == nil {
+		t.Fatal("expected error for non-existent file, got nil")
+	}
+}

--- a/internal/jobs/queue_types.go
+++ b/internal/jobs/queue_types.go
@@ -13,11 +13,12 @@ const (
 	JobTypeExtraction = "EXTRACTION"
 
 	// File operation job types for agent workspace access
-	JobTypeFileRead   = "FILE_READ"
-	JobTypeFileWrite  = "FILE_WRITE"
-	JobTypeFileEdit   = "FILE_EDIT"
-	JobTypeFileList   = "FILE_LIST"
-	JobTypeFileSearch = "FILE_SEARCH"
+	JobTypeFileRead      = "FILE_READ"
+	JobTypeFileReadBytes = "FILE_READ_BYTES"
+	JobTypeFileWrite     = "FILE_WRITE"
+	JobTypeFileEdit      = "FILE_EDIT"
+	JobTypeFileList      = "FILE_LIST"
+	JobTypeFileSearch    = "FILE_SEARCH"
 
 	// Model cache management job types
 	JobTypeModelCachePull  = "MODEL_CACHE_PULL"
@@ -62,7 +63,7 @@ type LLMInferencePayload struct {
 
 // ChatMessage represents a message in chat-style APIs.
 type ChatMessage struct {
-	Role    string `json:"role"`    // "system", "user", "assistant"
+	Role    string `json:"role"` // "system", "user", "assistant"
 	Content string `json:"content"`
 }
 

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -139,6 +139,7 @@ func CreateLegacyHandlersWithOpts(opts LegacyHandlerOpts) []JobHandler {
 	if opts.WorkspaceDir != "" {
 		handlers = append(handlers,
 			NewLegacyHandlerAdapter(JobTypeFileRead, jobs.NewFileReadHandler(opts.WorkspaceDir)),
+			NewLegacyHandlerAdapter(JobTypeFileReadBytes, jobs.NewFileReadBytesHandler(opts.WorkspaceDir)),
 			NewLegacyHandlerAdapter(JobTypeFileWrite, jobs.NewFileWriteHandler(opts.WorkspaceDir)),
 			NewLegacyHandlerAdapter(JobTypeFileEdit, jobs.NewFileEditHandler(opts.WorkspaceDir)),
 			NewLegacyHandlerAdapter(JobTypeFileList, jobs.NewFileListHandler(opts.WorkspaceDir)),

--- a/internal/worker/job.go
+++ b/internal/worker/job.go
@@ -107,6 +107,7 @@ const (
 	JobTypeExtraction        = "GLINER_EXTRACTION"   // Entity/relation extraction via GLiNER2
 	JobTypeHTTPProxy         = "HTTP_PROXY"          // Proxy HTTP requests through the local node
 	JobTypeFileRead          = "FILE_READ"           // Read a file from the workspace
+	JobTypeFileReadBytes     = "FILE_READ_BYTES"     // Read a file as raw base64-encoded bytes (binary-safe)
 	JobTypeFileWrite         = "FILE_WRITE"          // Write a file to the workspace
 	JobTypeFileEdit          = "FILE_EDIT"           // Edit (string replace) a file in the workspace
 	JobTypeFileList          = "FILE_LIST"           // List directory contents in the workspace


### PR DESCRIPTION
## Context

Issue [aceteam-ai/aceteam#3898](https://github.com/aceteam-ai/aceteam/issues/3898) ships file-by-reference email attachments and `upload_file` ingestion that read a file from the user's own Citadel node over the VPN mesh (org-scoped, no shared-server LFI). The python-backend side merged ([aceteam-ai/aceteam#3906](https://github.com/aceteam-ai/aceteam/pull/3906)), but it depends on a node-side handler that did not yet exist.

The existing `FILE_READ` handler is text-oriented: it adds `cat -n` line numbers and **explicitly rejects binary content**, so it cannot faithfully return a PDF / xlsx / CSV-with-NULs. The coordinator (`read_node_file_bytes` in `aceteam_mcp_code.py`) guards itself — it only base64-decodes a result when the node returns an explicit `encoding == "base64"` marker — so nothing breaks today, but binary attach-by-reference stays unavailable until this node-side handler lands.

This PR adds that handler.

## Summary

- **New `FILE_READ_BYTES` job type** (`internal/jobs/file_read_bytes.go`). A separate handler rather than overloading `FILE_READ`, whose response shape and binary-rejection must stay unchanged for the code tools.
  - Reads raw bytes (`os.ReadFile`) — **no line numbers, no binary rejection**.
  - `os.Stat` before reading to enforce the `max_bytes` cap **on the node side** (so we never load a 50 MB+ file just to reject it), with a post-read recheck to guard against a grow-between-stat-and-read race. The coordinator independently re-checks the decoded length.
  - `max_bytes` parsed from the payload as a decimal string; defaults to 50 MB (`52428800`) when absent/empty, matching the server cap.
  - Standard base64 (`base64.StdEncoding`, **not** url-safe) since the coordinator uses `base64.b64decode(validate=True)`.
  - Reuses the existing `ValidatePath` workspace/path-traversal validator and rejects directories.
- **Constants** `JobTypeFileReadBytes = "FILE_READ_BYTES"` added in both `internal/jobs/queue_types.go` and `internal/worker/job.go` (mirroring how `FILE_READ` already exists in both packages).
- **Registration** alongside the other `FILE_*` handlers in `internal/worker/handler_adapter.go` (only when a workspace is configured).

### Response shape (exactly the #3905 contract)

```json
{ "encoding": "base64", "content": "<std-base64>", "size": <decoded byte length> }
```

`size` is the raw/decoded byte count (`len(data)`), not the base64 string length. No extra fields.

## Test plan

`go build ./...`, `go vet ./...`, `gofmt`, `./build.sh`, and `go test ./...` all pass. New tests in `internal/jobs/file_read_bytes_test.go`:

| Test | Coverage |
|------|----------|
| `BinaryRoundTrip` | File with NUL bytes round-trips through std base64 (proves binary rejection is gone) |
| `TextRoundTrip` | Text decodes byte-identical; asserts no `cat -n` tab/line-numbering |
| `MaxBytesCap` | File over cap returns an error mentioning `max_bytes` |
| `MaxBytesAllowsWithinCap` | File at the cap is read successfully |
| `InvalidMaxBytes` | Non-numeric `max_bytes` rejected |
| `PathTraversal` | `/etc/passwd` rejected by `ValidatePath` |
| `RejectsDirectory` | Reading a directory errors |
| `MissingPath` / `NonExistent` | Missing payload field / missing file error cleanly |

## Related

- Contract: [aceteam-ai/aceteam#3905](https://github.com/aceteam-ai/aceteam/issues/3905)
- Feature: [aceteam-ai/aceteam#3898](https://github.com/aceteam-ai/aceteam/issues/3898)
- Server side (merged): [aceteam-ai/aceteam#3906](https://github.com/aceteam-ai/aceteam/pull/3906)