### PR TITLE
feat: macOS build job handlers (#140 Phase 2)

### DIFF
--- a/cmd/caffeinate_darwin.go
+++ b/cmd/caffeinate_darwin.go
@@ -1,0 +1,37 @@
+//go:build darwin
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// startCaffeinate starts the macOS caffeinate utility to prevent the system from
+// sleeping while the worker is active. Uses -dimsu to prevent display sleep,
+// idle sleep, disk sleep, and system sleep.
+//
+// Returns a cancel function that stops the caffeinate process. If caffeinate
+// is not available, logs a warning and returns a no-op cancel function.
+func startCaffeinate(ctx context.Context) func() {
+	path, err := exec.LookPath("caffeinate")
+	if err != nil {
+		fmt.Println("   - Warning: caffeinate not found, system may sleep during work")
+		return func() {}
+	}
+
+	cmd := exec.CommandContext(ctx, path, "-dimsu")
+	if err := cmd.Start(); err != nil {
+		fmt.Printf("   - Warning: failed to start caffeinate: %v\n", err)
+		return func() {}
+	}
+
+	fmt.Println("   - Sleep prevention: caffeinate active")
+	return func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	}
+}

--- a/cmd/caffeinate_other.go
+++ b/cmd/caffeinate_other.go
@@ -1,0 +1,12 @@
+//go:build !darwin
+
+package cmd
+
+import (
+	"context"
+)
+
+// startCaffeinate is a no-op on non-macOS platforms.
+func startCaffeinate(_ context.Context) func() {
+	return func() {}
+}

--- a/cmd/job_handlers.go
+++ b/cmd/job_handlers.go
@@ -65,5 +65,8 @@ func init() {
 		"SANDBOX_RESUME":     &jobs.SandboxResumeHandler{},
 		"MODEL_CACHE_PULL":   &jobs.ModelCachePullHandler{},
 		"MODEL_CACHE_EVICT":  &jobs.ModelCacheEvictHandler{},
+		"IOS_BUILD":          jobs.NewIOSBuildHandler(""),
+		"ANDROID_BUILD":      jobs.NewAndroidBuildHandler(""),
+		"GOMOBILE_BUILD":     jobs.NewGomobileBuildHandler(""),
 	}
 }

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -211,14 +211,25 @@ func runWork(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	// Log macOS developer toolchains (detected by DetectNodeCapabilities above)
-	if macTools := capabilities.DetectMacOSToolchains(); len(macTools) > 0 {
-		for _, tool := range macTools {
-			desc := tool.Name
-			if tool.Version != "" {
-				desc += " " + tool.Version
+	// Log macOS developer toolchains (tags already added by DetectNodeCapabilities)
+	for _, tag := range nodeCaps.Tags {
+		switch {
+		case strings.HasPrefix(tag, "tool:xcode:"):
+			fmt.Printf("   - Toolchain: Xcode %s\n", strings.TrimPrefix(tag, "tool:xcode:"))
+		case tag == "tool:xcode":
+			// Only log if there's no versioned tag (avoid duplicate)
+			hasVersion := false
+			for _, t := range nodeCaps.Tags {
+				if strings.HasPrefix(t, "tool:xcode:") {
+					hasVersion = true
+					break
+				}
 			}
-			fmt.Printf("   - Toolchain: %s (%s)\n", desc, tool.Path)
+			if !hasVersion {
+				fmt.Println("   - Toolchain: Xcode")
+			}
+		case tag == "tool:android-sdk":
+			fmt.Println("   - Toolchain: Android SDK")
 		}
 	}
 

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -160,6 +160,10 @@ func runWork(cmd *cobra.Command, args []string) {
 
 	// Note: Update check is now handled by root.go's PersistentPreRun
 
+	// Prevent macOS from sleeping while worker is active
+	stopCaffeinate := startCaffeinate(ctx)
+	defer stopCaffeinate()
+
 	// Auto-start services from manifest (unless --no-services is set)
 	if !workNoServices {
 		if err := autoStartServices(); err != nil {
@@ -204,6 +208,17 @@ func runWork(cmd *cobra.Command, args []string) {
 		fmt.Printf("\n")
 		if pveInfo.VMCount > 0 || pveInfo.CTCount > 0 {
 			fmt.Printf("   - Guests: %d VMs, %d containers\n", pveInfo.VMCount, pveInfo.CTCount)
+		}
+	}
+
+	// Log macOS developer toolchains (detected by DetectNodeCapabilities above)
+	if macTools := capabilities.DetectMacOSToolchains(); len(macTools) > 0 {
+		for _, tool := range macTools {
+			desc := tool.Name
+			if tool.Version != "" {
+				desc += " " + tool.Version
+			}
+			fmt.Printf("   - Toolchain: %s (%s)\n", desc, tool.Path)
 		}
 	}
 

--- a/internal/capabilities/detector.go
+++ b/internal/capabilities/detector.go
@@ -187,9 +187,27 @@ func DetectNodeCapabilities() *NodeCapabilities {
 
 	// Add OS tag
 	caps.Tags = append(caps.Tags, "os:"+runtime.GOOS)
+	// Add a human-friendly os:macos alias on Darwin
+	if runtime.GOOS == "darwin" {
+		caps.Tags = append(caps.Tags, "os:macos")
+	}
 
 	// Add architecture tag
 	caps.Tags = append(caps.Tags, "arch:"+runtime.GOARCH)
+
+	// Detect macOS developer toolchains (Xcode, Android SDK)
+	for _, tool := range DetectMacOSToolchains() {
+		if ValidateTag(tool.Tag) {
+			caps.Tags = append(caps.Tags, tool.Tag)
+		}
+		// Add versioned tag if available (e.g. tool:xcode:15.4)
+		if tool.Version != "" {
+			versionedTag := tool.Tag + ":" + tool.Version
+			if ValidateTag(versionedTag) {
+				caps.Tags = append(caps.Tags, versionedTag)
+			}
+		}
+	}
 
 	return caps
 }

--- a/internal/capabilities/macos.go
+++ b/internal/capabilities/macos.go
@@ -1,0 +1,71 @@
+//go:build darwin
+
+package capabilities
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// detectXcode checks for Xcode installation via xcode-select and returns the
+// developer directory path, or empty string if not installed.
+func detectXcode() string {
+	ctx, cancel := context.WithTimeout(context.Background(), detectionTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "xcode-select", "-p").Output()
+	if err != nil {
+		return ""
+	}
+	path := parseXcodePath(string(out))
+	if path == "" {
+		return ""
+	}
+	// Verify the directory exists
+	if _, err := os.Stat(path); err != nil {
+		return ""
+	}
+	return path
+}
+
+// detectXcodeVersion runs xcodebuild -version and returns the parsed version string.
+func detectXcodeVersion() string {
+	ctx, cancel := context.WithTimeout(context.Background(), detectionTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "xcodebuild", "-version").Output()
+	if err != nil {
+		return ""
+	}
+	return parseXcodeVersion(string(out))
+}
+
+// detectAndroidSDK checks for Android SDK installation via ANDROID_HOME or default paths.
+func detectAndroidSDK() string {
+	// Check ANDROID_HOME env var first
+	if home := os.Getenv("ANDROID_HOME"); home != "" {
+		if isValidAndroidSDK(home) {
+			return home
+		}
+	}
+	// Check ANDROID_SDK_ROOT (older convention)
+	if root := os.Getenv("ANDROID_SDK_ROOT"); root != "" {
+		if isValidAndroidSDK(root) {
+			return root
+		}
+	}
+	// Check default macOS paths
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	defaults := []string{
+		filepath.Join(homeDir, "Library", "Android", "sdk"),
+	}
+	for _, p := range defaults {
+		if isValidAndroidSDK(p) {
+			return p
+		}
+	}
+	return ""
+}

--- a/internal/capabilities/macos_other.go
+++ b/internal/capabilities/macos_other.go
@@ -1,0 +1,18 @@
+//go:build !darwin
+
+package capabilities
+
+// detectXcode is a no-op on non-macOS platforms.
+func detectXcode() string {
+	return ""
+}
+
+// detectXcodeVersion is a no-op on non-macOS platforms.
+func detectXcodeVersion() string {
+	return ""
+}
+
+// detectAndroidSDK is a no-op on non-macOS platforms.
+func detectAndroidSDK() string {
+	return ""
+}

--- a/internal/capabilities/macos_parse.go
+++ b/internal/capabilities/macos_parse.go
@@ -1,0 +1,79 @@
+package capabilities
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// parseXcodePath extracts the developer directory path from xcode-select -p output.
+func parseXcodePath(output string) string {
+	return strings.TrimSpace(output)
+}
+
+// parseXcodeVersion extracts the version string from xcodebuild -version output.
+// Input typically looks like:
+//
+//	Xcode 15.4
+//	Build version 15F31d
+//
+// Returns "15.4" (the version number only).
+func parseXcodeVersion(output string) string {
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "Xcode ") {
+			return strings.TrimPrefix(line, "Xcode ")
+		}
+	}
+	return ""
+}
+
+// isValidAndroidSDK checks whether a path looks like a valid Android SDK directory
+// by checking for the presence of characteristic subdirectories.
+func isValidAndroidSDK(path string) bool {
+	if _, err := os.Stat(path); err != nil {
+		return false
+	}
+	// Check for at least one of the expected SDK subdirectories
+	markers := []string{"platform-tools", "build-tools", "platforms"}
+	for _, m := range markers {
+		if _, err := os.Stat(filepath.Join(path, m)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// DetectMacOSToolchains detects macOS-specific developer toolchains and returns
+// capability tags. This function is called from DetectNodeCapabilities.
+func DetectMacOSToolchains() []MacOSToolchain {
+	var tools []MacOSToolchain
+
+	if xcodePath := detectXcode(); xcodePath != "" {
+		version := detectXcodeVersion()
+		tools = append(tools, MacOSToolchain{
+			Name:    "xcode",
+			Tag:     "tool:xcode",
+			Path:    xcodePath,
+			Version: version,
+		})
+	}
+
+	if sdkPath := detectAndroidSDK(); sdkPath != "" {
+		tools = append(tools, MacOSToolchain{
+			Name: "android-sdk",
+			Tag:  "tool:android-sdk",
+			Path: sdkPath,
+		})
+	}
+
+	return tools
+}
+
+// MacOSToolchain holds information about a detected macOS developer toolchain.
+type MacOSToolchain struct {
+	Name    string // short name (e.g. "xcode", "android-sdk")
+	Tag     string // capability tag (e.g. "tool:xcode")
+	Path    string // installation path
+	Version string // version string (optional)
+}

--- a/internal/capabilities/macos_parse_test.go
+++ b/internal/capabilities/macos_parse_test.go
@@ -1,0 +1,180 @@
+package capabilities
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseXcodeVersion(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect string
+	}{
+		{
+			name:   "standard output",
+			input:  "Xcode 15.4\nBuild version 15F31d\n",
+			expect: "15.4",
+		},
+		{
+			name:   "xcode 16",
+			input:  "Xcode 16.0\nBuild version 16A242d\n",
+			expect: "16.0",
+		},
+		{
+			name:   "beta version",
+			input:  "Xcode 16.1 Beta\nBuild version 16B5001e\n",
+			expect: "16.1 Beta",
+		},
+		{
+			name:   "empty input",
+			input:  "",
+			expect: "",
+		},
+		{
+			name:   "no xcode line",
+			input:  "Some other output\n",
+			expect: "",
+		},
+		{
+			name:   "only version line",
+			input:  "Xcode 14.3.1",
+			expect: "14.3.1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseXcodeVersion(tc.input)
+			if got != tc.expect {
+				t.Errorf("parseXcodeVersion(%q) = %q, want %q", tc.input, got, tc.expect)
+			}
+		})
+	}
+}
+
+func TestParseXcodePath(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect string
+	}{
+		{
+			name:   "standard xcode",
+			input:  "/Applications/Xcode.app/Contents/Developer\n",
+			expect: "/Applications/Xcode.app/Contents/Developer",
+		},
+		{
+			name:   "command line tools only",
+			input:  "/Library/Developer/CommandLineTools\n",
+			expect: "/Library/Developer/CommandLineTools",
+		},
+		{
+			name:   "no trailing newline",
+			input:  "/Applications/Xcode.app/Contents/Developer",
+			expect: "/Applications/Xcode.app/Contents/Developer",
+		},
+		{
+			name:   "empty",
+			input:  "",
+			expect: "",
+		},
+		{
+			name:   "whitespace only",
+			input:  "  \n  ",
+			expect: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseXcodePath(tc.input)
+			if got != tc.expect {
+				t.Errorf("parseXcodePath(%q) = %q, want %q", tc.input, got, tc.expect)
+			}
+		})
+	}
+}
+
+func TestIsValidAndroidSDK(t *testing.T) {
+	// Create a temp directory that looks like an Android SDK
+	tmpDir := t.TempDir()
+	validSDK := filepath.Join(tmpDir, "android-sdk")
+	if err := os.MkdirAll(filepath.Join(validSDK, "platform-tools"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create another with build-tools
+	validSDK2 := filepath.Join(tmpDir, "android-sdk2")
+	if err := os.MkdirAll(filepath.Join(validSDK2, "build-tools"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create an empty directory (not a valid SDK)
+	emptyDir := filepath.Join(tmpDir, "empty")
+	if err := os.MkdirAll(emptyDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name   string
+		path   string
+		expect bool
+	}{
+		{"valid SDK with platform-tools", validSDK, true},
+		{"valid SDK with build-tools", validSDK2, true},
+		{"empty directory", emptyDir, false},
+		{"nonexistent path", "/nonexistent/path", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isValidAndroidSDK(tc.path)
+			if got != tc.expect {
+				t.Errorf("isValidAndroidSDK(%q) = %v, want %v", tc.path, got, tc.expect)
+			}
+		})
+	}
+}
+
+func TestDetectMacOSToolchains_Tags(t *testing.T) {
+	// On non-macOS, detectXcode and detectAndroidSDK return "" via stubs,
+	// so DetectMacOSToolchains returns an empty slice.
+	// On macOS, results depend on whether Xcode/Android SDK are installed.
+	// Either way, returned tags must be valid.
+	tools := DetectMacOSToolchains()
+	for _, tool := range tools {
+		if !ValidateTag(tool.Tag) {
+			t.Errorf("invalid tag %q for tool %s", tool.Tag, tool.Name)
+		}
+		if tool.Version != "" {
+			vTag := tool.Tag + ":" + tool.Version
+			// Versioned tags with dots/spaces may not validate; just check the base tag
+			t.Logf("tool %s: version=%q versioned_tag=%q valid=%v", tool.Name, tool.Version, vTag, ValidateTag(vTag))
+		}
+	}
+}
+
+func TestMacOSToolchainStruct(t *testing.T) {
+	tc := MacOSToolchain{
+		Name:    "xcode",
+		Tag:     "tool:xcode",
+		Path:    "/Applications/Xcode.app/Contents/Developer",
+		Version: "15.4",
+	}
+	if tc.Name != "xcode" {
+		t.Errorf("unexpected name: %s", tc.Name)
+	}
+	if tc.Tag != "tool:xcode" {
+		t.Errorf("unexpected tag: %s", tc.Tag)
+	}
+	if !ValidateTag(tc.Tag) {
+		t.Errorf("tool:xcode should be a valid tag")
+	}
+	// Validate that versioned tags work
+	versionedTag := tc.Tag + ":" + tc.Version
+	if !ValidateTag(versionedTag) {
+		t.Errorf("tool:xcode:15.4 should be a valid tag, got invalid")
+	}
+}

--- a/internal/jobs/build_handlers.go
+++ b/internal/jobs/build_handlers.go
@@ -1,0 +1,303 @@
+// internal/jobs/build_handlers.go
+package jobs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+// buildTimeout caps a single build invocation. Real iOS/Android builds can take
+// several minutes; the cap protects the worker from a hung toolchain.
+const buildTimeout = 30 * time.Minute
+
+// runBuildCommand executes name with args in workspace (when non-empty) and
+// returns combined stdout/stderr plus the error. It is the single exec path for
+// all build handlers so platform gating and timeout behaviour stay consistent.
+//
+// It is a variable (not a plain function) so tests can stub the exec layer and
+// exercise the handlers' result/error shaping without a real toolchain.
+var runBuildCommand = func(workspace, name string, args []string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), buildTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, name, args...)
+	if workspace != "" {
+		cmd.Dir = workspace
+	}
+	return cmd.CombinedOutput()
+}
+
+// buildResult is the structured JSON returned by every build handler. The
+// adapter wraps this string under {"output": ...}; the coordinator pulls any
+// produced artifact by reference via FILE_READ_BYTES using artifact_path.
+type buildResult struct {
+	Tool         string `json:"tool"`
+	Command      string `json:"command"`
+	Output       string `json:"output"`
+	ArtifactPath string `json:"artifact_path,omitempty"`
+}
+
+func marshalBuildResult(r buildResult) ([]byte, error) {
+	return json.Marshal(r)
+}
+
+// nonEmptyField returns the trimmed value of the named payload field, or an
+// error naming the field when it is missing or blank.
+func nonEmptyField(payload map[string]string, field string) (string, error) {
+	v, ok := payload[field]
+	if !ok {
+		return "", fmt.Errorf("job payload missing %q field", field)
+	}
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return "", fmt.Errorf("job payload field %q is empty", field)
+	}
+	return v, nil
+}
+
+// splitTasks splits a whitespace-separated task/argument list, dropping blanks.
+func splitTasks(s string) []string {
+	fields := strings.Fields(s)
+	return fields
+}
+
+// IOSBuildHandler handles IOS_BUILD jobs by invoking xcodebuild. It is gated to
+// darwin at runtime; on other platforms Execute returns a structured error so
+// the binary still compiles and the job fails cleanly instead of panicking.
+type IOSBuildHandler struct {
+	WorkspaceDir string
+}
+
+// NewIOSBuildHandler creates an IOSBuildHandler rooted at workspace.
+func NewIOSBuildHandler(workspace string) *IOSBuildHandler {
+	return &IOSBuildHandler{WorkspaceDir: workspace}
+}
+
+// buildIOSArgs constructs the xcodebuild argument vector from the payload.
+//
+// Payload fields (all strings via nexus.Job):
+//   - scheme (required): the Xcode scheme to build
+//   - configuration (optional): e.g. "Debug" / "Release"
+//   - destination (optional): xcodebuild -destination value
+//   - workspace_file (optional): path to a .xcworkspace
+//   - project (optional): path to a .xcodeproj
+//   - sdk (optional): e.g. "iphonesimulator"
+//   - derived_data_path (optional): -derivedDataPath value
+//   - action (optional): build action(s), default "build"
+func buildIOSArgs(payload map[string]string) ([]string, error) {
+	scheme, err := nonEmptyField(payload, "scheme")
+	if err != nil {
+		return nil, err
+	}
+
+	var args []string
+	if ws := strings.TrimSpace(payload["workspace_file"]); ws != "" {
+		args = append(args, "-workspace", ws)
+	}
+	if proj := strings.TrimSpace(payload["project"]); proj != "" {
+		args = append(args, "-project", proj)
+	}
+	args = append(args, "-scheme", scheme)
+	if cfg := strings.TrimSpace(payload["configuration"]); cfg != "" {
+		args = append(args, "-configuration", cfg)
+	}
+	if sdk := strings.TrimSpace(payload["sdk"]); sdk != "" {
+		args = append(args, "-sdk", sdk)
+	}
+	if dest := strings.TrimSpace(payload["destination"]); dest != "" {
+		args = append(args, "-destination", dest)
+	}
+	if ddp := strings.TrimSpace(payload["derived_data_path"]); ddp != "" {
+		args = append(args, "-derivedDataPath", ddp)
+	}
+
+	action := strings.TrimSpace(payload["action"])
+	if action == "" {
+		action = "build"
+	}
+	args = append(args, splitTasks(action)...)
+
+	return args, nil
+}
+
+func (h *IOSBuildHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	if runtime.GOOS != "darwin" {
+		return nil, fmt.Errorf("IOS_BUILD requires macOS (xcodebuild); node is %s", runtime.GOOS)
+	}
+
+	args, err := buildIOSArgs(job.Payload)
+	if err != nil {
+		return nil, err
+	}
+
+	cmdStr := "xcodebuild " + strings.Join(args, " ")
+	ctx.Log("info", "     - [Job %s] IOS_BUILD: %s", job.ID, cmdStr)
+
+	out, runErr := runBuildCommand(h.WorkspaceDir, "xcodebuild", args)
+	if runErr != nil {
+		return out, fmt.Errorf("xcodebuild failed: %w", runErr)
+	}
+
+	return marshalBuildResult(buildResult{
+		Tool:         "xcodebuild",
+		Command:      cmdStr,
+		Output:       string(out),
+		ArtifactPath: strings.TrimSpace(job.Payload["artifact_path"]),
+	})
+}
+
+var _ JobHandler = (*IOSBuildHandler)(nil)
+
+// AndroidBuildHandler handles ANDROID_BUILD jobs by invoking the project's
+// Gradle wrapper. It runs on any platform but requires an Android SDK; the
+// caller is expected to route only to SDK-equipped nodes, and Execute fails
+// cleanly with a structured error if the wrapper is absent.
+type AndroidBuildHandler struct {
+	WorkspaceDir string
+}
+
+// NewAndroidBuildHandler creates an AndroidBuildHandler rooted at workspace.
+func NewAndroidBuildHandler(workspace string) *AndroidBuildHandler {
+	return &AndroidBuildHandler{WorkspaceDir: workspace}
+}
+
+// buildAndroidArgs constructs the gradlew argument vector from the payload.
+//
+// Payload fields:
+//   - tasks (required): whitespace-separated gradle tasks, e.g. "assembleDebug"
+//   - gradle_args (optional): extra flags, e.g. "--stacktrace -PflavorX"
+func buildAndroidArgs(payload map[string]string) ([]string, error) {
+	tasksRaw, err := nonEmptyField(payload, "tasks")
+	if err != nil {
+		return nil, err
+	}
+	tasks := splitTasks(tasksRaw)
+	if len(tasks) == 0 {
+		return nil, fmt.Errorf("job payload field \"tasks\" contains no tasks")
+	}
+
+	args := tasks
+	if extra := strings.TrimSpace(payload["gradle_args"]); extra != "" {
+		args = append(args, splitTasks(extra)...)
+	}
+	return args, nil
+}
+
+func (h *AndroidBuildHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	args, err := buildAndroidArgs(job.Payload)
+	if err != nil {
+		return nil, err
+	}
+
+	cmdStr := "./gradlew " + strings.Join(args, " ")
+	ctx.Log("info", "     - [Job %s] ANDROID_BUILD: %s", job.ID, cmdStr)
+
+	out, runErr := runBuildCommand(h.WorkspaceDir, "./gradlew", args)
+	if runErr != nil {
+		return out, fmt.Errorf("gradlew failed: %w", runErr)
+	}
+
+	return marshalBuildResult(buildResult{
+		Tool:         "gradlew",
+		Command:      cmdStr,
+		Output:       string(out),
+		ArtifactPath: strings.TrimSpace(job.Payload["artifact_path"]),
+	})
+}
+
+var _ JobHandler = (*AndroidBuildHandler)(nil)
+
+// GomobileBuildHandler handles GOMOBILE_BUILD jobs by cross-compiling a Go
+// package to a mobile framework via `gomobile bind`. The iOS (.xcframework)
+// target is gated to darwin at runtime; the Android (.aar) target runs on any
+// platform with the Android SDK + NDK.
+type GomobileBuildHandler struct {
+	WorkspaceDir string
+}
+
+// NewGomobileBuildHandler creates a GomobileBuildHandler rooted at workspace.
+func NewGomobileBuildHandler(workspace string) *GomobileBuildHandler {
+	return &GomobileBuildHandler{WorkspaceDir: workspace}
+}
+
+// gomobileTarget is a validated gomobile -target value.
+const (
+	gomobileTargetIOS     = "ios"
+	gomobileTargetAndroid = "android"
+)
+
+// buildGomobileArgs constructs the `gomobile bind` argument vector.
+//
+// Payload fields:
+//   - target (required): "ios" or "android"
+//   - package (required): the Go import path to bind, e.g. "./mobile"
+//   - output (optional): -o output path (.xcframework or .aar)
+//   - bind_args (optional): extra flags, e.g. "-ldflags=-s"
+//
+// goosForTarget is the host GOOS required for the requested target; iOS binds
+// can only be produced on darwin. The returned GOOS lets Execute gate at
+// runtime; empty means "any host".
+func buildGomobileArgs(payload map[string]string) (args []string, requiredGOOS string, err error) {
+	target, err := nonEmptyField(payload, "target")
+	if err != nil {
+		return nil, "", err
+	}
+	target = strings.ToLower(target)
+	switch target {
+	case gomobileTargetIOS:
+		requiredGOOS = "darwin"
+	case gomobileTargetAndroid:
+		requiredGOOS = ""
+	default:
+		return nil, "", fmt.Errorf("invalid target %q: must be %q or %q", target, gomobileTargetIOS, gomobileTargetAndroid)
+	}
+
+	pkg, err := nonEmptyField(payload, "package")
+	if err != nil {
+		return nil, "", err
+	}
+
+	args = []string{"bind", "-target", target}
+	if out := strings.TrimSpace(payload["output"]); out != "" {
+		args = append(args, "-o", out)
+	}
+	if extra := strings.TrimSpace(payload["bind_args"]); extra != "" {
+		args = append(args, splitTasks(extra)...)
+	}
+	args = append(args, pkg)
+	return args, requiredGOOS, nil
+}
+
+func (h *GomobileBuildHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	args, requiredGOOS, err := buildGomobileArgs(job.Payload)
+	if err != nil {
+		return nil, err
+	}
+	if requiredGOOS != "" && runtime.GOOS != requiredGOOS {
+		return nil, fmt.Errorf("GOMOBILE_BUILD target %q requires %s; node is %s",
+			job.Payload["target"], requiredGOOS, runtime.GOOS)
+	}
+
+	cmdStr := "gomobile " + strings.Join(args, " ")
+	ctx.Log("info", "     - [Job %s] GOMOBILE_BUILD: %s", job.ID, cmdStr)
+
+	out, runErr := runBuildCommand(h.WorkspaceDir, "gomobile", args)
+	if runErr != nil {
+		return out, fmt.Errorf("gomobile bind failed: %w", runErr)
+	}
+
+	return marshalBuildResult(buildResult{
+		Tool:         "gomobile",
+		Command:      cmdStr,
+		Output:       string(out),
+		ArtifactPath: strings.TrimSpace(job.Payload["output"]),
+	})
+}
+
+var _ JobHandler = (*GomobileBuildHandler)(nil)

--- a/internal/jobs/build_handlers_test.go
+++ b/internal/jobs/build_handlers_test.go
@@ -1,0 +1,427 @@
+package jobs
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"runtime"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+// stubBuildCommand replaces runBuildCommand for the duration of a test, capturing
+// the invocation and returning the supplied output/error. It restores the
+// original on cleanup so tests stay isolated.
+func stubBuildCommand(t *testing.T, out []byte, err error) *struct {
+	called    bool
+	workspace string
+	name      string
+	args      []string
+} {
+	t.Helper()
+	rec := &struct {
+		called    bool
+		workspace string
+		name      string
+		args      []string
+	}{}
+	orig := runBuildCommand
+	runBuildCommand = func(workspace, name string, args []string) ([]byte, error) {
+		rec.called = true
+		rec.workspace = workspace
+		rec.name = name
+		rec.args = args
+		return out, err
+	}
+	t.Cleanup(func() { runBuildCommand = orig })
+	return rec
+}
+
+func TestBuildIOSArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload map[string]string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:    "missing scheme",
+			payload: map[string]string{},
+			wantErr: true,
+		},
+		{
+			name:    "blank scheme",
+			payload: map[string]string{"scheme": "   "},
+			wantErr: true,
+		},
+		{
+			name:    "scheme only defaults to build action",
+			payload: map[string]string{"scheme": "MyApp"},
+			want:    []string{"-scheme", "MyApp", "build"},
+		},
+		{
+			name: "full configuration",
+			payload: map[string]string{
+				"workspace_file": "MyApp.xcworkspace",
+				"scheme":         "MyApp",
+				"configuration":  "Release",
+				"sdk":            "iphonesimulator",
+				"destination":    "generic/platform=iOS",
+			},
+			want: []string{
+				"-workspace", "MyApp.xcworkspace",
+				"-scheme", "MyApp",
+				"-configuration", "Release",
+				"-sdk", "iphonesimulator",
+				"-destination", "generic/platform=iOS",
+				"build",
+			},
+		},
+		{
+			name: "project and explicit clean+build action",
+			payload: map[string]string{
+				"project": "MyApp.xcodeproj",
+				"scheme":  "MyApp",
+				"action":  "clean build",
+			},
+			want: []string{
+				"-project", "MyApp.xcodeproj",
+				"-scheme", "MyApp",
+				"clean", "build",
+			},
+		},
+		{
+			name: "derived data path",
+			payload: map[string]string{
+				"scheme":            "MyApp",
+				"derived_data_path": "/tmp/dd",
+			},
+			want: []string{"-scheme", "MyApp", "-derivedDataPath", "/tmp/dd", "build"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := buildIOSArgs(tc.payload)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got args %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("args = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildAndroidArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload map[string]string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:    "missing tasks",
+			payload: map[string]string{},
+			wantErr: true,
+		},
+		{
+			name:    "blank tasks",
+			payload: map[string]string{"tasks": "   "},
+			wantErr: true,
+		},
+		{
+			name:    "single task",
+			payload: map[string]string{"tasks": "assembleDebug"},
+			want:    []string{"assembleDebug"},
+		},
+		{
+			name:    "multiple tasks plus extra args",
+			payload: map[string]string{"tasks": "clean assembleRelease", "gradle_args": "--stacktrace -Pflavor=pro"},
+			want:    []string{"clean", "assembleRelease", "--stacktrace", "-Pflavor=pro"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := buildAndroidArgs(tc.payload)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got args %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("args = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildGomobileArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		payload  map[string]string
+		wantArgs []string
+		wantGOOS string
+		wantErr  bool
+	}{
+		{
+			name:    "missing target",
+			payload: map[string]string{"package": "./mobile"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid target",
+			payload: map[string]string{"target": "web", "package": "./mobile"},
+			wantErr: true,
+		},
+		{
+			name:    "missing package",
+			payload: map[string]string{"target": "ios"},
+			wantErr: true,
+		},
+		{
+			name:     "ios requires darwin",
+			payload:  map[string]string{"target": "ios", "package": "./mobile", "output": "Mobile.xcframework"},
+			wantArgs: []string{"bind", "-target", "ios", "-o", "Mobile.xcframework", "./mobile"},
+			wantGOOS: "darwin",
+		},
+		{
+			name:     "android any host",
+			payload:  map[string]string{"target": "ANDROID", "package": "./mobile", "output": "mobile.aar", "bind_args": "-ldflags=-s"},
+			wantArgs: []string{"bind", "-target", "android", "-o", "mobile.aar", "-ldflags=-s", "./mobile"},
+			wantGOOS: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			args, goos, err := buildGomobileArgs(tc.payload)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got args %v", args)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(args, tc.wantArgs) {
+				t.Errorf("args = %v, want %v", args, tc.wantArgs)
+			}
+			if goos != tc.wantGOOS {
+				t.Errorf("requiredGOOS = %q, want %q", goos, tc.wantGOOS)
+			}
+		})
+	}
+}
+
+func jobWith(jobType string, payload map[string]string) *nexus.Job {
+	return &nexus.Job{ID: "test", Type: jobType, Payload: payload}
+}
+
+func TestIOSBuildHandler_PlatformGate(t *testing.T) {
+	// Stub the exec layer so darwin nodes don't invoke a real xcodebuild; we only
+	// care whether the platform gate short-circuits before the command runs.
+	rec := stubBuildCommand(t, []byte("** BUILD SUCCEEDED **"), nil)
+	h := NewIOSBuildHandler("")
+	_, err := h.Execute(JobContext{}, jobWith("IOS_BUILD", map[string]string{"scheme": "MyApp"}))
+	if runtime.GOOS == "darwin" {
+		if err != nil {
+			t.Fatalf("darwin node should pass the platform gate: %v", err)
+		}
+		if !rec.called {
+			t.Fatal("darwin node should reach the build command")
+		}
+	} else {
+		if err == nil {
+			t.Fatal("non-darwin node should reject IOS_BUILD")
+		}
+		if rec.called {
+			t.Fatal("runBuildCommand must not run when platform gate fails")
+		}
+	}
+}
+
+func TestIOSBuildHandler_Success(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("IOS_BUILD only executes on darwin")
+	}
+	rec := stubBuildCommand(t, []byte("** BUILD SUCCEEDED **"), nil)
+	h := NewIOSBuildHandler("/work")
+	out, err := h.Execute(JobContext{}, jobWith("IOS_BUILD", map[string]string{
+		"scheme":        "MyApp",
+		"configuration": "Release",
+		"artifact_path": "/work/build/MyApp.app",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !rec.called {
+		t.Fatal("expected runBuildCommand to be called")
+	}
+	if rec.name != "xcodebuild" {
+		t.Errorf("command = %q, want xcodebuild", rec.name)
+	}
+	if rec.workspace != "/work" {
+		t.Errorf("workspace = %q, want /work", rec.workspace)
+	}
+	var res buildResult
+	if err := json.Unmarshal(out, &res); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	if res.Tool != "xcodebuild" {
+		t.Errorf("tool = %q, want xcodebuild", res.Tool)
+	}
+	if res.ArtifactPath != "/work/build/MyApp.app" {
+		t.Errorf("artifact_path = %q", res.ArtifactPath)
+	}
+	if res.Output != "** BUILD SUCCEEDED **" {
+		t.Errorf("output = %q", res.Output)
+	}
+}
+
+func TestIOSBuildHandler_CommandFailurePropagates(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("IOS_BUILD only executes on darwin")
+	}
+	stubBuildCommand(t, []byte("** BUILD FAILED **"), errors.New("exit status 65"))
+	h := NewIOSBuildHandler("")
+	out, err := h.Execute(JobContext{}, jobWith("IOS_BUILD", map[string]string{"scheme": "MyApp"}))
+	if err == nil {
+		t.Fatal("expected build failure error")
+	}
+	// On failure the handler returns the raw combined output (not JSON) so the
+	// caller surfaces the build log.
+	if string(out) != "** BUILD FAILED **" {
+		t.Errorf("output = %q, want raw build log", string(out))
+	}
+}
+
+func TestIOSBuildHandler_InvalidInput(t *testing.T) {
+	h := NewIOSBuildHandler("")
+	if runtime.GOOS != "darwin" {
+		// Non-darwin hits the platform gate before validation; nothing to assert here.
+		t.Skip("validation path only reachable on darwin")
+	}
+	_, err := h.Execute(JobContext{}, jobWith("IOS_BUILD", map[string]string{}))
+	if err == nil {
+		t.Fatal("expected error for missing scheme")
+	}
+}
+
+func TestAndroidBuildHandler_Success(t *testing.T) {
+	rec := stubBuildCommand(t, []byte("BUILD SUCCESSFUL"), nil)
+	h := NewAndroidBuildHandler("/proj")
+	out, err := h.Execute(JobContext{}, jobWith("ANDROID_BUILD", map[string]string{
+		"tasks":         "assembleDebug",
+		"artifact_path": "/proj/app/build/outputs/apk/debug/app-debug.apk",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.name != "./gradlew" {
+		t.Errorf("command = %q, want ./gradlew", rec.name)
+	}
+	if !reflect.DeepEqual(rec.args, []string{"assembleDebug"}) {
+		t.Errorf("args = %v", rec.args)
+	}
+	var res buildResult
+	if err := json.Unmarshal(out, &res); err != nil {
+		t.Fatalf("output not JSON: %v", err)
+	}
+	if res.Tool != "gradlew" {
+		t.Errorf("tool = %q", res.Tool)
+	}
+}
+
+func TestAndroidBuildHandler_MissingTasks(t *testing.T) {
+	rec := stubBuildCommand(t, nil, nil)
+	h := NewAndroidBuildHandler("")
+	_, err := h.Execute(JobContext{}, jobWith("ANDROID_BUILD", map[string]string{}))
+	if err == nil {
+		t.Fatal("expected error for missing tasks")
+	}
+	if rec.called {
+		t.Fatal("runBuildCommand must not run when validation fails")
+	}
+}
+
+func TestAndroidBuildHandler_FailurePropagates(t *testing.T) {
+	stubBuildCommand(t, []byte("BUILD FAILED"), errors.New("exit status 1"))
+	h := NewAndroidBuildHandler("")
+	out, err := h.Execute(JobContext{}, jobWith("ANDROID_BUILD", map[string]string{"tasks": "assembleDebug"}))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if string(out) != "BUILD FAILED" {
+		t.Errorf("output = %q", string(out))
+	}
+}
+
+func TestGomobileBuildHandler_AndroidSuccess(t *testing.T) {
+	rec := stubBuildCommand(t, []byte(""), nil)
+	h := NewGomobileBuildHandler("/src")
+	out, err := h.Execute(JobContext{}, jobWith("GOMOBILE_BUILD", map[string]string{
+		"target":  "android",
+		"package": "./mobile",
+		"output":  "mobile.aar",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.name != "gomobile" {
+		t.Errorf("command = %q, want gomobile", rec.name)
+	}
+	var res buildResult
+	if err := json.Unmarshal(out, &res); err != nil {
+		t.Fatalf("output not JSON: %v", err)
+	}
+	if res.ArtifactPath != "mobile.aar" {
+		t.Errorf("artifact_path = %q", res.ArtifactPath)
+	}
+}
+
+func TestGomobileBuildHandler_IOSPlatformGate(t *testing.T) {
+	rec := stubBuildCommand(t, nil, nil)
+	h := NewGomobileBuildHandler("")
+	_, err := h.Execute(JobContext{}, jobWith("GOMOBILE_BUILD", map[string]string{
+		"target":  "ios",
+		"package": "./mobile",
+	}))
+	if runtime.GOOS == "darwin" {
+		if err != nil {
+			t.Fatalf("darwin should pass the gomobile ios gate: %v", err)
+		}
+	} else {
+		if err == nil {
+			t.Fatal("non-darwin should reject gomobile ios target")
+		}
+		if rec.called {
+			t.Fatal("runBuildCommand must not run when platform gate fails")
+		}
+	}
+}
+
+func TestGomobileBuildHandler_InvalidTarget(t *testing.T) {
+	rec := stubBuildCommand(t, nil, nil)
+	h := NewGomobileBuildHandler("")
+	_, err := h.Execute(JobContext{}, jobWith("GOMOBILE_BUILD", map[string]string{
+		"target":  "wasm",
+		"package": "./mobile",
+	}))
+	if err == nil {
+		t.Fatal("expected error for invalid target")
+	}
+	if rec.called {
+		t.Fatal("runBuildCommand must not run for invalid target")
+	}
+}

--- a/internal/jobs/queue_types.go
+++ b/internal/jobs/queue_types.go
@@ -23,6 +23,12 @@ const (
 	// Model cache management job types
 	JobTypeModelCachePull  = "MODEL_CACHE_PULL"
 	JobTypeModelCacheEvict = "MODEL_CACHE_EVICT"
+
+	// Mobile build job types (issue #140 Phase 2). iOS and gomobile-iOS builds
+	// require a macOS node with Xcode; Android builds require an Android SDK.
+	JobTypeIOSBuild      = "IOS_BUILD"
+	JobTypeAndroidBuild  = "ANDROID_BUILD"
+	JobTypeGomobileBuild = "GOMOBILE_BUILD"
 )
 
 // Queue names following PR #1105 convention

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -133,6 +133,9 @@ func CreateLegacyHandlersWithOpts(opts LegacyHandlerOpts) []JobHandler {
 		NewLegacyHandlerAdapter(JobTypeSandboxResume, &jobs.SandboxResumeHandler{}),
 		NewLegacyHandlerAdapter(JobTypeModelCachePull, &jobs.ModelCachePullHandler{}),
 		NewLegacyHandlerAdapter(JobTypeModelCacheEvict, &jobs.ModelCacheEvictHandler{}),
+		NewLegacyHandlerAdapter(JobTypeIOSBuild, jobs.NewIOSBuildHandler(opts.WorkspaceDir)),
+		NewLegacyHandlerAdapter(JobTypeAndroidBuild, jobs.NewAndroidBuildHandler(opts.WorkspaceDir)),
+		NewLegacyHandlerAdapter(JobTypeGomobileBuild, jobs.NewGomobileBuildHandler(opts.WorkspaceDir)),
 	}
 
 	// Register file-operation handlers when a workspace is configured.

--- a/internal/worker/job.go
+++ b/internal/worker/job.go
@@ -119,4 +119,7 @@ const (
 	JobTypeSandboxResume     = "SANDBOX_RESUME"      // Unpause a Docker container (sandbox resume)
 	JobTypeModelCachePull    = "MODEL_CACHE_PULL"    // Pull model weights into local cache
 	JobTypeModelCacheEvict   = "MODEL_CACHE_EVICT"   // Evict model weights from local cache
+	JobTypeIOSBuild          = "IOS_BUILD"           // Build an iOS app via xcodebuild (macOS only)
+	JobTypeAndroidBuild      = "ANDROID_BUILD"       // Build an Android app via the Gradle wrapper
+	JobTypeGomobileBuild     = "GOMOBILE_BUILD"      // Cross-compile a Go package via gomobile bind
 )


### PR DESCRIPTION
## Context

Jason's M1 MacBook Pro is being provisioned as the iOS/Android build server for the Sovereign Compute Fabric (issue #140). **Phase 1** (PR #263) added macOS capability detection — `os:macos`, `tool:xcode`, `tool:android-sdk` tags plus `caffeinate` sleep prevention — so the coordinator can route mobile build jobs to the node. **This PR (Phase 2)** adds the handlers that actually run those builds.

**This PR stacks on #263** (base branch `feat/140-macos-support`). It should be merged after #263 lands; GitHub will retarget it to `main` automatically once the parent merges.

## Summary

Three new `jobs.JobHandler` implementations, registered in both the worker adapter (`CreateLegacyHandlersWithOpts`) and the `cmd` test-command map, so they participate in the standard Redis-stream dispatch pipeline like `SHELL_COMMAND` and the `FILE_*` handlers.

| Handler | Tool | Platform gate | Notes |
| --- | --- | --- | --- |
| `IOS_BUILD` | `xcodebuild` | darwin (runtime check) | Builds from `scheme` (+ optional `configuration`/`destination`/`sdk`/`workspace_file`/`project`/`derived_data_path`/`action`). Returns `artifact_path` for pull-by-reference. |
| `ANDROID_BUILD` | `./gradlew` | any host with SDK | Runs the project's Gradle wrapper with `tasks` (+ optional `gradle_args`). Callers route only to `tool:android-sdk` nodes. |
| `GOMOBILE_BUILD` | `gomobile bind` | `ios` target → darwin; `android` target → any host | Cross-compiles a Go `package` to `.xcframework` / `.aar`. |

**Design decisions:**

- **Pure arg-construction functions** (`buildIOSArgs`, `buildAndroidArgs`, `buildGomobileArgs`) separate the testable command-vector logic from the exec call, mirroring the repo's existing `build*Command` helpers.
- **Stubbable exec layer**: `runBuildCommand` is a package var so tests exercise result/error shaping without a real toolchain (no Xcode/Gradle invocation needed in CI).
- **Artifact upload via the existing job-result path**: handlers return a JSON result (`tool`, `command`, `output`, `artifact_path`) which the `LegacyHandlerAdapter` wraps under `{"output": ...}`. Large build products (`.app`, `.xcframework`, `.aar`) are pulled by reference via the existing `FILE_READ_BYTES` handler using `artifact_path`, the same model as file-by-reference attachments — avoiding multi-GB inline payloads.
- **Platform gating is a runtime `runtime.GOOS` check** (not build tags) so the handler types stay registered on every platform and non-macOS builds still compile; iOS/gomobile-iOS jobs fail with a clean structured error on the wrong host instead of being silently undispatchable.

## Test plan

Table-driven Go tests in `internal/jobs/build_handlers_test.go`:

| Group | Coverage |
| --- | --- |
| Arg construction | `buildIOSArgs` / `buildAndroidArgs` / `buildGomobileArgs` — scheme/tasks/target permutations, optional flags, default `build` action |
| Input validation | missing/blank `scheme`, missing/blank `tasks`, missing `package`/`target`, invalid `target` — all reject before exec runs |
| Platform gating | iOS + gomobile-iOS rejected off-darwin; build command not invoked when the gate fails |
| Result/error shaping | success → valid JSON `buildResult` with `artifact_path`; command failure → raw build log returned + error propagated |

- `go build ./...` — pass
- `go test ./...` — all packages pass except the pre-existing `e2e.TestDeviceAuthExpiry` (requires a live AceTeam server at `localhost:3000`; fails identically on the base branch, untouched by this PR)
- `go vet ./...` — clean for changed packages (two pre-existing warnings remain in `internal/workflow/types.go`, not touched here)

Toolchain: Go 1.25.5 (darwin/arm64) via the repo nix flake.

## Deferred (follow-up issues)

- Real iOS code signing (signing identity, provisioning profiles, keychain) for `IOS_BUILD` — currently builds unsigned / simulator-style invocations.
- Phase 3 `citadel provision ios|android` subcommand (Xcode CLI tools install, SDK license acceptance, keychain/profile setup).

## Related

- #263 — Phase 1 (macOS capability detection); this PR stacks on it
- Issue #140 — macOS build server provisioning
- aceteam-ai/aceteam#3491 (iOS app), #3492 (Android app) — unblocked by this

---
*Generated by Claude*