### PR TITLE
fix(tui): display org name instead of raw UUID

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -488,6 +488,9 @@ func gatherControlCenterData() (controlcenter.StatusData, error) {
 		if data.OrgID == "" && deviceConfig.OrgID != "" {
 			data.OrgID = deviceConfig.OrgID
 		}
+		if data.OrgName == "" && deviceConfig.OrgName != "" {
+			data.OrgName = deviceConfig.OrgName
+		}
 	}
 
 	// Get hostname if not in manifest

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -877,6 +877,9 @@ func saveDeviceConfigToFile(token *nexus.TokenResponse) error {
 	if token.OrgID != "" {
 		config["org_id"] = token.OrgID
 	}
+	if token.OrgName != "" {
+		config["org_name"] = token.OrgName
+	}
 	if token.UserEmail != "" {
 		config["user_email"] = token.UserEmail
 	}

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1347,6 +1347,7 @@ type DeviceConfig struct {
 	DeviceAPIToken string `yaml:"device_api_token"`
 	APIBaseURL     string `yaml:"api_base_url"`
 	OrgID          string `yaml:"org_id"`
+	OrgName        string `yaml:"org_name"`
 	RedisURL       string `yaml:"redis_url"`
 	UserEmail      string `yaml:"user_email"`
 	UserName       string `yaml:"user_name"`

--- a/internal/nexus/deviceauth.go
+++ b/internal/nexus/deviceauth.go
@@ -34,6 +34,7 @@ type TokenResponse struct {
 	ExpiresIn      int    `json:"expires_in"`
 	NexusURL       string `json:"nexus_url,omitempty"`
 	OrgID          string `json:"org_id,omitempty"`
+	OrgName        string `json:"org_name,omitempty"`         // Human-readable org name
 	RedisURL       string `json:"redis_url,omitempty"`        // Deprecated: use DeviceAPIToken
 	DeviceAPIToken string `json:"device_api_token,omitempty"` // New secure API token
 	APIBaseURL     string `json:"api_base_url,omitempty"`     // Base URL for API calls

--- a/internal/tui/controlcenter/actions.go
+++ b/internal/tui/controlcenter/actions.go
@@ -1453,7 +1453,13 @@ func (cc *ControlCenter) showNodeDetailModal() {
 
 	sb.WriteString(fmt.Sprintf("[yellow]Name:[-]    %s\n", nodeName))
 	if cc.data.OrgID != "" {
-		sb.WriteString(fmt.Sprintf("[yellow]Org:[-]     %s\n", cc.data.OrgID))
+		orgDisplay := cc.data.OrgID
+		if cc.data.OrgName != "" {
+			orgDisplay = cc.data.OrgName
+		} else if len(cc.data.OrgID) > 12 {
+			orgDisplay = cc.data.OrgID[:12] + "..."
+		}
+		sb.WriteString(fmt.Sprintf("[yellow]Org:[-]     %s\n", orgDisplay))
 	}
 	if cc.data.UserEmail != "" {
 		sb.WriteString(fmt.Sprintf("[yellow]User:[-]    %s\n", cc.data.UserEmail))


### PR DESCRIPTION
## Context

The TUI dashboard shows `Org: 27464b19-024...` (truncated UUID) instead of the human-readable org name. The `OrgName` field existed in `StatusData` but was never populated.

## Summary

- **TokenResponse**: Added `OrgName` field to parse `org_name` from device auth API response
- **DeviceConfig**: Added `OrgName` field (persisted to `config.yaml`)
- **init.go**: Saves `org_name` to config during device auth flow
- **controlcenter.go**: Reads `OrgName` from device config into `StatusData`
- **actions.go**: System info panel now shows org name with same truncation fallback as dashboard

Requires server-side companion: https://github.com/aceteam-ai/aceteam/pull/new/fix/device-auth-org-name

## Test plan

- [ ] Fresh device auth → config.yaml has `org_name: AdaNomad`
- [ ] TUI dashboard shows `Org: AdaNomad` instead of UUID
- [ ] System info (`s` key) shows org name
- [ ] Existing configs without `org_name` still work (falls back to truncated UUID)