### PR TITLE
feat: macOS VNC provisioner (#122)

### DIFF
--- a/cmd/vnc.go
+++ b/cmd/vnc.go
@@ -110,6 +110,10 @@ func runVNCEnable(cmd *cobra.Command, args []string) error {
 	// Configure
 	fmt.Printf("Configuring VNC on port %d...\n", vncPort)
 	if err := mgr.Configure(password, vncPort); err != nil {
+		// Surface sudo-required errors directly without wrapping
+		if errors.Is(err, platform.ErrSudoRequired) || errors.Is(err, platform.ErrDarwinSudoRequired) {
+			return err
+		}
 		return fmt.Errorf("failed to configure VNC server: %w", err)
 	}
 

--- a/internal/platform/vnc.go
+++ b/internal/platform/vnc.go
@@ -375,6 +375,11 @@ func (w *WindowsVNCManager) Port() int {
 // The caller (cmd/vnc.go) should display an actionable message to the user.
 var ErrSudoRequired = fmt.Errorf("VNC server installation requires root privileges. Install sudo and run: sudo citadel vnc enable — or run directly as root: su -c 'citadel vnc enable'")
 
+// ErrDarwinSudoRequired is returned when macOS Screen Sharing provisioning
+// needs elevated privileges but sudo is unavailable. The kickstart tool
+// always requires root to change Remote Management configuration.
+var ErrDarwinSudoRequired = fmt.Errorf("macOS Screen Sharing provisioning requires root privileges. Run: sudo citadel vnc enable")
+
 // --- Linux implementation ---
 
 // LinuxVNCManager manages x11vnc on Linux.
@@ -738,45 +743,202 @@ func (l *LinuxVNCManager) effectivePort() int {
 	return DefaultVNCPort
 }
 
-// --- macOS implementation (stub) ---
+// --- macOS implementation ---
 
-// DarwinVNCManager is a stub VNC manager for macOS.
-// macOS has built-in Screen Sharing that can be enabled via system preferences.
+// kickstartPath is the absolute path to Apple Remote Desktop's kickstart
+// tool, which activates and configures the built-in Remote Management /
+// Screen Sharing VNC server. It ships with every macOS install.
+const kickstartPath = "/System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart"
+
+// DarwinVNCManager provisions the built-in macOS Screen Sharing / Apple
+// Remote Desktop VNC server via the kickstart tool. macOS ships a VNC
+// server as part of Remote Management, so there is nothing to install --
+// it only needs to be activated and configured (which requires root).
 type DarwinVNCManager struct{}
 
 func (d *DarwinVNCManager) IsInstalled() bool {
-	// macOS has built-in Screen Sharing (VNC)
-	return true
+	// The kickstart tool ships with every macOS install. Its presence
+	// means the built-in VNC server is available to be provisioned.
+	_, err := os.Stat(kickstartPath)
+	return err == nil
+}
+
+// kickstartActivateArgs returns the kickstart arguments that activate
+// Remote Management, grant full access privileges, enable VNC legacy mode,
+// set the VNC password, and restart the agent. Extracted as a pure function
+// for testability -- it never executes anything.
+//
+// The flags map to:
+//
+//	-activate              : turn on Remote Management
+//	-configure             : apply the following configuration
+//	-access -on            : enable access
+//	-clientopts -setvnclegacy -vnclegacy yes : allow legacy VNC clients
+//	-clientopts -setvncpw -vncpw <pw>        : set the VNC (RFB) password
+//	-privs -all            : grant all control privileges
+//	-restart -agent        : restart the ARD agent so changes take effect
+func kickstartActivateArgs(password string) []string {
+	return []string{
+		"-activate",
+		"-configure",
+		"-access", "-on",
+		"-clientopts", "-setvnclegacy", "-vnclegacy", "yes",
+		"-clientopts", "-setvncpw", "-vncpw", password,
+		"-restart", "-agent",
+		"-privs", "-all",
+	}
+}
+
+// kickstartDeactivateArgs returns the kickstart arguments that stop the
+// Remote Management agent and disable access. Pure function for testability.
+func kickstartDeactivateArgs() []string {
+	return []string{
+		"-deactivate",
+		"-configure",
+		"-access", "-off",
+	}
+}
+
+// kickstartRestartArgs returns the kickstart arguments that restart the
+// Remote Management agent without changing configuration. Pure function.
+func kickstartRestartArgs() []string {
+	return []string{"-restart", "-agent"}
+}
+
+// darwinCmd builds an *exec.Cmd for the given name+args, prefixing with
+// sudo when the current process is not root. macOS kickstart operations
+// require root; this mirrors the Linux sudoPrefix helper.
+func darwinCmd(needsSudo bool, name string, args ...string) *exec.Cmd {
+	if needsSudo {
+		return exec.Command("sudo", append([]string{name}, args...)...)
+	}
+	return exec.Command(name, args...)
 }
 
 func (d *DarwinVNCManager) Install() error {
-	fmt.Println("VNC server provisioning not yet supported on macOS (use built-in Screen Sharing)")
+	// macOS ships the VNC server (Remote Management); there is nothing to
+	// download or install. Activation/configuration happens in Configure,
+	// which is the step that actually enables Screen Sharing. We verify the
+	// kickstart tool is present so callers get a clear error on unusual
+	// systems where Remote Management has been removed.
+	if !d.IsInstalled() {
+		return fmt.Errorf("macOS Remote Management tool not found at %s", kickstartPath)
+	}
+	fmt.Println("macOS Screen Sharing is built in; no installation required.")
 	return nil
 }
 
 func (d *DarwinVNCManager) Uninstall() error {
-	fmt.Println("VNC server uninstall not yet supported on macOS.")
+	// We cannot uninstall a built-in macOS component, but we can disable it,
+	// which is the meaningful equivalent of "removing" the VNC server.
+	needsSudo := os.Getuid() != 0
+	if needsSudo {
+		if _, err := exec.LookPath("sudo"); err != nil {
+			return ErrDarwinSudoRequired
+		}
+	}
+
+	cmd := darwinCmd(needsSudo, kickstartPath, kickstartDeactivateArgs()...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to deactivate macOS Screen Sharing: %w (output: %s)", err, strings.TrimSpace(string(output)))
+	}
+
+	fmt.Println("macOS Screen Sharing disabled.")
 	return nil
 }
 
 func (d *DarwinVNCManager) Configure(password string, port int) error {
-	fmt.Println("VNC server provisioning not yet supported on macOS (use built-in Screen Sharing)")
+	if err := ValidateVNCPort(port); err != nil {
+		return err
+	}
+
+	// macOS Screen Sharing only listens on the standard VNC port (5900).
+	// A custom port is not configurable via kickstart, so warn rather than
+	// silently pretend it took effect.
+	if port != DefaultVNCPort {
+		fmt.Printf("Note: macOS Screen Sharing only supports port %d; ignoring requested port %d.\n", DefaultVNCPort, port)
+	}
+
+	// The RFB password is limited to 8 bytes by the VNC DES scheme.
+	if len(password) > 8 {
+		password = password[:8]
+	}
+
+	needsSudo := os.Getuid() != 0
+	if needsSudo {
+		if _, err := exec.LookPath("sudo"); err != nil {
+			return ErrDarwinSudoRequired
+		}
+	}
+
+	// Activating + configuring is a single kickstart invocation. This both
+	// turns on Remote Management and sets the VNC password.
+	cmd := darwinCmd(needsSudo, kickstartPath, kickstartActivateArgs(password)...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to configure macOS Screen Sharing: %w (output: %s)", err, strings.TrimSpace(string(output)))
+	}
+
 	return nil
 }
 
 func (d *DarwinVNCManager) Start() error {
-	fmt.Println("VNC server provisioning not yet supported on macOS (use built-in Screen Sharing)")
+	if d.IsRunning() {
+		return nil // Already running, idempotent
+	}
+
+	needsSudo := os.Getuid() != 0
+	if needsSudo {
+		if _, err := exec.LookPath("sudo"); err != nil {
+			return ErrDarwinSudoRequired
+		}
+	}
+
+	// Restart the ARD agent to ensure the service is up. Configure() already
+	// activates the service; this handles the case where it was deactivated
+	// or the agent needs to be (re)started.
+	cmd := darwinCmd(needsSudo, kickstartPath, kickstartRestartArgs()...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to start macOS Screen Sharing: %w (output: %s)", err, strings.TrimSpace(string(output)))
+	}
+
 	return nil
 }
 
 func (d *DarwinVNCManager) Stop() error {
-	fmt.Println("VNC server provisioning not yet supported on macOS (use built-in Screen Sharing)")
+	needsSudo := os.Getuid() != 0
+	if needsSudo {
+		if _, err := exec.LookPath("sudo"); err != nil {
+			return ErrDarwinSudoRequired
+		}
+	}
+
+	cmd := darwinCmd(needsSudo, kickstartPath, kickstartDeactivateArgs()...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to stop macOS Screen Sharing: %w (output: %s)", err, strings.TrimSpace(string(output)))
+	}
 	return nil
 }
 
 func (d *DarwinVNCManager) IsRunning() bool {
-	// Check if Screen Sharing is active
-	cmd := exec.Command("launchctl", "list", "com.apple.screensharing")
+	// The screensharing launchd service is loaded only when Screen Sharing
+	// is enabled. `launchctl list <label>` exits non-zero when the service
+	// is not present.
+	if exec.Command("launchctl", "list", "com.apple.screensharing").Run() == nil {
+		return true
+	}
+	// Fallback: a VNC server listening on the standard port is also a
+	// positive signal (e.g. a third-party server, or detection edge cases).
+	return darwinPortListening(DefaultVNCPort)
+}
+
+// darwinPortListening reports whether a TCP listener is bound to the given
+// port, using `lsof`. Best-effort: returns false on any error.
+func darwinPortListening(port int) bool {
+	cmd := exec.Command("lsof", "-nP", fmt.Sprintf("-iTCP:%d", port), "-sTCP:LISTEN")
 	return cmd.Run() == nil
 }
 

--- a/internal/platform/vnc_test.go
+++ b/internal/platform/vnc_test.go
@@ -448,6 +448,178 @@ func TestLinuxVNCManagerConfigureSetsPort(t *testing.T) {
 	}
 }
 
+func TestKickstartActivateArgs(t *testing.T) {
+	args := kickstartActivateArgs("secret12")
+	argStr := strings.Join(args, " ")
+
+	// Core activation flags must be present
+	for _, want := range []string{"-activate", "-configure", "-access", "-on", "-restart", "-agent", "-privs", "-all"} {
+		found := false
+		for _, a := range args {
+			if a == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("kickstartActivateArgs() missing %q in %v", want, args)
+		}
+	}
+
+	// VNC legacy mode and password must be configured
+	if !strings.Contains(argStr, "-setvnclegacy -vnclegacy yes") {
+		t.Errorf("kickstartActivateArgs() should enable VNC legacy mode, got: %s", argStr)
+	}
+	if !strings.Contains(argStr, "-setvncpw -vncpw secret12") {
+		t.Errorf("kickstartActivateArgs() should set the VNC password, got: %s", argStr)
+	}
+
+	// The password must appear immediately after -vncpw
+	for i, a := range args {
+		if a == "-vncpw" {
+			if i+1 >= len(args) || args[i+1] != "secret12" {
+				t.Errorf("kickstartActivateArgs() -vncpw not followed by password, got: %v", args)
+			}
+		}
+	}
+}
+
+func TestKickstartActivateArgsPasswordPositioning(t *testing.T) {
+	// A different password must flow through to the right slot.
+	args := kickstartActivateArgs("abc")
+	idx := -1
+	for i, a := range args {
+		if a == "-vncpw" {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		t.Fatal("kickstartActivateArgs() missing -vncpw flag")
+	}
+	if args[idx+1] != "abc" {
+		t.Errorf("kickstartActivateArgs() password = %q, want %q", args[idx+1], "abc")
+	}
+}
+
+func TestKickstartDeactivateArgs(t *testing.T) {
+	args := kickstartDeactivateArgs()
+	for _, want := range []string{"-deactivate", "-configure", "-access", "-off"} {
+		found := false
+		for _, a := range args {
+			if a == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("kickstartDeactivateArgs() missing %q in %v", want, args)
+		}
+	}
+	// Must not contain activation flags
+	for _, nw := range []string{"-activate", "-on"} {
+		for _, a := range args {
+			if a == nw {
+				t.Errorf("kickstartDeactivateArgs() should not contain %q, got: %v", nw, args)
+			}
+		}
+	}
+}
+
+func TestKickstartRestartArgs(t *testing.T) {
+	args := kickstartRestartArgs()
+	want := []string{"-restart", "-agent"}
+	if len(args) != len(want) {
+		t.Fatalf("kickstartRestartArgs() = %v, want %v", args, want)
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Errorf("kickstartRestartArgs()[%d] = %q, want %q", i, args[i], want[i])
+		}
+	}
+}
+
+func TestDarwinCmdSudoPrefix(t *testing.T) {
+	// With sudo: the command should be "sudo" and the real command shifted
+	// into the argument list.
+	cmd := darwinCmd(true, kickstartPath, "-activate")
+	if !strings.HasSuffix(cmd.Path, "sudo") && cmd.Args[0] != "sudo" {
+		t.Errorf("darwinCmd(needsSudo=true) should invoke sudo, got args: %v", cmd.Args)
+	}
+	if cmd.Args[1] != kickstartPath {
+		t.Errorf("darwinCmd(needsSudo=true) args[1] = %q, want %q", cmd.Args[1], kickstartPath)
+	}
+	if cmd.Args[2] != "-activate" {
+		t.Errorf("darwinCmd(needsSudo=true) args[2] = %q, want -activate", cmd.Args[2])
+	}
+
+	// Without sudo: the command runs kickstart directly.
+	cmd = darwinCmd(false, kickstartPath, "-activate")
+	if cmd.Args[0] != kickstartPath {
+		t.Errorf("darwinCmd(needsSudo=false) args[0] = %q, want %q", cmd.Args[0], kickstartPath)
+	}
+	if cmd.Args[1] != "-activate" {
+		t.Errorf("darwinCmd(needsSudo=false) args[1] = %q, want -activate", cmd.Args[1])
+	}
+}
+
+func TestKickstartPath(t *testing.T) {
+	// Guard against accidental edits to the well-known ARD kickstart path.
+	const want = "/System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart"
+	if kickstartPath != want {
+		t.Errorf("kickstartPath = %q, want %q", kickstartPath, want)
+	}
+}
+
+func TestErrDarwinSudoRequired(t *testing.T) {
+	if ErrDarwinSudoRequired == nil {
+		t.Fatal("ErrDarwinSudoRequired is nil")
+	}
+	msg := ErrDarwinSudoRequired.Error()
+	if !strings.Contains(msg, "sudo") {
+		t.Errorf("ErrDarwinSudoRequired should mention sudo, got: %s", msg)
+	}
+	if !strings.Contains(msg, "root privileges") {
+		t.Errorf("ErrDarwinSudoRequired should mention root privileges, got: %s", msg)
+	}
+}
+
+func TestDarwinVNCManagerDetection(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("Skipping macOS-specific test")
+	}
+
+	mgr := &DarwinVNCManager{}
+	// Detection methods must not panic regardless of Screen Sharing state.
+	_ = mgr.IsInstalled()
+	_ = mgr.IsRunning()
+	_ = mgr.Port()
+
+	// kickstart ships with macOS, so IsInstalled should be true.
+	if !mgr.IsInstalled() {
+		t.Errorf("DarwinVNCManager.IsInstalled() = false on macOS; kickstart should be present at %s", kickstartPath)
+	}
+
+	// Port() must be consistent with IsRunning().
+	if mgr.IsRunning() {
+		if mgr.Port() != DefaultVNCPort {
+			t.Errorf("DarwinVNCManager.Port() = %d while running, want %d", mgr.Port(), DefaultVNCPort)
+		}
+	} else if mgr.Port() != 0 {
+		t.Errorf("DarwinVNCManager.Port() = %d while not running, want 0", mgr.Port())
+	}
+}
+
+func TestDarwinVNCManagerConfigureValidation(t *testing.T) {
+	mgr := &DarwinVNCManager{}
+	// Invalid ports must be rejected before any kickstart invocation.
+	for _, p := range []int{0, -1, 70000} {
+		if err := mgr.Configure("testpass", p); err == nil {
+			t.Errorf("Configure() with port %d should return error", p)
+		}
+	}
+}
+
 func TestEmbeddedVNCPort(t *testing.T) {
 	// Initial state: no embedded VNC
 	ClearEmbeddedVNCPort()


### PR DESCRIPTION
## Context

VNC provisioning (#118) was built with per-OS managers behind a single `VNCManager` interface (`Install` / `Configure` / `Start` / `Stop` / `Uninstall` + `IsInstalled` / `IsRunning` / `Port`). The Windows path (TightVNC) was E2E-verified (#119), and Linux (x11vnc) followed. Per #122, the **macOS** implementation was left as no-op stubs for Install/Configure/Start while detection already worked.

This PR fills in the macOS provisioner so `citadel vnc enable` actually turns on remote desktop access on a Mac node.

**Why kickstart instead of a third-party server:** macOS ships a VNC server as part of Remote Management (Apple Remote Desktop / Screen Sharing). There is nothing to install — it only needs to be *activated and configured*. Apple provides the `kickstart` tool for exactly this, at:

```
/System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart
```

## Summary

**`internal/platform/vnc.go` — `DarwinVNCManager`**

| Method | Behavior |
| --- | --- |
| `IsInstalled` | `os.Stat` on the kickstart path (built into every macOS install). |
| `Install` | Nothing to download; verifies kickstart is present and returns a clear error if Remote Management has been stripped from the system. |
| `Configure` | `kickstart -activate -configure -access -on -clientopts -setvnclegacy -vnclegacy yes -clientopts -setvncpw -vncpw <pw> -restart -agent -privs -all` — enables Remote Management, allows legacy VNC clients, sets the 8-char RFB password, grants control privileges. Validates the port; warns that macOS Screen Sharing only listens on 5900 (custom ports aren't configurable via kickstart) rather than silently lying. |
| `Start` | `kickstart -restart -agent`, idempotent when already running. |
| `Stop` / `Uninstall` | `kickstart -deactivate -configure -access -off` (a built-in component can't be uninstalled; disabling is the meaningful equivalent). |
| `IsRunning` | `launchctl list com.apple.screensharing` (loaded only when enabled), with a port-5900 `lsof` listen check as fallback. |
| `Port` | 5900 when running, else 0. |

**Privilege handling:** every kickstart operation requires root. Commands are prefixed with `sudo` when not already root (mirroring the Linux `sudoPrefix` helper). When sudo is unavailable, a new `ErrDarwinSudoRequired` is returned. `cmd/vnc.go` now surfaces this (and the existing `ErrSudoRequired`) directly from the Configure step so the user sees an actionable `sudo citadel vnc enable` message instead of a wrapped failure.

**Testability:** command construction is extracted into pure functions — `kickstartActivateArgs`, `kickstartDeactivateArgs`, `kickstartRestartArgs`, `darwinCmd` — following the existing `buildX11VNCArgs` / `uninstallCmd` pattern. No build tags were added: the file compiles on all OSes (verified via cross-compile), matching the existing single-file structure where every manager is runtime-dispatched by `GetVNCManager()`.

## Test plan

New unit tests in `internal/platform/vnc_test.go` (no Screen Sharing changes required to run — pure builders + parsers + gating):

| Test | Coverage |
| --- | --- |
| `TestKickstartActivateArgs` / `...PasswordPositioning` | activation flags present; VNC legacy enabled; password lands immediately after `-vncpw` |
| `TestKickstartDeactivateArgs` | deactivate/off flags present; no activation flags leak in |
| `TestKickstartRestartArgs` | exact `-restart -agent` |
| `TestDarwinCmdSudoPrefix` | sudo prefixing shifts the real command into argv correctly; no-sudo runs kickstart directly |
| `TestKickstartPath` | guards the well-known ARD path |
| `TestErrDarwinSudoRequired` | error mentions sudo + root privileges |
| `TestDarwinVNCManagerDetection` (darwin-gated) | no panic; `IsInstalled` true; `Port` consistent with `IsRunning` |
| `TestDarwinVNCManagerConfigureValidation` | invalid ports rejected before any kickstart call |

**Results:**
- `go build ./...` — pass (darwin); cross-compiled `GOOS=linux` and `GOOS=windows` — pass.
- `go test ./internal/platform/ ./cmd/` — pass.
- Full `go test ./...` — pass except a pre-existing `e2e/TestDeviceAuthExpiry` failure that requires a live server on `localhost:3000` (unrelated to this change).
- Sanity check on an M1 Mac with Screen Sharing **off**: `citadel vnc status` correctly reports `Installed: true`, `Running: false`. No system state was modified.

## Not yet verified (needs sudo + a real Mac)

The activate/configure/start path requires `sudo` and actually enables Screen Sharing system-wide, so it was **not** exercised here — only the command construction and detection were verified. On-device E2E (enable → connect through the DesktopViewer/noVNC chain → disable) is tracked as a follow-up issue.

## Related

- Closes the macOS portion of #122
- Builds on the VNC provisioning interface from #118 / #119

---
*Generated by Claude*