### PR TITLE
feat(work): agent-facing worker introspection & control (#236)

### DIFF
--- a/cmd/agent_tools.go
+++ b/cmd/agent_tools.go
@@ -1,0 +1,338 @@
+// cmd/agent_tools.go
+//
+// Building blocks for the agent-facing introspection & control tools (issue
+// #236). These back the status server's /agent/* HTTP endpoints, which the
+// aceteam MCP server wraps as the citadel_* agent tools. The control path is
+// the tsnet status server, deliberately NOT the Redis shell-job queue, so an
+// agent can diagnose a node whose job consumption is broken.
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/network"
+	"github.com/aceteam-ai/citadel-cli/internal/status"
+	"github.com/aceteam-ai/citadel-cli/internal/worker"
+)
+
+// agentProviderDeps carries everything buildAgentProviders needs from runWork.
+type agentProviderDeps struct {
+	state           *worker.WorkerState
+	source          worker.JobSource
+	nodeName        string
+	headscaleNodeID string
+	baseURL         string
+	deviceConfig    *DeviceConfig
+}
+
+// buildAgentProviders constructs the status.AgentProviders that back the
+// /agent/* endpoints (issue #236). Closures capture the live worker state and
+// source so introspection and control act on the running process, not via the
+// Redis job queue.
+func buildAgentProviders(ctx context.Context, d agentProviderDeps) *status.AgentProviders {
+	orgID := ""
+	if d.deviceConfig != nil {
+		orgID = d.deviceConfig.OrgID
+	}
+	startedAt := time.Now()
+
+	return &status.AgentProviders{
+		WorkerStatus: func() any {
+			return d.state.Snapshot()
+		},
+		NodeInfo: func() any {
+			return agentNodeInfo(d.nodeName, d.headscaleNodeID, orgID, startedAt)
+		},
+		Doctor: func() any {
+			return agentDoctor(d.state.Snapshot())
+		},
+		Config: func() any {
+			return agentConfig(d.nodeName, d.baseURL, orgID, d.state.Snapshot().Queues)
+		},
+		Logs: func(q status.LogQuery) (string, error) {
+			return agentTailLogs(struct {
+				Lines int
+				Level string
+				Grep  string
+				Since string
+			}{Lines: q.Lines, Level: q.Level, Grep: q.Grep, Since: q.Since})
+		},
+		SetLogLevel: func(verbose bool) any {
+			debugMode = verbose
+			Log("agent: log level set verbose=%v", verbose)
+			return map[string]any{"ok": true, "verbose": verbose}
+		},
+		Resubscribe: func() (any, error) {
+			return agentResubscribe(ctx, d, orgID)
+		},
+		WorkerRestart: func() (any, error) {
+			// A safe in-place run-loop restart (Drain + reconnect + re-AddQueue)
+			// is non-trivial because Runner.Run blocks and owns the source. Rather
+			// than ship a half-working goroutine swap, return an actionable result
+			// pointing the agent at the supported recovery paths. Tracked as
+			// future work in #236.
+			return map[string]any{
+				"ok":      false,
+				"message": "in-place worker restart is not yet supported; use /agent/resubscribe to recover a dead consume loop, or restart the citadel systemd service (sudo systemctl restart citadel)",
+			}, nil
+		},
+	}
+}
+
+// agentResubscribe re-establishes the per-node shell stream subscription on the
+// live source without restarting the process, to recover from a startup race
+// where the Headscale node ID was unresolved (issue #236 / #3914).
+func agentResubscribe(ctx context.Context, d agentProviderDeps, orgID string) (any, error) {
+	// Re-resolve the Headscale node ID in case it was empty at startup.
+	nodeID := d.headscaleNodeID
+	if nodeID == "" {
+		nodeID = network.GetGlobalNodeID(ctx)
+	}
+	if nodeID == "" {
+		return map[string]any{
+			"ok":      false,
+			"message": "Headscale node ID still unresolved; cannot subscribe to the per-node stream. Ensure the VPN is connected.",
+		}, nil
+	}
+	if orgID == "" {
+		return map[string]any{
+			"ok":      false,
+			"message": "org id unknown; cannot build the per-node stream name. Re-run 'citadel init'.",
+		}, nil
+	}
+
+	perNodeQueue := nodeQueueName(orgID, nodeID)
+	switch src := d.source.(type) {
+	case *worker.APISource:
+		src.AddQueue(perNodeQueue)
+	case *worker.RedisSource:
+		if err := src.AddQueue(ctx, perNodeQueue); err != nil {
+			return nil, fmt.Errorf("failed to subscribe to %s: %w", perNodeQueue, err)
+		}
+	default:
+		return map[string]any{"ok": false, "message": "source does not support resubscription"}, nil
+	}
+	d.state.SetPerNodeQueue(perNodeQueue)
+	switch src := d.source.(type) {
+	case *worker.APISource:
+		d.state.SetQueues(src.QueueNames())
+	case *worker.RedisSource:
+		d.state.SetQueues(src.QueueNames())
+	}
+	Log("agent: resubscribed to per-node stream %s", perNodeQueue)
+	return map[string]any{
+		"ok":             true,
+		"per_node_queue": perNodeQueue,
+		"message":        "per-node stream subscription re-established",
+	}, nil
+}
+
+// agentNodeInfo returns node identity for citadel_node_info: headscale + fabric
+// node IDs, version, org, tsnet IP, hostname, uptime, connection state.
+func agentNodeInfo(nodeName, headscaleNodeID, orgID string, startedAt time.Time) map[string]any {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	info := map[string]any{
+		"node_name":         nodeName,
+		"headscale_node_id": headscaleNodeID,
+		"fabric_node_id":    headscaleNodeID, // platform targets nodes by headscale id
+		"org_id":            orgID,
+		"version":           Version,
+		"uptime_seconds":    int64(time.Since(startedAt).Seconds()),
+		"connected":         false,
+	}
+	if hn, err := os.Hostname(); err == nil {
+		info["hostname"] = hn
+	}
+	if st, err := network.GetGlobalStatus(ctx); err == nil {
+		info["connected"] = st.Connected
+		info["backend_state"] = st.BackendState
+		if st.Hostname != "" {
+			info["network_hostname"] = st.Hostname
+		}
+		if st.IPv4 != "" {
+			info["tailscale_ip"] = st.IPv4
+		}
+		if st.NodeID != "" {
+			info["headscale_node_id"] = st.NodeID
+			info["fabric_node_id"] = st.NodeID
+		}
+	}
+	return info
+}
+
+// agentTailLogs reads up to opts.Lines lines from ~/.citadel-cli/logs/latest.log,
+// applying optional level/grep/since filters. This is where the previously-lost
+// worker stdout now lives, because #234 routed the source LogFn and we now wire
+// the runner ActivityFn to Log() (issue #236).
+func agentTailLogs(opts struct {
+	Lines int
+	Level string
+	Grep  string
+	Since string
+}) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve home dir: %w", err)
+	}
+	logPath := filepath.Join(home, ".citadel-cli", "logs", "latest.log")
+	f, err := os.Open(logPath)
+	if err != nil {
+		return "", fmt.Errorf("cannot open log file %s: %w", logPath, err)
+	}
+	defer f.Close()
+
+	var since time.Time
+	if opts.Since != "" {
+		if d, derr := time.ParseDuration(opts.Since); derr == nil {
+			since = time.Now().Add(-d)
+		}
+	}
+
+	// Level filtering is best-effort: log lines are "[HH:MM:SS] [CITADEL] msg",
+	// and the routed worker lines are prefixed by their level in the message
+	// where present. We match the level token case-insensitively in the line.
+	levelFilter := strings.ToLower(strings.TrimSpace(opts.Level))
+	grep := strings.ToLower(opts.Grep)
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	var matched []string
+	for scanner.Scan() {
+		line := scanner.Text()
+		lower := strings.ToLower(line)
+		if grep != "" && !strings.Contains(lower, grep) {
+			continue
+		}
+		if levelFilter != "" && !strings.Contains(lower, levelFilter) {
+			continue
+		}
+		if !since.IsZero() && !logLineAfter(line, since) {
+			continue
+		}
+		matched = append(matched, line)
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("error reading log: %w", err)
+	}
+
+	// Keep only the last N lines.
+	if opts.Lines > 0 && len(matched) > opts.Lines {
+		matched = matched[len(matched)-opts.Lines:]
+	}
+	return strings.Join(matched, "\n"), nil
+}
+
+// logLineAfter reports whether a "[HH:MM:SS] ..." log line is at or after the
+// given time (today). Lines without a parseable timestamp are kept (returns
+// true) so we never silently drop content.
+func logLineAfter(line string, since time.Time) bool {
+	if !strings.HasPrefix(line, "[") {
+		return true
+	}
+	end := strings.Index(line, "]")
+	if end < 0 {
+		return true
+	}
+	ts := line[1:end]
+	parsed, err := time.Parse("15:04:05", ts)
+	if err != nil {
+		return true
+	}
+	now := time.Now()
+	full := time.Date(now.Year(), now.Month(), now.Day(), parsed.Hour(), parsed.Minute(), parsed.Second(), 0, now.Location())
+	return !full.Before(since)
+}
+
+// agentDoctor runs the one-shot healthcheck and the "why am I not receiving
+// per-node jobs" diagnosis (issue #236). It mirrors the warning branches in
+// runWork (Headscale ID empty, org unknown, per-node queue missing, consume
+// status != 200) so an agent gets the same conclusions without reading logs.
+func agentDoctor(snap worker.WorkerSnapshot) map[string]any {
+	checks := []map[string]any{}
+	add := func(name string, ok bool, detail string) {
+		checks = append(checks, map[string]any{"name": name, "ok": ok, "detail": detail})
+	}
+
+	// 1. Network / identity
+	netOK := snap.HeadscaleNodeID != ""
+	add("headscale_node_id_resolved", netOK, valueOrEmpty(snap.HeadscaleNodeID, "unresolved (node-targeted jobs fall back to shared org stream)"))
+
+	// 2. Org id known
+	orgOK := snap.OrgID != ""
+	add("org_id_known", orgOK, valueOrEmpty(snap.OrgID, "unknown (per-node stream skipped)"))
+
+	// 3. Per-node subscription present
+	perNodeOK := snap.PerNodeQueue != ""
+	add("per_node_stream_subscribed", perNodeOK, valueOrEmpty(snap.PerNodeQueue, "NOT subscribed — per-node jobs will be claimed by a peer on the shared stream"))
+
+	// 4. Consuming recently
+	add("worker_consuming", snap.Consuming, fmt.Sprintf("last poll: %s", formatTimePtr(snap.LastPollAt)))
+
+	// 5. Consume HTTP status healthy (API mode). 0 = direct redis / unknown.
+	consumeOK := snap.LastConsumeStatus == 0 || snap.LastConsumeStatus == 200
+	statusDetail := fmt.Sprintf("last consume HTTP status: %d", snap.LastConsumeStatus)
+	if snap.LastConsumeError != "" {
+		statusDetail += "; last error: " + snap.LastConsumeError
+	}
+	add("consume_http_status_ok", consumeOK, statusDetail)
+
+	healthy := netOK && orgOK && perNodeOK && snap.Consuming && consumeOK
+
+	diagnosis := "Node looks healthy for per-node job routing."
+	switch {
+	case !netOK:
+		diagnosis = "Headscale node ID is unresolved, so the per-node shell stream was never subscribed. Per-node jobs (terminal_exec, code_*, file reads) fall back to the shared org stream where a peer may claim them. Try /agent/resubscribe or restart the worker after the VPN is fully connected."
+	case !orgOK:
+		diagnosis = "Org ID is unknown, so the per-node shell stream was skipped. Re-run 'citadel init' to repopulate device config."
+	case !perNodeOK:
+		diagnosis = "The per-node shell stream is not subscribed even though identity is known. Call /agent/resubscribe to re-establish it."
+	case !snap.Consuming:
+		diagnosis = "The worker has not completed a poll recently — the consume loop may be stuck. Check logs and consider /agent/worker-restart."
+	case !consumeOK:
+		diagnosis = fmt.Sprintf("The consume requests are being rejected (HTTP %d). This is the #3924-class failure: the worker is alive but the backend rejects its consume calls. Inspect last_consume_error and the backend.", snap.LastConsumeStatus)
+	}
+
+	return map[string]any{
+		"healthy":   healthy,
+		"checks":    checks,
+		"diagnosis": diagnosis,
+		"worker":    snap,
+	}
+}
+
+func valueOrEmpty(v, emptyMsg string) string {
+	if v == "" {
+		return emptyMsg
+	}
+	return v
+}
+
+func formatTimePtr(t *time.Time) string {
+	if t == nil {
+		return "never"
+	}
+	return t.Format(time.RFC3339)
+}
+
+// agentConfig returns the effective config with secrets redacted (issue #236).
+func agentConfig(nodeName, baseURL, orgID string, queues []string) map[string]any {
+	home, _ := os.UserHomeDir()
+	return map[string]any{
+		"node_name":       nodeName,
+		"api_base_url":    baseURL,
+		"org_id":          orgID,
+		"node_config_dir": filepath.Join(home, ".citadel-node"),
+		"log_dir":         filepath.Join(home, ".citadel-cli", "logs"),
+		"queues":          queues,
+		"version":         Version,
+		// Secrets (device_api_token, redis password) are intentionally omitted.
+	}
+}

--- a/cmd/agent_tools_test.go
+++ b/cmd/agent_tools_test.go
@@ -1,0 +1,138 @@
+// cmd/agent_tools_test.go
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/worker"
+)
+
+func TestAgentDoctorHealthy(t *testing.T) {
+	s := worker.NewWorkerState()
+	s.SetIdentity("w", "redis-api", "citadel-workers", "1008", "org-x")
+	s.SetQueues([]string{"jobs:v1:shell:org_x"})
+	s.SetPerNodeQueue("jobs:v1:shell:org_x:node:1008")
+	s.RecordConsumeStatus(200, "")
+	s.RecordPoll()
+
+	d := agentDoctor(s.Snapshot())
+	if healthy, _ := d["healthy"].(bool); !healthy {
+		t.Fatalf("expected healthy node, got %+v", d)
+	}
+}
+
+func TestAgentDoctorMissingHeadscaleID(t *testing.T) {
+	s := worker.NewWorkerState()
+	s.SetIdentity("w", "redis-api", "citadel-workers", "", "org-x") // no headscale id
+	s.RecordConsumeStatus(200, "")
+	s.RecordPoll()
+
+	d := agentDoctor(s.Snapshot())
+	if healthy, _ := d["healthy"].(bool); healthy {
+		t.Fatalf("expected unhealthy when headscale id missing")
+	}
+	diag, _ := d["diagnosis"].(string)
+	if !strings.Contains(diag, "Headscale node ID") {
+		t.Fatalf("diagnosis should mention Headscale node ID, got %q", diag)
+	}
+}
+
+func TestAgentDoctorConsume400(t *testing.T) {
+	// The #3924-class failure: identity is fine, per-node stream subscribed,
+	// polling, but consume returns 400. Doctor must surface that.
+	s := worker.NewWorkerState()
+	s.SetIdentity("w", "redis-api", "citadel-workers", "1008", "org-x")
+	s.SetPerNodeQueue("jobs:v1:shell:org_x:node:1008")
+	s.RecordConsumeStatus(400, "API error: bad consumer group")
+	s.RecordPoll()
+
+	d := agentDoctor(s.Snapshot())
+	if healthy, _ := d["healthy"].(bool); healthy {
+		t.Fatalf("expected unhealthy on consume 400")
+	}
+	diag, _ := d["diagnosis"].(string)
+	if !strings.Contains(diag, "400") {
+		t.Fatalf("diagnosis should mention the 400, got %q", diag)
+	}
+}
+
+func TestAgentConfigRedacts(t *testing.T) {
+	cfg := agentConfig("node-1", "https://aceteam.ai", "org-x", []string{"jobs:v1:shell:org_x"})
+	// Should never include secret fields.
+	for k := range cfg {
+		lk := strings.ToLower(k)
+		if strings.Contains(lk, "token") || strings.Contains(lk, "password") || strings.Contains(lk, "secret") {
+			t.Fatalf("agentConfig leaked a secret field: %s", k)
+		}
+	}
+	if cfg["org_id"] != "org-x" || cfg["api_base_url"] != "https://aceteam.ai" {
+		t.Fatalf("agentConfig missing expected fields: %+v", cfg)
+	}
+}
+
+func TestAgentTailLogsFilters(t *testing.T) {
+	// Point HOME at a temp dir with a synthetic log file.
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	logDir := filepath.Join(tmp, ".citadel-cli", "logs")
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().Format("15:04:05")
+	content := strings.Join([]string{
+		"[" + now + "] [CITADEL] info: worker started",
+		"[" + now + "] [CITADEL] error: consume failed status 400",
+		"[" + now + "] [CITADEL] info: subscribed to per-node stream",
+	}, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(logDir, "latest.log"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := struct {
+		Lines int
+		Level string
+		Grep  string
+		Since string
+	}{Lines: 100}
+
+	// No filter: all 3 lines.
+	out, err := agentTailLogs(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := len(strings.Split(strings.TrimSpace(out), "\n")); n != 3 {
+		t.Fatalf("expected 3 lines, got %d: %q", n, out)
+	}
+
+	// Grep filter.
+	opts.Grep = "per-node"
+	out, _ = agentTailLogs(opts)
+	if !strings.Contains(out, "per-node") || strings.Contains(out, "worker started") {
+		t.Fatalf("grep filter failed: %q", out)
+	}
+
+	// Level filter (error).
+	opts.Grep = ""
+	opts.Level = "error"
+	out, _ = agentTailLogs(opts)
+	if !strings.Contains(out, "400") || strings.Contains(out, "worker started") {
+		t.Fatalf("level filter failed: %q", out)
+	}
+}
+
+func TestAgentNodeInfoFields(t *testing.T) {
+	info := agentNodeInfo("node-1", "1008", "org-x", time.Now().Add(-time.Minute))
+	if info["node_name"] != "node-1" {
+		t.Fatalf("node_name wrong: %+v", info)
+	}
+	if info["headscale_node_id"] != "1008" || info["fabric_node_id"] != "1008" {
+		t.Fatalf("node id fields wrong: %+v", info)
+	}
+	if up, _ := info["uptime_seconds"].(int64); up < 50 {
+		t.Fatalf("uptime should be ~60s, got %d", up)
+	}
+}

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -229,6 +229,12 @@ func runWork(cmd *cobra.Command, args []string) {
 	var apiSource *worker.APISource               // Keep reference for heartbeat
 	var setNodeMeta func(nodeID, nodeName string) // Set after node identity is resolved
 
+	// Live worker introspection state for the out-of-band control path
+	// (issue #236). Created here so the same pointer is shared by the runner
+	// (job counts, poll time) and the status server's /agent/* endpoints, which
+	// answer over the tsnet mesh even when Redis job consumption is broken.
+	workerState := worker.NewWorkerState()
+
 	if workRedisURL == "" && deviceConfig != nil && deviceConfig.DeviceAPIToken != "" {
 		// API mode: use secure HTTP API instead of direct Redis.
 		Debug("using API mode (device_api_token found)")
@@ -623,6 +629,7 @@ func runWork(cmd *cobra.Command, args []string) {
 					fmt.Fprintf(os.Stderr, "   - Warning: per-node stream subscribe failed: %v\n", err)
 				}
 			}
+			workerState.SetPerNodeQueue(perNodeQueue)
 			fmt.Printf("   - Per-node shell stream: %s\n", perNodeQueue)
 			Debug("per-node shell stream: %s", perNodeQueue)
 		} else {
@@ -634,6 +641,29 @@ func runWork(cmd *cobra.Command, args []string) {
 		fmt.Fprintln(os.Stderr, "   - Warning: per-node shell stream skipped (Headscale node ID "+
 			"unavailable); node-targeted jobs will fall back to the shared org stream")
 		Debug("per-node shell stream skipped: Headscale node ID unavailable")
+	}
+
+	// Populate the worker introspection state with the resolved identity and
+	// the full subscribed queue list (issue #236). This drives /agent/worker-status
+	// and the doctor diagnosis below.
+	{
+		stateOrgID := ""
+		if deviceConfig != nil {
+			stateOrgID = deviceConfig.OrgID
+		}
+		consumerGroup := workGroup
+		if consumerGroup == "" {
+			consumerGroup = "citadel-workers"
+		}
+		var queues []string
+		switch src := source.(type) {
+		case *worker.APISource:
+			queues = src.QueueNames()
+		case *worker.RedisSource:
+			queues = src.QueueNames()
+		}
+		workerState.SetIdentity(workerID, source.Name(), consumerGroup, headscaleNodeID, stateOrgID)
+		workerState.SetQueues(queues)
 	}
 
 	// Open usage store for per-job compute tracking
@@ -691,11 +721,26 @@ func runWork(cmd *cobra.Command, args []string) {
 		})
 	}
 
+	// Build the agent introspection & control providers (issue #236). These
+	// back the status server's /agent/* endpoints, which the aceteam MCP server
+	// wraps as citadel_* tools. They read the shared workerState and act on the
+	// live source — never via the Redis job queue, so they work even when job
+	// consumption is broken.
+	agentProviders := buildAgentProviders(ctx, agentProviderDeps{
+		state:           workerState,
+		source:          source,
+		nodeName:        nodeName,
+		headscaleNodeID: headscaleNodeID,
+		baseURL:         baseURL,
+		deviceConfig:    deviceConfig,
+	})
+
 	// Start status server if enabled
 	if workStatusPort > 0 {
 		serverCfg := status.ServerConfig{
 			Port:    workStatusPort,
 			Version: Version,
+			Agent:   agentProviders,
 		}
 
 		// Wire up desktop API auth if org ID is available
@@ -1205,13 +1250,22 @@ func runWork(cmd *cobra.Command, args []string) {
 		maxConcurrency = 1 // Default: sequential
 	}
 
-	// Create runner
+	// Create runner.
+	//
+	// ActivityFn routes the runner's per-job and lifecycle log lines to the
+	// citadel log file instead of stdout (which the log file does not capture).
+	// Before this, those lines were lost during a live node-routing debug
+	// (issue #3924/#236); #234 already routed the source's LogFn the same way.
+	// State threads the shared introspection metrics so the /agent/* endpoints
+	// can report consume/job activity.
 	runner := worker.NewRunner(source, handlers, worker.RunnerConfig{
 		WorkerID:       workerID,
 		Verbose:        true,
+		ActivityFn:     func(_ string, msg string) { Log("%s", msg) },
 		JobRecordFn:    jobRecordFn,
 		MaxConcurrency: maxConcurrency,
 		GPUTracker:     gpuTracker,
+		State:          workerState,
 	})
 
 	// Add stream writer factory if available

--- a/internal/redisapi/client.go
+++ b/internal/redisapi/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -28,6 +29,12 @@ type Client struct {
 
 	// Node identity metadata injected into stream events
 	nodeMeta *NodeMeta
+
+	// lastConsumeStatus is the HTTP status code of the most recent
+	// jobs/consume request. Exposed via LastConsumeStatus() so the worker
+	// introspection path can report it (issue #236). The pre-fix #3924 bug
+	// surfaced here as repeated 400s with no visible error in the log file.
+	lastConsumeStatus int32
 }
 
 // ClientConfig holds configuration for the API client.
@@ -72,6 +79,14 @@ func (c *Client) debug(format string, args ...any) {
 // WorkerID returns the unique worker identifier.
 func (c *Client) WorkerID() string {
 	return c.workerID
+}
+
+// LastConsumeStatus returns the HTTP status code of the most recent
+// jobs/consume request, or 0 if no consume request has been made yet.
+// Used by the worker introspection path (issue #236) to report whether the
+// consume loop is succeeding (200) or being rejected (e.g. 400/401/403).
+func (c *Client) LastConsumeStatus() int {
+	return int(atomic.LoadInt32(&c.lastConsumeStatus))
 }
 
 // Ping verifies the API connection by making a simple request.
@@ -207,6 +222,13 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body any, r
 	}
 
 	c.debug("response: %d - %s", resp.StatusCode, string(respBody))
+
+	// Record the consume HTTP status for worker introspection (issue #236).
+	// This is the single signal that would have surfaced the pre-fix #3924
+	// 400s, which otherwise only appeared as a generic "consume failed" error.
+	if strings.Contains(path, "/jobs/consume") {
+		atomic.StoreInt32(&c.lastConsumeStatus, int32(resp.StatusCode))
+	}
 
 	// Handle error responses
 	if resp.StatusCode >= 400 {

--- a/internal/redisapi/consume_status_test.go
+++ b/internal/redisapi/consume_status_test.go
@@ -1,0 +1,50 @@
+package redisapi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestLastConsumeStatusCaptures verifies that the HTTP status of a consume call
+// is recorded and exposed via LastConsumeStatus(). This is the signal that
+// would have surfaced the pre-fix #3924 400s (issue #236).
+func TestLastConsumeStatusCaptures(t *testing.T) {
+	var statusToReturn int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusToReturn)
+		if statusToReturn >= 400 {
+			w.Write([]byte(`{"error":"bad consumer group"}`))
+		} else {
+			w.Write([]byte(`{"messages":[]}`))
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(ClientConfig{BaseURL: srv.URL, Token: "t"})
+
+	if c.LastConsumeStatus() != 0 {
+		t.Fatalf("expected 0 before any consume, got %d", c.LastConsumeStatus())
+	}
+
+	// A 400 must be recorded even though ConsumeJob returns an error.
+	statusToReturn = http.StatusBadRequest
+	_, err := c.ConsumeJob(context.Background(), ConsumeRequest{Queue: "q", Group: "g", Consumer: "w", Count: 1, BlockMs: 100})
+	if err == nil {
+		t.Fatalf("expected error on 400 consume")
+	}
+	if c.LastConsumeStatus() != http.StatusBadRequest {
+		t.Fatalf("expected last consume status 400, got %d", c.LastConsumeStatus())
+	}
+
+	// A subsequent 200 must update the recorded status.
+	statusToReturn = http.StatusOK
+	if _, err := c.ConsumeJob(context.Background(), ConsumeRequest{Queue: "q", Group: "g", Consumer: "w", Count: 1, BlockMs: 100}); err != nil {
+		t.Fatalf("unexpected error on 200 consume: %v", err)
+	}
+	if c.LastConsumeStatus() != http.StatusOK {
+		t.Fatalf("expected last consume status 200, got %d", c.LastConsumeStatus())
+	}
+}

--- a/internal/status/agent.go
+++ b/internal/status/agent.go
@@ -1,0 +1,221 @@
+package status
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+)
+
+// Agent-facing introspection & control endpoints (issue #236).
+//
+// These endpoints are served by the same status HTTP server that already
+// dual-listens on localhost and the tsnet VPN. Crucially, this control path
+// does NOT depend on the Redis shell-job queue it is meant to debug: an agent
+// can call these even when job consumption is broken (a job dispatched over the
+// per-node stream would hang exactly when you need it). The aceteam MCP server
+// wraps these as the `citadel_*` agent tools over the VPN mesh.
+//
+// To keep the status package decoupled from the worker/runner internals, the
+// data and actions are supplied as provider callbacks on ServerConfig, wired up
+// in cmd/work.go. When a provider is nil the corresponding endpoint returns 503
+// (feature not available in this process), so a status server started outside
+// the worker (e.g. `citadel serve`) degrades gracefully.
+
+// AgentProviders supplies the data and actions backing the agent endpoints.
+// Read providers are wired on every worker; control providers may be nil.
+type AgentProviders struct {
+	// WorkerStatus returns a JSON-serializable snapshot of the worker's live
+	// consume/subscription state (issue #236, the primary debugging tool).
+	WorkerStatus func() any
+
+	// NodeInfo returns node identity: headscale/fabric IDs, version, org,
+	// tsnet IP, hostname, uptime, connection state.
+	NodeInfo func() any
+
+	// Logs returns up to `lines` recent log lines, optionally filtered by
+	// minimum level and a substring grep, since the given relative duration.
+	Logs func(opts LogQuery) (string, error)
+
+	// Doctor returns a one-shot healthcheck + "why am I not receiving per-node
+	// jobs" diagnosis.
+	Doctor func() any
+
+	// Config returns the effective config with secrets redacted.
+	Config func() any
+
+	// SetLogLevel toggles verbose/debug console logging. verbose=true enables.
+	SetLogLevel func(verbose bool) any
+
+	// Resubscribe re-establishes the per-node queue subscription without
+	// restarting the process. Returns a result object.
+	Resubscribe func() (any, error)
+
+	// WorkerRestart restarts the worker run loop in place. Returns a result.
+	WorkerRestart func() (any, error)
+}
+
+// LogQuery describes a log tail/grep request.
+type LogQuery struct {
+	Lines int    // max number of lines (default 200)
+	Level string // minimum level filter: "" | info | warning | error
+	Grep  string // substring filter
+	Since string // relative duration, e.g. "5m", "1h"
+}
+
+// registerAgentRoutes attaches the agent introspection & control routes to mux.
+// All routes require VPN origin or a valid org token (same posture as the SSH
+// key handler): the aceteam backend reaches them over the mesh after validating
+// org ownership; local callers must present a token.
+func (s *Server) registerAgentRoutes(mux *http.ServeMux) {
+	p := s.agent
+	if p == nil {
+		return
+	}
+
+	mux.HandleFunc("/agent/worker-status", s.requireVPNOrAuth(s.handleAgentJSON("worker_status", func(_ *http.Request) (any, error) {
+		if p.WorkerStatus == nil {
+			return nil, errUnavailable
+		}
+		return p.WorkerStatus(), nil
+	})))
+
+	mux.HandleFunc("/agent/node-info", s.requireVPNOrAuth(s.handleAgentJSON("node_info", func(_ *http.Request) (any, error) {
+		if p.NodeInfo == nil {
+			return nil, errUnavailable
+		}
+		return p.NodeInfo(), nil
+	})))
+
+	mux.HandleFunc("/agent/doctor", s.requireVPNOrAuth(s.handleAgentJSON("doctor", func(_ *http.Request) (any, error) {
+		if p.Doctor == nil {
+			return nil, errUnavailable
+		}
+		return p.Doctor(), nil
+	})))
+
+	mux.HandleFunc("/agent/config", s.requireVPNOrAuth(s.handleAgentJSON("config", func(_ *http.Request) (any, error) {
+		if p.Config == nil {
+			return nil, errUnavailable
+		}
+		return p.Config(), nil
+	})))
+
+	mux.HandleFunc("/agent/logs", s.requireVPNOrAuth(s.handleAgentLogs))
+
+	// Control endpoints (POST, may be nil -> 503).
+	mux.HandleFunc("/agent/set-log-level", s.requireVPNOrAuth(s.handleSetLogLevel))
+	mux.HandleFunc("/agent/resubscribe", s.requireVPNOrAuth(s.handleAgentAction("resubscribe", func() (any, error) {
+		if p.Resubscribe == nil {
+			return nil, errUnavailable
+		}
+		return p.Resubscribe()
+	})))
+	mux.HandleFunc("/agent/worker-restart", s.requireVPNOrAuth(s.handleAgentAction("worker_restart", func() (any, error) {
+		if p.WorkerRestart == nil {
+			return nil, errUnavailable
+		}
+		return p.WorkerRestart()
+	})))
+}
+
+// errUnavailable is returned by providers that are not wired in this process.
+var errUnavailable = &agentError{code: http.StatusServiceUnavailable, msg: "not available in this process"}
+
+type agentError struct {
+	code int
+	msg  string
+}
+
+func (e *agentError) Error() string { return e.msg }
+
+// handleAgentJSON wraps a read provider into a GET JSON handler.
+func (s *Server) handleAgentJSON(name string, fn func(*http.Request) (any, error)) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		result, err := fn(r)
+		if err != nil {
+			writeAgentError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, result)
+	}
+}
+
+// handleAgentAction wraps a control provider into a POST JSON handler.
+func (s *Server) handleAgentAction(name string, fn func() (any, error)) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		result, err := fn()
+		if err != nil {
+			writeAgentError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, result)
+	}
+}
+
+// handleAgentLogs serves GET /agent/logs?lines=&level=&grep=&since=.
+func (s *Server) handleAgentLogs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.agent == nil || s.agent.Logs == nil {
+		writeAgentError(w, errUnavailable)
+		return
+	}
+	q := LogQuery{
+		Lines: 200,
+		Level: r.URL.Query().Get("level"),
+		Grep:  r.URL.Query().Get("grep"),
+		Since: r.URL.Query().Get("since"),
+	}
+	if v := r.URL.Query().Get("lines"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			q.Lines = n
+		}
+	}
+	out, err := s.agent.Logs(q)
+	if err != nil {
+		writeAgentError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"logs": out})
+}
+
+// handleSetLogLevel serves POST /agent/set-log-level?verbose=true|false.
+func (s *Server) handleSetLogLevel(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.agent == nil || s.agent.SetLogLevel == nil {
+		writeAgentError(w, errUnavailable)
+		return
+	}
+	verbose := true
+	if v := r.URL.Query().Get("verbose"); v != "" {
+		verbose, _ = strconv.ParseBool(v)
+	}
+	writeJSON(w, http.StatusOK, s.agent.SetLogLevel(verbose))
+}
+
+func writeJSON(w http.ResponseWriter, code int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	json.NewEncoder(w).Encode(v)
+}
+
+func writeAgentError(w http.ResponseWriter, err error) {
+	code := http.StatusInternalServerError
+	if ae, ok := err.(*agentError); ok {
+		code = ae.code
+	}
+	writeJSON(w, code, map[string]string{"error": err.Error()})
+}

--- a/internal/status/agent_test.go
+++ b/internal/status/agent_test.go
@@ -1,0 +1,119 @@
+package status
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// newAgentMux builds a mux with only the agent routes registered, for testing.
+func newAgentMux(p *AgentProviders) (*Server, *http.ServeMux) {
+	s := NewServer(ServerConfig{Port: 8080, Version: "test", Agent: p}, NewCollector(CollectorConfig{NodeName: "n"}))
+	mux := http.NewServeMux()
+	s.registerAgentRoutes(mux)
+	return s, mux
+}
+
+// vpnReq builds a request that appears to originate from the Headscale VPN
+// (100.64.0.0/10), which requireVPNOrAuth trusts without a token.
+func vpnReq(method, target string) *http.Request {
+	r := httptest.NewRequest(method, target, nil)
+	r.RemoteAddr = "100.64.0.5:54321"
+	return r
+}
+
+func TestAgentWorkerStatusOverVPN(t *testing.T) {
+	called := false
+	_, mux := newAgentMux(&AgentProviders{
+		WorkerStatus: func() any { called = true; return map[string]any{"consuming": true} },
+	})
+
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, vpnReq(http.MethodGet, "/agent/worker-status"))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !called {
+		t.Fatalf("provider not invoked")
+	}
+	var body map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("bad json: %v", err)
+	}
+	if body["consuming"] != true {
+		t.Fatalf("unexpected body: %+v", body)
+	}
+}
+
+func TestAgentRequiresAuthFromLAN(t *testing.T) {
+	_, mux := newAgentMux(&AgentProviders{
+		WorkerStatus: func() any { return map[string]any{} },
+	})
+
+	// A non-VPN origin without a token must be rejected (no tokenValidator set).
+	r := httptest.NewRequest(http.MethodGet, "/agent/worker-status", nil)
+	r.RemoteAddr = "192.168.1.50:1234"
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 from LAN without token, got %d", w.Code)
+	}
+}
+
+func TestAgentNilProviderReturns503(t *testing.T) {
+	// Providers struct present but WorkerStatus nil -> 503.
+	_, mux := newAgentMux(&AgentProviders{})
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, vpnReq(http.MethodGet, "/agent/worker-status"))
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 for unwired provider, got %d", w.Code)
+	}
+}
+
+func TestAgentControlRequiresPost(t *testing.T) {
+	_, mux := newAgentMux(&AgentProviders{
+		Resubscribe: func() (any, error) { return map[string]any{"ok": true}, nil },
+	})
+	// GET on a control endpoint must be 405.
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, vpnReq(http.MethodGet, "/agent/resubscribe"))
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405 for GET on control endpoint, got %d", w.Code)
+	}
+	// POST works.
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, vpnReq(http.MethodPost, "/agent/resubscribe"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for POST resubscribe, got %d", w.Code)
+	}
+}
+
+func TestAgentLogsQueryParams(t *testing.T) {
+	var got LogQuery
+	_, mux := newAgentMux(&AgentProviders{
+		Logs: func(q LogQuery) (string, error) { got = q; return "line1\nline2", nil },
+	})
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, vpnReq(http.MethodGet, "/agent/logs?lines=50&level=error&grep=consume&since=5m"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if got.Lines != 50 || got.Level != "error" || got.Grep != "consume" || got.Since != "5m" {
+		t.Fatalf("query params not parsed: %+v", got)
+	}
+}
+
+func TestRegisterAgentRoutesNoopWhenNil(t *testing.T) {
+	// No panic and no routes when providers are nil.
+	s := NewServer(ServerConfig{Port: 8080}, NewCollector(CollectorConfig{NodeName: "n"}))
+	mux := http.NewServeMux()
+	s.registerAgentRoutes(mux)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, vpnReq(http.MethodGet, "/agent/worker-status"))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 (route not registered) when providers nil, got %d", w.Code)
+	}
+}

--- a/internal/status/server.go
+++ b/internal/status/server.go
@@ -26,6 +26,10 @@ type Server struct {
 	orgID          string
 	enableDesktop  bool
 
+	// agent provides the data/actions backing the /agent/* introspection &
+	// control endpoints (issue #236). Nil disables those routes.
+	agent *AgentProviders
+
 	// extraListeners are additional net.Listeners the server will also serve on
 	// (e.g., a tsnet VPN listener). Added via AddListener before Start.
 	extraListeners []net.Listener
@@ -38,6 +42,11 @@ type ServerConfig struct {
 	TokenValidator terminal.TokenValidator // Optional: enables authenticated desktop endpoints
 	OrgID          string                 // Required when TokenValidator is set
 	EnableDesktop  bool                   // When true AND TokenValidator is set, registers /api/screenshot and /api/actions
+
+	// Agent, when set, registers the /agent/* introspection & control
+	// endpoints (issue #236). These are served over the same dual (LAN+VPN)
+	// listeners but gated by requireVPNOrAuth.
+	Agent *AgentProviders
 }
 
 // NewServer creates a new status HTTP server.
@@ -52,6 +61,7 @@ func NewServer(cfg ServerConfig, collector *Collector) *Server {
 		tokenValidator: cfg.TokenValidator,
 		orgID:          cfg.OrgID,
 		enableDesktop:  cfg.EnableDesktop,
+		agent:          cfg.Agent,
 	}
 }
 
@@ -80,6 +90,10 @@ func (s *Server) Start(ctx context.Context) error {
 	// Uses VPN-origin check OR token auth — the platform relay calls this
 	// from within the VPN mesh after validating org ownership.
 	mux.HandleFunc("/ssh/authorized-keys", s.requireVPNOrAuth(s.handleSSHAuthorizedKeys))
+
+	// Agent introspection & control endpoints (issue #236), gated the same way
+	// (VPN origin or valid org token). No-op when no providers were supplied.
+	s.registerAgentRoutes(mux)
 
 	s.httpServer = &http.Server{
 		Addr:         fmt.Sprintf(":%d", s.port),

--- a/internal/worker/api_source.go
+++ b/internal/worker/api_source.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/aceteam-ai/citadel-cli/internal/redisapi"
 )
@@ -11,8 +12,13 @@ import (
 // This is the secure alternative to direct Redis connections.
 // Supports consuming from multiple queues by round-robining across them.
 type APISource struct {
-	client     *redisapi.Client
-	config     APISourceConfig
+	client *redisapi.Client
+	config APISourceConfig
+
+	// mu guards queueNames, which is read by the run loop (Next) and may be
+	// appended to at runtime by AddQueue (e.g. the /agent/resubscribe control
+	// endpoint, issue #236) from a different goroutine.
+	mu         sync.RWMutex
 	queueNames []string // resolved list of queues to consume from
 	queueIndex int      // round-robin index for multi-queue polling
 }
@@ -127,16 +133,25 @@ func (s *APISource) Connect(ctx context.Context) error {
 // When consuming from multiple queues, polls each queue in round-robin
 // with a short block timeout to avoid starving any queue.
 func (s *APISource) Next(ctx context.Context) (*Job, error) {
-	if len(s.queueNames) == 1 {
-		return s.nextSingle(ctx)
+	queues := s.snapshotQueues()
+	if len(queues) == 1 {
+		return s.nextSingle(ctx, queues[0])
 	}
-	return s.nextMulti(ctx)
+	return s.nextMulti(ctx, queues)
+}
+
+// snapshotQueues returns a stable copy of the queue list for one poll cycle,
+// so concurrent AddQueue calls (e.g. /agent/resubscribe) don't race the loop.
+func (s *APISource) snapshotQueues() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return append([]string(nil), s.queueNames...)
 }
 
 // nextSingle reads from a single queue (original behavior).
-func (s *APISource) nextSingle(ctx context.Context) (*Job, error) {
+func (s *APISource) nextSingle(ctx context.Context, queue string) (*Job, error) {
 	apiJob, err := s.client.ConsumeJob(ctx, redisapi.ConsumeRequest{
-		Queue:    s.queueNames[0],
+		Queue:    queue,
 		Group:    s.config.ConsumerGroup,
 		Consumer: s.client.WorkerID(),
 		Count:    1,
@@ -151,7 +166,7 @@ func (s *APISource) nextSingle(ctx context.Context) (*Job, error) {
 	}
 
 	job := s.convertJob(apiJob)
-	job.SourceQueue = s.queueNames[0]
+	job.SourceQueue = queue
 	return job, nil
 }
 
@@ -160,10 +175,10 @@ func (s *APISource) nextSingle(ctx context.Context) (*Job, error) {
 // Individual queue failures (e.g., rejected by server validation) are
 // logged and skipped rather than failing the entire poll cycle. Only
 // when all queues error does the caller see an error (triggering backoff).
-func (s *APISource) nextMulti(ctx context.Context) (*Job, error) {
+func (s *APISource) nextMulti(ctx context.Context, queues []string) (*Job, error) {
 	// Use a shorter block per queue so we cycle through them all within
 	// roughly the configured block timeout.
-	perQueueBlockMs := s.config.BlockMs / len(s.queueNames)
+	perQueueBlockMs := s.config.BlockMs / len(queues)
 	if perQueueBlockMs < 500 {
 		perQueueBlockMs = 500
 	}
@@ -171,15 +186,15 @@ func (s *APISource) nextMulti(ctx context.Context) (*Job, error) {
 	var lastErr error
 	errCount := 0
 
-	for i := 0; i < len(s.queueNames); i++ {
+	for i := 0; i < len(queues); i++ {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		default:
 		}
 
-		queue := s.queueNames[s.queueIndex]
-		s.queueIndex = (s.queueIndex + 1) % len(s.queueNames)
+		queue := queues[s.queueIndex%len(queues)]
+		s.queueIndex = (s.queueIndex + 1) % len(queues)
 
 		apiJob, err := s.client.ConsumeJob(ctx, redisapi.ConsumeRequest{
 			Queue:    queue,
@@ -204,7 +219,7 @@ func (s *APISource) nextMulti(ctx context.Context) (*Job, error) {
 	}
 
 	// Only propagate error (triggering backoff) if ALL queues failed.
-	if errCount == len(s.queueNames) {
+	if errCount == len(queues) {
 		return nil, fmt.Errorf("all queues failed: %w", lastErr)
 	}
 
@@ -239,7 +254,9 @@ func (s *APISource) Ack(ctx context.Context, job *Job) error {
 	s.client.SetJobStatus(ctx, job.ID, "completed", nil)
 	queue := job.SourceQueue
 	if queue == "" {
-		queue = s.queueNames[0]
+		if qs := s.snapshotQueues(); len(qs) > 0 {
+			queue = qs[0]
+		}
 	}
 	return s.client.AcknowledgeJob(ctx, redisapi.AcknowledgeRequest{
 		Queue:     queue,
@@ -271,9 +288,19 @@ func (s *APISource) Client() *redisapi.Client {
 	return s.client
 }
 
+// LastConsumeStatus returns the HTTP status code of the most recent consume
+// request, or 0 if not yet connected/polled. Satisfies consumeStatusReporter
+// so the runner can surface it for worker introspection (issue #236).
+func (s *APISource) LastConsumeStatus() int {
+	if s.client == nil {
+		return 0
+	}
+	return s.client.LastConsumeStatus()
+}
+
 // QueueNames returns the list of queues being consumed.
 func (s *APISource) QueueNames() []string {
-	return s.queueNames
+	return s.snapshotQueues()
 }
 
 // AddQueue appends an additional queue to consume from after construction.
@@ -281,19 +308,23 @@ func (s *APISource) QueueNames() []string {
 // This is used to subscribe to the worker's per-node shell stream once the
 // node's Headscale ID is known (issue #3914), which happens after the source
 // is built. The Redis API proxy creates the consumer group lazily on the first
-// XREADGROUP, so no explicit group-creation call is needed here. Must be called
-// before the run loop starts reading (single-threaded at that point), so no
-// locking is required. A blank or already-present queue is ignored.
+// XREADGROUP, so no explicit group-creation call is needed here. A blank or
+// already-present queue is ignored. Guarded by mu so it is safe to call at
+// runtime (e.g. from the /agent/resubscribe control endpoint, issue #236)
+// concurrently with the run loop, which reads via snapshotQueues.
 func (s *APISource) AddQueue(queue string) {
 	if queue == "" {
 		return
 	}
+	s.mu.Lock()
 	for _, q := range s.queueNames {
 		if q == queue {
+			s.mu.Unlock()
 			return
 		}
 	}
 	s.queueNames = append(s.queueNames, queue)
+	s.mu.Unlock()
 	s.log("info", "   - Added queue: %s", queue)
 }
 

--- a/internal/worker/redis_source.go
+++ b/internal/worker/redis_source.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"sync"
 
 	redisclient "github.com/aceteam-ai/citadel-cli/internal/redis"
 )
@@ -31,8 +32,12 @@ func maskRedisURL(redisURL string) string {
 // This is the job source for AceTeam's private GPU cloud infrastructure.
 // Supports consuming from multiple queues simultaneously for tag-based routing.
 type RedisSource struct {
-	client     *redisclient.Client
-	config     RedisSourceConfig
+	client *redisclient.Client
+	config RedisSourceConfig
+
+	// mu guards queueNames, which is read by the run loop (Next) and may be
+	// appended to at runtime by AddQueue (e.g. /agent/resubscribe, issue #236).
+	mu         sync.RWMutex
 	queueNames []string // resolved list of queues to consume from
 }
 
@@ -144,14 +149,23 @@ func (s *RedisSource) Connect(ctx context.Context) error {
 
 // Next blocks until a job is available or context is cancelled.
 func (s *RedisSource) Next(ctx context.Context) (*Job, error) {
-	if len(s.queueNames) == 1 {
-		return s.nextSingle(ctx)
+	queues := s.snapshotQueues()
+	if len(queues) == 1 {
+		return s.nextSingle(ctx, queues[0])
 	}
-	return s.nextMulti(ctx)
+	return s.nextMulti(ctx, queues)
+}
+
+// snapshotQueues returns a stable copy of the queue list for one poll cycle,
+// so concurrent AddQueue calls (e.g. /agent/resubscribe) don't race the loop.
+func (s *RedisSource) snapshotQueues() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return append([]string(nil), s.queueNames...)
 }
 
 // nextSingle reads from a single queue (original behavior).
-func (s *RedisSource) nextSingle(ctx context.Context) (*Job, error) {
+func (s *RedisSource) nextSingle(ctx context.Context, queue string) (*Job, error) {
 	redisJob, err := s.client.ReadJob(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read job from Redis: %w", err)
@@ -160,8 +174,6 @@ func (s *RedisSource) nextSingle(ctx context.Context) (*Job, error) {
 	if redisJob == nil {
 		return nil, nil
 	}
-
-	queue := s.queueNames[0]
 
 	// Check delivery count for DLQ handling
 	deliveryCount, _ := s.client.GetDeliveryCount(ctx, redisJob.MessageID)
@@ -181,8 +193,8 @@ func (s *RedisSource) nextSingle(ctx context.Context) (*Job, error) {
 }
 
 // nextMulti reads from multiple queues simultaneously.
-func (s *RedisSource) nextMulti(ctx context.Context) (*Job, error) {
-	redisJob, sourceQueue, err := s.client.ReadJobMulti(ctx, s.queueNames)
+func (s *RedisSource) nextMulti(ctx context.Context, queues []string) (*Job, error) {
+	redisJob, sourceQueue, err := s.client.ReadJobMulti(ctx, queues)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read job from Redis: %w", err)
 	}
@@ -262,7 +274,7 @@ func (s *RedisSource) Client() *redisclient.Client {
 
 // QueueNames returns the list of queues being consumed.
 func (s *RedisSource) QueueNames() []string {
-	return s.queueNames
+	return s.snapshotQueues()
 }
 
 // AddQueue appends an additional queue to consume from after Connect.
@@ -272,24 +284,30 @@ func (s *RedisSource) QueueNames() []string {
 // and connected. The consumer group (and stream, via MKSTREAM) is created
 // immediately so the platform dispatcher's consumer-presence check can see the
 // stream; the consumer itself registers on the next multi-queue XREADGROUP.
-// Must be called before the run loop starts reading (single-threaded at that
-// point), so no locking is required. A blank or already-present queue is
-// ignored. Returns an error only if the consumer group cannot be created.
+// Guarded by mu so it is safe to call at runtime (e.g. /agent/resubscribe,
+// issue #236) concurrently with the run loop, which reads via snapshotQueues.
+// A blank or already-present queue is ignored. Returns an error only if the
+// consumer group cannot be created.
 func (s *RedisSource) AddQueue(ctx context.Context, queue string) error {
 	if queue == "" {
 		return nil
 	}
+	s.mu.RLock()
 	for _, q := range s.queueNames {
 		if q == queue {
+			s.mu.RUnlock()
 			return nil
 		}
 	}
+	s.mu.RUnlock()
 	if s.client != nil {
 		if err := s.client.EnsureConsumerGroups(ctx, []string{queue}); err != nil {
 			return fmt.Errorf("failed to create consumer group for %s: %w", queue, err)
 		}
 	}
+	s.mu.Lock()
 	s.queueNames = append(s.queueNames, queue)
+	s.mu.Unlock()
 	s.log("info", "   - Added queue: %s", queue)
 	return nil
 }

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -30,6 +30,10 @@ type Runner struct {
 	maxConcurrency int
 	gpuTracker     *GPUTracker
 
+	// state, when set, records live introspection metrics (poll time, job
+	// counts) for the out-of-band status/control path (issue #236).
+	state *WorkerState
+
 	// Lifecycle observability for safe self-update.
 	// activeJobs counts jobs currently executing in a handler.
 	// draining, when set, stops the run loop from fetching new jobs so
@@ -57,6 +61,10 @@ type RunnerConfig struct {
 
 	// GPUTracker manages GPU slot allocation (optional, for GPU-aware jobs)
 	GPUTracker *GPUTracker
+
+	// State, when set, is updated with live introspection metrics so the
+	// status/control path can report consume/job activity (issue #236).
+	State *WorkerState
 }
 
 // NewRunner creates a new job runner.
@@ -69,6 +77,7 @@ func NewRunner(source JobSource, handlers []JobHandler, config RunnerConfig) *Ru
 		jobRecordFn:    config.JobRecordFn,
 		maxConcurrency: config.MaxConcurrency,
 		gpuTracker:     config.GPUTracker,
+		state:          config.State,
 	}
 }
 
@@ -85,6 +94,30 @@ func (r *Runner) log(level, format string, args ...interface{}) {
 			fmt.Printf("%s\n", msg)
 		}
 	}
+}
+
+// consumeStatusReporter is implemented by sources that can report the HTTP
+// status of their most recent consume call (currently APISource via the
+// redisapi client). Used to surface the pre-fix #3924 400s (issue #236).
+type consumeStatusReporter interface {
+	LastConsumeStatus() int
+}
+
+// recordConsumeStatus copies the source's last consume HTTP status and error
+// into the introspection state after each poll cycle.
+func (r *Runner) recordConsumeStatus(pollErr error) {
+	if r.state == nil {
+		return
+	}
+	status := 0
+	if rep, ok := r.source.(consumeStatusReporter); ok {
+		status = rep.LastConsumeStatus()
+	}
+	errStr := ""
+	if pollErr != nil {
+		errStr = pollErr.Error()
+	}
+	r.state.RecordConsumeStatus(status, errStr)
 }
 
 // recordJob records a job completion for usage tracking
@@ -184,6 +217,11 @@ runLoop:
 
 			// Fetch next job
 			job, err := r.source.Next(ctx)
+			// Record the poll cycle for introspection regardless of outcome,
+			// so the status path can report "last successful poll time" and
+			// whether the worker is actively consuming (issue #236).
+			r.state.RecordPoll()
+			r.recordConsumeStatus(err)
 			if err != nil {
 				if ctx.Err() != nil {
 					break runLoop // Context cancelled
@@ -236,6 +274,13 @@ func (r *Runner) processJob(ctx context.Context, job *Job) {
 	atomic.AddInt64(&r.activeJobs, 1)
 	defer atomic.AddInt64(&r.activeJobs, -1)
 
+	// Track job in the introspection state. jobOK is flipped to true only on a
+	// clean success; the deferred RecordJobDone classifies the outcome (issue
+	// #236). Covers every return path of this function.
+	r.state.RecordJobReceived()
+	jobOK := false
+	defer func() { r.state.RecordJobDone(jobOK) }()
+
 	r.log("info", "Received job %s (type: %s)", job.ID, job.Type)
 	startTime := time.Now()
 
@@ -252,6 +297,7 @@ func (r *Runner) processJob(ctx context.Context, job *Job) {
 			r.log("warning", "Failed to publish cancelled event for job %s: %v", job.ID, err)
 		}
 		r.recordJob(buildUsageRecord(job, "cancelled", startTime, time.Now(), nil, nil))
+		jobOK = true // cleanly acked, not a processing failure
 		r.source.Ack(ctx, job)
 		return
 	}
@@ -350,6 +396,7 @@ func (r *Runner) processJob(ctx context.Context, job *Job) {
 	}
 
 	// Success
+	jobOK = true
 	r.log("success", "Job %s completed (%v)", job.ID, duration)
 	r.recordJob(buildUsageRecord(job, "success", startTime, endTime, result, nil))
 	if result != nil {

--- a/internal/worker/state.go
+++ b/internal/worker/state.go
@@ -1,0 +1,200 @@
+package worker
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// WorkerState is a concurrency-safe snapshot of the running worker's live
+// introspection state. It exists so an out-of-band control path (the status
+// HTTP server, reachable over the tsnet mesh) can answer "is the worker
+// consuming, what is it subscribed to, and why are per-node jobs not arriving"
+// WITHOUT dispatching a job through the very Redis queue being debugged
+// (issue #236). A single *WorkerState is created in cmd/work.go and threaded by
+// pointer into the JobSource, the Runner, and the status server.
+//
+// All fields are read/written from multiple goroutines: the run loop (counts,
+// poll time), the source (consume status, queues), and the status handler
+// (reads). Counters use atomics; the queue slice and string fields are guarded
+// by mu.
+type WorkerState struct {
+	mu sync.RWMutex
+
+	workerID      string
+	consumerGroup string
+	source        string   // source name (e.g. "redis-api", "redis")
+	queues        []string // streams currently subscribed/consumed
+	perNodeQueue  string   // the per-node shell stream, if subscribed
+	headscaleID   string
+	orgID         string
+
+	startedAt time.Time
+
+	// lastPollUnixNano is the time of the most recent completed poll cycle
+	// (job received OR empty result), stored as UnixNano for lock-free reads.
+	lastPollUnixNano int64
+	// lastJobUnixNano is the time the most recent job was received.
+	lastJobUnixNano int64
+	// lastConsumeStatus is the HTTP status of the most recent consume call
+	// (API mode). 0 means "never polled / unknown". This is THE signal that
+	// would have surfaced the pre-fix 400s in #3924.
+	lastConsumeStatus int32
+	// lastConsumeErr is the most recent consume error string ("" if the last
+	// poll succeeded).
+	lastConsumeErr atomic.Pointer[string]
+
+	inFlight  int64
+	processed int64
+	failed    int64
+}
+
+// NewWorkerState creates an empty WorkerState stamped with the start time.
+func NewWorkerState() *WorkerState {
+	s := &WorkerState{startedAt: time.Now()}
+	return s
+}
+
+// SetIdentity records the static identity/config of the worker. Safe to call
+// during startup before the run loop begins.
+func (s *WorkerState) SetIdentity(workerID, source, consumerGroup, headscaleID, orgID string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.workerID = workerID
+	s.source = source
+	s.consumerGroup = consumerGroup
+	s.headscaleID = headscaleID
+	s.orgID = orgID
+	s.mu.Unlock()
+}
+
+// SetQueues records the full list of streams the worker consumes from.
+func (s *WorkerState) SetQueues(queues []string) {
+	if s == nil {
+		return
+	}
+	cp := make([]string, len(queues))
+	copy(cp, queues)
+	s.mu.Lock()
+	s.queues = cp
+	s.mu.Unlock()
+}
+
+// SetPerNodeQueue records the per-node shell stream name once subscribed.
+func (s *WorkerState) SetPerNodeQueue(queue string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.perNodeQueue = queue
+	s.mu.Unlock()
+}
+
+// RecordPoll stamps the time of a completed poll cycle.
+func (s *WorkerState) RecordPoll() {
+	if s == nil {
+		return
+	}
+	atomic.StoreInt64(&s.lastPollUnixNano, time.Now().UnixNano())
+}
+
+// RecordConsumeStatus records the HTTP status and error of the most recent
+// consume call. status<=0 is ignored (no HTTP status available, e.g. direct
+// Redis mode). err may be empty to clear a prior error.
+func (s *WorkerState) RecordConsumeStatus(status int, err string) {
+	if s == nil {
+		return
+	}
+	if status > 0 {
+		atomic.StoreInt32(&s.lastConsumeStatus, int32(status))
+	}
+	e := err
+	s.lastConsumeErr.Store(&e)
+}
+
+// RecordJobReceived stamps the time the worker received a job and increments
+// the in-flight counter. Pair with RecordJobDone.
+func (s *WorkerState) RecordJobReceived() {
+	if s == nil {
+		return
+	}
+	atomic.StoreInt64(&s.lastJobUnixNano, time.Now().UnixNano())
+	atomic.AddInt64(&s.inFlight, 1)
+}
+
+// RecordJobDone decrements in-flight and increments processed or failed.
+func (s *WorkerState) RecordJobDone(ok bool) {
+	if s == nil {
+		return
+	}
+	atomic.AddInt64(&s.inFlight, -1)
+	if ok {
+		atomic.AddInt64(&s.processed, 1)
+	} else {
+		atomic.AddInt64(&s.failed, 1)
+	}
+}
+
+// WorkerSnapshot is a point-in-time, JSON-serializable view of WorkerState.
+type WorkerSnapshot struct {
+	WorkerID          string    `json:"worker_id"`
+	Source            string    `json:"source"`
+	ConsumerGroup     string    `json:"consumer_group"`
+	Queues            []string  `json:"queues"`
+	PerNodeQueue      string    `json:"per_node_queue,omitempty"`
+	HeadscaleNodeID   string    `json:"headscale_node_id,omitempty"`
+	OrgID             string    `json:"org_id,omitempty"`
+	Consuming         bool      `json:"consuming"`
+	StartedAt         time.Time `json:"started_at"`
+	UptimeSeconds     int64     `json:"uptime_seconds"`
+	LastPollAt        *time.Time `json:"last_poll_at,omitempty"`
+	LastJobAt         *time.Time `json:"last_job_at,omitempty"`
+	LastConsumeStatus int       `json:"last_consume_status"`
+	LastConsumeError  string    `json:"last_consume_error,omitempty"`
+	InFlight          int64     `json:"in_flight"`
+	Processed         int64     `json:"processed"`
+	Failed            int64     `json:"failed"`
+}
+
+// Snapshot returns a consistent copy of the current state. Safe for concurrent
+// use. "Consuming" is true if a poll completed within the last 30s, which is a
+// generous bound given the default 5s block timeout.
+func (s *WorkerState) Snapshot() WorkerSnapshot {
+	if s == nil {
+		return WorkerSnapshot{}
+	}
+	s.mu.RLock()
+	snap := WorkerSnapshot{
+		WorkerID:        s.workerID,
+		Source:          s.source,
+		ConsumerGroup:   s.consumerGroup,
+		Queues:          append([]string(nil), s.queues...),
+		PerNodeQueue:    s.perNodeQueue,
+		HeadscaleNodeID: s.headscaleID,
+		OrgID:           s.orgID,
+		StartedAt:       s.startedAt,
+	}
+	s.mu.RUnlock()
+
+	snap.UptimeSeconds = int64(time.Since(snap.StartedAt).Seconds())
+	snap.LastConsumeStatus = int(atomic.LoadInt32(&s.lastConsumeStatus))
+	if p := s.lastConsumeErr.Load(); p != nil {
+		snap.LastConsumeError = *p
+	}
+	snap.InFlight = atomic.LoadInt64(&s.inFlight)
+	snap.Processed = atomic.LoadInt64(&s.processed)
+	snap.Failed = atomic.LoadInt64(&s.failed)
+
+	if ns := atomic.LoadInt64(&s.lastPollUnixNano); ns > 0 {
+		t := time.Unix(0, ns)
+		snap.LastPollAt = &t
+		snap.Consuming = time.Since(t) < 30*time.Second
+	}
+	if ns := atomic.LoadInt64(&s.lastJobUnixNano); ns > 0 {
+		t := time.Unix(0, ns)
+		snap.LastJobAt = &t
+	}
+	return snap
+}

--- a/internal/worker/state_test.go
+++ b/internal/worker/state_test.go
@@ -1,0 +1,110 @@
+package worker
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestWorkerStateNilSafe(t *testing.T) {
+	var s *WorkerState
+	// All methods must be no-ops on a nil receiver so callers can pass nil.
+	s.SetIdentity("w", "redis", "g", "1", "org")
+	s.SetQueues([]string{"a"})
+	s.SetPerNodeQueue("q")
+	s.RecordPoll()
+	s.RecordConsumeStatus(200, "")
+	s.RecordJobReceived()
+	s.RecordJobDone(true)
+	snap := s.Snapshot()
+	if snap.WorkerID != "" {
+		t.Fatalf("nil snapshot should be zero, got %+v", snap)
+	}
+}
+
+func TestWorkerStateSnapshot(t *testing.T) {
+	s := NewWorkerState()
+	s.SetIdentity("worker-1", "redis-api", "citadel-workers", "1008", "org-x")
+	s.SetQueues([]string{"jobs:v1:shell:org_x", "jobs:v1:gpu-general"})
+	s.SetPerNodeQueue("jobs:v1:shell:org_x:node:1008")
+	s.RecordConsumeStatus(200, "")
+	s.RecordPoll()
+	s.RecordJobReceived()
+	s.RecordJobDone(true)
+	s.RecordJobReceived()
+	s.RecordJobDone(false)
+
+	snap := s.Snapshot()
+	if snap.WorkerID != "worker-1" || snap.Source != "redis-api" {
+		t.Fatalf("identity not recorded: %+v", snap)
+	}
+	if snap.ConsumerGroup != "citadel-workers" || snap.HeadscaleNodeID != "1008" || snap.OrgID != "org-x" {
+		t.Fatalf("identity fields wrong: %+v", snap)
+	}
+	if len(snap.Queues) != 2 {
+		t.Fatalf("expected 2 queues, got %v", snap.Queues)
+	}
+	if snap.PerNodeQueue != "jobs:v1:shell:org_x:node:1008" {
+		t.Fatalf("per-node queue wrong: %q", snap.PerNodeQueue)
+	}
+	if snap.LastConsumeStatus != 200 {
+		t.Fatalf("expected consume status 200, got %d", snap.LastConsumeStatus)
+	}
+	if snap.Processed != 1 || snap.Failed != 1 || snap.InFlight != 0 {
+		t.Fatalf("counts wrong: processed=%d failed=%d inflight=%d", snap.Processed, snap.Failed, snap.InFlight)
+	}
+	if !snap.Consuming {
+		t.Fatalf("expected Consuming=true right after RecordPoll")
+	}
+	if snap.LastPollAt == nil || snap.LastJobAt == nil {
+		t.Fatalf("expected poll/job timestamps to be set")
+	}
+}
+
+func TestWorkerStateConsumingFalseWhenStale(t *testing.T) {
+	s := NewWorkerState()
+	// Force an old poll time.
+	old := time.Now().Add(-time.Hour).UnixNano()
+	s.lastPollUnixNano = old
+	if s.Snapshot().Consuming {
+		t.Fatalf("expected Consuming=false for a stale poll time")
+	}
+}
+
+func TestWorkerStateConsumeError(t *testing.T) {
+	s := NewWorkerState()
+	s.RecordConsumeStatus(400, "API error: bad consumer")
+	snap := s.Snapshot()
+	if snap.LastConsumeStatus != 400 {
+		t.Fatalf("expected 400, got %d", snap.LastConsumeStatus)
+	}
+	if snap.LastConsumeError != "API error: bad consumer" {
+		t.Fatalf("expected consume error recorded, got %q", snap.LastConsumeError)
+	}
+	// status<=0 should not clobber the recorded status.
+	s.RecordConsumeStatus(0, "")
+	if s.Snapshot().LastConsumeStatus != 400 {
+		t.Fatalf("status 0 should not overwrite, got %d", s.Snapshot().LastConsumeStatus)
+	}
+}
+
+func TestWorkerStateConcurrent(t *testing.T) {
+	s := NewWorkerState()
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s.RecordPoll()
+			s.RecordJobReceived()
+			s.RecordConsumeStatus(200, "")
+			s.SetQueues([]string{"a", "b"})
+			s.RecordJobDone(true)
+			_ = s.Snapshot()
+		}()
+	}
+	wg.Wait()
+	if got := s.Snapshot().Processed; got != 50 {
+		t.Fatalf("expected 50 processed, got %d", got)
+	}
+}


### PR DESCRIPTION
## Context

Debugging #3924 (per-node job routing) was blind: an agent had no way to interrogate a Citadel node's worker. Subscription/consume state was invisible, and the per-node subscription lines from #234 printed to terminal stdout, not the log file. We were reduced to guessing node IDs and blind restarts.

This adds an agent-facing introspection & control surface on the node, served over a path that does **not** depend on the Redis shell-job queue it diagnoses — so it works even when job consumption is broken.

Implements #236. Companion PR in aceteam exposes these as `citadel_*` MCP tools.

## Architecture: the control path

The existing `internal/status` HTTP server already dual-listens on `127.0.0.1` and the tsnet VPN listener (`work.go` wires `statusServer.AddListener(vpnLn)`). That mesh path is independent of Redis `XREADGROUP`, so it satisfies the issue's critical constraint. New `/agent/*` routes are added there, gated by `requireVPNOrAuth` (VPN origin or valid org token), same posture as the SSH-key relay. There is no in-process MCP server in Go; the aceteam Python MCP server wraps these HTTP endpoints.

A single `worker.WorkerState` (atomics + mutex) is created in `work.go` and threaded by pointer into the source, the runner, and the status server, so the endpoints read live in-process metrics.

## Summary

- **`internal/worker/state.go`** — `WorkerState`: queues, per-node stream, consumer group, last poll/job times, **last consume HTTP status**, in-flight/processed/failed counts; `Snapshot()` for JSON.
- **`internal/redisapi/client.go`** — record the consume HTTP status (`LastConsumeStatus()`); this is the signal that would have shown the pre-fix #3924 400s.
- **`internal/worker/runner.go`** — wire `ActivityFn` to the log file (per-job/lifecycle lines were lost to stdout; reuses #234's plumbing) and record poll/consume/job metrics into state.
- **`internal/status/agent.go` + `server.go`** — `/agent/worker-status|node-info|logs|doctor|config` (GET) and `/agent/resubscribe|worker-restart|set-log-level` (POST). Nil providers -> 503.
- **`cmd/agent_tools.go`** — node-info, log tail/grep (level/since), doctor diagnosis mirroring the per-node-routing warning branches in `work.go`, redacted config, and in-place resubscribe.
- **`api_source.go` / `redis_source.go`** — `AddQueue`/`QueueNames` made concurrency-safe so resubscribe is race-free.

`citadel_worker_restart` is an honest stub (returns guidance toward resubscribe / systemd restart): a safe in-place run-loop restart needs Drain + reconnect + re-AddQueue and was timeboxed out to land the read tools.

## Test plan

| Area | Tests |
|---|---|
| WorkerState | snapshot, nil-safe, stale-consuming, consume error, concurrent |
| Consume status capture | `redisapi` httptest: 400 recorded though ConsumeJob errors; 200 updates |
| Doctor | healthy / missing headscale ID / consume-400 branches |
| Logs | grep + level filters over a synthetic log |
| Endpoints | VPN-origin OK, LAN-without-token 401, nil provider 503, control requires POST, log query params |

`go build ./...`, `go vet ./...`, `go test ./...` all pass. (A pre-existing `-race`-only data race in `status/server_test.go` — concurrent `Start()` — is untouched by this PR.)

## Needs live validation

End-to-end agent -> aceteam MCP -> node `/agent/*` over a real tsnet mesh on a 2-node setup.

## Related
#236, #3924, #3914, #234, #233.