### PR TITLE
feat: macOS build server support (#140)

### DIFF
--- a/cmd/caffeinate_darwin.go
+++ b/cmd/caffeinate_darwin.go
@@ -1,0 +1,37 @@
+//go:build darwin
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// startCaffeinate starts the macOS caffeinate utility to prevent the system from
+// sleeping while the worker is active. Uses -dimsu to prevent display sleep,
+// idle sleep, disk sleep, and system sleep.
+//
+// Returns a cancel function that stops the caffeinate process. If caffeinate
+// is not available, logs a warning and returns a no-op cancel function.
+func startCaffeinate(ctx context.Context) func() {
+	path, err := exec.LookPath("caffeinate")
+	if err != nil {
+		fmt.Println("   - Warning: caffeinate not found, system may sleep during work")
+		return func() {}
+	}
+
+	cmd := exec.CommandContext(ctx, path, "-dimsu")
+	if err := cmd.Start(); err != nil {
+		fmt.Printf("   - Warning: failed to start caffeinate: %v\n", err)
+		return func() {}
+	}
+
+	fmt.Println("   - Sleep prevention: caffeinate active")
+	return func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	}
+}

--- a/cmd/caffeinate_other.go
+++ b/cmd/caffeinate_other.go
@@ -1,0 +1,12 @@
+//go:build !darwin
+
+package cmd
+
+import (
+	"context"
+)
+
+// startCaffeinate is a no-op on non-macOS platforms.
+func startCaffeinate(_ context.Context) func() {
+	return func() {}
+}

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -211,14 +211,25 @@ func runWork(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	// Log macOS developer toolchains (detected by DetectNodeCapabilities above)
-	if macTools := capabilities.DetectMacOSToolchains(); len(macTools) > 0 {
-		for _, tool := range macTools {
-			desc := tool.Name
-			if tool.Version != "" {
-				desc += " " + tool.Version
+	// Log macOS developer toolchains (tags already added by DetectNodeCapabilities)
+	for _, tag := range nodeCaps.Tags {
+		switch {
+		case strings.HasPrefix(tag, "tool:xcode:"):
+			fmt.Printf("   - Toolchain: Xcode %s\n", strings.TrimPrefix(tag, "tool:xcode:"))
+		case tag == "tool:xcode":
+			// Only log if there's no versioned tag (avoid duplicate)
+			hasVersion := false
+			for _, t := range nodeCaps.Tags {
+				if strings.HasPrefix(t, "tool:xcode:") {
+					hasVersion = true
+					break
+				}
 			}
-			fmt.Printf("   - Toolchain: %s (%s)\n", desc, tool.Path)
+			if !hasVersion {
+				fmt.Println("   - Toolchain: Xcode")
+			}
+		case tag == "tool:android-sdk":
+			fmt.Println("   - Toolchain: Android SDK")
 		}
 	}
 

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -160,6 +160,10 @@ func runWork(cmd *cobra.Command, args []string) {
 
 	// Note: Update check is now handled by root.go's PersistentPreRun
 
+	// Prevent macOS from sleeping while worker is active
+	stopCaffeinate := startCaffeinate(ctx)
+	defer stopCaffeinate()
+
 	// Auto-start services from manifest (unless --no-services is set)
 	if !workNoServices {
 		if err := autoStartServices(); err != nil {
@@ -204,6 +208,17 @@ func runWork(cmd *cobra.Command, args []string) {
 		fmt.Printf("\n")
 		if pveInfo.VMCount > 0 || pveInfo.CTCount > 0 {
 			fmt.Printf("   - Guests: %d VMs, %d containers\n", pveInfo.VMCount, pveInfo.CTCount)
+		}
+	}
+
+	// Log macOS developer toolchains (detected by DetectNodeCapabilities above)
+	if macTools := capabilities.DetectMacOSToolchains(); len(macTools) > 0 {
+		for _, tool := range macTools {
+			desc := tool.Name
+			if tool.Version != "" {
+				desc += " " + tool.Version
+			}
+			fmt.Printf("   - Toolchain: %s (%s)\n", desc, tool.Path)
 		}
 	}
 

--- a/internal/capabilities/detector.go
+++ b/internal/capabilities/detector.go
@@ -187,9 +187,27 @@ func DetectNodeCapabilities() *NodeCapabilities {
 
 	// Add OS tag
 	caps.Tags = append(caps.Tags, "os:"+runtime.GOOS)
+	// Add a human-friendly os:macos alias on Darwin
+	if runtime.GOOS == "darwin" {
+		caps.Tags = append(caps.Tags, "os:macos")
+	}
 
 	// Add architecture tag
 	caps.Tags = append(caps.Tags, "arch:"+runtime.GOARCH)
+
+	// Detect macOS developer toolchains (Xcode, Android SDK)
+	for _, tool := range DetectMacOSToolchains() {
+		if ValidateTag(tool.Tag) {
+			caps.Tags = append(caps.Tags, tool.Tag)
+		}
+		// Add versioned tag if available (e.g. tool:xcode:15.4)
+		if tool.Version != "" {
+			versionedTag := tool.Tag + ":" + tool.Version
+			if ValidateTag(versionedTag) {
+				caps.Tags = append(caps.Tags, versionedTag)
+			}
+		}
+	}
 
 	return caps
 }

--- a/internal/capabilities/macos.go
+++ b/internal/capabilities/macos.go
@@ -1,0 +1,71 @@
+//go:build darwin
+
+package capabilities
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// detectXcode checks for Xcode installation via xcode-select and returns the
+// developer directory path, or empty string if not installed.
+func detectXcode() string {
+	ctx, cancel := context.WithTimeout(context.Background(), detectionTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "xcode-select", "-p").Output()
+	if err != nil {
+		return ""
+	}
+	path := parseXcodePath(string(out))
+	if path == "" {
+		return ""
+	}
+	// Verify the directory exists
+	if _, err := os.Stat(path); err != nil {
+		return ""
+	}
+	return path
+}
+
+// detectXcodeVersion runs xcodebuild -version and returns the parsed version string.
+func detectXcodeVersion() string {
+	ctx, cancel := context.WithTimeout(context.Background(), detectionTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "xcodebuild", "-version").Output()
+	if err != nil {
+		return ""
+	}
+	return parseXcodeVersion(string(out))
+}
+
+// detectAndroidSDK checks for Android SDK installation via ANDROID_HOME or default paths.
+func detectAndroidSDK() string {
+	// Check ANDROID_HOME env var first
+	if home := os.Getenv("ANDROID_HOME"); home != "" {
+		if isValidAndroidSDK(home) {
+			return home
+		}
+	}
+	// Check ANDROID_SDK_ROOT (older convention)
+	if root := os.Getenv("ANDROID_SDK_ROOT"); root != "" {
+		if isValidAndroidSDK(root) {
+			return root
+		}
+	}
+	// Check default macOS paths
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	defaults := []string{
+		filepath.Join(homeDir, "Library", "Android", "sdk"),
+	}
+	for _, p := range defaults {
+		if isValidAndroidSDK(p) {
+			return p
+		}
+	}
+	return ""
+}

--- a/internal/capabilities/macos_other.go
+++ b/internal/capabilities/macos_other.go
@@ -1,0 +1,18 @@
+//go:build !darwin
+
+package capabilities
+
+// detectXcode is a no-op on non-macOS platforms.
+func detectXcode() string {
+	return ""
+}
+
+// detectXcodeVersion is a no-op on non-macOS platforms.
+func detectXcodeVersion() string {
+	return ""
+}
+
+// detectAndroidSDK is a no-op on non-macOS platforms.
+func detectAndroidSDK() string {
+	return ""
+}

--- a/internal/capabilities/macos_parse.go
+++ b/internal/capabilities/macos_parse.go
@@ -1,0 +1,79 @@
+package capabilities
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// parseXcodePath extracts the developer directory path from xcode-select -p output.
+func parseXcodePath(output string) string {
+	return strings.TrimSpace(output)
+}
+
+// parseXcodeVersion extracts the version string from xcodebuild -version output.
+// Input typically looks like:
+//
+//	Xcode 15.4
+//	Build version 15F31d
+//
+// Returns "15.4" (the version number only).
+func parseXcodeVersion(output string) string {
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "Xcode ") {
+			return strings.TrimPrefix(line, "Xcode ")
+		}
+	}
+	return ""
+}
+
+// isValidAndroidSDK checks whether a path looks like a valid Android SDK directory
+// by checking for the presence of characteristic subdirectories.
+func isValidAndroidSDK(path string) bool {
+	if _, err := os.Stat(path); err != nil {
+		return false
+	}
+	// Check for at least one of the expected SDK subdirectories
+	markers := []string{"platform-tools", "build-tools", "platforms"}
+	for _, m := range markers {
+		if _, err := os.Stat(filepath.Join(path, m)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// DetectMacOSToolchains detects macOS-specific developer toolchains and returns
+// capability tags. This function is called from DetectNodeCapabilities.
+func DetectMacOSToolchains() []MacOSToolchain {
+	var tools []MacOSToolchain
+
+	if xcodePath := detectXcode(); xcodePath != "" {
+		version := detectXcodeVersion()
+		tools = append(tools, MacOSToolchain{
+			Name:    "xcode",
+			Tag:     "tool:xcode",
+			Path:    xcodePath,
+			Version: version,
+		})
+	}
+
+	if sdkPath := detectAndroidSDK(); sdkPath != "" {
+		tools = append(tools, MacOSToolchain{
+			Name: "android-sdk",
+			Tag:  "tool:android-sdk",
+			Path: sdkPath,
+		})
+	}
+
+	return tools
+}
+
+// MacOSToolchain holds information about a detected macOS developer toolchain.
+type MacOSToolchain struct {
+	Name    string // short name (e.g. "xcode", "android-sdk")
+	Tag     string // capability tag (e.g. "tool:xcode")
+	Path    string // installation path
+	Version string // version string (optional)
+}

--- a/internal/capabilities/macos_parse_test.go
+++ b/internal/capabilities/macos_parse_test.go
@@ -1,0 +1,180 @@
+package capabilities
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseXcodeVersion(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect string
+	}{
+		{
+			name:   "standard output",
+			input:  "Xcode 15.4\nBuild version 15F31d\n",
+			expect: "15.4",
+		},
+		{
+			name:   "xcode 16",
+			input:  "Xcode 16.0\nBuild version 16A242d\n",
+			expect: "16.0",
+		},
+		{
+			name:   "beta version",
+			input:  "Xcode 16.1 Beta\nBuild version 16B5001e\n",
+			expect: "16.1 Beta",
+		},
+		{
+			name:   "empty input",
+			input:  "",
+			expect: "",
+		},
+		{
+			name:   "no xcode line",
+			input:  "Some other output\n",
+			expect: "",
+		},
+		{
+			name:   "only version line",
+			input:  "Xcode 14.3.1",
+			expect: "14.3.1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseXcodeVersion(tc.input)
+			if got != tc.expect {
+				t.Errorf("parseXcodeVersion(%q) = %q, want %q", tc.input, got, tc.expect)
+			}
+		})
+	}
+}
+
+func TestParseXcodePath(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect string
+	}{
+		{
+			name:   "standard xcode",
+			input:  "/Applications/Xcode.app/Contents/Developer\n",
+			expect: "/Applications/Xcode.app/Contents/Developer",
+		},
+		{
+			name:   "command line tools only",
+			input:  "/Library/Developer/CommandLineTools\n",
+			expect: "/Library/Developer/CommandLineTools",
+		},
+		{
+			name:   "no trailing newline",
+			input:  "/Applications/Xcode.app/Contents/Developer",
+			expect: "/Applications/Xcode.app/Contents/Developer",
+		},
+		{
+			name:   "empty",
+			input:  "",
+			expect: "",
+		},
+		{
+			name:   "whitespace only",
+			input:  "  \n  ",
+			expect: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseXcodePath(tc.input)
+			if got != tc.expect {
+				t.Errorf("parseXcodePath(%q) = %q, want %q", tc.input, got, tc.expect)
+			}
+		})
+	}
+}
+
+func TestIsValidAndroidSDK(t *testing.T) {
+	// Create a temp directory that looks like an Android SDK
+	tmpDir := t.TempDir()
+	validSDK := filepath.Join(tmpDir, "android-sdk")
+	if err := os.MkdirAll(filepath.Join(validSDK, "platform-tools"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create another with build-tools
+	validSDK2 := filepath.Join(tmpDir, "android-sdk2")
+	if err := os.MkdirAll(filepath.Join(validSDK2, "build-tools"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create an empty directory (not a valid SDK)
+	emptyDir := filepath.Join(tmpDir, "empty")
+	if err := os.MkdirAll(emptyDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name   string
+		path   string
+		expect bool
+	}{
+		{"valid SDK with platform-tools", validSDK, true},
+		{"valid SDK with build-tools", validSDK2, true},
+		{"empty directory", emptyDir, false},
+		{"nonexistent path", "/nonexistent/path", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isValidAndroidSDK(tc.path)
+			if got != tc.expect {
+				t.Errorf("isValidAndroidSDK(%q) = %v, want %v", tc.path, got, tc.expect)
+			}
+		})
+	}
+}
+
+func TestDetectMacOSToolchains_Tags(t *testing.T) {
+	// On non-macOS, detectXcode and detectAndroidSDK return "" via stubs,
+	// so DetectMacOSToolchains returns an empty slice.
+	// On macOS, results depend on whether Xcode/Android SDK are installed.
+	// Either way, returned tags must be valid.
+	tools := DetectMacOSToolchains()
+	for _, tool := range tools {
+		if !ValidateTag(tool.Tag) {
+			t.Errorf("invalid tag %q for tool %s", tool.Tag, tool.Name)
+		}
+		if tool.Version != "" {
+			vTag := tool.Tag + ":" + tool.Version
+			// Versioned tags with dots/spaces may not validate; just check the base tag
+			t.Logf("tool %s: version=%q versioned_tag=%q valid=%v", tool.Name, tool.Version, vTag, ValidateTag(vTag))
+		}
+	}
+}
+
+func TestMacOSToolchainStruct(t *testing.T) {
+	tc := MacOSToolchain{
+		Name:    "xcode",
+		Tag:     "tool:xcode",
+		Path:    "/Applications/Xcode.app/Contents/Developer",
+		Version: "15.4",
+	}
+	if tc.Name != "xcode" {
+		t.Errorf("unexpected name: %s", tc.Name)
+	}
+	if tc.Tag != "tool:xcode" {
+		t.Errorf("unexpected tag: %s", tc.Tag)
+	}
+	if !ValidateTag(tc.Tag) {
+		t.Errorf("tool:xcode should be a valid tag")
+	}
+	// Validate that versioned tags work
+	versionedTag := tc.Tag + ":" + tc.Version
+	if !ValidateTag(versionedTag) {
+		t.Errorf("tool:xcode:15.4 should be a valid tag, got invalid")
+	}
+}


### PR DESCRIPTION
## Context

Phase 1 of macOS build server provisioning (Issue #140). Jason's M1 MacBook Pro will serve as an iOS/Android build server on the Sovereign Compute Fabric. This PR adds macOS-specific capability auto-detection and sleep prevention so that `citadel work` properly advertises the node's developer toolchains and stays awake during long build jobs.

## Summary

**macOS Capability Detection** (`internal/capabilities/macos*.go`)
- Auto-detect Xcode installation via `xcode-select -p` and version via `xcodebuild -version` -- emits `tool:xcode` and `tool:xcode:<version>` tags for queue routing
- Auto-detect Android SDK via `ANDROID_HOME`, `ANDROID_SDK_ROOT`, or default `~/Library/Android/sdk` path -- emits `tool:android-sdk` tag
- Emit `os:macos` alias alongside existing `os:darwin` for human-friendly routing
- Platform separation via build tags: `macos.go` (darwin-only exec), `macos_other.go` (stubs), `macos_parse.go` (cross-platform parsers)

**Sleep Prevention** (`cmd/caffeinate_darwin.go`)
- Start `caffeinate -dimsu` on macOS during `citadel work` to prevent display, idle, disk, and system sleep
- Uses `exec.CommandContext` tied to worker context for automatic cleanup on shutdown
- Graceful fallback: warns and continues if caffeinate is not available
- No-op stub on non-macOS platforms (`caffeinate_other.go`)

**launchd Service** -- already fully implemented in the codebase (`internal/service/launchd.go`). No changes needed. Use `citadel service install --system` for headless build server (LaunchDaemon mode).

## Test plan

| Area | Tests | Coverage |
|------|-------|----------|
| Xcode version parsing | 6 cases (standard, beta, empty, missing line) | `TestParseXcodeVersion` |
| Xcode path parsing | 5 cases (standard, CLI tools, empty, whitespace) | `TestParseXcodePath` |
| Android SDK validation | 4 cases (platform-tools, build-tools, empty dir, nonexistent) | `TestIsValidAndroidSDK` |
| Tag validity | 2 cases (struct validation, versioned tag format) | `TestMacOSToolchainStruct`, `TestDetectMacOSToolchains_Tags` |
| Cross-compile | `CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build ./cmd/citadel/` passes | verified |
| Linux build | `CGO_ENABLED=0 go build ./...` passes | verified |
| Linux tests | `CGO_ENABLED=0 go test ./...` passes (all 17 new test cases) | verified |

## Related

- Closes #140