### PR TITLE
fix(workflow): gate HTTP API behind requireVPNOrAuth

### DIFF
--- a/cmd/work.go
+++ b/cmd/work.go
@@ -721,11 +721,11 @@ func runWork(cmd *cobra.Command, args []string) {
 
 	// Resolve workspace dir early — needed by both file-operation handlers and
 	// the workflow executor, and the workflow executor must be created before the
-	// status server config (which references it in the ExtraRoutes closure).
+	// status server starts (its AddRouteRegistrar closure references it).
 	wsDir := resolveWorkspaceDir()
 
 	// Workflow executor for WORKFLOW_RUN jobs (#105). Created here so the status
-	// server's ExtraRoutes closure and the job handler share a single instance.
+	// server's AddRouteRegistrar closure and the job handler share a single instance.
 	wfExec := workflow.NewExecutor(workflow.ExecutorConfig{
 		Shell: workflow.ShellConfig{WorkspaceDir: wsDir},
 	})
@@ -750,10 +750,6 @@ func runWork(cmd *cobra.Command, args []string) {
 			Port:    workStatusPort,
 			Version: Version,
 			Agent:   agentProviders,
-			ExtraRoutes: func(mux *http.ServeMux) {
-				wfServer := workflow.NewServer(wfExec)
-				wfServer.RegisterRoutes(mux)
-			},
 		}
 
 		// Wire up desktop API auth if org ID is available
@@ -795,6 +791,12 @@ func runWork(cmd *cobra.Command, args []string) {
 		if provisionHandler := initProvisionHandler(); provisionHandler != nil {
 			statusServer.AddRouteRegistrar(provisionHandler.RegisterRoutes)
 		}
+
+		// Register workflow API routes, gated by requireVPNOrAuth (#259).
+		statusServer.AddRouteRegistrar(func(mux *http.ServeMux, auth func(http.HandlerFunc) http.HandlerFunc) {
+			wfServer := workflow.NewServer(wfExec)
+			wfServer.RegisterRoutes(mux, auth)
+		})
 
 		// Add VPN listener so the status server is reachable over the tsnet VPN
 		if network.IsGlobalConnected() {

--- a/internal/workflow/server.go
+++ b/internal/workflow/server.go
@@ -16,10 +16,10 @@ func NewServer(executor *Executor) *Server {
 	return &Server{executor: executor}
 }
 
-func (s *Server) RegisterRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("/workflow/run", s.handleRun)
-	mux.HandleFunc("/workflow/", s.handleWorkflowByID)
-	mux.HandleFunc("/workflow", s.handleList)
+func (s *Server) RegisterRoutes(mux *http.ServeMux, authMiddleware func(http.HandlerFunc) http.HandlerFunc) {
+	mux.HandleFunc("/workflow/run", authMiddleware(s.handleRun))
+	mux.HandleFunc("/workflow/", authMiddleware(s.handleWorkflowByID))
+	mux.HandleFunc("/workflow", authMiddleware(s.handleList))
 }
 
 func (s *Server) handleRun(w http.ResponseWriter, r *http.Request) {

--- a/internal/workflow/server_test.go
+++ b/internal/workflow/server_test.go
@@ -10,6 +10,9 @@ import (
 	"time"
 )
 
+// noopAuth is a pass-through middleware used in tests that don't verify auth gating.
+func noopAuth(h http.HandlerFunc) http.HandlerFunc { return h }
+
 func newTestServer() (*Server, *Executor) {
 	executor := NewExecutor(ExecutorConfig{DefaultTimeout: 5 * time.Second})
 	server := NewServer(executor)
@@ -19,7 +22,7 @@ func newTestServer() (*Server, *Executor) {
 func TestServer_RunEndpoint(t *testing.T) {
 	srv, _ := newTestServer()
 	mux := http.NewServeMux()
-	srv.RegisterRoutes(mux)
+	srv.RegisterRoutes(mux, noopAuth)
 	body := `{"graph":{"input_node":{"id":"in","type":"Input"},"output_node":{"id":"out","type":"Output"},"inner_nodes":[],"edges":[{"source_id":"in","source_key":"data","target_id":"out","target_key":"result"}]},"input":{"data":"test"}}`
 	req := httptest.NewRequest(http.MethodPost, "/workflow/run", bytes.NewBufferString(body))
 	w := httptest.NewRecorder()
@@ -37,7 +40,7 @@ func TestServer_RunEndpoint(t *testing.T) {
 func TestServer_RunEndpoint_InvalidMethod(t *testing.T) {
 	srv, _ := newTestServer()
 	mux := http.NewServeMux()
-	srv.RegisterRoutes(mux)
+	srv.RegisterRoutes(mux, noopAuth)
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/workflow/run", nil))
 	if w.Code != http.StatusMethodNotAllowed {
@@ -48,7 +51,7 @@ func TestServer_RunEndpoint_InvalidMethod(t *testing.T) {
 func TestServer_RunEndpoint_InvalidJSON(t *testing.T) {
 	srv, _ := newTestServer()
 	mux := http.NewServeMux()
-	srv.RegisterRoutes(mux)
+	srv.RegisterRoutes(mux, noopAuth)
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/workflow/run", bytes.NewBufferString("not json")))
 	if w.Code != http.StatusBadRequest {
@@ -59,7 +62,7 @@ func TestServer_RunEndpoint_InvalidJSON(t *testing.T) {
 func TestServer_GetEndpoint(t *testing.T) {
 	srv, executor := newTestServer()
 	mux := http.NewServeMux()
-	srv.RegisterRoutes(mux)
+	srv.RegisterRoutes(mux, noopAuth)
 	graph := &WorkflowGraph{
 		InputNode: &Node{ID: "in", Type: NodeTypeInput}, OutputNode: &Node{ID: "out", Type: NodeTypeOutput},
 		Edges: []*Edge{{SourceID: "in", SourceKey: "x", TargetID: "out", TargetKey: "y"}},
@@ -76,7 +79,7 @@ func TestServer_GetEndpoint(t *testing.T) {
 func TestServer_GetEndpoint_NotFound(t *testing.T) {
 	srv, _ := newTestServer()
 	mux := http.NewServeMux()
-	srv.RegisterRoutes(mux)
+	srv.RegisterRoutes(mux, noopAuth)
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/workflow/nonexistent", nil))
 	if w.Code != http.StatusNotFound {
@@ -87,7 +90,7 @@ func TestServer_GetEndpoint_NotFound(t *testing.T) {
 func TestServer_ListEndpoint(t *testing.T) {
 	srv, executor := newTestServer()
 	mux := http.NewServeMux()
-	srv.RegisterRoutes(mux)
+	srv.RegisterRoutes(mux, noopAuth)
 	graph := &WorkflowGraph{
 		InputNode: &Node{ID: "in", Type: NodeTypeInput}, OutputNode: &Node{ID: "out", Type: NodeTypeOutput},
 		Edges: []*Edge{{SourceID: "in", SourceKey: "x", TargetID: "out", TargetKey: "y"}},
@@ -109,7 +112,7 @@ func TestServer_ListEndpoint(t *testing.T) {
 func TestServer_CancelEndpoint(t *testing.T) {
 	srv, executor := newTestServer()
 	mux := http.NewServeMux()
-	srv.RegisterRoutes(mux)
+	srv.RegisterRoutes(mux, noopAuth)
 	executor.mu.Lock()
 	executor.runs["cancel-me"] = &Execution{ID: "cancel-me", Status: StatusRunning}
 	executor.mu.Unlock()
@@ -117,5 +120,21 @@ func TestServer_CancelEndpoint(t *testing.T) {
 	mux.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, "/workflow/cancel-me", nil))
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestServer_RoutesGatedByAuth(t *testing.T) {
+	srv, _ := newTestServer()
+	mux := http.NewServeMux()
+	blocked := func(http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusUnauthorized) }
+	}
+	srv.RegisterRoutes(mux, blocked)
+	for _, p := range []string{"/workflow/run", "/workflow/abc", "/workflow"} {
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, httptest.NewRequest(http.MethodGet, p, nil))
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("path %s not gated: got %d", p, w.Code)
+		}
 	}
 }


### PR DESCRIPTION
## Context

Closes #259. PR #258 added a workflow executor with HTTP API routes in `internal/workflow/server.go`. The routes were wired via `ExtraRoutes` in `cmd/work.go`, which registers them on the status server mux **without** the `requireVPNOrAuth` auth middleware. This means the workflow API (`/workflow/run`, `/workflow/`, `/workflow`) was unauthenticated — anyone with network access to the status port could submit, list, query, and cancel workflow executions.

## Summary

- **`internal/workflow/server.go`** — `RegisterRoutes` now accepts an `authMiddleware` parameter and wraps all three route handlers with it, ensuring every workflow endpoint is gated by whatever auth middleware the caller provides.

- **`cmd/work.go`** — Replaced the `ExtraRoutes` closure (which bypassed auth) with `AddRouteRegistrar`, matching the existing pattern used by the provisioning API. The `AddRouteRegistrar` callback receives `requireVPNOrAuth` from the status server during `Start()`. Updated stale comments that referenced the old `ExtraRoutes` wiring.

- **`internal/workflow/server_test.go`** — All existing tests pass a no-op auth middleware so functional behavior is unchanged. Added `TestServer_RoutesGatedByAuth` which registers routes with a blocking middleware (returns 401) and verifies all three route patterns are gated — this test would catch a regression if someone accidentally removes the middleware wrapping.

## Test plan

| Group | Count | Coverage |
|-------|-------|----------|
| Existing functional tests | 6 | Run, invalid method, invalid JSON, get, get-not-found, list, cancel — all pass with no-op auth |
| Auth gating test | 1 | Blocking middleware returns 401 on `/workflow/run`, `/workflow/abc`, `/workflow` |
| Build | 1 | `CGO_ENABLED=0 go build ./...` passes |
| Full test suite | 1 | `CGO_ENABLED=0 go test ./...` passes (e2e skipped — requires Redis/server) |