### PR TITLE
fix(workflow): avoid copying sync.RWMutex in Execution.Snapshot

### DIFF
--- a/internal/workflow/types.go
+++ b/internal/workflow/types.go
@@ -204,8 +204,18 @@ func (e *Execution) AddNodeLog(log *NodeLog) {
 func (e *Execution) Snapshot() Execution {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
-	cp := *e
-	return cp
+	return Execution{
+		ID:        e.ID,
+		Status:    e.Status,
+		Graph:     e.Graph,
+		Input:     e.Input,
+		Output:    e.Output,
+		Error:     e.Error,
+		StartedAt: e.StartedAt,
+		EndedAt:   e.EndedAt,
+		NodeLogs:  e.NodeLogs,
+		Metrics:   e.Metrics,
+	}
 }
 
 func (e *Execution) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
## Summary

- Build `Execution.Snapshot()` field-by-field instead of struct copy (`cp := *e`) to avoid copying the embedded `sync.RWMutex`, which `go vet` flags as a bug.

## Test plan

- `go vet ./...` passes cleanly
- `go test ./internal/workflow/...` — all 44 tests pass