### PR TITLE
feat(update): persisted, runtime-toggleable auto-update (enables a web UI toggle)

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -76,8 +76,11 @@ var updateStatusCmd = &cobra.Command{
 
 var updateEnableCmd = &cobra.Command{
 	Use:   "enable",
-	Short: "Enable automatic update checks",
-	Long:  `Enables periodic update checks when running citadel work.`,
+	Short: "Enable automatic updates",
+	Long: `Enables automatic updates. A running 'citadel work' agent periodically
+checks for a newer release and installs it (draining in-flight jobs first).
+The setting is persisted and re-read each cycle, so it takes effect on a
+running agent without a restart.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		setAutoUpdate(true)
 	},
@@ -85,8 +88,9 @@ var updateEnableCmd = &cobra.Command{
 
 var updateDisableCmd = &cobra.Command{
 	Use:   "disable",
-	Short: "Disable automatic update checks",
-	Long:  `Disables automatic update checks.`,
+	Short: "Disable automatic updates",
+	Long: `Disables automatic updates. Takes effect on a running 'citadel work'
+agent within one check interval, without a restart.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		setAutoUpdate(false)
 	},
@@ -269,11 +273,11 @@ func setAutoUpdate(enabled bool) {
 	}
 
 	if enabled {
-		fmt.Println("Auto-update checks enabled.")
-		fmt.Println("Updates will be checked once per day when running 'citadel work'.")
+		fmt.Println("Automatic updates enabled.")
+		fmt.Println("A running 'citadel work' agent will periodically check for and install newer releases.")
 	} else {
-		fmt.Println("Auto-update checks disabled.")
-		fmt.Println("Run 'citadel update check' to manually check for updates.")
+		fmt.Println("Automatic updates disabled.")
+		fmt.Println("Run 'citadel update check' / 'citadel update install' to update manually.")
 	}
 }
 

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1111,26 +1111,27 @@ func runWork(cmd *cobra.Command, args []string) {
 		runner.WithStreamWriterFactory(streamFactory)
 	}
 
-	// Start the opt-in periodic auto-updater. Disabled by default; enable with
-	// --auto-update or CITADEL_AUTO_UPDATE=true. It checks GitHub Releases on
-	// the configured interval and, when a newer version is found, drains
+	// Start the periodic auto-updater. The goroutine always runs; whether it
+	// actually checks/installs on a given tick is decided per-tick by
+	// resolveAutoUpdateEnabled() so the switch can be flipped on a *running*
+	// agent — `citadel update enable/disable` (or the web UI, which dispatches
+	// those same commands) writes the persisted state and the next tick honors
+	// it without a restart. When enabled and a newer version is found, it drains
 	// in-flight jobs before atomically swapping the binary and restarting.
-	if resolveAutoUpdateEnabled() {
-		interval, err := update.ParseInterval(resolveAutoUpdateInterval())
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "   - Warning: %v; auto-update disabled\n", err)
-		} else {
-			updater := update.NewAutoUpdater(update.AutoUpdaterConfig{
-				Checker:    update.NewClientWithTimeout(Version, 30*time.Second),
-				Interval:   interval,
-				ActiveJobs: runner.ActiveJobs,
-				Drain:      func() { runner.Drain() },
-				Log: func(format string, args ...any) {
-					fmt.Printf("   - "+format+"\n", args...)
-				},
-			})
-			go updater.Run(ctx)
-		}
+	if interval, err := update.ParseInterval(resolveAutoUpdateInterval()); err != nil {
+		fmt.Fprintf(os.Stderr, "   - Warning: %v; auto-update disabled\n", err)
+	} else {
+		updater := update.NewAutoUpdater(update.AutoUpdaterConfig{
+			Checker:    update.NewClientWithTimeout(Version, 30*time.Second),
+			Interval:   interval,
+			Enabled:    resolveAutoUpdateEnabled,
+			ActiveJobs: runner.ActiveJobs,
+			Drain:      func() { runner.Drain() },
+			Log: func(format string, args ...any) {
+				fmt.Printf("   - "+format+"\n", args...)
+			},
+		})
+		go updater.Run(ctx)
 	}
 
 	// Run the worker
@@ -1255,8 +1256,11 @@ func resolveWorkspaceDir() string {
 	return abs
 }
 
-// resolveAutoUpdateEnabled reports whether the periodic auto-updater should run.
-// Priority: --auto-update flag > CITADEL_AUTO_UPDATE env. Disabled by default.
+// resolveAutoUpdateEnabled reports whether the periodic auto-updater should act
+// on the current tick. Priority: --auto-update flag > CITADEL_AUTO_UPDATE env
+// (explicit on/off) > the persisted `citadel update enable/disable` state.
+// Disabled by default. Evaluated every tick so the web UI (which dispatches
+// `citadel update enable/disable` to the node) can toggle a running agent.
 func resolveAutoUpdateEnabled() bool {
 	if workAutoUpdate {
 		return true
@@ -1264,8 +1268,14 @@ func resolveAutoUpdateEnabled() bool {
 	switch strings.ToLower(strings.TrimSpace(os.Getenv("CITADEL_AUTO_UPDATE"))) {
 	case "1", "true", "yes", "on":
 		return true
+	case "0", "false", "no", "off":
+		return false
 	}
-	return false
+	state, err := update.LoadState()
+	if err != nil || state == nil {
+		return false
+	}
+	return state.AutoUpdate
 }
 
 // resolveAutoUpdateInterval returns the configured auto-update interval string.

--- a/cmd/work_test.go
+++ b/cmd/work_test.go
@@ -1,6 +1,55 @@
 package cmd
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/update"
+)
+
+// TestResolveAutoUpdateEnabled verifies the precedence that lets the web UI /
+// `citadel update enable/disable` toggle a node: explicit --auto-update flag >
+// CITADEL_AUTO_UPDATE env (on/off) > persisted state > default-off.
+func TestResolveAutoUpdateEnabled(t *testing.T) {
+	writeState := func(t *testing.T, auto bool) {
+		t.Helper()
+		if err := update.SaveState(&update.State{AutoUpdate: auto, Channel: "stable"}); err != nil {
+			t.Fatalf("SaveState: %v", err)
+		}
+	}
+
+	cases := []struct {
+		name     string
+		flag     bool
+		env      string // "" means unset
+		state    *bool  // nil means no state file
+		expected bool
+	}{
+		{name: "default off when nothing set", expected: false},
+		{name: "persisted state enables", state: boolPtr(true), expected: true},
+		{name: "persisted state disables", state: boolPtr(false), expected: false},
+		{name: "env true overrides disabled state", env: "true", state: boolPtr(false), expected: true},
+		{name: "env off overrides enabled state", env: "off", state: boolPtr(true), expected: false},
+		{name: "flag wins over env and state", flag: true, env: "off", state: boolPtr(false), expected: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir()) // isolate the on-disk update state
+			t.Setenv("CITADEL_AUTO_UPDATE", tc.env)
+			orig := workAutoUpdate
+			workAutoUpdate = tc.flag
+			t.Cleanup(func() { workAutoUpdate = orig })
+			if tc.state != nil {
+				writeState(t, *tc.state)
+			}
+			if got := resolveAutoUpdateEnabled(); got != tc.expected {
+				t.Errorf("resolveAutoUpdateEnabled() = %v, want %v", got, tc.expected)
+			}
+		})
+	}
+}
+
+func boolPtr(v bool) *bool { return &v }
 
 func TestShellQueueName(t *testing.T) {
 	tests := []struct {

--- a/internal/update/autoupdater.go
+++ b/internal/update/autoupdater.go
@@ -54,6 +54,13 @@ type AutoUpdaterConfig struct {
 	// up to the floor. Zero uses DefaultAutoUpdateInterval.
 	Interval time.Duration
 
+	// Enabled is consulted at the start of every tick. When it returns false the
+	// updater skips that cycle entirely (no release check, no swap), so the
+	// switch can be flipped on a *running* agent — e.g. `citadel update
+	// enable/disable` (or the web UI) writes the persisted state and the next
+	// tick honors it without a restart. If nil, the updater is always enabled.
+	Enabled func() bool
+
 	// ActiveJobs reports the number of in-flight jobs. When it returns 0 the
 	// updater considers the node idle and safe to restart. If nil, the node is
 	// always considered idle (best-effort).
@@ -129,7 +136,7 @@ func NewAutoUpdater(cfg AutoUpdaterConfig) *AutoUpdater {
 // interval. It never returns an error: failures are logged and retried on the
 // next tick so the agent keeps running regardless.
 func (a *AutoUpdater) Run(ctx context.Context) {
-	a.cfg.Log("auto-update: enabled (interval %s)", a.cfg.Interval)
+	a.cfg.Log("auto-update: monitoring (interval %s)", a.cfg.Interval)
 	ticker := time.NewTicker(a.cfg.Interval)
 	defer ticker.Stop()
 
@@ -138,6 +145,11 @@ func (a *AutoUpdater) Run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+			// Re-check the toggle every tick so it can be flipped on a running
+			// agent without a restart.
+			if a.cfg.Enabled != nil && !a.cfg.Enabled() {
+				continue
+			}
 			// runOnce never panics; guard anyway so a bug here can never take
 			// down the agent.
 			func() {

--- a/internal/update/state.go
+++ b/internal/update/state.go
@@ -112,10 +112,13 @@ func RecordUpdate(state *State, oldVersion, newVersion string) {
 	state.LastUpdate = time.Now()
 }
 
-// defaultState returns a new state with sensible defaults
+// defaultState returns a new state with sensible defaults.
+// AutoUpdate defaults to false: auto-installing a new binary on a node is
+// consequential, so it is opt-in (turned on explicitly via `citadel update
+// enable` or the web UI), never on by default.
 func defaultState() *State {
 	return &State{
-		AutoUpdate: true,
+		AutoUpdate: false,
 		Channel:    "stable",
 	}
 }

--- a/internal/update/state_test.go
+++ b/internal/update/state_test.go
@@ -11,8 +11,8 @@ import (
 func TestDefaultState(t *testing.T) {
 	state := defaultState()
 
-	if !state.AutoUpdate {
-		t.Error("AutoUpdate should be true by default")
+	if state.AutoUpdate {
+		t.Error("AutoUpdate should be false by default (auto-install is opt-in)")
 	}
 
 	if state.Channel != "stable" {
@@ -183,8 +183,8 @@ func TestLoadStateNotFound(t *testing.T) {
 		t.Fatalf("LoadState should not fail for missing file: %v", err)
 	}
 
-	if !state.AutoUpdate {
-		t.Error("Default state should have AutoUpdate enabled")
+	if state.AutoUpdate {
+		t.Error("Default state should have AutoUpdate disabled (opt-in)")
 	}
 
 	if state.Channel != "stable" {


### PR DESCRIPTION
## Context

We want to control a node's auto-update from a **Settings toggle in the AceTeam web app**, not by setting `CITADEL_AUTO_UPDATE` on the box. This PR is the node-side enablement for that.

Today the periodic auto-updater (#221) reads its on/off **only** from the `--auto-update` flag / `CITADEL_AUTO_UPDATE` env, decided once at `citadel work` startup. So toggling it requires editing the environment and restarting the agent — no good for a remote UI.

## Summary

Drive the periodic auto-updater from the **persisted update state** that `citadel update enable/disable` already writes, re-checked every tick so it can be flipped on a **running** agent.

- **autoupdater**: new `Enabled func() bool` on the config, consulted at the start of every tick; when false the cycle is skipped (no release check, no swap). The goroutine in `citadel work` now **always starts** and is gated per-tick (instead of being created only when enabled at startup).
- **`resolveAutoUpdateEnabled`**: precedence is `--auto-update` flag > `CITADEL_AUTO_UPDATE` env (explicit on/off) > **persisted `State.AutoUpdate`**, re-evaluated each tick.
- **Default-off**: `defaultState().AutoUpdate` is now `false`. Auto-installing a binary is consequential, so it stays opt-in — enabled explicitly via `citadel update enable` or the UI.
- **`update enable/disable`** help/messages updated: they now control the periodic auto-installer and take effect on a running agent without a restart.

### How the web UI will use this (follow-up, aceteam side)
The UI dispatches `citadel update enable` / `disable` to the node over the existing command-dispatch path (the same Redis-stream mechanism `terminal_exec` / the MCP code tools use), and reads `citadel update status` back for current state. No node-side env vars; no restart. Tracked in the aceteam follow-up issue.

## Test plan

- `TestResolveAutoUpdateEnabled` — precedence matrix: flag > env(on/off) > persisted state > default-off, with an isolated temp `HOME` for on-disk state.
- Updated `TestDefaultState` / `TestLoadStateNotFound` for the new default-off.
- `go build ./...`, `go vet ./...`, `go test ./...` all pass; `gofmt` clean.

## Related

Node-side counterpart to the planned AceTeam fabric Settings toggle. Builds on #221 (periodic auto-update) and #222 (release-build fix).