### PR TITLE
fix(work): target_node ack-skip filter for multi-node orgs

### DIFF
--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1208,6 +1208,7 @@ func runWork(cmd *cobra.Command, args []string) {
 	// Create runner
 	runner := worker.NewRunner(source, handlers, worker.RunnerConfig{
 		WorkerID:       workerID,
+		NodeID:         headscaleNodeID,
 		Verbose:        true,
 		JobRecordFn:    jobRecordFn,
 		MaxConcurrency: maxConcurrency,

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -43,6 +43,12 @@ type RunnerConfig struct {
 	// WorkerID identifies this worker instance
 	WorkerID string
 
+	// NodeID is this node's Headscale numeric node ID (e.g. "758").
+	// Used to filter jobs with a target_node field: if set and the job's
+	// target_node doesn't match, the job is acknowledged and skipped.
+	// When empty, target_node filtering is disabled (all jobs are processed).
+	NodeID string
+
 	// Verbose enables detailed logging
 	Verbose bool
 
@@ -238,6 +244,20 @@ func (r *Runner) processJob(ctx context.Context, job *Job) {
 
 	r.log("info", "Received job %s (type: %s)", job.ID, job.Type)
 	startTime := time.Now()
+
+	// Target-node filter: when per-node consumer groups are used, every node
+	// sees every message on the shared org queue. If the job specifies a
+	// target_node that doesn't match this node's Headscale ID, acknowledge
+	// and skip it silently -- the correct node will process it from its own
+	// read position. When this node's ID is unknown (empty), skip filtering
+	// to preserve pre-filter behavior and avoid dropping jobs.
+	if r.config.NodeID != "" {
+		if targetNode, ok := job.Payload["target_node"].(string); ok && targetNode != "" && targetNode != r.config.NodeID {
+			r.log("info", "Skipping job %s: target_node=%s (this node=%s)", job.ID, targetNode, r.config.NodeID)
+			r.source.Ack(ctx, job)
+			return
+		}
+	}
 
 	// JQS-Core Section 5.6: Check cancellation before processing
 	if r.source.IsJobCancelled(ctx, job.ID) {

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -664,3 +664,198 @@ func TestRunnerRecordJobWithoutCallback(t *testing.T) {
 	// This should not panic even without JobRecordFn
 	runner.recordJob(usage.UsageRecord{JobID: "test-id", JobType: "test-type", Status: "success"})
 }
+
+// --- target_node filter tests ---
+
+// TestRunnerTargetNodeMismatchSkipsJob verifies that a job with a target_node
+// that doesn't match this runner's NodeID is acknowledged and skipped without
+// executing the handler or writing to the stream.
+func TestRunnerTargetNodeMismatchSkipsJob(t *testing.T) {
+	jobs := []*Job{
+		{ID: "job-1", Type: "TEST_JOB", Payload: map[string]any{
+			"target_node": "999",
+			"command":     "hostname",
+		}},
+	}
+
+	source := NewMockJobSource("test", jobs)
+	handler := NewMockJobHandler("TEST_JOB", false)
+
+	mockStream := &MockStreamWriter{}
+	config := RunnerConfig{
+		WorkerID: "test-worker",
+		NodeID:   "1008", // This node's ID -- doesn't match target_node "999"
+	}
+	runner := NewRunner(source, []JobHandler{handler}, config)
+	runner.WithStreamWriterFactory(func(job *Job) StreamWriter {
+		return mockStream
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	runner.Run(ctx)
+
+	// Handler should NOT have executed
+	if len(handler.ExecutedJobs()) != 0 {
+		t.Errorf("Expected 0 executed jobs, got %d", len(handler.ExecutedJobs()))
+	}
+	// Job should be acked (removed from this consumer's pending entries)
+	if len(source.AckedJobs()) != 1 {
+		t.Errorf("Expected 1 acked job, got %d", len(source.AckedJobs()))
+	}
+	// Stream should NOT have been written to (the correct node produces the result)
+	if mockStream.started || mockStream.ended || mockStream.errored || mockStream.cancelled {
+		t.Error("Stream writer should not be called for skipped jobs")
+	}
+}
+
+// TestRunnerTargetNodeMatchProcessesJob verifies that a job with a target_node
+// matching this runner's NodeID is processed normally.
+func TestRunnerTargetNodeMatchProcessesJob(t *testing.T) {
+	jobs := []*Job{
+		{ID: "job-1", Type: "TEST_JOB", Payload: map[string]any{
+			"target_node": "1008",
+			"command":     "hostname",
+		}},
+	}
+
+	source := NewMockJobSource("test", jobs)
+	handler := NewMockJobHandler("TEST_JOB", false)
+
+	config := RunnerConfig{
+		WorkerID: "test-worker",
+		NodeID:   "1008", // Matches target_node
+	}
+	runner := NewRunner(source, []JobHandler{handler}, config)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	runner.Run(ctx)
+
+	// Handler should have executed
+	if len(handler.ExecutedJobs()) != 1 {
+		t.Errorf("Expected 1 executed job, got %d", len(handler.ExecutedJobs()))
+	}
+	// Job should be acked (successful)
+	if len(source.AckedJobs()) != 1 {
+		t.Errorf("Expected 1 acked job, got %d", len(source.AckedJobs()))
+	}
+}
+
+// TestRunnerTargetNodeEmptyProcessesJob verifies that a job without a
+// target_node field (broadcast job) is processed normally.
+func TestRunnerTargetNodeEmptyProcessesJob(t *testing.T) {
+	jobs := []*Job{
+		{ID: "job-1", Type: "TEST_JOB", Payload: map[string]any{
+			"command": "hostname",
+		}},
+	}
+
+	source := NewMockJobSource("test", jobs)
+	handler := NewMockJobHandler("TEST_JOB", false)
+
+	config := RunnerConfig{
+		WorkerID: "test-worker",
+		NodeID:   "1008",
+	}
+	runner := NewRunner(source, []JobHandler{handler}, config)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	runner.Run(ctx)
+
+	// Handler should have executed (no target_node means broadcast)
+	if len(handler.ExecutedJobs()) != 1 {
+		t.Errorf("Expected 1 executed job, got %d", len(handler.ExecutedJobs()))
+	}
+}
+
+// TestRunnerTargetNodeEmptyStringProcessesJob verifies that a job with
+// target_node set to an empty string is treated as a broadcast.
+func TestRunnerTargetNodeEmptyStringProcessesJob(t *testing.T) {
+	jobs := []*Job{
+		{ID: "job-1", Type: "TEST_JOB", Payload: map[string]any{
+			"target_node": "",
+			"command":     "hostname",
+		}},
+	}
+
+	source := NewMockJobSource("test", jobs)
+	handler := NewMockJobHandler("TEST_JOB", false)
+
+	config := RunnerConfig{
+		WorkerID: "test-worker",
+		NodeID:   "1008",
+	}
+	runner := NewRunner(source, []JobHandler{handler}, config)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	runner.Run(ctx)
+
+	if len(handler.ExecutedJobs()) != 1 {
+		t.Errorf("Expected 1 executed job, got %d", len(handler.ExecutedJobs()))
+	}
+}
+
+// TestRunnerNodeIDEmptySkipsFilter verifies that when the runner's NodeID is
+// empty (Headscale ID unresolved), the target_node filter is disabled and
+// all jobs are processed -- including ones with a target_node set. This
+// preserves pre-filter behavior and avoids dropping jobs that might be ours.
+func TestRunnerNodeIDEmptySkipsFilter(t *testing.T) {
+	jobs := []*Job{
+		{ID: "job-1", Type: "TEST_JOB", Payload: map[string]any{
+			"target_node": "999",
+			"command":     "hostname",
+		}},
+	}
+
+	source := NewMockJobSource("test", jobs)
+	handler := NewMockJobHandler("TEST_JOB", false)
+
+	config := RunnerConfig{
+		WorkerID: "test-worker",
+		NodeID:   "", // Empty -- Headscale ID not resolved
+	}
+	runner := NewRunner(source, []JobHandler{handler}, config)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	runner.Run(ctx)
+
+	// Handler SHOULD have executed (filter disabled when NodeID is empty)
+	if len(handler.ExecutedJobs()) != 1 {
+		t.Errorf("Expected 1 executed job (filter should be disabled), got %d", len(handler.ExecutedJobs()))
+	}
+}
+
+// TestRunnerTargetNodeMismatchNoUsageRecord verifies that skipped jobs do not
+// produce usage records (which would attribute work to the wrong node).
+func TestRunnerTargetNodeMismatchNoUsageRecord(t *testing.T) {
+	jobs := []*Job{
+		{ID: "job-1", Type: "TEST_JOB", Payload: map[string]any{
+			"target_node": "999",
+		}},
+	}
+
+	source := NewMockJobSource("test", jobs)
+	handler := NewMockJobHandler("TEST_JOB", false)
+
+	var recordCount int
+	config := RunnerConfig{
+		WorkerID: "test-worker",
+		NodeID:   "1008",
+		JobRecordFn: func(record usage.UsageRecord) {
+			recordCount++
+		},
+	}
+	runner := NewRunner(source, []JobHandler{handler}, config)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	runner.Run(ctx)
+
+	if recordCount != 0 {
+		t.Errorf("Expected 0 usage records for skipped job, got %d", recordCount)
+	}
+}


### PR DESCRIPTION
## Context

Prerequisite for #160 / PR #162 (per-node consumer groups). When consumer groups become per-node, every node sees every message on the shared org queue. Without filtering, a job targeted at node A would also be processed by nodes B and C, causing duplicate execution.

## Summary

Adds a `target_node` filter in the Runner's job processing path (`processJob`). Before dispatching to a handler, the runner checks:

1. **Mismatched `target_node`** -- If `job.Payload["target_node"]` is set and doesn't match `RunnerConfig.NodeID` (the Headscale numeric node ID), the job is ACK'd and skipped silently. No handler execution, no stream write (avoids racing the real result), no usage record (avoids false attribution).

2. **Matching `target_node`** -- Processed normally.

3. **Empty/absent `target_node`** (broadcast jobs) -- Processed normally.

4. **Empty local `NodeID`** (Headscale ID unresolved at startup) -- Filter is disabled entirely; all jobs are processed. This preserves pre-filter behavior and avoids dropping jobs that might belong to this node.

The `headscaleNodeID` (already resolved in `cmd/work.go` during startup) is wired into the Runner via the new `RunnerConfig.NodeID` field.

### Verified: payload key and value match the producer

- Python backend sets `target_node` as a top-level key in the JSON payload string (confirmed in `aceteam_mcp_terminal.py`, `aceteam_mcp_code.py`, `node_management.py`)
- The value is the Headscale numeric node ID (same as `fabric_node_status.node_id`, same as `build_node_queue` uses)
- `redisapi.ParseStreamMessage` deserializes the payload JSON into `map[string]any`, which flows through to `Job.Payload`

## Test plan

| Test | What it verifies |
|------|-----------------|
| `TestRunnerTargetNodeMismatchSkipsJob` | Mismatched target -> handler NOT executed, job ACK'd, stream NOT written |
| `TestRunnerTargetNodeMatchProcessesJob` | Matching target -> handler executed, job ACK'd |
| `TestRunnerTargetNodeEmptyProcessesJob` | No target_node field -> handler executed (broadcast) |
| `TestRunnerTargetNodeEmptyStringProcessesJob` | Empty string target_node -> handler executed (broadcast) |
| `TestRunnerNodeIDEmptySkipsFilter` | Empty local NodeID -> filter disabled, all jobs processed |
| `TestRunnerTargetNodeMismatchNoUsageRecord` | Skipped jobs produce zero usage records |

All existing tests continue to pass (`go test ./...` -- e2e failures are pre-existing, require running services).

## Related

- Unblocks PR #162 (per-node consumer groups)
- #160 (parent issue)
- aceteam-ai/aceteam#3914 (per-node routing)
- aceteam-ai/aceteam#3755 (target_node field in dispatch)