### PR TITLE
feat: Proxmox hypervisor detection and capability tagging

### DIFF
--- a/cmd/work.go
+++ b/cmd/work.go
@@ -189,6 +189,21 @@ func runWork(cmd *cobra.Command, args []string) {
 		Debug("capability tags: %v", nodeCaps.Tags)
 	}
 
+	// Detect Proxmox hypervisor (host fact, checked regardless of manifest vs auto-detect)
+	var proxmoxInfo *platform.ProxmoxInfo
+	if pveInfo, err := platform.DetectProxmox(); err == nil && pveInfo.IsInstalled {
+		proxmoxInfo = pveInfo
+		nodeCaps.Tags = append(nodeCaps.Tags, "hypervisor:proxmox")
+		fmt.Printf("   - Hypervisor: Proxmox VE")
+		if pveInfo.Version != "" {
+			fmt.Printf(" (%s)", pveInfo.Version)
+		}
+		fmt.Printf("\n")
+		if pveInfo.VMCount > 0 || pveInfo.CTCount > 0 {
+			fmt.Printf("   - Guests: %d VMs, %d containers\n", pveInfo.VMCount, pveInfo.CTCount)
+		}
+	}
+
 	// Convert capabilities to status types for heartbeat
 	var statusCaps *status.NodeCapabilities
 	if nodeCaps != nil {
@@ -204,6 +219,16 @@ func runWork(cmd *cobra.Command, args []string) {
 					Tag:     dev.Tag,
 					VRAMTag: dev.VRAMTag,
 				})
+			}
+		}
+		if proxmoxInfo != nil {
+			statusCaps.Hypervisor = &status.HypervisorInfo{
+				Type:      "proxmox",
+				Version:   proxmoxInfo.Version,
+				NodeName:  proxmoxInfo.NodeName,
+				NodeCount: proxmoxInfo.NodeCount,
+				VMCount:   proxmoxInfo.VMCount,
+				CTCount:   proxmoxInfo.CTCount,
 			}
 		}
 	}

--- a/internal/platform/proxmox.go
+++ b/internal/platform/proxmox.go
@@ -1,0 +1,145 @@
+package platform
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const proxmoxDetectionTimeout = 5 * time.Second
+
+// ProxmoxInfo holds the result of Proxmox hypervisor detection.
+type ProxmoxInfo struct {
+	IsInstalled bool   `json:"is_installed"`
+	Version     string `json:"version,omitempty"`     // e.g. "pve-manager/8.2.4/..."
+	NodeName    string `json:"node_name,omitempty"`    // this PVE node's name
+	NodeCount   int    `json:"node_count,omitempty"`   // total nodes in cluster
+	VMCount     int    `json:"vm_count,omitempty"`     // QEMU VMs on this node
+	CTCount     int    `json:"ct_count,omitempty"`     // LXC containers on this node
+}
+
+// DetectProxmox checks whether the host is a Proxmox VE node.
+// Detection is split into two phases:
+//  1. Presence check (/etc/pve + pvesh on PATH) -- cheap, no root needed.
+//  2. Enumeration (pveversion, pvesh get) -- needs root, best-effort with timeout.
+//
+// On non-Proxmox systems, returns &ProxmoxInfo{IsInstalled: false}, nil.
+func DetectProxmox() (*ProxmoxInfo, error) {
+	// Phase 1: fast presence check
+	if _, err := os.Stat("/etc/pve"); os.IsNotExist(err) {
+		return &ProxmoxInfo{IsInstalled: false}, nil
+	}
+	if _, err := exec.LookPath("pvesh"); err != nil {
+		return &ProxmoxInfo{IsInstalled: false}, nil
+	}
+
+	info := &ProxmoxInfo{IsInstalled: true}
+
+	// Phase 2: best-effort enumeration (each call gets its own timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), proxmoxDetectionTimeout)
+	defer cancel()
+
+	// Get version
+	info.Version = detectProxmoxVersion(ctx)
+
+	// Get node list (gives us NodeName and NodeCount)
+	info.NodeName, info.NodeCount = detectProxmoxNodes(ctx)
+
+	// Get VM and CT counts (requires NodeName)
+	if info.NodeName != "" {
+		info.VMCount = countProxmoxGuests(ctx, info.NodeName, "qemu")
+		info.CTCount = countProxmoxGuests(ctx, info.NodeName, "lxc")
+	}
+
+	return info, nil
+}
+
+// detectProxmoxVersion runs pveversion and extracts the version string.
+func detectProxmoxVersion(ctx context.Context) string {
+	cmd := exec.CommandContext(ctx, "pveversion")
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(output))
+}
+
+// detectProxmoxNodes calls pvesh to list cluster nodes. Returns the local
+// node name (hostname match) and total node count.
+func detectProxmoxNodes(ctx context.Context) (nodeName string, nodeCount int) {
+	cmd := exec.CommandContext(ctx, "pvesh", "get", "/nodes", "--output-format", "json")
+	output, err := cmd.Output()
+	if err != nil {
+		// Fallback: use hostname as node name
+		if hn, err := os.Hostname(); err == nil {
+			return hn, 1
+		}
+		return "", 0
+	}
+
+	nodes, err := parseProxmoxNodeList(output)
+	if err != nil || len(nodes) == 0 {
+		if hn, err := os.Hostname(); err == nil {
+			return hn, 1
+		}
+		return "", 0
+	}
+
+	nodeCount = len(nodes)
+
+	// Find the local node (status "online" is typical, but just take the first
+	// if there's only one, or match hostname).
+	hostname, _ := os.Hostname()
+	for _, n := range nodes {
+		if n == hostname {
+			return n, nodeCount
+		}
+	}
+
+	// If hostname didn't match, return the first node
+	return nodes[0], nodeCount
+}
+
+// parseProxmoxNodeList extracts node names from pvesh JSON output.
+// Exported for testing with fixture data.
+func parseProxmoxNodeList(data []byte) ([]string, error) {
+	var nodes []struct {
+		Node string `json:"node"`
+	}
+	if err := json.Unmarshal(data, &nodes); err != nil {
+		return nil, fmt.Errorf("failed to parse node list: %w", err)
+	}
+	names := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		if n.Node != "" {
+			names = append(names, n.Node)
+		}
+	}
+	return names, nil
+}
+
+// countProxmoxGuests calls pvesh to count QEMU VMs or LXC containers.
+func countProxmoxGuests(ctx context.Context, nodeName, guestType string) int {
+	path := fmt.Sprintf("/nodes/%s/%s", nodeName, guestType)
+	cmd := exec.CommandContext(ctx, "pvesh", "get", path, "--output-format", "json")
+	output, err := cmd.Output()
+	if err != nil {
+		return 0
+	}
+	count, _ := parseProxmoxGuestCount(output)
+	return count
+}
+
+// parseProxmoxGuestCount counts entries in a pvesh guest list JSON array.
+// Exported for testing with fixture data.
+func parseProxmoxGuestCount(data []byte) (int, error) {
+	var guests []json.RawMessage
+	if err := json.Unmarshal(data, &guests); err != nil {
+		return 0, fmt.Errorf("failed to parse guest list: %w", err)
+	}
+	return len(guests), nil
+}

--- a/internal/platform/proxmox_test.go
+++ b/internal/platform/proxmox_test.go
@@ -1,0 +1,133 @@
+package platform
+
+import (
+	"testing"
+)
+
+func TestParseProxmoxNodeList(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantNames []string
+		wantErr   bool
+	}{
+		{
+			name:      "single node",
+			input:     `[{"node":"pve","status":"online","maxcpu":16,"maxmem":68719476736}]`,
+			wantNames: []string{"pve"},
+		},
+		{
+			name:      "cluster with three nodes",
+			input:     `[{"node":"pve1","status":"online"},{"node":"pve2","status":"online"},{"node":"pve3","status":"offline"}]`,
+			wantNames: []string{"pve1", "pve2", "pve3"},
+		},
+		{
+			name:      "empty array",
+			input:     `[]`,
+			wantNames: nil,
+		},
+		{
+			name:    "invalid json",
+			input:   `not json`,
+			wantErr: true,
+		},
+		{
+			name:      "node with empty name is skipped",
+			input:     `[{"node":"pve1"},{"node":""},{"node":"pve2"}]`,
+			wantNames: []string{"pve1", "pve2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			names, err := parseProxmoxNodeList([]byte(tt.input))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(names) != len(tt.wantNames) {
+				t.Fatalf("got %d names, want %d: %v", len(names), len(tt.wantNames), names)
+			}
+			for i, name := range names {
+				if name != tt.wantNames[i] {
+					t.Errorf("name[%d] = %q, want %q", i, name, tt.wantNames[i])
+				}
+			}
+		})
+	}
+}
+
+func TestParseProxmoxGuestCount(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    int
+		wantErr bool
+	}{
+		{
+			name:  "three VMs",
+			input: `[{"vmid":100,"name":"vm1","status":"running"},{"vmid":101,"name":"vm2","status":"stopped"},{"vmid":102,"name":"vm3","status":"running"}]`,
+			want:  3,
+		},
+		{
+			name:  "no guests",
+			input: `[]`,
+			want:  0,
+		},
+		{
+			name:  "single container",
+			input: `[{"vmid":200,"name":"ct1","status":"running"}]`,
+			want:  1,
+		},
+		{
+			name:    "invalid json",
+			input:   `{not valid}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			count, err := parseProxmoxGuestCount([]byte(tt.input))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if count != tt.want {
+				t.Errorf("got count %d, want %d", count, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectProxmox_NonProxmoxHost(t *testing.T) {
+	// On a non-Proxmox system, DetectProxmox should return IsInstalled=false
+	// without error. This test validates the fast-path early return.
+	info, err := DetectProxmox()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info == nil {
+		t.Fatal("expected non-nil ProxmoxInfo")
+	}
+	if info.IsInstalled {
+		// If this test is being run on an actual Proxmox host, skip instead of fail
+		t.Skip("running on a Proxmox host; skipping non-Proxmox assertion")
+	}
+	if info.Version != "" {
+		t.Errorf("expected empty version on non-Proxmox host, got %q", info.Version)
+	}
+	if info.NodeName != "" {
+		t.Errorf("expected empty node name on non-Proxmox host, got %q", info.NodeName)
+	}
+}

--- a/internal/status/types.go
+++ b/internal/status/types.go
@@ -39,9 +39,20 @@ type AppInfo struct {
 
 // NodeCapabilities describes the GPU and inference engine capabilities of a node.
 type NodeCapabilities struct {
-	GPUs    []GPUCapability `json:"gpus,omitempty"`
-	Engines []string        `json:"engines,omitempty"`
-	Tags    []string        `json:"tags,omitempty"`
+	GPUs       []GPUCapability `json:"gpus,omitempty"`
+	Engines    []string        `json:"engines,omitempty"`
+	Tags       []string        `json:"tags,omitempty"`
+	Hypervisor *HypervisorInfo `json:"hypervisor,omitempty"`
+}
+
+// HypervisorInfo describes a detected hypervisor on the node.
+type HypervisorInfo struct {
+	Type      string `json:"type"`                 // e.g. "proxmox"
+	Version   string `json:"version,omitempty"`    // e.g. "pve-manager/8.2.4/..."
+	NodeName  string `json:"node_name,omitempty"`  // this hypervisor node's name
+	NodeCount int    `json:"node_count,omitempty"` // total nodes in cluster
+	VMCount   int    `json:"vm_count,omitempty"`   // VMs on this node
+	CTCount   int    `json:"ct_count,omitempty"`   // containers on this node
 }
 
 // GPUCapability describes a single GPU's identity for capability reporting.


### PR DESCRIPTION
## Context

Phase 1 of #212 (Proxmox VM Management). This PR adds Proxmox hypervisor detection so that Citadel nodes running on Proxmox VE hosts report `hypervisor:proxmox` as a capability tag and include structured hypervisor metadata in heartbeats. This lays the groundwork for future Proxmox VM/CT management features (TUI pages, MCP tools, API integration) without implementing them yet.

## Summary

**Detection (`internal/platform/proxmox.go`):**
- `DetectProxmox()` uses a two-phase approach: fast presence check (`/etc/pve` + `pvesh` on PATH) returns immediately on non-Proxmox hosts, then best-effort enumeration (`pveversion`, `pvesh get /nodes`, `pvesh get /nodes/{node}/qemu|lxc`) with 5-second timeout gathers version, node count, VM count, and CT count. No new dependencies -- all detection uses `exec.Command`.

**Capability tagging (`cmd/work.go`):**
- `hypervisor:proxmox` tag is injected after capability resolution but before status conversion, covering both manifest and auto-detect code paths. Structured `HypervisorInfo` (type, version, node name, node count, VM count, CT count) is included in heartbeat payloads.

**Status types (`internal/status/types.go`):**
- Added `HypervisorInfo` struct and `Hypervisor` field on `NodeCapabilities` so hypervisor metadata flows through the collector into heartbeats.

**Tests (`internal/platform/proxmox_test.go`):**
- Table-driven tests for `parseProxmoxNodeList` (5 cases: single node, cluster, empty, invalid JSON, empty-name filtering)
- Table-driven tests for `parseProxmoxGuestCount` (4 cases: multiple VMs, empty, single CT, invalid JSON)
- Non-Proxmox host smoke test (verifies `IsInstalled=false` on systems without `/etc/pve`)

## Test plan

| Area | Tests | Coverage |
|------|-------|----------|
| Node list JSON parsing | 5 table-driven | single, cluster, empty, invalid, filtering |
| Guest count JSON parsing | 4 table-driven | VMs, empty, single CT, invalid |
| Non-Proxmox host | 1 | fast-path returns `IsInstalled=false` |
| Build | `CGO_ENABLED=0 go build ./...` | static binary compiles cleanly |
| Full test suite | `go test ./...` | no regressions (E2E skipped -- requires Redis) |

Needs manual testing on actual Proxmox host to verify detection output.

## Related

- Closes Phase 1 of #212