### PR TITLE
feat(tui): single-instance mode + console session multiplexer

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/demo"
 	"github.com/aceteam-ai/citadel-cli/internal/desktop"
 	"github.com/aceteam-ai/citadel-cli/internal/heartbeat"
+	"github.com/aceteam-ai/citadel-cli/internal/instance"
 	"github.com/aceteam-ai/citadel-cli/internal/network"
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
@@ -80,6 +81,16 @@ func runControlCenter() {
 		os.Exit(1)
 	}
 
+	// Single-instance detection: if another TUI is running, attach to it
+	configDir := platform.ConfigDir()
+	if instance.IsRunning(configDir) {
+		if err := instance.Attach(configDir); err != nil {
+			fmt.Fprintf(os.Stderr, "Attach failed: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
 	// Auto-update on startup
 	if updated := ccAutoUpdate(); updated {
 		// Binary was updated, restart
@@ -88,6 +99,16 @@ func runControlCenter() {
 
 	// Suppress tsnet/tailscale logs to prevent TUI corruption
 	network.SuppressLogs()
+
+	// Start the instance server for attach support
+	instanceServer, _ := instance.Listen(configDir)
+	if instanceServer != nil {
+		_ = instance.WritePID(configDir)
+		defer func() {
+			instanceServer.Close()
+			instance.RemovePID(configDir)
+		}()
+	}
 
 	// Start the demo server in the background
 	startDemoServer()

--- a/internal/instance/client.go
+++ b/internal/instance/client.go
@@ -1,0 +1,113 @@
+// client.go provides the attach client for connecting to a running Citadel instance.
+//
+//go:build !windows
+
+package instance
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"golang.org/x/term"
+)
+
+// Attach connects to a running Citadel instance via Unix socket and relays
+// stdin/stdout as a raw terminal. Returns when the session ends or Ctrl+]
+// is pressed. The caller's terminal is put into raw mode for the duration.
+func Attach(configDir string) error {
+	sockPath := SocketPath(configDir)
+
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		return fmt.Errorf("failed to connect to running instance: %w", err)
+	}
+	defer conn.Close()
+
+	pid := PID(configDir)
+	if pid > 0 {
+		fmt.Fprintf(os.Stderr, "Citadel is already running (PID %d). Starting a new shell on the running instance...\n", pid)
+	} else {
+		fmt.Fprintln(os.Stderr, "Citadel is already running. Starting a new shell on the running instance...")
+	}
+	fmt.Fprintln(os.Stderr, "Press Ctrl+] to detach.")
+	fmt.Fprintln(os.Stderr, "")
+
+	// Put terminal in raw mode
+	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
+	if err != nil {
+		return fmt.Errorf("failed to set raw mode: %w", err)
+	}
+	defer term.Restore(int(os.Stdin.Fd()), oldState)
+
+	// Send initial window size
+	sendResize(conn)
+
+	// Handle SIGWINCH for terminal resize
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGWINCH)
+	defer signal.Stop(sigCh)
+
+	go func() {
+		for range sigCh {
+			sendResize(conn)
+		}
+	}()
+
+	// Socket → stdout
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, 4096)
+		for {
+			n, err := conn.Read(buf)
+			if n > 0 {
+				os.Stdout.Write(buf[:n])
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	// stdin → socket (with Ctrl+] detection)
+	go func() {
+		buf := make([]byte, 256)
+		for {
+			n, err := os.Stdin.Read(buf)
+			if n > 0 {
+				for i := 0; i < n; i++ {
+					if buf[i] == 0x1d { // Ctrl+]
+						conn.Close()
+						return
+					}
+				}
+				conn.Write(buf[:n])
+			}
+			if err != nil {
+				conn.Close()
+				return
+			}
+		}
+	}()
+
+	<-done
+	fmt.Fprintln(os.Stderr, "\nDetached from Citadel.")
+	return nil
+}
+
+// sendResize sends the current terminal dimensions over the socket.
+func sendResize(conn net.Conn) {
+	w, h, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil || w == 0 || h == 0 {
+		return
+	}
+	var msg [5]byte
+	msg[0] = 0x00 // resize marker
+	binary.LittleEndian.PutUint16(msg[1:3], uint16(w))
+	binary.LittleEndian.PutUint16(msg[3:5], uint16(h))
+	conn.Write(msg[:])
+}

--- a/internal/instance/instance_test.go
+++ b/internal/instance/instance_test.go
@@ -1,0 +1,181 @@
+//go:build !windows
+
+package instance
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestListenAndIsRunning(t *testing.T) {
+	dir := t.TempDir()
+
+	// No instance running yet
+	if IsRunning(dir) {
+		t.Fatal("expected no instance running")
+	}
+
+	// Start server
+	srv, err := Listen(dir)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	if srv == nil {
+		t.Fatal("expected non-nil server")
+	}
+	defer srv.Close()
+
+	// Now it should be running
+	if !IsRunning(dir) {
+		t.Fatal("expected instance running after Listen")
+	}
+
+	// Second Listen should return nil (another instance detected)
+	srv2, err := Listen(dir)
+	if err != nil {
+		t.Fatalf("second Listen: %v", err)
+	}
+	if srv2 != nil {
+		srv2.Close()
+		t.Fatal("expected nil server from second Listen")
+	}
+}
+
+func TestStaleSocketCleanup(t *testing.T) {
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, socketName)
+
+	// Create a stale socket file (not listening)
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("create stale socket: %v", err)
+	}
+	ln.Close() // immediately close — socket file remains
+
+	// Listen should clean up the stale socket and succeed
+	srv, err := Listen(dir)
+	if err != nil {
+		t.Fatalf("Listen after stale: %v", err)
+	}
+	if srv == nil {
+		t.Fatal("expected server after stale cleanup")
+	}
+	defer srv.Close()
+
+	if !IsRunning(dir) {
+		t.Fatal("expected instance running after stale cleanup")
+	}
+}
+
+func TestPIDFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// No PID file → 0
+	if pid := PID(dir); pid != 0 {
+		t.Fatalf("expected PID 0, got %d", pid)
+	}
+
+	// Write PID
+	if err := WritePID(dir); err != nil {
+		t.Fatalf("WritePID: %v", err)
+	}
+
+	pid := PID(dir)
+	if pid != os.Getpid() {
+		t.Fatalf("expected PID %d, got %d", os.Getpid(), pid)
+	}
+
+	// Remove PID
+	RemovePID(dir)
+	if pid := PID(dir); pid != 0 {
+		t.Fatalf("expected PID 0 after remove, got %d", pid)
+	}
+}
+
+func TestServerClose(t *testing.T) {
+	dir := t.TempDir()
+
+	srv, err := Listen(dir)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	if srv == nil {
+		t.Fatal("expected server")
+	}
+
+	srv.Close()
+
+	// Socket should be removed
+	sockPath := filepath.Join(dir, socketName)
+	if _, err := os.Stat(sockPath); !os.IsNotExist(err) {
+		t.Fatal("expected socket removed after Close")
+	}
+
+	// IsRunning should return false
+	if IsRunning(dir) {
+		t.Fatal("expected not running after Close")
+	}
+}
+
+func TestSocketPermissions(t *testing.T) {
+	dir := t.TempDir()
+
+	srv, err := Listen(dir)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer srv.Close()
+
+	sockPath := filepath.Join(dir, socketName)
+	info, err := os.Stat(sockPath)
+	if err != nil {
+		t.Fatalf("stat socket: %v", err)
+	}
+
+	perm := info.Mode().Perm()
+	if perm&0077 != 0 {
+		t.Errorf("socket permissions too open: %o (expected 0600)", perm)
+	}
+}
+
+func TestClientConnect(t *testing.T) {
+	dir := t.TempDir()
+
+	srv, err := Listen(dir)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer srv.Close()
+
+	// Connect as a client
+	sockPath := SocketPath(dir)
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+
+	// Give server time to accept and spawn PTY
+	time.Sleep(200 * time.Millisecond)
+
+	// The server should have spawned a PTY — write a command and read output
+	_, err = conn.Write([]byte("echo hello-test\r"))
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Read some output (PTY should echo back and show prompt)
+	buf := make([]byte, 4096)
+	conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if n == 0 {
+		t.Fatal("expected some PTY output")
+	}
+
+	conn.Close()
+}

--- a/internal/instance/server.go
+++ b/internal/instance/server.go
@@ -1,0 +1,253 @@
+// Package instance provides single-instance detection and session attach
+// for the Citadel TUI. The first TUI instance creates a Unix domain socket
+// at ~/.citadel-cli/citadel.sock; subsequent invocations detect it and
+// attach as raw terminal clients (similar to tmux attach).
+//
+//go:build !windows
+
+package instance
+
+import (
+	"encoding/binary"
+	"log"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+
+	"github.com/aceteam-ai/citadel-cli/internal/console"
+)
+
+const socketName = "citadel.sock"
+
+// Server listens on a Unix domain socket and relays PTY sessions
+// to attached clients.
+type Server struct {
+	ln       net.Listener
+	sockPath string
+	mu       sync.Mutex
+	clients  []net.Conn
+	closed   bool
+}
+
+// Listen creates a Unix socket server at configDir/citadel.sock.
+// Returns nil, nil if another instance already holds the socket.
+func Listen(configDir string) (*Server, error) {
+	sockPath := filepath.Join(configDir, socketName)
+
+	if err := os.MkdirAll(configDir, 0700); err != nil {
+		return nil, err
+	}
+
+	// Try to connect first — if we can, another instance is alive
+	if conn, err := net.Dial("unix", sockPath); err == nil {
+		conn.Close()
+		return nil, nil
+	}
+
+	// Stale socket: remove and try again
+	os.Remove(sockPath)
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Restrict socket permissions
+	os.Chmod(sockPath, 0600)
+
+	s := &Server{
+		ln:       ln,
+		sockPath: sockPath,
+	}
+	go s.acceptLoop()
+	return s, nil
+}
+
+// SocketPath returns the path for client connections.
+func SocketPath(configDir string) string {
+	return filepath.Join(configDir, socketName)
+}
+
+// IsRunning checks if another instance is listening on the socket.
+func IsRunning(configDir string) bool {
+	sockPath := filepath.Join(configDir, socketName)
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
+}
+
+// PID returns the PID stored in configDir/citadel.pid, or 0 if absent.
+func PID(configDir string) int {
+	data, err := os.ReadFile(filepath.Join(configDir, "citadel.pid"))
+	if err != nil {
+		return 0
+	}
+	var pid int
+	for _, b := range data {
+		if b >= '0' && b <= '9' {
+			pid = pid*10 + int(b-'0')
+		}
+	}
+	return pid
+}
+
+// WritePID writes the current PID to configDir/citadel.pid.
+func WritePID(configDir string) error {
+	return os.WriteFile(
+		filepath.Join(configDir, "citadel.pid"),
+		[]byte(itoa(os.Getpid())),
+		0600,
+	)
+}
+
+// RemovePID removes the PID file.
+func RemovePID(configDir string) {
+	os.Remove(filepath.Join(configDir, "citadel.pid"))
+}
+
+func (s *Server) acceptLoop() {
+	for {
+		conn, err := s.ln.Accept()
+		if err != nil {
+			s.mu.Lock()
+			closed := s.closed
+			s.mu.Unlock()
+			if closed {
+				return
+			}
+			continue
+		}
+
+		s.mu.Lock()
+		s.clients = append(s.clients, conn)
+		s.mu.Unlock()
+
+		go s.handleClient(conn)
+	}
+}
+
+// handleClient spawns a fresh PTY for the attached client and relays I/O.
+// The protocol is simple: raw bytes in both directions, with a 4-byte
+// resize message prefix (cols uint16 LE, rows uint16 LE) when the client
+// sends exactly 4 bytes starting with 0x00.
+func (s *Server) handleClient(conn net.Conn) {
+	defer func() {
+		conn.Close()
+		s.removeClient(conn)
+	}()
+
+	session, err := console.NewPTYSession(console.PTYConfig{
+		InitialCols: 80,
+		InitialRows: 24,
+	})
+	if err != nil {
+		log.Printf("[instance] failed to create PTY for attached client: %v", err)
+		return
+	}
+	defer session.Close()
+
+	// PTY → client
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			n, err := session.Read(buf)
+			if n > 0 {
+				if _, werr := conn.Write(buf[:n]); werr != nil {
+					return
+				}
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	// client → PTY (with resize detection)
+	buf := make([]byte, 4096)
+	for {
+		n, err := conn.Read(buf)
+		if n > 0 {
+			data := buf[:n]
+			// Resize message: 0x00 + 4 bytes (cols_le16 + rows_le16)
+			if n == 5 && data[0] == 0x00 {
+				cols := binary.LittleEndian.Uint16(data[1:3])
+				rows := binary.LittleEndian.Uint16(data[3:5])
+				if cols > 0 && rows > 0 {
+					_ = session.Resize(cols, rows)
+				}
+				continue
+			}
+			if _, werr := session.Write(data); werr != nil {
+				return
+			}
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+func (s *Server) removeClient(conn net.Conn) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, c := range s.clients {
+		if c == conn {
+			s.clients = append(s.clients[:i], s.clients[i+1:]...)
+			return
+		}
+	}
+}
+
+// Close shuts down the server and removes the socket.
+func (s *Server) Close() {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return
+	}
+	s.closed = true
+	clients := make([]net.Conn, len(s.clients))
+	copy(clients, s.clients)
+	s.mu.Unlock()
+
+	for _, c := range clients {
+		c.Close()
+	}
+
+	s.ln.Close()
+	os.Remove(s.sockPath)
+}
+
+// SendSIGWINCH sends SIGWINCH to the current process (used by the client
+// to trigger a resize propagation when connecting).
+func SendSIGWINCH() {
+	p, _ := os.FindProcess(os.Getpid())
+	if p != nil {
+		_ = p.Signal(syscall.SIGWINCH)
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}
+
+// ReadPIDFile reads and returns the PID from configDir/citadel.pid.
+func ReadPIDFile(configDir string) int {
+	return PID(configDir)
+}
+

--- a/internal/tui/controlcenter/console_page.go
+++ b/internal/tui/controlcenter/console_page.go
@@ -2,8 +2,8 @@ package controlcenter
 
 import (
 	"fmt"
-	"io"
 	"runtime"
+	"strings"
 	"sync"
 
 	"github.com/aceteam-ai/citadel-cli/internal/console"
@@ -11,9 +11,19 @@ import (
 	"github.com/rivo/tview"
 )
 
-// ConsolePage provides an embedded terminal (PTY) in the TUI.
-// PTY output is rendered through tview's ANSIWriter for basic color
-// support and streamed to web viewers via the Streamer.
+// ConsolePage provides an embedded terminal (PTY) in the TUI with a
+// built-in session multiplexer. Multiple shell sessions can be created
+// and switched between using a Ctrl+B prefix key (like tmux).
+//
+// Key bindings (after Ctrl+B prefix):
+//
+//	c       - Create new session
+//	n       - Next session
+//	p       - Previous session
+//	1-9     - Jump to session N
+//	d       - Close current session
+//	Ctrl+B  - Send literal Ctrl+B to shell
+//	?       - Show help
 //
 // Limitations (v1):
 //   - tview.TextView is line-oriented, not a terminal emulator.
@@ -21,15 +31,16 @@ import (
 //   - Windows is not supported; the page is hidden on that platform.
 type ConsolePage struct {
 	app      *tview.Application
-	view     *tview.TextView
+	rootFlex *tview.Flex
+	tabView  *tview.TextView
+	sessions *sessionManager
 	streamer *console.Streamer
 
-	mu       sync.Mutex
-	pty      *console.PTYSession
-	active   bool
-	started  bool
-	closed   bool // page-level closed flag (set by Close, prevents restart)
-	stopRead chan struct{}
+	mu          sync.Mutex
+	active      bool
+	closed      bool
+	prefixOn    bool // true when Ctrl+B was just pressed, awaiting command key
+	currentView tview.Primitive
 }
 
 // NewConsolePage creates a ConsolePage with an optional Streamer for
@@ -41,7 +52,6 @@ func NewConsolePage(streamer *console.Streamer) *ConsolePage {
 	}
 	return &ConsolePage{
 		streamer: streamer,
-		stopRead: make(chan struct{}),
 	}
 }
 
@@ -50,43 +60,60 @@ func (c *ConsolePage) Title() string { return "Console" }
 
 func (c *ConsolePage) Build(app *tview.Application) tview.Primitive {
 	c.app = app
+	c.sessions = newSessionManager(app)
 
-	c.view = tview.NewTextView().
+	c.tabView = tview.NewTextView().
 		SetDynamicColors(true).
-		SetScrollable(true).
-		SetWordWrap(false).
-		SetChangedFunc(func() {
-			app.Draw()
-		})
-	c.view.SetBorder(true).
-		SetTitle(" Console ").
-		SetTitleAlign(tview.AlignLeft)
+		SetTextAlign(tview.AlignLeft)
+
+	c.rootFlex = tview.NewFlex().SetDirection(tview.FlexRow)
 
 	if runtime.GOOS == "windows" {
-		c.view.SetText("[red]Embedded console is not supported on Windows.[-]")
+		view := tview.NewTextView().SetDynamicColors(true)
+		view.SetBorder(true).SetTitle(" Console ").SetTitleAlign(tview.AlignLeft)
+		view.SetText("[red]Embedded console is not supported on Windows.[-]")
+		c.rootFlex.AddItem(view, 0, 1, true)
 	} else {
-		c.view.SetText("[gray]Press any key to start the console...[-]")
+		// Create the first session automatically
+		idx := c.sessions.createSession(c.streamer)
+		s := c.sessions.getSession(idx)
+		s.view.SetBorder(true).
+			SetTitle(" Console ").
+			SetTitleAlign(tview.AlignLeft)
+
+		c.currentView = s.view
+		c.rootFlex.AddItem(c.tabView, 1, 0, false)
+		c.rootFlex.AddItem(s.view, 0, 1, true)
 	}
 
-	return c.view
+	c.updateTabBar()
+	return c.rootFlex
 }
 
 // OnActivate is called when the Console tab gains focus.
+// Auto-starts the first shell on first activation.
 func (c *ConsolePage) OnActivate() {
 	c.mu.Lock()
 	c.active = true
 	c.mu.Unlock()
+
+	// Auto-start the first session if not yet started
+	s := c.sessions.activeSession()
+	if s != nil && !s.started && !s.closed {
+		_ = c.sessions.startSession(c.sessions.activeIndex())
+	}
 }
 
 // OnDeactivate is called when the Console tab loses focus.
-// The PTY read loop keeps running to avoid blocking the shell.
 func (c *ConsolePage) OnDeactivate() {
 	c.mu.Lock()
 	c.active = false
+	c.prefixOn = false
 	c.mu.Unlock()
 }
 
-// HandleInput captures keystrokes and writes them to the PTY.
+// HandleInput captures keystrokes and routes them through the
+// prefix-key state machine or directly to the active PTY.
 func (c *ConsolePage) HandleInput(event *tcell.EventKey) *tcell.EventKey {
 	if runtime.GOOS == "windows" {
 		return event
@@ -98,29 +125,192 @@ func (c *ConsolePage) HandleInput(event *tcell.EventKey) *tcell.EventKey {
 		return event
 	}
 
-	// Start the PTY on first keypress (or restart after session ended)
-	if !c.started {
-		c.started = true
+	// Prefix key state machine
+	if c.prefixOn {
+		c.prefixOn = false
 		c.mu.Unlock()
-		c.startPTY()
-		return nil // don't forward the activation key to the shell
+		return c.handlePrefixCommand(event)
 	}
 
-	pty := c.pty
+	// Detect Ctrl+B (prefix key)
+	if event.Key() == tcell.KeyCtrlB {
+		c.prefixOn = true
+		c.mu.Unlock()
+		c.showPrefixIndicator()
+		return nil
+	}
 	c.mu.Unlock()
 
-	if pty == nil || pty.IsClosed() {
+	s := c.sessions.activeSession()
+	if s == nil {
 		return event
 	}
 
-	// Convert tcell event to bytes for the PTY
+	// Start session on first keypress if needed (restart after ended)
+	if !s.started {
+		idx := c.sessions.activeIndex()
+		_ = c.sessions.startSession(idx)
+		return nil
+	}
+
+	if s.pty == nil || s.pty.IsClosed() {
+		return event
+	}
+
 	data := keyToBytes(event)
 	if data != nil {
-		_, _ = pty.Write(data)
-		return nil // consumed
+		_, _ = s.pty.Write(data)
+		return nil
 	}
 
 	return event
+}
+
+// handlePrefixCommand processes the key after Ctrl+B.
+func (c *ConsolePage) handlePrefixCommand(event *tcell.EventKey) *tcell.EventKey {
+	// Ctrl+B again: send literal Ctrl+B to shell
+	if event.Key() == tcell.KeyCtrlB {
+		s := c.sessions.activeSession()
+		if s != nil && s.pty != nil && !s.pty.IsClosed() {
+			s.pty.Write([]byte{0x02})
+		}
+		c.clearPrefixIndicator()
+		return nil
+	}
+
+	if event.Key() == tcell.KeyRune {
+		switch event.Rune() {
+		case 'c': // Create new session
+			c.createNewSession()
+			return nil
+		case 'n': // Next session
+			c.sessions.next()
+			c.switchView()
+			return nil
+		case 'p': // Previous session
+			c.sessions.prev()
+			c.switchView()
+			return nil
+		case 'd': // Close current session
+			c.closeCurrentSession()
+			return nil
+		case '?': // Help
+			c.showHelp()
+			return nil
+		}
+
+		// 1-9: jump to session
+		digit := int(event.Rune() - '0')
+		if digit >= 1 && digit <= 9 && digit <= c.sessions.count() {
+			c.sessions.switchTo(digit - 1)
+			c.switchView()
+			return nil
+		}
+	}
+
+	c.clearPrefixIndicator()
+	return nil
+}
+
+// createNewSession adds and starts a new shell session.
+func (c *ConsolePage) createNewSession() {
+	idx := c.sessions.createSession(c.streamer)
+	s := c.sessions.getSession(idx)
+	s.view.SetBorder(true).
+		SetTitle(" Console ").
+		SetTitleAlign(tview.AlignLeft)
+
+	c.sessions.switchTo(idx)
+	_ = c.sessions.startSession(idx)
+	c.switchView()
+}
+
+// closeCurrentSession closes the active session.
+func (c *ConsolePage) closeCurrentSession() {
+	idx := c.sessions.activeIndex()
+	if idx < 0 {
+		return
+	}
+
+	c.sessions.closeSession(idx)
+
+	if c.sessions.count() == 0 {
+		// Create a new session to replace
+		c.createNewSession()
+		return
+	}
+
+	c.switchView()
+}
+
+// switchView replaces the displayed view with the active session's view.
+func (c *ConsolePage) switchView() {
+	s := c.sessions.activeSession()
+	if s == nil {
+		return
+	}
+
+	c.app.QueueUpdateDraw(func() {
+		if c.currentView != nil {
+			c.rootFlex.RemoveItem(c.currentView)
+		}
+		c.currentView = s.view
+		c.rootFlex.AddItem(s.view, 0, 1, true)
+		c.updateTabBar()
+	})
+}
+
+func (c *ConsolePage) updateTabBar() {
+	bar := c.sessions.tabBar()
+	if bar == "" {
+		c.tabView.SetText("")
+	} else {
+		c.tabView.SetText(bar)
+	}
+}
+
+func (c *ConsolePage) showPrefixIndicator() {
+	c.app.QueueUpdateDraw(func() {
+		s := c.sessions.activeSession()
+		if s != nil {
+			s.view.SetTitle(" Console [yellow](Ctrl+B)[-] ")
+		}
+	})
+}
+
+func (c *ConsolePage) clearPrefixIndicator() {
+	c.app.QueueUpdateDraw(func() {
+		s := c.sessions.activeSession()
+		if s != nil {
+			s.view.SetTitle(" Console ")
+		}
+		c.updateTabBar()
+	})
+}
+
+func (c *ConsolePage) showHelp() {
+	c.app.QueueUpdateDraw(func() {
+		s := c.sessions.activeSession()
+		if s == nil {
+			return
+		}
+		help := strings.Join([]string{
+			"",
+			"[yellow::b]Session multiplexer (Ctrl+B prefix)[-:-:-]",
+			"",
+			"  [white]Ctrl+B, c[-]  Create new session",
+			"  [white]Ctrl+B, n[-]  Next session",
+			"  [white]Ctrl+B, p[-]  Previous session",
+			"  [white]Ctrl+B, 1-9[-] Jump to session N",
+			"  [white]Ctrl+B, d[-]  Close current session",
+			"  [white]Ctrl+B, Ctrl+B[-] Send literal Ctrl+B",
+			"  [white]Ctrl+B, ?[-]  This help",
+			"",
+			"[gray]Press any key to dismiss[-]",
+		}, "\n")
+		fmt.Fprintln(tview.ANSIWriter(s.view), help)
+		s.view.SetTitle(" Console ")
+	})
 }
 
 // Streamer returns the Streamer for external access (e.g. wiring into an HTTP handler).
@@ -128,8 +318,7 @@ func (c *ConsolePage) Streamer() *console.Streamer {
 	return c.streamer
 }
 
-// Close shuts down the PTY session and disconnects all stream clients.
-// Safe to call from any goroutine; does not re-enter the mutex during PTY teardown.
+// Close shuts down all PTY sessions and disconnects all stream clients.
 func (c *ConsolePage) Close() {
 	c.mu.Lock()
 	if c.closed {
@@ -137,120 +326,12 @@ func (c *ConsolePage) Close() {
 		return
 	}
 	c.closed = true
-
-	pty := c.pty
-	c.pty = nil
-
-	// Signal the read loop to stop
-	select {
-	case <-c.stopRead:
-		// already closed
-	default:
-		close(c.stopRead)
-	}
 	c.mu.Unlock()
 
-	// Close the PTY outside the lock to avoid deadlock
-	if pty != nil && !pty.IsClosed() {
-		_ = pty.Close()
+	if c.sessions != nil {
+		c.sessions.closeAll()
 	}
 	c.streamer.CloseAll()
-}
-
-// startPTY spawns the shell and starts the read loop.
-func (c *ConsolePage) startPTY() {
-	c.view.Clear()
-
-	session, err := console.NewPTYSession(console.PTYConfig{
-		InitialCols: 80,
-		InitialRows: 24,
-	})
-	if err != nil {
-		c.app.QueueUpdateDraw(func() {
-			c.view.SetText(fmt.Sprintf("[red]Failed to start console: %s[-]", err))
-		})
-		c.mu.Lock()
-		c.started = false
-		c.mu.Unlock()
-		return
-	}
-
-	c.mu.Lock()
-	c.pty = session
-	c.mu.Unlock()
-
-	go c.readLoop(session)
-}
-
-// readLoop continuously reads PTY output and dispatches it to the
-// tview widget and the WebSocket streamer. It runs until the PTY
-// closes, stopRead is signaled, or the shell exits naturally.
-//
-// On natural shell exit (read returns EIO/EOF), readLoop handles
-// teardown: closes the PTY, resets state, and shows the restart prompt.
-// This avoids the need for an onClose callback that would re-enter the mutex.
-func (c *ConsolePage) readLoop(session *console.PTYSession) {
-	buf := make([]byte, 4096)
-	ansiW := tview.ANSIWriter(c.view)
-
-	defer c.onSessionEnd(session)
-
-	for {
-		select {
-		case <-c.stopRead:
-			return
-		default:
-		}
-
-		n, err := session.Read(buf)
-		if n > 0 {
-			chunk := make([]byte, n)
-			copy(chunk, buf[:n])
-
-			// Stream to WebSocket viewers (always, even when tab is inactive)
-			c.streamer.Broadcast(chunk)
-
-			// Render in the TUI view
-			c.app.QueueUpdate(func() {
-				_, _ = ansiW.Write(chunk)
-				c.view.ScrollToEnd()
-			})
-		}
-		if err != nil {
-			if err != io.EOF {
-				c.app.QueueUpdateDraw(func() {
-					fmt.Fprintf(c.view, "\n[red]Read error: %s[-]", err)
-				})
-			}
-			return
-		}
-	}
-}
-
-// onSessionEnd cleans up after a PTY session ends (natural exit or forced close).
-// It closes the PTY, resets state so a new session can start on keypress,
-// and shows the restart prompt (unless the page itself is being torn down).
-func (c *ConsolePage) onSessionEnd(session *console.PTYSession) {
-	// Close the PTY if it's still open (idempotent)
-	if !session.IsClosed() {
-		_ = session.Close()
-	}
-
-	c.mu.Lock()
-	// Only reset for restart if the page isn't being torn down
-	if c.closed {
-		c.mu.Unlock()
-		return
-	}
-	c.started = false
-	c.pty = nil
-	c.stopRead = make(chan struct{})
-	c.mu.Unlock()
-
-	c.app.QueueUpdateDraw(func() {
-		fmt.Fprintln(tview.ANSIWriter(c.view), "")
-		fmt.Fprintln(c.view, "[yellow]Session ended. Press any key to restart.[-]")
-	})
 }
 
 // keyToBytes converts a tcell key event to bytes suitable for a PTY.
@@ -259,7 +340,6 @@ func keyToBytes(ev *tcell.EventKey) []byte {
 	if ev.Key() == tcell.KeyRune {
 		r := ev.Rune()
 		if ev.Modifiers()&tcell.ModAlt != 0 {
-			// Alt+key: ESC prefix
 			return []byte{0x1b, byte(r)}
 		}
 		buf := make([]byte, 4)

--- a/internal/tui/controlcenter/session_manager.go
+++ b/internal/tui/controlcenter/session_manager.go
@@ -1,0 +1,315 @@
+package controlcenter
+
+import (
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/aceteam-ai/citadel-cli/internal/console"
+	"github.com/rivo/tview"
+)
+
+// consoleSession wraps a single PTY session and its output state.
+type consoleSession struct {
+	id       int
+	label    string
+	pty      *console.PTYSession
+	streamer *console.Streamer
+	view     *tview.TextView
+	stopRead chan struct{}
+	started  bool
+	closed   bool
+}
+
+// sessionManager tracks multiple PTY sessions for the Console tab.
+type sessionManager struct {
+	mu       sync.Mutex
+	sessions []*consoleSession
+	active   int
+	nextID   int
+	app      *tview.Application
+}
+
+func newSessionManager(app *tview.Application) *sessionManager {
+	return &sessionManager{
+		app:    app,
+		active: -1,
+	}
+}
+
+// createSession adds a new session and returns its index.
+func (sm *sessionManager) createSession(streamer *console.Streamer) int {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	sm.nextID++
+	id := sm.nextID
+
+	view := tview.NewTextView().
+		SetDynamicColors(true).
+		SetScrollable(true).
+		SetWordWrap(false).
+		SetChangedFunc(func() {
+			sm.app.Draw()
+		})
+
+	s := &consoleSession{
+		id:       id,
+		label:    "bash",
+		streamer: streamer,
+		view:     view,
+		stopRead: make(chan struct{}),
+	}
+	sm.sessions = append(sm.sessions, s)
+	idx := len(sm.sessions) - 1
+
+	if sm.active < 0 {
+		sm.active = idx
+	}
+
+	return idx
+}
+
+// startSession spawns a PTY for the session at idx.
+func (sm *sessionManager) startSession(idx int) error {
+	sm.mu.Lock()
+	if idx < 0 || idx >= len(sm.sessions) {
+		sm.mu.Unlock()
+		return fmt.Errorf("invalid session index: %d", idx)
+	}
+	s := sm.sessions[idx]
+	if s.started || s.closed {
+		sm.mu.Unlock()
+		return nil
+	}
+	s.started = true
+	sm.mu.Unlock()
+
+	session, err := console.NewPTYSession(console.PTYConfig{
+		InitialCols: 80,
+		InitialRows: 24,
+	})
+	if err != nil {
+		sm.mu.Lock()
+		s.started = false
+		sm.mu.Unlock()
+		return err
+	}
+
+	sm.mu.Lock()
+	s.pty = session
+	sm.mu.Unlock()
+
+	go sm.readLoop(s, session)
+	return nil
+}
+
+// readLoop reads PTY output and writes to the session's view and streamer.
+func (sm *sessionManager) readLoop(s *consoleSession, session *console.PTYSession) {
+	buf := make([]byte, 4096)
+	ansiW := tview.ANSIWriter(s.view)
+
+	defer sm.onSessionEnd(s, session)
+
+	for {
+		select {
+		case <-s.stopRead:
+			return
+		default:
+		}
+
+		n, err := session.Read(buf)
+		if n > 0 {
+			chunk := make([]byte, n)
+			copy(chunk, buf[:n])
+
+			// Only stream to WebSocket viewers from the active session
+			sm.mu.Lock()
+			isActive := sm.active >= 0 && sm.active < len(sm.sessions) && sm.sessions[sm.active] == s
+			sm.mu.Unlock()
+			if isActive && s.streamer != nil {
+				s.streamer.Broadcast(chunk)
+			}
+
+			sm.app.QueueUpdate(func() {
+				_, _ = ansiW.Write(chunk)
+				s.view.ScrollToEnd()
+			})
+		}
+		if err != nil {
+			if err != io.EOF {
+				sm.app.QueueUpdateDraw(func() {
+					fmt.Fprintf(s.view, "\n[red]Read error: %s[-]", err)
+				})
+			}
+			return
+		}
+	}
+}
+
+// onSessionEnd handles cleanup when a PTY session ends.
+func (sm *sessionManager) onSessionEnd(s *consoleSession, session *console.PTYSession) {
+	if !session.IsClosed() {
+		_ = session.Close()
+	}
+
+	sm.mu.Lock()
+	if s.closed {
+		sm.mu.Unlock()
+		return
+	}
+	s.started = false
+	s.pty = nil
+	s.stopRead = make(chan struct{})
+	sm.mu.Unlock()
+
+	sm.app.QueueUpdateDraw(func() {
+		fmt.Fprintln(tview.ANSIWriter(s.view), "")
+		fmt.Fprintln(s.view, "[yellow]Session ended. Press any key to restart.[-]")
+	})
+}
+
+// activeSession returns the currently active session (nil if none).
+func (sm *sessionManager) activeSession() *consoleSession {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	if sm.active < 0 || sm.active >= len(sm.sessions) {
+		return nil
+	}
+	return sm.sessions[sm.active]
+}
+
+// switchTo changes the active session.
+func (sm *sessionManager) switchTo(idx int) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	if idx < 0 || idx >= len(sm.sessions) {
+		return
+	}
+	sm.active = idx
+}
+
+// next cycles to the next session.
+func (sm *sessionManager) next() {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	if len(sm.sessions) == 0 {
+		return
+	}
+	sm.active = (sm.active + 1) % len(sm.sessions)
+}
+
+// prev cycles to the previous session.
+func (sm *sessionManager) prev() {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	if len(sm.sessions) == 0 {
+		return
+	}
+	sm.active = (sm.active - 1 + len(sm.sessions)) % len(sm.sessions)
+}
+
+// closeSession closes and removes the session at idx.
+func (sm *sessionManager) closeSession(idx int) {
+	sm.mu.Lock()
+	if idx < 0 || idx >= len(sm.sessions) {
+		sm.mu.Unlock()
+		return
+	}
+	s := sm.sessions[idx]
+	s.closed = true
+
+	pty := s.pty
+	s.pty = nil
+
+	select {
+	case <-s.stopRead:
+	default:
+		close(s.stopRead)
+	}
+
+	// Remove from list
+	sm.sessions = append(sm.sessions[:idx], sm.sessions[idx+1:]...)
+
+	// Adjust active index
+	if len(sm.sessions) == 0 {
+		sm.active = -1
+	} else if sm.active >= len(sm.sessions) {
+		sm.active = len(sm.sessions) - 1
+	} else if sm.active > idx {
+		sm.active--
+	}
+	sm.mu.Unlock()
+
+	if pty != nil && !pty.IsClosed() {
+		_ = pty.Close()
+	}
+}
+
+// count returns the number of sessions.
+func (sm *sessionManager) count() int {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	return len(sm.sessions)
+}
+
+// activeIndex returns the active session index.
+func (sm *sessionManager) activeIndex() int {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	return sm.active
+}
+
+// getSession returns the session at idx under lock (nil if out of bounds).
+func (sm *sessionManager) getSession(idx int) *consoleSession {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	if idx < 0 || idx >= len(sm.sessions) {
+		return nil
+	}
+	return sm.sessions[idx]
+}
+
+// closeAll shuts down all sessions.
+func (sm *sessionManager) closeAll() {
+	sm.mu.Lock()
+	sessions := make([]*consoleSession, len(sm.sessions))
+	copy(sessions, sm.sessions)
+	sm.sessions = nil
+	sm.active = -1
+	sm.mu.Unlock()
+
+	for _, s := range sessions {
+		s.closed = true
+		select {
+		case <-s.stopRead:
+		default:
+			close(s.stopRead)
+		}
+		if s.pty != nil && !s.pty.IsClosed() {
+			_ = s.pty.Close()
+		}
+	}
+}
+
+// tabBar renders the session tab indicator text.
+func (sm *sessionManager) tabBar() string {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	if len(sm.sessions) <= 1 {
+		return ""
+	}
+
+	var result string
+	for i, s := range sm.sessions {
+		marker := fmt.Sprintf("%d:%s", i+1, s.label)
+		if i == sm.active {
+			result += fmt.Sprintf("[yellow::b][%s][-:-:-] ", marker)
+		} else {
+			result += fmt.Sprintf("[gray]%s[-] ", marker)
+		}
+	}
+	result += "[gray]Ctrl+B,? for help[-]"
+	return result
+}


### PR DESCRIPTION
## Context

Addresses #274 (single-instance detection) and #275 (console session multiplexer). The Citadel TUI needs to handle the case where a user runs `citadel` while it's already running (currently launches a competing instance), and the Console tab should offer built-in terminal multiplexing so users don't need to manually install/run tmux.

## Summary

**Single-instance detection** (`internal/instance/`):
- Unix domain socket server at `~/.citadel-cli/citadel.sock` for instance detection — socket-based rather than PID-file-only for reliable stale detection
- `IsRunning()` connect-tests the socket; stale sockets (ECONNREFUSED) are automatically cleaned up
- Attach client puts terminal in raw mode, relays stdin/stdout with Ctrl+] to detach
- 5-byte resize protocol (0x00 marker + cols/rows as LE uint16) propagates SIGWINCH to server PTY
- PID file management for user-facing "already running (PID X)" messages
- Socket permissions 0600, directory 0700

**Console session multiplexer** (`session_manager.go`, rewritten `console_page.go`):
- Ctrl+B prefix key (matching tmux default) with state machine: c=create, n/p=next/prev, 1-9=jump, d=close, ?=help
- Each session wraps an independent PTY with its own tview.TextView output buffer
- Tab bar only appears when multiple sessions exist (clean single-session UX)
- Auto-starts first shell on Console tab activation (no "press any key" prompt)
- WebSocket streaming broadcasts from the active session only
- Pure Go implementation — no tmux/screen dependency

**Concurrency safety**:
- All session slice access goes through locked `getSession()` accessor
- `readLoop` bounds-checks `sm.active` before indexing to prevent panic when all sessions are closed

## Test plan

| Area | Tests | Coverage |
|------|-------|----------|
| Instance detection | 6 unit tests | Listen/IsRunning, stale socket cleanup, PID file CRUD, server close, socket permissions, client connect+PTY |
| Race safety | `go test -race` on all changed packages | Clean (pre-existing race in `internal/workflow` is unrelated) |
| Build | `go build ./...` | Compiles cleanly |

**Manual testing needed:**
- [ ] Launch `citadel`, verify Console tab auto-starts shell
- [ ] Ctrl+B,c to create sessions, Ctrl+B,n/p to switch, verify tab bar
- [ ] Ctrl+B,d to close session, verify replacement session spawns when last is closed
- [ ] Run `citadel` in second terminal, verify it attaches and Ctrl+] detaches
- [ ] Verify view-swapping doesn't leave stale content in the flex layout

## Related

- Closes #274 (single-instance detection)
- Closes #275 (console multiplexer)
- Build tag `//go:build !windows` on instance package and Console page