### PR TITLE
fix(work): subscribe to per-node shell stream in TUI worker (canonical path)

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -1015,6 +1015,41 @@ func runTUIWorker(ctx context.Context, activityFn func(level, msg string)) error
 		nodeName, _ = os.Hostname()
 	}
 
+	// Subscribe to this node's per-node shell stream so node-targeted MCP jobs
+	// (terminal_exec, code_*, file reads, node attachments) reach ONLY this node
+	// instead of being claimed by a greedy peer on the shared shell stream
+	// (issue #3914). The canonical `citadel` (TUI) path must do this too, not
+	// just `citadel work` -- otherwise node-targeted jobs are never consumed in
+	// the normal run mode. Mirrors the subscription in runWork(); purely additive
+	// (the shared shell stream is still consumed for untargeted work).
+	if headscaleNodeID == "" {
+		if id := network.GetGlobalNodeID(ctx); id != "" {
+			headscaleNodeID = id
+		}
+	}
+	if headscaleNodeID != "" {
+		perNodeOrgID := ""
+		if deviceConfig != nil {
+			perNodeOrgID = deviceConfig.OrgID
+		}
+		if perNodeOrgID == "" {
+			if manifest, _, mErr := findAndReadManifest(); mErr == nil && manifest != nil {
+				perNodeOrgID = manifest.Node.OrgID
+			}
+		}
+		if perNodeOrgID != "" {
+			perNodeQueue := nodeQueueName(perNodeOrgID, headscaleNodeID)
+			if apiSrc, ok := source.(*worker.APISource); ok {
+				apiSrc.AddQueue(perNodeQueue)
+			}
+			activity("info", fmt.Sprintf("Per-node shell stream: %s", perNodeQueue))
+		} else {
+			activity("warning", "Per-node shell stream skipped (org id unknown); node-targeted jobs fall back to the shared stream")
+		}
+	} else {
+		activity("warning", "Per-node shell stream skipped (node ID unavailable); node-targeted jobs fall back to the shared stream")
+	}
+
 	// Create status collector for heartbeat
 	collector := status.NewCollector(status.CollectorConfig{
 		NodeName:  nodeName,


### PR DESCRIPTION
## Context
After #3914/#3924/#224/#234, node-targeted MCP jobs still timed out when the node ran the **canonical** `citadel` command (control-center TUI), even though they worked under `citadel work`.

## Root cause
`runTUIWorker` (cmd/controlcenter.go) builds its APISource with an empty QueueName and **never calls AddQueue for the per-node shell stream**. All the per-node subscription work landed in `runWork` (the `citadel work` debug path) only. Since canonical operation is bare `citadel` (auto-runs the worker via the TUI), node-targeted jobs were never consumed there → terminal_exec / file attachments hang and time out.

## Fix
Mirror runWork's per-node subscription into runTUIWorker: resolve the Headscale node ID (with a fallback), resolve org id (device config → manifest), and `AddQueue(jobs:v1:shell:org_{org}:node:{id})` on the APISource before the run loop. Purely additive; the shared shell stream is still consumed for untargeted work.

## Testing
`go build ./cmd/citadel`, `go vet ./cmd/` pass. Needs live verification: run canonical `citadel`, then a node-targeted terminal_exec/attach should be consumed by this node instead of timing out.

Related: #3914, #3924 (aceteam #3937), #224, #234, #246.