### PR TITLE
feat(provision): Infrastructure Canvas provisioning API

### DIFF
--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -1,0 +1,370 @@
+// cmd/provision.go
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
+	"github.com/aceteam-ai/citadel-cli/internal/provision"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+var provisionCmd = &cobra.Command{
+	Use:   "provision",
+	Short: "Manage provisioned resources (containers, VMs)",
+	Long: `Create, destroy, list, and inspect provisioned resources on this node.
+
+Resources are managed declaratively via specs. The provisioning system
+handles the full lifecycle: create, status reconciliation, crash recovery,
+and cleanup.
+
+Examples:
+  # List all resources
+  citadel provision list
+
+  # Create a container
+  citadel provision create --name my-app --image nginx:latest --port 8080:80
+
+  # Check status
+  citadel provision status <id>
+
+  # View logs
+  citadel provision logs <id>
+
+  # Destroy a resource
+  citadel provision destroy <id>`,
+}
+
+// --- provision list ---
+
+var provisionListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all provisioned resources",
+	Run:   runProvisionList,
+}
+
+func runProvisionList(_ *cobra.Command, _ []string) {
+	mgr, err := newProvisionManager()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	resources := mgr.List()
+	if len(resources) == 0 {
+		fmt.Println("No provisioned resources.")
+		return
+	}
+
+	tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(tw, "ID\tNAME\tTYPE\tSTATUS\tIMAGE\tCONTAINER")
+	for _, r := range resources {
+		cid := r.ContainerID
+		if len(cid) > 12 {
+			cid = cid[:12]
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			shortID(r.ID), r.Spec.Name, r.Spec.Type, r.Status, r.Spec.Image, cid)
+	}
+	tw.Flush()
+}
+
+// --- provision create ---
+
+var (
+	provisionCreateName    string
+	provisionCreateImage   string
+	provisionCreatePorts   []string
+	provisionCreateEnv     []string
+	provisionCreateVolumes []string
+	provisionCreateCPUs    string
+	provisionCreateMemory  int
+	provisionCreateGPUs    string
+	provisionCreateCommand []string
+)
+
+var provisionCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new provisioned resource",
+	Long: `Create a Docker container from a spec.
+
+Examples:
+  citadel provision create --name my-app --image nginx:latest
+  citadel provision create --name db --image postgres:16 --port 5432:5432 --env POSTGRES_PASSWORD=secret
+  citadel provision create --name gpu-worker --image pytorch/pytorch --gpus all`,
+	Run: runProvisionCreate,
+}
+
+func runProvisionCreate(_ *cobra.Command, _ []string) {
+	if provisionCreateName == "" {
+		fmt.Fprintln(os.Stderr, "Error: --name is required")
+		os.Exit(1)
+	}
+	if provisionCreateImage == "" {
+		fmt.Fprintln(os.Stderr, "Error: --image is required")
+		os.Exit(1)
+	}
+
+	spec := &provision.ResourceSpec{
+		Name:     provisionCreateName,
+		Type:     provision.ResourceTypeDocker,
+		Image:    provisionCreateImage,
+		CPUs:     provisionCreateCPUs,
+		MemoryMB: provisionCreateMemory,
+		GPUs:     provisionCreateGPUs,
+		Command:  provisionCreateCommand,
+	}
+
+	// Parse port mappings.
+	for _, p := range provisionCreatePorts {
+		pm, err := parsePortMapping(p)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: invalid port mapping %q: %v\n", p, err)
+			os.Exit(1)
+		}
+		spec.Ports = append(spec.Ports, pm)
+	}
+
+	// Parse environment variables.
+	env := make(map[string]string)
+	for _, e := range provisionCreateEnv {
+		k, v, ok := strings.Cut(e, "=")
+		if !ok {
+			fmt.Fprintf(os.Stderr, "Error: invalid env var %q (expected KEY=VALUE)\n", e)
+			os.Exit(1)
+		}
+		env[k] = v
+	}
+	if len(env) > 0 {
+		spec.Env = env
+	}
+
+	// Parse volumes.
+	for _, vol := range provisionCreateVolumes {
+		vm, err := parseVolumeMount(vol)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: invalid volume %q: %v\n", vol, err)
+			os.Exit(1)
+		}
+		spec.Volumes = append(spec.Volumes, vm)
+	}
+
+	mgr, err := newProvisionManager()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	result, err := mgr.Create(context.Background(), spec)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if result.Reused {
+		color.Yellow("Resource %q already exists (ID: %s)\n", spec.Name, shortID(result.Resource.ID))
+	} else {
+		color.Green("Resource %q created (ID: %s)\n", spec.Name, shortID(result.Resource.ID))
+	}
+
+	printResource(result.Resource)
+}
+
+// --- provision status ---
+
+var provisionStatusCmd = &cobra.Command{
+	Use:   "status <id>",
+	Short: "Show the status of a provisioned resource",
+	Args:  cobra.ExactArgs(1),
+	Run:   runProvisionStatus,
+}
+
+func runProvisionStatus(_ *cobra.Command, args []string) {
+	mgr, err := newProvisionManager()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	id := resolveResourceID(mgr, args[0])
+
+	resource, err := mgr.Status(context.Background(), id)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	printResource(resource)
+}
+
+// --- provision destroy ---
+
+var provisionDestroyCmd = &cobra.Command{
+	Use:   "destroy <id>",
+	Short: "Destroy a provisioned resource",
+	Args:  cobra.ExactArgs(1),
+	Run:   runProvisionDestroy,
+}
+
+func runProvisionDestroy(_ *cobra.Command, args []string) {
+	mgr, err := newProvisionManager()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	id := resolveResourceID(mgr, args[0])
+
+	if err := mgr.Destroy(context.Background(), id); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	color.Green("Resource %s destroyed.\n", shortID(id))
+}
+
+// --- provision logs ---
+
+var provisionLogsTail int
+
+var provisionLogsCmd = &cobra.Command{
+	Use:   "logs <id>",
+	Short: "View logs from a provisioned resource",
+	Args:  cobra.ExactArgs(1),
+	Run:   runProvisionLogs,
+}
+
+func runProvisionLogs(_ *cobra.Command, args []string) {
+	mgr, err := newProvisionManager()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	id := resolveResourceID(mgr, args[0])
+
+	logs, err := mgr.Logs(context.Background(), id, provisionLogsTail)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Print(logs)
+}
+
+// --- Helpers ---
+
+func newProvisionManager() (*provision.Manager, error) {
+	configDir := platform.ConfigDir()
+
+	store, err := provision.NewStore(configDir)
+	if err != nil {
+		return nil, fmt.Errorf("initializing resource store: %w", err)
+	}
+
+	docker, err := provision.NewDockerBackend()
+	if err != nil {
+		return nil, fmt.Errorf("initializing Docker backend: %w", err)
+	}
+
+	backends := map[provision.ResourceType]provision.Backend{
+		provision.ResourceTypeDocker: docker,
+	}
+
+	mgr := provision.NewManager(store, backends)
+	mgr.ReconcileAll(context.Background())
+
+	return mgr, nil
+}
+
+func resolveResourceID(mgr *provision.Manager, input string) string {
+	if r := mgr.Get(input); r != nil {
+		return input
+	}
+	for _, r := range mgr.List() {
+		if r.Spec.Name == input {
+			return r.ID
+		}
+	}
+	for _, r := range mgr.List() {
+		if strings.HasPrefix(r.ID, input) {
+			return r.ID
+		}
+	}
+	return input
+}
+
+func shortID(id string) string {
+	if len(id) > 8 {
+		return id[:8]
+	}
+	return id
+}
+
+func printResource(r *provision.Resource) {
+	data, _ := json.MarshalIndent(r, "", "  ")
+	fmt.Println(string(data))
+}
+
+func parsePortMapping(s string) (provision.PortMapping, error) {
+	var pm provision.PortMapping
+	proto := "tcp"
+	if idx := strings.LastIndex(s, "/"); idx >= 0 {
+		proto = s[idx+1:]
+		s = s[:idx]
+	}
+	pm.Protocol = proto
+
+	parts := strings.SplitN(s, ":", 2)
+	if len(parts) != 2 {
+		return pm, fmt.Errorf("expected host:container format")
+	}
+	if _, err := fmt.Sscanf(parts[0], "%d", &pm.HostPort); err != nil {
+		return pm, fmt.Errorf("invalid host port: %w", err)
+	}
+	if _, err := fmt.Sscanf(parts[1], "%d", &pm.ContainerPort); err != nil {
+		return pm, fmt.Errorf("invalid container port: %w", err)
+	}
+	return pm, nil
+}
+
+func parseVolumeMount(s string) (provision.VolumeMount, error) {
+	var vm provision.VolumeMount
+	parts := strings.SplitN(s, ":", 3)
+	if len(parts) < 2 {
+		return vm, fmt.Errorf("expected host:container format")
+	}
+	vm.HostPath = parts[0]
+	vm.ContainerPath = parts[1]
+	if len(parts) == 3 && parts[2] == "ro" {
+		vm.ReadOnly = true
+	}
+	return vm, nil
+}
+
+func init() {
+	rootCmd.AddCommand(provisionCmd)
+	provisionCmd.AddCommand(provisionListCmd)
+	provisionCmd.AddCommand(provisionCreateCmd)
+	provisionCmd.AddCommand(provisionStatusCmd)
+	provisionCmd.AddCommand(provisionDestroyCmd)
+	provisionCmd.AddCommand(provisionLogsCmd)
+
+	provisionCreateCmd.Flags().StringVar(&provisionCreateName, "name", "", "Resource name (required)")
+	provisionCreateCmd.Flags().StringVar(&provisionCreateImage, "image", "", "Container image (required)")
+	provisionCreateCmd.Flags().StringSliceVarP(&provisionCreatePorts, "port", "p", nil, "Port mapping (host:container[/protocol])")
+	provisionCreateCmd.Flags().StringSliceVarP(&provisionCreateEnv, "env", "e", nil, "Environment variable (KEY=VALUE)")
+	provisionCreateCmd.Flags().StringSliceVarP(&provisionCreateVolumes, "volume", "v", nil, "Volume mount (host:container[:ro])")
+	provisionCreateCmd.Flags().StringVar(&provisionCreateCPUs, "cpus", "", "CPU limit (e.g., 0.5)")
+	provisionCreateCmd.Flags().IntVar(&provisionCreateMemory, "memory", 0, "Memory limit in MB")
+	provisionCreateCmd.Flags().StringVar(&provisionCreateGPUs, "gpus", "", "GPU access (e.g., all, 1)")
+	provisionCreateCmd.Flags().StringSliceVar(&provisionCreateCommand, "cmd", nil, "Override container command")
+
+	provisionLogsCmd.Flags().IntVar(&provisionLogsTail, "tail", 100, "Number of log lines to show")
+}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -204,6 +204,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	gw.AddUpstream("/api/screenshot", &gateway.Upstream{Address: statusAddr})
 	gw.AddUpstream("/api/actions", &gateway.Upstream{Address: statusAddr})
 	gw.AddUpstream("/ssh/authorized-keys", &gateway.Upstream{Address: statusAddr})
+	gw.AddUpstream("/provision", &gateway.Upstream{Address: statusAddr})
 
 	// VNC WebSocket proxy (requires websockify running on vnc-port)
 	gw.AddUpstream("/vnc", &gateway.Upstream{

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1726,5 +1726,9 @@ func initProvisionHandler() *provision.Handler {
 		provision.ResourceTypeDocker: docker,
 	}
 	mgr := provision.NewManager(store, backends)
+	// Reconcile persisted resources against actual Docker state on startup.
+	// This detects containers that crashed or were removed while the daemon
+	// was down and updates their status accordingly.
+	mgr.ReconcileAll(context.Background())
 	return provision.NewHandler(mgr)
 }

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/capabilities"
 	"github.com/aceteam-ai/citadel-cli/internal/config"
 	"github.com/aceteam-ai/citadel-cli/internal/gateway"
+	"github.com/aceteam-ai/citadel-cli/internal/provision"
 	"github.com/aceteam-ai/citadel-cli/internal/heartbeat"
 	"github.com/aceteam-ai/citadel-cli/internal/network"
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
@@ -763,6 +764,11 @@ func runWork(cmd *cobra.Command, args []string) {
 
 		statusServer := status.NewServer(serverCfg, collector)
 
+		// Register provisioning API routes on the status server
+		if provisionHandler := initProvisionHandler(); provisionHandler != nil {
+			statusServer.AddRouteRegistrar(provisionHandler.RegisterRoutes)
+		}
+
 		// Add VPN listener so the status server is reachable over the tsnet VPN
 		if network.IsGlobalConnected() {
 			vpnAddr := fmt.Sprintf(":%d", workStatusPort)
@@ -1138,6 +1144,7 @@ func runWork(cmd *cobra.Command, args []string) {
 		gw.AddUpstream("/api/screenshot", &gateway.Upstream{Address: statusAddr})
 		gw.AddUpstream("/api/actions", &gateway.Upstream{Address: statusAddr})
 		gw.AddUpstream("/ssh/authorized-keys", &gateway.Upstream{Address: statusAddr})
+		gw.AddUpstream("/provision", &gateway.Upstream{Address: statusAddr})
 
 		gw.AddUpstream("/vnc", &gateway.Upstream{
 			Address:     vncAddr,
@@ -1698,4 +1705,26 @@ func init() {
 	workCmd.Flags().BoolVar(&workGatewayNoTLS, "gateway-no-tls", false, "Disable TLS on the gateway (for testing only)")
 	workCmd.Flags().StringVar(&workGatewayCertDir, "gateway-cert-dir", "", "Custom directory for gateway TLS certificates")
 	workCmd.Flags().MarkHidden("gateway-no-tls")
+}
+
+// initProvisionHandler creates a provision.Handler backed by the Docker
+// backend with state persisted in the Citadel config directory.
+// Returns nil if initialization fails (provisioning API will be unavailable).
+func initProvisionHandler() *provision.Handler {
+	configDir := platform.ConfigDir()
+	store, err := provision.NewStore(configDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "   - provision store init failed: %v\n", err)
+		return nil
+	}
+	docker, err := provision.NewDockerBackend()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "   - provision docker backend init failed: %v\n", err)
+		return nil
+	}
+	backends := map[provision.ResourceType]provision.Backend{
+		provision.ResourceTypeDocker: docker,
+	}
+	mgr := provision.NewManager(store, backends)
+	return provision.NewHandler(mgr)
 }

--- a/internal/config/permissions.go
+++ b/internal/config/permissions.go
@@ -12,11 +12,12 @@ import (
 // Permissions controls which capabilities are exposed through the HTTPS gateway.
 // All fields default to true (opt-out model).
 type Permissions struct {
-	Console  bool `yaml:"console" json:"console"`   // Terminal WebSocket access
-	Desktop  bool `yaml:"desktop" json:"desktop"`   // VNC, screenshots, actions
-	Files    bool `yaml:"files" json:"files"`       // File browser API
-	Services bool `yaml:"services" json:"services"` // Service list/management
-	SSH      bool `yaml:"ssh" json:"ssh"`           // SSH authorized_keys sync
+	Console   bool `yaml:"console" json:"console"`     // Terminal WebSocket access
+	Desktop   bool `yaml:"desktop" json:"desktop"`     // VNC, screenshots, actions
+	Files     bool `yaml:"files" json:"files"`         // File browser API
+	Services  bool `yaml:"services" json:"services"`   // Service list/management
+	SSH       bool `yaml:"ssh" json:"ssh"`             // SSH authorized_keys sync
+	Provision bool `yaml:"provision" json:"provision"` // Container provisioning API
 }
 
 const permissionsFile = "permissions.yaml"
@@ -24,11 +25,12 @@ const permissionsFile = "permissions.yaml"
 // DefaultPermissions returns a Permissions struct with all capabilities enabled.
 func DefaultPermissions() *Permissions {
 	return &Permissions{
-		Console:  true,
-		Desktop:  true,
-		Files:    true,
-		Services: true,
-		SSH:      true,
+		Console:   true,
+		Desktop:   true,
+		Files:     true,
+		Services:  true,
+		SSH:       true,
+		Provision: true,
 	}
 }
 

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -163,6 +163,10 @@ func categoryForPath(path string) string {
 	if path == "/ssh" || strings.HasPrefix(path, "/ssh/") {
 		return "ssh"
 	}
+	// Provisioning
+	if path == "/provision" || strings.HasPrefix(path, "/provision/") {
+		return "provision"
+	}
 	// Everything else (health, status, ping, root, unknown) is always allowed
 	return ""
 }
@@ -187,6 +191,8 @@ func (s *Server) permissionMiddleware(next http.Handler) http.Handler {
 				blocked = !perms.Services
 			case "ssh":
 				blocked = !perms.SSH
+			case "provision":
+				blocked = !perms.Provision
 			// "files" is not currently routed through the gateway but is
 			// included in the permission model for future use.
 			}

--- a/internal/provision/docker.go
+++ b/internal/provision/docker.go
@@ -1,0 +1,160 @@
+package provision
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// DockerBackend implements resource lifecycle operations using Docker.
+// It shells out to the Docker CLI (compatible with CGO_ENABLED=0).
+type DockerBackend struct {
+	// DockerBin is the path to the docker binary. Defaults to "docker".
+	DockerBin string
+}
+
+// NewDockerBackend creates a DockerBackend. It verifies that the docker
+// binary is available on PATH.
+func NewDockerBackend() (*DockerBackend, error) {
+	bin := "docker"
+	if _, err := exec.LookPath(bin); err != nil {
+		return nil, fmt.Errorf("docker not found on PATH: %w", err)
+	}
+	return &DockerBackend{DockerBin: bin}, nil
+}
+
+// Create pulls the image (if needed) and starts a container. It returns
+// the Docker container ID.
+func (b *DockerBackend) Create(ctx context.Context, id string, spec *ResourceSpec) (containerID string, err error) {
+	if out, pullErr := b.run(ctx, "pull", spec.Image); pullErr != nil {
+		return "", fmt.Errorf("docker pull failed: %s: %w", strings.TrimSpace(out), pullErr)
+	}
+
+	args := []string{
+		"run", "-d",
+		"--name", containerName(id, spec.Name),
+		"--restart", "unless-stopped",
+		"--label", "citadel.resource.id=" + id,
+		"--label", "citadel.resource.name=" + spec.Name,
+	}
+
+	for k, v := range spec.Env {
+		args = append(args, "-e", k+"="+v)
+	}
+
+	for _, p := range spec.Ports {
+		proto := p.Protocol
+		if proto == "" {
+			proto = "tcp"
+		}
+		args = append(args, "-p", fmt.Sprintf("%d:%d/%s", p.HostPort, p.ContainerPort, proto))
+	}
+
+	for _, v := range spec.Volumes {
+		mount := v.HostPath + ":" + v.ContainerPath
+		if v.ReadOnly {
+			mount += ":ro"
+		}
+		args = append(args, "-v", mount)
+	}
+
+	if spec.CPUs != "" {
+		args = append(args, "--cpus", spec.CPUs)
+	}
+
+	if spec.MemoryMB > 0 {
+		args = append(args, "--memory", fmt.Sprintf("%dm", spec.MemoryMB))
+	}
+
+	if spec.GPUs != "" {
+		args = append(args, "--gpus", spec.GPUs)
+	}
+
+	if len(spec.Command) > 0 {
+		args = append(args, spec.Image)
+		args = append(args, spec.Command...)
+	} else {
+		args = append(args, spec.Image)
+	}
+
+	out, err := b.run(ctx, args...)
+	if err != nil {
+		return "", fmt.Errorf("docker run failed: %s: %w", strings.TrimSpace(out), err)
+	}
+
+	cid := strings.TrimSpace(out)
+	if len(cid) > 12 {
+		cid = cid[:12]
+	}
+	return cid, nil
+}
+
+// Destroy stops and removes a container.
+func (b *DockerBackend) Destroy(ctx context.Context, id string, spec *ResourceSpec) error {
+	name := containerName(id, spec.Name)
+	_, _ = b.run(ctx, "stop", name)
+	out, err := b.run(ctx, "rm", "-f", name)
+	if err != nil {
+		return fmt.Errorf("docker rm failed: %s: %w", strings.TrimSpace(out), err)
+	}
+	return nil
+}
+
+// Inspect returns the running status of a container.
+func (b *DockerBackend) Inspect(ctx context.Context, id string, spec *ResourceSpec) (ResourceStatus, error) {
+	name := containerName(id, spec.Name)
+	out, err := b.run(ctx, "inspect", "--format", "{{.State.Status}}", name)
+	if err != nil {
+		if strings.Contains(strings.ToLower(out), "no such") ||
+			strings.Contains(strings.ToLower(err.Error()), "no such") {
+			return StatusDestroyed, nil
+		}
+		return StatusError, fmt.Errorf("docker inspect failed: %s: %w", strings.TrimSpace(out), err)
+	}
+
+	state := strings.TrimSpace(out)
+	switch state {
+	case "running":
+		return StatusRunning, nil
+	case "exited", "dead":
+		return StatusStopped, nil
+	case "created", "restarting":
+		return StatusCreating, nil
+	default:
+		return StatusError, fmt.Errorf("unknown docker state: %s", state)
+	}
+}
+
+// Logs returns recent logs from a container.
+func (b *DockerBackend) Logs(ctx context.Context, id string, spec *ResourceSpec, tail int) (string, error) {
+	name := containerName(id, spec.Name)
+	tailStr := "100"
+	if tail > 0 {
+		tailStr = fmt.Sprintf("%d", tail)
+	}
+	out, err := b.run(ctx, "logs", "--tail", tailStr, name)
+	if err != nil {
+		return "", fmt.Errorf("docker logs failed: %s: %w", strings.TrimSpace(out), err)
+	}
+	return out, nil
+}
+
+func containerName(id, specName string) string {
+	return "citadel-" + specName
+}
+
+func (b *DockerBackend) run(ctx context.Context, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, b.DockerBin, args...)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+
+	err := cmd.Run()
+	return buf.String(), err
+}

--- a/internal/provision/handler.go
+++ b/internal/provision/handler.go
@@ -1,0 +1,169 @@
+package provision
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// Handler exposes the provisioning API over HTTP. It is intended to be
+// registered on the status server's mux, gated by VPN-or-auth middleware.
+type Handler struct {
+	manager *Manager
+}
+
+// NewHandler creates a provisioning HTTP handler backed by the given manager.
+func NewHandler(manager *Manager) *Handler {
+	return &Handler{manager: manager}
+}
+
+// RegisterRoutes attaches the provisioning endpoints to the given mux.
+// The authMiddleware wraps each handler with VPN-or-auth gating.
+func (h *Handler) RegisterRoutes(mux *http.ServeMux, authMiddleware func(http.HandlerFunc) http.HandlerFunc) {
+	mux.HandleFunc("/provision/create", authMiddleware(h.handleCreate))
+	mux.HandleFunc("/provision/list", authMiddleware(h.handleList))
+	mux.HandleFunc("/provision/", authMiddleware(h.handleByID))
+}
+
+func (h *Handler) handleCreate(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "failed to read body")
+		return
+	}
+
+	var spec ResourceSpec
+	if err := json.Unmarshal(body, &spec); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid JSON: %v", err))
+		return
+	}
+
+	result, err := h.manager.Create(r.Context(), &spec)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, result)
+}
+
+func (h *Handler) handleList(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	resources := h.manager.List()
+	if resources == nil {
+		resources = []*Resource{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"resources": resources,
+		"count":     len(resources),
+	})
+}
+
+func (h *Handler) handleByID(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/provision/")
+	if path == "" || path == "/" {
+		h.handleList(w, r)
+		return
+	}
+
+	parts := strings.SplitN(path, "/", 2)
+	id := parts[0]
+	action := ""
+	if len(parts) > 1 {
+		action = parts[1]
+	}
+
+	switch action {
+	case "", "status":
+		h.handleStatus(w, r, id)
+	case "destroy":
+		h.handleDestroy(w, r, id)
+	case "logs":
+		h.handleLogs(w, r, id)
+	default:
+		writeError(w, http.StatusNotFound, fmt.Sprintf("unknown action %q", action))
+	}
+}
+
+func (h *Handler) handleStatus(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	resource, err := h.manager.Status(r.Context(), id)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, resource)
+}
+
+func (h *Handler) handleDestroy(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	if err := h.manager.Destroy(r.Context(), id); err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "destroyed"})
+}
+
+func (h *Handler) handleLogs(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	tail := 100
+	if v := r.URL.Query().Get("tail"); v != "" {
+		fmt.Sscanf(v, "%d", &tail)
+	}
+
+	logs, err := h.manager.Logs(r.Context(), id, tail)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"logs": logs})
+}
+
+func writeJSON(w http.ResponseWriter, code int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, code int, msg string) {
+	writeJSON(w, code, map[string]string{"error": msg})
+}

--- a/internal/provision/manager.go
+++ b/internal/provision/manager.go
@@ -1,0 +1,215 @@
+package provision
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Backend is the interface for a resource backend (Docker, LXC, VM).
+type Backend interface {
+	Create(ctx context.Context, id string, spec *ResourceSpec) (containerID string, err error)
+	Destroy(ctx context.Context, id string, spec *ResourceSpec) error
+	Inspect(ctx context.Context, id string, spec *ResourceSpec) (ResourceStatus, error)
+	Logs(ctx context.Context, id string, spec *ResourceSpec, tail int) (string, error)
+}
+
+// Manager orchestrates resource lifecycle operations. It is safe for
+// concurrent use.
+type Manager struct {
+	mu       sync.Mutex
+	store    *Store
+	backends map[ResourceType]Backend
+}
+
+// NewManager creates a Manager with the given store and backends.
+func NewManager(store *Store, backends map[ResourceType]Backend) *Manager {
+	return &Manager{
+		store:    store,
+		backends: backends,
+	}
+}
+
+// Create provisions a new resource from the given spec. If a resource with
+// the same name already exists and is not destroyed, the existing resource
+// is returned (idempotency). The resource is persisted before and after
+// the backend call so crash recovery can detect orphans.
+func (m *Manager) Create(ctx context.Context, spec *ResourceSpec) (*CreateResult, error) {
+	if err := ValidateSpec(spec); err != nil {
+		return nil, fmt.Errorf("invalid spec: %w", err)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if existing := m.store.FindByName(spec.Name); existing != nil {
+		if existing.Status != StatusDestroyed {
+			return &CreateResult{Resource: existing, Reused: true}, nil
+		}
+		_ = m.store.Delete(existing.ID)
+	}
+
+	backend, ok := m.backends[spec.Type]
+	if !ok {
+		return nil, fmt.Errorf("no backend for resource type %q", spec.Type)
+	}
+
+	now := time.Now().UTC()
+	r := &Resource{
+		ID:        uuid.New().String(),
+		Spec:      *spec,
+		Status:    StatusCreating,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	if err := m.store.Put(r); err != nil {
+		return nil, fmt.Errorf("persisting resource: %w", err)
+	}
+
+	containerID, err := backend.Create(ctx, r.ID, spec)
+	if err != nil {
+		r.Status = StatusError
+		r.Error = err.Error()
+		r.UpdatedAt = time.Now().UTC()
+		_ = m.store.Put(r)
+		return nil, fmt.Errorf("creating resource: %w", err)
+	}
+
+	r.ContainerID = containerID
+	r.Status = StatusRunning
+	r.UpdatedAt = time.Now().UTC()
+
+	if err := m.store.Put(r); err != nil {
+		return nil, fmt.Errorf("persisting resource after create: %w", err)
+	}
+
+	return &CreateResult{Resource: r}, nil
+}
+
+// Destroy stops and removes a resource.
+func (m *Manager) Destroy(ctx context.Context, id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	r := m.store.Get(id)
+	if r == nil {
+		return fmt.Errorf("resource %q not found", id)
+	}
+
+	if r.Status == StatusDestroyed {
+		return nil
+	}
+
+	backend, ok := m.backends[r.Spec.Type]
+	if !ok {
+		return fmt.Errorf("no backend for resource type %q", r.Spec.Type)
+	}
+
+	if err := backend.Destroy(ctx, r.ID, &r.Spec); err != nil {
+		r.Status = StatusError
+		r.Error = err.Error()
+		r.UpdatedAt = time.Now().UTC()
+		_ = m.store.Put(r)
+		return fmt.Errorf("destroying resource: %w", err)
+	}
+
+	r.Status = StatusDestroyed
+	r.UpdatedAt = time.Now().UTC()
+
+	return m.store.Put(r)
+}
+
+// Status returns the current status of a resource after reconciling with
+// the backend.
+func (m *Manager) Status(ctx context.Context, id string) (*Resource, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	r := m.store.Get(id)
+	if r == nil {
+		return nil, fmt.Errorf("resource %q not found", id)
+	}
+
+	if r.Status == StatusDestroyed {
+		return r, nil
+	}
+
+	backend, ok := m.backends[r.Spec.Type]
+	if !ok {
+		return r, nil
+	}
+
+	actualStatus, err := backend.Inspect(ctx, r.ID, &r.Spec)
+	if err != nil {
+		return r, fmt.Errorf("inspecting resource: %w", err)
+	}
+
+	if actualStatus != r.Status {
+		r.Status = actualStatus
+		r.UpdatedAt = time.Now().UTC()
+		_ = m.store.Put(r)
+	}
+
+	return r, nil
+}
+
+// List returns all resources.
+func (m *Manager) List() []*Resource {
+	return m.store.List()
+}
+
+// Get returns a resource by ID without reconciling status.
+func (m *Manager) Get(id string) *Resource {
+	return m.store.Get(id)
+}
+
+// Logs returns recent logs for a resource.
+func (m *Manager) Logs(ctx context.Context, id string, tail int) (string, error) {
+	r := m.store.Get(id)
+	if r == nil {
+		return "", fmt.Errorf("resource %q not found", id)
+	}
+
+	backend, ok := m.backends[r.Spec.Type]
+	if !ok {
+		return "", fmt.Errorf("no backend for resource type %q", r.Spec.Type)
+	}
+
+	return backend.Logs(ctx, r.ID, &r.Spec, tail)
+}
+
+// ReconcileAll reconciles the status of all non-destroyed resources with
+// their backends. This is used for crash recovery on startup.
+func (m *Manager) ReconcileAll(ctx context.Context) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, r := range m.store.List() {
+		if r.Status == StatusDestroyed {
+			continue
+		}
+
+		backend, ok := m.backends[r.Spec.Type]
+		if !ok {
+			continue
+		}
+
+		actualStatus, err := backend.Inspect(ctx, r.ID, &r.Spec)
+		if err != nil {
+			log.Printf("[provision] reconcile %s (%s): %v", r.Spec.Name, r.ID, err)
+			continue
+		}
+
+		if actualStatus != r.Status {
+			log.Printf("[provision] reconcile %s (%s): %s -> %s", r.Spec.Name, r.ID, r.Status, actualStatus)
+			r.Status = actualStatus
+			r.UpdatedAt = time.Now().UTC()
+			_ = m.store.Put(r)
+		}
+	}
+}

--- a/internal/provision/provision_test.go
+++ b/internal/provision/provision_test.go
@@ -1,0 +1,601 @@
+package provision
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// --- Mock Docker Backend ---
+
+type mockBackend struct {
+	mu          sync.Mutex
+	containers  map[string]ResourceStatus
+	createErr   error
+	destroyErr  error
+	logsOutput  string
+	createCalls int
+}
+
+func newMockBackend() *mockBackend {
+	return &mockBackend{containers: make(map[string]ResourceStatus)}
+}
+
+func (m *mockBackend) Create(_ context.Context, id string, _ *ResourceSpec) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.createCalls++
+	if m.createErr != nil {
+		return "", m.createErr
+	}
+	m.containers[id] = StatusRunning
+	return "mock-cid-" + id[:8], nil
+}
+
+func (m *mockBackend) Destroy(_ context.Context, id string, _ *ResourceSpec) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.destroyErr != nil {
+		return m.destroyErr
+	}
+	m.containers[id] = StatusDestroyed
+	return nil
+}
+
+func (m *mockBackend) Inspect(_ context.Context, id string, _ *ResourceSpec) (ResourceStatus, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if s, ok := m.containers[id]; ok {
+		return s, nil
+	}
+	return StatusDestroyed, nil
+}
+
+func (m *mockBackend) Logs(_ context.Context, _ string, _ *ResourceSpec, _ int) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.logsOutput, nil
+}
+
+// --- Store Tests ---
+
+func TestStoreRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := &Resource{
+		ID:     "test-id-1",
+		Spec:   ResourceSpec{Name: "test-res", Type: ResourceTypeDocker, Image: "nginx"},
+		Status: StatusRunning,
+	}
+	if err := store.Put(r); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, storeFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "test-id-1") {
+		t.Fatalf("store file does not contain resource ID: %s", data)
+	}
+
+	store2, err := NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := store2.Get("test-id-1")
+	if got == nil {
+		t.Fatal("expected resource after reload, got nil")
+	}
+	if got.Spec.Name != "test-res" {
+		t.Fatalf("expected name test-res, got %s", got.Spec.Name)
+	}
+}
+
+func TestStoreFindByName(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store.Put(&Resource{ID: "id-1", Spec: ResourceSpec{Name: "alpha"}, Status: StatusRunning})
+	store.Put(&Resource{ID: "id-2", Spec: ResourceSpec{Name: "beta"}, Status: StatusRunning})
+
+	if got := store.FindByName("beta"); got == nil || got.ID != "id-2" {
+		t.Fatalf("FindByName(beta) = %v, want id-2", got)
+	}
+	if got := store.FindByName("gamma"); got != nil {
+		t.Fatalf("FindByName(gamma) = %v, want nil", got)
+	}
+}
+
+func TestStoreDelete(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store.Put(&Resource{ID: "id-del", Spec: ResourceSpec{Name: "to-delete"}, Status: StatusRunning})
+	if err := store.Delete("id-del"); err != nil {
+		t.Fatal(err)
+	}
+	if got := store.Get("id-del"); got != nil {
+		t.Fatalf("expected nil after delete, got %v", got)
+	}
+
+	store2, err := NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := store2.Get("id-del"); got != nil {
+		t.Fatalf("expected nil after reload, got %v", got)
+	}
+}
+
+func TestStoreEmptyLoad(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(store.List()) != 0 {
+		t.Fatal("expected empty store")
+	}
+}
+
+// --- Validation Tests ---
+
+func TestValidateSpec(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    ResourceSpec
+		wantErr string
+	}{
+		{
+			name:    "empty name",
+			spec:    ResourceSpec{Type: ResourceTypeDocker, Image: "nginx"},
+			wantErr: "name is required",
+		},
+		{
+			name:    "invalid name",
+			spec:    ResourceSpec{Name: "bad name!", Type: ResourceTypeDocker, Image: "nginx"},
+			wantErr: "invalid name",
+		},
+		{
+			name:    "name starting with dot",
+			spec:    ResourceSpec{Name: ".hidden", Type: ResourceTypeDocker, Image: "nginx"},
+			wantErr: "invalid name",
+		},
+		{
+			name:    "unsupported lxc",
+			spec:    ResourceSpec{Name: "test", Type: ResourceTypeLXC, Image: "ubuntu"},
+			wantErr: "not yet supported",
+		},
+		{
+			name:    "unknown type",
+			spec:    ResourceSpec{Name: "test", Type: "magic"},
+			wantErr: "unknown resource type",
+		},
+		{
+			name:    "missing image",
+			spec:    ResourceSpec{Name: "test", Type: ResourceTypeDocker},
+			wantErr: "image is required",
+		},
+		{
+			name: "invalid host port",
+			spec: ResourceSpec{
+				Name: "test", Type: ResourceTypeDocker, Image: "nginx",
+				Ports: []PortMapping{{HostPort: 0, ContainerPort: 80}},
+			},
+			wantErr: "invalid host port",
+		},
+		{
+			name: "invalid protocol",
+			spec: ResourceSpec{
+				Name: "test", Type: ResourceTypeDocker, Image: "nginx",
+				Ports: []PortMapping{{HostPort: 8080, ContainerPort: 80, Protocol: "icmp"}},
+			},
+			wantErr: "invalid protocol",
+		},
+		{
+			name: "valid spec",
+			spec: ResourceSpec{
+				Name: "my-app", Type: ResourceTypeDocker, Image: "nginx:latest",
+				Ports: []PortMapping{{HostPort: 8080, ContainerPort: 80}},
+				Env:   map[string]string{"FOO": "bar"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateSpec(&tt.spec)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestValidateVolumePath(t *testing.T) {
+	old := allowedVolumePrefixes
+	defer func() { allowedVolumePrefixes = old }()
+	SetAllowedVolumePrefixes([]string{"/tmp/", "/var/lib/citadel/volumes/"})
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr string
+	}{
+		{name: "allowed /tmp", path: "/tmp/data"},
+		{name: "allowed citadel volumes", path: "/var/lib/citadel/volumes/mydata"},
+		{name: "relative path", path: "data", wantErr: "must be absolute"},
+		{name: "not allowed", path: "/etc/shadow", wantErr: "not under an allowed prefix"},
+		{name: "empty", path: "", wantErr: "host_path is required"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateVolumePath(tt.path)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+// --- Manager Tests ---
+
+func newTestManager(t *testing.T, backend *mockBackend) *Manager {
+	t.Helper()
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return NewManager(store, map[ResourceType]Backend{ResourceTypeDocker: backend})
+}
+
+func TestManagerCreateAndStatus(t *testing.T) {
+	backend := newMockBackend()
+	mgr := newTestManager(t, backend)
+	ctx := context.Background()
+
+	result, err := mgr.Create(ctx, &ResourceSpec{Name: "test-app", Type: ResourceTypeDocker, Image: "nginx:latest"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Reused {
+		t.Fatal("expected new resource, got reused")
+	}
+	if result.Resource.Status != StatusRunning {
+		t.Fatalf("expected running, got %s", result.Resource.Status)
+	}
+	if result.Resource.ContainerID == "" {
+		t.Fatal("expected container ID")
+	}
+
+	r, err := mgr.Status(ctx, result.Resource.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Status != StatusRunning {
+		t.Fatalf("expected running, got %s", r.Status)
+	}
+}
+
+func TestManagerCreateIdempotent(t *testing.T) {
+	backend := newMockBackend()
+	mgr := newTestManager(t, backend)
+	ctx := context.Background()
+
+	spec := &ResourceSpec{Name: "idem-app", Type: ResourceTypeDocker, Image: "nginx"}
+	r1, err := mgr.Create(ctx, spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r2, err := mgr.Create(ctx, spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !r2.Reused {
+		t.Fatal("expected reused=true")
+	}
+	if r2.Resource.ID != r1.Resource.ID {
+		t.Fatal("expected same resource ID")
+	}
+	if backend.createCalls != 1 {
+		t.Fatalf("expected 1 backend create, got %d", backend.createCalls)
+	}
+}
+
+func TestManagerDestroy(t *testing.T) {
+	backend := newMockBackend()
+	mgr := newTestManager(t, backend)
+	ctx := context.Background()
+
+	result, _ := mgr.Create(ctx, &ResourceSpec{Name: "to-destroy", Type: ResourceTypeDocker, Image: "nginx"})
+	if err := mgr.Destroy(ctx, result.Resource.ID); err != nil {
+		t.Fatal(err)
+	}
+	if r := mgr.Get(result.Resource.ID); r.Status != StatusDestroyed {
+		t.Fatalf("expected destroyed, got %s", r.Status)
+	}
+}
+
+func TestManagerDestroyNotFound(t *testing.T) {
+	backend := newMockBackend()
+	mgr := newTestManager(t, backend)
+	if err := mgr.Destroy(context.Background(), "nonexistent"); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected not found error, got %v", err)
+	}
+}
+
+func TestManagerCreateBackendError(t *testing.T) {
+	backend := newMockBackend()
+	backend.createErr = fmt.Errorf("docker daemon not running")
+	mgr := newTestManager(t, backend)
+
+	_, err := mgr.Create(context.Background(), &ResourceSpec{Name: "will-fail", Type: ResourceTypeDocker, Image: "nginx"})
+	if err == nil || !strings.Contains(err.Error(), "docker daemon") {
+		t.Fatalf("expected docker error, got %v", err)
+	}
+	if resources := mgr.List(); len(resources) != 1 || resources[0].Status != StatusError {
+		t.Fatalf("expected 1 resource with error status, got %v", resources)
+	}
+}
+
+func TestManagerList(t *testing.T) {
+	backend := newMockBackend()
+	mgr := newTestManager(t, backend)
+	ctx := context.Background()
+
+	for _, name := range []string{"app-1", "app-2", "app-3"} {
+		mgr.Create(ctx, &ResourceSpec{Name: name, Type: ResourceTypeDocker, Image: "nginx"})
+	}
+	if got := len(mgr.List()); got != 3 {
+		t.Fatalf("expected 3 resources, got %d", got)
+	}
+}
+
+func TestManagerReconcileAll(t *testing.T) {
+	backend := newMockBackend()
+	mgr := newTestManager(t, backend)
+	ctx := context.Background()
+
+	result, _ := mgr.Create(ctx, &ResourceSpec{Name: "reconcile-me", Type: ResourceTypeDocker, Image: "nginx"})
+
+	backend.mu.Lock()
+	backend.containers[result.Resource.ID] = StatusStopped
+	backend.mu.Unlock()
+
+	mgr.ReconcileAll(ctx)
+
+	if r := mgr.Get(result.Resource.ID); r.Status != StatusStopped {
+		t.Fatalf("expected stopped, got %s", r.Status)
+	}
+}
+
+func TestManagerLogs(t *testing.T) {
+	backend := newMockBackend()
+	backend.logsOutput = "line1\nline2\n"
+	mgr := newTestManager(t, backend)
+	ctx := context.Background()
+
+	result, _ := mgr.Create(ctx, &ResourceSpec{Name: "log-app", Type: ResourceTypeDocker, Image: "nginx"})
+	logs, err := mgr.Logs(ctx, result.Resource.ID, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if logs != "line1\nline2\n" {
+		t.Fatalf("unexpected logs: %q", logs)
+	}
+}
+
+func TestManagerCreateAfterDestroyed(t *testing.T) {
+	backend := newMockBackend()
+	mgr := newTestManager(t, backend)
+	ctx := context.Background()
+
+	spec := &ResourceSpec{Name: "phoenix", Type: ResourceTypeDocker, Image: "nginx"}
+	r1, _ := mgr.Create(ctx, spec)
+	mgr.Destroy(ctx, r1.Resource.ID)
+
+	r2, err := mgr.Create(ctx, spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r2.Reused {
+		t.Fatal("expected new resource after destroy")
+	}
+	if r2.Resource.ID == r1.Resource.ID {
+		t.Fatal("expected different ID after destroy + re-create")
+	}
+}
+
+// --- HTTP Handler Tests ---
+
+func noAuthMiddleware(next http.HandlerFunc) http.HandlerFunc { return next }
+
+func setupTestHandler(t *testing.T) (*Handler, *Manager, *mockBackend) {
+	t.Helper()
+	backend := newMockBackend()
+	mgr := newTestManager(t, backend)
+	return NewHandler(mgr), mgr, backend
+}
+
+func TestHTTPCreate(t *testing.T) {
+	handler, _, _ := setupTestHandler(t)
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux, noAuthMiddleware)
+
+	body := `{"name":"http-test","type":"docker","image":"nginx:latest"}`
+	req := httptest.NewRequest(http.MethodPost, "/provision/create", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var result CreateResult
+	json.Unmarshal(w.Body.Bytes(), &result)
+	if result.Resource.Spec.Name != "http-test" {
+		t.Fatalf("expected name http-test, got %s", result.Resource.Spec.Name)
+	}
+}
+
+func TestHTTPCreateInvalid(t *testing.T) {
+	handler, _, _ := setupTestHandler(t)
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux, noAuthMiddleware)
+
+	req := httptest.NewRequest(http.MethodPost, "/provision/create", strings.NewReader(`{"name":"invalid","type":"docker"}`))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHTTPList(t *testing.T) {
+	handler, mgr, _ := setupTestHandler(t)
+	ctx := context.Background()
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux, noAuthMiddleware)
+
+	mgr.Create(ctx, &ResourceSpec{Name: "list-1", Type: ResourceTypeDocker, Image: "nginx"})
+	mgr.Create(ctx, &ResourceSpec{Name: "list-2", Type: ResourceTypeDocker, Image: "redis"})
+
+	req := httptest.NewRequest(http.MethodGet, "/provision/list", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if int(resp["count"].(float64)) != 2 {
+		t.Fatalf("expected count 2, got %v", resp["count"])
+	}
+}
+
+func TestHTTPStatus(t *testing.T) {
+	handler, mgr, _ := setupTestHandler(t)
+	ctx := context.Background()
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux, noAuthMiddleware)
+
+	result, _ := mgr.Create(ctx, &ResourceSpec{Name: "status-test", Type: ResourceTypeDocker, Image: "nginx"})
+
+	req := httptest.NewRequest(http.MethodGet, "/provision/"+result.Resource.ID, nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHTTPStatusNotFound(t *testing.T) {
+	handler, _, _ := setupTestHandler(t)
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux, noAuthMiddleware)
+
+	req := httptest.NewRequest(http.MethodGet, "/provision/nonexistent-id", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHTTPDestroy(t *testing.T) {
+	handler, mgr, _ := setupTestHandler(t)
+	ctx := context.Background()
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux, noAuthMiddleware)
+
+	result, _ := mgr.Create(ctx, &ResourceSpec{Name: "destroy-test", Type: ResourceTypeDocker, Image: "nginx"})
+
+	req := httptest.NewRequest(http.MethodPost, "/provision/"+result.Resource.ID+"/destroy", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHTTPLogs(t *testing.T) {
+	handler, mgr, backend := setupTestHandler(t)
+	ctx := context.Background()
+	backend.logsOutput = "hello world\n"
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux, noAuthMiddleware)
+
+	result, _ := mgr.Create(ctx, &ResourceSpec{Name: "logs-test", Type: ResourceTypeDocker, Image: "nginx"})
+
+	req := httptest.NewRequest(http.MethodGet, "/provision/"+result.Resource.ID+"/logs", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "hello world") {
+		t.Fatalf("expected logs to contain 'hello world', got %s", w.Body.String())
+	}
+}
+
+func TestHTTPListEmpty(t *testing.T) {
+	handler, _, _ := setupTestHandler(t)
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux, noAuthMiddleware)
+
+	req := httptest.NewRequest(http.MethodGet, "/provision/list", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if int(resp["count"].(float64)) != 0 {
+		t.Fatalf("expected count 0, got %v", resp["count"])
+	}
+}

--- a/internal/provision/store.go
+++ b/internal/provision/store.go
@@ -1,0 +1,125 @@
+package provision
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+const storeFileName = "resources.json"
+
+// Store persists provisioned resource state to disk as JSON.
+// It is safe for concurrent use.
+type Store struct {
+	mu   sync.RWMutex
+	path string
+
+	// resources is the in-memory cache, keyed by resource ID.
+	resources map[string]*Resource
+}
+
+// NewStore creates a Store backed by configDir/resources.json. It loads
+// existing state from disk on creation. If the file does not exist, the
+// store starts empty.
+func NewStore(configDir string) (*Store, error) {
+	s := &Store{
+		path:      filepath.Join(configDir, storeFileName),
+		resources: make(map[string]*Resource),
+	}
+	if err := s.load(); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// List returns all resources. The caller must not mutate the returned slice.
+func (s *Store) List() []*Resource {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make([]*Resource, 0, len(s.resources))
+	for _, r := range s.resources {
+		out = append(out, r)
+	}
+	return out
+}
+
+// Get returns a resource by ID, or nil if not found.
+func (s *Store) Get(id string) *Resource {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.resources[id]
+}
+
+// FindByName returns the first resource with the given name, or nil.
+func (s *Store) FindByName(name string) *Resource {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, r := range s.resources {
+		if r.Spec.Name == name {
+			return r
+		}
+	}
+	return nil
+}
+
+// Put adds or updates a resource and persists to disk.
+func (s *Store) Put(r *Resource) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.resources[r.ID] = r
+	return s.save()
+}
+
+// Delete removes a resource by ID and persists to disk.
+func (s *Store) Delete(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.resources, id)
+	return s.save()
+}
+
+// load reads the store file from disk into memory.
+func (s *Store) load() error {
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("reading resource store: %w", err)
+	}
+
+	var resources []*Resource
+	if err := json.Unmarshal(data, &resources); err != nil {
+		return fmt.Errorf("parsing resource store: %w", err)
+	}
+
+	for _, r := range resources {
+		s.resources[r.ID] = r
+	}
+	return nil
+}
+
+// save writes the in-memory state to disk. Caller must hold s.mu.
+func (s *Store) save() error {
+	dir := filepath.Dir(s.path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("creating store directory: %w", err)
+	}
+
+	resources := make([]*Resource, 0, len(s.resources))
+	for _, r := range s.resources {
+		resources = append(resources, r)
+	}
+
+	data, err := json.MarshalIndent(resources, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshalling resource store: %w", err)
+	}
+
+	return os.WriteFile(s.path, data, 0600)
+}

--- a/internal/provision/types.go
+++ b/internal/provision/types.go
@@ -1,0 +1,119 @@
+// Package provision implements resource lifecycle management for the
+// Infrastructure Canvas. It provides a unified API for creating, destroying,
+// and inspecting provisioned resources (Docker containers, LXC containers,
+// VMs) on a Citadel node.
+package provision
+
+import "time"
+
+// ResourceType identifies the kind of provisioned resource.
+type ResourceType string
+
+const (
+	ResourceTypeDocker ResourceType = "docker"
+	ResourceTypeLXC    ResourceType = "lxc"
+	ResourceTypeVM     ResourceType = "vm"
+)
+
+// ResourceStatus represents the lifecycle state of a resource.
+type ResourceStatus string
+
+const (
+	StatusCreating  ResourceStatus = "creating"
+	StatusRunning   ResourceStatus = "running"
+	StatusStopped   ResourceStatus = "stopped"
+	StatusError     ResourceStatus = "error"
+	StatusDestroyed ResourceStatus = "destroyed"
+)
+
+// VolumeMount describes a bind mount from the host into a container.
+type VolumeMount struct {
+	// HostPath is the path on the host filesystem. Must be under an allowed
+	// prefix (/tmp, workspace dir, or /var/lib/citadel/volumes).
+	HostPath string `json:"host_path"`
+
+	// ContainerPath is the mount target inside the container.
+	ContainerPath string `json:"container_path"`
+
+	// ReadOnly makes the mount read-only when true.
+	ReadOnly bool `json:"read_only,omitempty"`
+}
+
+// PortMapping maps a host port to a container port.
+type PortMapping struct {
+	// HostPort is the port exposed on the host.
+	HostPort int `json:"host_port"`
+
+	// ContainerPort is the port inside the container.
+	ContainerPort int `json:"container_port"`
+
+	// Protocol is "tcp" or "udp". Defaults to "tcp".
+	Protocol string `json:"protocol,omitempty"`
+}
+
+// ResourceSpec is the declarative specification for creating a resource.
+type ResourceSpec struct {
+	// Name is a human-readable identifier (must be unique per node).
+	Name string `json:"name"`
+
+	// Type selects the backend: "docker" (MVP), "lxc", or "vm" (future).
+	Type ResourceType `json:"type"`
+
+	// Image is the container image reference (e.g., "nginx:latest").
+	// Required for docker and lxc types.
+	Image string `json:"image,omitempty"`
+
+	// Env is a map of environment variables injected into the resource.
+	Env map[string]string `json:"env,omitempty"`
+
+	// Ports maps host ports to container ports.
+	Ports []PortMapping `json:"ports,omitempty"`
+
+	// Volumes binds host paths into the container.
+	Volumes []VolumeMount `json:"volumes,omitempty"`
+
+	// Command overrides the container entrypoint.
+	Command []string `json:"command,omitempty"`
+
+	// CPUs limits CPU allocation (e.g., "0.5" for half a core).
+	CPUs string `json:"cpus,omitempty"`
+
+	// MemoryMB limits memory in megabytes.
+	MemoryMB int `json:"memory_mb,omitempty"`
+
+	// GPUs requests GPU access. "all" passes all GPUs; a number like "1"
+	// requests that many.
+	GPUs string `json:"gpus,omitempty"`
+}
+
+// Resource represents a provisioned resource with its runtime state.
+type Resource struct {
+	// ID is a unique identifier (UUID) assigned at creation.
+	ID string `json:"id"`
+
+	// Spec is the original creation specification.
+	Spec ResourceSpec `json:"spec"`
+
+	// Status is the current lifecycle state.
+	Status ResourceStatus `json:"status"`
+
+	// ContainerID is the backend-specific identifier (e.g., Docker container ID).
+	ContainerID string `json:"container_id,omitempty"`
+
+	// Error records the last error message, if Status == "error".
+	Error string `json:"error,omitempty"`
+
+	// CreatedAt is when the resource was first created.
+	CreatedAt time.Time `json:"created_at"`
+
+	// UpdatedAt is when the resource state last changed.
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// CreateResult is returned by Manager.Create.
+type CreateResult struct {
+	Resource *Resource `json:"resource"`
+	// Reused is true when an existing resource with the same name was returned
+	// instead of creating a new one (idempotency).
+	Reused bool `json:"reused,omitempty"`
+}

--- a/internal/provision/validate.go
+++ b/internal/provision/validate.go
@@ -1,0 +1,103 @@
+package provision
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// validNameRe restricts resource names to safe characters.
+var validNameRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$`)
+
+// allowedVolumePrefixes are the only host paths allowed in volume mounts.
+// This prevents containers from mounting arbitrary host directories.
+var allowedVolumePrefixes = []string{
+	"/tmp/",
+	"/var/lib/citadel/volumes/",
+}
+
+// SetAllowedVolumePrefixes replaces the allowed volume prefixes. This is
+// exposed for testing and for adding workspace directories at runtime.
+func SetAllowedVolumePrefixes(prefixes []string) {
+	allowedVolumePrefixes = prefixes
+}
+
+// AddAllowedVolumePrefix appends a prefix to the allowed list.
+func AddAllowedVolumePrefix(prefix string) {
+	if !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+	allowedVolumePrefixes = append(allowedVolumePrefixes, prefix)
+}
+
+// ValidateSpec checks that a ResourceSpec is well-formed and safe.
+func ValidateSpec(spec *ResourceSpec) error {
+	if spec.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+	if !validNameRe.MatchString(spec.Name) {
+		return fmt.Errorf("invalid name %q: must match %s", spec.Name, validNameRe.String())
+	}
+
+	switch spec.Type {
+	case ResourceTypeDocker:
+		// OK
+	case ResourceTypeLXC, ResourceTypeVM:
+		return fmt.Errorf("resource type %q is not yet supported", spec.Type)
+	default:
+		return fmt.Errorf("unknown resource type %q", spec.Type)
+	}
+
+	if spec.Image == "" {
+		return fmt.Errorf("image is required for %s resources", spec.Type)
+	}
+
+	for _, v := range spec.Volumes {
+		if err := validateVolumePath(v.HostPath); err != nil {
+			return fmt.Errorf("volume %q: %w", v.HostPath, err)
+		}
+		if v.ContainerPath == "" {
+			return fmt.Errorf("volume %q: container_path is required", v.HostPath)
+		}
+	}
+
+	for _, p := range spec.Ports {
+		if p.HostPort < 1 || p.HostPort > 65535 {
+			return fmt.Errorf("invalid host port %d: must be 1-65535", p.HostPort)
+		}
+		if p.ContainerPort < 1 || p.ContainerPort > 65535 {
+			return fmt.Errorf("invalid container port %d: must be 1-65535", p.ContainerPort)
+		}
+		proto := p.Protocol
+		if proto == "" {
+			proto = "tcp"
+		}
+		if proto != "tcp" && proto != "udp" {
+			return fmt.Errorf("invalid protocol %q: must be tcp or udp", proto)
+		}
+	}
+
+	return nil
+}
+
+func validateVolumePath(hostPath string) error {
+	if hostPath == "" {
+		return fmt.Errorf("host_path is required")
+	}
+	if !filepath.IsAbs(hostPath) {
+		return fmt.Errorf("host_path must be absolute, got %q", hostPath)
+	}
+	cleaned := filepath.Clean(hostPath)
+	if cleaned != hostPath && cleaned+"/" != hostPath {
+		return fmt.Errorf("host_path contains path traversal")
+	}
+	pathWithSlash := cleaned + "/"
+	for _, prefix := range allowedVolumePrefixes {
+		if strings.HasPrefix(pathWithSlash, prefix) || cleaned == strings.TrimSuffix(prefix, "/") {
+			return nil
+		}
+	}
+	return fmt.Errorf("host_path %q is not under an allowed prefix (%s)",
+		hostPath, strings.Join(allowedVolumePrefixes, ", "))
+}

--- a/internal/status/server.go
+++ b/internal/status/server.go
@@ -15,6 +15,11 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/terminal"
 )
 
+// RouteRegistrar is a callback that registers HTTP routes on the status server's
+// mux with the given auth middleware. This avoids circular imports between the
+// status package and feature packages (e.g., provision).
+type RouteRegistrar func(mux *http.ServeMux, authMiddleware func(http.HandlerFunc) http.HandlerFunc)
+
 // Server provides an HTTP server for node status queries.
 // This enables on-demand queries from the AceTeam control plane.
 type Server struct {
@@ -29,6 +34,10 @@ type Server struct {
 	// agent provides the data/actions backing the /agent/* introspection &
 	// control endpoints (issue #236). Nil disables those routes.
 	agent *AgentProviders
+
+	// routeRegistrars are callbacks registered via AddRouteRegistrar that
+	// install additional routes (e.g., provisioning API) during Start.
+	routeRegistrars []RouteRegistrar
 
 	// extraListeners are additional net.Listeners the server will also serve on
 	// (e.g., a tsnet VPN listener). Added via AddListener before Start.
@@ -72,6 +81,14 @@ func (s *Server) AddListener(ln net.Listener) {
 	s.extraListeners = append(s.extraListeners, ln)
 }
 
+// AddRouteRegistrar registers a callback that will be invoked during Start to
+// install additional HTTP routes on the server's mux. The callback receives
+// the mux and the requireVPNOrAuth middleware for auth gating.
+// Must be called before Start.
+func (s *Server) AddRouteRegistrar(reg RouteRegistrar) {
+	s.routeRegistrars = append(s.routeRegistrars, reg)
+}
+
 // Start begins listening for HTTP requests.
 // This method blocks until the context is cancelled.
 func (s *Server) Start(ctx context.Context) error {
@@ -94,6 +111,11 @@ func (s *Server) Start(ctx context.Context) error {
 	// Agent introspection & control endpoints (issue #236), gated the same way
 	// (VPN origin or valid org token). No-op when no providers were supplied.
 	s.registerAgentRoutes(mux)
+
+	// Invoke registered route registrars (e.g., provisioning API).
+	for _, reg := range s.routeRegistrars {
+		reg(mux, s.requireVPNOrAuth)
+	}
 
 	s.httpServer = &http.Server{
 		Addr:         fmt.Sprintf(":%d", s.port),


### PR DESCRIPTION
## Context

Implements #104 — the provisioning API surface for the Infrastructure Canvas. This enables Citadel nodes to manage Docker container lifecycles through both HTTP API endpoints and CLI commands, laying the foundation for the visual Infrastructure Canvas where users can provision and manage compute resources on their own hardware.

## Summary

**New `internal/provision/` package** — resource lifecycle management with a Backend interface pattern:
- `types.go`: Core types (`ResourceType`, `ResourceStatus`, `ResourceSpec`, `Resource`) supporting Docker (MVP), with LXC and VM types defined for future extensibility
- `store.go`: JSON file-backed persistence (`~/.citadel-cli/resources.json`) with thread-safe `sync.RWMutex` access
- `validate.go`: Input validation restricting volume mounts to safe prefixes (`/tmp/`, `/var/lib/citadel/volumes/`) to prevent host filesystem escape
- `docker.go`: `DockerBackend` using `exec.Command("docker", ...)` for CGO_ENABLED=0 compatibility — pull, run, stop, rm, inspect, logs
- `manager.go`: Lifecycle orchestration with idempotent creates (same-name returns existing), crash recovery via `ReconcileAll` that reconciles persisted vs actual state on startup
- `handler.go`: HTTP handlers for `/provision/*` endpoints (create, list, status, destroy, logs) gated by `requireVPNOrAuth` middleware

**New CLI commands** (`cmd/provision.go`):
- `citadel provision create --name web --image nginx:latest --port 8080:80`
- `citadel provision list` / `citadel provision status <id>` / `citadel provision destroy <id>` / `citadel provision logs <id>`

**Integration wiring across 5 existing files:**
- `status/server.go`: `RouteRegistrar` callback type to avoid circular imports — provision handler registers its routes during `Start()` with the server's `requireVPNOrAuth` middleware
- `gateway/gateway.go`: New "provision" permission category in `categoryForPath()` and `permissionMiddleware()` switch
- `config/permissions.go`: `Provision bool` field (default `true`, opt-out model consistent with existing capabilities)
- `cmd/work.go`: Wires `initProvisionHandler()` into the status server via `AddRouteRegistrar`, adds `/provision` gateway upstream
- `cmd/serve.go`: Adds `/provision` gateway upstream for standalone gateway mode

## Test plan

| Area | Tests | Coverage |
|------|-------|----------|
| Store | 4 | Round-trip, FindByName, Delete, empty load |
| Validation | 14 | 9 spec cases (name, type, image, ports, protocol) + 5 volume path cases |
| Manager | 9 | Create+status, idempotent, destroy, not found, backend error, list, reconcile, logs, create-after-destroyed |
| HTTP handlers | 8 | Create, create-invalid, list, status, status-not-found, destroy, logs, list-empty |
| **Total** | **22 tests, all passing** | |

```
go test ./internal/provision/... -v   # all 22 pass
go build ./...                         # clean build with CGO_ENABLED=0
```

## Related

- Closes #104