### PR TITLE
fix: prevent node ID churn on restart + log registration to file

### DIFF
--- a/cmd/reconnect.go
+++ b/cmd/reconnect.go
@@ -147,37 +147,45 @@ func attemptVPNRecovery(ctx context.Context, deviceConfig *DeviceConfig, hostnam
 // 'citadel reconnect'). Also used by the --force path to avoid
 // duplicating fetch+connect logic.
 func recoverStaleVPN(ctx context.Context, deviceConfig *DeviceConfig, hostname, apiBaseURL string) VPNRecoveryResult {
-	Debug("VPN state is stale, attempting recovery...")
+	Log("VPN state is stale, attempting recovery (state_dir=%s, has_state=%v)...",
+		network.GetStateDir(), network.HasState())
 
 	if deviceConfig == nil || deviceConfig.DeviceAPIToken == "" {
+		Log("no device API token available for auto-recovery")
 		return VPNRecoveryResult{
 			Err: fmt.Errorf("no device API token available for auto-recovery"),
 		}
 	}
 
 	// Fetch a fresh authkey from the platform
-	Debug("requesting fresh authkey from %s", apiBaseURL)
+	Log("requesting fresh authkey from %s", apiBaseURL)
 	freshKey, fetchErr := network.FetchFreshAuthkey(ctx, apiBaseURL, deviceConfig.DeviceAPIToken)
 	if fetchErr != nil {
-		Debug("failed to fetch fresh authkey: %v", fetchErr)
+		Log("failed to fetch fresh authkey: %v", fetchErr)
 		return VPNRecoveryResult{
 			Err: fmt.Errorf("could not fetch fresh authkey: %w", fetchErr),
 		}
 	}
 
 	// Attempt 1: reconnect with existing state + fresh key (preserves IP)
-	Debug("attempting reconnect with existing state (IP-preserving)...")
+	Log("attempting reconnect with existing state (IP-preserving)...")
 	if ok, reconnErr := network.ReconnectWithAuthKey(ctx, freshKey); reconnErr == nil && ok {
-		Debug("reconnected with existing state (IP preserved)")
+		Log("reconnected with existing state (IP preserved)")
 		return VPNRecoveryResult{Connected: true, IPPreserved: true}
 	} else {
-		Debug("IP-preserving reconnect failed: %v", reconnErr)
+		Log("IP-preserving reconnect failed: %v", reconnErr)
 	}
 
-	// Attempt 2: clear state and connect from scratch (new IP/hostname)
-	Debug("clearing state for fresh connect...")
+	// Attempt 2: clear state and connect from scratch (new IP/hostname).
+	// Before clearing, reclaim the stale Headscale node so the dashboard
+	// doesn't accumulate duplicate entries on every restart (issue #246).
+	if deviceConfig.DeviceAPIToken != "" && hostname != "" {
+		Log("reclaiming stale node '%s' before fresh connect...", hostname)
+		reclaimStaleNodeByHostname(deviceConfig.DeviceAPIToken, hostname)
+	}
+	Log("clearing state for fresh connect...")
 	if clearErr := network.ClearState(); clearErr != nil {
-		Debug("failed to clear network state: %v", clearErr)
+		Log("failed to clear network state: %v", clearErr)
 	}
 	freshCtx, freshCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer freshCancel()
@@ -189,11 +197,11 @@ func recoverStaleVPN(ctx context.Context, deviceConfig *DeviceConfig, hostname, 
 	}
 	_, connectErr := network.Connect(freshCtx, config)
 	if connectErr == nil {
-		Debug("reconnected with fresh state (new IP)")
+		Log("reconnected with fresh state (new IP)")
 		return VPNRecoveryResult{Connected: true, IPPreserved: false}
 	}
 
-	Debug("fresh connect also failed: %v", connectErr)
+	Log("fresh connect also failed: %v", connectErr)
 	return VPNRecoveryResult{
 		Err: fmt.Errorf("all recovery attempts failed: %w", connectErr),
 	}

--- a/cmd/reconnect_test.go
+++ b/cmd/reconnect_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -79,5 +80,25 @@ func TestRecoverStaleVPNNoToken(t *testing.T) {
 	}
 	if r2.Err == nil || r2.Err.Error() != "no device API token available for auto-recovery" {
 		t.Errorf("expected token error, got: %v", r2.Err)
+	}
+}
+
+// TestRecoverStaleVPNFetchAuthkeyFails verifies that recoverStaleVPN returns
+// a clear error when FetchFreshAuthkey fails (e.g. network down, bad token).
+func TestRecoverStaleVPNFetchAuthkeyFails(t *testing.T) {
+	ctx := context.Background()
+
+	// Use a config with a token but pointing to a non-existent server.
+	// FetchFreshAuthkey will fail with a connection error.
+	cfg := &DeviceConfig{DeviceAPIToken: "act_test_token_12345"}
+	r := recoverStaleVPN(ctx, cfg, "test-node", "http://127.0.0.1:1")
+	if r.Connected {
+		t.Error("expected Connected=false when authkey fetch fails")
+	}
+	if r.Err == nil {
+		t.Fatal("expected error when authkey fetch fails")
+	}
+	if !strings.Contains(r.Err.Error(), "could not fetch fresh authkey") {
+		t.Errorf("expected authkey fetch error, got: %v", r.Err)
 	}
 }

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -466,10 +466,11 @@ func runWork(cmd *cobra.Command, args []string) {
 	// Uses attemptVPNRecovery (shared with 'citadel reconnect') to handle
 	// stale state: IP-preserving reconnect first, then clear + fresh connect.
 	network.SetLogf(Debug)
-	Debug("verifying network connection...")
+	Log("verifying network connection (state_dir=%s, has_state=%v)...",
+		network.GetStateDir(), network.HasState())
 	connected, err := network.VerifyOrReconnect(ctx)
 	if err != nil && errors.Is(err, network.ErrStaleState) {
-		Debug("network state is stale, attempting auto-recovery...")
+		Log("network state is stale after retries, attempting auto-recovery...")
 		fmt.Println("   - VPN state is stale, attempting auto-recovery...")
 
 		apiBaseURL := ""
@@ -484,29 +485,33 @@ func runWork(cmd *cobra.Command, args []string) {
 		connected = result.Connected
 		if result.Connected {
 			if result.IPPreserved {
+				Log("VPN reconnected (IP preserved)")
 				fmt.Println("   - VPN reconnected (IP preserved)")
 			} else {
+				Log("VPN reconnected (fresh state, new IP)")
 				fmt.Println("   - VPN reconnected (fresh state)")
 			}
 		} else {
 			if result.Err != nil {
+				Log("VPN auto-recovery failed: %v", result.Err)
 				fmt.Fprintf(os.Stderr, "   - Warning: VPN auto-recovery failed: %v\n", result.Err)
 			}
+			Log("VPN connection could not be restored automatically")
 			fmt.Fprintln(os.Stderr, "   - Warning: VPN connection could not be restored automatically.")
 			fmt.Fprintln(os.Stderr, "     Run 'citadel reconnect' or 'citadel login --authkey <key>' to fix.")
 		}
 	} else if err != nil {
-		Debug("network reconnect failed: %v", err)
+		Log("network reconnect failed: %v", err)
 	} else if connected {
-		Debug("network connected")
+		Log("network connected")
 	} else {
-		Debug("network not configured (no saved state)")
+		Log("network not configured (no saved state)")
 	}
 
 	// Get node name and Headscale node ID from network status
 	nodeName := workNodeName
 	var headscaleNodeID string // Headscale numeric node ID (e.g., "758")
-	Debug("resolving node name...")
+	Log("resolving node name...")
 	Debug("workNodeName flag: %q", workNodeName)
 	Debug("CITADEL_NODE_NAME env: %q", os.Getenv("CITADEL_NODE_NAME"))
 	if nodeName == "" {
@@ -565,10 +570,15 @@ func runWork(cmd *cobra.Command, args []string) {
 			Debug("Headscale node ID still empty on retry %d", attempt)
 		}
 		if headscaleNodeID == "" {
+			Log("Headscale node ID unresolved after retries; node-targeted jobs will fall back to the shared org stream")
 			fmt.Fprintln(os.Stderr, "   - Warning: Headscale node ID unresolved after retries; "+
 				"node-targeted jobs will fall back to the shared org stream")
 		}
 	}
+
+	// Log the final registration outcome for post-mortem diagnosis (issue #246).
+	Log("registered: online=%v node_name=%s headscale_id=%s state_dir=%s",
+		connected, nodeName, headscaleNodeID, network.GetStateDir())
 
 	// Default consumer group to node identity when --group is not explicitly set.
 	workGroup = resolveConsumerGroup(workGroup, headscaleNodeID, nodeName)

--- a/internal/network/singleton.go
+++ b/internal/network/singleton.go
@@ -22,11 +22,18 @@ import (
 // Callers should clear state and re-authenticate with a fresh authkey.
 var ErrStaleState = errors.New("network state is stale: connection cannot be re-established with existing keys")
 
-// reconnectTimeout is the maximum time to wait for a reconnection attempt
-// using existing state before declaring the state stale. A working WireGuard
-// handshake completes in under 5s; 10s gives margin for slow networks without
-// making interactive login feel stuck.
+// reconnectTimeout is the maximum time to wait for a single reconnection
+// attempt using existing state before declaring it timed out. A working
+// WireGuard handshake completes in under 5s; 10s gives margin for slow
+// networks without making interactive login feel stuck.
 const reconnectTimeout = 10 * time.Second
+
+// reconnectAttempts is the number of times VerifyOrReconnect tries the
+// no-authkey reconnect before declaring the state stale. On boot the network
+// interface may not be ready within the first 10s timeout, so retrying avoids
+// a premature ClearState + fresh connect that mints a new Headscale node ID
+// (issue #246).
+const reconnectAttempts = 3
 
 var (
 	globalServer *NetworkServer
@@ -219,8 +226,8 @@ func Listen(network, addr string) (net.Listener, error) {
 // Returns (connected, error). No error if simply not logged in.
 //
 // If state exists but the connection times out (e.g. expired/revoked Headscale key),
-// returns ErrStaleState. Callers should handle this by clearing state and
-// re-authenticating with a fresh authkey.
+// returns ErrStaleState after reconnectAttempts failures. Callers should handle
+// this by clearing state and re-authenticating with a fresh authkey.
 func VerifyOrReconnect(ctx context.Context) (bool, error) {
 	if IsGlobalConnected() {
 		return true, nil
@@ -229,13 +236,6 @@ func VerifyOrReconnect(ctx context.Context) (bool, error) {
 		return false, nil
 	}
 
-	// Reconnect using saved state with a bounded timeout.
-	// When the existing WireGuard keys are expired/revoked, tsnet will
-	// hang until the parent context deadline — cap it to reconnectTimeout
-	// so callers get a fast, actionable error.
-	reconnectCtx, cancel := context.WithTimeout(ctx, reconnectTimeout)
-	defer cancel()
-
 	hostname := getHostnameForReconnect()
 	config := ServerConfig{
 		Hostname:   hostname,
@@ -243,16 +243,48 @@ func VerifyOrReconnect(ctx context.Context) (bool, error) {
 		StateDir:   GetStateDir(),
 	}
 
-	srv := NewServer(config)
-	if err := srv.Connect(reconnectCtx, ""); err != nil {
-		if isStaleStateError(err) {
-			return false, ErrStaleState
+	// Retry the no-authkey reconnect with backoff. The first attempt may
+	// fail simply because the network interface is not ready yet at boot.
+	// Retrying here is far cheaper than falling through to ClearState,
+	// which destroys the node's WireGuard keys and mints a new Headscale ID.
+	for attempt := 1; attempt <= reconnectAttempts; attempt++ {
+		if attempt > 1 {
+			backoff := time.Duration(attempt) * 5 * time.Second
+			if logf != nil {
+				logf("reconnect attempt %d/%d in %s...", attempt, reconnectAttempts, backoff)
+			}
+			select {
+			case <-ctx.Done():
+				return false, ctx.Err()
+			case <-time.After(backoff):
+			}
 		}
-		return false, fmt.Errorf("failed to reconnect: %w", err)
+
+		reconnectCtx, cancel := context.WithTimeout(ctx, reconnectTimeout)
+		srv := NewServer(config)
+		connErr := srv.Connect(reconnectCtx, "")
+		cancel()
+
+		if connErr == nil {
+			SetGlobal(srv)
+			if logf != nil && attempt > 1 {
+				logf("reconnected on attempt %d", attempt)
+			}
+			return true, nil
+		}
+
+		// Non-stale errors (e.g. permission denied, state dir missing) won't
+		// improve on retry, so bail immediately.
+		if !isStaleStateError(connErr) {
+			return false, fmt.Errorf("failed to reconnect: %w", connErr)
+		}
+
+		if logf != nil {
+			logf("reconnect attempt %d/%d failed: %v", attempt, reconnectAttempts, connErr)
+		}
 	}
 
-	SetGlobal(srv)
-	return true, nil
+	return false, ErrStaleState
 }
 
 // ReconnectWithAuthKey attempts to connect using an existing state directory

--- a/internal/network/singleton_test.go
+++ b/internal/network/singleton_test.go
@@ -319,3 +319,37 @@ func TestReconnectTimeoutConstant(t *testing.T) {
 		t.Errorf("reconnectTimeout = %v, should be under 60s to provide timely feedback", reconnectTimeout)
 	}
 }
+
+// TestReconnectAttemptsConstant verifies the retry count for VerifyOrReconnect
+// is high enough to survive boot-time network delays without being so high
+// that a genuinely revoked key wastes minutes before failing (issue #246).
+func TestReconnectAttemptsConstant(t *testing.T) {
+	if reconnectAttempts < 2 {
+		t.Errorf("reconnectAttempts = %d, should be >= 2 to survive boot-time network delays", reconnectAttempts)
+	}
+	if reconnectAttempts > 5 {
+		t.Errorf("reconnectAttempts = %d, should be <= 5 to avoid excessive wait on revoked keys", reconnectAttempts)
+	}
+}
+
+// TestReconnectRetryBackoffTiming verifies the total worst-case wait time
+// for the retry loop is bounded. With 3 attempts and 5s * attempt backoff
+// (0 + 10 + 15 = 25s backoff) plus 10s per attempt timeout (30s total),
+// the worst case is ~55s. This must be under 2 minutes.
+func TestReconnectRetryBackoffTiming(t *testing.T) {
+	// Calculate worst-case total time
+	var totalBackoff time.Duration
+	for attempt := 2; attempt <= reconnectAttempts; attempt++ {
+		totalBackoff += time.Duration(attempt) * 5 * time.Second
+	}
+	totalTimeout := time.Duration(reconnectAttempts) * reconnectTimeout
+	worstCase := totalBackoff + totalTimeout
+
+	if worstCase > 2*time.Minute {
+		t.Errorf("worst-case retry time = %v, should be under 2 minutes", worstCase)
+	}
+	if worstCase < 20*time.Second {
+		t.Errorf("worst-case retry time = %v, seems too short to give the network a fair chance", worstCase)
+	}
+	t.Logf("worst-case retry time: %v (backoff: %v, timeouts: %v)", worstCase, totalBackoff, totalTimeout)
+}


### PR DESCRIPTION
## Context

Fixes #246. After restarting the citadel agent on v2.38.0+, nodes fail to come online reliably. The node registers stale, and repeated restarts mint NEW node IDs each time (702 -> 1008 -> 1015 -> none). The agent logs its connect sequence to stdout but NOT to the log file, making post-mortem diagnosis impossible from `~/.citadel-cli/logs/latest.log`.

## Summary

Three root causes identified and fixed:

**1. Identity churn -- stale node not reclaimed before fresh connect** (`cmd/reconnect.go`)
When `recoverStaleVPN()` falls back from IP-preserving reconnect to `ClearState()` + fresh connect, the old Headscale node entry was NOT reclaimed. The reclamation logic (`reclaimStaleNodeByHostname`) existed in `cmd/init.go` but was never called from the work command's recovery path. Each restart that triggered a fresh connect created a new Headscale node while old ones accumulated stale in the dashboard. Now calls `reclaimStaleNodeByHostname()` before `ClearState()`.

**2. Premature stale detection -- single 10s attempt before giving up** (`internal/network/singleton.go`)
`VerifyOrReconnect()` made a single no-authkey reconnect with a 10s timeout. On boot, the network interface is often not ready within 10s, causing a false "stale" verdict that cascaded into `ClearState()` and a new Headscale ID. Now retries 3 times with escalating backoff (0s, 10s, 15s) before declaring stale. Worst case ~55s, well under 2 minutes. Non-stale errors (permission denied, missing state dir) bail immediately without retry.

**3. Registration not logged to file** (`cmd/work.go`, `cmd/reconnect.go`)
Key VPN status messages used `fmt.Println`/`fmt.Printf` (stdout-only) instead of `Log()`. The `Log()` function always writes to the log file, but many startup messages bypassed it. All critical registration-path messages now use `Log()`. Added a post-resolution summary line: `registered: online=true node_name=X headscale_id=Y state_dir=Z`.

## Test plan

| Area | Tests | Coverage |
|------|-------|----------|
| Retry constants | `TestReconnectAttemptsConstant` | Bounds check: 2-5 attempts |
| Backoff timing | `TestReconnectRetryBackoffTiming` | Worst case under 2 min, over 20s |
| Recovery no-token | `TestRecoverStaleVPNNoToken` | nil config + empty token |
| Recovery fetch fail | `TestRecoverStaleVPNFetchAuthkeyFails` | Unreachable server returns authkey error |
| Stale error detection | `TestIsStaleStateError` (existing) | 11 error patterns |
| All existing tests | Full suite | `go test ./internal/network/... ./cmd/` passes |

```
$ go test ./internal/network/... ./cmd/ -count=1
ok  	github.com/aceteam-ai/citadel-cli/internal/network	0.250s
ok  	github.com/aceteam-ai/citadel-cli/cmd	0.339s
```

## Related

- Closes #246
- Uses `reclaimStaleNodeByHostname()` from `cmd/init.go` (issue #159)
- Uses `ReclaimStaleNode()` from `internal/nexus/reclaim.go`