### PR TITLE
feat(vnc): testable Linux install path + macOS VNC E2E runbook (#122)

### DIFF
--- a/cmd/vnc.go
+++ b/cmd/vnc.go
@@ -110,6 +110,10 @@ func runVNCEnable(cmd *cobra.Command, args []string) error {
 	// Configure
 	fmt.Printf("Configuring VNC on port %d...\n", vncPort)
 	if err := mgr.Configure(password, vncPort); err != nil {
+		// Surface sudo-required errors directly without wrapping
+		if errors.Is(err, platform.ErrSudoRequired) || errors.Is(err, platform.ErrDarwinSudoRequired) {
+			return err
+		}
 		return fmt.Errorf("failed to configure VNC server: %w", err)
 	}
 

--- a/docs/vnc-macos-e2e.md
+++ b/docs/vnc-macos-e2e.md
@@ -1,0 +1,158 @@
+# macOS VNC Provisioner — On-Device E2E Runbook
+
+This runbook covers the manual, on-device verification of the macOS VNC
+provisioner (`DarwinVNCManager` in `internal/platform/vnc.go`). It exists because
+the activate/configure/start path **cannot run in CI**: it requires `sudo` and
+enables Screen Sharing system-wide. Unit tests only cover command construction
+(`kickstart*Args`) and detection (`citadel vnc status` with Screen Sharing off).
+
+These steps must be run by an operator on a real Mac. Tracking issue: **#268**
+(follow-up to #267, parent #122).
+
+## What the provisioner does
+
+macOS ships a VNC server as part of Remote Management / Screen Sharing, so there
+is nothing to install. The provisioner drives Apple's `kickstart` tool:
+
+```
+/System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart
+```
+
+- **enable** → `kickstart -activate -configure -access -on -clientopts -setvnclegacy -vnclegacy yes -clientopts -setvncpw -vncpw <pw> -restart -agent -privs -all`
+- **disable** → `kickstart -deactivate -configure -access -off`
+- **status** → `launchctl list com.apple.screensharing` (with an `lsof` port-5900 fallback)
+
+All `kickstart` invocations require root; when not root the provisioner returns
+`ErrDarwinSudoRequired` (`sudo citadel vnc enable`) rather than a wrapped error.
+
+## Prerequisites
+
+- A macOS node with **Screen Sharing OFF** (System Settings → General → Sharing).
+- An admin account able to run `sudo`.
+- The latest `citadel` binary deployed to the node (`darwin/arm64` or
+  `darwin/amd64` as appropriate).
+- A second machine on the same network (or Headscale mesh) with a VNC / noVNC
+  client to connect back into the Mac.
+
+## Procedure
+
+### 1. Baseline — confirm starting state
+
+```bash
+citadel vnc status
+```
+
+Expect:
+
+```
+Installed: true        # kickstart tool is always present on macOS
+Running:   false       # Screen Sharing is off
+```
+
+`Installed: true` is expected even before enabling — it only means the built-in
+Remote Management tool exists. No `Port:` line is printed while not running.
+
+### 2. Verify the no-sudo error path
+
+Run **without** sudo first to confirm the error surfaces cleanly:
+
+```bash
+citadel vnc enable
+```
+
+Expect the process to fail with the actionable message (not a wrapped/opaque
+error):
+
+```
+macOS Screen Sharing provisioning requires root privileges. Run: sudo citadel vnc enable
+```
+
+### 3. Enable with sudo
+
+```bash
+sudo citadel vnc enable
+# optional explicit password (max 8 chars, VNC DES limit):
+# sudo citadel vnc enable --password hunter2x
+```
+
+If no `--password` is given, an 8-character password is generated and printed to
+stdout. **Record it** — it is needed to connect. Passwords longer than 8 chars
+are truncated (you will see a truncation notice). macOS Screen Sharing only
+listens on port **5900**; a non-default `--port` is accepted but ignored with a
+note.
+
+### 4. Confirm running status
+
+```bash
+citadel vnc status
+```
+
+Expect:
+
+```
+Installed: true
+Running:   true
+Port:      5900
+```
+
+`Running: true` comes from `launchctl list com.apple.screensharing` returning
+exit 0 once Screen Sharing is loaded.
+
+### 5. Confirm in System Settings
+
+Open **System Settings → General → Sharing** and confirm **Remote Management**
+(or **Screen Sharing**) is now enabled, and that a VNC password was set under its
+options. This is the system-wide change that cannot be exercised in CI.
+
+### 6. Connect end-to-end
+
+From the second machine, connect to the Mac on port 5900 using the recorded
+password, via either:
+
+- a standard VNC client (e.g. `vnc://<mac-ip>:5900`), or
+- the DesktopViewer / noVNC chain (the same flow verified on Windows in #119).
+
+Confirm the macOS desktop **renders** and **accepts keyboard/mouse input**.
+
+### 7. Disable and confirm teardown
+
+```bash
+sudo citadel vnc disable
+citadel vnc status
+```
+
+Expect `disable` to run `kickstart -deactivate` and `status` to report:
+
+```
+Installed: true
+Running:   false
+```
+
+Re-confirm in System Settings → Sharing that Remote Management is back **off**,
+and that the previous VNC client can no longer connect.
+
+There is nothing to uninstall on macOS (the server is a built-in component);
+`citadel vnc disable --uninstall` maps to the same deactivate path as `disable`.
+
+## Caveats to watch for (from #267)
+
+- **TCC / Privacy prompts.** macOS may gate Screen Recording / Accessibility
+  behind TCC. A headless fleet agent cannot click through these prompts. On a
+  managed fleet, pre-grant the relevant TCC permissions (e.g. via MDM Privacy
+  Preferences Policy Control profiles) before relying on the agent path. Note
+  whether the prompts block the connection during this run.
+- **Legacy VNC password.** Modern macOS requires the legacy VNC password option
+  for non-ARD clients. The provisioner already passes
+  `-setvnclegacy -vnclegacy yes`. Confirm that **noVNC / standard VNC clients**
+  (not just Apple Screen Sharing.app) can authenticate with the 8-char password.
+- **8-char password truncation.** The RFB DES scheme caps passwords at 8 bytes.
+  Verify that the truncated password is exactly what the VNC client expects —
+  enter only the first 8 characters if you supplied a longer one.
+- **No-sudo behavior.** Re-confirm step 2: without sudo the command must surface
+  `ErrDarwinSudoRequired`, never a generic failure.
+
+## Result reporting
+
+Record on issue #268: the macOS version, whether each step passed, the exact
+`citadel vnc status` output before/after, whether noVNC connected with the legacy
+password, and any TCC prompts encountered (and how they were resolved).

--- a/internal/platform/vnc.go
+++ b/internal/platform/vnc.go
@@ -375,6 +375,11 @@ func (w *WindowsVNCManager) Port() int {
 // The caller (cmd/vnc.go) should display an actionable message to the user.
 var ErrSudoRequired = fmt.Errorf("VNC server installation requires root privileges. Install sudo and run: sudo citadel vnc enable — or run directly as root: su -c 'citadel vnc enable'")
 
+// ErrDarwinSudoRequired is returned when macOS Screen Sharing provisioning
+// needs elevated privileges but sudo is unavailable. The kickstart tool
+// always requires root to change Remote Management configuration.
+var ErrDarwinSudoRequired = fmt.Errorf("macOS Screen Sharing provisioning requires root privileges. Run: sudo citadel vnc enable")
+
 // --- Linux implementation ---
 
 // LinuxVNCManager manages x11vnc on Linux.
@@ -738,45 +743,202 @@ func (l *LinuxVNCManager) effectivePort() int {
 	return DefaultVNCPort
 }
 
-// --- macOS implementation (stub) ---
+// --- macOS implementation ---
 
-// DarwinVNCManager is a stub VNC manager for macOS.
-// macOS has built-in Screen Sharing that can be enabled via system preferences.
+// kickstartPath is the absolute path to Apple Remote Desktop's kickstart
+// tool, which activates and configures the built-in Remote Management /
+// Screen Sharing VNC server. It ships with every macOS install.
+const kickstartPath = "/System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart"
+
+// DarwinVNCManager provisions the built-in macOS Screen Sharing / Apple
+// Remote Desktop VNC server via the kickstart tool. macOS ships a VNC
+// server as part of Remote Management, so there is nothing to install --
+// it only needs to be activated and configured (which requires root).
 type DarwinVNCManager struct{}
 
 func (d *DarwinVNCManager) IsInstalled() bool {
-	// macOS has built-in Screen Sharing (VNC)
-	return true
+	// The kickstart tool ships with every macOS install. Its presence
+	// means the built-in VNC server is available to be provisioned.
+	_, err := os.Stat(kickstartPath)
+	return err == nil
+}
+
+// kickstartActivateArgs returns the kickstart arguments that activate
+// Remote Management, grant full access privileges, enable VNC legacy mode,
+// set the VNC password, and restart the agent. Extracted as a pure function
+// for testability -- it never executes anything.
+//
+// The flags map to:
+//
+//	-activate              : turn on Remote Management
+//	-configure             : apply the following configuration
+//	-access -on            : enable access
+//	-clientopts -setvnclegacy -vnclegacy yes : allow legacy VNC clients
+//	-clientopts -setvncpw -vncpw <pw>        : set the VNC (RFB) password
+//	-privs -all            : grant all control privileges
+//	-restart -agent        : restart the ARD agent so changes take effect
+func kickstartActivateArgs(password string) []string {
+	return []string{
+		"-activate",
+		"-configure",
+		"-access", "-on",
+		"-clientopts", "-setvnclegacy", "-vnclegacy", "yes",
+		"-clientopts", "-setvncpw", "-vncpw", password,
+		"-restart", "-agent",
+		"-privs", "-all",
+	}
+}
+
+// kickstartDeactivateArgs returns the kickstart arguments that stop the
+// Remote Management agent and disable access. Pure function for testability.
+func kickstartDeactivateArgs() []string {
+	return []string{
+		"-deactivate",
+		"-configure",
+		"-access", "-off",
+	}
+}
+
+// kickstartRestartArgs returns the kickstart arguments that restart the
+// Remote Management agent without changing configuration. Pure function.
+func kickstartRestartArgs() []string {
+	return []string{"-restart", "-agent"}
+}
+
+// darwinCmd builds an *exec.Cmd for the given name+args, prefixing with
+// sudo when the current process is not root. macOS kickstart operations
+// require root; this mirrors the Linux sudoPrefix helper.
+func darwinCmd(needsSudo bool, name string, args ...string) *exec.Cmd {
+	if needsSudo {
+		return exec.Command("sudo", append([]string{name}, args...)...)
+	}
+	return exec.Command(name, args...)
 }
 
 func (d *DarwinVNCManager) Install() error {
-	fmt.Println("VNC server provisioning not yet supported on macOS (use built-in Screen Sharing)")
+	// macOS ships the VNC server (Remote Management); there is nothing to
+	// download or install. Activation/configuration happens in Configure,
+	// which is the step that actually enables Screen Sharing. We verify the
+	// kickstart tool is present so callers get a clear error on unusual
+	// systems where Remote Management has been removed.
+	if !d.IsInstalled() {
+		return fmt.Errorf("macOS Remote Management tool not found at %s", kickstartPath)
+	}
+	fmt.Println("macOS Screen Sharing is built in; no installation required.")
 	return nil
 }
 
 func (d *DarwinVNCManager) Uninstall() error {
-	fmt.Println("VNC server uninstall not yet supported on macOS.")
+	// We cannot uninstall a built-in macOS component, but we can disable it,
+	// which is the meaningful equivalent of "removing" the VNC server.
+	needsSudo := os.Getuid() != 0
+	if needsSudo {
+		if _, err := exec.LookPath("sudo"); err != nil {
+			return ErrDarwinSudoRequired
+		}
+	}
+
+	cmd := darwinCmd(needsSudo, kickstartPath, kickstartDeactivateArgs()...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to deactivate macOS Screen Sharing: %w (output: %s)", err, strings.TrimSpace(string(output)))
+	}
+
+	fmt.Println("macOS Screen Sharing disabled.")
 	return nil
 }
 
 func (d *DarwinVNCManager) Configure(password string, port int) error {
-	fmt.Println("VNC server provisioning not yet supported on macOS (use built-in Screen Sharing)")
+	if err := ValidateVNCPort(port); err != nil {
+		return err
+	}
+
+	// macOS Screen Sharing only listens on the standard VNC port (5900).
+	// A custom port is not configurable via kickstart, so warn rather than
+	// silently pretend it took effect.
+	if port != DefaultVNCPort {
+		fmt.Printf("Note: macOS Screen Sharing only supports port %d; ignoring requested port %d.\n", DefaultVNCPort, port)
+	}
+
+	// The RFB password is limited to 8 bytes by the VNC DES scheme.
+	if len(password) > 8 {
+		password = password[:8]
+	}
+
+	needsSudo := os.Getuid() != 0
+	if needsSudo {
+		if _, err := exec.LookPath("sudo"); err != nil {
+			return ErrDarwinSudoRequired
+		}
+	}
+
+	// Activating + configuring is a single kickstart invocation. This both
+	// turns on Remote Management and sets the VNC password.
+	cmd := darwinCmd(needsSudo, kickstartPath, kickstartActivateArgs(password)...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to configure macOS Screen Sharing: %w (output: %s)", err, strings.TrimSpace(string(output)))
+	}
+
 	return nil
 }
 
 func (d *DarwinVNCManager) Start() error {
-	fmt.Println("VNC server provisioning not yet supported on macOS (use built-in Screen Sharing)")
+	if d.IsRunning() {
+		return nil // Already running, idempotent
+	}
+
+	needsSudo := os.Getuid() != 0
+	if needsSudo {
+		if _, err := exec.LookPath("sudo"); err != nil {
+			return ErrDarwinSudoRequired
+		}
+	}
+
+	// Restart the ARD agent to ensure the service is up. Configure() already
+	// activates the service; this handles the case where it was deactivated
+	// or the agent needs to be (re)started.
+	cmd := darwinCmd(needsSudo, kickstartPath, kickstartRestartArgs()...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to start macOS Screen Sharing: %w (output: %s)", err, strings.TrimSpace(string(output)))
+	}
+
 	return nil
 }
 
 func (d *DarwinVNCManager) Stop() error {
-	fmt.Println("VNC server provisioning not yet supported on macOS (use built-in Screen Sharing)")
+	needsSudo := os.Getuid() != 0
+	if needsSudo {
+		if _, err := exec.LookPath("sudo"); err != nil {
+			return ErrDarwinSudoRequired
+		}
+	}
+
+	cmd := darwinCmd(needsSudo, kickstartPath, kickstartDeactivateArgs()...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to stop macOS Screen Sharing: %w (output: %s)", err, strings.TrimSpace(string(output)))
+	}
 	return nil
 }
 
 func (d *DarwinVNCManager) IsRunning() bool {
-	// Check if Screen Sharing is active
-	cmd := exec.Command("launchctl", "list", "com.apple.screensharing")
+	// The screensharing launchd service is loaded only when Screen Sharing
+	// is enabled. `launchctl list <label>` exits non-zero when the service
+	// is not present.
+	if exec.Command("launchctl", "list", "com.apple.screensharing").Run() == nil {
+		return true
+	}
+	// Fallback: a VNC server listening on the standard port is also a
+	// positive signal (e.g. a third-party server, or detection edge cases).
+	return darwinPortListening(DefaultVNCPort)
+}
+
+// darwinPortListening reports whether a TCP listener is bound to the given
+// port, using `lsof`. Best-effort: returns false on any error.
+func darwinPortListening(port int) bool {
+	cmd := exec.Command("lsof", "-nP", fmt.Sprintf("-iTCP:%d", port), "-sTCP:LISTEN")
 	return cmd.Run() == nil
 }
 

--- a/internal/platform/vnc.go
+++ b/internal/platform/vnc.go
@@ -392,6 +392,27 @@ func (l *LinuxVNCManager) IsInstalled() bool {
 	return err == nil
 }
 
+// installCmd returns the package manager command name and arguments for
+// installing x11vnc on the given package manager. This is a pure function
+// extracted for testability -- it never executes anything. It mirrors
+// uninstallCmd so the install and uninstall paths stay symmetric.
+func installCmd(pkgMgr string) (name string, args []string) {
+	switch pkgMgr {
+	case "apt-get":
+		return "apt-get", []string{"install", "-y", "-qq", "x11vnc"}
+	case "dnf":
+		return "dnf", []string{"install", "-y", "x11vnc"}
+	case "yum":
+		return "yum", []string{"install", "-y", "x11vnc"}
+	case "pacman":
+		return "pacman", []string{"-S", "--noconfirm", "x11vnc"}
+	case "zypper":
+		return "zypper", []string{"install", "-y", "x11vnc"}
+	default:
+		return "", nil
+	}
+}
+
 func (l *LinuxVNCManager) Install() error {
 	if l.IsInstalled() {
 		return nil
@@ -415,57 +436,30 @@ func (l *LinuxVNCManager) Install() error {
 		return exec.Command(name, args...)
 	}
 
-	if _, err := exec.LookPath("apt-get"); err == nil {
+	pkgMgr := detectPackageManager()
+	if pkgMgr == "" {
+		return fmt.Errorf("no supported package manager found (tried apt-get, dnf, yum, pacman, zypper)")
+	}
+
+	// Refresh the package index for apt before installing; other managers
+	// resolve the package without a separate update step.
+	if pkgMgr == "apt-get" {
 		updateCmd := sudoPrefix("apt-get", "update", "-qq")
 		_ = updateCmd.Run()
-
-		installCmd := sudoPrefix("apt-get", "install", "-y", "-qq", "x11vnc")
-		installCmd.Env = append(os.Environ(), "DEBIAN_FRONTEND=noninteractive")
-		installCmd.Stdout = os.Stdout
-		installCmd.Stderr = os.Stderr
-		if err := installCmd.Run(); err != nil {
-			return fmt.Errorf("failed to install x11vnc via apt: %w", err)
-		}
-		return nil
-	}
-	if _, err := exec.LookPath("dnf"); err == nil {
-		cmd := sudoPrefix("dnf", "install", "-y", "x11vnc")
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("failed to install x11vnc via dnf: %w", err)
-		}
-		return nil
-	}
-	if _, err := exec.LookPath("yum"); err == nil {
-		cmd := sudoPrefix("yum", "install", "-y", "x11vnc")
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("failed to install x11vnc via yum: %w", err)
-		}
-		return nil
-	}
-	if _, err := exec.LookPath("pacman"); err == nil {
-		cmd := sudoPrefix("pacman", "-S", "--noconfirm", "x11vnc")
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("failed to install x11vnc via pacman: %w", err)
-		}
-		return nil
-	}
-	if _, err := exec.LookPath("zypper"); err == nil {
-		cmd := sudoPrefix("zypper", "install", "-y", "x11vnc")
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("failed to install x11vnc via zypper: %w", err)
-		}
-		return nil
 	}
 
-	return fmt.Errorf("no supported package manager found (tried apt-get, dnf, yum, pacman, zypper)")
+	cmdName, cmdArgs := installCmd(pkgMgr)
+	cmd := sudoPrefix(cmdName, cmdArgs...)
+	if pkgMgr == "apt-get" {
+		cmd.Env = append(os.Environ(), "DEBIAN_FRONTEND=noninteractive")
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to install x11vnc via %s: %w", pkgMgr, err)
+	}
+
+	return nil
 }
 
 // uninstallCmd returns the package manager command name and arguments for

--- a/internal/platform/vnc_test.go
+++ b/internal/platform/vnc_test.go
@@ -448,6 +448,178 @@ func TestLinuxVNCManagerConfigureSetsPort(t *testing.T) {
 	}
 }
 
+func TestKickstartActivateArgs(t *testing.T) {
+	args := kickstartActivateArgs("secret12")
+	argStr := strings.Join(args, " ")
+
+	// Core activation flags must be present
+	for _, want := range []string{"-activate", "-configure", "-access", "-on", "-restart", "-agent", "-privs", "-all"} {
+		found := false
+		for _, a := range args {
+			if a == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("kickstartActivateArgs() missing %q in %v", want, args)
+		}
+	}
+
+	// VNC legacy mode and password must be configured
+	if !strings.Contains(argStr, "-setvnclegacy -vnclegacy yes") {
+		t.Errorf("kickstartActivateArgs() should enable VNC legacy mode, got: %s", argStr)
+	}
+	if !strings.Contains(argStr, "-setvncpw -vncpw secret12") {
+		t.Errorf("kickstartActivateArgs() should set the VNC password, got: %s", argStr)
+	}
+
+	// The password must appear immediately after -vncpw
+	for i, a := range args {
+		if a == "-vncpw" {
+			if i+1 >= len(args) || args[i+1] != "secret12" {
+				t.Errorf("kickstartActivateArgs() -vncpw not followed by password, got: %v", args)
+			}
+		}
+	}
+}
+
+func TestKickstartActivateArgsPasswordPositioning(t *testing.T) {
+	// A different password must flow through to the right slot.
+	args := kickstartActivateArgs("abc")
+	idx := -1
+	for i, a := range args {
+		if a == "-vncpw" {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		t.Fatal("kickstartActivateArgs() missing -vncpw flag")
+	}
+	if args[idx+1] != "abc" {
+		t.Errorf("kickstartActivateArgs() password = %q, want %q", args[idx+1], "abc")
+	}
+}
+
+func TestKickstartDeactivateArgs(t *testing.T) {
+	args := kickstartDeactivateArgs()
+	for _, want := range []string{"-deactivate", "-configure", "-access", "-off"} {
+		found := false
+		for _, a := range args {
+			if a == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("kickstartDeactivateArgs() missing %q in %v", want, args)
+		}
+	}
+	// Must not contain activation flags
+	for _, nw := range []string{"-activate", "-on"} {
+		for _, a := range args {
+			if a == nw {
+				t.Errorf("kickstartDeactivateArgs() should not contain %q, got: %v", nw, args)
+			}
+		}
+	}
+}
+
+func TestKickstartRestartArgs(t *testing.T) {
+	args := kickstartRestartArgs()
+	want := []string{"-restart", "-agent"}
+	if len(args) != len(want) {
+		t.Fatalf("kickstartRestartArgs() = %v, want %v", args, want)
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Errorf("kickstartRestartArgs()[%d] = %q, want %q", i, args[i], want[i])
+		}
+	}
+}
+
+func TestDarwinCmdSudoPrefix(t *testing.T) {
+	// With sudo: the command should be "sudo" and the real command shifted
+	// into the argument list.
+	cmd := darwinCmd(true, kickstartPath, "-activate")
+	if !strings.HasSuffix(cmd.Path, "sudo") && cmd.Args[0] != "sudo" {
+		t.Errorf("darwinCmd(needsSudo=true) should invoke sudo, got args: %v", cmd.Args)
+	}
+	if cmd.Args[1] != kickstartPath {
+		t.Errorf("darwinCmd(needsSudo=true) args[1] = %q, want %q", cmd.Args[1], kickstartPath)
+	}
+	if cmd.Args[2] != "-activate" {
+		t.Errorf("darwinCmd(needsSudo=true) args[2] = %q, want -activate", cmd.Args[2])
+	}
+
+	// Without sudo: the command runs kickstart directly.
+	cmd = darwinCmd(false, kickstartPath, "-activate")
+	if cmd.Args[0] != kickstartPath {
+		t.Errorf("darwinCmd(needsSudo=false) args[0] = %q, want %q", cmd.Args[0], kickstartPath)
+	}
+	if cmd.Args[1] != "-activate" {
+		t.Errorf("darwinCmd(needsSudo=false) args[1] = %q, want -activate", cmd.Args[1])
+	}
+}
+
+func TestKickstartPath(t *testing.T) {
+	// Guard against accidental edits to the well-known ARD kickstart path.
+	const want = "/System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart"
+	if kickstartPath != want {
+		t.Errorf("kickstartPath = %q, want %q", kickstartPath, want)
+	}
+}
+
+func TestErrDarwinSudoRequired(t *testing.T) {
+	if ErrDarwinSudoRequired == nil {
+		t.Fatal("ErrDarwinSudoRequired is nil")
+	}
+	msg := ErrDarwinSudoRequired.Error()
+	if !strings.Contains(msg, "sudo") {
+		t.Errorf("ErrDarwinSudoRequired should mention sudo, got: %s", msg)
+	}
+	if !strings.Contains(msg, "root privileges") {
+		t.Errorf("ErrDarwinSudoRequired should mention root privileges, got: %s", msg)
+	}
+}
+
+func TestDarwinVNCManagerDetection(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("Skipping macOS-specific test")
+	}
+
+	mgr := &DarwinVNCManager{}
+	// Detection methods must not panic regardless of Screen Sharing state.
+	_ = mgr.IsInstalled()
+	_ = mgr.IsRunning()
+	_ = mgr.Port()
+
+	// kickstart ships with macOS, so IsInstalled should be true.
+	if !mgr.IsInstalled() {
+		t.Errorf("DarwinVNCManager.IsInstalled() = false on macOS; kickstart should be present at %s", kickstartPath)
+	}
+
+	// Port() must be consistent with IsRunning().
+	if mgr.IsRunning() {
+		if mgr.Port() != DefaultVNCPort {
+			t.Errorf("DarwinVNCManager.Port() = %d while running, want %d", mgr.Port(), DefaultVNCPort)
+		}
+	} else if mgr.Port() != 0 {
+		t.Errorf("DarwinVNCManager.Port() = %d while not running, want 0", mgr.Port())
+	}
+}
+
+func TestDarwinVNCManagerConfigureValidation(t *testing.T) {
+	mgr := &DarwinVNCManager{}
+	// Invalid ports must be rejected before any kickstart invocation.
+	for _, p := range []int{0, -1, 70000} {
+		if err := mgr.Configure("testpass", p); err == nil {
+			t.Errorf("Configure() with port %d should return error", p)
+		}
+	}
+}
+
 func TestEmbeddedVNCPort(t *testing.T) {
 	// Initial state: no embedded VNC
 	ClearEmbeddedVNCPort()

--- a/internal/platform/vnc_test.go
+++ b/internal/platform/vnc_test.go
@@ -237,6 +237,73 @@ func TestUninstallCmdUnknown(t *testing.T) {
 	}
 }
 
+func TestInstallCmd(t *testing.T) {
+	// Pure function test: verifies the correct install command + args for each
+	// package manager without executing anything (no real apt/x11vnc needed).
+	tests := []struct {
+		pkgMgr   string
+		wantName string
+		wantArgs []string
+	}{
+		{"apt-get", "apt-get", []string{"install", "-y", "-qq", "x11vnc"}},
+		{"dnf", "dnf", []string{"install", "-y", "x11vnc"}},
+		{"yum", "yum", []string{"install", "-y", "x11vnc"}},
+		{"pacman", "pacman", []string{"-S", "--noconfirm", "x11vnc"}},
+		{"zypper", "zypper", []string{"install", "-y", "x11vnc"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pkgMgr, func(t *testing.T) {
+			name, args := installCmd(tt.pkgMgr)
+			if name != tt.wantName {
+				t.Errorf("installCmd(%q) name = %q, want %q", tt.pkgMgr, name, tt.wantName)
+			}
+			if len(args) != len(tt.wantArgs) {
+				t.Fatalf("installCmd(%q) args count = %d, want %d", tt.pkgMgr, len(args), len(tt.wantArgs))
+			}
+			for i, arg := range args {
+				if arg != tt.wantArgs[i] {
+					t.Errorf("installCmd(%q) args[%d] = %q, want %q", tt.pkgMgr, i, arg, tt.wantArgs[i])
+				}
+			}
+			// Every install command must reference the x11vnc package as the
+			// final argument so we never accidentally install the wrong thing.
+			if len(args) == 0 || args[len(args)-1] != "x11vnc" {
+				t.Errorf("installCmd(%q) last arg = %v, want trailing \"x11vnc\"", tt.pkgMgr, args)
+			}
+		})
+	}
+}
+
+func TestInstallCmdUnknown(t *testing.T) {
+	// Unknown package manager returns empty name and nil args, matching
+	// uninstallCmd's contract so Install() can detect the unsupported case.
+	name, args := installCmd("brew")
+	if name != "" {
+		t.Errorf("installCmd(\"brew\") name = %q, want empty", name)
+	}
+	if args != nil {
+		t.Errorf("installCmd(\"brew\") args = %v, want nil", args)
+	}
+}
+
+func TestInstallUninstallCmdSymmetry(t *testing.T) {
+	// The install and uninstall paths must support exactly the same set of
+	// package managers; a mismatch would mean one path silently fails.
+	for _, pm := range []string{"apt-get", "dnf", "yum", "pacman", "zypper"} {
+		t.Run(pm, func(t *testing.T) {
+			iName, _ := installCmd(pm)
+			uName, _ := uninstallCmd(pm)
+			if iName == "" {
+				t.Errorf("installCmd(%q) returned empty name; uninstall supports it", pm)
+			}
+			if uName == "" {
+				t.Errorf("uninstallCmd(%q) returned empty name; install supports it", pm)
+			}
+		})
+	}
+}
+
 func TestDetectPackageManager(t *testing.T) {
 	// detectPackageManager should return a non-empty string on any Linux CI
 	// or dev machine. We can't know which one, but it should not panic.


### PR DESCRIPTION
## Context

Stacks on **#267** (macOS VNC provisioner, base branch `feat/122-macos-vnc`), which already merged the core Linux `x11vnc` provisioner (`Install`/`Configure`/`Start`/`Stop`/`Uninstall`) from #262. This PR closes the remaining gaps under **#122**:

- The Linux `Install()` path was the one provisioning step whose command construction was **not** unit-testable — it built per-package-manager `exec.Cmd` inline, unlike `uninstallCmd` which was already extracted as a pure function. So the x11vnc install command had no coverage.
- The macOS provisioner's enable/configure/start path **cannot be exercised in CI** (needs `sudo`, enables Screen Sharing system-wide). #268 asks for an operator runbook so a human can verify it on a real Mac.

## Summary

**Part A — #122 Linux provisioner testability** (`internal/platform/vnc.go`)
- Extracted `installCmd(pkgMgr) (name string, args []string)` as a pure function mirroring the existing `uninstallCmd`, covering `apt-get`/`dnf`/`yum`/`pacman`/`zypper`.
- Refactored `LinuxVNCManager.Install` to resolve the package manager via `detectPackageManager()` and build its command through `installCmd`, replacing the inline per-manager branches. Behavior is **preserved**: apt still runs `apt-get update -qq` first and sets `DEBIAN_FRONTEND=noninteractive`; sudo-prefixing and `ErrSudoRequired` handling are unchanged; the "no supported package manager" error is unchanged.
- Why: makes install command construction unit-testable with no real apt/x11vnc, and keeps the install and uninstall code paths structurally symmetric.

**Part B — #268 macOS E2E runbook** (`docs/vnc-macos-e2e.md`)
- Exact operator steps to verify `DarwinVNCManager` on a real Mac: `citadel vnc status` baseline → no-sudo `ErrDarwinSudoRequired` check → `sudo citadel vnc enable` → `status` shows `Running: true`, `Port: 5900` → confirm in System Settings → connect via VNC/noVNC → `sudo citadel vnc disable` and confirm teardown.
- Documents the `kickstart` flag mapping and the #267 caveats: TCC/Privacy prompts on headless fleet nodes, legacy-VNC-password requirement for non-ARD/noVNC clients, 8-char RFB password truncation, and the no-sudo error path.

## Test plan

| Test group | Coverage |
| --- | --- |
| `TestInstallCmd` | Correct name+args for all 5 package managers; trailing arg is always `x11vnc` |
| `TestInstallCmdUnknown` | Unknown manager returns empty name + nil args |
| `TestInstallUninstallCmdSymmetry` | Install and uninstall support the identical manager set |
| Pre-existing `TestUninstallCmd`, `TestBuildX11VNCArgs`, `TestDetectPackageManager`, etc. | Still pass |

- `nix develop -c go build ./...` — pass
- `nix develop -c go test ./...` — pass (only failure is the pre-existing `e2e/TestDeviceAuthExpiry`, which needs a `localhost:3000` dev server; unrelated to VNC and fails identically on the base branch)
- Cross-compile: `GOOS=darwin GOARCH=arm64`, `GOOS=windows GOARCH=amd64`, `GOOS=linux GOARCH=amd64` builds all pass

**Out of scope / operator tasks (cannot run in CI):**
- **Linux E2E on `aceteamvm`** — real `apt`/x11vnc install + start + remote connect on the Ubuntu GUI node (#122 Linux test plan).
- **macOS on-device E2E** — sudo + system-wide Screen Sharing enable via `docs/vnc-macos-e2e.md` (#268).

## Related

- Part of #122
- Adds the runbook requested in #268
- Stacks on #267 (`feat/122-macos-vnc`); builds on #262 (merged Linux provisioner)

---
*Generated by Claude*