### PR TITLE
feat(tui): Chat tab with Redis-backed node messaging

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -127,6 +127,7 @@ func runControlCenter() {
 			},
 		},
 		OnConnect: ccOnNetworkConnect,
+		Chat:      buildChatConfig(),
 	}
 
 	cc := controlcenter.New(cfg)
@@ -214,6 +215,7 @@ func runControlCenter() {
 		// Auto-start servers and worker after network is connected
 		if networkConnected {
 			ccOnNetworkConnect(cc.AddActivity)
+			cc.ShowChat()
 		} else {
 			// Not connected - show login prompt after a short delay
 			// to allow the TUI to fully initialize
@@ -453,6 +455,47 @@ func stopVNCServer() {
 	}
 	ccVNCRunning = false
 	platform.ClearEmbeddedVNCPort()
+}
+
+// buildChatConfig constructs ChatPageConfig from device config and manifest.
+// Returns a zero-value config if credentials are not yet available — the
+// ChatPage handles this gracefully by showing an error on activation.
+func buildChatConfig() controlcenter.ChatPageConfig {
+	deviceConfig := getDeviceConfigFromFile()
+	if deviceConfig == nil || deviceConfig.DeviceAPIToken == "" {
+		return controlcenter.ChatPageConfig{}
+	}
+
+	apiBaseURL := deviceConfig.APIBaseURL
+	if apiBaseURL == "" {
+		apiBaseURL = authServiceURL
+	}
+
+	orgID := deviceConfig.OrgID
+	if orgID == "" {
+		if manifest, _, err := findAndReadManifest(); err == nil {
+			orgID = manifest.Node.OrgID
+		}
+	}
+
+	nodeName, _ := os.Hostname()
+	nodeID := nodeName
+	if netStatus, err := network.GetGlobalStatus(context.Background()); err == nil && netStatus.Connected {
+		if netStatus.Hostname != "" {
+			nodeName = netStatus.Hostname
+		}
+		if netStatus.NodeID != "" {
+			nodeID = netStatus.NodeID
+		}
+	}
+
+	return controlcenter.ChatPageConfig{
+		APIBaseURL: apiBaseURL,
+		APIToken:   deviceConfig.DeviceAPIToken,
+		OrgID:      orgID,
+		NodeID:     nodeID,
+		NodeName:   nodeName,
+	}
 }
 
 // getOrgIDFromConfig gets the organization ID from manifest or device config

--- a/internal/chat/client.go
+++ b/internal/chat/client.go
@@ -1,0 +1,265 @@
+package chat
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/redisapi"
+)
+
+// Client provides chat messaging over the AceTeam Redis API proxy.
+//
+// Real-time delivery uses WebSocket Pub/Sub (a dedicated connection, separate
+// from the HTTP path — satisfying the "never block the shared connection"
+// constraint). Message persistence uses StreamAdd via HTTP.
+//
+// History (XRANGE) is not yet available in the Redis API proxy, so only
+// messages received while the client is subscribed are displayed. A future
+// backend endpoint will enable loading the last N messages on connect.
+type Client struct {
+	api      *redisapi.Client
+	orgID    string
+	nodeID   string
+	nodeName string
+
+	// Callbacks
+	onMessage  func(Message)
+	onPresence func(PresenceInfo)
+	mu         sync.RWMutex
+
+	// Presence tracking
+	peers   map[string]PresenceInfo
+	peersMu sync.RWMutex
+
+	// Lifecycle
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+// ClientConfig holds configuration for the chat client.
+type ClientConfig struct {
+	// APIBaseURL is the AceTeam API base URL (e.g., "https://aceteam.ai").
+	APIBaseURL string
+	// Token is the device_api_token from device authentication.
+	Token string
+	// OrgID is the organization ID for channel scoping.
+	OrgID string
+	// NodeID is the Headscale node ID or hostname.
+	NodeID string
+	// NodeName is the human-readable node name.
+	NodeName string
+}
+
+// NewClient creates a new chat client. Call Connect to start receiving messages.
+func NewClient(cfg ClientConfig) *Client {
+	apiClient := redisapi.NewClient(redisapi.ClientConfig{
+		BaseURL: cfg.APIBaseURL,
+		Token:   cfg.Token,
+		Timeout: 30 * time.Second,
+	})
+
+	return &Client{
+		api:      apiClient,
+		orgID:    cfg.OrgID,
+		nodeID:   cfg.NodeID,
+		nodeName: cfg.NodeName,
+		peers:    make(map[string]PresenceInfo),
+		done:     make(chan struct{}),
+	}
+}
+
+// OnMessage sets the callback invoked when a chat message arrives.
+func (c *Client) OnMessage(fn func(Message)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onMessage = fn
+}
+
+// OnPresence sets the callback invoked when a presence update arrives.
+func (c *Client) OnPresence(fn func(PresenceInfo)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onPresence = fn
+}
+
+// Connect establishes the WebSocket subscription for real-time messages
+// and starts the presence heartbeat. Blocks until ctx is cancelled or
+// Close is called.
+func (c *Client) Connect(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	c.cancel = cancel
+
+	// Connect WebSocket (dedicated connection for subscriptions)
+	if err := c.api.EnableWebSocket(ctx); err != nil {
+		cancel()
+		return fmt.Errorf("websocket connect: %w", err)
+	}
+
+	ws := c.api.WebSocket()
+	if ws == nil {
+		cancel()
+		return fmt.Errorf("websocket not available after enable")
+	}
+
+	// Register message handler for incoming pub/sub messages
+	ws.OnMessage("message", func(msg redisapi.WSMessage) {
+		c.handleWSMessage(msg)
+	})
+
+	// Subscribe to chat channel and presence channel
+	chatCh := ChannelName(c.orgID, "general")
+	presCh := PresenceChannel(c.orgID)
+
+	if err := ws.Subscribe(ctx, chatCh, presCh); err != nil {
+		cancel()
+		return fmt.Errorf("subscribe: %w", err)
+	}
+
+	// Start presence heartbeat
+	go c.presenceLoop(ctx)
+
+	// Wait for cancellation
+	<-ctx.Done()
+	close(c.done)
+	return ctx.Err()
+}
+
+// Send publishes a chat message to the general channel.
+func (c *Client) Send(ctx context.Context, body string) error {
+	msg := Message{
+		FromNodeID:   c.nodeID,
+		FromNodeName: c.nodeName,
+		Channel:      "general",
+		Body:         body,
+		Timestamp:    time.Now().UTC(),
+	}
+
+	chatCh := ChannelName(c.orgID, "general")
+
+	// Publish via Pub/Sub for real-time delivery
+	if err := c.api.Publish(ctx, chatCh, msg); err != nil {
+		return fmt.Errorf("publish message: %w", err)
+	}
+
+	// Persist to stream for history (best-effort; no read endpoint yet)
+	msgJSON, err := json.Marshal(msg)
+	if err == nil {
+		streamKey := StreamName(c.orgID, "general")
+		_ = c.api.StreamAdd(ctx, streamKey, map[string]string{
+			"data": string(msgJSON),
+		}, 100)
+	}
+
+	return nil
+}
+
+// Peers returns a snapshot of currently tracked peers.
+func (c *Client) Peers() []PresenceInfo {
+	c.peersMu.RLock()
+	defer c.peersMu.RUnlock()
+
+	peers := make([]PresenceInfo, 0, len(c.peers))
+	for _, p := range c.peers {
+		peers = append(peers, p)
+	}
+	return peers
+}
+
+// OnlinePeers returns peers seen within the given timeout.
+func (c *Client) OnlinePeers(timeout time.Duration) []PresenceInfo {
+	c.peersMu.RLock()
+	defer c.peersMu.RUnlock()
+
+	peers := make([]PresenceInfo, 0, len(c.peers))
+	for _, p := range c.peers {
+		if p.IsOnline(timeout) {
+			peers = append(peers, p)
+		}
+	}
+	return peers
+}
+
+// Close shuts down the chat client.
+func (c *Client) Close() error {
+	if c.cancel != nil {
+		c.cancel()
+	}
+	if c.api != nil {
+		return c.api.Close()
+	}
+	return nil
+}
+
+// handleWSMessage dispatches incoming WebSocket messages to the appropriate callback.
+func (c *Client) handleWSMessage(msg redisapi.WSMessage) {
+	if msg.Message == nil {
+		return
+	}
+
+	channel := msg.Channel
+
+	// Determine if this is a presence or chat message based on channel
+	if channel == PresenceChannel(c.orgID) {
+		p, err := UnmarshalPresenceFromMap(msg.Message)
+		if err != nil {
+			return
+		}
+		c.peersMu.Lock()
+		c.peers[p.NodeID] = p
+		c.peersMu.Unlock()
+
+		c.mu.RLock()
+		fn := c.onPresence
+		c.mu.RUnlock()
+		if fn != nil {
+			fn(p)
+		}
+		return
+	}
+
+	// Chat message
+	chatMsg, err := UnmarshalMessageFromMap(msg.Message)
+	if err != nil {
+		return
+	}
+
+	c.mu.RLock()
+	fn := c.onMessage
+	c.mu.RUnlock()
+	if fn != nil {
+		fn(chatMsg)
+	}
+}
+
+// presenceLoop publishes this node's presence every 30 seconds.
+func (c *Client) presenceLoop(ctx context.Context) {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	// Publish immediately on start
+	c.publishPresence(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.publishPresence(ctx)
+		}
+	}
+}
+
+// publishPresence sends a presence heartbeat.
+func (c *Client) publishPresence(ctx context.Context) {
+	info := PresenceInfo{
+		NodeID:   c.nodeID,
+		NodeName: c.nodeName,
+		LastSeen: time.Now().UTC(),
+	}
+
+	presCh := PresenceChannel(c.orgID)
+	_ = c.api.Publish(ctx, presCh, info)
+}

--- a/internal/chat/client_test.go
+++ b/internal/chat/client_test.go
@@ -1,0 +1,153 @@
+package chat
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestChannelName(t *testing.T) {
+	tests := []struct {
+		orgID   string
+		channel string
+		want    string
+	}{
+		{"abc-123", "general", "chat:v1:org_abc-123:general"},
+		{"org-uuid", "random", "chat:v1:org_org-uuid:random"},
+	}
+	for _, tt := range tests {
+		got := ChannelName(tt.orgID, tt.channel)
+		if got != tt.want {
+			t.Errorf("ChannelName(%q, %q) = %q, want %q", tt.orgID, tt.channel, got, tt.want)
+		}
+	}
+}
+
+func TestPresenceChannel(t *testing.T) {
+	got := PresenceChannel("org-uuid")
+	want := "chat:v1:org_org-uuid:presence"
+	if got != want {
+		t.Errorf("PresenceChannel = %q, want %q", got, want)
+	}
+}
+
+func TestStreamName(t *testing.T) {
+	got := StreamName("org-uuid", "general")
+	want := "chat:v1:org_org-uuid:general:stream"
+	if got != want {
+		t.Errorf("StreamName = %q, want %q", got, want)
+	}
+}
+
+func TestMessageMarshalRoundTrip(t *testing.T) {
+	ts := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	original := Message{
+		FromNodeID:   "node-abc",
+		FromNodeName: "gpu-workstation",
+		Channel:      "general",
+		Body:         "hello world",
+		Timestamp:    ts,
+	}
+
+	data, err := MarshalMessage(original)
+	if err != nil {
+		t.Fatalf("MarshalMessage: %v", err)
+	}
+
+	got, err := UnmarshalMessage(data)
+	if err != nil {
+		t.Fatalf("UnmarshalMessage: %v", err)
+	}
+
+	if got.FromNodeID != original.FromNodeID {
+		t.Errorf("FromNodeID = %q, want %q", got.FromNodeID, original.FromNodeID)
+	}
+	if got.FromNodeName != original.FromNodeName {
+		t.Errorf("FromNodeName = %q, want %q", got.FromNodeName, original.FromNodeName)
+	}
+	if got.Channel != original.Channel {
+		t.Errorf("Channel = %q, want %q", got.Channel, original.Channel)
+	}
+	if got.Body != original.Body {
+		t.Errorf("Body = %q, want %q", got.Body, original.Body)
+	}
+	if !got.Timestamp.Equal(original.Timestamp) {
+		t.Errorf("Timestamp = %v, want %v", got.Timestamp, original.Timestamp)
+	}
+}
+
+func TestUnmarshalMessageFromMap(t *testing.T) {
+	m := map[string]any{
+		"from_node_id":   "node-abc",
+		"from_node_name": "gpu-workstation",
+		"channel":        "general",
+		"body":           "test message",
+		"ts":             "2026-06-20T12:00:00Z",
+	}
+
+	msg, err := UnmarshalMessageFromMap(m)
+	if err != nil {
+		t.Fatalf("UnmarshalMessageFromMap: %v", err)
+	}
+
+	if msg.FromNodeID != "node-abc" {
+		t.Errorf("FromNodeID = %q, want %q", msg.FromNodeID, "node-abc")
+	}
+	if msg.Body != "test message" {
+		t.Errorf("Body = %q, want %q", msg.Body, "test message")
+	}
+}
+
+func TestUnmarshalPresenceFromMap(t *testing.T) {
+	m := map[string]any{
+		"node_id":   "node-abc",
+		"node_name": "gpu-workstation",
+		"last_seen": "2026-06-20T12:00:00Z",
+	}
+
+	p, err := UnmarshalPresenceFromMap(m)
+	if err != nil {
+		t.Fatalf("UnmarshalPresenceFromMap: %v", err)
+	}
+
+	if p.NodeID != "node-abc" {
+		t.Errorf("NodeID = %q, want %q", p.NodeID, "node-abc")
+	}
+	if p.NodeName != "gpu-workstation" {
+		t.Errorf("NodeName = %q, want %q", p.NodeName, "gpu-workstation")
+	}
+}
+
+func TestPresenceInfo_IsOnline(t *testing.T) {
+	recent := PresenceInfo{LastSeen: time.Now().Add(-10 * time.Second)}
+	if !recent.IsOnline(60 * time.Second) {
+		t.Error("recent presence should be online")
+	}
+
+	stale := PresenceInfo{LastSeen: time.Now().Add(-5 * time.Minute)}
+	if stale.IsOnline(60 * time.Second) {
+		t.Error("stale presence should be offline")
+	}
+}
+
+func TestMessageJSONFieldNames(t *testing.T) {
+	msg := Message{
+		FromNodeID:   "id",
+		FromNodeName: "name",
+		Channel:      "ch",
+		Body:         "hi",
+		Timestamp:    time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	data, _ := json.Marshal(msg)
+	var raw map[string]any
+	_ = json.Unmarshal(data, &raw)
+
+	// Verify JSON field names match protocol spec
+	expectedKeys := []string{"from_node_id", "from_node_name", "channel", "body", "ts"}
+	for _, key := range expectedKeys {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("expected JSON key %q not found in serialized message", key)
+		}
+	}
+}

--- a/internal/chat/message.go
+++ b/internal/chat/message.go
@@ -1,0 +1,79 @@
+// Package chat provides node-to-node messaging over the AceTeam Redis API proxy.
+//
+// Messages are delivered in real-time via WebSocket-backed Pub/Sub and persisted
+// to Redis Streams for history. Each organization gets a scoped set of channels.
+package chat
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Message represents a chat message exchanged between nodes.
+type Message struct {
+	FromNodeID   string    `json:"from_node_id"`
+	FromNodeName string    `json:"from_node_name"`
+	Channel      string    `json:"channel"`
+	Body         string    `json:"body"`
+	Timestamp    time.Time `json:"ts"`
+}
+
+// PresenceInfo represents the online presence of a node.
+type PresenceInfo struct {
+	NodeID   string    `json:"node_id"`
+	NodeName string    `json:"node_name"`
+	LastSeen time.Time `json:"last_seen"`
+}
+
+// IsOnline returns true if the node was seen within the given timeout.
+func (p PresenceInfo) IsOnline(timeout time.Duration) bool {
+	return time.Since(p.LastSeen) < timeout
+}
+
+// ChannelName constructs the Pub/Sub channel name for a chat channel within an org.
+func ChannelName(orgID, channel string) string {
+	return fmt.Sprintf("chat:v1:org_%s:%s", orgID, channel)
+}
+
+// PresenceChannel constructs the Pub/Sub channel name for presence within an org.
+func PresenceChannel(orgID string) string {
+	return fmt.Sprintf("chat:v1:org_%s:presence", orgID)
+}
+
+// StreamName constructs the Redis Streams key for persistent message history.
+func StreamName(orgID, channel string) string {
+	return fmt.Sprintf("chat:v1:org_%s:%s:stream", orgID, channel)
+}
+
+// MarshalMessage serializes a Message to JSON bytes.
+func MarshalMessage(msg Message) ([]byte, error) {
+	return json.Marshal(msg)
+}
+
+// UnmarshalMessage deserializes a Message from JSON bytes.
+func UnmarshalMessage(data []byte) (Message, error) {
+	var msg Message
+	err := json.Unmarshal(data, &msg)
+	return msg, err
+}
+
+// UnmarshalMessageFromMap converts a map[string]any (from WebSocket) to a Message.
+func UnmarshalMessageFromMap(m map[string]any) (Message, error) {
+	data, err := json.Marshal(m)
+	if err != nil {
+		return Message{}, fmt.Errorf("marshal map: %w", err)
+	}
+	return UnmarshalMessage(data)
+}
+
+// UnmarshalPresenceFromMap converts a map[string]any to PresenceInfo.
+func UnmarshalPresenceFromMap(m map[string]any) (PresenceInfo, error) {
+	data, err := json.Marshal(m)
+	if err != nil {
+		return PresenceInfo{}, fmt.Errorf("marshal map: %w", err)
+	}
+	var p PresenceInfo
+	err = json.Unmarshal(data, &p)
+	return p, err
+}

--- a/internal/tui/controlcenter/actions.go
+++ b/internal/tui/controlcenter/actions.go
@@ -1420,6 +1420,7 @@ func (cc *ControlCenter) showDeviceAuthModal(config *DeviceAuthConfig) {
 						if cc.onConnect != nil {
 							cc.onConnect(cc.AddActivity)
 						}
+						cc.ShowChat()
 
 						// Set device URL for the "V" key shortcut
 						cc.deviceURL = cc.authServiceURL + "/fabric"

--- a/internal/tui/controlcenter/chat_page.go
+++ b/internal/tui/controlcenter/chat_page.go
@@ -1,0 +1,396 @@
+package controlcenter
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/chat"
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+// presenceTimeout is how long since last heartbeat before a node is considered offline.
+const presenceTimeout = 90 * time.Second
+
+// ChatPage implements the Page interface for the Chat tab.
+// It provides org-scoped node-to-node messaging over the Redis API proxy.
+type ChatPage struct {
+	app *tview.Application
+
+	// Config (set at construction, read-only after)
+	apiBaseURL string
+	apiToken   string
+	orgID      string
+	nodeID     string
+	nodeName   string
+
+	// UI components
+	root       *tview.Flex
+	sidebar    *tview.Flex
+	channelBox *tview.TextView
+	peersBox   *tview.TextView
+	msgView    *tview.TextView
+	input      *tview.InputField
+
+	// Chat client
+	client   *chat.Client
+	clientMu sync.Mutex
+
+	// Message buffer
+	messages   []chat.Message
+	messagesMu sync.Mutex
+
+	// Track recently sent message timestamps to suppress echo duplicates
+	recentSends   map[string]time.Time
+	recentSendsMu sync.Mutex
+
+	// Presence tracking
+	peers   map[string]chat.PresenceInfo
+	peersMu sync.RWMutex
+
+	// Lifecycle
+	connected bool
+	cancel    context.CancelFunc
+}
+
+// ChatPageConfig holds the configuration needed to create a ChatPage.
+type ChatPageConfig struct {
+	APIBaseURL string
+	APIToken   string
+	OrgID      string
+	NodeID     string
+	NodeName   string
+}
+
+// NewChatPage creates a new chat page. The page connects lazily on first activation.
+func NewChatPage(cfg ChatPageConfig) *ChatPage {
+	return &ChatPage{
+		apiBaseURL:  cfg.APIBaseURL,
+		apiToken:    cfg.APIToken,
+		orgID:       cfg.OrgID,
+		nodeID:      cfg.NodeID,
+		nodeName:    cfg.NodeName,
+		messages:    make([]chat.Message, 0, 200),
+		peers:       make(map[string]chat.PresenceInfo),
+		recentSends: make(map[string]time.Time),
+	}
+}
+
+// Name implements Page.
+func (p *ChatPage) Name() string { return "chat" }
+
+// Title implements Page.
+func (p *ChatPage) Title() string { return "Chat" }
+
+// Build implements Page. Constructs the split-pane chat layout.
+func (p *ChatPage) Build(app *tview.Application) tview.Primitive {
+	p.app = app
+
+	// -- Left sidebar: channels + online nodes --
+
+	p.channelBox = tview.NewTextView()
+	p.channelBox.SetDynamicColors(true)
+	p.channelBox.SetBorder(true)
+	p.channelBox.SetTitle(" Channels ")
+	p.channelBox.SetTitleAlign(tview.AlignLeft)
+	p.channelBox.SetText(" [green]# general[white]")
+
+	p.peersBox = tview.NewTextView()
+	p.peersBox.SetDynamicColors(true)
+	p.peersBox.SetBorder(true)
+	p.peersBox.SetTitle(" Online ")
+	p.peersBox.SetTitleAlign(tview.AlignLeft)
+	p.peersBox.SetText(" [gray]connecting...[white]")
+
+	p.sidebar = tview.NewFlex().SetDirection(tview.FlexRow).
+		AddItem(p.channelBox, 5, 0, false).
+		AddItem(p.peersBox, 0, 1, false)
+
+	// -- Right panel: message view + input --
+
+	p.msgView = tview.NewTextView()
+	p.msgView.SetDynamicColors(true)
+	p.msgView.SetScrollable(true)
+	p.msgView.SetBorder(true)
+	p.msgView.SetTitle(" #general ")
+	p.msgView.SetTitleAlign(tview.AlignLeft)
+	p.msgView.SetText(" [gray]Connecting to chat...[white]\n")
+
+	p.input = tview.NewInputField()
+	p.input.SetLabel("> ")
+	p.input.SetFieldBackgroundColor(tcell.ColorDarkSlateGray)
+	p.input.SetLabelColor(tcell.ColorGreen)
+	p.input.SetPlaceholder("Type a message and press Enter")
+	p.input.SetPlaceholderTextColor(tcell.ColorDimGray)
+	p.input.SetDoneFunc(func(key tcell.Key) {
+		if key == tcell.KeyEnter {
+			p.sendMessage()
+		}
+	})
+
+	rightPanel := tview.NewFlex().SetDirection(tview.FlexRow).
+		AddItem(p.msgView, 0, 1, false).
+		AddItem(p.input, 1, 0, true)
+
+	// -- Root layout --
+
+	p.root = tview.NewFlex().
+		AddItem(p.sidebar, 24, 0, false).
+		AddItem(rightPanel, 0, 1, true)
+
+	return p.root
+}
+
+// OnActivate implements Page. Lazily connects the chat client on first activation.
+func (p *ChatPage) OnActivate() {
+	// Focus the input field
+	if p.app != nil && p.input != nil {
+		p.app.SetFocus(p.input)
+	}
+
+	p.clientMu.Lock()
+	alreadyConnected := p.connected
+	p.clientMu.Unlock()
+
+	if alreadyConnected {
+		return
+	}
+
+	// Connect in background
+	go p.connect()
+}
+
+// OnDeactivate implements Page.
+func (p *ChatPage) OnDeactivate() {}
+
+// HandleInput implements Page. Routes input to the input field or message view.
+func (p *ChatPage) HandleInput(event *tcell.EventKey) *tcell.EventKey {
+	// Page Up / Page Down scroll the message view
+	switch event.Key() {
+	case tcell.KeyPgUp:
+		row, col := p.msgView.GetScrollOffset()
+		p.msgView.ScrollTo(row-10, col)
+		return nil
+	case tcell.KeyPgDn:
+		row, col := p.msgView.GetScrollOffset()
+		p.msgView.ScrollTo(row+10, col)
+		return nil
+	}
+
+	return event
+}
+
+// connect establishes the chat client connection.
+func (p *ChatPage) connect() {
+	p.clientMu.Lock()
+	if p.connected {
+		p.clientMu.Unlock()
+		return
+	}
+
+	if p.apiBaseURL == "" || p.apiToken == "" || p.orgID == "" {
+		p.clientMu.Unlock()
+		p.setStatus("[red]Not configured[white] — device authorization required")
+		return
+	}
+
+	client := chat.NewClient(chat.ClientConfig{
+		APIBaseURL: p.apiBaseURL,
+		Token:      p.apiToken,
+		OrgID:      p.orgID,
+		NodeID:     p.nodeID,
+		NodeName:   p.nodeName,
+	})
+	p.client = client
+	p.clientMu.Unlock()
+
+	// Wire up callbacks
+	client.OnMessage(func(msg chat.Message) {
+		// Suppress echo of own messages (already rendered via local echo)
+		if msg.FromNodeID == p.nodeID {
+			key := msg.Body + "|" + msg.Timestamp.Format(time.RFC3339)
+			p.recentSendsMu.Lock()
+			if _, dup := p.recentSends[key]; dup {
+				delete(p.recentSends, key)
+				p.recentSendsMu.Unlock()
+				return
+			}
+			p.recentSendsMu.Unlock()
+		}
+
+		p.messagesMu.Lock()
+		p.messages = append(p.messages, msg)
+		// Keep last 200 messages
+		if len(p.messages) > 200 {
+			p.messages = p.messages[len(p.messages)-200:]
+		}
+		p.messagesMu.Unlock()
+
+		p.app.QueueUpdateDraw(func() {
+			p.appendMessage(msg)
+		})
+	})
+
+	client.OnPresence(func(info chat.PresenceInfo) {
+		p.peersMu.Lock()
+		p.peers[info.NodeID] = info
+		p.peersMu.Unlock()
+
+		p.app.QueueUpdateDraw(func() {
+			p.updatePeersView()
+		})
+	})
+
+	p.setStatus("[green]Connected[white] to #general")
+
+	p.clientMu.Lock()
+	p.connected = true
+	p.clientMu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	p.cancel = cancel
+
+	// This blocks until ctx is cancelled
+	_ = client.Connect(ctx)
+}
+
+// sendMessage sends the current input as a chat message.
+func (p *ChatPage) sendMessage() {
+	text := strings.TrimSpace(p.input.GetText())
+	if text == "" {
+		return
+	}
+
+	p.clientMu.Lock()
+	client := p.client
+	p.clientMu.Unlock()
+
+	if client == nil {
+		return
+	}
+
+	p.input.SetText("")
+
+	// Local echo: render immediately so the sender sees their message
+	now := time.Now().UTC()
+	localMsg := chat.Message{
+		FromNodeID:   p.nodeID,
+		FromNodeName: p.nodeName,
+		Channel:      "general",
+		Body:         text,
+		Timestamp:    now,
+	}
+
+	// Track for dedup when the server echo arrives
+	key := text + "|" + now.Format(time.RFC3339)
+	p.recentSendsMu.Lock()
+	p.recentSends[key] = now
+	p.recentSendsMu.Unlock()
+
+	p.messagesMu.Lock()
+	p.messages = append(p.messages, localMsg)
+	if len(p.messages) > 200 {
+		p.messages = p.messages[len(p.messages)-200:]
+	}
+	p.messagesMu.Unlock()
+
+	p.appendMessage(localMsg)
+
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		if err := client.Send(ctx, text); err != nil {
+			p.app.QueueUpdateDraw(func() {
+				fmt.Fprintf(p.msgView, " [red]Send failed: %s[white]\n", err.Error())
+				p.msgView.ScrollToEnd()
+			})
+
+			// Remove dedup entry on failure so re-sends aren't suppressed
+			p.recentSendsMu.Lock()
+			delete(p.recentSends, key)
+			p.recentSendsMu.Unlock()
+		}
+	}()
+}
+
+// appendMessage renders a single message in the message view.
+func (p *ChatPage) appendMessage(msg chat.Message) {
+	ts := msg.Timestamp.Local().Format("15:04")
+	name := msg.FromNodeName
+	if name == "" {
+		name = msg.FromNodeID
+	}
+
+	// Highlight own messages
+	nameColor := "cyan"
+	if msg.FromNodeID == p.nodeID {
+		nameColor = "green"
+	}
+
+	fmt.Fprintf(p.msgView, " [gray]%s[white] [%s]%s[white]: %s\n",
+		ts, nameColor, tview.Escape(name), tview.Escape(msg.Body))
+	p.msgView.ScrollToEnd()
+}
+
+// setStatus updates the message view with a status line.
+func (p *ChatPage) setStatus(text string) {
+	p.app.QueueUpdateDraw(func() {
+		p.msgView.Clear()
+		fmt.Fprintf(p.msgView, " %s\n\n", text)
+		p.msgView.ScrollToEnd()
+	})
+}
+
+// updatePeersView refreshes the online peers sidebar.
+func (p *ChatPage) updatePeersView() {
+	p.peersMu.RLock()
+	defer p.peersMu.RUnlock()
+
+	if len(p.peers) == 0 {
+		p.peersBox.SetText(" [gray]no peers yet[white]")
+		return
+	}
+
+	// Sort peers by name
+	sorted := make([]chat.PresenceInfo, 0, len(p.peers))
+	for _, peer := range p.peers {
+		sorted = append(sorted, peer)
+	}
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].NodeName < sorted[j].NodeName
+	})
+
+	var sb strings.Builder
+	for _, peer := range sorted {
+		name := peer.NodeName
+		if name == "" {
+			name = peer.NodeID
+		}
+		if peer.IsOnline(presenceTimeout) {
+			fmt.Fprintf(&sb, " [green]●[white] %s\n", tview.Escape(name))
+		} else {
+			fmt.Fprintf(&sb, " [gray]○[white] [gray]%s[white]\n", tview.Escape(name))
+		}
+	}
+
+	p.peersBox.SetText(sb.String())
+}
+
+// Close shuts down the chat page and its client.
+func (p *ChatPage) Close() {
+	if p.cancel != nil {
+		p.cancel()
+	}
+	p.clientMu.Lock()
+	if p.client != nil {
+		_ = p.client.Close()
+		p.client = nil
+	}
+	p.connected = false
+	p.clientMu.Unlock()
+}

--- a/internal/tui/controlcenter/controlcenter.go
+++ b/internal/tui/controlcenter/controlcenter.go
@@ -407,6 +407,10 @@ type ControlCenter struct {
 
 	// Console page (nil on Windows)
 	consolePage *ConsolePage
+
+	// Chat
+	chatConfig ChatPageConfig // stored from Config; used to lazily create ChatPage
+	chatPage   *ChatPage     // nil until registered in Run
 }
 
 // Pane focus constants
@@ -469,6 +473,7 @@ type Config struct {
 	Worker             WorkerCallbacks             // Worker management callbacks
 	Permissions        PermissionsCallbacks        // Gateway permissions callbacks
 	OnConnect          func(activityFn func(level, msg string)) // Called after VPN connects (starts terminal/VNC servers)
+	Chat               ChatPageConfig                          // Chat page configuration (empty = disabled)
 }
 
 // New creates a new control center
@@ -494,6 +499,7 @@ func New(cfg Config) *ControlCenter {
 		onConnect:       cfg.OnConnect,
 		authServiceURL:  cfg.AuthServiceURL,
 		nexusURL:        cfg.NexusURL,
+		chatConfig:      cfg.Chat,
 	}
 }
 
@@ -567,6 +573,10 @@ func (cc *ControlCenter) Run() error {
 	} else {
 		cc.pmgr.Register(NewPlaceholderPage("console", "Console"), false)
 	}
+
+	// Alt+3: Chat page (hidden until network is connected and org is known)
+	cc.chatPage = NewChatPage(cc.chatConfig)
+	cc.pmgr.Register(cc.chatPage, false)
 	cc.pmgr.Register(NewPlaceholderPage("services", "Services"), false)
 	cc.pmgr.Register(NewPlaceholderPage("jobs", "Jobs"), false)
 	cc.pmgr.Register(NewPlaceholderPage("network", "Network"), false)
@@ -598,11 +608,24 @@ func (cc *ControlCenter) Run() error {
 	return cc.app.Run()
 }
 
+// ShowChat makes the chat tab visible in the tab bar. Call this after the
+// network connects and org/token info is available. If the ChatPage was
+// created without valid config (empty token/org), it will show an error on
+// activation rather than crash.
+func (cc *ControlCenter) ShowChat() {
+	if cc.pmgr != nil {
+		cc.pmgr.Show("chat")
+	}
+}
+
 // Stop stops the control center
 func (cc *ControlCenter) Stop() {
 	close(cc.stopChan)
 	if cc.consolePage != nil {
 		cc.consolePage.Close()
+	}
+	if cc.chatPage != nil {
+		cc.chatPage.Close()
 	}
 	if cc.app != nil {
 		cc.app.Stop()


### PR DESCRIPTION
## Context

Implements #225. The TUI currently has no inter-node communication — operators managing multiple Citadel nodes in an org have no way to coordinate or see who else is online. This adds a Chat tab (Alt+2) that enables real-time messaging between all nodes in the same organization, laying the groundwork for collaborative compute workflows.

## Summary

### Protocol layer (`internal/chat/`)
- **`message.go`** — Wire types (`Message`, `PresenceInfo`) and channel naming convention (`chat:v1:org_{orgID}:{channel}`, `chat:v1:org_{orgID}:presence`). `StreamName` helper for future message persistence.
- **`client.go`** — Chat client wrapping a **dedicated** `redisapi.Client` (never the shared connection — satisfies the "no blocking reads on shared connection" constraint). WebSocket Pub/Sub for real-time delivery, `StreamAdd` for best-effort persistence. 30-second presence heartbeat loop. `OnMessage`/`OnPresence` callbacks.
- **`client_test.go`** — 8 unit tests covering channel name construction, JSON round-trip, `map[string]any` deserialization (matching the server's WS message shape), and presence timeout logic.

### TUI integration (`internal/tui/controlcenter/`)
- **`chat_page.go`** — `ChatPage` implementing the `Page` interface. Split-pane layout: 24-wide left sidebar (channel list + online peers with green/gray dot indicators) and right panel (scrollable message view + input field). Lazy connection on first activation — shows "Not configured" gracefully if device auth hasn't completed. Local echo on send with server-echo dedup to avoid double-rendering. PgUp/PgDn scrolling. Own messages in green, others in cyan.
- **`controlcenter.go`** — Registers `ChatPage` at page index 1 (Alt+2), initially hidden. `ShowChat()` method makes it visible. `Close()` on Stop to clean up WebSocket.
- **`actions.go`** — Calls `ShowChat()` after interactive device auth completes.

### Entry point (`cmd/controlcenter.go`)
- `buildChatConfig()` reads `DeviceConfig` (token, orgID, API base URL) and resolves node name/ID from network status or hostname.
- Calls `ShowChat()` on the auto-connect path.

### Known limitations (deferred to follow-ups)
1. **Server allowlist** — The WebSocket route in aceteam (`app/api/fabric/redis/ws/route.ts`) does not yet include `chat:v1:*` in `ALLOWED_SUBSCRIBE_PATTERNS` / `ALLOWED_PUBLISH_PATTERNS`. A follow-up PR in aceteam-ai/aceteam is needed to add these patterns before chat messages can flow.
2. **Message history** — `StreamAdd` persists messages, but no `streams/range` (XRANGE) endpoint exists in the Redis API proxy yet. Only live messages are visible. The v1 scope in #225 listed "last 100 via Redis Streams" but this is blocked on a backend endpoint.
3. **Single channel** — Only `#general` is available; multi-channel support is a future enhancement.

## Test plan

| Area | Tests | Coverage |
|------|-------|----------|
| Channel naming | 3 | `ChannelName`, `PresenceChannel`, `StreamName` output format |
| JSON serialization | 2 | `MarshalMessage` round-trip, JSON field name verification |
| WS message parsing | 2 | `UnmarshalMessageFromMap`, `UnmarshalPresenceFromMap` for `map[string]any` payloads |
| Presence timeout | 1 | `IsOnline` with recent vs stale heartbeats |
| Build | 1 | `CGO_ENABLED=0 go build ./...` passes clean |
| Existing tests | all | `go test ./internal/tui/controlcenter/...` unchanged |

## Related

- #225 (parent issue — not closed; history and server allowlist remain)
- aceteam-ai/aceteam `app/api/fabric/redis/ws/route.ts` needs allowlist update