### PR TITLE
fix(build): pin man-page deps so release build works from clean checkout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
 	github.com/coder/websocket v1.8.12 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/creachadair/msync v0.7.1 // indirect
 	github.com/dblohm7/wingoes v0.0.0-20240119213807-a09d6be7affa // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
@@ -91,6 +92,7 @@ require (
 	github.com/prometheus-community/pro-bing v0.4.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/safchain/ethtool v0.3.0 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/tailscale/certstore v0.1.1-0.20231202035212-d3fa0460f47e // indirect

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,7 @@ github.com/coder/websocket v1.8.12 h1:5bUXkEPPIbewrnkU8LTCLVaxi4N4J8ahufH2vlo4NA
 github.com/coder/websocket v1.8.12/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/coreos/go-iptables v0.7.1-0.20240112124308-65c67c9f46e6 h1:8h5+bWd7R6AYUslN6c6iuZWTKsKxUFDlpnmilO6R2n0=
 github.com/coreos/go-iptables v0.7.1-0.20240112124308-65c67c9f46e6/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
+github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creachadair/msync v0.7.1 h1:SeZmuEBXQPe5GqV/C94ER7QIZPwtvFbeQiykzt/7uho=
 github.com/creachadair/msync v0.7.1/go.mod h1:8CcFlLsSujfHE5wWm19uUBLHIPDAUr6LXDwneVMO008=
@@ -233,6 +234,7 @@ github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/safchain/ethtool v0.3.0 h1:gimQJpsI6sc1yIqP/y8GYgiXn/NjgvpM0RNoWLVVmP0=
 github.com/safchain/ethtool v0.3.0/go.mod h1:SA9BwrgyAqNo7M+uaL6IYbxpm5wk3L7Mm6ocLW+CJUs=

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,15 @@
+//go:build tools
+
+// Package tools pins build-time-only dependencies so `go mod tidy` keeps them
+// in go.mod/go.sum. The release build runs `go run docs/gen-manpage.go` (a
+// `//go:build ignore` script) to generate man pages; it imports
+// github.com/spf13/cobra/doc, which transitively needs
+// github.com/cpuguy83/go-md2man/v2. Because the man-gen script is excluded from
+// normal builds, `go mod tidy` would otherwise strip go-md2man from go.sum and
+// `build.sh --all` would fail from a clean checkout. This file is never
+// compiled into any binary (the `tools` build tag is never enabled).
+package tools
+
+import (
+	_ "github.com/spf13/cobra/doc"
+)


### PR DESCRIPTION
## Context

`./build.sh --all` (the canonical release build) fails from a clean checkout:

```
missing go.sum entry for module providing package github.com/cpuguy83/go-md2man/v2/md2man (imported by github.com/spf13/cobra/doc)
```

The man-page step runs `go run docs/gen-manpage.go`, a `//go:build ignore` script that imports `cobra/doc` → `go-md2man` + `blackfriday`. Because the script is excluded from normal builds, `go mod tidy` strips those transitive deps from `go.sum`, so the release build can't generate man pages.

This blocks cutting **any** Citadel release (discovered while preparing v2.33.0 with FILE_READ_BYTES + auto-update).

## Summary

- Add a `//go:build tools` `tools.go` that blank-imports `github.com/spf13/cobra/doc`, so `go mod tidy` keeps `go-md2man` + `blackfriday` pinned. The file is never compiled into any binary.
- `go.mod` / `go.sum` now track `go-md2man/v2 v2.0.6` + `blackfriday/v2 v2.1.0` (existing versions, no upgrade).

## Test plan

`./build.sh --all` from a clean checkout now generates all 56 man pages and packages all 6 platform archives + checksums. `go build ./...` / `go vet ./...` unaffected.

## Related

Unblocks the v2.33.0 release (aceteam-ai/aceteam#3905 / #3898 node rollout, plus the auto-updater #220/#221).