### PR TITLE
fix(worker): subscribe to per-node shell stream for node-targeted jobs (#3914)

### DIFF
--- a/cmd/work.go
+++ b/cmd/work.go
@@ -551,6 +551,45 @@ func runWork(cmd *cobra.Command, args []string) {
 		Debug("node meta set: node_id=%s, node_name=%s", nodeName, nodeName)
 	}
 
+	// Subscribe to this node's per-node shell stream so node-targeted MCP jobs
+	// (terminal_exec, code_*, file reads, node attachments) reach ONLY this node
+	// instead of being claimed by a greedy peer on the shared shell stream
+	// (issue #3914). Keyed by the Headscale numeric node ID, which matches the
+	// platform's fabric_node_status.node_id used for targeting. We still consume
+	// the shared shell stream for untargeted work, so this is purely additive and
+	// safe for older platform deployments that don't yet route per-node.
+	//
+	// AddQueue is a Redis-only concept, so it's accessed via an optional
+	// interface rather than the JobSource contract (the Nexus HTTP source does
+	// not implement it). Done before the run loop starts, so no locking needed.
+	if headscaleNodeID != "" {
+		perNodeOrgID := ""
+		if deviceConfig != nil {
+			perNodeOrgID = deviceConfig.OrgID
+		}
+		if perNodeOrgID == "" {
+			if manifest, _, mErr := findAndReadManifest(); mErr == nil && manifest != nil {
+				perNodeOrgID = manifest.Node.OrgID
+			}
+		}
+		if perNodeOrgID != "" {
+			perNodeQueue := nodeQueueName(perNodeOrgID, headscaleNodeID)
+			switch src := source.(type) {
+			case *worker.APISource:
+				src.AddQueue(perNodeQueue)
+			case *worker.RedisSource:
+				if err := src.AddQueue(ctx, perNodeQueue); err != nil {
+					fmt.Fprintf(os.Stderr, "   - Warning: per-node stream subscribe failed: %v\n", err)
+				}
+			}
+			Debug("per-node shell stream: %s", perNodeQueue)
+		} else {
+			Debug("per-node shell stream skipped: org id unknown")
+		}
+	} else {
+		Debug("per-node shell stream skipped: Headscale node ID unavailable")
+	}
+
 	// Open usage store for per-job compute tracking
 	var usageStore *usage.Store
 	if nodeDir, err := platform.DefaultNodeDir(""); err != nil {
@@ -1187,11 +1226,26 @@ func autoStartServices() error {
 	return nil
 }
 
-// shellQueueName returns the per-org shell command queue name.
-// Jobs dispatched by platform MCP tools (terminal_exec, code_read, etc.)
-// are enqueued to this queue using the pattern jobs:v1:shell:org_{org_id}.
+// shellQueueName returns the shared per-org shell command queue name.
+// Untargeted jobs dispatched by platform MCP tools (terminal_exec, code_read,
+// etc.) are enqueued to this queue using the pattern jobs:v1:shell:org_{org_id}.
+// Every online worker in the org consumes it, so any of them may claim a job.
 func shellQueueName(orgID string) string {
 	return fmt.Sprintf("jobs:v1:shell:org_%s", orgID)
+}
+
+// nodeQueueName returns the per-node shell stream name for node-targeted jobs.
+//
+// Node-targeted MCP jobs (terminal_exec, code_*, file reads, node attachments)
+// must run on a specific node, identified by its Headscale numeric node ID.
+// The platform dispatcher routes such jobs to this stream so only the intended
+// worker can claim them, instead of any greedy peer on the shared shell stream
+// (issue #3914). The name is namespaced under the org's shell stream and MUST
+// stay byte-for-byte identical to the Python build_node_queue helper:
+//
+//	jobs:v1:shell:org_{org_id}:node:{node_id}
+func nodeQueueName(orgID, nodeID string) string {
+	return fmt.Sprintf("jobs:v1:shell:org_%s:node:%s", orgID, nodeID)
 }
 
 // getWorkHostname returns the hostname to use for VPN reconnection.

--- a/cmd/work_test.go
+++ b/cmd/work_test.go
@@ -77,3 +77,33 @@ func TestShellQueueName(t *testing.T) {
 		}
 	}
 }
+
+// TestNodeQueueName guards the per-node shell stream naming convention. This
+// string MUST match the Python build_node_queue helper byte-for-byte, otherwise
+// node-targeted jobs (issue #3914) silently fall back to the shared stream and
+// per-node routing never engages.
+func TestNodeQueueName(t *testing.T) {
+	tests := []struct {
+		orgID  string
+		nodeID string
+		want   string
+	}{
+		{
+			orgID:  "550e8400-e29b-41d4-a716-446655440000",
+			nodeID: "1008",
+			want:   "jobs:v1:shell:org_550e8400-e29b-41d4-a716-446655440000:node:1008",
+		},
+		{
+			orgID:  "test-org-id",
+			nodeID: "969",
+			want:   "jobs:v1:shell:org_test-org-id:node:969",
+		},
+	}
+
+	for _, tt := range tests {
+		got := nodeQueueName(tt.orgID, tt.nodeID)
+		if got != tt.want {
+			t.Errorf("nodeQueueName(%q, %q) = %q, want %q", tt.orgID, tt.nodeID, got, tt.want)
+		}
+	}
+}

--- a/internal/worker/add_queue_test.go
+++ b/internal/worker/add_queue_test.go
@@ -1,0 +1,127 @@
+package worker
+
+import (
+	"context"
+	"testing"
+)
+
+// TestRedisSourceAddQueueCreatesStreamAndDelivers covers the worker side of the
+// per-node routing fix (issue #3914): AddQueue must (1) create the per-node
+// stream + consumer group immediately (so the platform dispatcher's
+// consumer-presence check can see the stream), and (2) cause jobs enqueued to
+// the per-node stream to be delivered to this worker.
+//
+// NOTE: the dispatcher gates routing on XINFO GROUPS reporting consumers > 0.
+// miniredis does not track XREADGROUP consumers (XInfoGroups always reports 0),
+// so that exact signal is verified against real Redis as a manual/integration
+// test-plan item, not here. Real Redis registers the consumer on the first
+// XREADGROUP, which the worker issues every poll once the queue is added.
+func TestRedisSourceAddQueueCreatesStreamAndDelivers(t *testing.T) {
+	_, source, raw := setupWorkerIntegration(t, "jobs:v1:shell:org_test", 3)
+	ctx := context.Background()
+
+	perNode := "jobs:v1:shell:org_test:node:1008"
+	if err := source.AddQueue(ctx, perNode); err != nil {
+		t.Fatalf("AddQueue failed: %v", err)
+	}
+
+	// The stream/group must exist immediately (EnsureConsumerGroups -> MKSTREAM)
+	// so the dispatcher can inspect it before any job is written.
+	groups, err := raw.XInfoGroups(ctx, perNode).Result()
+	if err != nil {
+		t.Fatalf("XInfoGroups after AddQueue failed (stream not created?): %v", err)
+	}
+	if len(groups) == 0 {
+		t.Fatalf("expected a consumer group on %s after AddQueue", perNode)
+	}
+
+	// A job enqueued to the per-node stream is actually delivered to this worker.
+	enqueueTestJob(t, raw, perNode, map[string]interface{}{
+		"jobId":   "job-per-node",
+		"type":    "SHELL_COMMAND",
+		"payload": `{"command":"hostname","target_node":"1008"}`,
+	})
+
+	var got *Job
+	for i := 0; i < 50; i++ {
+		j, err := source.Next(ctx)
+		if err != nil {
+			t.Fatalf("Next() failed: %v", err)
+		}
+		if j != nil {
+			got = j
+			break
+		}
+	}
+	if got == nil {
+		t.Fatal("job enqueued to per-node stream was never delivered")
+	}
+	if got.ID != "job-per-node" {
+		t.Errorf("delivered job ID = %q, want job-per-node", got.ID)
+	}
+	if got.SourceQueue != perNode {
+		t.Errorf("SourceQueue = %q, want %q", got.SourceQueue, perNode)
+	}
+}
+
+// TestRedisSourceAddQueueIdempotentAndBlank verifies AddQueue ignores blanks
+// and duplicates so the per-node subscription wiring is safe to call defensively.
+func TestRedisSourceAddQueueIdempotentAndBlank(t *testing.T) {
+	_, source, _ := setupWorkerIntegration(t, "jobs:v1:shell:org_test", 3)
+	ctx := context.Background()
+
+	before := len(source.QueueNames())
+
+	if err := source.AddQueue(ctx, ""); err != nil {
+		t.Fatalf("AddQueue(\"\") returned error: %v", err)
+	}
+	if len(source.QueueNames()) != before {
+		t.Errorf("blank queue must be ignored; queues changed to %v", source.QueueNames())
+	}
+
+	q := "jobs:v1:shell:org_test:node:42"
+	if err := source.AddQueue(ctx, q); err != nil {
+		t.Fatalf("AddQueue failed: %v", err)
+	}
+	if err := source.AddQueue(ctx, q); err != nil {
+		t.Fatalf("second AddQueue failed: %v", err)
+	}
+	count := 0
+	for _, name := range source.QueueNames() {
+		if name == q {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("queue %q should appear exactly once, found %d times in %v", q, count, source.QueueNames())
+	}
+}
+
+// TestAPISourceAddQueue verifies the API source appends queues, ignores blanks,
+// and dedupes (group creation is handled lazily by the proxy on first read).
+func TestAPISourceAddQueue(t *testing.T) {
+	source := NewAPISource(APISourceConfig{
+		QueueName:     "jobs:v1:shell:org_test",
+		ConsumerGroup: "citadel-workers",
+		LogFn:         func(level, msg string) {},
+	})
+
+	before := len(source.QueueNames())
+	source.AddQueue("")
+	if len(source.QueueNames()) != before {
+		t.Errorf("blank queue must be ignored; queues = %v", source.QueueNames())
+	}
+
+	q := "jobs:v1:shell:org_test:node:1008"
+	source.AddQueue(q)
+	source.AddQueue(q)
+	count := 0
+	for _, name := range source.QueueNames() {
+		if name == q {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("queue %q should appear exactly once, found %d in %v", q, count, source.QueueNames())
+	}
+}

--- a/internal/worker/api_source.go
+++ b/internal/worker/api_source.go
@@ -276,6 +276,27 @@ func (s *APISource) QueueNames() []string {
 	return s.queueNames
 }
 
+// AddQueue appends an additional queue to consume from after construction.
+//
+// This is used to subscribe to the worker's per-node shell stream once the
+// node's Headscale ID is known (issue #3914), which happens after the source
+// is built. The Redis API proxy creates the consumer group lazily on the first
+// XREADGROUP, so no explicit group-creation call is needed here. Must be called
+// before the run loop starts reading (single-threaded at that point), so no
+// locking is required. A blank or already-present queue is ignored.
+func (s *APISource) AddQueue(queue string) {
+	if queue == "" {
+		return
+	}
+	for _, q := range s.queueNames {
+		if q == queue {
+			return
+		}
+	}
+	s.queueNames = append(s.queueNames, queue)
+	s.log("info", "   - Added queue: %s", queue)
+}
+
 // IsJobCancelled checks whether a job has been cancelled by the producer.
 func (s *APISource) IsJobCancelled(ctx context.Context, jobID string) bool {
 	cancelled, err := s.client.IsJobCancelled(ctx, jobID)

--- a/internal/worker/redis_source.go
+++ b/internal/worker/redis_source.go
@@ -265,6 +265,35 @@ func (s *RedisSource) QueueNames() []string {
 	return s.queueNames
 }
 
+// AddQueue appends an additional queue to consume from after Connect.
+//
+// Used to subscribe to the worker's per-node shell stream once the node's
+// Headscale ID is known (issue #3914), which happens after the source is built
+// and connected. The consumer group (and stream, via MKSTREAM) is created
+// immediately so the platform dispatcher's consumer-presence check can see the
+// stream; the consumer itself registers on the next multi-queue XREADGROUP.
+// Must be called before the run loop starts reading (single-threaded at that
+// point), so no locking is required. A blank or already-present queue is
+// ignored. Returns an error only if the consumer group cannot be created.
+func (s *RedisSource) AddQueue(ctx context.Context, queue string) error {
+	if queue == "" {
+		return nil
+	}
+	for _, q := range s.queueNames {
+		if q == queue {
+			return nil
+		}
+	}
+	if s.client != nil {
+		if err := s.client.EnsureConsumerGroups(ctx, []string{queue}); err != nil {
+			return fmt.Errorf("failed to create consumer group for %s: %w", queue, err)
+		}
+	}
+	s.queueNames = append(s.queueNames, queue)
+	s.log("info", "   - Added queue: %s", queue)
+	return nil
+}
+
 // IsJobCancelled checks whether a job has been cancelled by the producer.
 func (s *RedisSource) IsJobCancelled(ctx context.Context, jobID string) bool {
 	cancelled, err := s.client.IsJobCancelled(ctx, jobID)


### PR DESCRIPTION
## Context

Companion to **aceteam-ai/aceteam#3916** for issue aceteam-ai/aceteam#3914.

Node-targeted MCP jobs (`terminal_exec`, `code_*`, file reads, node attachments, ping) were dispatched by the platform to a single shared per-org shell stream `jobs:v1:shell:org_{org}` that **every** online worker in the org consumes via the same consumer group. The first worker to read claimed the job regardless of the intended target node, so jobs ran on the wrong node or timed out. Confirmed live: a job targeted at node `1008` (ubuntu-gpu) was executed by a different node (`aceteamvm`).

## Root cause (worker side)

The worker only ever subscribed to the shared `jobs:v1:shell:org_{org}` stream — it had no way to claim *only* the jobs meant for it.

## Changes

Each worker now **additionally** subscribes to its own per-node stream:

```
jobs:v1:shell:org_{org_id}:node:{headscale_node_id}
```

keyed by the Headscale numeric node ID (`network.GetGlobalStatus().NodeID`), which is the same value the platform stores in `fabric_node_status.node_id` and targets on.

- **`cmd/work.go`** — new `nodeQueueName(org, nodeID)`; comment notes it MUST match the Python `build_node_queue` byte-for-byte. After the Headscale node ID resolves (post network reconnect, where it becomes available), the worker subscribes to its per-node stream via an optional `AddQueue` interface, type-switched over `*APISource` / `*RedisSource`. Skips cleanly when the node ID or org is unknown (the platform's consumer-presence fallback covers those nodes).
- **`internal/worker/api_source.go`** — `APISource.AddQueue(queue)`: appends a queue after construction (the Redis API proxy creates the consumer group lazily on first XREADGROUP). Ignores blanks/duplicates.
- **`internal/worker/redis_source.go`** — `RedisSource.AddQueue(ctx, queue)`: appends a queue and creates the consumer group + stream (`EnsureConsumerGroups` → MKSTREAM) so the platform dispatcher's consumer-presence check can see the stream immediately. Ignores blanks/duplicates.

`AddQueue` is intentionally **not** part of the `JobSource` interface — it's a Redis-only concept and the Nexus HTTP-polling source must not be forced to implement it.

### Why this is safe (rollout)

The platform dispatcher routes a targeted job to the per-node stream **only when that stream has a live consumer**, falling back to the shared stream otherwise. So:

- Upgraded worker (this PR) → consumer present on its per-node stream → targeted jobs delivered only to it.
- Older worker (no per-node subscription) → no consumer → dispatcher uses the shared stream → node still works as today.

Purely additive: the worker keeps consuming the shared shell stream for untargeted/any-node work. No behavior change for existing deployments until the platform side ships.

## Testing

```
go vet ./...        # clean
go test ./...       # all packages pass
go test ./cmd/ ./internal/worker/ -run 'AddQueue|NodeQueueName|ShellQueue' -v
```

| Test | Coverage |
|------|----------|
| `cmd.TestNodeQueueName` | cross-repo guarantee: the per-node stream name equals the Python `build_node_queue` string |
| `worker.TestRedisSourceAddQueueCreatesStreamAndDelivers` | `AddQueue` creates the per-node stream/group (MKSTREAM) and jobs enqueued there are delivered with the right `SourceQueue` |
| `worker.TestRedisSourceAddQueueIdempotentAndBlank` | blanks and duplicates ignored |
| `worker.TestAPISourceAddQueue` | API source appends, ignores blanks, dedupes |

**Note:** the platform dispatcher gates routing on `XINFO GROUPS` reporting `consumers > 0`. miniredis does **not** track XREADGROUP consumers (it reports 0 even after a real read), so that exact signal is verified against real Redis as a manual/integration item rather than in a unit test. Real Redis registers the consumer on the first `XREADGROUP`, which the worker issues every poll once the queue is added.

**Manual (post-deploy):** on a node connected to the AceTeam Network, run `citadel work --verbose` and confirm the log line `per-node shell stream: jobs:v1:shell:org_{org}:node:{id}` with `{id}` equal to the node's Headscale numeric ID, then dispatch a targeted `terminal_exec` from the platform and confirm it lands on this node.

## Related

- Platform PR: aceteam-ai/aceteam#3916
- Issue: aceteam-ai/aceteam#3914
