### PR TITLE
feat: managed service installation (systemd/launchd/Windows)

### DIFF
--- a/cmd/service_cmd.go
+++ b/cmd/service_cmd.go
@@ -1,18 +1,26 @@
 // cmd/service_cmd.go
-// System service installation and management commands
+// System service installation and management commands.
+//
+// Provides "citadel service install/uninstall/start/stop/status" subcommands
+// and top-level aliases "citadel install-service", "citadel uninstall-service",
+// "citadel service-status" for convenience.
 package cmd
 
 import (
 	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"runtime"
-	"strings"
 
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
+	"github.com/aceteam-ai/citadel-cli/internal/service"
 	"github.com/spf13/cobra"
 )
+
+// Flags for service install.
+var (
+	svcUserMode   bool
+	svcSystemMode bool
+)
+
+// --- Subcommand group: citadel service ... ---
 
 var svcCmd = &cobra.Command{
 	Use:     "service",
@@ -20,26 +28,34 @@ var svcCmd = &cobra.Command{
 	Short:   "Manage Citadel as a system service",
 	Long: `Install, uninstall, start, stop, or check the status of Citadel as a system service.
 
-This allows Citadel to run in the background and start automatically on boot.`,
+This allows Citadel to run in the background and start automatically on boot.
+
+On Linux:   Creates a systemd unit (user unit by default, --system for system-wide)
+On macOS:   Creates a launchd plist (user agent by default, --system for daemon)
+On Windows: Creates a Windows Service (always system-wide)`,
 }
 
 var svcInstallCmd = &cobra.Command{
 	Use:   "install",
 	Short: "Install Citadel as a system service",
-	Long: `Install Citadel as a system service that runs in the background.
+	Long: `Install Citadel as a managed background service that runs on boot.
 
-On Linux: Creates a systemd service unit
-On macOS: Creates a launchd plist
-On Windows: Creates a Windows Service
+By default installs as a user service (no root/admin required on Linux/macOS).
+Use --system to install as a system-wide service (requires root/admin).
 
-The service will start automatically on boot and keep your node connected to the AceTeam Network.`,
+The service runs "citadel work" with the CITADEL_SERVICE=true environment
+variable set, enabling auto-restart on failure and boot-time startup.`,
 	RunE: runSvcInstall,
 }
 
 var svcUninstallCmd = &cobra.Command{
 	Use:   "uninstall",
 	Short: "Uninstall the Citadel system service",
-	RunE:  runSvcUninstall,
+	Long: `Stop and remove the Citadel managed service.
+
+This stops the running service, disables auto-start, and removes the service
+configuration file. It does NOT remove Citadel config or data.`,
+	RunE: runSvcUninstall,
 }
 
 var svcStartCmd = &cobra.Command{
@@ -56,108 +72,82 @@ var svcStopCmd = &cobra.Command{
 
 var svcStatusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "Check the status of the Citadel service",
+	Short: "Show service installation and running status",
+	RunE:  runSvcStatus,
+}
+
+// --- Top-level aliases ---
+
+var installServiceCmd = &cobra.Command{
+	Use:   "install-service",
+	Short: "Install Citadel as a system service (alias for 'service install')",
+	Long:  svcInstallCmd.Long,
+	RunE:  runSvcInstall,
+}
+
+var uninstallServiceCmd = &cobra.Command{
+	Use:   "uninstall-service",
+	Short: "Uninstall the Citadel system service (alias for 'service uninstall')",
+	Long:  svcUninstallCmd.Long,
+	RunE:  runSvcUninstall,
+}
+
+var serviceStatusCmd = &cobra.Command{
+	Use:   "service-status",
+	Short: "Show service status (alias for 'service status')",
 	RunE:  runSvcStatus,
 }
 
 func init() {
+	// Subcommand group.
 	rootCmd.AddCommand(svcCmd)
 	svcCmd.AddCommand(svcInstallCmd)
 	svcCmd.AddCommand(svcUninstallCmd)
 	svcCmd.AddCommand(svcStartCmd)
 	svcCmd.AddCommand(svcStopCmd)
 	svcCmd.AddCommand(svcStatusCmd)
-}
 
-// Service file templates
-const systemdServiceTemplate = `[Unit]
-Description=Citadel - AceTeam Sovereign Compute Agent
-Documentation=https://github.com/aceteam-ai/citadel-cli
-After=network-online.target docker.service
-Wants=network-online.target
-Requires=docker.service
+	// Top-level aliases.
+	rootCmd.AddCommand(installServiceCmd)
+	rootCmd.AddCommand(uninstallServiceCmd)
+	rootCmd.AddCommand(serviceStatusCmd)
 
-[Service]
-Type=simple
-ExecStart=%s --daemon
-Restart=always
-RestartSec=10
-User=%s
-Group=%s
-Environment=HOME=%s
-
-# Logging
-StandardOutput=journal
-StandardError=journal
-SyslogIdentifier=citadel
-
-# Security hardening
-NoNewPrivileges=true
-ProtectSystem=strict
-ProtectHome=read-only
-ReadWritePaths=%s
-
-[Install]
-WantedBy=multi-user.target
-`
-
-const launchdPlistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>Label</key>
-    <string>ai.aceteam.citadel</string>
-    <key>ProgramArguments</key>
-    <array>
-        <string>%s</string>
-        <string>--daemon</string>
-    </array>
-    <key>RunAtLoad</key>
-    <true/>
-    <key>KeepAlive</key>
-    <true/>
-    <key>StandardOutPath</key>
-    <string>%s/citadel.log</string>
-    <key>StandardErrorPath</key>
-    <string>%s/citadel.error.log</string>
-    <key>WorkingDirectory</key>
-    <string>%s</string>
-    <key>EnvironmentVariables</key>
-    <dict>
-        <key>HOME</key>
-        <string>%s</string>
-    </dict>
-</dict>
-</plist>
-`
-
-func runSvcInstall(cmd *cobra.Command, args []string) error {
-	switch runtime.GOOS {
-	case "linux":
-		return installLinuxSvc()
-	case "darwin":
-		return installDarwinSvc()
-	case "windows":
-		return installWindowsSvc()
-	default:
-		return fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
+	// Flags for install (shared between subcommand and alias).
+	for _, cmd := range []*cobra.Command{svcInstallCmd, installServiceCmd} {
+		cmd.Flags().BoolVar(&svcUserMode, "user", false, "Install as a user service (default on Linux/macOS)")
+		cmd.Flags().BoolVar(&svcSystemMode, "system", false, "Install as a system-wide service (requires root/admin)")
 	}
 }
 
-func runSvcUninstall(cmd *cobra.Command, args []string) error {
-	var err error
-	switch runtime.GOOS {
-	case "linux":
-		err = uninstallLinuxSvc()
-	case "darwin":
-		err = uninstallDarwinSvc()
-	case "windows":
-		err = uninstallWindowsSvc()
-	default:
-		return fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
+// resolveUserMode determines whether to install as a user or system service.
+// --system takes explicit precedence; --user is the default on Linux/macOS.
+func resolveUserMode() bool {
+	if svcSystemMode {
+		return false
 	}
+	if svcUserMode {
+		return true
+	}
+	// Default: user mode on Linux/macOS, system on Windows.
+	return !platform.IsWindows()
+}
 
-	// Clean up VNC if installed
+func runSvcInstall(_ *cobra.Command, _ []string) error {
+	cfg, err := service.DefaultConfig()
+	if err != nil {
+		return err
+	}
+	cfg.UserMode = resolveUserMode()
+
+	mgr := service.NewManager()
+	return mgr.Install(cfg)
+}
+
+func runSvcUninstall(_ *cobra.Command, _ []string) error {
+	mgr := service.NewManager()
+	err := mgr.Uninstall()
+
+	// Clean up VNC if installed.
 	vncMgr := platform.GetVNCManager()
 	if vncMgr.IsInstalled() {
 		fmt.Println("Removing VNC server...")
@@ -169,330 +159,42 @@ func runSvcUninstall(cmd *cobra.Command, args []string) error {
 	return err
 }
 
-func runSvcStart(cmd *cobra.Command, args []string) error {
-	switch runtime.GOOS {
-	case "linux":
-		return runSvcCommand("sudo", "systemctl", "start", "citadel")
-	case "darwin":
-		return runSvcCommand("launchctl", "load", getSvcLaunchdPlistPath())
-	case "windows":
-		return runSvcCommand("sc", "start", "citadel")
-	default:
-		return fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
-	}
+func runSvcStart(_ *cobra.Command, _ []string) error {
+	mgr := service.NewManager()
+	return mgr.Start()
 }
 
-func runSvcStop(cmd *cobra.Command, args []string) error {
-	switch runtime.GOOS {
-	case "linux":
-		return runSvcCommand("sudo", "systemctl", "stop", "citadel")
-	case "darwin":
-		return runSvcCommand("launchctl", "unload", getSvcLaunchdPlistPath())
-	case "windows":
-		return runSvcCommand("sc", "stop", "citadel")
-	default:
-		return fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
-	}
+func runSvcStop(_ *cobra.Command, _ []string) error {
+	mgr := service.NewManager()
+	return mgr.Stop()
 }
 
-func runSvcStatus(cmd *cobra.Command, args []string) error {
-	switch runtime.GOOS {
-	case "linux":
-		return runSvcCommand("systemctl", "status", "citadel")
-	case "darwin":
-		return runSvcCommand("launchctl", "list", "ai.aceteam.citadel")
-	case "windows":
-		return runSvcCommand("sc", "query", "citadel")
-	default:
-		return fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
-	}
-}
-
-// Linux (systemd) implementation
-func installLinuxSvc() error {
-	// Check for root
-	if os.Geteuid() != 0 {
-		return fmt.Errorf("installing a system service requires root privileges.\nRun: sudo citadel service install")
-	}
-
-	// Get the path to the citadel binary
-	exePath, err := os.Executable()
+func runSvcStatus(_ *cobra.Command, _ []string) error {
+	mgr := service.NewManager()
+	st, err := mgr.Status()
 	if err != nil {
-		return fmt.Errorf("failed to get executable path: %w", err)
-	}
-	exePath, err = filepath.EvalSymlinks(exePath)
-	if err != nil {
-		return fmt.Errorf("failed to resolve executable path: %w", err)
-	}
-
-	// Get current user info (the user who ran sudo)
-	username := os.Getenv("SUDO_USER")
-	if username == "" {
-		username = "root"
-	}
-
-	homeDir := os.Getenv("HOME")
-	if sudoUser := os.Getenv("SUDO_USER"); sudoUser != "" {
-		homeDir = "/home/" + sudoUser
-		// Check if it's actually there
-		if _, err := os.Stat(homeDir); os.IsNotExist(err) {
-			homeDir = "/root"
-		}
-	}
-
-	citadelDir := filepath.Join(homeDir, ".citadel-cli")
-
-	// Create the service file
-	serviceContent := fmt.Sprintf(systemdServiceTemplate,
-		exePath,
-		username,
-		username,
-		homeDir,
-		citadelDir,
-	)
-
-	servicePath := "/etc/systemd/system/citadel.service"
-	if err := os.WriteFile(servicePath, []byte(serviceContent), 0644); err != nil {
-		return fmt.Errorf("failed to write service file: %w", err)
-	}
-
-	fmt.Printf("✓ Created systemd service file: %s\n", servicePath)
-
-	// Reload systemd
-	if err := runSvcCommand("systemctl", "daemon-reload"); err != nil {
-		return fmt.Errorf("failed to reload systemd: %w", err)
-	}
-	fmt.Println("✓ Reloaded systemd daemon")
-
-	// Enable the service
-	if err := runSvcCommand("systemctl", "enable", "citadel"); err != nil {
-		return fmt.Errorf("failed to enable service: %w", err)
-	}
-	fmt.Println("✓ Enabled citadel service (will start on boot)")
-
-	// Start the service
-	if err := runSvcCommand("systemctl", "start", "citadel"); err != nil {
-		return fmt.Errorf("failed to start service: %w", err)
-	}
-	fmt.Println("✓ Started citadel service")
-
-	fmt.Println("\nCitadel is now running as a system service!")
-	fmt.Println("\nUseful commands:")
-	fmt.Println("  sudo systemctl status citadel   - Check status")
-	fmt.Println("  sudo systemctl stop citadel     - Stop service")
-	fmt.Println("  sudo systemctl restart citadel  - Restart service")
-	fmt.Println("  sudo journalctl -u citadel -f   - View logs")
-
-	return nil
-}
-
-func uninstallLinuxSvc() error {
-	if os.Geteuid() != 0 {
-		return fmt.Errorf("uninstalling a system service requires root privileges.\nRun: sudo citadel service uninstall")
-	}
-
-	// Stop the service if running
-	_ = runSvcCommand("systemctl", "stop", "citadel")
-	fmt.Println("✓ Stopped citadel service")
-
-	// Disable the service
-	_ = runSvcCommand("systemctl", "disable", "citadel")
-	fmt.Println("✓ Disabled citadel service")
-
-	// Remove the service file
-	servicePath := "/etc/systemd/system/citadel.service"
-	if err := os.Remove(servicePath); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to remove service file: %w", err)
-	}
-	fmt.Printf("✓ Removed %s\n", servicePath)
-
-	// Reload systemd
-	if err := runSvcCommand("systemctl", "daemon-reload"); err != nil {
-		return fmt.Errorf("failed to reload systemd: %w", err)
-	}
-	fmt.Println("✓ Reloaded systemd daemon")
-
-	fmt.Println("\nCitadel system service has been uninstalled.")
-	return nil
-}
-
-// macOS (launchd) implementation
-func getSvcLaunchdPlistPath() string {
-	homeDir, _ := os.UserHomeDir()
-	return filepath.Join(homeDir, "Library", "LaunchAgents", "ai.aceteam.citadel.plist")
-}
-
-func installDarwinSvc() error {
-	// Get the path to the citadel binary
-	exePath, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("failed to get executable path: %w", err)
-	}
-	exePath, err = filepath.EvalSymlinks(exePath)
-	if err != nil {
-		return fmt.Errorf("failed to resolve executable path: %w", err)
-	}
-
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("failed to get home directory: %w", err)
-	}
-
-	logDir := filepath.Join(homeDir, ".citadel-cli", "logs")
-	if err := os.MkdirAll(logDir, 0755); err != nil {
-		return fmt.Errorf("failed to create log directory: %w", err)
-	}
-
-	// Create LaunchAgents directory if it doesn't exist
-	launchAgentsDir := filepath.Join(homeDir, "Library", "LaunchAgents")
-	if err := os.MkdirAll(launchAgentsDir, 0755); err != nil {
-		return fmt.Errorf("failed to create LaunchAgents directory: %w", err)
-	}
-
-	// Create the plist file
-	plistContent := fmt.Sprintf(launchdPlistTemplate,
-		exePath,
-		logDir,
-		logDir,
-		homeDir,
-		homeDir,
-	)
-
-	plistPath := getSvcLaunchdPlistPath()
-	if err := os.WriteFile(plistPath, []byte(plistContent), 0644); err != nil {
-		return fmt.Errorf("failed to write plist file: %w", err)
-	}
-
-	fmt.Printf("✓ Created launchd plist: %s\n", plistPath)
-
-	// Load the service
-	if err := runSvcCommand("launchctl", "load", plistPath); err != nil {
-		return fmt.Errorf("failed to load service: %w", err)
-	}
-	fmt.Println("✓ Loaded citadel service")
-
-	fmt.Println("\nCitadel is now running as a launchd service!")
-	fmt.Println("\nUseful commands:")
-	fmt.Println("  launchctl list ai.aceteam.citadel        - Check status")
-	fmt.Println("  launchctl unload <plist>                 - Stop service")
-	fmt.Println("  tail -f ~/.citadel-cli/logs/citadel.log  - View logs")
-
-	return nil
-}
-
-func uninstallDarwinSvc() error {
-	plistPath := getSvcLaunchdPlistPath()
-
-	// Unload the service if loaded
-	_ = runSvcCommand("launchctl", "unload", plistPath)
-	fmt.Println("✓ Unloaded citadel service")
-
-	// Remove the plist file
-	if err := os.Remove(plistPath); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to remove plist file: %w", err)
-	}
-	fmt.Printf("✓ Removed %s\n", plistPath)
-
-	fmt.Println("\nCitadel launchd service has been uninstalled.")
-	return nil
-}
-
-// Windows implementation
-func installWindowsSvc() error {
-	// Get the path to the citadel binary
-	exePath, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("failed to get executable path: %w", err)
-	}
-	exePath, err = filepath.EvalSymlinks(exePath)
-	if err != nil {
-		return fmt.Errorf("failed to resolve executable path: %w", err)
-	}
-
-	// Check if running as admin
-	if !isSvcWindowsAdmin() {
-		return fmt.Errorf("installing a Windows service requires Administrator privileges.\nRight-click Command Prompt and select 'Run as administrator'")
-	}
-
-	// Create the service using sc.exe
-	binPath := fmt.Sprintf("\"%s\" --daemon", exePath)
-
-	// First try to delete existing service (ignore error)
-	_ = runSvcCommand("sc", "delete", "citadel")
-
-	// Create the service
-	if err := runSvcCommand("sc", "create", "citadel",
-		"binPath=", binPath,
-		"DisplayName=", "Citadel - AceTeam Sovereign Compute Agent",
-		"start=", "auto",
-		"obj=", "LocalSystem",
-	); err != nil {
-		return fmt.Errorf("failed to create service: %w", err)
-	}
-	fmt.Println("✓ Created Windows service")
-
-	// Set description
-	_ = runSvcCommand("sc", "description", "citadel",
-		"Citadel agent for the AceTeam Sovereign Compute Fabric. Connects this machine to your private AI infrastructure.")
-
-	// Configure failure recovery (restart on failure)
-	_ = runSvcCommand("sc", "failure", "citadel", "reset=", "86400", "actions=", "restart/60000/restart/60000/restart/60000")
-
-	// Start the service
-	if err := runSvcCommand("sc", "start", "citadel"); err != nil {
-		return fmt.Errorf("failed to start service: %w", err)
-	}
-	fmt.Println("✓ Started citadel service")
-
-	fmt.Println("\nCitadel is now running as a Windows service!")
-	fmt.Println("\nUseful commands:")
-	fmt.Println("  sc query citadel     - Check status")
-	fmt.Println("  sc stop citadel      - Stop service")
-	fmt.Println("  sc start citadel     - Start service")
-	fmt.Println("\nYou can also manage it from Services (services.msc)")
-
-	return nil
-}
-
-func uninstallWindowsSvc() error {
-	if !isSvcWindowsAdmin() {
-		return fmt.Errorf("uninstalling a Windows service requires Administrator privileges.\nRight-click Command Prompt and select 'Run as administrator'")
-	}
-
-	// Stop the service
-	_ = runSvcCommand("sc", "stop", "citadel")
-	fmt.Println("✓ Stopped citadel service")
-
-	// Delete the service
-	if err := runSvcCommand("sc", "delete", "citadel"); err != nil {
-		return fmt.Errorf("failed to delete service: %w", err)
-	}
-	fmt.Println("✓ Deleted citadel service")
-
-	fmt.Println("\nCitadel Windows service has been uninstalled.")
-	return nil
-}
-
-func isSvcWindowsAdmin() bool {
-	if runtime.GOOS != "windows" {
-		return false
-	}
-	// Try to open a file that requires admin rights
-	_, err := os.Open("\\\\.\\PHYSICALDRIVE0")
-	return err == nil
-}
-
-// Helper to run commands and show output
-func runSvcCommand(name string, args ...string) error {
-	cmd := exec.Command(name, args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		// Check if command exists
-		if strings.Contains(err.Error(), "executable file not found") {
-			return fmt.Errorf("command not found: %s", name)
-		}
 		return err
 	}
+
+	if !st.Installed {
+		fmt.Println("Citadel service is not installed.")
+		fmt.Println("\nRun 'citadel service install' to install it.")
+		return nil
+	}
+
+	fmt.Println("Citadel service: installed")
+	if st.Running {
+		fmt.Printf("  Status:  running (PID %d)\n", st.PID)
+	} else {
+		fmt.Println("  Status:  stopped")
+	}
+
+	if len(st.RecentLogs) > 0 {
+		fmt.Println("\nRecent logs:")
+		for _, line := range st.RecentLogs {
+			fmt.Printf("  %s\n", line)
+		}
+	}
+
 	return nil
 }

--- a/internal/service/launchd.go
+++ b/internal/service/launchd.go
@@ -1,0 +1,275 @@
+//go:build darwin
+
+package service
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const launchdLabel = "ai.aceteam.citadel"
+
+type launchdManager struct{}
+
+func newPlatformManager() Manager {
+	return &launchdManager{}
+}
+
+// plistPath returns the path for the launchd plist.
+// User mode:  ~/Library/LaunchAgents/ai.aceteam.citadel.plist
+// System mode: /Library/LaunchDaemons/ai.aceteam.citadel.plist
+func plistPath(userMode bool) (string, error) {
+	if userMode {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("cannot determine home directory: %w", err)
+		}
+		return filepath.Join(home, "Library", "LaunchAgents", launchdLabel+".plist"), nil
+	}
+	return filepath.Join("/Library/LaunchDaemons", launchdLabel+".plist"), nil
+}
+
+// logDir returns the directory for launchd service logs.
+func logDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "Library", "Logs", "citadel"), nil
+}
+
+// GeneratePlist produces a launchd plist XML string from the given config.
+// Exported so tests can verify the output.
+func GeneratePlist(cfg ServiceConfig) (string, error) {
+	if cfg.Description == "" {
+		cfg.Description = DefaultDescription
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+
+	ld, err := logDir()
+	if err != nil {
+		return "", err
+	}
+
+	// Build ProgramArguments array.
+	var progArgs strings.Builder
+	progArgs.WriteString(fmt.Sprintf("        <string>%s</string>\n", cfg.ExecPath))
+	for _, a := range cfg.Args {
+		progArgs.WriteString(fmt.Sprintf("        <string>%s</string>\n", a))
+	}
+
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>%s</string>
+    <key>ProgramArguments</key>
+    <array>
+%s    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>%s/citadel.log</string>
+    <key>StandardErrorPath</key>
+    <string>%s/citadel-error.log</string>
+    <key>WorkingDirectory</key>
+    <string>%s</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>%s</string>
+        <key>CITADEL_SERVICE</key>
+        <string>true</string>
+    </dict>
+</dict>
+</plist>
+`, launchdLabel, progArgs.String(), ld, ld, home, home), nil
+}
+
+func (m *launchdManager) Install(cfg ServiceConfig) error {
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
+
+	// System mode requires root.
+	if !cfg.UserMode && os.Geteuid() != 0 {
+		return fmt.Errorf("installing a system daemon requires root privileges.\nRun: sudo citadel service install --system")
+	}
+
+	plistContent, err := GeneratePlist(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to generate plist: %w", err)
+	}
+
+	pp, err := plistPath(cfg.UserMode)
+	if err != nil {
+		return err
+	}
+
+	// Ensure parent directory + log directory exist.
+	if err := os.MkdirAll(filepath.Dir(pp), 0755); err != nil {
+		return fmt.Errorf("failed to create plist directory: %w", err)
+	}
+	ld, err := logDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(ld, 0755); err != nil {
+		return fmt.Errorf("failed to create log directory: %w", err)
+	}
+
+	if err := os.WriteFile(pp, []byte(plistContent), 0644); err != nil {
+		return fmt.Errorf("failed to write plist: %w", err)
+	}
+	fmt.Printf("Created plist: %s\n", pp)
+
+	// Load the service.
+	if err := runCmd("launchctl", "load", pp); err != nil {
+		return fmt.Errorf("launchctl load failed: %w", err)
+	}
+
+	fmt.Println("Citadel service installed and started.")
+
+	if cfg.UserMode {
+		fmt.Println("\nNote: User LaunchAgents start at login. For headless/boot-time startup,")
+		fmt.Println("install as a system daemon: sudo citadel service install --system")
+	}
+
+	fmt.Println("\nUseful commands:")
+	fmt.Printf("  launchctl list %s            - Check status\n", launchdLabel)
+	fmt.Printf("  launchctl unload %s          - Stop service\n", pp)
+	fmt.Printf("  tail -f %s/citadel.log       - View logs\n", ld)
+	return nil
+}
+
+func (m *launchdManager) Uninstall() error {
+	userMode := detectInstalledMode()
+
+	pp, err := plistPath(userMode)
+	if err != nil {
+		return err
+	}
+
+	// Unload (ignore errors — may already be unloaded).
+	_ = runCmd("launchctl", "unload", pp)
+	fmt.Println("Unloaded citadel service")
+
+	if err := os.Remove(pp); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove plist: %w", err)
+	}
+	fmt.Printf("Removed %s\n", pp)
+	fmt.Println("Citadel service uninstalled.")
+	return nil
+}
+
+func (m *launchdManager) Start() error {
+	userMode := detectInstalledMode()
+	pp, err := plistPath(userMode)
+	if err != nil {
+		return err
+	}
+	return runCmd("launchctl", "load", pp)
+}
+
+func (m *launchdManager) Stop() error {
+	userMode := detectInstalledMode()
+	pp, err := plistPath(userMode)
+	if err != nil {
+		return err
+	}
+	return runCmd("launchctl", "unload", pp)
+}
+
+func (m *launchdManager) Status() (*ServiceStatus, error) {
+	userMode := detectInstalledMode()
+	pp, err := plistPath(userMode)
+	if err != nil {
+		return &ServiceStatus{Installed: false}, nil
+	}
+	if _, err := os.Stat(pp); os.IsNotExist(err) {
+		return &ServiceStatus{Installed: false}, nil
+	}
+
+	st := &ServiceStatus{Installed: true}
+
+	// Parse `launchctl list <label>` to get PID and status.
+	out, err := exec.Command("launchctl", "list", launchdLabel).Output()
+	if err != nil {
+		// Service is installed but not loaded.
+		return st, nil
+	}
+
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "\"PID\"") || strings.HasPrefix(line, "PID") {
+			// launchctl list output: "PID" = 12345;
+			parts := strings.Split(line, "=")
+			if len(parts) == 2 {
+				pidStr := strings.TrimRight(strings.TrimSpace(parts[1]), ";")
+				if pid, err := strconv.Atoi(pidStr); err == nil && pid > 0 {
+					st.PID = pid
+					st.Running = true
+				}
+			}
+		}
+	}
+
+	// Fallback: if we got output without error, the service is loaded.
+	if !st.Running && len(out) > 0 {
+		// Check if PID appears in tab-separated format (launchctl list output varies).
+		lines := strings.Split(string(out), "\n")
+		for _, l := range lines {
+			fields := strings.Fields(l)
+			if len(fields) >= 3 && fields[2] == launchdLabel {
+				if pid, err := strconv.Atoi(fields[0]); err == nil && pid > 0 {
+					st.PID = pid
+					st.Running = true
+				}
+			}
+		}
+	}
+
+	// Fetch recent log lines (best-effort).
+	ld, err := logDir()
+	if err == nil {
+		logFile := filepath.Join(ld, "citadel.log")
+		if logOut, err := exec.Command("tail", "-n", "10", logFile).Output(); err == nil {
+			for _, l := range strings.Split(strings.TrimSpace(string(logOut)), "\n") {
+				if l != "" {
+					st.RecentLogs = append(st.RecentLogs, l)
+				}
+			}
+		}
+	}
+
+	return st, nil
+}
+
+// detectInstalledMode checks whether the plist is installed as user or system.
+func detectInstalledMode() bool {
+	if p, err := plistPath(true); err == nil {
+		if _, err := os.Stat(p); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// runCmd executes a command, forwarding stdout/stderr.
+func runCmd(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/internal/service/launchd_test.go
+++ b/internal/service/launchd_test.go
@@ -1,0 +1,88 @@
+//go:build darwin
+
+package service
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGeneratePlist(t *testing.T) {
+	cfg := ServiceConfig{
+		ExecPath:    "/usr/local/bin/citadel",
+		Args:        []string{"work", "--gateway"},
+		Description: "Citadel Node Agent",
+		UserMode:    true,
+	}
+
+	content, err := GeneratePlist(cfg)
+	if err != nil {
+		t.Fatalf("GeneratePlist() error: %v", err)
+	}
+
+	checks := []struct {
+		label    string
+		contains string
+	}{
+		{"label", "<string>ai.aceteam.citadel</string>"},
+		{"exec path", "<string>/usr/local/bin/citadel</string>"},
+		{"arg work", "<string>work</string>"},
+		{"arg gateway", "<string>--gateway</string>"},
+		{"run at load", "<key>RunAtLoad</key>"},
+		{"keep alive", "<key>KeepAlive</key>"},
+		{"env citadel service", "<string>true</string>"},
+		{"env key", "<key>CITADEL_SERVICE</key>"},
+		{"stdout log", "citadel.log"},
+		{"stderr log", "citadel-error.log"},
+		{"xml header", "<?xml version=\"1.0\""},
+	}
+
+	for _, c := range checks {
+		t.Run(c.label, func(t *testing.T) {
+			if !strings.Contains(content, c.contains) {
+				t.Errorf("plist missing %q:\n%s", c.contains, content)
+			}
+		})
+	}
+}
+
+func TestGeneratePlist_NoArgs(t *testing.T) {
+	cfg := ServiceConfig{
+		ExecPath: "/usr/local/bin/citadel",
+		UserMode: true,
+	}
+
+	content, err := GeneratePlist(cfg)
+	if err != nil {
+		t.Fatalf("GeneratePlist() error: %v", err)
+	}
+
+	if !strings.Contains(content, "<string>/usr/local/bin/citadel</string>") {
+		t.Errorf("plist missing exec path:\n%s", content)
+	}
+
+	// Should not contain "work" since no args were provided.
+	if strings.Contains(content, "<string>work</string>") {
+		t.Error("plist should not contain 'work' when no args provided")
+	}
+}
+
+func TestPlistPath(t *testing.T) {
+	// User mode.
+	userPath, err := plistPath(true)
+	if err != nil {
+		t.Fatalf("plistPath(true) error: %v", err)
+	}
+	if !strings.Contains(userPath, "Library/LaunchAgents/ai.aceteam.citadel.plist") {
+		t.Errorf("unexpected user plist path: %s", userPath)
+	}
+
+	// System mode.
+	sysPath, err := plistPath(false)
+	if err != nil {
+		t.Fatalf("plistPath(false) error: %v", err)
+	}
+	if sysPath != "/Library/LaunchDaemons/ai.aceteam.citadel.plist" {
+		t.Errorf("unexpected system plist path: %s", sysPath)
+	}
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1,0 +1,97 @@
+// Package service provides platform-agnostic managed service installation
+// for the Citadel node agent (systemd, launchd, Windows Service).
+package service
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+)
+
+// Manager is the platform-specific interface for managing the Citadel
+// system service (install, uninstall, start, stop, status).
+type Manager interface {
+	Install(config ServiceConfig) error
+	Uninstall() error
+	Start() error
+	Stop() error
+	Status() (*ServiceStatus, error)
+}
+
+// ServiceConfig holds the parameters needed to install the Citadel service.
+type ServiceConfig struct {
+	// ExecPath is the absolute path to the citadel binary.
+	ExecPath string
+
+	// Args are the arguments passed to the binary (e.g., ["work", "--gateway"]).
+	Args []string
+
+	// Description is the human-readable service description.
+	Description string
+
+	// UserMode installs as a user service (systemd --user / launchd LaunchAgent)
+	// instead of a system-wide service. Ignored on Windows.
+	UserMode bool
+}
+
+// ServiceStatus describes the current state of the installed service.
+type ServiceStatus struct {
+	Installed  bool
+	Running    bool
+	PID        int
+	Uptime     time.Duration
+	RecentLogs []string // last few lines from the service log
+}
+
+// DefaultDescription is the service description used when none is provided.
+const DefaultDescription = "Citadel Node Agent - AceTeam Sovereign Compute"
+
+// ServiceName is the identifier used across all platforms.
+const ServiceName = "citadel"
+
+// NewManager returns the platform-appropriate Manager. The returned value
+// is always non-nil; unsupported platforms get an error only when a method
+// is called.
+func NewManager() Manager {
+	return newPlatformManager()
+}
+
+// Validate checks that a ServiceConfig is usable.
+func (c *ServiceConfig) Validate() error {
+	if c.ExecPath == "" {
+		return fmt.Errorf("ExecPath must not be empty")
+	}
+	if !filepath.IsAbs(c.ExecPath) {
+		return fmt.Errorf("ExecPath must be an absolute path, got %q", c.ExecPath)
+	}
+	if _, err := os.Stat(c.ExecPath); err != nil {
+		return fmt.Errorf("ExecPath does not exist: %w", err)
+	}
+	if c.Description == "" {
+		c.Description = DefaultDescription
+	}
+	return nil
+}
+
+// DefaultConfig builds a ServiceConfig from the running binary with
+// sensible defaults. The binary path is resolved via os.Executable.
+func DefaultConfig() (ServiceConfig, error) {
+	exePath, err := os.Executable()
+	if err != nil {
+		return ServiceConfig{}, fmt.Errorf("failed to get executable path: %w", err)
+	}
+	exePath, err = filepath.EvalSymlinks(exePath)
+	if err != nil {
+		return ServiceConfig{}, fmt.Errorf("failed to resolve executable path: %w", err)
+	}
+
+	cfg := ServiceConfig{
+		ExecPath:    exePath,
+		Args:        []string{"work"},
+		Description: DefaultDescription,
+		UserMode:    runtime.GOOS != "windows", // default to user mode on Unix
+	}
+	return cfg, nil
+}

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -1,0 +1,94 @@
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestServiceConfig_Validate(t *testing.T) {
+	// Create a temp file to act as a fake binary.
+	tmpDir := t.TempDir()
+	fakeBin := filepath.Join(tmpDir, "citadel")
+	if err := os.WriteFile(fakeBin, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		cfg     ServiceConfig
+		wantErr bool
+	}{
+		{
+			name:    "empty ExecPath",
+			cfg:     ServiceConfig{},
+			wantErr: true,
+		},
+		{
+			name:    "relative ExecPath",
+			cfg:     ServiceConfig{ExecPath: "citadel"},
+			wantErr: true,
+		},
+		{
+			name:    "nonexistent ExecPath",
+			cfg:     ServiceConfig{ExecPath: "/nonexistent/path/citadel"},
+			wantErr: true,
+		},
+		{
+			name: "valid config",
+			cfg: ServiceConfig{
+				ExecPath:    fakeBin,
+				Args:        []string{"work"},
+				Description: "test",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid config fills default description",
+			cfg: ServiceConfig{
+				ExecPath: fakeBin,
+				Args:     []string{"work"},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			if (err != nil) != tc.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			// If valid and no description was set, it should be filled.
+			if !tc.wantErr && tc.cfg.Description == "" {
+				t.Error("expected Description to be set to default after Validate")
+			}
+		})
+	}
+}
+
+func TestDefaultConfig(t *testing.T) {
+	cfg, err := DefaultConfig()
+	if err != nil {
+		t.Fatalf("DefaultConfig() error: %v", err)
+	}
+	if cfg.ExecPath == "" {
+		t.Error("expected ExecPath to be non-empty")
+	}
+	if !filepath.IsAbs(cfg.ExecPath) {
+		t.Errorf("expected absolute ExecPath, got %q", cfg.ExecPath)
+	}
+	if len(cfg.Args) == 0 || cfg.Args[0] != "work" {
+		t.Errorf("expected Args to start with 'work', got %v", cfg.Args)
+	}
+	if cfg.Description == "" {
+		t.Error("expected Description to be set")
+	}
+}
+
+func TestNewManager(t *testing.T) {
+	mgr := NewManager()
+	if mgr == nil {
+		t.Fatal("NewManager() returned nil")
+	}
+}

--- a/internal/service/systemd.go
+++ b/internal/service/systemd.go
@@ -1,0 +1,335 @@
+//go:build linux
+
+package service
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+type systemdManager struct{}
+
+func newPlatformManager() Manager {
+	return &systemdManager{}
+}
+
+// unitFilePath returns the path to the systemd unit file.
+// User mode:  ~/.config/systemd/user/citadel.service
+// System mode: /etc/systemd/system/citadel.service
+func unitFilePath(userMode bool) (string, error) {
+	if userMode {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("cannot determine home directory: %w", err)
+		}
+		return filepath.Join(home, ".config", "systemd", "user", ServiceName+".service"), nil
+	}
+	return filepath.Join("/etc/systemd/system", ServiceName+".service"), nil
+}
+
+// GenerateUnitFile produces a systemd unit file from the given config.
+// Exported so tests can verify the output without needing systemctl.
+func GenerateUnitFile(cfg ServiceConfig) (string, error) {
+	if cfg.Description == "" {
+		cfg.Description = DefaultDescription
+	}
+
+	execLine := cfg.ExecPath
+	if len(cfg.Args) > 0 {
+		execLine += " " + strings.Join(cfg.Args, " ")
+	}
+
+	if cfg.UserMode {
+		return generateUserUnit(cfg.Description, execLine), nil
+	}
+	return generateSystemUnit(cfg, execLine)
+}
+
+func generateUserUnit(description, execLine string) string {
+	return fmt.Sprintf(`[Unit]
+Description=%s
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=%s
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal+console
+StandardError=journal+console
+Environment=CITADEL_SERVICE=true
+
+[Install]
+WantedBy=default.target
+`, description, execLine)
+}
+
+func generateSystemUnit(cfg ServiceConfig, execLine string) (string, error) {
+	// Resolve the owning user (the person who ran sudo, or root).
+	username := os.Getenv("SUDO_USER")
+	if username == "" {
+		username = "root"
+	}
+
+	homeDir, err := resolveHomeDir(username)
+	if err != nil {
+		return "", err
+	}
+
+	group := username
+	citadelDir := filepath.Join(homeDir, ".citadel-cli")
+
+	return fmt.Sprintf(`[Unit]
+Description=%s
+Documentation=https://github.com/aceteam-ai/citadel-cli
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=%s
+Restart=on-failure
+RestartSec=10
+User=%s
+Group=%s
+Environment=HOME=%s
+Environment=CITADEL_SERVICE=true
+StandardOutput=journal+console
+StandardError=journal+console
+SyslogIdentifier=citadel
+
+# Security hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=%s
+
+[Install]
+WantedBy=multi-user.target
+`, cfg.Description, execLine, username, group, homeDir, citadelDir), nil
+}
+
+func resolveHomeDir(username string) (string, error) {
+	if username == "root" {
+		return "/root", nil
+	}
+	u, err := user.Lookup(username)
+	if err != nil {
+		return "", fmt.Errorf("failed to lookup user %s: %w", username, err)
+	}
+	return u.HomeDir, nil
+}
+
+// Install creates the systemd unit file, reloads the daemon, enables, and starts
+// the service.
+func (m *systemdManager) Install(cfg ServiceConfig) error {
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
+
+	// System mode requires root.
+	if !cfg.UserMode && os.Geteuid() != 0 {
+		return fmt.Errorf("installing a system service requires root privileges.\nRun: sudo citadel service install --system")
+	}
+
+	unitContent, err := GenerateUnitFile(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to generate unit file: %w", err)
+	}
+
+	unitPath, err := unitFilePath(cfg.UserMode)
+	if err != nil {
+		return err
+	}
+
+	// Ensure parent directory exists (user mode).
+	if cfg.UserMode {
+		if err := os.MkdirAll(filepath.Dir(unitPath), 0755); err != nil {
+			return fmt.Errorf("failed to create unit directory: %w", err)
+		}
+	}
+
+	if err := os.WriteFile(unitPath, []byte(unitContent), 0644); err != nil {
+		return fmt.Errorf("failed to write unit file: %w", err)
+	}
+	fmt.Printf("Created unit file: %s\n", unitPath)
+
+	// Reload, enable, start.
+	ctl := systemctlArgs(cfg.UserMode)
+
+	if err := runCmd("systemctl", append(ctl, "daemon-reload")...); err != nil {
+		return fmt.Errorf("daemon-reload failed: %w", err)
+	}
+	if err := runCmd("systemctl", append(ctl, "enable", ServiceName)...); err != nil {
+		return fmt.Errorf("enable failed: %w", err)
+	}
+	if err := runCmd("systemctl", append(ctl, "start", ServiceName)...); err != nil {
+		return fmt.Errorf("start failed: %w", err)
+	}
+
+	// Enable lingering so the user service survives logout and starts on boot
+	// without requiring a login session. Best-effort; non-fatal if it fails
+	// (e.g., loginctl not available in a container).
+	if cfg.UserMode {
+		u, _ := user.Current()
+		if u != nil {
+			if err := runCmd("loginctl", "enable-linger", u.Username); err != nil {
+				fmt.Printf("Warning: loginctl enable-linger failed: %v\n", err)
+				fmt.Println("  The service may not start on boot without an active login session.")
+				fmt.Println("  Run manually: loginctl enable-linger " + u.Username)
+			} else {
+				fmt.Println("Enabled linger (service will start on boot without login).")
+			}
+		}
+	}
+
+	fmt.Println("Citadel service installed and started.")
+	m.printHelp(cfg.UserMode)
+	return nil
+}
+
+// Uninstall stops, disables, and removes the unit file.
+func (m *systemdManager) Uninstall() error {
+	userMode := detectInstalledMode()
+
+	if !userMode && os.Geteuid() != 0 {
+		return fmt.Errorf("uninstalling the system service requires root.\nRun: sudo citadel service uninstall")
+	}
+
+	ctl := systemctlArgs(userMode)
+
+	// Stop + disable (ignore errors — service may already be stopped).
+	_ = runCmd("systemctl", append(ctl, "stop", ServiceName)...)
+	_ = runCmd("systemctl", append(ctl, "disable", ServiceName)...)
+
+	unitPath, err := unitFilePath(userMode)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(unitPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove unit file: %w", err)
+	}
+	fmt.Printf("Removed %s\n", unitPath)
+
+	_ = runCmd("systemctl", append(ctl, "daemon-reload")...)
+	fmt.Println("Citadel service uninstalled.")
+	return nil
+}
+
+func (m *systemdManager) Start() error {
+	userMode := detectInstalledMode()
+	ctl := systemctlArgs(userMode)
+	return runCmd("systemctl", append(ctl, "start", ServiceName)...)
+}
+
+func (m *systemdManager) Stop() error {
+	userMode := detectInstalledMode()
+	ctl := systemctlArgs(userMode)
+	return runCmd("systemctl", append(ctl, "stop", ServiceName)...)
+}
+
+func (m *systemdManager) Status() (*ServiceStatus, error) {
+	userMode := detectInstalledMode()
+	ctl := systemctlArgs(userMode)
+
+	unitPath, err := unitFilePath(userMode)
+	if err != nil {
+		return &ServiceStatus{Installed: false}, nil
+	}
+	if _, err := os.Stat(unitPath); os.IsNotExist(err) {
+		return &ServiceStatus{Installed: false}, nil
+	}
+
+	st := &ServiceStatus{Installed: true}
+
+	// Parse `systemctl show` for state + PID.
+	args := append(ctl, "show", ServiceName,
+		"--property=ActiveState,MainPID,ExecMainStartTimestamp")
+	out, err := exec.Command("systemctl", args...).Output()
+	if err != nil {
+		return st, nil
+	}
+
+	for _, line := range strings.Split(string(out), "\n") {
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key, val := parts[0], parts[1]
+		switch key {
+		case "ActiveState":
+			st.Running = val == "active"
+		case "MainPID":
+			if pid, err := strconv.Atoi(val); err == nil {
+				st.PID = pid
+			}
+		}
+	}
+
+	// Fetch recent log lines (best-effort).
+	jArgs := []string{"-u", ServiceName, "-n", "10", "--no-pager"}
+	if userMode {
+		jArgs = append([]string{"--user"}, jArgs...)
+	}
+	if logOut, err := exec.Command("journalctl", jArgs...).Output(); err == nil {
+		for _, l := range strings.Split(strings.TrimSpace(string(logOut)), "\n") {
+			if l != "" {
+				st.RecentLogs = append(st.RecentLogs, l)
+			}
+		}
+	}
+
+	return st, nil
+}
+
+func (m *systemdManager) printHelp(userMode bool) {
+	flag := ""
+	sudo := ""
+	if userMode {
+		flag = " --user"
+	} else {
+		sudo = "sudo "
+	}
+	jflag := ""
+	if userMode {
+		jflag = " --user"
+	}
+	fmt.Println("\nUseful commands:")
+	fmt.Printf("  %ssystemctl%s status %s   - Check status\n", sudo, flag, ServiceName)
+	fmt.Printf("  %ssystemctl%s stop %s     - Stop service\n", sudo, flag, ServiceName)
+	fmt.Printf("  %ssystemctl%s restart %s  - Restart service\n", sudo, flag, ServiceName)
+	fmt.Printf("  journalctl%s -u %s -f      - View logs\n", jflag, ServiceName)
+}
+
+// detectInstalledMode checks whether the unit is installed as a user or
+// system service. User mode is checked first.
+func detectInstalledMode() bool {
+	if p, err := unitFilePath(true); err == nil {
+		if _, err := os.Stat(p); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// systemctlArgs returns the extra arguments for user vs system mode.
+func systemctlArgs(userMode bool) []string {
+	if userMode {
+		return []string{"--user"}
+	}
+	return nil
+}
+
+// runCmd executes a command, forwarding stdout/stderr.
+func runCmd(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/internal/service/systemd_test.go
+++ b/internal/service/systemd_test.go
@@ -1,0 +1,150 @@
+//go:build linux
+
+package service
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateUnitFile_UserMode(t *testing.T) {
+	cfg := ServiceConfig{
+		ExecPath:    "/usr/local/bin/citadel",
+		Args:        []string{"work", "--gateway"},
+		Description: "Citadel Node Agent",
+		UserMode:    true,
+	}
+
+	content, err := GenerateUnitFile(cfg)
+	if err != nil {
+		t.Fatalf("GenerateUnitFile() error: %v", err)
+	}
+
+	// Verify key fields.
+	checks := []struct {
+		label    string
+		contains string
+	}{
+		{"description", "Description=Citadel Node Agent"},
+		{"exec start", "ExecStart=/usr/local/bin/citadel work --gateway"},
+		{"restart", "Restart=on-failure"},
+		{"restart sec", "RestartSec=10"},
+		{"env var", "Environment=CITADEL_SERVICE=true"},
+		{"wanted by", "WantedBy=default.target"},
+		{"output", "StandardOutput=journal+console"},
+		{"error", "StandardError=journal+console"},
+		{"network", "After=network-online.target"},
+	}
+
+	for _, c := range checks {
+		t.Run(c.label, func(t *testing.T) {
+			if !strings.Contains(content, c.contains) {
+				t.Errorf("unit file missing %q:\n%s", c.contains, content)
+			}
+		})
+	}
+
+	// User units should NOT have User/Group/ProtectHome directives.
+	forbidden := []string{"User=", "Group=", "ProtectHome=", "NoNewPrivileges="}
+	for _, f := range forbidden {
+		if strings.Contains(content, f) {
+			t.Errorf("user unit should not contain %q", f)
+		}
+	}
+}
+
+func TestGenerateUnitFile_SystemMode(t *testing.T) {
+	// System mode calls user.Lookup which requires a real user. We can't
+	// easily test this without root / mock, but we CAN test the user-mode
+	// path comprehensively and verify the system template structure through
+	// the generateSystemUnit helper by verifying key template strings.
+	//
+	// We verify the template indirectly: generateSystemUnit is called by
+	// GenerateUnitFile when UserMode=false, and it requires SUDO_USER to
+	// resolve the user. In CI this may not be set, so we just verify that
+	// the error message is helpful when the lookup fails.
+	cfg := ServiceConfig{
+		ExecPath:    "/usr/local/bin/citadel",
+		Args:        []string{"work"},
+		Description: "Test",
+		UserMode:    false,
+	}
+
+	content, err := GenerateUnitFile(cfg)
+	if err != nil {
+		// Expected on CI where SUDO_USER points to a non-existent user.
+		// Just verify it's a lookup error, not a panic.
+		if !strings.Contains(err.Error(), "lookup") && !strings.Contains(err.Error(), "user") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		return
+	}
+
+	// If it succeeded (e.g. SUDO_USER was empty -> root), verify structure.
+	mustContain := []string{
+		"ExecStart=/usr/local/bin/citadel work",
+		"Environment=CITADEL_SERVICE=true",
+		"WantedBy=multi-user.target",
+		"Restart=on-failure",
+		"NoNewPrivileges=true",
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(content, s) {
+			t.Errorf("system unit missing %q:\n%s", s, content)
+		}
+	}
+}
+
+func TestGenerateUnitFile_DefaultDescription(t *testing.T) {
+	cfg := ServiceConfig{
+		ExecPath: "/usr/local/bin/citadel",
+		Args:     []string{"work"},
+		UserMode: true,
+	}
+
+	content, err := GenerateUnitFile(cfg)
+	if err != nil {
+		t.Fatalf("GenerateUnitFile() error: %v", err)
+	}
+
+	if !strings.Contains(content, "Description="+DefaultDescription) {
+		t.Errorf("expected default description %q in unit file:\n%s", DefaultDescription, content)
+	}
+}
+
+func TestGenerateUnitFile_NoArgs(t *testing.T) {
+	cfg := ServiceConfig{
+		ExecPath: "/usr/local/bin/citadel",
+		UserMode: true,
+	}
+
+	content, err := GenerateUnitFile(cfg)
+	if err != nil {
+		t.Fatalf("GenerateUnitFile() error: %v", err)
+	}
+
+	// ExecStart should be just the binary, no trailing space.
+	if !strings.Contains(content, "ExecStart=/usr/local/bin/citadel\n") {
+		t.Errorf("expected ExecStart with no args:\n%s", content)
+	}
+}
+
+func TestUnitFilePath(t *testing.T) {
+	// User mode path.
+	userPath, err := unitFilePath(true)
+	if err != nil {
+		t.Fatalf("unitFilePath(true) error: %v", err)
+	}
+	if !strings.Contains(userPath, ".config/systemd/user/citadel.service") {
+		t.Errorf("unexpected user unit path: %s", userPath)
+	}
+
+	// System mode path.
+	sysPath, err := unitFilePath(false)
+	if err != nil {
+		t.Fatalf("unitFilePath(false) error: %v", err)
+	}
+	if sysPath != "/etc/systemd/system/citadel.service" {
+		t.Errorf("unexpected system unit path: %s", sysPath)
+	}
+}

--- a/internal/service/windows.go
+++ b/internal/service/windows.go
@@ -1,0 +1,165 @@
+//go:build windows
+
+package service
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const windowsServiceName = "CitadelAgent"
+const windowsDisplayName = "Citadel Node Agent"
+
+type windowsManager struct{}
+
+func newPlatformManager() Manager {
+	return &windowsManager{}
+}
+
+func (m *windowsManager) Install(cfg ServiceConfig) error {
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
+
+	if !isWindowsAdmin() {
+		return fmt.Errorf("installing a Windows service requires Administrator privileges.\nRight-click your terminal and select 'Run as administrator'")
+	}
+
+	// Build binPath for sc.exe. Quotes around the full command are required
+	// so that spaces in the path are handled correctly.
+	binPath := fmt.Sprintf("\"%s\" %s", cfg.ExecPath, strings.Join(cfg.Args, " "))
+
+	// Delete any existing service (ignore error).
+	_ = runCmd("sc.exe", "delete", windowsServiceName)
+
+	// Create the service.
+	if err := runCmd("sc.exe", "create", windowsServiceName,
+		"binPath=", binPath,
+		"DisplayName=", windowsDisplayName,
+		"start=", "auto",
+		"obj=", "LocalSystem",
+	); err != nil {
+		return fmt.Errorf("sc create failed: %w", err)
+	}
+	fmt.Println("Created Windows service: " + windowsServiceName)
+
+	// Set description.
+	desc := cfg.Description
+	if desc == "" {
+		desc = DefaultDescription
+	}
+	_ = runCmd("sc.exe", "description", windowsServiceName, desc)
+
+	// Configure failure recovery: restart after 60s on each of the first 3 failures.
+	_ = runCmd("sc.exe", "failure", windowsServiceName,
+		"reset=", "86400",
+		"actions=", "restart/60000/restart/60000/restart/60000")
+
+	// Set the CITADEL_SERVICE environment variable for the service.
+	// Windows services inherit system environment, so we set it at the
+	// machine level. This is best-effort; the service will work without it.
+	_ = runCmd("setx", "/M", "CITADEL_SERVICE", "true")
+
+	// Start the service.
+	if err := runCmd("sc.exe", "start", windowsServiceName); err != nil {
+		return fmt.Errorf("sc start failed: %w", err)
+	}
+
+	fmt.Println("Citadel service installed and started.")
+	fmt.Println("\nUseful commands:")
+	fmt.Printf("  sc query %s       - Check status\n", windowsServiceName)
+	fmt.Printf("  sc stop %s        - Stop service\n", windowsServiceName)
+	fmt.Printf("  sc start %s       - Start service\n", windowsServiceName)
+	fmt.Println("  services.msc                  - Manage via GUI")
+	return nil
+}
+
+func (m *windowsManager) Uninstall() error {
+	if !isWindowsAdmin() {
+		return fmt.Errorf("uninstalling a Windows service requires Administrator privileges.\nRight-click your terminal and select 'Run as administrator'")
+	}
+
+	// Stop (ignore error).
+	_ = runCmd("sc.exe", "stop", windowsServiceName)
+	fmt.Println("Stopped " + windowsServiceName)
+
+	if err := runCmd("sc.exe", "delete", windowsServiceName); err != nil {
+		return fmt.Errorf("sc delete failed: %w", err)
+	}
+	fmt.Println("Deleted " + windowsServiceName)
+	fmt.Println("Citadel service uninstalled.")
+	return nil
+}
+
+func (m *windowsManager) Start() error {
+	return runCmd("sc.exe", "start", windowsServiceName)
+}
+
+func (m *windowsManager) Stop() error {
+	return runCmd("sc.exe", "stop", windowsServiceName)
+}
+
+func (m *windowsManager) Status() (*ServiceStatus, error) {
+	st := &ServiceStatus{}
+
+	out, err := exec.Command("sc.exe", "query", windowsServiceName).Output()
+	if err != nil {
+		// Service not found.
+		return st, nil
+	}
+
+	st.Installed = true
+
+	// Parse sc query output for STATE line.
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "STATE") {
+			// e.g. "STATE              : 4  RUNNING"
+			if strings.Contains(line, "RUNNING") {
+				st.Running = true
+			}
+		}
+		if strings.HasPrefix(line, "PID") || strings.Contains(line, "PID") {
+			// Parse PID if present: "PID                : 1234"
+			parts := strings.Split(line, ":")
+			if len(parts) == 2 {
+				pidStr := strings.TrimSpace(parts[1])
+				var pid int
+				if _, scanErr := fmt.Sscanf(pidStr, "%d", &pid); scanErr == nil && pid > 0 {
+					st.PID = pid
+				}
+			}
+		}
+	}
+
+	// Fetch recent Event Log entries (best-effort).
+	logOut, logErr := exec.Command("powershell", "-NoProfile", "-Command",
+		fmt.Sprintf(`Get-EventLog -LogName Application -Source '%s' -Newest 10 -ErrorAction SilentlyContinue | Format-List -Property TimeGenerated,Message`, windowsServiceName),
+	).Output()
+	if logErr == nil {
+		for _, l := range strings.Split(strings.TrimSpace(string(logOut)), "\n") {
+			l = strings.TrimSpace(l)
+			if l != "" {
+				st.RecentLogs = append(st.RecentLogs, l)
+			}
+		}
+	}
+
+	return st, nil
+}
+
+// isWindowsAdmin checks for admin privileges by trying to open a protected handle.
+func isWindowsAdmin() bool {
+	_, err := os.Open("\\\\.\\PHYSICALDRIVE0")
+	return err == nil
+}
+
+// runCmd executes a command, forwarding stdout/stderr.
+func runCmd(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}


### PR DESCRIPTION
## Context

Closes #238. Citadel nodes need to run as persistent background services that survive terminal close and system reboot. Currently, users rely on `nohup`, `screen`, or manual systemd configuration. This PR adds first-class `citadel install-service` / `citadel uninstall-service` / `citadel service-status` commands with platform-native service management.

## Summary

**New package `internal/service/`** — platform-agnostic `Manager` interface with build-tag-separated implementations:

- **`service.go`** — `Manager` interface, `ServiceConfig`, `ServiceStatus` (including `RecentLogs`), `DefaultConfig()`, `Validate()`
- **`systemd.go` (Linux)** — User units (`~/.config/systemd/user/`) with `loginctl enable-linger` for boot survival, and hardened system units (`NoNewPrivileges`, `ProtectSystem=strict`, `ProtectHome=read-only`). Status includes `journalctl` log tail.
- **`launchd.go` (macOS)** — User LaunchAgents with `KeepAlive`/`RunAtLoad`, and system LaunchDaemons. Logs to `~/Library/Logs/citadel/`. Status includes `tail` of log file. Prints a note that user agents require login for boot (suggests `--system` for headless).
- **`windows.go` (Windows)** — Uses `sc.exe` (no CGO, no `golang.org/x/sys/windows/svc` dependency) for service creation, failure recovery (3 restarts at 60s intervals), and `setx /M CITADEL_SERVICE=true`. Status includes Event Log query via PowerShell.

**Refactored `cmd/service_cmd.go`** — Replaced 400+ lines of inline platform logic with delegation to `service.NewManager()`. Added `--user`/`--system` flags and top-level aliases (`install-service`, `uninstall-service`, `service-status`). Status output now shows install state, PID, and recent log lines.

All services run `citadel work` with `CITADEL_SERVICE=true` environment variable set.

### Known limitations

1. **Windows service will not start correctly** — The Windows Service Control Manager expects `citadel work` to connect to the SCM dispatcher via `svc.Run()`, but `cmd/work.go` does not implement this (and the task spec prohibits modifying it). The service will be created and configured but SCM will kill it with error 1053. A follow-up issue is needed to add SCM integration to `work.go` or create a dedicated `run-service` command.

2. **macOS user LaunchAgents require login** — Unlike systemd with linger, macOS LaunchAgents only load at GUI login, not bare boot. The install command prints a note suggesting `--system` for headless nodes. This is inherent to launchd's design.

## Test plan

| Area | Tests | Coverage |
|------|-------|----------|
| Config validation | 5 | Empty, relative, nonexistent paths; valid config; default description fill |
| DefaultConfig | 1 | Absolute path, "work" args, non-empty description |
| NewManager | 1 | Non-nil return on current platform |
| systemd unit generation | 5 | User mode content, system mode (graceful CI), default description, no-args, file paths |
| launchd plist generation | 3 | Content checks, no-args case, plist paths |
| Cross-compilation | 3 | `CGO_ENABLED=0` builds for linux/darwin/windows |

```
$ CGO_ENABLED=0 go test ./internal/service/... ./cmd/...
ok   github.com/aceteam-ai/citadel-cli/internal/service   0.002s
ok   github.com/aceteam-ai/citadel-cli/cmd                0.014s
```

## Related

- #238 — original issue
- Follow-up needed: Windows SCM dispatcher integration in `cmd/work.go`