### PR TITLE
fix(work): retry Headscale node ID resolution for per-node stream (#3924)

### DIFF
--- a/cmd/work.go
+++ b/cmd/work.go
@@ -541,6 +541,36 @@ func runWork(cmd *cobra.Command, args []string) {
 		Debug("final Headscale node ID: %s", headscaleNodeID)
 	}
 
+	// The Headscale numeric node ID is required to subscribe to this node's
+	// per-node shell stream (issues #3914/#3924). Right after a (re)connect the
+	// tsnet netmap may not be populated yet, so the single resolution above can
+	// return an empty ID even though the node is otherwise online and heartbeats
+	// fine (the platform re-resolves the heartbeat by hostname). An empty ID
+	// here permanently skips the per-node subscription for the worker's whole
+	// lifetime, silently downgrading node-targeted jobs (terminal_exec, code_*,
+	// file reads, node attachments) to the shared org stream where a peer node
+	// can claim them. Retry a few times with a short backoff to close that
+	// startup race before we build the queue list.
+	if headscaleNodeID == "" {
+		for attempt := 1; attempt <= 5; attempt++ {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(time.Duration(attempt) * time.Second):
+			}
+			if id := network.GetGlobalNodeID(ctx); id != "" {
+				headscaleNodeID = id
+				Debug("resolved Headscale node ID on retry %d: %s", attempt, headscaleNodeID)
+				break
+			}
+			Debug("Headscale node ID still empty on retry %d", attempt)
+		}
+		if headscaleNodeID == "" {
+			fmt.Fprintln(os.Stderr, "   - Warning: Headscale node ID unresolved after retries; "+
+				"node-targeted jobs will fall back to the shared org stream")
+		}
+	}
+
 	// Set node identity on the stream event publisher for operator attribution.
 	// Note: We keep using nodeName (hostname) here rather than the Headscale
 	// numeric ID, because the usage/earnings pipeline may key on hostname.
@@ -582,11 +612,16 @@ func runWork(cmd *cobra.Command, args []string) {
 					fmt.Fprintf(os.Stderr, "   - Warning: per-node stream subscribe failed: %v\n", err)
 				}
 			}
+			fmt.Printf("   - Per-node shell stream: %s\n", perNodeQueue)
 			Debug("per-node shell stream: %s", perNodeQueue)
 		} else {
+			fmt.Fprintln(os.Stderr, "   - Warning: per-node shell stream skipped (org id unknown); "+
+				"node-targeted jobs will fall back to the shared org stream")
 			Debug("per-node shell stream skipped: org id unknown")
 		}
 	} else {
+		fmt.Fprintln(os.Stderr, "   - Warning: per-node shell stream skipped (Headscale node ID "+
+			"unavailable); node-targeted jobs will fall back to the shared org stream")
 		Debug("per-node shell stream skipped: Headscale node ID unavailable")
 	}
 


### PR DESCRIPTION
## Context

Bug #3924: a node-path file attach (\`email_draft\`/\`upload_file\` with \`{node_id, path}\`) targeting an online node hangs and never completes. The node's worker log showed no Redis stream subscription / consumer-group activity for its per-node stream.

This is the citadel-cli side of the diagnosis. See #3914 for the per-node routing design and #3916 (aceteam backend) for the dispatcher side.

## Root cause analysis

The diagnosis ruled out the two loudest initial hypotheses:

- **No name/value mismatch.** The platform stores \`fabric_node_status.node_id\` as the Headscale numeric ID (resolved server-side by hostname via the Headscale API). The worker subscribes to \`jobs:v1:shell:org_{org}:node:{id}\` using \`string(status.Self.ID)\`. \`status.Self.ID\` is a \`tailcfg.StableNodeID\`, and Headscale sets \`StableID = strconv.FormatUint(node.ID)\` — the decimal numeric ID. So both sides agree by construction.
- **The file-read path already has a timeout.** The backend's \`_dispatch_file_job\` wait is bounded (120s for binary reads). The Python layer cannot hang indefinitely.

The remaining citadel-side defect is a **startup race**: the Headscale numeric node ID is resolved exactly once at worker startup (\`cmd/work.go\`). Immediately after a (re)connect the tsnet netmap may not be populated yet, so that single resolution can return an empty ID even though the node is online and heartbeats fine (the platform re-resolves heartbeats by hostname, so the node still appears online and numbered). An empty ID **permanently** skips the per-node stream subscription for the worker's entire lifetime, silently downgrading node-targeted jobs (\`terminal_exec\`, \`code_*\`, file reads, node attachments) to the shared org stream — where a peer node may claim them and cannot serve the target's file.

## Changes

- \`cmd/work.go\`: retry the Headscale node ID resolution with a short bounded backoff (5 attempts, 1s..5s) before building the queue list, closing the post-reconnect race.
- \`cmd/work.go\`: log (non-verbose) when the per-node shell stream is subscribed, and warn when it is skipped (org id unknown, or node ID unresolved after retries), so the condition is visible in worker logs.

## Testing

- \`go build ./...\`, \`go vet ./cmd/\`, and all unit tests pass (\`go test ./cmd/ ./internal/...\`). The \`e2e\` package requires live Redis + Nexus and is not run locally.
- **Live re-test required (why this is a draft):** needs a citadel-cli release and node-1008 upgrade. On re-test, capture the **full worker startup log** and confirm:
  - the APISource \`- API / Queue / Consumer group\` lines appear,
  - a \`- Per-node shell stream: jobs:v1:shell:org_{org}:node:1008\` line appears (no "skipped" warning),
  - the node-path attach completes, and which node executed the job.

## Caveats

The 15+ minute hang reported in the issue is **not fully explained** by this race alone (a shared-stream fallback would still let node 1008 serve its own file, and any wait is capped at 120s backend-side). This fix is correct hardening for #3914/#3924 and makes the failure visible, but the live re-test should also confirm where the wait actually blocked (worker startup vs. the agent/MCP/Next.js layer).

---
*Generated by Claude*