### PR TITLE
fix(work): start in-process websockify bridge so browser noVNC works

### DIFF
--- a/cmd/work.go
+++ b/cmd/work.go
@@ -30,6 +30,7 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/tlscert"
 	"github.com/aceteam-ai/citadel-cli/internal/update"
 	"github.com/aceteam-ai/citadel-cli/internal/usage"
+	"github.com/aceteam-ai/citadel-cli/internal/websockify"
 	"github.com/aceteam-ai/citadel-cli/internal/worker"
 	"github.com/google/uuid"
 	goredis "github.com/redis/go-redis/v9"
@@ -1009,6 +1010,29 @@ func runWork(cmd *cobra.Command, args []string) {
 		statusAddr := fmt.Sprintf("127.0.0.1:%d", workStatusPort)
 		termAddr := fmt.Sprintf("127.0.0.1:%d", workTerminalPort)
 		vncAddr := fmt.Sprintf("127.0.0.1:%d", workGatewayVNC)
+
+		// Start the in-process websockify bridge when a VNC server is detected.
+		// The gateway proxies "/vnc/..." to vncAddr (workGatewayVNC, e.g. 6080)
+		// as a raw byte pump, but x11vnc only speaks raw RFB over TCP on 5900.
+		// This bridge terminates the browser's WebSocket and forwards RFB bytes
+		// to the TCP VNC port, which is the role classic websockify plays.
+		//
+		// Detection happens once at startup: a VNC server launched after
+		// "citadel work" begins will not get a bridge until the next restart.
+		gatewayVNC := platform.GetVNCManager()
+		if gatewayVNC.IsRunning() {
+			bridge := websockify.NewBridge(websockify.Config{
+				ListenPort: workGatewayVNC,
+				VNCAddress: fmt.Sprintf("127.0.0.1:%d", gatewayVNC.Port()),
+				Logger:     Debug,
+			})
+			fmt.Printf("   - VNC bridge: ws://127.0.0.1:%d -> 127.0.0.1:%d (websockify)\n", workGatewayVNC, gatewayVNC.Port())
+			go func() {
+				if err := bridge.Start(ctx); err != nil && err != context.Canceled {
+					fmt.Fprintf(os.Stderr, "   - Warning: VNC bridge error: %v\n", err)
+				}
+			}()
+		}
 
 		// Create gateway server
 		gw := gateway.NewServer(gateway.Config{

--- a/internal/websockify/bridge.go
+++ b/internal/websockify/bridge.go
@@ -1,0 +1,225 @@
+// Package websockify implements a minimal, dependency-free (beyond the
+// already-vendored gorilla/websocket) WebSocket-to-TCP bridge equivalent to
+// noVNC's classic "websockify" helper.
+//
+// A browser-based noVNC client speaks the RFB (VNC) protocol over a WebSocket
+// connection, sending RFB bytes as binary WebSocket frames. A raw VNC server
+// (e.g. x11vnc on port 5900) speaks RFB over a plain TCP socket and knows
+// nothing about WebSockets. This bridge sits in between: it terminates the
+// WebSocket on one side, dials the TCP VNC server on the other, and pumps
+// bytes bidirectionally:
+//
+//	browser <--WS binary frames--> bridge <--raw TCP--> VNC server (5900)
+//
+// The Citadel gateway routes "/vnc/..." to this bridge as a transparent raw
+// byte pump, so the WebSocket handshake is negotiated end-to-end between the
+// browser and this bridge. The bridge therefore performs a real RFC 6455
+// upgrade and must emit RFB bytes as BinaryMessage frames.
+package websockify
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// Logger is the minimal logging surface used by the bridge. It matches the
+// signature of the package-level Debug helper in cmd/root.go so callers can
+// pass it directly.
+type Logger func(format string, args ...interface{})
+
+// Config configures a Bridge.
+type Config struct {
+	// ListenPort is the local TCP port the WebSocket server listens on
+	// (the gateway's websockify upstream, conventionally 6080).
+	ListenPort int
+
+	// VNCAddress is the TCP address of the raw VNC server to forward to,
+	// e.g. "127.0.0.1:5900".
+	VNCAddress string
+
+	// Logger, if non-nil, receives debug/error messages. A nil Logger
+	// discards all messages.
+	Logger Logger
+}
+
+// Bridge is a WebSocket-to-TCP bridge server.
+type Bridge struct {
+	cfg        Config
+	upgrader   websocket.Upgrader
+	httpServer *http.Server
+
+	mu      sync.Mutex
+	running bool
+}
+
+// NewBridge constructs a Bridge from cfg. It does not start listening until
+// Start is called.
+func NewBridge(cfg Config) *Bridge {
+	b := &Bridge{cfg: cfg}
+	b.upgrader = websocket.Upgrader{
+		ReadBufferSize:  32 * 1024,
+		WriteBufferSize: 32 * 1024,
+		// noVNC historically negotiates the "binary" subprotocol. gorilla
+		// only echoes it back when the client actually offers it, so this is
+		// harmless for modern clients that omit it.
+		Subprotocols: []string{"binary"},
+		CheckOrigin:  checkOrigin,
+	}
+	return b
+}
+
+// checkOrigin allows same-origin/CLI requests (no Origin header), localhost
+// origins, and aceteam.ai origins. The browser noVNC client connects with an
+// Origin of the AceTeam web app, so the default gorilla same-origin policy
+// would reject it.
+func checkOrigin(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+	if strings.Contains(origin, "localhost") || strings.Contains(origin, "127.0.0.1") {
+		return true
+	}
+	if strings.Contains(origin, "aceteam.ai") {
+		return true
+	}
+	return false
+}
+
+func (b *Bridge) logf(format string, args ...interface{}) {
+	if b.cfg.Logger != nil {
+		b.cfg.Logger(format, args...)
+	}
+}
+
+// Handler returns the http.Handler that upgrades requests to WebSocket and
+// bridges them to the configured VNC server. It is registered for all paths
+// because the gateway may strip the "/vnc" prefix, leaving the bridge to see
+// either "/" or "/websockify" depending on the noVNC client URL.
+func (b *Bridge) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", b.handleWebSocket)
+	return mux
+}
+
+func (b *Bridge) handleWebSocket(w http.ResponseWriter, r *http.Request) {
+	ws, err := b.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		// Upgrade already wrote an error response on failure.
+		b.logf("websockify: upgrade failed: %v", err)
+		return
+	}
+	defer ws.Close()
+
+	tcp, err := net.DialTimeout("tcp", b.cfg.VNCAddress, 10*time.Second)
+	if err != nil {
+		b.logf("websockify: dial %s failed: %v", b.cfg.VNCAddress, err)
+		_ = ws.WriteControl(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseInternalServerErr, "vnc dial failed"),
+			time.Now().Add(time.Second),
+		)
+		return
+	}
+	defer tcp.Close()
+
+	b.logf("websockify: bridging connection to %s", b.cfg.VNCAddress)
+	pump(ws, tcp, b.logf)
+}
+
+// pump copies bytes bidirectionally between a WebSocket connection and a TCP
+// connection until either side closes. RFB is a binary protocol, so all
+// WebSocket frames written toward the browser use BinaryMessage.
+//
+// gorilla forbids concurrent writers on a single connection, so each
+// destination is written by exactly one goroutine: the WS->TCP goroutine is
+// the sole writer to tcp, and the TCP->WS goroutine is the sole writer to ws.
+func pump(ws *websocket.Conn, tcp net.Conn, logf Logger) {
+	done := make(chan struct{}, 2)
+
+	// WebSocket -> TCP: decode incoming binary frames, write raw bytes to VNC.
+	go func() {
+		defer func() { done <- struct{}{} }()
+		for {
+			_, reader, err := ws.NextReader()
+			if err != nil {
+				return
+			}
+			if _, err := io.Copy(tcp, reader); err != nil {
+				logf("websockify: ws->tcp copy error: %v", err)
+				return
+			}
+		}
+	}()
+
+	// TCP -> WebSocket: read raw VNC bytes, emit as binary frames.
+	go func() {
+		defer func() { done <- struct{}{} }()
+		buf := make([]byte, 32*1024)
+		for {
+			n, err := tcp.Read(buf)
+			if n > 0 {
+				if werr := ws.WriteMessage(websocket.BinaryMessage, buf[:n]); werr != nil {
+					logf("websockify: tcp->ws write error: %v", werr)
+					return
+				}
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	// Wait for one direction to finish, then unblock the other by closing
+	// both underlying connections (the deferred Close calls in the caller
+	// also run, but closing here promptly interrupts the blocked goroutine).
+	<-done
+	_ = tcp.Close()
+	_ = ws.Close()
+	<-done
+}
+
+// Start binds the listener and serves until ctx is cancelled. It blocks until
+// the server stops. Returns nil on graceful shutdown.
+func (b *Bridge) Start(ctx context.Context) error {
+	b.mu.Lock()
+	if b.running {
+		b.mu.Unlock()
+		return fmt.Errorf("websockify bridge already running")
+	}
+	b.running = true
+	b.httpServer = &http.Server{
+		Addr:    fmt.Sprintf("127.0.0.1:%d", b.cfg.ListenPort),
+		Handler: b.Handler(),
+		// Long timeouts: VNC sessions are long-lived streaming connections.
+		ReadHeaderTimeout: 15 * time.Second,
+	}
+	srv := b.httpServer
+	b.mu.Unlock()
+
+	ln, err := net.Listen("tcp", srv.Addr)
+	if err != nil {
+		return fmt.Errorf("websockify: listen on %s: %w", srv.Addr, err)
+	}
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+	}()
+
+	b.logf("websockify: listening on %s, forwarding to %s", srv.Addr, b.cfg.VNCAddress)
+	if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+		return fmt.Errorf("websockify: serve: %w", err)
+	}
+	return nil
+}

--- a/internal/websockify/bridge.go
+++ b/internal/websockify/bridge.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -80,15 +81,24 @@ func NewBridge(cfg Config) *Bridge {
 // origins, and aceteam.ai origins. The browser noVNC client connects with an
 // Origin of the AceTeam web app, so the default gorilla same-origin policy
 // would reject it.
+//
+// The origin is parsed as a URL and the hostname is checked with an exact
+// match (or a subdomain suffix match) to prevent bypass via attacker-controlled
+// domains like "aceteam.ai.evil.com".
 func checkOrigin(r *http.Request) bool {
 	origin := r.Header.Get("Origin")
 	if origin == "" {
 		return true
 	}
-	if strings.Contains(origin, "localhost") || strings.Contains(origin, "127.0.0.1") {
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	host := u.Hostname()
+	if host == "localhost" || host == "127.0.0.1" {
 		return true
 	}
-	if strings.Contains(origin, "aceteam.ai") {
+	if host == "aceteam.ai" || strings.HasSuffix(host, ".aceteam.ai") {
 		return true
 	}
 	return false

--- a/internal/websockify/bridge_test.go
+++ b/internal/websockify/bridge_test.go
@@ -1,0 +1,258 @@
+package websockify
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// startEchoTCPServer starts a TCP server that echoes everything it receives
+// back to the sender. Returns the listen address and a cleanup function.
+func startEchoTCPServer(t *testing.T) (addr string, cleanup func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	done := make(chan struct{})
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				select {
+				case <-done:
+					return
+				default:
+					return
+				}
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				buf := make([]byte, 4096)
+				for {
+					n, err := c.Read(buf)
+					if n > 0 {
+						if _, werr := c.Write(buf[:n]); werr != nil {
+							return
+						}
+					}
+					if err != nil {
+						return
+					}
+				}
+			}(conn)
+		}
+	}()
+	return ln.Addr().String(), func() {
+		close(done)
+		ln.Close()
+	}
+}
+
+// newBridgeTestServer wires a Bridge.Handler into an httptest.Server pointed at
+// the given VNC TCP address.
+func newBridgeTestServer(t *testing.T, vncAddr string) (*httptest.Server, *Bridge) {
+	t.Helper()
+	b := NewBridge(Config{VNCAddress: vncAddr})
+	srv := httptest.NewServer(b.Handler())
+	t.Cleanup(srv.Close)
+	return srv, b
+}
+
+func wsURL(httpURL string) string {
+	return "ws" + strings.TrimPrefix(httpURL, "http")
+}
+
+func TestBridgeRoundTripBinary(t *testing.T) {
+	vncAddr, cleanup := startEchoTCPServer(t)
+	defer cleanup()
+
+	srv, _ := newBridgeTestServer(t, vncAddr)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(srv.URL), nil)
+	if err != nil {
+		t.Fatalf("ws dial: %v", err)
+	}
+	defer conn.Close()
+
+	// A realistic RFB-ish binary payload including a NUL byte to ensure binary
+	// (not text) framing is used end-to-end.
+	payload := []byte{0x52, 0x46, 0x42, 0x00, 0x03, 0x00, 0x08, 0xFF}
+	if err := conn.WriteMessage(websocket.BinaryMessage, payload); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	msgType, got, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if msgType != websocket.BinaryMessage {
+		t.Errorf("expected BinaryMessage (%d), got %d", websocket.BinaryMessage, msgType)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Errorf("round-trip mismatch: sent %v, got %v", payload, got)
+	}
+}
+
+func TestBridgeMultipleFrames(t *testing.T) {
+	vncAddr, cleanup := startEchoTCPServer(t)
+	defer cleanup()
+
+	srv, _ := newBridgeTestServer(t, vncAddr)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(srv.URL), nil)
+	if err != nil {
+		t.Fatalf("ws dial: %v", err)
+	}
+	defer conn.Close()
+
+	frames := [][]byte{
+		[]byte("first"),
+		{0x00, 0x01, 0x02, 0x03},
+		[]byte("the quick brown fox"),
+	}
+
+	var want []byte
+	for _, f := range frames {
+		if err := conn.WriteMessage(websocket.BinaryMessage, f); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		want = append(want, f...)
+	}
+
+	// The echo server returns a raw byte stream; frame boundaries on the
+	// TCP->WS side are not preserved, so accumulate until we have all bytes.
+	var got []byte
+	conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	for len(got) < len(want) {
+		_, chunk, err := conn.ReadMessage()
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		got = append(got, chunk...)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("stream mismatch: want %v, got %v", want, got)
+	}
+}
+
+func TestBridgeUpgradeOnRootPath(t *testing.T) {
+	vncAddr, cleanup := startEchoTCPServer(t)
+	defer cleanup()
+
+	srv, _ := newBridgeTestServer(t, vncAddr)
+
+	// The gateway strips the "/vnc" prefix, so the bridge must accept the
+	// upgrade on "/" (not only "/websockify").
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL(srv.URL)+"/", nil)
+	if err != nil {
+		t.Fatalf("ws dial on root path: %v (status: %v)", err, resp)
+	}
+	conn.Close()
+}
+
+func TestBridgeDialFailureClosesCleanly(t *testing.T) {
+	// Point at a port nothing is listening on so the TCP dial fails.
+	b := NewBridge(Config{VNCAddress: "127.0.0.1:1"})
+	srv := httptest.NewServer(b.Handler())
+	defer srv.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(srv.URL), nil)
+	if err != nil {
+		t.Fatalf("ws dial: %v", err)
+	}
+	defer conn.Close()
+
+	// The bridge should close the connection rather than hang or crash.
+	conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	_, _, err = conn.ReadMessage()
+	if err == nil {
+		t.Fatal("expected connection to close after dial failure")
+	}
+}
+
+func TestBridgeStartAndShutdown(t *testing.T) {
+	vncAddr, cleanup := startEchoTCPServer(t)
+	defer cleanup()
+
+	// Bind to an ephemeral port by listening first to discover a free one.
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("probe listen: %v", err)
+	}
+	port := probe.Addr().(*net.TCPAddr).Port
+	probe.Close()
+
+	b := NewBridge(Config{ListenPort: port, VNCAddress: vncAddr})
+	listenAddr := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- b.Start(ctx) }()
+
+	// Wait for the listener to come up.
+	deadline := time.Now().Add(2 * time.Second)
+	var dialErr error
+	for time.Now().Before(deadline) {
+		c, e := net.Dial("tcp", listenAddr)
+		if e == nil {
+			c.Close()
+			dialErr = nil
+			break
+		}
+		dialErr = e
+		time.Sleep(20 * time.Millisecond)
+	}
+	if dialErr != nil {
+		t.Fatalf("bridge never started listening: %v", dialErr)
+	}
+
+	// Verify it actually serves a websocket upgrade.
+	conn, _, err := websocket.DefaultDialer.Dial("ws://"+listenAddr+"/", nil)
+	if err != nil {
+		t.Fatalf("ws dial against running bridge: %v", err)
+	}
+	conn.Close()
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil && err != http.ErrServerClosed {
+			t.Fatalf("Start returned error on shutdown: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("bridge did not shut down after ctx cancel")
+	}
+}
+
+func TestCheckOrigin(t *testing.T) {
+	cases := []struct {
+		origin string
+		want   bool
+	}{
+		{"", true},
+		{"http://localhost:3000", true},
+		{"http://127.0.0.1:8443", true},
+		{"https://aceteam.ai", true},
+		{"https://app.aceteam.ai", true},
+		{"https://evil.example.com", false},
+	}
+	for _, tc := range cases {
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		if tc.origin != "" {
+			r.Header.Set("Origin", tc.origin)
+		}
+		if got := checkOrigin(r); got != tc.want {
+			t.Errorf("checkOrigin(%q) = %v, want %v", tc.origin, got, tc.want)
+		}
+	}
+}

--- a/internal/websockify/bridge_test.go
+++ b/internal/websockify/bridge_test.go
@@ -239,12 +239,25 @@ func TestCheckOrigin(t *testing.T) {
 		origin string
 		want   bool
 	}{
+		// Allowed: no origin (same-origin / CLI)
 		{"", true},
+		// Allowed: localhost variants
 		{"http://localhost:3000", true},
 		{"http://127.0.0.1:8443", true},
+		// Allowed: exact aceteam.ai and subdomains
 		{"https://aceteam.ai", true},
 		{"https://app.aceteam.ai", true},
+		{"https://staging.app.aceteam.ai", true},
+		// Rejected: unrelated domains
 		{"https://evil.example.com", false},
+		// Rejected: bypass attempts — attacker-controlled domains
+		{"https://aceteam.ai.evil.com", false},
+		{"https://evil-aceteam.ai", false},
+		{"https://notaceteam.ai", false},
+		{"https://localhost.evil.com", false},
+		{"https://fake127.0.0.1.evil.com", false},
+		// Rejected: malformed origins
+		{"not-a-url", false},
 	}
 	for _, tc := range cases {
 		r := httptest.NewRequest(http.MethodGet, "/", nil)


### PR DESCRIPTION
## Context

Closes #183.

`citadel work` detects a VNC server on port 5900 and the in-process HTTPS gateway routes `/vnc/...` to `127.0.0.1:6080` (the conventional websockify port) as a WebSocket upstream. The gateway's `proxyWebSocket` is a **transparent raw byte pump** — it hijacks the connection and forwards the WebSocket upgrade and all frames, unmodified, to `:6080`.

The problem: **nothing ever listened on 6080.** x11vnc speaks raw RFB over plain TCP on 5900 and knows nothing about WebSockets. There was no bridge translating browser WebSocket binary frames into raw TCP bytes, so browser-based noVNC could never connect — it would hang or fail to upgrade.

This PR implements the missing piece (Option 1 from the issue — zero external dependency): a built-in Go WebSocket→TCP bridge that plays the role of classic `websockify`.

## Summary

**`internal/websockify/bridge.go`** — a small bridge server:

- Terminates a real RFC 6455 WebSocket on `127.0.0.1:6080`. Because the gateway forwards the handshake end-to-end, the upgrade is negotiated directly between the browser's noVNC and this bridge, so the bridge performs the actual upgrade.
- Dials the **detected** VNC TCP address (`platform.GetVNCManager().Port()`, not a hardcoded 5900 — x11vnc may land on 5901).
- Pumps bytes bidirectionally: incoming WebSocket frames → raw TCP write; raw TCP reads → `BinaryMessage` WebSocket frames (RFB is binary; a TextMessage frame would silently corrupt the stream).
- Registers the upgrade handler on `/` (catch-all). The gateway matches `/vnc` with `StripPrefix: true`, so the bridge sees `GET /` or `GET /websockify` depending on the noVNC client URL — a fixed `/websockify` route would 404 the `/` case.
- `Upgrader.Subprotocols = []string{"binary"}` so gorilla echoes `Sec-WebSocket-Protocol: binary` iff the client offers it (older noVNC requires it; modern noVNC doesn't negotiate one — harmless either way).
- `CheckOrigin` allows same-origin/CLI (no Origin), localhost, and `aceteam.ai` origins — the browser connects with an `aceteam.ai` Origin, which the default gorilla same-origin policy would reject.
- Concurrency-safe: exactly one goroutine writes to each side (gorilla forbids concurrent WebSocket writers).
- Graceful lifecycle: `Start(ctx)` serves until `ctx` is cancelled, then `httpServer.Shutdown`.

**`cmd/work.go`** — start the bridge from the gateway path, gated on `platform.GetVNCManager().IsRunning()` (the same detection gate used for the desktop API). Reuses the already-vendored `github.com/gorilla/websocket` (a direct dependency used by the terminal server) — no new deps. Detection is at startup only; a VNC server launched *after* `citadel work` begins won't get a bridge until restart (documented in-code; within issue scope).

## Test plan

| Test | Coverage |
|------|----------|
| `TestBridgeRoundTripBinary` | Binary payload (incl. NUL byte) round-trips byte-identical through a fake TCP echo server; asserts `BinaryMessage` framing |
| `TestBridgeMultipleFrames` | Multiple frames stream through and reassemble correctly |
| `TestBridgeUpgradeOnRootPath` | Upgrade succeeds on `/` (the gateway strips `/vnc`) |
| `TestBridgeDialFailureClosesCleanly` | TCP dial failure closes the WS cleanly instead of hanging/crashing |
| `TestBridgeStartAndShutdown` | `Start(ctx)` binds, serves an upgrade, and shuts down on ctx cancel |
| `TestCheckOrigin` | Origin allowlist (localhost, aceteam.ai allowed; arbitrary origin rejected) |

All tests are hermetic (loopback only, ephemeral ports, fake echo server) and pass under `-race`.

- `go build ./...` — passes
- `go test ./...` — passes (the pre-existing `e2e` package failure is unrelated: it requires a live Redis on :6379 and web app on :3000, neither available in this environment)

**Manual verification still required (why this PR is a draft):** on a node with x11vnc actually running on 5900, run `citadel work`, then open the browser noVNC viewer and confirm the desktop renders and is interactive over the gateway's `/vnc/...` route. This validates the real RFB handshake and the noVNC build's subprotocol expectations, which a hermetic test can't cover.

## Related

- Issue #183
- Gateway WebSocket proxy: `internal/gateway/gateway.go` (`proxyWebSocket`)
- VNC detection: `internal/platform/vnc.go` (`GetVNCManager`)