### PR TITLE
fix(work): route source info logs to latest.log (#3924)

### DIFF
--- a/cmd/work.go
+++ b/cmd/work.go
@@ -294,6 +294,12 @@ func runWork(cmd *cobra.Command, args []string) {
 			BlockMs:       workPollMs,
 			MaxAttempts:   workMaxRetries,
 			DebugFunc:     Debug,
+			// Route the source's info logs (subscribed queues, consumer group,
+			// per-node AddQueue) through Log() so they land in latest.log. The
+			// default sink is stdout, which the worker's log file does not
+			// capture -- masking whether the per-node shell stream was actually
+			// subscribed during a live node-routing test (issue #3924).
+			LogFn: func(_ string, msg string) { Log("%s", msg) },
 		})
 
 		// Connect early so client is available for heartbeat
@@ -396,6 +402,10 @@ func runWork(cmd *cobra.Command, args []string) {
 			ConsumerGroup: workGroup,
 			BlockMs:       workPollMs,
 			MaxAttempts:   workMaxRetries,
+			// Route source info logs (queues, consumer group, per-node AddQueue)
+			// to latest.log instead of stdout so subscription activity is
+			// visible in the worker log (issue #3924).
+			LogFn: func(_ string, msg string) { Log("%s", msg) },
 		})
 		source = redisSource
 		streamFactory = worker.CreateRedisStreamWriterFactory(ctx, redisSource)


### PR DESCRIPTION
## Context

While diagnosing #3924 (node-targeted MCP jobs never reaching a node's per-node Redis stream), node 1008's worker log (`~/.citadel-cli/logs/latest.log`) showed only the terminal/VNC listener lines and no Redis subscription / consumer-group / per-node `AddQueue` activity. That made it impossible to confirm from the log whether the worker actually subscribed to its per-node shell stream, or with WHICH node id.

## Root Cause (of the missing log visibility)

The Redis API job source (`internal/worker/api_source.go`) and the direct-Redis source log their info lines — subscribed queues, consumer group, and the per-node `AddQueue` ("Added queue") line — through the source's `LogFn`. In `cmd/work.go` only `DebugFunc` was wired; `LogFn` was left nil, so the source fell back to its default sink (`fmt.Printf` → stdout). The worker's `Log()`/`latest.log` writer does not capture stdout, so those lines never reached the log file.

This is a diagnosability fix, not the functional bug. The functional root cause of #3924 is backend-only: the Redis consume/acknowledge proxy's `isValidQueueName` rejected the per-node queue name (see aceteam-ai/aceteam#3937).

## Changes

- `cmd/work.go` — set `LogFn` on both the `APISource` and `RedisSource` configs to route source info logs through `Log()`, so subscribed-queue / consumer-group / per-node-`AddQueue` lines land in `latest.log`.

## Test plan

- `go build ./...` — clean
- `go vet ./cmd/ ./internal/worker/` — clean
- `go test ./internal/worker/` — pass (includes the #224 `add_queue_test.go` per-node coverage)

## Live re-test — resolves the gating unknown for #3924

The backend fix (#3937) is necessary and correct, but its *sufficiency* depends on the worker's per-node stream id matching the platform's `fabric_node_status.node_id` (the value the agent targets, e.g. "1008"). The worker subscribes using `status.Self.ID` (tsnet `tailcfg.StableNodeID`); the backend derives `node_id` from the Headscale API `node.id`. Test fixtures across this repo use the plain decimal form (`NodeID: "758"`, `HeadscaleNodeID: "758"`), strongly suggesting these are equal on this Headscale, but the original live test could NOT confirm it: the validation bug 400'd every per-node consume before any subscription registered.

After deploying #3937, on node 1008 confirm `latest.log` shows:

```
Added queue: jobs:v1:shell:org_<uuid>:node:<XXXX>
```

and verify **`<XXXX>` == 1008** (the id the platform targets). If they match, #3937 alone resolves the hang and no citadel-cli release is required beyond this logging aid. If they differ, the worker's per-node id derivation needs a fix + a citadel-cli release + node-1008 upgrade.

## Related

- aceteam-ai/aceteam#3937 (backend fix, primary), #3914 / #224

---
*Generated by Claude*