### PR TITLE
fix(manifest): guard against nil map when global config is empty

### DIFF
--- a/cmd/manifest.go
+++ b/cmd/manifest.go
@@ -81,9 +81,12 @@ func findAndReadManifest() (*CitadelManifest, string, error) {
 			// Found manifest in default location - auto-fix the config
 			globalConf.NodeConfigDir = defaultNodeDir
 
-			// Read existing config to preserve other fields
+			// Read existing config to preserve other fields. A successful
+			// unmarshal of an empty/whitespace/null file yields a nil map (e.g.
+			// when the config was truncated by a disk-full event), so guard
+			// against nil before writing or the assignment below panics.
 			var config map[string]interface{}
-			if err := yaml.Unmarshal(globalConfigData, &config); err != nil {
+			if err := yaml.Unmarshal(globalConfigData, &config); err != nil || config == nil {
 				config = make(map[string]interface{})
 			}
 			config["node_config_dir"] = defaultNodeDir


### PR DESCRIPTION
## Context
A disk-full event truncated the global `config.yaml` to 0 bytes on a live node.

## Root cause
`findAndReadManifest` (cmd/manifest.go) reads the global config, and when `node_config_dir` is empty it tries to auto-fix by unmarshalling into a `map[string]interface{}` and writing a key. A successful unmarshal of an empty/whitespace/null file yields a **nil map**, so the assignment panicked: `assignment to entry in nil map`. This crashed `citadel status`, the control center, and agent startup, so the node never came online.

## Fix
Treat a nil unmarshal result as empty (`|| config == nil`) before writing. Empty/corrupt config now degrades gracefully instead of panicking.

## Testing
`go build ./cmd/citadel`, `go vet ./cmd/` pass. Verified `citadel status` runs against a 0-byte config without panicking.

Related: disk-full during auto-update; see #245 (dirty-release guard), #246 (node offline after restart).