### PR TITLE
feat(tui): Gateway tab with ACET metering proxy

### DIFF
--- a/cmd/gateway.go
+++ b/cmd/gateway.go
@@ -1,0 +1,171 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/gateway"
+	"github.com/spf13/cobra"
+)
+
+var (
+	gatewayPort      int
+	gatewayUpstream  string
+	gatewayModelTier string
+	gatewayAPIToken  string
+	gatewayPlatform  string
+)
+
+var gatewayCmd = &cobra.Command{
+	Use:   "gateway",
+	Short: "Start the inference gateway proxy with ACET metering",
+	Long: `Starts a local HTTP reverse proxy that sits in front of an inference engine
+(vLLM, Ollama, etc.) and meters all OpenAI-compatible API requests.
+
+Metered endpoints:
+  /v1/chat/completions   - Chat completions
+  /v1/completions        - Text completions
+  /v1/embeddings         - Embeddings
+
+All other paths are proxied through without metering.
+
+Token usage is extracted from OpenAI-compatible responses (both streaming and
+non-streaming) and recorded to ~/.citadel-cli/gateway/transactions.jsonl.
+
+ACET pricing tiers:
+  small   (0-8B params)    1 ACET per 1K tokens  ($0.001)
+  medium  (8-70B params)   5 ACET per 1K tokens  ($0.005)
+  large   (70-400B params) 25 ACET per 1K tokens ($0.025)
+  xlarge  (400B+ params)   100 ACET per 1K tokens ($0.100)
+
+Revenue split: 80% operator / 20% platform.
+
+Examples:
+  # Proxy to local Ollama
+  citadel gateway --upstream http://localhost:11434
+
+  # Proxy to vLLM with custom port and large model tier
+  citadel gateway --port 9090 --upstream http://localhost:8000 --model-tier large
+
+  # With ACET settlement enabled
+  citadel gateway --upstream http://localhost:11434 --platform https://aceteam.ai/api --api-token act_xxx`,
+	RunE: runGateway,
+}
+
+func init() {
+	gatewayCmd.Flags().IntVar(&gatewayPort, "port", 8080, "Port to listen on")
+	gatewayCmd.Flags().StringVar(&gatewayUpstream, "upstream", "http://localhost:11434", "Upstream inference engine URL")
+	gatewayCmd.Flags().StringVar(&gatewayModelTier, "model-tier", "medium", "Pricing tier: small, medium, large, xlarge")
+	gatewayCmd.Flags().StringVar(&gatewayAPIToken, "api-token", "", "API token for ACET settlement (optional)")
+	gatewayCmd.Flags().StringVar(&gatewayPlatform, "platform", "", "Platform base URL for ACET settlement (optional)")
+	rootCmd.AddCommand(gatewayCmd)
+}
+
+func runGateway(cmd *cobra.Command, args []string) error {
+	// Validate tier
+	tier, ok := gateway.TierByName(gatewayModelTier)
+	if !ok {
+		return fmt.Errorf("unknown model tier %q (valid: small, medium, large, xlarge)", gatewayModelTier)
+	}
+
+	// Parse upstream URL
+	upstreamURL, err := url.Parse(gatewayUpstream)
+	if err != nil {
+		return fmt.Errorf("invalid upstream URL: %w", err)
+	}
+
+	// Set up ledger
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("get home dir: %w", err)
+	}
+	baseDir := filepath.Join(homeDir, ".citadel-cli")
+	ledger := gateway.NewLedger(baseDir)
+
+	// Set up ACET client (optional)
+	var acet *gateway.ACETClient
+	if gatewayPlatform != "" && gatewayAPIToken != "" {
+		acet = gateway.NewACETClient(gatewayPlatform, gatewayAPIToken)
+		log.Printf("[Gateway] ACET settlement enabled (platform: %s)", gatewayPlatform)
+	}
+
+	// Create reverse proxy
+	proxy := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL.Scheme = upstreamURL.Scheme
+			req.URL.Host = upstreamURL.Host
+			req.Header.Set("X-Forwarded-For", req.RemoteAddr)
+		},
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			log.Printf("[Gateway] upstream error: %v", err)
+			http.Error(w, fmt.Sprintf(`{"error":"upstream unavailable: %v"}`, err), http.StatusBadGateway)
+		},
+	}
+
+	// Wrap with metering middleware
+	metered := gateway.NewMeteringMiddleware(proxy, ledger, acet, tier)
+
+	// Create server
+	addr := fmt.Sprintf("0.0.0.0:%d", gatewayPort)
+	server := &http.Server{
+		Addr:         addr,
+		Handler:      metered,
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 120 * time.Second,
+		IdleTimeout:  120 * time.Second,
+	}
+
+	// Handle shutdown
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		<-sigCh
+		log.Println("[Gateway] Shutting down...")
+		cancel()
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		server.Shutdown(shutdownCtx)
+	}()
+
+	// Periodic offline queue flush
+	if acet != nil {
+		go func() {
+			ticker := time.NewTicker(30 * time.Second)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					if settled, remaining := acet.FlushOfflineQueue(); settled > 0 {
+						log.Printf("[Gateway] Flushed %d queued settlements (%d remaining)", settled, remaining)
+					}
+				}
+			}
+		}()
+	}
+
+	log.Printf("[Gateway] Inference gateway starting on %s", addr)
+	log.Printf("[Gateway] Upstream: %s", gatewayUpstream)
+	log.Printf("[Gateway] Pricing tier: %s (%d ACET/1K tokens)", tier.Name, tier.ACETPer1K)
+	log.Printf("[Gateway] Transaction log: %s/gateway/transactions.jsonl", baseDir)
+
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return fmt.Errorf("gateway server: %w", err)
+	}
+
+	return nil
+}

--- a/internal/gateway/acet.go
+++ b/internal/gateway/acet.go
@@ -1,0 +1,206 @@
+package gateway
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// PricingTier defines ACET cost per 1K tokens for a model size range.
+type PricingTier struct {
+	Name        string // "small", "medium", "large", "xlarge"
+	MinParams   int    // billions, inclusive
+	MaxParams   int    // billions, exclusive (0 = unbounded)
+	ACETPer1K   int    // ACET tokens per 1,000 tokens
+}
+
+// DefaultPricingTiers returns the standard ACET pricing tiers.
+func DefaultPricingTiers() []PricingTier {
+	return []PricingTier{
+		{Name: "small", MinParams: 0, MaxParams: 8, ACETPer1K: 1},
+		{Name: "medium", MinParams: 8, MaxParams: 70, ACETPer1K: 5},
+		{Name: "large", MinParams: 70, MaxParams: 400, ACETPer1K: 25},
+		{Name: "xlarge", MinParams: 400, MaxParams: 0, ACETPer1K: 100},
+	}
+}
+
+// TierByName returns the pricing tier for a given name.
+func TierByName(name string) (PricingTier, bool) {
+	for _, t := range DefaultPricingTiers() {
+		if t.Name == name {
+			return t, true
+		}
+	}
+	return PricingTier{}, false
+}
+
+// CalculateACETCost computes the total ACET cost for a request.
+func CalculateACETCost(tier PricingTier, tokensIn, tokensOut int) int {
+	totalTokens := tokensIn + tokensOut
+	// ACET per 1K tokens, round up to ensure minimum billing
+	cost := int(math.Ceil(float64(totalTokens) * float64(tier.ACETPer1K) / 1000.0))
+	if cost < 1 && totalTokens > 0 {
+		cost = 1 // minimum charge
+	}
+	return cost
+}
+
+// OperatorShare returns the operator's portion: ceil(80% of cost).
+func OperatorShare(cost int) int {
+	return int(math.Ceil(float64(cost) * 0.80))
+}
+
+// PlatformShare returns the platform's portion: cost - operator share.
+func PlatformShare(cost int) int {
+	return cost - OperatorShare(cost)
+}
+
+// settleRequest is the payload sent to the platform settlement endpoint.
+type settleRequest struct {
+	Model       string `json:"model"`
+	TokensIn    int    `json:"tokens_in"`
+	TokensOut   int    `json:"tokens_out"`
+	ACETCost    int    `json:"acet_cost"`
+	ConsumerOrg string `json:"consumer_org"`
+}
+
+// balanceResponse is returned from the platform balance check endpoint.
+type balanceResponse struct {
+	Balance int  `json:"balance"`
+	OK      bool `json:"ok"`
+}
+
+// ACETClient handles ACET token settlement with the platform.
+type ACETClient struct {
+	baseURL    string
+	apiToken   string
+	httpClient *http.Client
+
+	// offlineQueue stores settlements that failed due to connectivity
+	offlineQueue []settleRequest
+	offlineMu    sync.Mutex
+}
+
+// NewACETClient creates a client for ACET settlement.
+func NewACETClient(baseURL, apiToken string) *ACETClient {
+	return &ACETClient{
+		baseURL:  baseURL,
+		apiToken: apiToken,
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+// Settle reports a completed request to the platform for ACET settlement.
+// If the platform is unreachable, the settlement is queued locally.
+func (c *ACETClient) Settle(model string, tokensIn, tokensOut, acetCost int, consumerOrg string) error {
+	req := settleRequest{
+		Model:       model,
+		TokensIn:    tokensIn,
+		TokensOut:   tokensOut,
+		ACETCost:    acetCost,
+		ConsumerOrg: consumerOrg,
+	}
+
+	if err := c.doSettle(req); err != nil {
+		// Queue for later
+		c.offlineMu.Lock()
+		c.offlineQueue = append(c.offlineQueue, req)
+		c.offlineMu.Unlock()
+		return fmt.Errorf("settle queued (offline): %w", err)
+	}
+
+	return nil
+}
+
+func (c *ACETClient) doSettle(s settleRequest) error {
+	body, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, c.baseURL+"/acet/settle", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.apiToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiToken)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("settlement failed: HTTP %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// CheckBalance queries the platform for a consumer's ACET balance.
+func (c *ACETClient) CheckBalance(consumerOrg string) (int, error) {
+	req, err := http.NewRequest(http.MethodGet,
+		fmt.Sprintf("%s/acet/balance?org=%s", c.baseURL, consumerOrg), nil)
+	if err != nil {
+		return 0, err
+	}
+	if c.apiToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiToken)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("balance check failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return 0, fmt.Errorf("balance check: HTTP %d", resp.StatusCode)
+	}
+
+	var br balanceResponse
+	if err := json.NewDecoder(resp.Body).Decode(&br); err != nil {
+		return 0, fmt.Errorf("decode balance: %w", err)
+	}
+	return br.Balance, nil
+}
+
+// FlushOfflineQueue attempts to settle all queued transactions.
+// Returns the number successfully settled and any remaining errors.
+func (c *ACETClient) FlushOfflineQueue() (settled int, remaining int) {
+	c.offlineMu.Lock()
+	queue := c.offlineQueue
+	c.offlineQueue = nil
+	c.offlineMu.Unlock()
+
+	var failed []settleRequest
+	for _, s := range queue {
+		if err := c.doSettle(s); err != nil {
+			failed = append(failed, s)
+		} else {
+			settled++
+		}
+	}
+
+	if len(failed) > 0 {
+		c.offlineMu.Lock()
+		c.offlineQueue = append(c.offlineQueue, failed...)
+		c.offlineMu.Unlock()
+	}
+	return settled, len(failed)
+}
+
+// QueueLen returns the number of unsettled transactions in the offline queue.
+func (c *ACETClient) QueueLen() int {
+	c.offlineMu.Lock()
+	defer c.offlineMu.Unlock()
+	return len(c.offlineQueue)
+}

--- a/internal/gateway/acet_test.go
+++ b/internal/gateway/acet_test.go
@@ -1,0 +1,221 @@
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestCalculateACETCost(t *testing.T) {
+	tests := []struct {
+		tier     string
+		in, out  int
+		wantCost int
+	}{
+		// Small tier: 1 ACET per 1K tokens
+		{"small", 500, 500, 1},   // 1000 tokens = 1 ACET
+		{"small", 100, 50, 1},    // 150 tokens = ceil(0.15) = 1
+		{"small", 2000, 1000, 3}, // 3000 tokens = 3 ACET
+
+		// Medium tier: 5 ACET per 1K tokens
+		{"medium", 1000, 500, 8}, // 1500 tokens = ceil(7.5) = 8
+		{"medium", 100, 100, 1},  // 200 tokens = ceil(1.0) = 1
+
+		// Large tier: 25 ACET per 1K tokens
+		{"large", 1000, 500, 38}, // 1500 tokens = ceil(37.5) = 38
+		{"large", 100, 0, 3},     // 100 tokens = ceil(2.5) = 3
+
+		// XLarge tier: 100 ACET per 1K tokens
+		{"xlarge", 1000, 1000, 200}, // 2000 tokens = 200 ACET
+		{"xlarge", 10, 10, 2},       // 20 tokens = ceil(2.0) = 2
+	}
+
+	for _, tt := range tests {
+		tier, ok := TierByName(tt.tier)
+		if !ok {
+			t.Fatalf("unknown tier: %s", tt.tier)
+		}
+		got := CalculateACETCost(tier, tt.in, tt.out)
+		if got != tt.wantCost {
+			t.Errorf("%s(%d in, %d out) = %d ACET, want %d",
+				tt.tier, tt.in, tt.out, got, tt.wantCost)
+		}
+	}
+}
+
+func TestOperatorPlatformSplit(t *testing.T) {
+	tests := []struct {
+		cost         int
+		wantOperator int
+		wantPlatform int
+	}{
+		{1, 1, 0},   // ceil(0.8) = 1
+		{2, 2, 0},   // ceil(1.6) = 2
+		{3, 3, 0},   // ceil(2.4) = 3
+		{5, 4, 1},   // ceil(4.0) = 4
+		{10, 8, 2},  // ceil(8.0) = 8
+		{100, 80, 20},
+	}
+
+	for _, tt := range tests {
+		op := OperatorShare(tt.cost)
+		pl := PlatformShare(tt.cost)
+		if op != tt.wantOperator {
+			t.Errorf("OperatorShare(%d) = %d, want %d", tt.cost, op, tt.wantOperator)
+		}
+		if pl != tt.wantPlatform {
+			t.Errorf("PlatformShare(%d) = %d, want %d", tt.cost, pl, tt.wantPlatform)
+		}
+		if op+pl != tt.cost {
+			t.Errorf("shares don't sum: %d + %d != %d", op, pl, tt.cost)
+		}
+	}
+}
+
+func TestACETClient_Settle(t *testing.T) {
+	var callCount int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/acet/settle" {
+			t.Errorf("path = %s, want /acet/settle", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Errorf("auth = %q, want 'Bearer test-token'", r.Header.Get("Authorization"))
+		}
+
+		var body settleRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		if body.Model != "llama-7b" {
+			t.Errorf("model = %s, want llama-7b", body.Model)
+		}
+		if body.ACETCost != 5 {
+			t.Errorf("cost = %d, want 5", body.ACETCost)
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewACETClient(server.URL, "test-token")
+	err := client.Settle("llama-7b", 1000, 500, 5, "org-123")
+	if err != nil {
+		t.Fatalf("Settle: %v", err)
+	}
+
+	if atomic.LoadInt32(&callCount) != 1 {
+		t.Errorf("settle called %d times, want 1", callCount)
+	}
+}
+
+func TestACETClient_SettleOfflineQueue(t *testing.T) {
+	var callCount int32
+	failFirst := true
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		if failFirst {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewACETClient(server.URL, "test-token")
+
+	// First settle should fail and queue
+	err := client.Settle("llama-7b", 100, 50, 1, "org-1")
+	if err == nil {
+		t.Fatal("expected error from offline settle")
+	}
+
+	if client.QueueLen() != 1 {
+		t.Errorf("queue len = %d, want 1", client.QueueLen())
+	}
+
+	// Now allow settlements
+	failFirst = false
+	settled, remaining := client.FlushOfflineQueue()
+	if settled != 1 {
+		t.Errorf("settled = %d, want 1", settled)
+	}
+	if remaining != 0 {
+		t.Errorf("remaining = %d, want 0", remaining)
+	}
+	if client.QueueLen() != 0 {
+		t.Errorf("queue len after flush = %d, want 0", client.QueueLen())
+	}
+}
+
+func TestACETClient_CheckBalance(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/acet/balance" {
+			t.Errorf("path = %s, want /acet/balance", r.URL.Path)
+		}
+		if r.URL.Query().Get("org") != "org-42" {
+			t.Errorf("org = %s, want org-42", r.URL.Query().Get("org"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(balanceResponse{Balance: 1500, OK: true})
+	}))
+	defer server.Close()
+
+	client := NewACETClient(server.URL, "")
+	balance, err := client.CheckBalance("org-42")
+	if err != nil {
+		t.Fatalf("CheckBalance: %v", err)
+	}
+	if balance != 1500 {
+		t.Errorf("balance = %d, want 1500", balance)
+	}
+}
+
+func TestTierByName(t *testing.T) {
+	for _, name := range []string{"small", "medium", "large", "xlarge"} {
+		tier, ok := TierByName(name)
+		if !ok {
+			t.Errorf("TierByName(%q) not found", name)
+		}
+		if tier.Name != name {
+			t.Errorf("tier.Name = %q, want %q", tier.Name, name)
+		}
+	}
+
+	_, ok := TierByName("nonexistent")
+	if ok {
+		t.Error("TierByName('nonexistent') should return false")
+	}
+}
+
+func TestDefaultPricingTiers(t *testing.T) {
+	tiers := DefaultPricingTiers()
+	if len(tiers) != 4 {
+		t.Fatalf("got %d tiers, want 4", len(tiers))
+	}
+
+	// Verify tiers are ordered by model size
+	expected := []struct {
+		name    string
+		per1K   int
+	}{
+		{"small", 1},
+		{"medium", 5},
+		{"large", 25},
+		{"xlarge", 100},
+	}
+
+	for i, e := range expected {
+		if tiers[i].Name != e.name || tiers[i].ACETPer1K != e.per1K {
+			t.Errorf("tier[%d] = {%s, %d}, want {%s, %d}",
+				i, tiers[i].Name, tiers[i].ACETPer1K, e.name, e.per1K)
+		}
+	}
+}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -76,6 +76,12 @@ type Server struct {
 	// routes are allowed (backwards-compatible with existing callers).
 	permissions *config.Permissions
 
+	// metering optionally wraps the handler chain with ACET token metering.
+	// When non-nil, OpenAI-compatible API requests (/v1/chat/completions,
+	// /v1/completions, /v1/embeddings) are metered and billed. Set via
+	// SetMetering before Start.
+	metering *MeteringMiddleware
+
 	// extraListeners are additional net.Listeners the server will also serve on
 	// (e.g., a TLS-wrapped tsnet VPN listener). Added via AddListener before Start.
 	extraListeners []net.Listener
@@ -121,6 +127,15 @@ func (s *Server) SetPermissions(p *config.Permissions) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.permissions = p
+}
+
+// SetMetering enables ACET token metering on the gateway. When set,
+// OpenAI-compatible API requests are intercepted to extract token usage
+// and record billing transactions. Must be called before Start.
+func (s *Server) SetMetering(m *MeteringMiddleware) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.metering = m
 }
 
 // categoryForPath returns the permission category for a request path, or ""
@@ -411,10 +426,15 @@ func isWebSocketUpgrade(r *http.Request) bool {
 		strings.EqualFold(r.Header.Get("Upgrade"), "websocket")
 }
 
-// BuildHandler constructs the full middleware chain (logging + permissions + mux)
-// without starting a server. Useful for testing the middleware stack.
+// BuildHandler constructs the full middleware chain (logging + permissions +
+// optional metering + mux) without starting a server. Useful for testing the
+// middleware stack.
 func (s *Server) BuildHandler() http.Handler {
-	return s.loggingMiddleware(s.permissionMiddleware(s.mux))
+	var handler http.Handler = s.mux
+	if s.metering != nil {
+		handler = s.metering.WrapHandler(handler)
+	}
+	return s.loggingMiddleware(s.permissionMiddleware(handler))
 }
 
 // loggingMiddleware logs all requests.

--- a/internal/gateway/ledger.go
+++ b/internal/gateway/ledger.go
@@ -1,0 +1,172 @@
+package gateway
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// Transaction represents a single metered API request through the gateway.
+type Transaction struct {
+	Timestamp   time.Time `json:"timestamp"`
+	Model       string    `json:"model"`
+	TokensIn    int       `json:"tokens_in"`
+	TokensOut   int       `json:"tokens_out"`
+	ACETCost    int       `json:"acet_cost"`    // total ACET charged
+	ConsumerKey string    `json:"consumer_key"` // API key prefix or identifier
+	Latency     float64   `json:"latency_ms"`
+	Path        string    `json:"path"`
+}
+
+// Stats summarises gateway activity.
+type Stats struct {
+	TotalEarnings  int     `json:"total_earnings"`  // lifetime ACET earned (operator share)
+	TodayEarnings  int     `json:"today_earnings"`  // ACET earned today
+	TotalRequests  int     `json:"total_requests"`  // lifetime request count
+	TodayRequests  int     `json:"today_requests"`  // requests today
+	AvgLatency     float64 `json:"avg_latency_ms"`  // average latency in ms
+}
+
+// Ledger records gateway transactions to an append-only JSONL file.
+// It is safe for concurrent use.
+type Ledger struct {
+	mu      sync.Mutex
+	baseDir string
+}
+
+// NewLedger creates a ledger that writes to the given base directory.
+// The transaction file is created at <baseDir>/gateway/transactions.jsonl.
+func NewLedger(baseDir string) *Ledger {
+	return &Ledger{baseDir: baseDir}
+}
+
+func (l *Ledger) filePath() string {
+	return filepath.Join(l.baseDir, "gateway", "transactions.jsonl")
+}
+
+// Record appends a transaction to the log file.
+func (l *Ledger) Record(tx Transaction) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	dir := filepath.Dir(l.filePath())
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("create ledger dir: %w", err)
+	}
+
+	f, err := os.OpenFile(l.filePath(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("open ledger file: %w", err)
+	}
+	defer f.Close()
+
+	data, err := json.Marshal(tx)
+	if err != nil {
+		return fmt.Errorf("marshal transaction: %w", err)
+	}
+	data = append(data, '\n')
+	if _, err := f.Write(data); err != nil {
+		return fmt.Errorf("write transaction: %w", err)
+	}
+	return nil
+}
+
+// Recent returns the last n transactions, most recent first.
+func (l *Ledger) Recent(n int) ([]Transaction, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	all, err := l.readAll()
+	if err != nil {
+		return nil, err
+	}
+
+	// Reverse to get most-recent-first
+	for i, j := 0, len(all)-1; i < j; i, j = i+1, j-1 {
+		all[i], all[j] = all[j], all[i]
+	}
+
+	if n > len(all) {
+		n = len(all)
+	}
+	return all[:n], nil
+}
+
+// StatsFromDisk computes stats by reading the full transaction log.
+// This is designed for cross-process reads (e.g., the TUI reading
+// the gateway's file).
+func (l *Ledger) StatsFromDisk() (Stats, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	all, err := l.readAll()
+	if err != nil {
+		return Stats{}, err
+	}
+	return computeStats(all), nil
+}
+
+func computeStats(txns []Transaction) Stats {
+	if len(txns) == 0 {
+		return Stats{}
+	}
+
+	now := time.Now()
+	todayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+
+	var s Stats
+	var totalLatency float64
+
+	for _, tx := range txns {
+		// Operator share: ceil(80% of cost)
+		operatorShare := int(math.Ceil(float64(tx.ACETCost) * 0.80))
+		s.TotalEarnings += operatorShare
+		s.TotalRequests++
+		totalLatency += tx.Latency
+
+		if !tx.Timestamp.Before(todayStart) {
+			s.TodayEarnings += operatorShare
+			s.TodayRequests++
+		}
+	}
+
+	s.AvgLatency = totalLatency / float64(len(txns))
+	return s
+}
+
+// readAll reads all transactions from the file. Caller must hold l.mu.
+func (l *Ledger) readAll() ([]Transaction, error) {
+	f, err := os.Open(l.filePath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("open ledger: %w", err)
+	}
+	defer f.Close()
+
+	var txns []Transaction
+	scanner := bufio.NewScanner(f)
+	// Support long lines (up to 1MB)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var tx Transaction
+		if err := json.Unmarshal(line, &tx); err != nil {
+			continue // skip malformed lines
+		}
+		txns = append(txns, tx)
+	}
+	if err := scanner.Err(); err != nil {
+		return txns, fmt.Errorf("scan ledger: %w", err)
+	}
+	return txns, nil
+}

--- a/internal/gateway/ledger_test.go
+++ b/internal/gateway/ledger_test.go
@@ -1,0 +1,168 @@
+package gateway
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestLedger_RecordAndRecent(t *testing.T) {
+	dir := t.TempDir()
+	l := NewLedger(dir)
+
+	// Record three transactions
+	for i := 1; i <= 3; i++ {
+		err := l.Record(Transaction{
+			Timestamp: time.Now().Add(time.Duration(i) * time.Second),
+			Model:     "llama-7b",
+			TokensIn:  100 * i,
+			TokensOut: 50 * i,
+			ACETCost:  i,
+			Latency:   float64(100 * i),
+			Path:      "/v1/chat/completions",
+		})
+		if err != nil {
+			t.Fatalf("Record(%d): %v", i, err)
+		}
+	}
+
+	// File should exist
+	fp := filepath.Join(dir, "gateway", "transactions.jsonl")
+	if _, err := os.Stat(fp); err != nil {
+		t.Fatalf("ledger file not found: %v", err)
+	}
+
+	// Recent(2) should return 2 items, most-recent first
+	recent, err := l.Recent(2)
+	if err != nil {
+		t.Fatalf("Recent: %v", err)
+	}
+	if len(recent) != 2 {
+		t.Fatalf("Recent(2) returned %d items, want 2", len(recent))
+	}
+	// Most recent should have ACETCost=3
+	if recent[0].ACETCost != 3 {
+		t.Errorf("most recent cost = %d, want 3", recent[0].ACETCost)
+	}
+	if recent[1].ACETCost != 2 {
+		t.Errorf("second recent cost = %d, want 2", recent[1].ACETCost)
+	}
+
+	// Recent(100) should return all 3
+	all, err := l.Recent(100)
+	if err != nil {
+		t.Fatalf("Recent(100): %v", err)
+	}
+	if len(all) != 3 {
+		t.Errorf("Recent(100) returned %d items, want 3", len(all))
+	}
+}
+
+func TestLedger_StatsFromDisk(t *testing.T) {
+	dir := t.TempDir()
+	l := NewLedger(dir)
+
+	now := time.Now()
+	yesterday := now.Add(-24 * time.Hour)
+
+	// Record a yesterday transaction
+	if err := l.Record(Transaction{
+		Timestamp: yesterday,
+		Model:     "llama-70b",
+		TokensIn:  1000,
+		TokensOut: 500,
+		ACETCost:  10,
+		Latency:   200.0,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Record two today transactions
+	for i := 0; i < 2; i++ {
+		if err := l.Record(Transaction{
+			Timestamp: now,
+			Model:     "llama-7b",
+			TokensIn:  100,
+			TokensOut: 50,
+			ACETCost:  5,
+			Latency:   100.0,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	stats, err := l.StatsFromDisk()
+	if err != nil {
+		t.Fatalf("StatsFromDisk: %v", err)
+	}
+
+	if stats.TotalRequests != 3 {
+		t.Errorf("TotalRequests = %d, want 3", stats.TotalRequests)
+	}
+	if stats.TodayRequests != 2 {
+		t.Errorf("TodayRequests = %d, want 2", stats.TodayRequests)
+	}
+
+	// Operator share: ceil(80% of cost)
+	// Yesterday: ceil(0.8 * 10) = 8
+	// Today: 2 * ceil(0.8 * 5) = 2 * 4 = 8
+	// Total: 16
+	if stats.TotalEarnings != 16 {
+		t.Errorf("TotalEarnings = %d, want 16", stats.TotalEarnings)
+	}
+	if stats.TodayEarnings != 8 {
+		t.Errorf("TodayEarnings = %d, want 8", stats.TodayEarnings)
+	}
+
+	// Avg latency: (200 + 100 + 100) / 3 ≈ 133.33
+	if stats.AvgLatency < 133 || stats.AvgLatency > 134 {
+		t.Errorf("AvgLatency = %.2f, want ~133.33", stats.AvgLatency)
+	}
+}
+
+func TestLedger_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	l := NewLedger(dir)
+
+	recent, err := l.Recent(10)
+	if err != nil {
+		t.Fatalf("Recent on empty: %v", err)
+	}
+	if len(recent) != 0 {
+		t.Errorf("Recent on empty returned %d, want 0", len(recent))
+	}
+
+	stats, err := l.StatsFromDisk()
+	if err != nil {
+		t.Fatalf("StatsFromDisk on empty: %v", err)
+	}
+	if stats.TotalRequests != 0 {
+		t.Errorf("TotalRequests on empty = %d, want 0", stats.TotalRequests)
+	}
+}
+
+func TestComputeStats_OperatorCeiling(t *testing.T) {
+	// Test that operator share is ceil(80%) — important for small costs
+	tests := []struct {
+		cost int
+		want int // operator share
+	}{
+		{1, 1},  // ceil(0.8) = 1
+		{2, 2},  // ceil(1.6) = 2
+		{3, 3},  // ceil(2.4) = 3
+		{5, 4},  // ceil(4.0) = 4
+		{10, 8}, // ceil(8.0) = 8
+	}
+
+	for _, tt := range tests {
+		s := computeStats([]Transaction{{
+			Timestamp: time.Now(),
+			ACETCost:  tt.cost,
+			Latency:   100,
+		}})
+		if s.TotalEarnings != tt.want {
+			t.Errorf("cost %d: operator share = %d, want %d", tt.cost, s.TotalEarnings, tt.want)
+		}
+	}
+}

--- a/internal/gateway/metering.go
+++ b/internal/gateway/metering.go
@@ -39,6 +39,19 @@ func NewMeteringMiddleware(next http.Handler, ledger *Ledger, acet *ACETClient, 
 	}
 }
 
+// WrapHandler returns a new http.Handler that applies metering around the
+// given handler. This is useful when the MeteringMiddleware was created
+// without a next handler (e.g., for use with Server.SetMetering where the
+// handler is determined later by BuildHandler).
+func (m *MeteringMiddleware) WrapHandler(next http.Handler) http.Handler {
+	return &MeteringMiddleware{
+		next:   next,
+		ledger: m.ledger,
+		acet:   m.acet,
+		tier:   m.tier,
+	}
+}
+
 // InProcessStats returns stats accumulated in this process (not from disk).
 func (m *MeteringMiddleware) InProcessStats() (totalIn, totalOut, totalCost, requestCount int) {
 	m.mu.Lock()
@@ -64,8 +77,17 @@ func (m *MeteringMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// Peek at the body to check for "stream": true
 		bodyBytes, err := io.ReadAll(r.Body)
 		if err == nil {
-			r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 			isStream = detectStream(bodyBytes)
+			if isStream {
+				// Inject stream_options.include_usage=true so the upstream
+				// always returns a final chunk with token counts. Without
+				// this, OpenAI-compatible APIs only emit usage when the
+				// client explicitly opts in, leaving streaming requests
+				// un-billed.
+				bodyBytes = injectStreamUsageOption(bodyBytes)
+			}
+			r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+			r.ContentLength = int64(len(bodyBytes))
 		}
 	}
 
@@ -231,6 +253,40 @@ func detectStream(body []byte) bool {
 	return req.Stream
 }
 
+// injectStreamUsageOption ensures stream_options.include_usage is true in the
+// request body. OpenAI-compatible APIs only return token usage in streaming
+// responses when the client sets this flag. We inject it so every streaming
+// request is billable.
+func injectStreamUsageOption(body []byte) []byte {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(body, &obj); err != nil {
+		return body
+	}
+
+	streamOpts := map[string]bool{"include_usage": true}
+	// If the client already set stream_options, merge include_usage into it
+	if existing, ok := obj["stream_options"]; ok {
+		var opts map[string]json.RawMessage
+		if json.Unmarshal(existing, &opts) == nil {
+			val, _ := json.Marshal(true)
+			opts["include_usage"] = val
+			merged, _ := json.Marshal(opts)
+			obj["stream_options"] = merged
+			result, _ := json.Marshal(obj)
+			return result
+		}
+	}
+
+	// Set stream_options from scratch
+	soBytes, _ := json.Marshal(streamOpts)
+	obj["stream_options"] = soBytes
+	result, err := json.Marshal(obj)
+	if err != nil {
+		return body
+	}
+	return result
+}
+
 func extractConsumerKey(r *http.Request) string {
 	auth := r.Header.Get("Authorization")
 	if strings.HasPrefix(auth, "Bearer ") {
@@ -265,22 +321,45 @@ func (r *responseRecorder) Write(b []byte) (int, error) {
 }
 
 // streamRecorder intercepts streaming responses to extract usage from SSE chunks.
+// It buffers a partial line remainder across Write calls to handle SSE lines
+// that are split across flush boundaries.
 type streamRecorder struct {
 	http.ResponseWriter
-	flusher http.Flusher
-	usage   openAIUsage
+	flusher   http.Flusher
+	usage     openAIUsage
+	remainder []byte // partial line carried across Write boundaries
 }
 
 func (s *streamRecorder) Write(b []byte) (int, error) {
+	// Prepend any remainder from the previous Write
+	data := b
+	if len(s.remainder) > 0 {
+		data = append(s.remainder, b...)
+		s.remainder = nil
+	}
+
 	// Parse SSE lines from the chunk
-	scanner := bufio.NewScanner(bytes.NewReader(b))
+	scanner := bufio.NewScanner(bytes.NewReader(data))
 	for scanner.Scan() {
 		if usage, ok := extractUsageFromSSELine(scanner.Bytes()); ok {
 			s.usage = usage
 		}
 	}
 
-	// Always write through to the client
+	// If the data doesn't end with a newline, the last partial line was not
+	// scanned — save it as a remainder for the next Write.
+	if len(data) > 0 && data[len(data)-1] != '\n' {
+		// Find the last newline; everything after it is the remainder
+		lastNL := bytes.LastIndexByte(data, '\n')
+		if lastNL >= 0 {
+			s.remainder = append([]byte(nil), data[lastNL+1:]...)
+		} else {
+			// No newline at all — entire chunk is a partial line
+			s.remainder = append([]byte(nil), data...)
+		}
+	}
+
+	// Always write the original bytes through to the client
 	n, err := s.ResponseWriter.Write(b)
 	if s.flusher != nil {
 		s.flusher.Flush()

--- a/internal/gateway/metering.go
+++ b/internal/gateway/metering.go
@@ -1,0 +1,295 @@
+package gateway
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// MeteringMiddleware intercepts OpenAI-compatible API responses to extract
+// token usage and record billing transactions.
+type MeteringMiddleware struct {
+	next    http.Handler
+	ledger  *Ledger
+	acet    *ACETClient // may be nil if settlement is disabled
+	tier    PricingTier
+
+	// Accumulated stats (in-process, for the gateway's own use)
+	mu           sync.Mutex
+	totalIn      int
+	totalOut     int
+	totalCost    int
+	requestCount int
+}
+
+// NewMeteringMiddleware wraps a handler with token metering.
+// tier determines the ACET pricing. acet may be nil to skip settlement.
+func NewMeteringMiddleware(next http.Handler, ledger *Ledger, acet *ACETClient, tier PricingTier) *MeteringMiddleware {
+	return &MeteringMiddleware{
+		next:   next,
+		ledger: ledger,
+		acet:   acet,
+		tier:   tier,
+	}
+}
+
+// InProcessStats returns stats accumulated in this process (not from disk).
+func (m *MeteringMiddleware) InProcessStats() (totalIn, totalOut, totalCost, requestCount int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.totalIn, m.totalOut, m.totalCost, m.requestCount
+}
+
+func (m *MeteringMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Only meter OpenAI-compatible endpoints
+	if !isMeteredPath(r.URL.Path) {
+		m.next.ServeHTTP(w, r)
+		return
+	}
+
+	start := time.Now()
+
+	// Extract consumer key from Authorization header
+	consumerKey := extractConsumerKey(r)
+
+	// Detect if client requested streaming
+	isStream := false
+	if r.Body != nil {
+		// Peek at the body to check for "stream": true
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err == nil {
+			r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+			isStream = detectStream(bodyBytes)
+		}
+	}
+
+	if isStream {
+		m.handleStreamingResponse(w, r, start, consumerKey)
+	} else {
+		m.handleNonStreamingResponse(w, r, start, consumerKey)
+	}
+}
+
+// handleNonStreamingResponse captures the full response body to extract usage.
+func (m *MeteringMiddleware) handleNonStreamingResponse(w http.ResponseWriter, r *http.Request, start time.Time, consumerKey string) {
+	rec := &responseRecorder{
+		ResponseWriter: w,
+		body:           &bytes.Buffer{},
+		statusCode:     http.StatusOK,
+	}
+
+	m.next.ServeHTTP(rec, r)
+
+	latency := time.Since(start).Seconds() * 1000
+
+	// Extract usage from response
+	usage := extractUsageFromBody(rec.body.Bytes())
+	if usage.PromptTokens == 0 && usage.CompletionTokens == 0 {
+		return // no usage data, skip metering
+	}
+
+	m.recordUsage(usage, r.URL.Path, consumerKey, latency)
+}
+
+// handleStreamingResponse tees SSE chunks to the client while accumulating
+// token counts from the final usage chunk.
+func (m *MeteringMiddleware) handleStreamingResponse(w http.ResponseWriter, r *http.Request, start time.Time, consumerKey string) {
+	rec := &streamRecorder{
+		ResponseWriter: w,
+		flusher:        w.(http.Flusher),
+	}
+
+	m.next.ServeHTTP(rec, r)
+
+	latency := time.Since(start).Seconds() * 1000
+
+	// Parse accumulated SSE data for usage
+	usage := rec.usage
+	if usage.PromptTokens == 0 && usage.CompletionTokens == 0 {
+		return
+	}
+
+	m.recordUsage(usage, r.URL.Path, consumerKey, latency)
+}
+
+func (m *MeteringMiddleware) recordUsage(usage openAIUsage, path, consumerKey string, latencyMs float64) {
+	cost := CalculateACETCost(m.tier, usage.PromptTokens, usage.CompletionTokens)
+
+	// Update in-process stats
+	m.mu.Lock()
+	m.totalIn += usage.PromptTokens
+	m.totalOut += usage.CompletionTokens
+	m.totalCost += cost
+	m.requestCount++
+	m.mu.Unlock()
+
+	tx := Transaction{
+		Timestamp:   time.Now(),
+		Model:       usage.Model,
+		TokensIn:    usage.PromptTokens,
+		TokensOut:   usage.CompletionTokens,
+		ACETCost:    cost,
+		ConsumerKey: consumerKey,
+		Latency:     latencyMs,
+		Path:        path,
+	}
+
+	if err := m.ledger.Record(tx); err != nil {
+		log.Printf("[Gateway] ledger write error: %v", err)
+	}
+
+	// Settle with platform (async, non-blocking)
+	if m.acet != nil {
+		go func() {
+			if err := m.acet.Settle(usage.Model, usage.PromptTokens, usage.CompletionTokens, cost, consumerKey); err != nil {
+				log.Printf("[Gateway] ACET settlement queued: %v", err)
+			}
+		}()
+	}
+}
+
+// openAIUsage holds token counts from an OpenAI-compatible response.
+type openAIUsage struct {
+	PromptTokens     int    `json:"prompt_tokens"`
+	CompletionTokens int    `json:"completion_tokens"`
+	TotalTokens      int    `json:"total_tokens"`
+	Model            string `json:"-"` // extracted from the parent object
+}
+
+// openAIResponse is the minimal structure to extract usage from a response.
+type openAIResponse struct {
+	Model string       `json:"model"`
+	Usage *openAIUsage `json:"usage,omitempty"`
+}
+
+// openAIStreamChunk is a streaming chunk that may contain usage info.
+type openAIStreamChunk struct {
+	Model string       `json:"model"`
+	Usage *openAIUsage `json:"usage,omitempty"`
+}
+
+func extractUsageFromBody(body []byte) openAIUsage {
+	var resp openAIResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return openAIUsage{}
+	}
+	if resp.Usage == nil {
+		return openAIUsage{}
+	}
+	usage := *resp.Usage
+	usage.Model = resp.Model
+	return usage
+}
+
+func extractUsageFromSSELine(line []byte) (openAIUsage, bool) {
+	// SSE lines: "data: {json}" or "data: [DONE]"
+	line = bytes.TrimSpace(line)
+	if !bytes.HasPrefix(line, []byte("data: ")) {
+		return openAIUsage{}, false
+	}
+	data := bytes.TrimPrefix(line, []byte("data: "))
+	if bytes.Equal(data, []byte("[DONE]")) {
+		return openAIUsage{}, false
+	}
+
+	var chunk openAIStreamChunk
+	if err := json.Unmarshal(data, &chunk); err != nil {
+		return openAIUsage{}, false
+	}
+	if chunk.Usage == nil {
+		return openAIUsage{}, false
+	}
+	usage := *chunk.Usage
+	usage.Model = chunk.Model
+	return usage, true
+}
+
+// isMeteredPath returns true for OpenAI-compatible API paths.
+// Note: r.URL.Path never includes query strings, so exact match suffices.
+func isMeteredPath(path string) bool {
+	switch path {
+	case "/v1/chat/completions", "/v1/completions", "/v1/embeddings":
+		return true
+	}
+	return false
+}
+
+func detectStream(body []byte) bool {
+	// Quick check for "stream":true in the request body
+	var req struct {
+		Stream bool `json:"stream"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return false
+	}
+	return req.Stream
+}
+
+func extractConsumerKey(r *http.Request) string {
+	auth := r.Header.Get("Authorization")
+	if strings.HasPrefix(auth, "Bearer ") {
+		key := strings.TrimPrefix(auth, "Bearer ")
+		// Return prefix for privacy
+		if len(key) > 8 {
+			return key[:8] + "..."
+		}
+		return key
+	}
+	return "anonymous"
+}
+
+// responseRecorder captures the response body for non-streaming responses
+// while still writing to the underlying ResponseWriter.
+type responseRecorder struct {
+	http.ResponseWriter
+	body       *bytes.Buffer
+	statusCode int
+	wroteHeader bool
+}
+
+func (r *responseRecorder) WriteHeader(code int) {
+	r.statusCode = code
+	r.wroteHeader = true
+	r.ResponseWriter.WriteHeader(code)
+}
+
+func (r *responseRecorder) Write(b []byte) (int, error) {
+	r.body.Write(b)
+	return r.ResponseWriter.Write(b)
+}
+
+// streamRecorder intercepts streaming responses to extract usage from SSE chunks.
+type streamRecorder struct {
+	http.ResponseWriter
+	flusher http.Flusher
+	usage   openAIUsage
+}
+
+func (s *streamRecorder) Write(b []byte) (int, error) {
+	// Parse SSE lines from the chunk
+	scanner := bufio.NewScanner(bytes.NewReader(b))
+	for scanner.Scan() {
+		if usage, ok := extractUsageFromSSELine(scanner.Bytes()); ok {
+			s.usage = usage
+		}
+	}
+
+	// Always write through to the client
+	n, err := s.ResponseWriter.Write(b)
+	if s.flusher != nil {
+		s.flusher.Flush()
+	}
+	return n, err
+}
+
+func (s *streamRecorder) Flush() {
+	if s.flusher != nil {
+		s.flusher.Flush()
+	}
+}

--- a/internal/gateway/metering_test.go
+++ b/internal/gateway/metering_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestIsMeteredPath(t *testing.T) {
@@ -375,14 +376,87 @@ func TestMeteringMiddleware_WithACETSettlement(t *testing.T) {
 	select {
 	case <-settleCalled:
 		// success
-	case <-func() <-chan struct{} {
-		ch := make(chan struct{})
-		go func() {
-			// Give it a second
-			<-make(chan struct{})
-		}()
-		return ch
-	}():
-		// We don't wait forever, just check it was called
+	case <-time.After(2 * time.Second):
+		t.Error("timed out waiting for ACET settlement call")
+	}
+}
+
+func TestInjectStreamUsageOption(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantKey  bool
+		wantVal  bool
+	}{
+		{
+			name:    "adds stream_options when absent",
+			input:   `{"model":"gpt-4","stream":true}`,
+			wantKey: true,
+			wantVal: true,
+		},
+		{
+			name:    "preserves existing stream_options and adds include_usage",
+			input:   `{"model":"gpt-4","stream":true,"stream_options":{"other":true}}`,
+			wantKey: true,
+			wantVal: true,
+		},
+		{
+			name:    "preserves include_usage when already true",
+			input:   `{"model":"gpt-4","stream":true,"stream_options":{"include_usage":true}}`,
+			wantKey: true,
+			wantVal: true,
+		},
+		{
+			name:    "overrides include_usage when false",
+			input:   `{"model":"gpt-4","stream":true,"stream_options":{"include_usage":false}}`,
+			wantKey: true,
+			wantVal: true,
+		},
+		{
+			name:  "returns original on invalid JSON",
+			input: `not json`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := injectStreamUsageOption([]byte(tt.input))
+
+			if !tt.wantKey {
+				// Should be unchanged for invalid input
+				if string(result) != tt.input {
+					t.Errorf("expected unchanged input for invalid JSON")
+				}
+				return
+			}
+
+			var obj map[string]json.RawMessage
+			if err := json.Unmarshal(result, &obj); err != nil {
+				t.Fatalf("result is not valid JSON: %v", err)
+			}
+
+			soRaw, ok := obj["stream_options"]
+			if !ok {
+				t.Fatal("stream_options key missing from result")
+			}
+
+			var so map[string]interface{}
+			if err := json.Unmarshal(soRaw, &so); err != nil {
+				t.Fatalf("stream_options is not a JSON object: %v", err)
+			}
+
+			includeUsage, ok := so["include_usage"]
+			if !ok {
+				t.Fatal("include_usage key missing from stream_options")
+			}
+			if includeUsage != true {
+				t.Errorf("include_usage = %v, want true", includeUsage)
+			}
+
+			// Verify model field is preserved
+			if _, ok := obj["model"]; !ok {
+				t.Error("model field lost during injection")
+			}
+		})
 	}
 }

--- a/internal/gateway/metering_test.go
+++ b/internal/gateway/metering_test.go
@@ -1,0 +1,388 @@
+package gateway
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestIsMeteredPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/v1/chat/completions", true},
+		{"/v1/completions", true},
+		{"/v1/embeddings", true},
+		{"/v1/models", false},
+		{"/health", false},
+		{"/", false},
+		{"/v1/chat", false},
+	}
+
+	for _, tt := range tests {
+		got := isMeteredPath(tt.path)
+		if got != tt.want {
+			t.Errorf("isMeteredPath(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestExtractConsumerKey(t *testing.T) {
+	tests := []struct {
+		auth string
+		want string
+	}{
+		{"Bearer sk-12345678abcdefgh", "sk-12345..."},
+		{"Bearer short", "short"},
+		{"Bearer 12345678", "12345678"},
+		{"", "anonymous"},
+		{"Basic dXNlcjpwYXNz", "anonymous"},
+	}
+
+	for _, tt := range tests {
+		r := httptest.NewRequest(http.MethodPost, "/", nil)
+		if tt.auth != "" {
+			r.Header.Set("Authorization", tt.auth)
+		}
+		got := extractConsumerKey(r)
+		if got != tt.want {
+			t.Errorf("auth=%q: got %q, want %q", tt.auth, got, tt.want)
+		}
+	}
+}
+
+func TestDetectStream(t *testing.T) {
+	tests := []struct {
+		body string
+		want bool
+	}{
+		{`{"model":"gpt-4","stream":true}`, true},
+		{`{"model":"gpt-4","stream":false}`, false},
+		{`{"model":"gpt-4"}`, false},
+		{`invalid json`, false},
+	}
+
+	for _, tt := range tests {
+		got := detectStream([]byte(tt.body))
+		if got != tt.want {
+			t.Errorf("detectStream(%q) = %v, want %v", tt.body, got, tt.want)
+		}
+	}
+}
+
+func TestExtractUsageFromBody(t *testing.T) {
+	body := `{
+		"id": "chatcmpl-123",
+		"model": "llama-7b",
+		"choices": [{"message": {"content": "Hello!"}}],
+		"usage": {
+			"prompt_tokens": 100,
+			"completion_tokens": 50,
+			"total_tokens": 150
+		}
+	}`
+
+	usage := extractUsageFromBody([]byte(body))
+	if usage.PromptTokens != 100 {
+		t.Errorf("prompt_tokens = %d, want 100", usage.PromptTokens)
+	}
+	if usage.CompletionTokens != 50 {
+		t.Errorf("completion_tokens = %d, want 50", usage.CompletionTokens)
+	}
+	if usage.Model != "llama-7b" {
+		t.Errorf("model = %q, want llama-7b", usage.Model)
+	}
+}
+
+func TestExtractUsageFromBody_NoUsage(t *testing.T) {
+	body := `{"id":"chatcmpl-123","model":"llama-7b","choices":[]}`
+	usage := extractUsageFromBody([]byte(body))
+	if usage.PromptTokens != 0 || usage.CompletionTokens != 0 {
+		t.Errorf("expected zero usage, got %+v", usage)
+	}
+}
+
+func TestExtractUsageFromSSELine(t *testing.T) {
+	tests := []struct {
+		name  string
+		line  string
+		want  bool
+		in    int
+		out   int
+		model string
+	}{
+		{
+			name: "usage chunk",
+			line: `data: {"model":"llama-7b","usage":{"prompt_tokens":100,"completion_tokens":50,"total_tokens":150}}`,
+			want: true, in: 100, out: 50, model: "llama-7b",
+		},
+		{
+			name: "content chunk (no usage)",
+			line: `data: {"model":"llama-7b","choices":[{"delta":{"content":"Hello"}}]}`,
+			want: false,
+		},
+		{
+			name: "done marker",
+			line: `data: [DONE]`,
+			want: false,
+		},
+		{
+			name: "empty line",
+			line: ``,
+			want: false,
+		},
+		{
+			name: "non-data line",
+			line: `event: message`,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			usage, ok := extractUsageFromSSELine([]byte(tt.line))
+			if ok != tt.want {
+				t.Errorf("ok = %v, want %v", ok, tt.want)
+			}
+			if ok {
+				if usage.PromptTokens != tt.in {
+					t.Errorf("prompt_tokens = %d, want %d", usage.PromptTokens, tt.in)
+				}
+				if usage.CompletionTokens != tt.out {
+					t.Errorf("completion_tokens = %d, want %d", usage.CompletionTokens, tt.out)
+				}
+				if usage.Model != tt.model {
+					t.Errorf("model = %q, want %q", usage.Model, tt.model)
+				}
+			}
+		})
+	}
+}
+
+func TestMeteringMiddleware_NonStreaming(t *testing.T) {
+	dir := t.TempDir()
+	ledger := NewLedger(dir)
+	tier, _ := TierByName("small")
+
+	// Backend returns an OpenAI-compatible response with usage
+	backend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"id":    "chatcmpl-test",
+			"model": "llama-7b",
+			"choices": []map[string]interface{}{
+				{"message": map[string]string{"content": "Hello!"}},
+			},
+			"usage": map[string]int{
+				"prompt_tokens":     200,
+				"completion_tokens": 100,
+				"total_tokens":      300,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	middleware := NewMeteringMiddleware(backend, ledger, nil, tier)
+	server := httptest.NewServer(middleware)
+	defer server.Close()
+
+	// Non-streaming request
+	body := `{"model":"llama-7b","messages":[{"role":"user","content":"Hi"}]}`
+	resp, err := http.Post(server.URL+"/v1/chat/completions", "application/json",
+		strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+
+	// Check in-process stats
+	totalIn, totalOut, totalCost, reqCount := middleware.InProcessStats()
+	if totalIn != 200 {
+		t.Errorf("totalIn = %d, want 200", totalIn)
+	}
+	if totalOut != 100 {
+		t.Errorf("totalOut = %d, want 100", totalOut)
+	}
+	// Small tier: 300 tokens * 1/1K = ceil(0.3) = 1 ACET
+	if totalCost != 1 {
+		t.Errorf("totalCost = %d, want 1", totalCost)
+	}
+	if reqCount != 1 {
+		t.Errorf("requestCount = %d, want 1", reqCount)
+	}
+
+	// Check ledger
+	recent, err := ledger.Recent(10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recent) != 1 {
+		t.Fatalf("ledger has %d records, want 1", len(recent))
+	}
+	if recent[0].Model != "llama-7b" {
+		t.Errorf("model = %q, want llama-7b", recent[0].Model)
+	}
+}
+
+func TestMeteringMiddleware_Streaming(t *testing.T) {
+	dir := t.TempDir()
+	ledger := NewLedger(dir)
+	tier, _ := TierByName("medium")
+
+	// Backend returns SSE chunks with usage in the final chunk
+	backend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("expected flusher")
+		}
+
+		// Content chunks
+		chunks := []string{
+			`data: {"model":"llama-70b","choices":[{"delta":{"content":"Hello"}}]}`,
+			`data: {"model":"llama-70b","choices":[{"delta":{"content":" world"}}]}`,
+			// Final chunk with usage (when stream_options.include_usage=true)
+			`data: {"model":"llama-70b","usage":{"prompt_tokens":500,"completion_tokens":200,"total_tokens":700}}`,
+			`data: [DONE]`,
+		}
+		for _, chunk := range chunks {
+			fmt.Fprintf(w, "%s\n\n", chunk)
+			flusher.Flush()
+		}
+	})
+
+	middleware := NewMeteringMiddleware(backend, ledger, nil, tier)
+	server := httptest.NewServer(middleware)
+	defer server.Close()
+
+	body := `{"model":"llama-70b","messages":[{"role":"user","content":"Hi"}],"stream":true}`
+	resp, err := http.Post(server.URL+"/v1/chat/completions", "application/json",
+		strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	// Read the full response
+	var buf bytes.Buffer
+	buf.ReadFrom(resp.Body)
+
+	// Verify content was passed through
+	if !strings.Contains(buf.String(), "Hello") {
+		t.Error("response should contain streamed content")
+	}
+
+	// Check metering captured the usage
+	totalIn, totalOut, totalCost, reqCount := middleware.InProcessStats()
+	if totalIn != 500 {
+		t.Errorf("totalIn = %d, want 500", totalIn)
+	}
+	if totalOut != 200 {
+		t.Errorf("totalOut = %d, want 200", totalOut)
+	}
+	// Medium tier: 700 tokens * 5/1K = ceil(3.5) = 4 ACET
+	if totalCost != 4 {
+		t.Errorf("totalCost = %d, want 4", totalCost)
+	}
+	if reqCount != 1 {
+		t.Errorf("requestCount = %d, want 1", reqCount)
+	}
+}
+
+func TestMeteringMiddleware_NonMeteredPath(t *testing.T) {
+	dir := t.TempDir()
+	ledger := NewLedger(dir)
+	tier, _ := TierByName("small")
+
+	called := false
+	backend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	middleware := NewMeteringMiddleware(backend, ledger, nil, tier)
+	server := httptest.NewServer(middleware)
+	defer server.Close()
+
+	// Request to a non-metered path
+	resp, err := http.Get(server.URL + "/v1/models")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	if !called {
+		t.Error("backend should have been called")
+	}
+
+	// No transactions should be recorded
+	_, _, _, reqCount := middleware.InProcessStats()
+	if reqCount != 0 {
+		t.Errorf("requestCount = %d, want 0 for non-metered path", reqCount)
+	}
+}
+
+func TestMeteringMiddleware_WithACETSettlement(t *testing.T) {
+	dir := t.TempDir()
+	ledger := NewLedger(dir)
+	tier, _ := TierByName("small")
+
+	settleCalled := make(chan bool, 1)
+	settleServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/acet/settle" {
+			settleCalled <- true
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer settleServer.Close()
+
+	acet := NewACETClient(settleServer.URL, "test")
+
+	backend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"model": "test-model",
+			"usage": map[string]int{
+				"prompt_tokens":     100,
+				"completion_tokens": 50,
+				"total_tokens":      150,
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	middleware := NewMeteringMiddleware(backend, ledger, acet, tier)
+	server := httptest.NewServer(middleware)
+	defer server.Close()
+
+	body := `{"model":"test-model","messages":[{"role":"user","content":"Hi"}]}`
+	resp, err := http.Post(server.URL+"/v1/chat/completions", "application/json",
+		strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	// Settlement should happen asynchronously
+	select {
+	case <-settleCalled:
+		// success
+	case <-func() <-chan struct{} {
+		ch := make(chan struct{})
+		go func() {
+			// Give it a second
+			<-make(chan struct{})
+		}()
+		return ch
+	}():
+		// We don't wait forever, just check it was called
+	}
+}

--- a/internal/tui/controlcenter/controlcenter.go
+++ b/internal/tui/controlcenter/controlcenter.go
@@ -602,6 +602,9 @@ func (cc *ControlCenter) Run() error {
 		cc.AddActivity("info", "Control center started")
 		go cc.autoRefreshLoop()
 
+		// Show the Gateway tab if the ledger file exists (gateway is or was running)
+		go cc.gatewayVisibilityLoop(gatewayBaseDir)
+
 		// Show context-aware suggestion after startup
 		time.Sleep(500 * time.Millisecond)
 		cc.app.QueueUpdateDraw(func() {
@@ -1989,6 +1992,29 @@ func (cc *ControlCenter) autoRefreshLoop() {
 			return
 		case <-ticker.C:
 			cc.refresh()
+		}
+	}
+}
+
+// gatewayVisibilityLoop checks for the gateway ledger file and shows the
+// Gateway tab when it appears. Once shown, the loop exits — the tab stays
+// visible for the remainder of the session.
+func (cc *ControlCenter) gatewayVisibilityLoop(baseDir string) {
+	ledgerPath := filepath.Join(baseDir, "gateway", "transactions.jsonl")
+
+	// Check immediately, then poll every 5 seconds
+	for {
+		if _, err := os.Stat(ledgerPath); err == nil {
+			cc.app.QueueUpdateDraw(func() {
+				cc.pmgr.Show("gateway")
+			})
+			return
+		}
+
+		select {
+		case <-cc.stopChan:
+			return
+		case <-time.After(5 * time.Second):
 		}
 	}
 }

--- a/internal/tui/controlcenter/controlcenter.go
+++ b/internal/tui/controlcenter/controlcenter.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -577,7 +578,10 @@ func (cc *ControlCenter) Run() error {
 	// Alt+3: Chat page (hidden until network is connected and org is known)
 	cc.chatPage = NewChatPage(cc.chatConfig)
 	cc.pmgr.Register(cc.chatPage, false)
-	cc.pmgr.Register(NewPlaceholderPage("services", "Services"), false)
+
+	// Alt+4: Gateway page (hidden until gateway ledger appears on disk)
+	gatewayBaseDir := filepath.Join(os.Getenv("HOME"), ".citadel-cli")
+	cc.pmgr.Register(NewGatewayPage(gatewayBaseDir), false)
 	cc.pmgr.Register(NewPlaceholderPage("jobs", "Jobs"), false)
 	cc.pmgr.Register(NewPlaceholderPage("network", "Network"), false)
 

--- a/internal/tui/controlcenter/gateway_page.go
+++ b/internal/tui/controlcenter/gateway_page.go
@@ -1,0 +1,244 @@
+package controlcenter
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/gateway"
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+// GatewayPage displays gateway metering stats and recent transactions.
+// It reads data from the on-disk transaction ledger, so it works across
+// processes (the gateway runs via `citadel gateway`, the TUI via `citadel`).
+type GatewayPage struct {
+	name  string
+	title string
+	app   *tview.Application
+
+	// UI components
+	root         *tview.Flex
+	statusView   *tview.TextView
+	statsView    *tview.TextView
+	recentTable  *tview.Table
+	endpointView *tview.TextView
+
+	// Data
+	ledger  *gateway.Ledger
+	mu      sync.Mutex
+	stats   gateway.Stats
+	recent  []gateway.Transaction
+	active  bool
+	stopCh  chan struct{}
+}
+
+// NewGatewayPage creates a gateway page backed by a ledger at the given
+// base directory (typically ~/.citadel-cli).
+func NewGatewayPage(baseDir string) *GatewayPage {
+	return &GatewayPage{
+		name:   "gateway",
+		title:  "Gateway",
+		ledger: gateway.NewLedger(baseDir),
+	}
+}
+
+func (g *GatewayPage) Name() string  { return g.name }
+func (g *GatewayPage) Title() string { return g.title }
+
+func (g *GatewayPage) Build(app *tview.Application) tview.Primitive {
+	g.app = app
+
+	// Status bar (top)
+	g.statusView = tview.NewTextView().
+		SetDynamicColors(true).
+		SetTextAlign(tview.AlignLeft)
+
+	// Stats panel
+	g.statsView = tview.NewTextView().
+		SetDynamicColors(true)
+	g.statsView.SetBorder(true).
+		SetTitle(" Earnings ").
+		SetTitleAlign(tview.AlignLeft)
+
+	// Recent requests table
+	g.recentTable = tview.NewTable().
+		SetFixed(1, 0).
+		SetSelectable(true, false)
+	g.recentTable.SetBorder(true).
+		SetTitle(" Recent Requests ").
+		SetTitleAlign(tview.AlignLeft)
+
+	// Endpoint info (bottom)
+	g.endpointView = tview.NewTextView().
+		SetDynamicColors(true).
+		SetTextAlign(tview.AlignLeft)
+
+	// Layout
+	g.root = tview.NewFlex().SetDirection(tview.FlexRow).
+		AddItem(g.statusView, 1, 0, false).
+		AddItem(g.statsView, 7, 0, false).
+		AddItem(g.recentTable, 0, 1, true).
+		AddItem(g.endpointView, 1, 0, false)
+
+	g.updateStatus()
+	g.updateStats()
+	g.updateRecentTable()
+	g.updateEndpoint()
+
+	return g.root
+}
+
+func (g *GatewayPage) OnActivate() {
+	g.mu.Lock()
+	g.active = true
+	g.stopCh = make(chan struct{})
+	g.mu.Unlock()
+
+	// Start polling the ledger for updates
+	go g.pollLoop()
+}
+
+func (g *GatewayPage) OnDeactivate() {
+	g.mu.Lock()
+	g.active = false
+	if g.stopCh != nil {
+		close(g.stopCh)
+		g.stopCh = nil
+	}
+	g.mu.Unlock()
+}
+
+func (g *GatewayPage) HandleInput(event *tcell.EventKey) *tcell.EventKey {
+	return event
+}
+
+// pollLoop reads the ledger from disk every 2 seconds and updates the UI.
+func (g *GatewayPage) pollLoop() {
+	g.refreshData()
+
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		g.mu.Lock()
+		stopCh := g.stopCh
+		g.mu.Unlock()
+
+		select {
+		case <-stopCh:
+			return
+		case <-ticker.C:
+			g.refreshData()
+		}
+	}
+}
+
+func (g *GatewayPage) refreshData() {
+	stats, err := g.ledger.StatsFromDisk()
+	if err != nil {
+		return
+	}
+	recent, err := g.ledger.Recent(20)
+	if err != nil {
+		return
+	}
+
+	g.mu.Lock()
+	g.stats = stats
+	g.recent = recent
+	g.mu.Unlock()
+
+	g.app.QueueUpdateDraw(func() {
+		g.updateStatus()
+		g.updateStats()
+		g.updateRecentTable()
+	})
+}
+
+func (g *GatewayPage) updateStatus() {
+	g.mu.Lock()
+	s := g.stats
+	g.mu.Unlock()
+
+	if s.TotalRequests > 0 {
+		g.statusView.SetText(" [green::b]Gateway[-:-:-]                    [green]● Active[-]")
+	} else {
+		g.statusView.SetText(" [yellow::b]Gateway[-:-:-]                    [gray]○ No activity[-]")
+	}
+}
+
+func (g *GatewayPage) updateStats() {
+	g.mu.Lock()
+	s := g.stats
+	g.mu.Unlock()
+
+	todayDollars := float64(s.TodayEarnings) * 0.001
+	totalDollars := float64(s.TotalEarnings) * 0.001
+	avgLatency := s.AvgLatency
+
+	text := fmt.Sprintf(
+		" [white::b]Earnings Today[white:-:-]    [green]▲ %d ACET[-]  ($%.3f)\n"+
+			" [white::b]Total Earnings[white:-:-]      %d ACET  ($%.2f)\n"+
+			" [white::b]Requests Today[white:-:-]      %d\n"+
+			" [white::b]Total Requests[white:-:-]      %d\n"+
+			" [white::b]Avg Latency[white:-:-]         %.0fms",
+		s.TodayEarnings, todayDollars,
+		s.TotalEarnings, totalDollars,
+		s.TodayRequests,
+		s.TotalRequests,
+		avgLatency,
+	)
+	g.statsView.SetText(text)
+}
+
+func (g *GatewayPage) updateRecentTable() {
+	g.mu.Lock()
+	recent := g.recent
+	g.mu.Unlock()
+
+	g.recentTable.Clear()
+
+	// Header row
+	headers := []string{"Time", "Method", "Path", "Model", "Tokens", "ACET", "Latency"}
+	for i, h := range headers {
+		cell := tview.NewTableCell(h).
+			SetTextColor(tcell.ColorYellow).
+			SetSelectable(false).
+			SetExpansion(1)
+		if i == 0 {
+			cell.SetExpansion(0)
+		}
+		g.recentTable.SetCell(0, i, cell)
+	}
+
+	if len(recent) == 0 {
+		g.recentTable.SetCell(1, 0,
+			tview.NewTableCell("  No requests yet").
+				SetTextColor(tcell.ColorGray).
+				SetSelectable(false).
+				SetExpansion(1))
+		return
+	}
+
+	for i, tx := range recent {
+		row := i + 1
+		timeStr := tx.Timestamp.Format("15:04:05")
+		tokenStr := fmt.Sprintf("%d/%d", tx.TokensIn, tx.TokensOut)
+		acetStr := fmt.Sprintf("%d", tx.ACETCost)
+		latencyStr := fmt.Sprintf("%.0fms", tx.Latency)
+
+		g.recentTable.SetCell(row, 0, tview.NewTableCell(timeStr).SetTextColor(tcell.ColorWhite))
+		g.recentTable.SetCell(row, 1, tview.NewTableCell("POST").SetTextColor(tcell.ColorWhite))
+		g.recentTable.SetCell(row, 2, tview.NewTableCell(tx.Path).SetTextColor(tcell.ColorWhite).SetExpansion(1))
+		g.recentTable.SetCell(row, 3, tview.NewTableCell(tx.Model).SetTextColor(tcell.ColorAqua).SetExpansion(1))
+		g.recentTable.SetCell(row, 4, tview.NewTableCell(tokenStr).SetTextColor(tcell.ColorWhite))
+		g.recentTable.SetCell(row, 5, tview.NewTableCell(acetStr).SetTextColor(tcell.ColorGreen))
+		g.recentTable.SetCell(row, 6, tview.NewTableCell(latencyStr).SetTextColor(tcell.ColorWhite))
+	}
+}
+
+func (g *GatewayPage) updateEndpoint() {
+	g.endpointView.SetText(" [gray]Endpoint: http://localhost:8080/v1  |  Start with: citadel gateway[-]")
+}


### PR DESCRIPTION
## Context

Closes #227

The Sovereign Compute Fabric lets operators earn ACET tokens by serving inference through their Citadel nodes. This PR adds the "run your own API endpoint" experience: a local HTTP reverse proxy that sits in front of any OpenAI-compatible inference engine (vLLM, Ollama, etc.) and meters every request with ACET billing.

The gateway runs as `citadel gateway` and the TUI shows a real-time earnings dashboard that reads the transaction ledger from disk -- no in-process coupling between the proxy and the dashboard.

## Summary

### Metering Middleware (`internal/gateway/metering.go`)
- **`MeteringMiddleware`** -- wraps any `http.Handler`, intercepts `/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`
- Extracts token usage from both **streaming** (SSE `text/event-stream`) and **non-streaming** JSON responses
- **Injects `stream_options.include_usage=true`** into streaming request bodies so upstreams always return usage data (without this, OpenAI-compatible APIs silently omit usage in streams)
- Buffers SSE line remainder across `Write()` boundaries to handle lines split across flush calls
- `WrapHandler()` factory method for use with `Server.SetMetering()` (existing gateway integration)

### ACET Billing (`internal/gateway/acet.go`)
- Pricing tiers: Small 0-8B (1 ACET/1K), Medium 8-70B (5), Large 70-400B (25), XLarge 400B+ (100)
- `CalculateACETCost()` with ceiling arithmetic (small jobs never round to zero)
- `OperatorShare()` / `PlatformShare()` with 80/20 split, operator gets `ceil(80%)`
- `ACETClient` with `Settle()` calls to platform `/acet/settle` endpoint
- Offline settlement queue for connectivity resilience with periodic flush

### Transaction Ledger (`internal/gateway/ledger.go`)
- Append-only JSONL at `~/.citadel-cli/gateway/transactions.jsonl`
- `StatsFromDisk()` for cross-process reads (TUI reads what the gateway writes)
- `computeStats()` applies operator share per-transaction for accurate earnings

### Gateway Server Integration (`internal/gateway/gateway.go`)
- Added `SetMetering(*MeteringMiddleware)` to `Server` so the existing HTTPS gateway can opt into ACET metering
- `BuildHandler()` now applies metering in the middleware chain: logging -> permissions -> metering -> mux

### TUI Gateway Page (`internal/tui/controlcenter/gateway_page.go`)
- Implements `Page` interface with status bar, earnings panel, recent requests table, endpoint info
- Polls ledger from disk every 2 seconds via goroutine with `app.QueueUpdateDraw()`
- Hidden by default; `gatewayVisibilityLoop` in `controlcenter.go` surfaces the tab when the ledger file appears on disk

### CLI Command (`cmd/gateway.go`)
- `citadel gateway` with flags: `--port`, `--upstream`, `--model-tier`, `--api-token`, `--platform`
- Creates reverse proxy to upstream, wraps with `MeteringMiddleware`
- Graceful shutdown on SIGINT/SIGTERM; periodic offline queue flush every 30s

## Caveats

1. **`/acet/settle` endpoint** -- the settlement client assumes a platform endpoint at `{baseURL}/acet/settle`. This endpoint exists in the AceTeam Python backend but the request schema assumed here (model, tokens_in, tokens_out, acet_cost, consumer_key) needs validation against the actual endpoint.

2. **`CheckBalance` not wired as pre-flight** -- the architecture diagram shows a pre-request balance check, but it's not wired into the middleware. The function exists and can be enabled later, gated by `ACET_BILLING_ENABLED`.

3. **Streaming usage injection** -- `stream_options.include_usage=true` is injected into all streaming requests. This is an OpenAI API extension that Ollama and vLLM support, but very old inference engines may reject the unknown field.

## Test plan

| Area | Tests | Coverage |
|------|-------|----------|
| ACET pricing | 8 | All tiers, edge cases (0 tokens, large counts) |
| Operator/platform split | 6 | Rounding, small amounts, zero, exact multiples |
| Settlement client | 2 | HTTP settle + offline queue flush |
| Balance check | 1 | Mock HTTP response parsing |
| Tier lookup | 2 | Valid names + unknown tier |
| Ledger I/O | 4 | Record/recent, stats, empty file, operator ceiling |
| Metered paths | 1 | 7 path cases |
| Consumer key extraction | 1 | 5 auth header variants |
| Stream detection | 1 | 4 body variants |
| Usage extraction (body) | 2 | With/without usage |
| Usage extraction (SSE) | 1 | 5 line variants |
| Middleware (non-streaming) | 1 | Full request cycle + ledger verification |
| Middleware (streaming) | 1 | SSE pass-through + usage capture |
| Middleware (non-metered) | 1 | Pass-through without recording |
| ACET settlement integration | 1 | Async settle with timeout guard |
| Stream usage injection | 5 | Add/merge/preserve/override/invalid |
| **Total** | **39** | |

All tests pass with `CGO_ENABLED=0 go build ./...` and `go test ./internal/gateway/... -v -count=1`.