### PR TITLE
feat(tui): add Console tab with embedded PTY

### DIFF
--- a/internal/console/pty_test.go
+++ b/internal/console/pty_test.go
@@ -1,0 +1,227 @@
+// internal/console/pty_test.go
+//go:build !windows
+
+package console
+
+import (
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNewPTYSession(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY not supported on Windows")
+	}
+
+	session, err := NewPTYSession(PTYConfig{
+		Shell:       "/bin/sh",
+		InitialCols: 80,
+		InitialRows: 24,
+	})
+	if err != nil {
+		t.Fatalf("NewPTYSession failed: %v", err)
+	}
+	defer session.Close()
+
+	if session.IsClosed() {
+		t.Fatal("session should not be closed after creation")
+	}
+
+	cols, rows := session.Size()
+	if cols != 80 || rows != 24 {
+		t.Fatalf("expected 80x24, got %dx%d", cols, rows)
+	}
+}
+
+func TestPTYSessionDefaultSize(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY not supported on Windows")
+	}
+
+	session, err := NewPTYSession(PTYConfig{Shell: "/bin/sh"})
+	if err != nil {
+		t.Fatalf("NewPTYSession failed: %v", err)
+	}
+	defer session.Close()
+
+	cols, rows := session.Size()
+	if cols != 80 || rows != 24 {
+		t.Fatalf("default size should be 80x24, got %dx%d", cols, rows)
+	}
+}
+
+func TestPTYSessionReadWrite(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY not supported on Windows")
+	}
+
+	session, err := NewPTYSession(PTYConfig{Shell: "/bin/sh"})
+	if err != nil {
+		t.Fatalf("NewPTYSession failed: %v", err)
+	}
+	defer session.Close()
+
+	// Write a command
+	marker := "HELLO_CONSOLE_TEST_12345"
+	_, err = session.Write([]byte("echo " + marker + "\n"))
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	// Read output until we find the marker or timeout
+	buf := make([]byte, 4096)
+	var collected strings.Builder
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for echo output; got so far: %s", collected.String())
+		default:
+		}
+		n, err := session.Read(buf)
+		if n > 0 {
+			collected.Write(buf[:n])
+			if strings.Contains(collected.String(), marker) {
+				return // success
+			}
+		}
+		if err != nil {
+			t.Fatalf("Read error: %v; collected: %s", err, collected.String())
+		}
+	}
+}
+
+func TestPTYSessionResize(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY not supported on Windows")
+	}
+
+	session, err := NewPTYSession(PTYConfig{Shell: "/bin/sh"})
+	if err != nil {
+		t.Fatalf("NewPTYSession failed: %v", err)
+	}
+	defer session.Close()
+
+	err = session.Resize(120, 40)
+	if err != nil {
+		t.Fatalf("Resize failed: %v", err)
+	}
+
+	cols, rows := session.Size()
+	if cols != 120 || rows != 40 {
+		t.Fatalf("expected 120x40 after resize, got %dx%d", cols, rows)
+	}
+}
+
+func TestPTYSessionResizeInvalid(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY not supported on Windows")
+	}
+
+	session, err := NewPTYSession(PTYConfig{Shell: "/bin/sh"})
+	if err != nil {
+		t.Fatalf("NewPTYSession failed: %v", err)
+	}
+	defer session.Close()
+
+	err = session.Resize(0, 24)
+	if err == nil {
+		t.Fatal("expected error for zero cols")
+	}
+
+	err = session.Resize(80, 0)
+	if err == nil {
+		t.Fatal("expected error for zero rows")
+	}
+}
+
+func TestPTYSessionClose(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY not supported on Windows")
+	}
+
+	closeCalled := false
+	var closeOnce sync.Mutex
+	session, err := NewPTYSession(PTYConfig{
+		Shell: "/bin/sh",
+		OnClose: func() {
+			closeOnce.Lock()
+			closeCalled = true
+			closeOnce.Unlock()
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewPTYSession failed: %v", err)
+	}
+
+	err = session.Close()
+	if err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	if !session.IsClosed() {
+		t.Fatal("session should be closed after Close()")
+	}
+
+	closeOnce.Lock()
+	if !closeCalled {
+		t.Fatal("OnClose callback was not called")
+	}
+	closeOnce.Unlock()
+
+	// Double close should be safe
+	err = session.Close()
+	if err != nil {
+		t.Fatalf("second Close should be no-op, got: %v", err)
+	}
+}
+
+func TestPTYSessionInvalidShell(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY not supported on Windows")
+	}
+
+	_, err := NewPTYSession(PTYConfig{Shell: "/nonexistent/shell"})
+	if err == nil {
+		t.Fatal("expected error for nonexistent shell")
+	}
+}
+
+func TestPTYSessionWriteAfterClose(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY not supported on Windows")
+	}
+
+	session, err := NewPTYSession(PTYConfig{Shell: "/bin/sh"})
+	if err != nil {
+		t.Fatalf("NewPTYSession failed: %v", err)
+	}
+
+	_ = session.Close()
+
+	_, err = session.Write([]byte("hello"))
+	if err == nil {
+		t.Fatal("expected error writing to closed session")
+	}
+}
+
+func TestPTYSessionResizeAfterClose(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PTY not supported on Windows")
+	}
+
+	session, err := NewPTYSession(PTYConfig{Shell: "/bin/sh"})
+	if err != nil {
+		t.Fatalf("NewPTYSession failed: %v", err)
+	}
+
+	_ = session.Close()
+
+	err = session.Resize(100, 50)
+	if err == nil {
+		t.Fatal("expected error resizing closed session")
+	}
+}

--- a/internal/console/pty_unix.go
+++ b/internal/console/pty_unix.go
@@ -1,0 +1,184 @@
+// internal/console/pty_unix.go
+//go:build !windows
+
+package console
+
+import (
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/creack/pty"
+)
+
+// PTYSession manages an embedded PTY for the TUI Console tab.
+// Unlike terminal.Session (which serves remote WebSocket clients),
+// PTYSession is owned by the TUI and streamed to viewers via Streamer.
+type PTYSession struct {
+	cmd  *exec.Cmd
+	ptmx *os.File
+
+	cols uint16
+	rows uint16
+
+	mu     sync.RWMutex
+	closed bool
+
+	onClose func()
+}
+
+// PTYConfig holds the configuration for creating a PTYSession.
+type PTYConfig struct {
+	Shell       string
+	InitialCols uint16
+	InitialRows uint16
+	Env         []string
+	OnClose     func()
+}
+
+// NewPTYSession spawns a shell in a new PTY.
+func NewPTYSession(cfg PTYConfig) (*PTYSession, error) {
+	if cfg.InitialCols == 0 {
+		cfg.InitialCols = 80
+	}
+	if cfg.InitialRows == 0 {
+		cfg.InitialRows = 24
+	}
+
+	shell := cfg.Shell
+	if shell == "" {
+		if s := os.Getenv("SHELL"); s != "" {
+			shell = s
+		} else {
+			shell = "/bin/bash"
+		}
+	}
+
+	if _, err := exec.LookPath(shell); err != nil {
+		return nil, errors.New("console: shell not found: " + shell)
+	}
+
+	cmd := exec.Command(shell)
+	cmd.Env = append(os.Environ(), cfg.Env...)
+	cmd.Env = append(cmd.Env,
+		"TERM=xterm-256color",
+		"COLORTERM=truecolor",
+	)
+
+	size := &pty.Winsize{
+		Cols: cfg.InitialCols,
+		Rows: cfg.InitialRows,
+	}
+
+	ptmx, err := pty.StartWithSize(cmd, size)
+	if err != nil {
+		return nil, errors.New("console: failed to create PTY: " + err.Error())
+	}
+
+	return &PTYSession{
+		cmd:     cmd,
+		ptmx:    ptmx,
+		cols:    cfg.InitialCols,
+		rows:    cfg.InitialRows,
+		onClose: cfg.OnClose,
+	}, nil
+}
+
+// Read reads output from the PTY. Blocks until data is available.
+func (s *PTYSession) Read(p []byte) (int, error) {
+	s.mu.RLock()
+	if s.closed {
+		s.mu.RUnlock()
+		return 0, io.EOF
+	}
+	s.mu.RUnlock()
+
+	return s.ptmx.Read(p)
+}
+
+// Write sends input to the PTY.
+func (s *PTYSession) Write(p []byte) (int, error) {
+	s.mu.RLock()
+	if s.closed {
+		s.mu.RUnlock()
+		return 0, io.ErrClosedPipe
+	}
+	s.mu.RUnlock()
+
+	return s.ptmx.Write(p)
+}
+
+// Resize changes the PTY dimensions.
+func (s *PTYSession) Resize(cols, rows uint16) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return io.ErrClosedPipe
+	}
+	if cols == 0 || rows == 0 {
+		return errors.New("console: invalid resize dimensions")
+	}
+
+	if err := pty.Setsize(s.ptmx, &pty.Winsize{Cols: cols, Rows: rows}); err != nil {
+		return err
+	}
+	s.cols = cols
+	s.rows = rows
+	return nil
+}
+
+// Size returns the current PTY dimensions.
+func (s *PTYSession) Size() (cols, rows uint16) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.cols, s.rows
+}
+
+// Close terminates the shell and closes the PTY.
+func (s *PTYSession) Close() error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil
+	}
+	s.closed = true
+	s.mu.Unlock()
+
+	// Signal the process to exit
+	if s.cmd.Process != nil {
+		_ = s.cmd.Process.Signal(syscall.SIGHUP)
+
+		done := make(chan struct{})
+		go func() {
+			_ = s.cmd.Wait()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			_ = s.cmd.Process.Kill()
+			<-done
+		}
+	}
+
+	err := s.ptmx.Close()
+
+	if s.onClose != nil {
+		s.onClose()
+	}
+
+	return err
+}
+
+// IsClosed returns whether the session has been closed.
+func (s *PTYSession) IsClosed() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.closed
+}

--- a/internal/console/pty_windows.go
+++ b/internal/console/pty_windows.go
@@ -1,0 +1,60 @@
+// internal/console/pty_windows.go
+//go:build windows
+
+package console
+
+import (
+	"errors"
+	"io"
+)
+
+// errUnsupported is returned on Windows where the embedded console PTY is not
+// yet supported. The TUI Console tab should be hidden on this platform.
+var errUnsupported = errors.New("console: embedded PTY is not supported on Windows")
+
+// PTYSession is the Windows stub. All methods return errUnsupported.
+type PTYSession struct{}
+
+// PTYConfig holds the configuration for creating a PTYSession.
+type PTYConfig struct {
+	Shell       string
+	InitialCols uint16
+	InitialRows uint16
+	Env         []string
+	OnClose     func()
+}
+
+// NewPTYSession always returns an error on Windows.
+func NewPTYSession(_ PTYConfig) (*PTYSession, error) {
+	return nil, errUnsupported
+}
+
+// Read always returns an error on Windows.
+func (s *PTYSession) Read(_ []byte) (int, error) {
+	return 0, io.EOF
+}
+
+// Write always returns an error on Windows.
+func (s *PTYSession) Write(_ []byte) (int, error) {
+	return 0, io.ErrClosedPipe
+}
+
+// Resize always returns an error on Windows.
+func (s *PTYSession) Resize(_, _ uint16) error {
+	return errUnsupported
+}
+
+// Size returns zero dimensions on Windows.
+func (s *PTYSession) Size() (cols, rows uint16) {
+	return 0, 0
+}
+
+// Close is a no-op on Windows.
+func (s *PTYSession) Close() error {
+	return nil
+}
+
+// IsClosed always returns true on Windows.
+func (s *PTYSession) IsClosed() bool {
+	return true
+}

--- a/internal/console/streamer.go
+++ b/internal/console/streamer.go
@@ -1,0 +1,120 @@
+// internal/console/streamer.go
+package console
+
+import (
+	"log"
+	"sync"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/terminal"
+	"github.com/gorilla/websocket"
+)
+
+// Streamer fans PTY output to multiple WebSocket viewers.
+// It speaks the same JSON protocol as the terminal server
+// (terminal.Message with type "output"), so the web Console tab
+// can connect without any protocol changes.
+type Streamer struct {
+	mu      sync.RWMutex
+	clients map[*websocket.Conn]struct{}
+	silent  bool
+}
+
+// NewStreamer creates a new Streamer with no connected clients.
+func NewStreamer() *Streamer {
+	return &Streamer{
+		clients: make(map[*websocket.Conn]struct{}),
+	}
+}
+
+// SetSilent suppresses log output (useful when running inside the TUI).
+func (s *Streamer) SetSilent(silent bool) {
+	s.mu.Lock()
+	s.silent = silent
+	s.mu.Unlock()
+}
+
+// AddClient registers a WebSocket connection for receiving PTY output.
+func (s *Streamer) AddClient(conn *websocket.Conn) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.clients[conn] = struct{}{}
+	if !s.silent {
+		log.Printf("[console/streamer] client added (%d total)", len(s.clients))
+	}
+}
+
+// RemoveClient unregisters a WebSocket connection and closes it.
+func (s *Streamer) RemoveClient(conn *websocket.Conn) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.clients, conn)
+	_ = conn.Close()
+	if !s.silent {
+		log.Printf("[console/streamer] client removed (%d remaining)", len(s.clients))
+	}
+}
+
+// ClientCount returns the number of connected viewers.
+func (s *Streamer) ClientCount() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.clients)
+}
+
+// Broadcast sends PTY output bytes to all connected clients as
+// terminal.MessageTypeOutput messages. Clients that fail to receive
+// are removed.
+func (s *Streamer) Broadcast(data []byte) {
+	if len(data) == 0 {
+		return
+	}
+
+	msg := terminal.NewOutputMessage(data)
+	encoded, err := msg.Marshal()
+	if err != nil {
+		return
+	}
+
+	s.mu.RLock()
+	clients := make([]*websocket.Conn, 0, len(s.clients))
+	for c := range s.clients {
+		clients = append(clients, c)
+	}
+	s.mu.RUnlock()
+
+	if len(clients) == 0 {
+		return
+	}
+
+	var failed []*websocket.Conn
+	for _, c := range clients {
+		_ = c.SetWriteDeadline(time.Now().Add(5 * time.Second))
+		if err := c.WriteMessage(websocket.TextMessage, encoded); err != nil {
+			failed = append(failed, c)
+		}
+	}
+
+	for _, c := range failed {
+		s.RemoveClient(c)
+	}
+}
+
+// CloseAll disconnects all clients.
+func (s *Streamer) CloseAll() {
+	s.mu.Lock()
+	clients := make([]*websocket.Conn, 0, len(s.clients))
+	for c := range s.clients {
+		clients = append(clients, c)
+	}
+	s.clients = make(map[*websocket.Conn]struct{})
+	s.mu.Unlock()
+
+	for _, c := range clients {
+		_ = c.WriteMessage(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseNormalClosure, "session ended"),
+		)
+		_ = c.Close()
+	}
+}

--- a/internal/console/streamer_test.go
+++ b/internal/console/streamer_test.go
@@ -1,0 +1,126 @@
+package console
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/terminal"
+	"github.com/gorilla/websocket"
+)
+
+func TestStreamerAddRemoveClient(t *testing.T) {
+	s := NewStreamer()
+
+	if s.ClientCount() != 0 {
+		t.Fatalf("expected 0 clients, got %d", s.ClientCount())
+	}
+
+	// Create a test WebSocket pair
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrader := websocket.Upgrader{}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		s.AddClient(conn)
+	}))
+	defer srv.Close()
+
+	url := "ws" + strings.TrimPrefix(srv.URL, "http")
+	client, _, err := websocket.DefaultDialer.Dial(url, nil)
+	if err != nil {
+		t.Fatalf("dial failed: %v", err)
+	}
+
+	// Give the server handler time to execute
+	time.Sleep(50 * time.Millisecond)
+
+	if s.ClientCount() != 1 {
+		t.Fatalf("expected 1 client after add, got %d", s.ClientCount())
+	}
+
+	// The server-side conn is what we added to the streamer.
+	// Remove the client by closing all.
+	s.CloseAll()
+
+	if s.ClientCount() != 0 {
+		t.Fatalf("expected 0 clients after CloseAll, got %d", s.ClientCount())
+	}
+
+	client.Close()
+}
+
+func TestStreamerBroadcast(t *testing.T) {
+	s := NewStreamer()
+	s.SetSilent(true)
+
+	// Set up a test server where the server-side conn is added to the streamer
+	var serverConn *websocket.Conn
+	done := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrader := websocket.Upgrader{}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		serverConn = conn
+		s.AddClient(conn)
+		close(done)
+	}))
+	defer srv.Close()
+
+	url := "ws" + strings.TrimPrefix(srv.URL, "http")
+	client, _, err := websocket.DefaultDialer.Dial(url, nil)
+	if err != nil {
+		t.Fatalf("dial failed: %v", err)
+	}
+	defer client.Close()
+
+	// Wait for server handler to register the client
+	<-done
+
+	// Broadcast data
+	testData := []byte("hello from PTY")
+	s.Broadcast(testData)
+
+	// Read from the client side
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, msgBytes, err := client.ReadMessage()
+	if err != nil {
+		t.Fatalf("client read failed: %v", err)
+	}
+
+	// Parse the protocol message
+	msg, err := terminal.UnmarshalMessage(msgBytes)
+	if err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if msg.Type != terminal.MessageTypeOutput {
+		t.Fatalf("expected output message, got %s", msg.Type)
+	}
+
+	if string(msg.Payload) != string(testData) {
+		t.Fatalf("expected payload %q, got %q", testData, msg.Payload)
+	}
+
+	_ = serverConn
+}
+
+func TestStreamerBroadcastEmpty(t *testing.T) {
+	s := NewStreamer()
+	// Should not panic
+	s.Broadcast(nil)
+	s.Broadcast([]byte{})
+}
+
+func TestStreamerCloseAllIdempotent(t *testing.T) {
+	s := NewStreamer()
+	// Should not panic on empty
+	s.CloseAll()
+	s.CloseAll()
+}

--- a/internal/tui/controlcenter/console_page.go
+++ b/internal/tui/controlcenter/console_page.go
@@ -18,18 +18,17 @@ import (
 // Limitations (v1):
 //   - tview.TextView is line-oriented, not a terminal emulator.
 //     Full-screen programs (vim, htop, etc.) will render incorrectly.
-//   - Windows is not supported; the page returns an error on Build.
+//   - Windows is not supported; the page is hidden on that platform.
 type ConsolePage struct {
 	app      *tview.Application
 	view     *tview.TextView
-	pty      *console.PTYSession
 	streamer *console.Streamer
 
-	mu      sync.Mutex
-	active  bool
-	started bool
-
-	// stopRead signals the read loop to exit
+	mu       sync.Mutex
+	pty      *console.PTYSession
+	active   bool
+	started  bool
+	closed   bool // page-level closed flag (set by Close, prevents restart)
 	stopRead chan struct{}
 }
 
@@ -93,25 +92,31 @@ func (c *ConsolePage) HandleInput(event *tcell.EventKey) *tcell.EventKey {
 		return event
 	}
 
-	// Start the PTY on first keypress
 	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return event
+	}
+
+	// Start the PTY on first keypress (or restart after session ended)
 	if !c.started {
 		c.started = true
 		c.mu.Unlock()
 		c.startPTY()
-		// Don't forward the activation key to the shell
-		return nil
+		return nil // don't forward the activation key to the shell
 	}
+
+	pty := c.pty
 	c.mu.Unlock()
 
-	if c.pty == nil || c.pty.IsClosed() {
+	if pty == nil || pty.IsClosed() {
 		return event
 	}
 
 	// Convert tcell event to bytes for the PTY
 	data := keyToBytes(event)
 	if data != nil {
-		_, _ = c.pty.Write(data)
+		_, _ = pty.Write(data)
 		return nil // consumed
 	}
 
@@ -124,13 +129,30 @@ func (c *ConsolePage) Streamer() *console.Streamer {
 }
 
 // Close shuts down the PTY session and disconnects all stream clients.
+// Safe to call from any goroutine; does not re-enter the mutex during PTY teardown.
 func (c *ConsolePage) Close() {
 	c.mu.Lock()
-	defer c.mu.Unlock()
+	if c.closed {
+		c.mu.Unlock()
+		return
+	}
+	c.closed = true
 
-	if c.pty != nil && !c.pty.IsClosed() {
+	pty := c.pty
+	c.pty = nil
+
+	// Signal the read loop to stop
+	select {
+	case <-c.stopRead:
+		// already closed
+	default:
 		close(c.stopRead)
-		_ = c.pty.Close()
+	}
+	c.mu.Unlock()
+
+	// Close the PTY outside the lock to avoid deadlock
+	if pty != nil && !pty.IsClosed() {
+		_ = pty.Close()
 	}
 	c.streamer.CloseAll()
 }
@@ -142,16 +164,6 @@ func (c *ConsolePage) startPTY() {
 	session, err := console.NewPTYSession(console.PTYConfig{
 		InitialCols: 80,
 		InitialRows: 24,
-		OnClose: func() {
-			c.app.QueueUpdateDraw(func() {
-				fmt.Fprintln(tview.ANSIWriter(c.view), "")
-				fmt.Fprintln(c.view, "[yellow]Session ended. Press any key to restart.[-]")
-			})
-			c.mu.Lock()
-			c.started = false
-			c.stopRead = make(chan struct{})
-			c.mu.Unlock()
-		},
 	})
 	if err != nil {
 		c.app.QueueUpdateDraw(func() {
@@ -163,18 +175,25 @@ func (c *ConsolePage) startPTY() {
 		return
 	}
 
+	c.mu.Lock()
 	c.pty = session
+	c.mu.Unlock()
 
-	// Background read loop: drains PTY output, writes to view + streamer.
-	go c.readLoop()
+	go c.readLoop(session)
 }
 
 // readLoop continuously reads PTY output and dispatches it to the
 // tview widget and the WebSocket streamer. It runs until the PTY
-// closes or stopRead is signaled.
-func (c *ConsolePage) readLoop() {
+// closes, stopRead is signaled, or the shell exits naturally.
+//
+// On natural shell exit (read returns EIO/EOF), readLoop handles
+// teardown: closes the PTY, resets state, and shows the restart prompt.
+// This avoids the need for an onClose callback that would re-enter the mutex.
+func (c *ConsolePage) readLoop(session *console.PTYSession) {
 	buf := make([]byte, 4096)
 	ansiW := tview.ANSIWriter(c.view)
+
+	defer c.onSessionEnd(session)
 
 	for {
 		select {
@@ -183,7 +202,7 @@ func (c *ConsolePage) readLoop() {
 		default:
 		}
 
-		n, err := c.pty.Read(buf)
+		n, err := session.Read(buf)
 		if n > 0 {
 			chunk := make([]byte, n)
 			copy(chunk, buf[:n])
@@ -206,6 +225,32 @@ func (c *ConsolePage) readLoop() {
 			return
 		}
 	}
+}
+
+// onSessionEnd cleans up after a PTY session ends (natural exit or forced close).
+// It closes the PTY, resets state so a new session can start on keypress,
+// and shows the restart prompt (unless the page itself is being torn down).
+func (c *ConsolePage) onSessionEnd(session *console.PTYSession) {
+	// Close the PTY if it's still open (idempotent)
+	if !session.IsClosed() {
+		_ = session.Close()
+	}
+
+	c.mu.Lock()
+	// Only reset for restart if the page isn't being torn down
+	if c.closed {
+		c.mu.Unlock()
+		return
+	}
+	c.started = false
+	c.pty = nil
+	c.stopRead = make(chan struct{})
+	c.mu.Unlock()
+
+	c.app.QueueUpdateDraw(func() {
+		fmt.Fprintln(tview.ANSIWriter(c.view), "")
+		fmt.Fprintln(c.view, "[yellow]Session ended. Press any key to restart.[-]")
+	})
 }
 
 // keyToBytes converts a tcell key event to bytes suitable for a PTY.

--- a/internal/tui/controlcenter/console_page.go
+++ b/internal/tui/controlcenter/console_page.go
@@ -1,0 +1,332 @@
+package controlcenter
+
+import (
+	"fmt"
+	"io"
+	"runtime"
+	"sync"
+
+	"github.com/aceteam-ai/citadel-cli/internal/console"
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+// ConsolePage provides an embedded terminal (PTY) in the TUI.
+// PTY output is rendered through tview's ANSIWriter for basic color
+// support and streamed to web viewers via the Streamer.
+//
+// Limitations (v1):
+//   - tview.TextView is line-oriented, not a terminal emulator.
+//     Full-screen programs (vim, htop, etc.) will render incorrectly.
+//   - Windows is not supported; the page returns an error on Build.
+type ConsolePage struct {
+	app      *tview.Application
+	view     *tview.TextView
+	pty      *console.PTYSession
+	streamer *console.Streamer
+
+	mu      sync.Mutex
+	active  bool
+	started bool
+
+	// stopRead signals the read loop to exit
+	stopRead chan struct{}
+}
+
+// NewConsolePage creates a ConsolePage with an optional Streamer for
+// broadcasting PTY output to WebSocket viewers. Pass nil if streaming
+// is not needed.
+func NewConsolePage(streamer *console.Streamer) *ConsolePage {
+	if streamer == nil {
+		streamer = console.NewStreamer()
+	}
+	return &ConsolePage{
+		streamer: streamer,
+		stopRead: make(chan struct{}),
+	}
+}
+
+func (c *ConsolePage) Name() string  { return "console" }
+func (c *ConsolePage) Title() string { return "Console" }
+
+func (c *ConsolePage) Build(app *tview.Application) tview.Primitive {
+	c.app = app
+
+	c.view = tview.NewTextView().
+		SetDynamicColors(true).
+		SetScrollable(true).
+		SetWordWrap(false).
+		SetChangedFunc(func() {
+			app.Draw()
+		})
+	c.view.SetBorder(true).
+		SetTitle(" Console ").
+		SetTitleAlign(tview.AlignLeft)
+
+	if runtime.GOOS == "windows" {
+		c.view.SetText("[red]Embedded console is not supported on Windows.[-]")
+	} else {
+		c.view.SetText("[gray]Press any key to start the console...[-]")
+	}
+
+	return c.view
+}
+
+// OnActivate is called when the Console tab gains focus.
+func (c *ConsolePage) OnActivate() {
+	c.mu.Lock()
+	c.active = true
+	c.mu.Unlock()
+}
+
+// OnDeactivate is called when the Console tab loses focus.
+// The PTY read loop keeps running to avoid blocking the shell.
+func (c *ConsolePage) OnDeactivate() {
+	c.mu.Lock()
+	c.active = false
+	c.mu.Unlock()
+}
+
+// HandleInput captures keystrokes and writes them to the PTY.
+func (c *ConsolePage) HandleInput(event *tcell.EventKey) *tcell.EventKey {
+	if runtime.GOOS == "windows" {
+		return event
+	}
+
+	// Start the PTY on first keypress
+	c.mu.Lock()
+	if !c.started {
+		c.started = true
+		c.mu.Unlock()
+		c.startPTY()
+		// Don't forward the activation key to the shell
+		return nil
+	}
+	c.mu.Unlock()
+
+	if c.pty == nil || c.pty.IsClosed() {
+		return event
+	}
+
+	// Convert tcell event to bytes for the PTY
+	data := keyToBytes(event)
+	if data != nil {
+		_, _ = c.pty.Write(data)
+		return nil // consumed
+	}
+
+	return event
+}
+
+// Streamer returns the Streamer for external access (e.g. wiring into an HTTP handler).
+func (c *ConsolePage) Streamer() *console.Streamer {
+	return c.streamer
+}
+
+// Close shuts down the PTY session and disconnects all stream clients.
+func (c *ConsolePage) Close() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.pty != nil && !c.pty.IsClosed() {
+		close(c.stopRead)
+		_ = c.pty.Close()
+	}
+	c.streamer.CloseAll()
+}
+
+// startPTY spawns the shell and starts the read loop.
+func (c *ConsolePage) startPTY() {
+	c.view.Clear()
+
+	session, err := console.NewPTYSession(console.PTYConfig{
+		InitialCols: 80,
+		InitialRows: 24,
+		OnClose: func() {
+			c.app.QueueUpdateDraw(func() {
+				fmt.Fprintln(tview.ANSIWriter(c.view), "")
+				fmt.Fprintln(c.view, "[yellow]Session ended. Press any key to restart.[-]")
+			})
+			c.mu.Lock()
+			c.started = false
+			c.stopRead = make(chan struct{})
+			c.mu.Unlock()
+		},
+	})
+	if err != nil {
+		c.app.QueueUpdateDraw(func() {
+			c.view.SetText(fmt.Sprintf("[red]Failed to start console: %s[-]", err))
+		})
+		c.mu.Lock()
+		c.started = false
+		c.mu.Unlock()
+		return
+	}
+
+	c.pty = session
+
+	// Background read loop: drains PTY output, writes to view + streamer.
+	go c.readLoop()
+}
+
+// readLoop continuously reads PTY output and dispatches it to the
+// tview widget and the WebSocket streamer. It runs until the PTY
+// closes or stopRead is signaled.
+func (c *ConsolePage) readLoop() {
+	buf := make([]byte, 4096)
+	ansiW := tview.ANSIWriter(c.view)
+
+	for {
+		select {
+		case <-c.stopRead:
+			return
+		default:
+		}
+
+		n, err := c.pty.Read(buf)
+		if n > 0 {
+			chunk := make([]byte, n)
+			copy(chunk, buf[:n])
+
+			// Stream to WebSocket viewers (always, even when tab is inactive)
+			c.streamer.Broadcast(chunk)
+
+			// Render in the TUI view
+			c.app.QueueUpdate(func() {
+				_, _ = ansiW.Write(chunk)
+				c.view.ScrollToEnd()
+			})
+		}
+		if err != nil {
+			if err != io.EOF {
+				c.app.QueueUpdateDraw(func() {
+					fmt.Fprintf(c.view, "\n[red]Read error: %s[-]", err)
+				})
+			}
+			return
+		}
+	}
+}
+
+// keyToBytes converts a tcell key event to bytes suitable for a PTY.
+func keyToBytes(ev *tcell.EventKey) []byte {
+	// Regular character
+	if ev.Key() == tcell.KeyRune {
+		r := ev.Rune()
+		if ev.Modifiers()&tcell.ModAlt != 0 {
+			// Alt+key: ESC prefix
+			return []byte{0x1b, byte(r)}
+		}
+		buf := make([]byte, 4)
+		n := encodeRune(buf, r)
+		return buf[:n]
+	}
+
+	// Ctrl+key combinations
+	if ev.Modifiers()&tcell.ModCtrl != 0 {
+		switch ev.Key() {
+		case tcell.KeyCtrlA:
+			return []byte{0x01}
+		case tcell.KeyCtrlB:
+			return []byte{0x02}
+		case tcell.KeyCtrlC:
+			return []byte{0x03}
+		case tcell.KeyCtrlD:
+			return []byte{0x04}
+		case tcell.KeyCtrlE:
+			return []byte{0x05}
+		case tcell.KeyCtrlF:
+			return []byte{0x06}
+		case tcell.KeyCtrlG:
+			return []byte{0x07}
+		case tcell.KeyCtrlK:
+			return []byte{0x0b}
+		case tcell.KeyCtrlL:
+			return []byte{0x0c}
+		case tcell.KeyCtrlN:
+			return []byte{0x0e}
+		case tcell.KeyCtrlO:
+			return []byte{0x0f}
+		case tcell.KeyCtrlP:
+			return []byte{0x10}
+		case tcell.KeyCtrlQ:
+			return []byte{0x11}
+		case tcell.KeyCtrlR:
+			return []byte{0x12}
+		case tcell.KeyCtrlS:
+			return []byte{0x13}
+		case tcell.KeyCtrlT:
+			return []byte{0x14}
+		case tcell.KeyCtrlU:
+			return []byte{0x15}
+		case tcell.KeyCtrlV:
+			return []byte{0x16}
+		case tcell.KeyCtrlW:
+			return []byte{0x17}
+		case tcell.KeyCtrlX:
+			return []byte{0x18}
+		case tcell.KeyCtrlY:
+			return []byte{0x19}
+		case tcell.KeyCtrlZ:
+			return []byte{0x1a}
+		}
+	}
+
+	// Special keys -> ANSI escape sequences
+	switch ev.Key() {
+	case tcell.KeyEnter:
+		return []byte{'\r'}
+	case tcell.KeyBackspace, tcell.KeyBackspace2:
+		return []byte{0x7f}
+	case tcell.KeyTab:
+		return []byte{'\t'}
+	case tcell.KeyEscape:
+		return []byte{0x1b}
+	case tcell.KeyUp:
+		return []byte{0x1b, '[', 'A'}
+	case tcell.KeyDown:
+		return []byte{0x1b, '[', 'B'}
+	case tcell.KeyRight:
+		return []byte{0x1b, '[', 'C'}
+	case tcell.KeyLeft:
+		return []byte{0x1b, '[', 'D'}
+	case tcell.KeyHome:
+		return []byte{0x1b, '[', 'H'}
+	case tcell.KeyEnd:
+		return []byte{0x1b, '[', 'F'}
+	case tcell.KeyInsert:
+		return []byte{0x1b, '[', '2', '~'}
+	case tcell.KeyDelete:
+		return []byte{0x1b, '[', '3', '~'}
+	case tcell.KeyPgUp:
+		return []byte{0x1b, '[', '5', '~'}
+	case tcell.KeyPgDn:
+		return []byte{0x1b, '[', '6', '~'}
+	}
+
+	return nil
+}
+
+// encodeRune encodes a rune as UTF-8 into buf and returns the number of bytes written.
+func encodeRune(buf []byte, r rune) int {
+	if r < 0x80 {
+		buf[0] = byte(r)
+		return 1
+	}
+	if r < 0x800 {
+		buf[0] = byte(0xC0 | (r >> 6))
+		buf[1] = byte(0x80 | (r & 0x3F))
+		return 2
+	}
+	if r < 0x10000 {
+		buf[0] = byte(0xE0 | (r >> 12))
+		buf[1] = byte(0x80 | ((r >> 6) & 0x3F))
+		buf[2] = byte(0x80 | (r & 0x3F))
+		return 3
+	}
+	buf[0] = byte(0xF0 | (r >> 18))
+	buf[1] = byte(0x80 | ((r >> 12) & 0x3F))
+	buf[2] = byte(0x80 | ((r >> 6) & 0x3F))
+	buf[3] = byte(0x80 | (r & 0x3F))
+	return 4
+}

--- a/internal/tui/controlcenter/controlcenter.go
+++ b/internal/tui/controlcenter/controlcenter.go
@@ -404,6 +404,9 @@ type ControlCenter struct {
 
 	// Device URL set after successful device auth + connect
 	deviceURL string
+
+	// Console page (nil on Windows)
+	consolePage *ConsolePage
 }
 
 // Pane focus constants
@@ -558,7 +561,12 @@ func (cc *ControlCenter) Run() error {
 
 	// Register pages: Alt+1=Dashboard, rest hidden until ready
 	cc.pmgr.Register(cc, true)
-	cc.pmgr.Register(NewPlaceholderPage("console", "Console"), false)
+	cc.consolePage = NewConsolePage(nil)
+	if runtime.GOOS != "windows" {
+		cc.pmgr.Register(cc.consolePage, true)
+	} else {
+		cc.pmgr.Register(NewPlaceholderPage("console", "Console"), false)
+	}
 	cc.pmgr.Register(NewPlaceholderPage("services", "Services"), false)
 	cc.pmgr.Register(NewPlaceholderPage("jobs", "Jobs"), false)
 	cc.pmgr.Register(NewPlaceholderPage("network", "Network"), false)
@@ -593,6 +601,9 @@ func (cc *ControlCenter) Run() error {
 // Stop stops the control center
 func (cc *ControlCenter) Stop() {
 	close(cc.stopChan)
+	if cc.consolePage != nil {
+		cc.consolePage.Close()
+	}
 	if cc.app != nil {
 		cc.app.Stop()
 	}


### PR DESCRIPTION
## Context

Closes #228. The TUI control center currently has a Console tab placeholder. This PR replaces it with a working embedded terminal (PTY) that lets users interact with a local shell directly within the TUI, and lays the groundwork for streaming the session to the web Console tab.

## Summary

**`internal/console/pty_unix.go`** -- Unix PTY session using `creack/pty` (pure Go, CGO_ENABLED=0 safe). Mirrors the existing `terminal.Session` API but without the auth/session-manager overhead. Spawns a shell process, provides Read/Write/Resize/Close with mutex protection, and signals SIGHUP on close with a 2s kill timeout.

**`internal/console/pty_windows.go`** -- Windows stub that returns "unsupported" errors for all operations. The Console tab is hidden on Windows via `runtime.GOOS` check at registration time.

**`internal/console/streamer.go`** -- Thread-safe WebSocket fan-out. Broadcasts PTY output bytes to all connected viewers as `terminal.MessageTypeOutput` JSON messages, reusing the existing terminal protocol. Failed clients are automatically removed. This is a self-contained unit that does not modify the terminal server -- wiring it into the HTTP handler is left as a follow-up.

**`console_page.go`** -- TUI page implementing the `Page` interface. Key design decisions:
- **Lazy spawn**: PTY starts on first keypress, not at Build time, so launching the TUI doesn't create a shell process until the user actually wants one
- **Continuous drain**: The read loop runs even when the tab is inactive to prevent a full PTY buffer from blocking the shell
- **ANSI colors**: Output goes through `tview.ANSIWriter` for basic color/style support
- **Session restart**: After the shell exits, the user can press any key to start a new session

**`controlcenter.go`** -- Replaced the console placeholder with `ConsolePage`. Added cleanup in `Stop()`. Console tab is visible by default on Unix, hidden on Windows.

## Limitations (v1)

`tview.TextView` is line-oriented, not a terminal emulator. Full-screen programs (vim, htop, ncurses apps) will render incorrectly. Basic shell usage (commands, output, tab completion, Ctrl+C) works well.

## Test plan

| Group | Count | Coverage |
|-------|-------|----------|
| PTY lifecycle | 4 | Create, default size, close + callback, double close |
| PTY I/O | 2 | Write echo command + read output, write after close |
| PTY resize | 3 | Valid resize, invalid (zero) dimensions, resize after close |
| PTY errors | 1 | Invalid shell path |
| Streamer | 4 | Add/remove clients, broadcast with protocol verification, empty broadcast, idempotent CloseAll |
| Cross-compile | 3 | `CGO_ENABLED=0 go build ./...` for linux, windows, darwin |
| Existing tests | all | TUI controlcenter, terminal, dashboard -- all pass |

## Related

- #228 (closes)
- Existing terminal server: `internal/terminal/` (protocol reuse, no modifications)