### PR TITLE
feat: opt-in periodic auto-update

### DIFF
--- a/cmd/work.go
+++ b/cmd/work.go
@@ -28,6 +28,7 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/status"
 	"github.com/aceteam-ai/citadel-cli/internal/terminal"
 	"github.com/aceteam-ai/citadel-cli/internal/tlscert"
+	"github.com/aceteam-ai/citadel-cli/internal/update"
 	"github.com/aceteam-ai/citadel-cli/internal/usage"
 	"github.com/aceteam-ai/citadel-cli/internal/worker"
 	"github.com/google/uuid"
@@ -71,6 +72,10 @@ var (
 
 	// Update check flag
 	workNoUpdate bool
+
+	// Auto-update (periodic self-update) flags
+	workAutoUpdate         bool
+	workAutoUpdateInterval string
 
 	// Capability detection flags
 	workCapabilities string
@@ -1106,6 +1111,28 @@ func runWork(cmd *cobra.Command, args []string) {
 		runner.WithStreamWriterFactory(streamFactory)
 	}
 
+	// Start the opt-in periodic auto-updater. Disabled by default; enable with
+	// --auto-update or CITADEL_AUTO_UPDATE=true. It checks GitHub Releases on
+	// the configured interval and, when a newer version is found, drains
+	// in-flight jobs before atomically swapping the binary and restarting.
+	if resolveAutoUpdateEnabled() {
+		interval, err := update.ParseInterval(resolveAutoUpdateInterval())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "   - Warning: %v; auto-update disabled\n", err)
+		} else {
+			updater := update.NewAutoUpdater(update.AutoUpdaterConfig{
+				Checker:    update.NewClientWithTimeout(Version, 30*time.Second),
+				Interval:   interval,
+				ActiveJobs: runner.ActiveJobs,
+				Drain:      func() { runner.Drain() },
+				Log: func(format string, args ...any) {
+					fmt.Printf("   - "+format+"\n", args...)
+				},
+			})
+			go updater.Run(ctx)
+		}
+	}
+
 	// Run the worker
 	if err := runner.Run(ctx); err != nil {
 		if err != context.Canceled {
@@ -1226,6 +1253,29 @@ func resolveWorkspaceDir() string {
 		return dir
 	}
 	return abs
+}
+
+// resolveAutoUpdateEnabled reports whether the periodic auto-updater should run.
+// Priority: --auto-update flag > CITADEL_AUTO_UPDATE env. Disabled by default.
+func resolveAutoUpdateEnabled() bool {
+	if workAutoUpdate {
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("CITADEL_AUTO_UPDATE"))) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
+}
+
+// resolveAutoUpdateInterval returns the configured auto-update interval string.
+// Priority: --auto-update-interval flag > CITADEL_AUTO_UPDATE_INTERVAL env.
+// Empty means use the default (1h).
+func resolveAutoUpdateInterval() string {
+	if workAutoUpdateInterval != "" {
+		return workAutoUpdateInterval
+	}
+	return os.Getenv("CITADEL_AUTO_UPDATE_INTERVAL")
 }
 
 // DeviceConfig holds device authentication configuration from the global config file.
@@ -1426,6 +1476,10 @@ func init() {
 	// Update check flags (deprecated - update check now runs on all commands via root.go)
 	workCmd.Flags().BoolVar(&workNoUpdate, "no-update", false, "(Deprecated) No longer has any effect - use 'citadel update disable' instead")
 	workCmd.Flags().MarkDeprecated("no-update", "use 'citadel update disable' to disable auto-update checks")
+
+	// Auto-update (periodic self-update) flags
+	workCmd.Flags().BoolVar(&workAutoUpdate, "auto-update", false, "Periodically check for and install newer releases (or set CITADEL_AUTO_UPDATE=true)")
+	workCmd.Flags().StringVar(&workAutoUpdateInterval, "auto-update-interval", "", "Interval between auto-update checks, e.g. 1h, 30m (default 1h; or set CITADEL_AUTO_UPDATE_INTERVAL)")
 
 	// Capability detection flags
 	workCmd.Flags().StringVar(&workCapabilities, "capabilities", "", "Additional comma-separated capability tags (e.g., gpu:rtx4090,llm:llama3)")

--- a/internal/update/autoupdater.go
+++ b/internal/update/autoupdater.go
@@ -1,0 +1,264 @@
+// internal/update/autoupdater.go
+// Opt-in periodic self-update for the long-lived Citadel agent.
+//
+// The AutoUpdater runs as a background goroutine launched by `citadel work`
+// when enabled. On each tick it checks GitHub Releases for a newer version,
+// and if one is found it downloads + checksum-verifies the binary, waits for
+// an idle moment (no in-flight jobs), atomically swaps the running binary, and
+// restarts the process so the new node-side capabilities take effect.
+//
+// Design notes:
+//   - Reuses the existing Client (CheckForUpdate / DownloadAndVerify) and
+//     ApplyUpdate / Rollback machinery so the release-asset naming and checksum
+//     contract is preserved.
+//   - This is a separate opt-in from the notify-only State.AutoUpdate gate used
+//     by root.go: auto-INSTALL must be explicitly enabled and defaults off.
+//   - Fail-safe: any error is reported via the logger and never panics or kills
+//     the agent. In-flight jobs are always drained before the swap.
+package update
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+const (
+	// DefaultAutoUpdateInterval is how often the auto-updater checks for a
+	// newer release when no interval is configured.
+	DefaultAutoUpdateInterval = 1 * time.Hour
+
+	// MinAutoUpdateInterval is the floor for the configured interval. The
+	// unauthenticated GitHub API allows ~60 requests/hour, so we refuse to
+	// poll more often than this to stay well within that budget.
+	MinAutoUpdateInterval = 5 * time.Minute
+)
+
+// ReleaseChecker abstracts the "is there a newer release?" lookup so the loop
+// can be tested without hitting the network. *Client satisfies it.
+type ReleaseChecker interface {
+	// CheckForUpdate returns a non-nil Release if a strictly newer version is
+	// available, or (nil, nil) if already up to date.
+	CheckForUpdate() (*Release, error)
+	// DownloadAndVerify downloads the release asset for the current platform
+	// to destPath and verifies its checksum.
+	DownloadAndVerify(release *Release, destPath string) error
+}
+
+// AutoUpdaterConfig configures an AutoUpdater.
+type AutoUpdaterConfig struct {
+	// Checker performs release lookups and downloads. Required.
+	Checker ReleaseChecker
+
+	// Interval between checks. Values below MinAutoUpdateInterval are clamped
+	// up to the floor. Zero uses DefaultAutoUpdateInterval.
+	Interval time.Duration
+
+	// ActiveJobs reports the number of in-flight jobs. When it returns 0 the
+	// updater considers the node idle and safe to restart. If nil, the node is
+	// always considered idle (best-effort).
+	ActiveJobs func() int
+
+	// Drain, if set, is called once an update is downloaded and verified to
+	// stop the runner from fetching new jobs while we wait for idle.
+	Drain func()
+
+	// IdlePollInterval is how often to re-check ActiveJobs while waiting for
+	// the node to drain. Zero uses a sensible default (2s).
+	IdlePollInterval time.Duration
+
+	// IdleTimeout bounds how long to wait for in-flight jobs to finish before
+	// giving up on this update attempt (the next tick will retry). Zero uses a
+	// sensible default (10m). A long-running job should never block the agent
+	// from making progress on real work.
+	IdleTimeout time.Duration
+
+	// Apply replaces the running binary with the verified pending binary.
+	// Defaults to ApplyUpdate. Overridable for testing.
+	Apply func(pendingPath string) error
+
+	// Restart re-execs / restarts the process onto the new binary.
+	// Defaults to RestartProcess. Overridable for testing.
+	Restart func() error
+
+	// PendingPath is where the downloaded binary is staged.
+	// Defaults to GetPendingBinaryPath().
+	PendingPath string
+
+	// Log reports progress and errors. Required for visibility; if nil a no-op
+	// logger is used.
+	Log func(format string, args ...any)
+}
+
+// AutoUpdater periodically checks for and applies updates.
+type AutoUpdater struct {
+	cfg AutoUpdaterConfig
+}
+
+// NewAutoUpdater constructs an AutoUpdater, applying defaults and clamping the
+// interval to the safe floor.
+func NewAutoUpdater(cfg AutoUpdaterConfig) *AutoUpdater {
+	if cfg.Interval <= 0 {
+		cfg.Interval = DefaultAutoUpdateInterval
+	}
+	if cfg.Interval < MinAutoUpdateInterval {
+		cfg.Interval = MinAutoUpdateInterval
+	}
+	if cfg.IdlePollInterval <= 0 {
+		cfg.IdlePollInterval = 2 * time.Second
+	}
+	if cfg.IdleTimeout <= 0 {
+		cfg.IdleTimeout = 10 * time.Minute
+	}
+	if cfg.Apply == nil {
+		cfg.Apply = ApplyUpdate
+	}
+	if cfg.Restart == nil {
+		cfg.Restart = RestartProcess
+	}
+	if cfg.PendingPath == "" {
+		cfg.PendingPath = GetPendingBinaryPath()
+	}
+	if cfg.Log == nil {
+		cfg.Log = func(string, ...any) {}
+	}
+	return &AutoUpdater{cfg: cfg}
+}
+
+// Run blocks until ctx is cancelled, checking for updates on the configured
+// interval. It never returns an error: failures are logged and retried on the
+// next tick so the agent keeps running regardless.
+func (a *AutoUpdater) Run(ctx context.Context) {
+	a.cfg.Log("auto-update: enabled (interval %s)", a.cfg.Interval)
+	ticker := time.NewTicker(a.cfg.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			// runOnce never panics; guard anyway so a bug here can never take
+			// down the agent.
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						a.cfg.Log("auto-update: recovered from panic: %v", r)
+					}
+				}()
+				if restarted := a.runOnce(ctx); restarted {
+					// RestartProcess only returns on failure; if it somehow
+					// returns success we still keep the loop alive.
+					a.cfg.Log("auto-update: restart requested")
+				}
+			}()
+		}
+	}
+}
+
+// runOnce performs a single check-download-apply-restart cycle.
+// It returns true if a restart was attempted (the process is expected to be
+// replaced and not return). On any error it logs and returns false so the next
+// tick retries.
+func (a *AutoUpdater) runOnce(ctx context.Context) (restarted bool) {
+	release, err := a.cfg.Checker.CheckForUpdate()
+	if err != nil {
+		a.cfg.Log("auto-update: check failed: %v", err)
+		return false
+	}
+	if release == nil {
+		a.cfg.Log("auto-update: up to date")
+		return false
+	}
+
+	a.cfg.Log("auto-update: new version available: %s, downloading...", release.TagName)
+
+	// Download + verify while jobs may still be running — this is the slow part
+	// and does not require an idle node.
+	if err := a.cfg.Checker.DownloadAndVerify(release, a.cfg.PendingPath); err != nil {
+		a.cfg.Log("auto-update: download/verify failed: %v", err)
+		return false
+	}
+	a.cfg.Log("auto-update: downloaded and verified %s", release.TagName)
+
+	// Stop fetching new jobs, then wait for in-flight jobs to finish. Draining
+	// BEFORE observing idle closes the race where a new job is picked up
+	// between the idle check and the binary swap.
+	if a.cfg.Drain != nil {
+		a.cfg.Drain()
+	}
+
+	if err := a.waitForIdle(ctx); err != nil {
+		a.cfg.Log("auto-update: %v; deferring to next cycle", err)
+		return false
+	}
+
+	// Apply the swap (atomic; validates the new binary and rolls back on
+	// failure internally).
+	if err := a.cfg.Apply(a.cfg.PendingPath); err != nil {
+		a.cfg.Log("auto-update: apply failed (kept current version): %v", err)
+		return false
+	}
+	a.cfg.Log("auto-update: applied %s, restarting...", release.TagName)
+
+	// Record the update in persistent state for the new process / status cmd.
+	if state, serr := LoadState(); serr == nil {
+		RecordUpdate(state, state.CurrentVersion, release.TagName)
+		state.AvailableUpdate = ""
+		UpdateLastCheck(state)
+		_ = SaveState(state)
+	}
+
+	if err := a.cfg.Restart(); err != nil {
+		// If restart fails the new binary is already in place; the supervisor
+		// (systemd Restart=always / Windows SCM) will pick it up on the next
+		// natural restart. Log and keep running on the old image for now.
+		a.cfg.Log("auto-update: restart failed: %v (new binary will load on next restart)", err)
+		return false
+	}
+	return true
+}
+
+// waitForIdle blocks until ActiveJobs reports 0, ctx is cancelled, or the idle
+// timeout elapses.
+func (a *AutoUpdater) waitForIdle(ctx context.Context) error {
+	if a.cfg.ActiveJobs == nil {
+		return nil
+	}
+	deadline := time.Now().Add(a.cfg.IdleTimeout)
+	ticker := time.NewTicker(a.cfg.IdlePollInterval)
+	defer ticker.Stop()
+
+	for {
+		if a.cfg.ActiveJobs() == 0 {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out after %s waiting for %d in-flight job(s) to finish",
+				a.cfg.IdleTimeout, a.cfg.ActiveJobs())
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context cancelled while draining in-flight jobs")
+		case <-ticker.C:
+		}
+	}
+}
+
+// ParseInterval parses a human duration string (e.g. "1h", "30m") into a
+// duration suitable for AutoUpdaterConfig.Interval. Empty input yields the
+// default interval. Invalid input returns an error so misconfiguration is
+// surfaced rather than silently ignored.
+func ParseInterval(s string) (time.Duration, error) {
+	if s == "" {
+		return DefaultAutoUpdateInterval, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid auto-update interval %q: %w", s, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("auto-update interval must be positive, got %q", s)
+	}
+	return d, nil
+}

--- a/internal/update/autoupdater_test.go
+++ b/internal/update/autoupdater_test.go
@@ -1,0 +1,247 @@
+// internal/update/autoupdater_test.go
+package update
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeChecker is an in-memory ReleaseChecker for tests. No network.
+type fakeChecker struct {
+	release      *Release
+	checkErr     error
+	downloadErr  error
+	checkCalls   int32
+	downloadHits int32
+}
+
+func (f *fakeChecker) CheckForUpdate() (*Release, error) {
+	atomic.AddInt32(&f.checkCalls, 1)
+	if f.checkErr != nil {
+		return nil, f.checkErr
+	}
+	return f.release, nil
+}
+
+func (f *fakeChecker) DownloadAndVerify(release *Release, destPath string) error {
+	atomic.AddInt32(&f.downloadHits, 1)
+	return f.downloadErr
+}
+
+func TestParseInterval(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    time.Duration
+		wantErr bool
+	}{
+		{"empty uses default", "", DefaultAutoUpdateInterval, false},
+		{"one hour", "1h", time.Hour, false},
+		{"thirty minutes", "30m", 30 * time.Minute, false},
+		{"invalid", "banana", 0, true},
+		{"zero rejected", "0s", 0, true},
+		{"negative rejected", "-5m", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseInterval(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseInterval(%q) err=%v wantErr=%v", tt.in, err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("ParseInterval(%q)=%v want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewAutoUpdaterClampsInterval(t *testing.T) {
+	// Below the floor is clamped up.
+	u := NewAutoUpdater(AutoUpdaterConfig{Checker: &fakeChecker{}, Interval: time.Second})
+	if u.cfg.Interval != MinAutoUpdateInterval {
+		t.Errorf("interval below floor not clamped: got %v want %v", u.cfg.Interval, MinAutoUpdateInterval)
+	}
+	// Zero uses the default.
+	u = NewAutoUpdater(AutoUpdaterConfig{Checker: &fakeChecker{}, Interval: 0})
+	if u.cfg.Interval != DefaultAutoUpdateInterval {
+		t.Errorf("zero interval not defaulted: got %v want %v", u.cfg.Interval, DefaultAutoUpdateInterval)
+	}
+	// Above the floor is preserved.
+	u = NewAutoUpdater(AutoUpdaterConfig{Checker: &fakeChecker{}, Interval: 2 * time.Hour})
+	if u.cfg.Interval != 2*time.Hour {
+		t.Errorf("valid interval not preserved: got %v", u.cfg.Interval)
+	}
+}
+
+func TestRunOnce_UpToDate_NoApply(t *testing.T) {
+	applied := false
+	restarted := false
+	u := NewAutoUpdater(AutoUpdaterConfig{
+		Checker: &fakeChecker{release: nil}, // up to date
+		Apply:   func(string) error { applied = true; return nil },
+		Restart: func() error { restarted = true; return nil },
+	})
+	if got := u.runOnce(context.Background()); got {
+		t.Error("runOnce should not report restart when up to date")
+	}
+	if applied || restarted {
+		t.Errorf("apply/restart must not run when up to date (applied=%v restarted=%v)", applied, restarted)
+	}
+}
+
+func TestRunOnce_CheckError_NoApply(t *testing.T) {
+	applied := false
+	u := NewAutoUpdater(AutoUpdaterConfig{
+		Checker: &fakeChecker{checkErr: errors.New("network down")},
+		Apply:   func(string) error { applied = true; return nil },
+		Restart: func() error { return nil },
+	})
+	if u.runOnce(context.Background()) {
+		t.Error("runOnce should return false on check error")
+	}
+	if applied {
+		t.Error("apply must not run on check error")
+	}
+}
+
+func TestRunOnce_DownloadError_NoApply(t *testing.T) {
+	applied := false
+	drained := false
+	u := NewAutoUpdater(AutoUpdaterConfig{
+		Checker: &fakeChecker{release: &Release{TagName: "v9.9.9"}, downloadErr: errors.New("checksum mismatch")},
+		Apply:   func(string) error { applied = true; return nil },
+		Restart: func() error { return nil },
+		Drain:   func() { drained = true },
+	})
+	if u.runOnce(context.Background()) {
+		t.Error("runOnce should return false on download error")
+	}
+	if applied {
+		t.Error("apply must not run when download/verify fails")
+	}
+	if drained {
+		t.Error("must not drain before a successful download")
+	}
+}
+
+func TestRunOnce_HappyPath_DrainsAppliesRestarts(t *testing.T) {
+	var order []string
+	var mu sync.Mutex
+	add := func(s string) { mu.Lock(); order = append(order, s); mu.Unlock() }
+
+	drained := false
+	u := NewAutoUpdater(AutoUpdaterConfig{
+		Checker:    &fakeChecker{release: &Release{TagName: "v9.9.9"}},
+		ActiveJobs: func() int { return 0 }, // idle immediately
+		Drain:      func() { drained = true; add("drain") },
+		Apply:      func(string) error { add("apply"); return nil },
+		Restart:    func() error { add("restart"); return nil },
+	})
+
+	if !u.runOnce(context.Background()) {
+		t.Fatal("runOnce should report restart on happy path")
+	}
+	if !drained {
+		t.Error("expected drain to be called")
+	}
+	want := []string{"drain", "apply", "restart"}
+	if len(order) != len(want) {
+		t.Fatalf("call order = %v, want %v", order, want)
+	}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Fatalf("call order = %v, want %v", order, want)
+		}
+	}
+}
+
+func TestRunOnce_DrainsBeforeApply_WaitsForIdle(t *testing.T) {
+	// active starts at 1, drops to 0 after Drain is called: verifies the
+	// updater waits for in-flight work and only applies once idle.
+	var active int32 = 1
+	applyCalledWhileBusy := false
+
+	u := NewAutoUpdater(AutoUpdaterConfig{
+		Checker:          &fakeChecker{release: &Release{TagName: "v9.9.9"}},
+		IdlePollInterval: time.Millisecond,
+		IdleTimeout:      2 * time.Second,
+		ActiveJobs:       func() int { return int(atomic.LoadInt32(&active)) },
+		Drain: func() {
+			// Simulate the in-flight job finishing shortly after drain.
+			go func() {
+				time.Sleep(20 * time.Millisecond)
+				atomic.StoreInt32(&active, 0)
+			}()
+		},
+		Apply: func(string) error {
+			if atomic.LoadInt32(&active) != 0 {
+				applyCalledWhileBusy = true
+			}
+			return nil
+		},
+		Restart: func() error { return nil },
+	})
+
+	if !u.runOnce(context.Background()) {
+		t.Fatal("expected restart on happy path")
+	}
+	if applyCalledWhileBusy {
+		t.Error("apply must not run while jobs are still in flight")
+	}
+}
+
+func TestRunOnce_IdleTimeout_DefersUpdate(t *testing.T) {
+	applied := false
+	u := NewAutoUpdater(AutoUpdaterConfig{
+		Checker:          &fakeChecker{release: &Release{TagName: "v9.9.9"}},
+		IdlePollInterval: time.Millisecond,
+		IdleTimeout:      30 * time.Millisecond,
+		ActiveJobs:       func() int { return 1 }, // never idle
+		Drain:            func() {},
+		Apply:            func(string) error { applied = true; return nil },
+		Restart:          func() error { return nil },
+	})
+	if u.runOnce(context.Background()) {
+		t.Error("runOnce should not restart when idle wait times out")
+	}
+	if applied {
+		t.Error("apply must not run if the node never drains")
+	}
+}
+
+func TestRunOnce_ApplyError_NoRestart(t *testing.T) {
+	restarted := false
+	u := NewAutoUpdater(AutoUpdaterConfig{
+		Checker:    &fakeChecker{release: &Release{TagName: "v9.9.9"}},
+		ActiveJobs: func() int { return 0 },
+		Drain:      func() {},
+		Apply:      func(string) error { return errors.New("swap failed") },
+		Restart:    func() error { restarted = true; return nil },
+	})
+	if u.runOnce(context.Background()) {
+		t.Error("runOnce should return false when apply fails")
+	}
+	if restarted {
+		t.Error("must not restart when apply fails")
+	}
+}
+
+func TestRun_StopsOnContextCancel(t *testing.T) {
+	u := NewAutoUpdater(AutoUpdaterConfig{
+		Checker:  &fakeChecker{release: nil},
+		Interval: MinAutoUpdateInterval,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { u.Run(ctx); close(done) }()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after context cancel")
+	}
+}

--- a/internal/update/restart_unix.go
+++ b/internal/update/restart_unix.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+// internal/update/restart_unix.go
+// Clean self-restart for Unix-like systems after an in-place binary swap.
+package update
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// RestartProcess re-execs the current process onto the freshly-installed binary
+// using execve(2). The PID is preserved and the new binary takes over the
+// process image, so this works both for foreground runs and under a supervisor
+// (systemd Restart=always). On success this call does not return.
+func RestartProcess() error {
+	path, err := GetCurrentBinaryPath()
+	if err != nil {
+		return fmt.Errorf("resolve current binary: %w", err)
+	}
+	// os.Args[0] may be a relative/symlinked name; exec the resolved path but
+	// keep the original argv so the new process sees the same flags.
+	argv := os.Args
+	if err := syscall.Exec(path, argv, os.Environ()); err != nil {
+		return fmt.Errorf("exec %s: %w", path, err)
+	}
+	return nil // unreachable on success
+}

--- a/internal/update/restart_windows.go
+++ b/internal/update/restart_windows.go
@@ -1,0 +1,49 @@
+//go:build windows
+
+// internal/update/restart_windows.go
+// Clean self-restart for Windows after an in-place binary swap.
+//
+// Windows does not support execve(2), and running executables are file-locked,
+// so the swap uses the rename workaround in atomicReplaceWindows. To pick up
+// the new binary we exit cleanly and let the supervisor relaunch us: Citadel is
+// installed as a Windows service (sc.exe) configured to restart, and the
+// service manager will start the new binary. If Citadel is run in the
+// foreground without a supervisor, the operator must restart it manually; we
+// log that expectation at the call site.
+package update
+
+import (
+	"os"
+	"os/exec"
+)
+
+// RestartProcess relaunches the agent onto the new binary. It spawns a fresh
+// detached process from the (now-replaced) binary path with the same arguments
+// and then exits the current process. Under the Windows service manager the
+// service will be restarted regardless; the spawned process covers the
+// foreground case. On success this call does not return.
+func RestartProcess() error {
+	path, err := GetCurrentBinaryPath()
+	if err != nil {
+		// Fall back to a clean exit so a supervisor can relaunch us.
+		os.Exit(0)
+		return nil
+	}
+
+	cmd := exec.Command(path, os.Args[1:]...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = os.Environ()
+	if err := cmd.Start(); err != nil {
+		// Could not spawn; rely on the service manager to relaunch.
+		os.Exit(0)
+		return nil
+	}
+
+	// Detach and exit so the old image releases any locks; the new process (or
+	// service manager) continues on the updated binary.
+	_ = cmd.Process.Release()
+	os.Exit(0)
+	return nil // unreachable
+}

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -28,6 +29,13 @@ type Runner struct {
 	// Concurrency support
 	maxConcurrency int
 	gpuTracker     *GPUTracker
+
+	// Lifecycle observability for safe self-update.
+	// activeJobs counts jobs currently executing in a handler.
+	// draining, when set, stops the run loop from fetching new jobs so
+	// in-flight work can finish before the process is replaced/restarted.
+	activeJobs int64
+	draining   int32
 }
 
 // RunnerConfig holds configuration for the runner.
@@ -84,6 +92,25 @@ func (r *Runner) recordJob(record usage.UsageRecord) {
 	if r.jobRecordFn != nil {
 		r.jobRecordFn(record)
 	}
+}
+
+// ActiveJobs returns the number of jobs currently executing in a handler.
+// It is safe to call concurrently and is used by the auto-updater to find an
+// idle moment before swapping the binary.
+func (r *Runner) ActiveJobs() int {
+	return int(atomic.LoadInt64(&r.activeJobs))
+}
+
+// Drain signals the run loop to stop fetching new jobs. In-flight jobs are
+// allowed to finish. This is used by the auto-updater so that no new work is
+// picked up once an update has been downloaded and is ready to apply.
+func (r *Runner) Drain() {
+	atomic.StoreInt32(&r.draining, 1)
+}
+
+// isDraining reports whether Drain has been called.
+func (r *Runner) isDraining() bool {
+	return atomic.LoadInt32(&r.draining) == 1
 }
 
 // WithStreamWriterFactory sets a factory for creating stream writers.
@@ -144,6 +171,17 @@ runLoop:
 		case <-ctx.Done():
 			break runLoop
 		default:
+			// Stop fetching new jobs once draining (e.g. an auto-update is
+			// ready to apply). In-flight jobs continue to completion below.
+			if r.isDraining() {
+				select {
+				case <-time.After(200 * time.Millisecond):
+				case <-ctx.Done():
+					break runLoop
+				}
+				continue
+			}
+
 			// Fetch next job
 			job, err := r.source.Next(ctx)
 			if err != nil {
@@ -195,6 +233,9 @@ runLoop:
 
 // processJob dispatches a job to the appropriate handler.
 func (r *Runner) processJob(ctx context.Context, job *Job) {
+	atomic.AddInt64(&r.activeJobs, 1)
+	defer atomic.AddInt64(&r.activeJobs, -1)
+
 	r.log("info", "Received job %s (type: %s)", job.ID, job.Type)
 	startTime := time.Now()
 

--- a/internal/worker/runner_drain_test.go
+++ b/internal/worker/runner_drain_test.go
@@ -1,0 +1,95 @@
+package worker
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// blockingHandler blocks in Execute until release is closed, letting tests
+// observe the runner's in-flight job count and drain behavior.
+type blockingHandler struct {
+	jobType string
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func newBlockingHandler(jobType string) *blockingHandler {
+	return &blockingHandler{
+		jobType: jobType,
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (h *blockingHandler) CanHandle(jobType string) bool { return h.jobType == jobType }
+
+func (h *blockingHandler) Execute(ctx context.Context, job *Job, stream StreamWriter) (*JobResult, error) {
+	h.once.Do(func() { close(h.started) })
+	select {
+	case <-h.release:
+	case <-ctx.Done():
+	}
+	return &JobResult{Status: JobStatusSuccess, Output: map[string]any{"ok": true}}, nil
+}
+
+func TestRunnerActiveJobsAndDrain(t *testing.T) {
+	handler := newBlockingHandler("BLOCK")
+	job := &Job{ID: "j1", Type: "BLOCK", Payload: map[string]any{}}
+	// Two jobs so we can confirm draining stops the second from starting.
+	source := NewMockJobSource("test", []*Job{job, {ID: "j2", Type: "BLOCK", Payload: map[string]any{}}})
+
+	runner := NewRunner(source, []JobHandler{handler}, RunnerConfig{
+		WorkerID:       "w",
+		MaxConcurrency: 1,
+		ActivityFn:     func(string, string) {}, // silence
+	})
+
+	if runner.ActiveJobs() != 0 {
+		t.Fatalf("expected 0 active jobs before start, got %d", runner.ActiveJobs())
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() { _ = runner.Run(ctx); close(done) }()
+
+	// Wait for the first job to enter the handler.
+	select {
+	case <-handler.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first job never started")
+	}
+
+	if got := runner.ActiveJobs(); got != 1 {
+		t.Errorf("expected 1 active job, got %d", got)
+	}
+
+	// Drain: no new jobs should be fetched. Release the in-flight job.
+	runner.Drain()
+	close(handler.release)
+
+	// Active jobs should return to 0 and stay there (j2 must never start).
+	deadline := time.Now().Add(2 * time.Second)
+	for runner.ActiveJobs() != 0 {
+		if time.Now().After(deadline) {
+			t.Fatalf("active jobs did not return to 0, got %d", runner.ActiveJobs())
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Give the loop a moment; ensure j2 was not picked up while draining.
+	time.Sleep(100 * time.Millisecond)
+	if got := runner.ActiveJobs(); got != 0 {
+		t.Errorf("expected runner to stay idle while draining, got %d active", got)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runner did not shut down")
+	}
+}


### PR DESCRIPTION
## Context

Citadel runs as a long-lived agent on user nodes. Today, shipping a node-side change requires every operator to manually run `citadel update install` — so capability rollouts stall until people remember to update. The just-merged `FILE_READ_BYTES` handler (#219) is a concrete example: it only reaches a node once that node's binary is refreshed.

This PR adds an **opt-in** background auto-updater so node-side capabilities roll out automatically. When enabled, the agent periodically (default `1h`) checks GitHub Releases, and if a newer version exists it downloads + checksum-verifies the asset, **drains in-flight jobs**, atomically swaps the binary, and restarts cleanly onto the new version.

It is **off by default** and reuses the repo's existing update machinery rather than adding a new dependency.

## Summary

**`internal/update/autoupdater.go` — the periodic loop (new)**
- `AutoUpdater` is an injectable type built on the existing `Client.CheckForUpdate` / `DownloadAndVerify` and `ApplyUpdate` / `Rollback`. No new library: this preserves the release-asset naming + `checksums.txt` contract the existing manual `citadel update` flow already depends on.
- Commit order is deliberately race-free: **download+verify while jobs run** (slow, no idle needed) → **Drain** (stop fetching new work) → **wait for `ActiveJobs()==0`** → **Apply** (atomic swap, self-validating + auto-rollback) → **Restart**. Draining *before* observing idle closes the observe-idle → swap race.
- Fail-safe by construction: `Run` never returns an error, recovers from panics, and any check/download/apply failure is logged and retried on the next tick. The agent keeps running on the old binary if anything goes wrong.
- Interval is parsed with `time.ParseDuration` and clamped to a `5m` floor (the unauthenticated GitHub API allows ~60 req/hr).

**`internal/update/restart_{unix,windows}.go` — clean restart (new)**
- Unix: `syscall.Exec` re-execs onto the new binary in place (works foreground or under a supervisor).
- Windows: `syscall.Exec` is unsupported and running exes are locked, so we respawn a detached process and exit; the Windows service (`sc.exe`) / systemd `Restart=always` supervisor relaunches the new binary.

**`internal/worker/runner.go` — lifecycle observability**
- `ActiveJobs() int` (atomic counter, inc/dec around `processJob`) and `Drain()` (atomic flag the run loop checks before fetching). This is what lets the updater find an idle moment and never kill running work mid-flight.

**`cmd/work.go` — wiring + config**
- New gate, **distinct** from the existing notify-only `State.AutoUpdate` (which defaults on) so we don't silently enable binary auto-replace for everyone:
  - `--auto-update` / `CITADEL_AUTO_UPDATE=true` (default: off)
  - `--auto-update-interval` / `CITADEL_AUTO_UPDATE_INTERVAL` (e.g. `1h`, `30m`; default `1h`)
- Launches `updater.Run(ctx)` as a goroutine after the runner is created, only when enabled.

## How in-flight jobs are protected

`Drain()` stops the run loop from calling `source.Next`, so no new job is pulled once an update is staged. The updater then blocks on `ActiveJobs()==0` (bounded by a 10m idle timeout — if a job runs longer the update simply defers to the next tick) before swapping the binary and restarting. A job executing at any point is always allowed to finish first.

## Test plan

All tests mock the release lookup — **no network access**.

| Area | Coverage |
|------|----------|
| Interval parsing | empty→default, `1h`/`30m`, invalid/zero/negative rejected |
| Config gating | interval clamped to floor, zero→default, valid preserved |
| Happy path | drain → apply → restart called in order |
| Drain-before-apply | apply only fires once `ActiveJobs()==0`; never while busy |
| Idle timeout | update deferred (no apply) when node never drains |
| Fail-safes | check error / download error / apply error → no apply/restart |
| Lifecycle | `Run` returns on context cancel |
| Runner | `ActiveJobs()` reflects in-flight count; `Drain()` stops new fetches |

`go build ./...`, `go vet ./...`, `go test ./...` all pass (incl. `GOOS=windows` build/vet of the update package); `gofmt` clean on all touched files.

## Related

- Tracking issue: #220
- Motivating handler: #219 (`FILE_READ_BYTES`)
- Motivating rollout: aceteam-ai/aceteam#3905 / #3906