### PR TITLE
feat(transcribe): node-local STT handler + FILE_WRITE_BYTES (#3911 Phase 1)

### DIFF
--- a/internal/jobs/file_write_bytes.go
+++ b/internal/jobs/file_write_bytes.go
@@ -1,0 +1,113 @@
+// internal/jobs/file_write_bytes.go
+package jobs
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+// defaultMaxWriteBytes caps a single FILE_WRITE_BYTES write at 50 MB, matching
+// the FILE_READ_BYTES read cap. Used when the payload omits 'max_bytes'.
+const defaultMaxWriteBytes int64 = 50 * 1024 * 1024
+
+// FileWriteBytesHandler handles FILE_WRITE_BYTES jobs.
+//
+// Unlike FILE_WRITE (which writes the payload string verbatim and is therefore
+// text-only), this handler base64-decodes the payload content into raw bytes
+// before writing. It is the binary-safe counterpart to FileReadBytesHandler and
+// powers uploads of recorded meeting audio (webm/wav) into the node workspace,
+// where the TRANSCRIBE_AUDIO handler then picks them up. Audio bytes must cross
+// the Redis wire intact, which the text FILE_WRITE path cannot guarantee.
+type FileWriteBytesHandler struct {
+	WorkspaceDir string
+}
+
+// NewFileWriteBytesHandler creates a handler rooted at workspace.
+func NewFileWriteBytesHandler(workspace string) *FileWriteBytesHandler {
+	return &FileWriteBytesHandler{WorkspaceDir: workspace}
+}
+
+// Execute base64-decodes the payload content and writes the raw bytes to disk.
+//
+// Payload fields (all strings via nexus.Job):
+//   - path:      absolute or workspace-relative path to write.
+//   - content:   standard base64 of the raw bytes to write.
+//   - max_bytes: decoded-size cap as a decimal string (default 50 MB).
+//
+// Response JSON:
+//   - path:          validated absolute path written.
+//   - bytes_written: decoded byte length actually written.
+func (h *FileWriteBytesHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	path, ok := job.Payload["path"]
+	if !ok || path == "" {
+		return nil, fmt.Errorf("job payload missing 'path' field")
+	}
+
+	encoded, ok := job.Payload["content"]
+	if !ok {
+		return nil, fmt.Errorf("job payload missing 'content' field")
+	}
+
+	validated, err := ValidatePath(h.WorkspaceDir, path)
+	if err != nil {
+		return nil, fmt.Errorf("path validation failed: %w", err)
+	}
+
+	maxBytes := defaultMaxWriteBytes
+	if v, ok := job.Payload["max_bytes"]; ok && v != "" {
+		parsed, perr := parsePositiveInt64(v)
+		if perr != nil {
+			return nil, fmt.Errorf("invalid max_bytes: %q", v)
+		}
+		maxBytes = parsed
+	}
+
+	data, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("content is not valid base64: %w", err)
+	}
+
+	if int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("decoded size %d exceeds max_bytes %d", len(data), maxBytes)
+	}
+
+	ctx.Log("info", "     - [Job %s] FILE_WRITE_BYTES %s (%d bytes)", job.ID, validated, len(data))
+
+	dir := filepath.Dir(validated)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create parent directories: %w", err)
+	}
+
+	if err := os.WriteFile(validated, data, 0644); err != nil {
+		return nil, fmt.Errorf("failed to write file: %w", err)
+	}
+
+	result := map[string]any{
+		"path":          validated,
+		"bytes_written": len(data),
+	}
+	return json.Marshal(result)
+}
+
+// parsePositiveInt64 parses a positive decimal integer string.
+func parsePositiveInt64(s string) (int64, error) {
+	var n int64
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0, fmt.Errorf("not a number")
+		}
+		n = n*10 + int64(c-'0')
+	}
+	if n <= 0 {
+		return 0, fmt.Errorf("must be positive")
+	}
+	return n, nil
+}
+
+// Ensure FileWriteBytesHandler implements JobHandler.
+var _ JobHandler = (*FileWriteBytesHandler)(nil)

--- a/internal/jobs/file_write_bytes.go
+++ b/internal/jobs/file_write_bytes.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
 )
@@ -60,8 +61,9 @@ func (h *FileWriteBytesHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte,
 
 	maxBytes := defaultMaxWriteBytes
 	if v, ok := job.Payload["max_bytes"]; ok && v != "" {
-		parsed, perr := parsePositiveInt64(v)
-		if perr != nil {
+		// Mirror FILE_READ_BYTES: strconv.ParseInt with a positive-value check.
+		parsed, perr := strconv.ParseInt(v, 10, 64)
+		if perr != nil || parsed <= 0 {
 			return nil, fmt.Errorf("invalid max_bytes: %q", v)
 		}
 		maxBytes = parsed
@@ -92,21 +94,6 @@ func (h *FileWriteBytesHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte,
 		"bytes_written": len(data),
 	}
 	return json.Marshal(result)
-}
-
-// parsePositiveInt64 parses a positive decimal integer string.
-func parsePositiveInt64(s string) (int64, error) {
-	var n int64
-	for _, c := range s {
-		if c < '0' || c > '9' {
-			return 0, fmt.Errorf("not a number")
-		}
-		n = n*10 + int64(c-'0')
-	}
-	if n <= 0 {
-		return 0, fmt.Errorf("must be positive")
-	}
-	return n, nil
 }
 
 // Ensure FileWriteBytesHandler implements JobHandler.

--- a/internal/jobs/file_write_bytes_test.go
+++ b/internal/jobs/file_write_bytes_test.go
@@ -1,0 +1,122 @@
+package jobs
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+func TestFileWriteBytes_MissingPath(t *testing.T) {
+	h := NewFileWriteBytesHandler(t.TempDir())
+	_, err := h.Execute(JobContext{}, &nexus.Job{
+		ID:      "t1",
+		Type:    "FILE_WRITE_BYTES",
+		Payload: map[string]string{"content": "AAAA"},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing path")
+	}
+}
+
+func TestFileWriteBytes_MissingContent(t *testing.T) {
+	h := NewFileWriteBytesHandler(t.TempDir())
+	_, err := h.Execute(JobContext{}, &nexus.Job{
+		ID:      "t2",
+		Type:    "FILE_WRITE_BYTES",
+		Payload: map[string]string{"path": "audio.webm"},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing content")
+	}
+}
+
+func TestFileWriteBytes_InvalidBase64(t *testing.T) {
+	h := NewFileWriteBytesHandler(t.TempDir())
+	_, err := h.Execute(JobContext{}, &nexus.Job{
+		ID:   "t3",
+		Type: "FILE_WRITE_BYTES",
+		Payload: map[string]string{
+			"path":    "audio.webm",
+			"content": "not!valid!base64!",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid base64")
+	}
+}
+
+func TestFileWriteBytes_Success(t *testing.T) {
+	dir := t.TempDir()
+	h := NewFileWriteBytesHandler(dir)
+
+	// Binary payload with a NUL byte to prove binary-safety vs. text FILE_WRITE.
+	raw := []byte{0x00, 0x01, 0x02, 0xff, 'h', 'i'}
+	encoded := base64.StdEncoding.EncodeToString(raw)
+
+	out, err := h.Execute(JobContext{}, &nexus.Job{
+		ID:   "t4",
+		Type: "FILE_WRITE_BYTES",
+		Payload: map[string]string{
+			"path":    "recordings/meeting.webm",
+			"content": encoded,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var res map[string]any
+	if err := json.Unmarshal(out, &res); err != nil {
+		t.Fatalf("result not JSON: %v", err)
+	}
+	if bw, ok := res["bytes_written"].(float64); !ok || int(bw) != len(raw) {
+		t.Errorf("bytes_written = %v, want %d", res["bytes_written"], len(raw))
+	}
+
+	// Verify the file on disk contains the exact raw bytes.
+	written, err := os.ReadFile(filepath.Join(dir, "recordings", "meeting.webm"))
+	if err != nil {
+		t.Fatalf("reading written file: %v", err)
+	}
+	if string(written) != string(raw) {
+		t.Errorf("written bytes = %v, want %v", written, raw)
+	}
+}
+
+func TestFileWriteBytes_ExceedsMaxBytes(t *testing.T) {
+	h := NewFileWriteBytesHandler(t.TempDir())
+	raw := make([]byte, 100)
+	encoded := base64.StdEncoding.EncodeToString(raw)
+
+	_, err := h.Execute(JobContext{}, &nexus.Job{
+		ID:   "t5",
+		Type: "FILE_WRITE_BYTES",
+		Payload: map[string]string{
+			"path":      "big.bin",
+			"content":   encoded,
+			"max_bytes": "10",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error when decoded size exceeds max_bytes")
+	}
+}
+
+func TestFileWriteBytes_PathEscapeRejected(t *testing.T) {
+	h := NewFileWriteBytesHandler(t.TempDir())
+	_, err := h.Execute(JobContext{}, &nexus.Job{
+		ID:   "t6",
+		Type: "FILE_WRITE_BYTES",
+		Payload: map[string]string{
+			"path":    "../../etc/evil",
+			"content": base64.StdEncoding.EncodeToString([]byte("x")),
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for path escaping the workspace")
+	}
+}

--- a/internal/jobs/service_handler.go
+++ b/internal/jobs/service_handler.go
@@ -34,11 +34,22 @@ type manifestService struct {
 type ServiceHandler struct {
 	// ConfigDir is the absolute path to the directory containing citadel.yaml.
 	ConfigDir string
+	// WorkspaceDir is the absolute node workspace root. It is exported to
+	// docker compose as CITADEL_WORKSPACE so compose files that bind-mount the
+	// workspace (e.g. the transcribe sidecar) resolve to an absolute path even
+	// when the worker was started without CITADEL_WORKSPACE in its environment.
+	WorkspaceDir string
 }
 
 // NewServiceHandler creates a ServiceHandler rooted at configDir.
 func NewServiceHandler(configDir string) *ServiceHandler {
 	return &ServiceHandler{ConfigDir: configDir}
+}
+
+// NewServiceHandlerWithWorkspace creates a ServiceHandler that also knows the
+// node workspace, so workspace-mounting compose services can be started.
+func NewServiceHandlerWithWorkspace(configDir, workspaceDir string) *ServiceHandler {
+	return &ServiceHandler{ConfigDir: configDir, WorkspaceDir: workspaceDir}
 }
 
 // serviceResult is the JSON structure returned for all service operations.
@@ -134,6 +145,7 @@ func (h *ServiceHandler) serviceStart(ctx JobContext, svc manifestService) ([]by
 			return nil, pathErr
 		}
 		cmd := exec.Command("docker", "compose", "-f", composePath, "up", "-d")
+		cmd.Env = h.composeEnv()
 		out, cmdErr := cmd.CombinedOutput()
 		if cmdErr != nil {
 			err = fmt.Errorf("docker compose up failed: %s", strings.TrimSpace(string(out)))
@@ -180,6 +192,7 @@ func (h *ServiceHandler) serviceStop(ctx JobContext, svc manifestService) ([]byt
 			return nil, pathErr
 		}
 		cmd := exec.Command("docker", "compose", "-f", composePath, "down")
+		cmd.Env = h.composeEnv()
 		out, cmdErr := cmd.CombinedOutput()
 		if cmdErr != nil {
 			err = fmt.Errorf("docker compose down failed: %s", strings.TrimSpace(string(out)))
@@ -256,6 +269,21 @@ func (h *ServiceHandler) isDockerServiceRunning(svcName string) bool {
 		return false
 	}
 	return strings.TrimSpace(string(out)) == "running"
+}
+
+// composeEnv returns the environment for docker compose invocations. It starts
+// from the worker's own environment and guarantees CITADEL_WORKSPACE is set to
+// the absolute workspace path. Compose files that bind-mount the workspace use
+// ${CITADEL_WORKSPACE:?...}; without this, a worker started via --workspace (or
+// the default path) has no CITADEL_WORKSPACE in its env and compose would fail.
+func (h *ServiceHandler) composeEnv() []string {
+	env := os.Environ()
+	if h.WorkspaceDir != "" {
+		// Override any inherited value so it always matches the workspace this
+		// node actually writes job files into.
+		env = append(env, "CITADEL_WORKSPACE="+h.WorkspaceDir)
+	}
+	return env
 }
 
 func (h *ServiceHandler) resolveComposePath(svc manifestService) (string, error) {

--- a/internal/jobs/service_handler_test.go
+++ b/internal/jobs/service_handler_test.go
@@ -1,0 +1,47 @@
+// internal/jobs/service_handler_test.go
+package jobs
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestComposeEnv_InjectsWorkspace verifies that SERVICE_START exports an
+// absolute CITADEL_WORKSPACE to docker compose. The transcribe sidecar compose
+// uses ${CITADEL_WORKSPACE:?...}; without this injection a worker started via
+// --workspace (or the default path) would have no CITADEL_WORKSPACE in its env
+// and compose would fail, leaving the node-local STT path dead.
+func TestComposeEnv_InjectsWorkspace(t *testing.T) {
+	h := NewServiceHandlerWithWorkspace("/etc/citadel", "/home/u/citadel-node/workspace")
+	env := h.composeEnv()
+
+	var got string
+	found := false
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "CITADEL_WORKSPACE=") {
+			got = strings.TrimPrefix(kv, "CITADEL_WORKSPACE=")
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("composeEnv did not set CITADEL_WORKSPACE")
+	}
+	if got != "/home/u/citadel-node/workspace" {
+		t.Errorf("CITADEL_WORKSPACE = %q, want the workspace dir", got)
+	}
+}
+
+// TestComposeEnv_NoWorkspaceLeavesEnvUntouched verifies that when no workspace
+// is configured we do not inject an empty CITADEL_WORKSPACE (which would mount
+// the wrong path); compose's :? guard should then fail loudly instead.
+func TestComposeEnv_NoWorkspaceLeavesEnvUntouched(t *testing.T) {
+	h := NewServiceHandler("/etc/citadel")
+	for _, kv := range h.composeEnv() {
+		if strings.HasPrefix(kv, "CITADEL_WORKSPACE=") {
+			// Only acceptable if it was already present in the process env.
+			if strings.TrimPrefix(kv, "CITADEL_WORKSPACE=") == "" {
+				t.Errorf("injected empty CITADEL_WORKSPACE when workspace unset")
+			}
+		}
+	}
+}

--- a/internal/jobs/transcribe_audio.go
+++ b/internal/jobs/transcribe_audio.go
@@ -1,0 +1,166 @@
+// internal/jobs/transcribe_audio.go
+package jobs
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+// defaultTranscribeServiceURL is the local faster-whisper sidecar address.
+// Mirrors the extraction service pattern (localhost HTTP, Docker compose
+// managed via SERVICE_START). Port 8101 avoids the extraction service (8100).
+const defaultTranscribeServiceURL = "http://localhost:8101"
+
+// transcribeReadyTimeout bounds how long we wait for the whisper sidecar to
+// load its model and report healthy. Model load (faster-whisper "base", int8)
+// is a one-time cost on first job; subsequent jobs hit a warm service.
+const transcribeReadyTimeout = 120 * time.Second
+
+// transcribeRequestTimeout bounds a single transcription. Whisper on CPU is
+// roughly real-time-ish for the "base" model, so a long meeting needs headroom.
+const transcribeRequestTimeout = 30 * time.Minute
+
+// TranscribeAudioHandler handles TRANSCRIBE_AUDIO jobs node-locally.
+//
+// It mirrors ExtractionHandler: the heavy Python/ML dependency (faster-whisper)
+// lives in a Docker sidecar (services/compose/transcribe.yml) reachable over
+// localhost, and this Go handler just proxies a request to it and relays the
+// JSON result. Audio bytes were placed in the node workspace beforehand via
+// FILE_WRITE_BYTES, so nothing here touches the cloud: the audio and the
+// resulting transcript stay on the user's machine.
+type TranscribeAudioHandler struct {
+	// WorkspaceDir roots audio path validation, matching the file handlers.
+	WorkspaceDir string
+	// ServiceURL is the whisper sidecar base URL; defaults to localhost:8101.
+	ServiceURL string
+	// HTTPClient lets tests inject a stub; nil uses a default client.
+	HTTPClient *http.Client
+}
+
+// NewTranscribeAudioHandler creates a handler rooted at workspace.
+func NewTranscribeAudioHandler(workspace string) *TranscribeAudioHandler {
+	return &TranscribeAudioHandler{
+		WorkspaceDir: workspace,
+		ServiceURL:   defaultTranscribeServiceURL,
+	}
+}
+
+func (h *TranscribeAudioHandler) serviceURL() string {
+	if h.ServiceURL != "" {
+		return h.ServiceURL
+	}
+	return defaultTranscribeServiceURL
+}
+
+func (h *TranscribeAudioHandler) client() *http.Client {
+	if h.HTTPClient != nil {
+		return h.HTTPClient
+	}
+	return &http.Client{Timeout: transcribeRequestTimeout}
+}
+
+// Execute transcribes a workspace-local audio file via the whisper sidecar.
+//
+// Payload fields (all strings via nexus.Job):
+//   - audio_path: workspace-relative or absolute path to the recorded audio.
+//   - language:   optional ISO language hint (e.g. "en"); empty = auto-detect.
+//   - diarize:    optional "true"/"false"; basic per-segment speaker labels.
+//
+// Response JSON (relayed verbatim from the sidecar):
+//
+//	{
+//	  "text": "full transcript",
+//	  "language": "en",
+//	  "language_probability": 0.98,
+//	  "segments": [
+//	    {"start": 0.0, "end": 3.2, "text": "...", "speaker": "Speaker 1"}
+//	  ]
+//	}
+func (h *TranscribeAudioHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	audioPath, ok := job.Payload["audio_path"]
+	if !ok || audioPath == "" {
+		return nil, fmt.Errorf("job payload missing 'audio_path' field")
+	}
+
+	// Validate the path against the workspace so a malicious payload cannot
+	// point the sidecar at an arbitrary file outside the sandbox.
+	validated, err := ValidatePath(h.WorkspaceDir, audioPath)
+	if err != nil {
+		return nil, fmt.Errorf("path validation failed: %w", err)
+	}
+
+	// The whisper sidecar mounts the workspace at /workspace, so send the path
+	// RELATIVE to the workspace root. The service joins it under its own mount;
+	// it never sees (or can escape to) the host filesystem.
+	rel, err := filepath.Rel(h.WorkspaceDir, validated)
+	if err != nil {
+		return nil, fmt.Errorf("cannot compute workspace-relative path: %w", err)
+	}
+
+	ctx.Log("info", "     - [Job %s] Waiting for transcription service to become ready...", job.ID)
+	if err := h.waitForReady(); err != nil {
+		return nil, err
+	}
+	ctx.Log("info", "     - [Job %s] TRANSCRIBE_AUDIO %s", job.ID, rel)
+
+	requestPayload := map[string]any{
+		"audio_path": rel,
+	}
+	if lang, ok := job.Payload["language"]; ok && lang != "" {
+		requestPayload["language"] = lang
+	}
+	if diarize, ok := job.Payload["diarize"]; ok && diarize == "true" {
+		requestPayload["diarize"] = true
+	}
+
+	reqBody, err := json.Marshal(requestPayload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	resp, err := h.client().Post(
+		h.serviceURL()+"/transcribe",
+		"application/json",
+		bytes.NewBuffer(reqBody),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to transcription service: %w", err)
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return bodyBytes, fmt.Errorf("transcription API returned non-200 status: %s", resp.Status)
+	}
+
+	return bodyBytes, nil
+}
+
+func (h *TranscribeAudioHandler) waitForReady() error {
+	healthURL := h.serviceURL() + "/health"
+	pollInterval := 1 * time.Second
+	startTime := time.Now()
+
+	for time.Since(startTime) < transcribeReadyTimeout {
+		resp, err := http.Get(healthURL)
+		if err == nil && resp.StatusCode == http.StatusOK {
+			resp.Body.Close()
+			return nil
+		}
+		if resp != nil {
+			resp.Body.Close()
+		}
+		time.Sleep(pollInterval)
+	}
+	return fmt.Errorf("transcription service did not become ready within %v", transcribeReadyTimeout)
+}
+
+// Ensure TranscribeAudioHandler implements JobHandler.
+var _ JobHandler = (*TranscribeAudioHandler)(nil)

--- a/internal/jobs/transcribe_audio.go
+++ b/internal/jobs/transcribe_audio.go
@@ -99,7 +99,17 @@ func (h *TranscribeAudioHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte
 	// The whisper sidecar mounts the workspace at /workspace, so send the path
 	// RELATIVE to the workspace root. The service joins it under its own mount;
 	// it never sees (or can escape to) the host filesystem.
-	rel, err := filepath.Rel(h.WorkspaceDir, validated)
+	//
+	// ValidatePath resolves relative inputs against the SYMLINK-RESOLVED
+	// workspace root, so compute the relative path against the resolved root
+	// too. Using the raw WorkspaceDir here would emit spurious "../" prefixes
+	// when the workspace contains a symlinked component (e.g. a symlinked
+	// tmpdir, or /var -> /private/var on macOS), which the sidecar would reject.
+	resolvedWorkspace, err := filepath.EvalSymlinks(h.WorkspaceDir)
+	if err != nil {
+		return nil, fmt.Errorf("cannot resolve workspace %q: %w", h.WorkspaceDir, err)
+	}
+	rel, err := filepath.Rel(resolvedWorkspace, validated)
 	if err != nil {
 		return nil, fmt.Errorf("cannot compute workspace-relative path: %w", err)
 	}

--- a/internal/jobs/transcribe_audio_test.go
+++ b/internal/jobs/transcribe_audio_test.go
@@ -127,3 +127,60 @@ func TestTranscribeAudio_ServiceError(t *testing.T) {
 		t.Fatal("expected error for non-200 service response")
 	}
 }
+
+// TestTranscribeAudio_SymlinkedWorkspace guards the workspace-relative path
+// computation when the workspace root itself is a symlink. ValidatePath
+// resolves the audio path under the SYMLINK-RESOLVED root, so the handler must
+// compute the relative path against the resolved root too. A naive
+// filepath.Rel(rawWorkspace, validated) would yield spurious "../" prefixes and
+// the sidecar would reject the path.
+func TestTranscribeAudio_SymlinkedWorkspace(t *testing.T) {
+	realDir := t.TempDir()
+	// A sibling symlink that points at the real workspace.
+	linkDir := filepath.Join(t.TempDir(), "ws-link")
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Fatalf("setup symlink: %v", err)
+	}
+
+	audioRel := filepath.Join("recordings", "meeting.webm")
+	if err := os.MkdirAll(filepath.Join(realDir, "recordings"), 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(realDir, audioRel), []byte("fakeaudio"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		_ = json.Unmarshal(body, &req)
+		gotPath, _ = req["audio_path"].(string)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"text":"ok","language":"en","segments":[]}`))
+	}))
+	defer srv.Close()
+
+	// Root the handler at the SYMLINKED path, as a real worker would when its
+	// workspace is under a symlinked directory.
+	h := NewTranscribeAudioHandler(linkDir)
+	h.ServiceURL = srv.URL
+
+	_, err := h.Execute(JobContext{}, &nexus.Job{
+		ID:      "t5",
+		Type:    "TRANSCRIBE_AUDIO",
+		Payload: map[string]string{"audio_path": audioRel},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The forwarded path must be clean and workspace-relative, with no "../".
+	if gotPath != audioRel {
+		t.Errorf("forwarded audio_path = %q, want %q (no leading ../)", gotPath, audioRel)
+	}
+}

--- a/internal/jobs/transcribe_audio_test.go
+++ b/internal/jobs/transcribe_audio_test.go
@@ -1,0 +1,129 @@
+package jobs
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+func TestTranscribeAudio_MissingAudioPath(t *testing.T) {
+	h := NewTranscribeAudioHandler(t.TempDir())
+	_, err := h.Execute(JobContext{}, &nexus.Job{
+		ID:      "t1",
+		Type:    "TRANSCRIBE_AUDIO",
+		Payload: map[string]string{},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing audio_path")
+	}
+}
+
+func TestTranscribeAudio_PathEscapeRejected(t *testing.T) {
+	h := NewTranscribeAudioHandler(t.TempDir())
+	_, err := h.Execute(JobContext{}, &nexus.Job{
+		ID:   "t2",
+		Type: "TRANSCRIBE_AUDIO",
+		Payload: map[string]string{
+			"audio_path": "../../etc/passwd",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for audio_path escaping the workspace")
+	}
+}
+
+// TestTranscribeAudio_Success drives the handler against a stub whisper sidecar.
+// The audio path must resolve inside the workspace; the handler then forwards a
+// workspace-relative path to the service and relays the JSON response verbatim.
+func TestTranscribeAudio_Success(t *testing.T) {
+	dir := t.TempDir()
+	// Create the audio file so ValidatePath resolves it.
+	audioRel := filepath.Join("recordings", "meeting.webm")
+	if err := os.MkdirAll(filepath.Join(dir, "recordings"), 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, audioRel), []byte("fakeaudio"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.URL.Path == "/transcribe" {
+			body, _ := io.ReadAll(r.Body)
+			var req map[string]any
+			_ = json.Unmarshal(body, &req)
+			gotPath, _ = req["audio_path"].(string)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"text":"hello world","language":"en","segments":[]}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	h := NewTranscribeAudioHandler(dir)
+	h.ServiceURL = srv.URL
+
+	out, err := h.Execute(JobContext{}, &nexus.Job{
+		ID:   "t3",
+		Type: "TRANSCRIBE_AUDIO",
+		Payload: map[string]string{
+			"audio_path": audioRel,
+			"language":   "en",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The sidecar must receive the workspace-RELATIVE path, never the host abs path.
+	if gotPath != audioRel {
+		t.Errorf("forwarded audio_path = %q, want %q", gotPath, audioRel)
+	}
+
+	var res map[string]any
+	if err := json.Unmarshal(out, &res); err != nil {
+		t.Fatalf("result not JSON: %v", err)
+	}
+	if res["text"] != "hello world" {
+		t.Errorf("text = %v, want 'hello world'", res["text"])
+	}
+}
+
+func TestTranscribeAudio_ServiceError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.webm"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"boom"}`))
+	}))
+	defer srv.Close()
+
+	h := NewTranscribeAudioHandler(dir)
+	h.ServiceURL = srv.URL
+
+	_, err := h.Execute(JobContext{}, &nexus.Job{
+		ID:      "t4",
+		Type:    "TRANSCRIBE_AUDIO",
+		Payload: map[string]string{"audio_path": "a.webm"},
+	})
+	if err == nil {
+		t.Fatal("expected error for non-200 service response")
+	}
+}

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -194,7 +194,7 @@ func CreateLegacyHandlersWithOpts(opts LegacyHandlerOpts) []JobHandler {
 
 	// Register service-management handlers when a config directory is available.
 	if opts.ConfigDir != "" {
-		svcHandler := jobs.NewServiceHandler(opts.ConfigDir)
+		svcHandler := jobs.NewServiceHandlerWithWorkspace(opts.ConfigDir, opts.WorkspaceDir)
 		handlers = append(handlers,
 			NewLegacyHandlerAdapter(JobTypeServiceStart, svcHandler),
 			NewLegacyHandlerAdapter(JobTypeServiceStop, svcHandler),

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -179,9 +179,16 @@ func CreateLegacyHandlersWithOpts(opts LegacyHandlerOpts) []JobHandler {
 			NewLegacyHandlerAdapter(JobTypeFileRead, readHandler),
 			NewLegacyHandlerAdapter(JobTypeFileReadBytes, readBytesHandler),
 			NewLegacyHandlerAdapter(JobTypeFileWrite, jobs.NewFileWriteHandler(opts.WorkspaceDir)),
+			NewLegacyHandlerAdapter(JobTypeFileWriteBytes, jobs.NewFileWriteBytesHandler(opts.WorkspaceDir)),
 			NewLegacyHandlerAdapter(JobTypeFileEdit, jobs.NewFileEditHandler(opts.WorkspaceDir)),
 			NewLegacyHandlerAdapter(JobTypeFileList, listHandler),
 			NewLegacyHandlerAdapter(JobTypeFileSearch, searchHandler),
+			NewLegacyHandlerAdapter(JobTypeFileList, jobs.NewFileListHandler(opts.WorkspaceDir)),
+			NewLegacyHandlerAdapter(JobTypeFileSearch, jobs.NewFileSearchHandler(opts.WorkspaceDir)),
+			// Node-local meeting transcription (faster-whisper sidecar). Registered
+			// with the workspace so it can validate audio paths the same way the
+			// file handlers do.
+			NewLegacyHandlerAdapter(JobTypeTranscribeAudio, jobs.NewTranscribeAudioHandler(opts.WorkspaceDir)),
 		)
 	}
 

--- a/internal/worker/job.go
+++ b/internal/worker/job.go
@@ -110,6 +110,7 @@ const (
 	JobTypeFileRead          = "FILE_READ"           // Read a file from the workspace
 	JobTypeFileReadBytes     = "FILE_READ_BYTES"     // Read a file as raw base64-encoded bytes (binary-safe)
 	JobTypeFileWrite         = "FILE_WRITE"          // Write a file to the workspace
+	JobTypeFileWriteBytes    = "FILE_WRITE_BYTES"    // Write a file from raw base64-encoded bytes (binary-safe)
 	JobTypeFileEdit          = "FILE_EDIT"           // Edit (string replace) a file in the workspace
 	JobTypeFileList          = "FILE_LIST"           // List directory contents in the workspace
 	JobTypeFileSearch        = "FILE_SEARCH"         // Search for text across files in the workspace
@@ -129,4 +130,5 @@ const (
 	JobTypeVNCKeys           = "VNC_KEYS"            // Send a key combo to the node's display (issue #4179)
 	JobTypeVNCActions        = "VNC_ACTIONS"         // Execute pointer/keyboard actions (click, move, drag) on the node's display (issue #4180)
 	JobTypeCobrowse          = "COBROWSE"            // Human-in-the-loop co-browse over CDP (#4079)
+	JobTypeTranscribeAudio   = "TRANSCRIBE_AUDIO"    // Transcribe workspace audio node-locally via the faster-whisper sidecar
 )

--- a/services/compose/transcribe.yml
+++ b/services/compose/transcribe.yml
@@ -1,0 +1,25 @@
+services:
+  transcribe:
+    image: ghcr.io/aceteam-ai/whisper-service:latest
+    container_name: citadel-transcribe
+    ports:
+      - "8101:8101"
+    volumes:
+      # faster-whisper model cache (shared with other HF-based services).
+      - ~/citadel-cache/huggingface:/root/.cache/huggingface
+      # Mount the node workspace read-only so the service can read audio files
+      # that FILE_WRITE_BYTES placed there.
+      # IMPORTANT: CITADEL_WORKSPACE must be an ABSOLUTE path. Docker Compose
+      # does NOT expand "~", so the default below is only correct when the env
+      # var is set (citadel-cli resolves the workspace to an absolute path and
+      # should export it before `docker compose up`). Set e.g.
+      #   CITADEL_WORKSPACE=/home/<user>/citadel-node/workspace
+      - ${CITADEL_WORKSPACE:?set CITADEL_WORKSPACE to an absolute workspace path}:/workspace:ro
+    environment:
+      # faster-whisper model size: base = good CPU speed/accuracy tradeoff,
+      # matching the proven WeChat microservice configuration.
+      - WHISPER_MODEL=base
+      - WHISPER_DEVICE=cpu
+      - WHISPER_COMPUTE_TYPE=int8
+      - PORT=8101
+    restart: unless-stopped

--- a/services/compose/transcribe.yml
+++ b/services/compose/transcribe.yml
@@ -9,15 +9,16 @@ services:
       - ~/citadel-cache/huggingface:/root/.cache/huggingface
       # Mount the node workspace read-only so the service can read audio files
       # that FILE_WRITE_BYTES placed there.
-      # IMPORTANT: CITADEL_WORKSPACE must be an ABSOLUTE path. Docker Compose
-      # does NOT expand "~", so the default below is only correct when the env
-      # var is set (citadel-cli resolves the workspace to an absolute path and
-      # should export it before `docker compose up`). Set e.g.
+      # CITADEL_WORKSPACE must be an ABSOLUTE path (Docker Compose does NOT
+      # expand "~"). When this service is started via SERVICE_START, the
+      # citadel-cli worker exports CITADEL_WORKSPACE automatically, set to the
+      # same absolute workspace it writes job files into. The :? guard makes a
+      # manual `docker compose up` without the var fail loudly rather than
+      # silently mounting the wrong path. To run by hand set e.g.
       #   CITADEL_WORKSPACE=/home/<user>/citadel-node/workspace
       - ${CITADEL_WORKSPACE:?set CITADEL_WORKSPACE to an absolute workspace path}:/workspace:ro
     environment:
-      # faster-whisper model size: base = good CPU speed/accuracy tradeoff,
-      # matching the proven WeChat microservice configuration.
+      # faster-whisper model size: base = good CPU speed/accuracy tradeoff.
       - WHISPER_MODEL=base
       - WHISPER_DEVICE=cpu
       - WHISPER_COMPUTE_TYPE=int8

--- a/services/embed.go
+++ b/services/embed.go
@@ -27,6 +27,9 @@ var ExtractionCompose string
 //go:embed compose/whatsapp-bridge.yml
 var WhatsAppBridgeCompose string
 
+//go:embed compose/transcribe.yml
+var TranscribeCompose string
+
 // ServiceMap provides a lookup for pre-packaged service compose files.
 var ServiceMap = map[string]string{
 	"ollama":          OllamaCompose,
@@ -36,6 +39,7 @@ var ServiceMap = map[string]string{
 	"sglang":          SGLangCompose,
 	"extraction":      ExtractionCompose,
 	"whatsapp-bridge": WhatsAppBridgeCompose,
+	"transcribe":      TranscribeCompose,
 }
 
 // GetAvailableServices returns a sorted list of service names.

--- a/services/whisper-service/Dockerfile
+++ b/services/whisper-service/Dockerfile
@@ -1,0 +1,20 @@
+# Node-local faster-whisper STT sidecar for Citadel.
+# Built and published as ghcr.io/aceteam-ai/whisper-service (see transcribe.yml).
+FROM python:3.12-slim
+
+# ffmpeg is required by faster-whisper to decode webm/mp3/wav inputs.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app.py /app/app.py
+
+ENV PORT=8101
+EXPOSE 8101
+
+CMD ["sh", "-c", "uvicorn app:app --host 0.0.0.0 --port ${PORT}"]

--- a/services/whisper-service/app.py
+++ b/services/whisper-service/app.py
@@ -1,9 +1,10 @@
 """Node-local speech-to-text sidecar for Citadel.
 
-Mirrors the proven WeChat microservice pattern (faster-whisper on CPU): a tiny
-FastAPI service that loads a faster-whisper model once and transcribes audio
-files placed in the node workspace. Used by the citadel-cli TRANSCRIBE_AUDIO
-job handler, which POSTs a workspace-relative audio path here.
+A tiny FastAPI service (faster-whisper on CPU) that loads a model once and
+transcribes audio files placed in the node workspace, reusing the proven
+node-local faster-whisper STT pattern already shipped elsewhere in Citadel.
+Used by the citadel-cli TRANSCRIBE_AUDIO job handler, which POSTs a
+workspace-relative audio path here.
 
 Audio never leaves the node: the workspace is mounted read-only at /workspace
 and the resulting transcript is returned to the local Go worker, which relays
@@ -11,8 +12,8 @@ it back over the VPN mesh to the user's own AceTeam org.
 
 Diarization (Phase 1): BASIC. faster-whisper produces timestamped segments but
 no speaker identities. We label segments heuristically (a new speaker after a
-silence gap) so distinct speakers read better than Otter's `[None]` imports.
-Full diarization (pyannote/whisperx) is deferred to a later phase.
+silence gap) so distinct speakers read better than unlabelled imports. Full
+diarization (pyannote/whisperx) is deferred to a later phase.
 """
 
 import os
@@ -38,7 +39,7 @@ _model = None
 
 
 def _get_model():
-    """Lazy-load the faster-whisper model once (same as the WeChat service)."""
+    """Lazy-load the faster-whisper model once on first transcription."""
     global _model
     if _model is None:
         from faster_whisper import WhisperModel
@@ -64,7 +65,7 @@ class TranscribeRequest(BaseModel):
 def _resolve_audio_path(audio_path: str) -> str:
     """Resolve an audio path safely under the workspace mount.
 
-    Rejects paths that escape WORKSPACE_ROOT (defense in depth — the Go handler
+    Rejects paths that escape WORKSPACE_ROOT (defense in depth: the Go handler
     already validates, but the service must not trust the wire blindly).
     """
     candidate = os.path.normpath(os.path.join(WORKSPACE_ROOT, audio_path))

--- a/services/whisper-service/app.py
+++ b/services/whisper-service/app.py
@@ -1,0 +1,133 @@
+"""Node-local speech-to-text sidecar for Citadel.
+
+Mirrors the proven WeChat microservice pattern (faster-whisper on CPU): a tiny
+FastAPI service that loads a faster-whisper model once and transcribes audio
+files placed in the node workspace. Used by the citadel-cli TRANSCRIBE_AUDIO
+job handler, which POSTs a workspace-relative audio path here.
+
+Audio never leaves the node: the workspace is mounted read-only at /workspace
+and the resulting transcript is returned to the local Go worker, which relays
+it back over the VPN mesh to the user's own AceTeam org.
+
+Diarization (Phase 1): BASIC. faster-whisper produces timestamped segments but
+no speaker identities. We label segments heuristically (a new speaker after a
+silence gap) so distinct speakers read better than Otter's `[None]` imports.
+Full diarization (pyannote/whisperx) is deferred to a later phase.
+"""
+
+import os
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+# Workspace mount inside the container (see services/compose/transcribe.yml).
+WORKSPACE_ROOT = os.environ.get("WORKSPACE_ROOT", "/workspace")
+
+WHISPER_MODEL = os.environ.get("WHISPER_MODEL", "base")
+WHISPER_DEVICE = os.environ.get("WHISPER_DEVICE", "cpu")
+WHISPER_COMPUTE_TYPE = os.environ.get("WHISPER_COMPUTE_TYPE", "int8")
+
+# A pause longer than this (seconds) between segments is treated as a likely
+# speaker change for BASIC diarization. Tuned conservatively; better than
+# tagging every line the same.
+SPEAKER_GAP_SECONDS = float(os.environ.get("WHISPER_SPEAKER_GAP_SECONDS", "2.0"))
+
+app = FastAPI(title="citadel-whisper-service")
+
+_model = None
+
+
+def _get_model():
+    """Lazy-load the faster-whisper model once (same as the WeChat service)."""
+    global _model
+    if _model is None:
+        from faster_whisper import WhisperModel
+
+        _model = WhisperModel(
+            WHISPER_MODEL,
+            device=WHISPER_DEVICE,
+            compute_type=WHISPER_COMPUTE_TYPE,
+        )
+    return _model
+
+
+class TranscribeRequest(BaseModel):
+    # Workspace-relative path to the audio file (the Go handler strips the
+    # host workspace prefix before sending). Joined under WORKSPACE_ROOT.
+    audio_path: str
+    # Optional ISO language hint (e.g. "en"); None = auto-detect.
+    language: str | None = None
+    # BASIC speaker labelling when True.
+    diarize: bool = False
+
+
+def _resolve_audio_path(audio_path: str) -> str:
+    """Resolve an audio path safely under the workspace mount.
+
+    Rejects paths that escape WORKSPACE_ROOT (defense in depth — the Go handler
+    already validates, but the service must not trust the wire blindly).
+    """
+    candidate = os.path.normpath(os.path.join(WORKSPACE_ROOT, audio_path))
+    root = os.path.normpath(WORKSPACE_ROOT)
+    if candidate != root and not candidate.startswith(root + os.sep):
+        raise HTTPException(400, "audio_path resolves outside the workspace")
+    if not os.path.isfile(candidate):
+        raise HTTPException(404, f"audio file not found: {audio_path}")
+    return candidate
+
+
+def _label_speakers(segments: list[dict]) -> list[dict]:
+    """Assign BASIC speaker labels by silence-gap heuristic.
+
+    Increments the speaker number whenever the gap since the previous segment
+    exceeds SPEAKER_GAP_SECONDS. This is intentionally simple; it just beats a
+    single `[None]` label. Full diarization is deferred.
+    """
+    speaker_idx = 1
+    prev_end: float | None = None
+    for seg in segments:
+        if prev_end is not None and (seg["start"] - prev_end) > SPEAKER_GAP_SECONDS:
+            speaker_idx += 1
+        seg["speaker"] = f"Speaker {speaker_idx}"
+        prev_end = seg["end"]
+    return segments
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok", "model": WHISPER_MODEL}
+
+
+@app.post("/transcribe")
+def transcribe(req: TranscribeRequest):
+    path = _resolve_audio_path(req.audio_path)
+    model = _get_model()
+
+    segments_iter, info = model.transcribe(
+        path,
+        beam_size=5,
+        language=req.language,
+    )
+
+    segments = [
+        {
+            "start": round(s.start, 3),
+            "end": round(s.end, 3),
+            "text": s.text.strip(),
+        }
+        for s in segments_iter
+    ]
+
+    if req.diarize:
+        segments = _label_speakers(segments)
+
+    text = " ".join(s["text"] for s in segments).strip()
+
+    return {
+        "text": text,
+        "language": info.language,
+        "language_probability": round(info.language_probability, 3),
+        "segments": segments,
+        # Surface diarization status so callers know what they got.
+        "diarization": "basic" if req.diarize else "none",
+    }

--- a/services/whisper-service/requirements.txt
+++ b/services/whisper-service/requirements.txt
@@ -1,0 +1,4 @@
+faster-whisper==1.0.3
+fastapi==0.115.6
+uvicorn==0.34.0
+pydantic==2.10.4


### PR DESCRIPTION
Node side of native meeting transcription (aceteam-ai/aceteam#3911, Phase 1). Pairs with the aceteam PR.

## What

- **TRANSCRIBE_AUDIO** job handler (`internal/jobs/transcribe_audio.go`): validates a workspace audio path, forwards a workspace-relative path to a local faster-whisper sidecar (`localhost:8101`), relays the transcript. Mirrors the existing `extraction_handler.go` sidecar pattern (proxy to a localhost Docker service, no cloud dependency).
- **FILE_WRITE_BYTES** job handler (`internal/jobs/file_write_bytes.go`): binary-safe counterpart to the existing `FILE_READ_BYTES` — base64-decodes payload content and writes raw bytes. The text `FILE_WRITE` path cannot carry audio intact; this is how recorded audio lands in the node workspace.
- **whisper sidecar** (`services/whisper-service/`): FastAPI + faster-whisper (CPU, int8, `base`). Mounts the workspace read-only, BASIC silence-gap speaker labelling, defense-in-depth path validation.
- Registered both job types, the `transcribe` packaged compose service, and the embed entry.

## Contract (verified against the aceteam side)

Confirmed exact match with `python-backend/routes/native_transcribe.py`:
- `FILE_WRITE_BYTES` payload `{path, content, max_bytes}` → result `{path, bytes_written}`.
- `TRANSCRIBE_AUDIO` payload `{audio_path, language, diarize}` → result `{text, language, language_probability, segments, diarization}`.

The backend writes audio to `recordings/<uuid>.<ext>` then transcribes the same relative path. Both job types are registered in the worker handler adapter and the `transcribe` service auto-flows through the generic `ServiceMap` registration (`citadel service start` and `APPLY_DEVICE_CONFIG`), so no per-service hardcoding was needed.

## Pipeline

Audio + transcript stay on the user's machine: backend writes audio to the node (FILE_WRITE_BYTES) → node transcribes locally (TRANSCRIBE_AUDIO → whisper sidecar) → transcript returns over the mesh.

## Pre-merge review fixes (this round)

- **SERVICE_START now exports an absolute `CITADEL_WORKSPACE` to docker compose** (up/down). The transcribe compose mounts the workspace via `${CITADEL_WORKSPACE:?...}`; a worker started with `--workspace` or the default path has no such env var, so the sidecar could never start. `ServiceHandler` now carries the workspace dir and injects it.
- **Symlinked-workspace fix:** TRANSCRIBE_AUDIO computes the workspace-relative path against the symlink-resolved root (matching `ValidatePath`), so a symlinked workspace no longer produces spurious `../` prefixes the sidecar would reject. Added a regression test.
- `FILE_WRITE_BYTES` `max_bytes` parsing now uses `strconv.ParseInt`, mirroring `FILE_READ_BYTES`.

## Runtime prerequisite

The sidecar must be started once via `citadel service start transcribe` (or declared in the node config) before the node-local path works — same convention as the extraction service. The aceteam route dispatches FILE_WRITE_BYTES + TRANSCRIBE_AUDIO and falls back to cloud STT (HTTP 409) if the node path fails, so a not-yet-started sidecar degrades gracefully rather than hard-failing.

## Diarization

BASIC — segments labelled `Speaker N` by silence-gap heuristic. Full diarization (pyannote/whisperx) deferred.

## Verification

- `go build ./...` clean, `go vet ./internal/jobs/ ./internal/worker/ ./services/` clean.
- `go test ./internal/jobs/ ./internal/worker/ ./services/` pass (missing-field, base64, path-escape, symlinked-workspace, stub-sidecar, compose-env-injection tests). No unscoped `go test ./...`, no tmux packages.
- Python sidecar `py_compile` clean.
- **Runtime-pending (cannot verify in CI):** building/publishing `ghcr.io/aceteam-ai/whisper-service`, and a live 2-node end-to-end STT run.

## Deferred

Phase 2 (auto-join meeting bot) and Phase 3 (mobile, aceteam-ai/aceteam#4081).
