### PR TITLE
fix: guard release.sh against dirty working tree

### DIFF
--- a/scripts/release-engine.sh
+++ b/scripts/release-engine.sh
@@ -239,12 +239,23 @@ declare -F hook_post_release &>/dev/null || hook_post_release() { true; }
 run_release() {
   local bump_type="${1:-minor}"
   local dry_run="${DRY_RUN:-false}"
+  local allow_dirty="${ALLOW_DIRTY:-false}"
 
   log "=== Release started: bump=$bump_type dry_run=$dry_run ==="
 
   # ── Step 1: Validate ──────────────────────────────────────────────────
   if ! step_done "validate"; then
     step_msg "Validating prerequisites..."
+
+    # Clean-tree check: catches untracked, modified, and staged changes.
+    # Runs in all modes (including --dry-run) to prevent dirty releases.
+    if [[ "$allow_dirty" != "true" ]]; then
+      if [[ -n "$(git status --porcelain 2>/dev/null)" ]]; then
+        fatal "Working tree is not clean. Commit, stash, or remove untracked files first.\n       Use --allow-dirty to override."
+      fi
+    else
+      warn "Skipping clean-tree check (--allow-dirty)."
+    fi
 
     local current_branch
     current_branch=$(git branch --show-current)
@@ -257,10 +268,6 @@ run_release() {
     fi
 
     if [[ "$dry_run" != "true" ]]; then
-      if ! git diff --quiet HEAD -- 2>/dev/null || [[ -n "$(git status --porcelain --untracked-files=no 2>/dev/null)" ]]; then
-        fatal "Working directory has uncommitted changes. Commit or stash first."
-      fi
-
       log_and_info "Pulling latest from origin..."
       git pull --ff-only origin main || fatal "Failed to pull. Resolve conflicts first."
     fi
@@ -458,10 +465,11 @@ engine_main() {
 
   while [[ $# -gt 0 ]]; do
     case $1 in
-      --dry-run)   DRY_RUN=true; shift ;;
-      --status)    show_status; exit 0 ;;
-      --clean)     clear_state; exit 0 ;;
-      --resume)    shift ;; # resume is the default behavior
+      --dry-run)      DRY_RUN=true; shift ;;
+      --allow-dirty)  ALLOW_DIRTY=true; shift ;;
+      --status)       show_status; exit 0 ;;
+      --clean)        clear_state; exit 0 ;;
+      --resume)       shift ;; # resume is the default behavior
       -h|--help)
         echo "Usage: $0 [OPTIONS] [BUMP_TYPE]"
         echo ""
@@ -472,11 +480,12 @@ engine_main() {
         echo "  X.Y.Z      Explicit version"
         echo ""
         echo "Options:"
-        echo "  --dry-run   Preview changes without modifying anything"
-        echo "  --status    Show current release state and last run info"
-        echo "  --resume    Resume a failed release (default behavior)"
-        echo "  --clean     Clear release state and start fresh"
-        echo "  -h, --help  Show this help"
+        echo "  --dry-run       Preview changes without modifying anything"
+        echo "  --allow-dirty   Allow release from a dirty working tree"
+        echo "  --status        Show current release state and last run info"
+        echo "  --resume        Resume a failed release (default behavior)"
+        echo "  --clean         Clear release state and start fresh"
+        echo "  -h, --help      Show this help"
         echo ""
         echo "Project: ${RELEASE_PROJECT_NAME:-unknown}"
         echo "Tag prefix: ${RELEASE_TAG_PREFIX:-v}"


### PR DESCRIPTION
## Context

Fixes #245. The release script shipped a build with uncommitted/changed files, producing a dirty release that didn't match the tagged commit.

**Root cause:** The clean-tree check in `release-engine.sh` had two gaps:
1. It used `--untracked-files=no`, so untracked files passed validation but got swept into the release commit by `git add -A`
2. It was inside the `if [[ "$dry_run" != "true" ]]` gate, so `--dry-run` never validated tree cleanliness

## Summary

- Replace the old compound check (`git diff --quiet` + `git status --porcelain --untracked-files=no`) with a single `git status --porcelain` that catches all dirty state: untracked, modified, and staged files
- Move the check above the dry-run gate so it runs in all modes
- Add `--allow-dirty` flag for exceptional overrides, consistent with the existing flag pattern (`--dry-run`, `--status`, etc.)
- Update `--help` output to document the new flag

**Note:** `release-engine.sh` is vendored across repos (citadel-cli, citadel-os). This fix should be propagated to the canonical source and other copies.

## Test plan

| Scenario | Expected | Result |
|----------|----------|--------|
| Modified tracked file + `--dry-run` | Abort with error | Pass |
| Untracked file + `--dry-run` | Abort with error (the bug) | Pass |
| `--allow-dirty --dry-run` | Warn and continue | Pass |
| Clean tree + `--dry-run` | Normal operation | Pass |
| `--help` | Shows `--allow-dirty` | Pass |