### PR TITLE
feat: real code signing for IOS_BUILD (#270)

### DIFF
--- a/internal/jobs/build_handlers.go
+++ b/internal/jobs/build_handlers.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -79,6 +80,101 @@ func NewIOSBuildHandler(workspace string) *IOSBuildHandler {
 	return &IOSBuildHandler{WorkspaceDir: workspace}
 }
 
+// Code-sign style values accepted in the IOS_BUILD payload's "code_sign_style"
+// field. They map to xcodebuild's CODE_SIGN_STYLE build setting.
+const (
+	codeSignStyleManual    = "manual"
+	codeSignStyleAutomatic = "automatic"
+)
+
+// iosSigning holds the optional signing parameters parsed from an IOS_BUILD
+// payload. signed reports whether any signing was requested; when false the
+// builders fall back to unsigned/simulator behaviour.
+type iosSigning struct {
+	signed              bool
+	style               string // "manual" or "automatic"
+	teamID              string
+	identity            string // CODE_SIGN_IDENTITY, e.g. "Apple Distribution"
+	provisioningProfile string // PROVISIONING_PROFILE_SPECIFIER (name or UUID)
+}
+
+// parseIOSSigning extracts and validates the signing parameters from the
+// payload. Signing is considered requested when any of team_id, signing_identity,
+// provisioning_profile, or code_sign_style is present.
+//
+// Validation rules:
+//   - code_sign_style, when present, must be "manual" or "automatic"; when
+//     absent it defaults to "manual" (the only style that needs explicit
+//     identity/profile wiring on a CI node).
+//   - manual signing requires a team_id (Apple requires a DEVELOPMENT_TEAM for
+//     manual provisioning).
+func parseIOSSigning(payload map[string]string) (iosSigning, error) {
+	var s iosSigning
+	s.teamID = strings.TrimSpace(payload["team_id"])
+	s.identity = strings.TrimSpace(payload["signing_identity"])
+	s.provisioningProfile = strings.TrimSpace(payload["provisioning_profile"])
+	style := strings.ToLower(strings.TrimSpace(payload["code_sign_style"]))
+
+	if s.teamID == "" && s.identity == "" && s.provisioningProfile == "" && style == "" {
+		// No signing parameters supplied: unsigned/simulator build.
+		return s, nil
+	}
+	s.signed = true
+
+	switch style {
+	case "":
+		s.style = codeSignStyleManual
+	case codeSignStyleManual, codeSignStyleAutomatic:
+		s.style = style
+	default:
+		return iosSigning{}, fmt.Errorf("invalid code_sign_style %q: must be %q or %q", style, codeSignStyleManual, codeSignStyleAutomatic)
+	}
+
+	if s.style == codeSignStyleManual && s.teamID == "" {
+		return iosSigning{}, fmt.Errorf("manual code signing requires a team_id")
+	}
+
+	return s, nil
+}
+
+// signingBuildSettings returns the xcodebuild build-setting arguments (KEY=VALUE
+// tokens) implied by the signing configuration. For an unsigned build it returns
+// CODE_SIGNING_ALLOWED=NO so simulator/compile-only builds never trip on a
+// missing identity. For a signed build it emits CODE_SIGN_STYLE plus whichever of
+// DEVELOPMENT_TEAM / CODE_SIGN_IDENTITY / PROVISIONING_PROFILE_SPECIFIER were
+// provided.
+func (s iosSigning) signingBuildSettings() []string {
+	if !s.signed {
+		return []string{"CODE_SIGNING_ALLOWED=NO"}
+	}
+
+	var settings []string
+	settings = append(settings, "CODE_SIGN_STYLE="+capitalizeStyle(s.style))
+	if s.teamID != "" {
+		settings = append(settings, "DEVELOPMENT_TEAM="+s.teamID)
+	}
+	if s.identity != "" {
+		settings = append(settings, "CODE_SIGN_IDENTITY="+s.identity)
+	}
+	if s.provisioningProfile != "" {
+		settings = append(settings, "PROVISIONING_PROFILE_SPECIFIER="+s.provisioningProfile)
+	}
+	return settings
+}
+
+// capitalizeStyle maps the lowercase style token to xcodebuild's expected
+// CODE_SIGN_STYLE value ("Manual" / "Automatic").
+func capitalizeStyle(style string) string {
+	switch style {
+	case codeSignStyleManual:
+		return "Manual"
+	case codeSignStyleAutomatic:
+		return "Automatic"
+	default:
+		return style
+	}
+}
+
 // buildIOSArgs constructs the xcodebuild argument vector from the payload.
 //
 // Payload fields (all strings via nexus.Job):
@@ -90,8 +186,20 @@ func NewIOSBuildHandler(workspace string) *IOSBuildHandler {
 //   - sdk (optional): e.g. "iphonesimulator"
 //   - derived_data_path (optional): -derivedDataPath value
 //   - action (optional): build action(s), default "build"
+//
+// Signing fields (all optional; see parseIOSSigning):
+//   - team_id, signing_identity, provisioning_profile, code_sign_style
+//
+// When no signing fields are present the build is unsigned
+// (CODE_SIGNING_ALLOWED=NO). When manual signing with an automatic style is
+// requested, -allowProvisioningUpdates is added so Xcode can manage profiles.
 func buildIOSArgs(payload map[string]string) ([]string, error) {
 	scheme, err := nonEmptyField(payload, "scheme")
+	if err != nil {
+		return nil, err
+	}
+
+	signing, err := parseIOSSigning(payload)
 	if err != nil {
 		return nil, err
 	}
@@ -117,18 +225,196 @@ func buildIOSArgs(payload map[string]string) ([]string, error) {
 		args = append(args, "-derivedDataPath", ddp)
 	}
 
+	if signing.signed && signing.style == codeSignStyleAutomatic {
+		args = append(args, "-allowProvisioningUpdates")
+	}
+
 	action := strings.TrimSpace(payload["action"])
 	if action == "" {
 		action = "build"
 	}
 	args = append(args, splitTasks(action)...)
 
+	args = append(args, signing.signingBuildSettings()...)
+
 	return args, nil
+}
+
+// buildIOSArchiveArgs constructs the xcodebuild argument vector for the archive
+// phase of a signed export. It mirrors buildIOSArgs but forces the "archive"
+// action and writes to -archivePath. Signing is required: an archive that will
+// be exported to a distributable .ipa must be signed.
+//
+// Additional payload field:
+//   - archive_path (required): -archivePath value (a .xcarchive bundle path)
+func buildIOSArchiveArgs(payload map[string]string) ([]string, error) {
+	scheme, err := nonEmptyField(payload, "scheme")
+	if err != nil {
+		return nil, err
+	}
+	archivePath, err := nonEmptyField(payload, "archive_path")
+	if err != nil {
+		return nil, err
+	}
+	signing, err := parseIOSSigning(payload)
+	if err != nil {
+		return nil, err
+	}
+	if !signing.signed {
+		return nil, fmt.Errorf("archive/export requires signing parameters (team_id, signing_identity, or provisioning_profile)")
+	}
+
+	var args []string
+	if ws := strings.TrimSpace(payload["workspace_file"]); ws != "" {
+		args = append(args, "-workspace", ws)
+	}
+	if proj := strings.TrimSpace(payload["project"]); proj != "" {
+		args = append(args, "-project", proj)
+	}
+	args = append(args, "-scheme", scheme)
+	if cfg := strings.TrimSpace(payload["configuration"]); cfg != "" {
+		args = append(args, "-configuration", cfg)
+	}
+	if dest := strings.TrimSpace(payload["destination"]); dest != "" {
+		args = append(args, "-destination", dest)
+	}
+	if ddp := strings.TrimSpace(payload["derived_data_path"]); ddp != "" {
+		args = append(args, "-derivedDataPath", ddp)
+	}
+	if signing.style == codeSignStyleAutomatic {
+		args = append(args, "-allowProvisioningUpdates")
+	}
+	args = append(args, "archive", "-archivePath", archivePath)
+	args = append(args, signing.signingBuildSettings()...)
+
+	return args, nil
+}
+
+// buildIOSExportArgs constructs the `xcodebuild -exportArchive` argument vector.
+//
+// Additional payload fields:
+//   - archive_path (required): the -archivePath produced by the archive phase
+//   - export_path (required): -exportPath directory for the produced .ipa
+//
+// exportOptionsPlist is written by the handler to a temp file; its path is
+// supplied here as the -exportOptionsPlist value.
+func buildIOSExportArgs(payload map[string]string, exportOptionsPlistPath string) ([]string, error) {
+	archivePath, err := nonEmptyField(payload, "archive_path")
+	if err != nil {
+		return nil, err
+	}
+	exportPath, err := nonEmptyField(payload, "export_path")
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(exportOptionsPlistPath) == "" {
+		return nil, fmt.Errorf("export requires an ExportOptions.plist path")
+	}
+	return []string{
+		"-exportArchive",
+		"-archivePath", archivePath,
+		"-exportPath", exportPath,
+		"-exportOptionsPlist", exportOptionsPlistPath,
+	}, nil
+}
+
+// validExportMethods are the supported -exportOptionsPlist "method" values.
+var validExportMethods = map[string]bool{
+	"app-store":   true,
+	"ad-hoc":      true,
+	"enterprise":  true,
+	"development": true,
+	"validation":  true,
+	"package":     true,
+}
+
+// buildExportOptionsPlist generates the XML content for an ExportOptions.plist
+// used by `xcodebuild -exportArchive`.
+//
+// Payload fields consumed:
+//   - export_method (optional): default "development". One of app-store, ad-hoc,
+//     enterprise, development, validation, package.
+//   - team_id (optional): teamID key
+//   - provisioning_profile (optional): the bundle-id -> profile mapping requires
+//     a bundle id; when provisioning_profile_bundle_id is supplied a
+//     provisioningProfiles dict is emitted.
+//   - provisioning_profile_bundle_id (optional): bundle id keyed in
+//     provisioningProfiles.
+//   - export_signing_style (optional): signingStyle, default derived from
+//     code_sign_style ("manual"/"automatic").
+func buildExportOptionsPlist(payload map[string]string) (string, error) {
+	method := strings.TrimSpace(payload["export_method"])
+	if method == "" {
+		method = "development"
+	}
+	if !validExportMethods[method] {
+		return "", fmt.Errorf("invalid export_method %q", method)
+	}
+
+	signing, err := parseIOSSigning(payload)
+	if err != nil {
+		return "", err
+	}
+	signingStyle := strings.ToLower(strings.TrimSpace(payload["export_signing_style"]))
+	if signingStyle == "" {
+		if signing.style != "" {
+			signingStyle = signing.style
+		} else {
+			signingStyle = codeSignStyleManual
+		}
+	}
+	if signingStyle != codeSignStyleManual && signingStyle != codeSignStyleAutomatic {
+		return "", fmt.Errorf("invalid export_signing_style %q: must be %q or %q", signingStyle, codeSignStyleManual, codeSignStyleAutomatic)
+	}
+
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0" encoding="UTF-8"?>` + "\n")
+	b.WriteString(`<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">` + "\n")
+	b.WriteString(`<plist version="1.0">` + "\n")
+	b.WriteString("<dict>\n")
+	writePlistString(&b, "method", method)
+	writePlistString(&b, "signingStyle", signingStyle)
+	if signing.teamID != "" {
+		writePlistString(&b, "teamID", signing.teamID)
+	}
+	bundleID := strings.TrimSpace(payload["provisioning_profile_bundle_id"])
+	if signing.provisioningProfile != "" && bundleID != "" {
+		b.WriteString("  <key>provisioningProfiles</key>\n")
+		b.WriteString("  <dict>\n")
+		b.WriteString("    <key>" + plistEscape(bundleID) + "</key>\n")
+		b.WriteString("    <string>" + plistEscape(signing.provisioningProfile) + "</string>\n")
+		b.WriteString("  </dict>\n")
+	}
+	b.WriteString("</dict>\n")
+	b.WriteString("</plist>\n")
+	return b.String(), nil
+}
+
+func writePlistString(b *strings.Builder, key, value string) {
+	b.WriteString("  <key>" + plistEscape(key) + "</key>\n")
+	b.WriteString("  <string>" + plistEscape(value) + "</string>\n")
+}
+
+// plistEscape escapes the XML metacharacters that can appear in plist string
+// values so a profile name or team id can never break the document.
+func plistEscape(s string) string {
+	r := strings.NewReplacer(
+		"&", "&amp;",
+		"<", "&lt;",
+		">", "&gt;",
+	)
+	return r.Replace(s)
 }
 
 func (h *IOSBuildHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
 	if runtime.GOOS != "darwin" {
 		return nil, fmt.Errorf("IOS_BUILD requires macOS (xcodebuild); node is %s", runtime.GOOS)
+	}
+
+	// Archive+export path: requested when export_path is present. Produces a
+	// signed .ipa via `xcodebuild archive` then `xcodebuild -exportArchive`.
+	if strings.TrimSpace(job.Payload["export_path"]) != "" {
+		return h.executeArchiveExport(ctx, job)
 	}
 
 	args, err := buildIOSArgs(job.Payload)
@@ -150,6 +436,71 @@ func (h *IOSBuildHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error
 		Output:       string(out),
 		ArtifactPath: strings.TrimSpace(job.Payload["artifact_path"]),
 	})
+}
+
+// executeArchiveExport runs the two-phase signed export: archive the scheme,
+// generate an ExportOptions.plist, then export to a signed .ipa. The plist is
+// written to a temp file (cleaned up on return).
+func (h *IOSBuildHandler) executeArchiveExport(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	archiveArgs, err := buildIOSArchiveArgs(job.Payload)
+	if err != nil {
+		return nil, err
+	}
+
+	archiveCmd := "xcodebuild " + strings.Join(archiveArgs, " ")
+	ctx.Log("info", "     - [Job %s] IOS_BUILD archive: %s", job.ID, archiveCmd)
+	archiveOut, runErr := runBuildCommand(h.WorkspaceDir, "xcodebuild", archiveArgs)
+	if runErr != nil {
+		return archiveOut, fmt.Errorf("xcodebuild archive failed: %w", runErr)
+	}
+
+	plist, err := buildExportOptionsPlist(job.Payload)
+	if err != nil {
+		return nil, err
+	}
+	plistPath, cleanup, err := writeExportOptionsPlist(plist)
+	if err != nil {
+		return nil, fmt.Errorf("writing ExportOptions.plist: %w", err)
+	}
+	defer cleanup()
+
+	exportArgs, err := buildIOSExportArgs(job.Payload, plistPath)
+	if err != nil {
+		return nil, err
+	}
+	exportCmd := "xcodebuild " + strings.Join(exportArgs, " ")
+	ctx.Log("info", "     - [Job %s] IOS_BUILD export: %s", job.ID, exportCmd)
+	exportOut, runErr := runBuildCommand(h.WorkspaceDir, "xcodebuild", exportArgs)
+	if runErr != nil {
+		return exportOut, fmt.Errorf("xcodebuild -exportArchive failed: %w", runErr)
+	}
+
+	return marshalBuildResult(buildResult{
+		Tool:         "xcodebuild",
+		Command:      archiveCmd + " && " + exportCmd,
+		Output:       string(archiveOut) + string(exportOut),
+		ArtifactPath: strings.TrimSpace(job.Payload["artifact_path"]),
+	})
+}
+
+// writeExportOptionsPlist writes content to a temp file and returns its path and
+// a cleanup func. It is a variable so tests can stub file IO if needed.
+var writeExportOptionsPlist = func(content string) (path string, cleanup func(), err error) {
+	f, err := os.CreateTemp("", "ExportOptions-*.plist")
+	if err != nil {
+		return "", func() {}, err
+	}
+	if _, err := f.WriteString(content); err != nil {
+		f.Close()
+		os.Remove(f.Name())
+		return "", func() {}, err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(f.Name())
+		return "", func() {}, err
+	}
+	name := f.Name()
+	return name, func() { os.Remove(name) }, nil
 }
 
 var _ JobHandler = (*IOSBuildHandler)(nil)

--- a/internal/jobs/build_handlers_test.go
+++ b/internal/jobs/build_handlers_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"reflect"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
@@ -56,12 +57,12 @@ func TestBuildIOSArgs(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "scheme only defaults to build action",
+			name:    "scheme only defaults to build action (unsigned)",
 			payload: map[string]string{"scheme": "MyApp"},
-			want:    []string{"-scheme", "MyApp", "build"},
+			want:    []string{"-scheme", "MyApp", "build", "CODE_SIGNING_ALLOWED=NO"},
 		},
 		{
-			name: "full configuration",
+			name: "full configuration (unsigned)",
 			payload: map[string]string{
 				"workspace_file": "MyApp.xcworkspace",
 				"scheme":         "MyApp",
@@ -76,10 +77,11 @@ func TestBuildIOSArgs(t *testing.T) {
 				"-sdk", "iphonesimulator",
 				"-destination", "generic/platform=iOS",
 				"build",
+				"CODE_SIGNING_ALLOWED=NO",
 			},
 		},
 		{
-			name: "project and explicit clean+build action",
+			name: "project and explicit clean+build action (unsigned)",
 			payload: map[string]string{
 				"project": "MyApp.xcodeproj",
 				"scheme":  "MyApp",
@@ -89,15 +91,16 @@ func TestBuildIOSArgs(t *testing.T) {
 				"-project", "MyApp.xcodeproj",
 				"-scheme", "MyApp",
 				"clean", "build",
+				"CODE_SIGNING_ALLOWED=NO",
 			},
 		},
 		{
-			name: "derived data path",
+			name: "derived data path (unsigned)",
 			payload: map[string]string{
 				"scheme":            "MyApp",
 				"derived_data_path": "/tmp/dd",
 			},
-			want: []string{"-scheme", "MyApp", "-derivedDataPath", "/tmp/dd", "build"},
+			want: []string{"-scheme", "MyApp", "-derivedDataPath", "/tmp/dd", "build", "CODE_SIGNING_ALLOWED=NO"},
 		},
 	}
 	for _, tc := range tests {
@@ -117,6 +120,440 @@ func TestBuildIOSArgs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildIOSArgs_Signing(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload map[string]string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:    "unsigned build appends CODE_SIGNING_ALLOWED=NO",
+			payload: map[string]string{"scheme": "MyApp", "sdk": "iphonesimulator"},
+			want: []string{
+				"-scheme", "MyApp",
+				"-sdk", "iphonesimulator",
+				"build",
+				"CODE_SIGNING_ALLOWED=NO",
+			},
+		},
+		{
+			name: "manual signing with all params",
+			payload: map[string]string{
+				"scheme":               "MyApp",
+				"configuration":        "Release",
+				"team_id":              "ABCDE12345",
+				"signing_identity":     "Apple Distribution",
+				"provisioning_profile": "MyApp Distribution",
+				"code_sign_style":      "manual",
+			},
+			want: []string{
+				"-scheme", "MyApp",
+				"-configuration", "Release",
+				"build",
+				"CODE_SIGN_STYLE=Manual",
+				"DEVELOPMENT_TEAM=ABCDE12345",
+				"CODE_SIGN_IDENTITY=Apple Distribution",
+				"PROVISIONING_PROFILE_SPECIFIER=MyApp Distribution",
+			},
+		},
+		{
+			name: "team_id only defaults to manual style",
+			payload: map[string]string{
+				"scheme":  "MyApp",
+				"team_id": "ABCDE12345",
+			},
+			want: []string{
+				"-scheme", "MyApp",
+				"build",
+				"CODE_SIGN_STYLE=Manual",
+				"DEVELOPMENT_TEAM=ABCDE12345",
+			},
+		},
+		{
+			name: "automatic style adds -allowProvisioningUpdates",
+			payload: map[string]string{
+				"scheme":          "MyApp",
+				"team_id":         "ABCDE12345",
+				"code_sign_style": "automatic",
+			},
+			want: []string{
+				"-scheme", "MyApp",
+				"-allowProvisioningUpdates",
+				"build",
+				"CODE_SIGN_STYLE=Automatic",
+				"DEVELOPMENT_TEAM=ABCDE12345",
+			},
+		},
+		{
+			name: "invalid code_sign_style rejected",
+			payload: map[string]string{
+				"scheme":          "MyApp",
+				"team_id":         "ABCDE12345",
+				"code_sign_style": "adhoc",
+			},
+			wantErr: true,
+		},
+		{
+			name: "manual signing without team_id rejected",
+			payload: map[string]string{
+				"scheme":           "MyApp",
+				"signing_identity": "Apple Distribution",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := buildIOSArgs(tc.payload)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got args %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("args = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildIOSArchiveArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload map[string]string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:    "missing scheme",
+			payload: map[string]string{"archive_path": "/tmp/MyApp.xcarchive", "team_id": "ABCDE12345"},
+			wantErr: true,
+		},
+		{
+			name:    "missing archive_path",
+			payload: map[string]string{"scheme": "MyApp", "team_id": "ABCDE12345"},
+			wantErr: true,
+		},
+		{
+			name:    "archive requires signing params",
+			payload: map[string]string{"scheme": "MyApp", "archive_path": "/tmp/MyApp.xcarchive"},
+			wantErr: true,
+		},
+		{
+			name: "manual archive",
+			payload: map[string]string{
+				"workspace_file":       "MyApp.xcworkspace",
+				"scheme":               "MyApp",
+				"configuration":        "Release",
+				"archive_path":         "/tmp/MyApp.xcarchive",
+				"team_id":              "ABCDE12345",
+				"signing_identity":     "Apple Distribution",
+				"provisioning_profile": "MyApp Distribution",
+			},
+			want: []string{
+				"-workspace", "MyApp.xcworkspace",
+				"-scheme", "MyApp",
+				"-configuration", "Release",
+				"archive", "-archivePath", "/tmp/MyApp.xcarchive",
+				"CODE_SIGN_STYLE=Manual",
+				"DEVELOPMENT_TEAM=ABCDE12345",
+				"CODE_SIGN_IDENTITY=Apple Distribution",
+				"PROVISIONING_PROFILE_SPECIFIER=MyApp Distribution",
+			},
+		},
+		{
+			name: "automatic archive adds -allowProvisioningUpdates",
+			payload: map[string]string{
+				"scheme":          "MyApp",
+				"archive_path":    "/tmp/MyApp.xcarchive",
+				"team_id":         "ABCDE12345",
+				"code_sign_style": "automatic",
+			},
+			want: []string{
+				"-scheme", "MyApp",
+				"-allowProvisioningUpdates",
+				"archive", "-archivePath", "/tmp/MyApp.xcarchive",
+				"CODE_SIGN_STYLE=Automatic",
+				"DEVELOPMENT_TEAM=ABCDE12345",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := buildIOSArchiveArgs(tc.payload)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got args %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("args = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildIOSExportArgs(t *testing.T) {
+	tests := []struct {
+		name      string
+		payload   map[string]string
+		plistPath string
+		want      []string
+		wantErr   bool
+	}{
+		{
+			name:      "missing archive_path",
+			payload:   map[string]string{"export_path": "/tmp/out"},
+			plistPath: "/tmp/ExportOptions.plist",
+			wantErr:   true,
+		},
+		{
+			name:      "missing export_path",
+			payload:   map[string]string{"archive_path": "/tmp/MyApp.xcarchive"},
+			plistPath: "/tmp/ExportOptions.plist",
+			wantErr:   true,
+		},
+		{
+			name:      "missing plist path",
+			payload:   map[string]string{"archive_path": "/tmp/MyApp.xcarchive", "export_path": "/tmp/out"},
+			plistPath: "",
+			wantErr:   true,
+		},
+		{
+			name:      "valid export",
+			payload:   map[string]string{"archive_path": "/tmp/MyApp.xcarchive", "export_path": "/tmp/out"},
+			plistPath: "/tmp/ExportOptions.plist",
+			want: []string{
+				"-exportArchive",
+				"-archivePath", "/tmp/MyApp.xcarchive",
+				"-exportPath", "/tmp/out",
+				"-exportOptionsPlist", "/tmp/ExportOptions.plist",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := buildIOSExportArgs(tc.payload, tc.plistPath)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got args %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("args = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildExportOptionsPlist(t *testing.T) {
+	t.Run("invalid export_method rejected", func(t *testing.T) {
+		_, err := buildExportOptionsPlist(map[string]string{"export_method": "carrier", "team_id": "ABCDE12345"})
+		if err == nil {
+			t.Fatal("expected error for invalid export_method")
+		}
+	})
+
+	t.Run("default method development with manual style", func(t *testing.T) {
+		got, err := buildExportOptionsPlist(map[string]string{"team_id": "ABCDE12345"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, want := range []string{
+			"<key>method</key>",
+			"<string>development</string>",
+			"<key>signingStyle</key>",
+			"<string>manual</string>",
+			"<key>teamID</key>",
+			"<string>ABCDE12345</string>",
+		} {
+			if !strings.Contains(got, want) {
+				t.Errorf("plist missing %q\n%s", want, got)
+			}
+		}
+		if strings.Contains(got, "provisioningProfiles") {
+			t.Errorf("did not expect provisioningProfiles without bundle id\n%s", got)
+		}
+	})
+
+	t.Run("app-store with provisioning profile mapping", func(t *testing.T) {
+		got, err := buildExportOptionsPlist(map[string]string{
+			"export_method":                  "app-store",
+			"team_id":                        "ABCDE12345",
+			"provisioning_profile":           "MyApp AppStore",
+			"provisioning_profile_bundle_id": "com.example.MyApp",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, want := range []string{
+			"<string>app-store</string>",
+			"<key>provisioningProfiles</key>",
+			"<key>com.example.MyApp</key>",
+			"<string>MyApp AppStore</string>",
+		} {
+			if !strings.Contains(got, want) {
+				t.Errorf("plist missing %q\n%s", want, got)
+			}
+		}
+	})
+
+	t.Run("escapes XML metacharacters", func(t *testing.T) {
+		got, err := buildExportOptionsPlist(map[string]string{
+			"team_id":                        "ABCDE12345",
+			"provisioning_profile":           "Profile <A&B>",
+			"provisioning_profile_bundle_id": "com.example.app",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(got, "Profile &lt;A&amp;B&gt;") {
+			t.Errorf("expected escaped profile name\n%s", got)
+		}
+	})
+
+	t.Run("explicit export_signing_style overrides", func(t *testing.T) {
+		got, err := buildExportOptionsPlist(map[string]string{
+			"team_id":              "ABCDE12345",
+			"code_sign_style":      "manual",
+			"export_signing_style": "automatic",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(got, "<string>automatic</string>") {
+			t.Errorf("expected automatic signingStyle\n%s", got)
+		}
+	})
+
+	t.Run("invalid export_signing_style rejected", func(t *testing.T) {
+		_, err := buildExportOptionsPlist(map[string]string{
+			"team_id":              "ABCDE12345",
+			"export_signing_style": "bogus",
+		})
+		if err == nil {
+			t.Fatal("expected error for invalid export_signing_style")
+		}
+	})
+}
+
+func TestIOSBuildHandler_ArchiveExportFlow(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("IOS_BUILD only executes on darwin")
+	}
+
+	// Capture every xcodebuild invocation so we can assert the archive phase runs
+	// before the export phase.
+	var calls [][]string
+	orig := runBuildCommand
+	runBuildCommand = func(workspace, name string, args []string) ([]byte, error) {
+		calls = append(calls, args)
+		return []byte("** OK **"), nil
+	}
+	t.Cleanup(func() { runBuildCommand = orig })
+
+	// Stub the plist writer so no real temp file is needed and we can confirm the
+	// generated content reaches the export args.
+	origWriter := writeExportOptionsPlist
+	var wroteContent string
+	writeExportOptionsPlist = func(content string) (string, func(), error) {
+		wroteContent = content
+		return "/tmp/stub-ExportOptions.plist", func() {}, nil
+	}
+	t.Cleanup(func() { writeExportOptionsPlist = origWriter })
+
+	h := NewIOSBuildHandler("/work")
+	out, err := h.Execute(JobContext{}, jobWith("IOS_BUILD", map[string]string{
+		"scheme":               "MyApp",
+		"configuration":        "Release",
+		"archive_path":         "/tmp/MyApp.xcarchive",
+		"export_path":          "/tmp/out",
+		"export_method":        "app-store",
+		"team_id":              "ABCDE12345",
+		"signing_identity":     "Apple Distribution",
+		"provisioning_profile": "MyApp AppStore",
+		"artifact_path":        "/tmp/out/MyApp.ipa",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 xcodebuild calls (archive, export), got %d", len(calls))
+	}
+	if !containsArg(calls[0], "archive") {
+		t.Errorf("first call should be the archive phase: %v", calls[0])
+	}
+	if !containsArg(calls[1], "-exportArchive") {
+		t.Errorf("second call should be the export phase: %v", calls[1])
+	}
+	if !containsArg(calls[1], "-exportOptionsPlist") {
+		t.Errorf("export phase should reference the plist: %v", calls[1])
+	}
+	if !strings.Contains(wroteContent, "<string>app-store</string>") {
+		t.Errorf("plist content missing method: %s", wroteContent)
+	}
+
+	var res buildResult
+	if err := json.Unmarshal(out, &res); err != nil {
+		t.Fatalf("output not JSON: %v", err)
+	}
+	if res.ArtifactPath != "/tmp/out/MyApp.ipa" {
+		t.Errorf("artifact_path = %q", res.ArtifactPath)
+	}
+}
+
+func TestIOSBuildHandler_ArchiveFailureStops(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("IOS_BUILD only executes on darwin")
+	}
+	var calls int
+	orig := runBuildCommand
+	runBuildCommand = func(workspace, name string, args []string) ([]byte, error) {
+		calls++
+		return []byte("** ARCHIVE FAILED **"), errors.New("exit status 65")
+	}
+	t.Cleanup(func() { runBuildCommand = orig })
+
+	h := NewIOSBuildHandler("/work")
+	out, err := h.Execute(JobContext{}, jobWith("IOS_BUILD", map[string]string{
+		"scheme":       "MyApp",
+		"archive_path": "/tmp/MyApp.xcarchive",
+		"export_path":  "/tmp/out",
+		"team_id":      "ABCDE12345",
+	}))
+	if err == nil {
+		t.Fatal("expected archive failure to propagate")
+	}
+	if calls != 1 {
+		t.Errorf("export phase must not run after archive failure; calls=%d", calls)
+	}
+	if string(out) != "** ARCHIVE FAILED **" {
+		t.Errorf("output = %q, want raw archive log", string(out))
+	}
+}
+
+func containsArg(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestBuildAndroidArgs(t *testing.T) {


### PR DESCRIPTION
## Context

The `IOS_BUILD` handler from #269 (issue #140 Phase 2) invokes `xcodebuild` with a scheme/configuration/destination but does **no code-signing setup**. That is fine for simulator builds and unsigned compile checks, but device builds and `.ipa` distribution require a signing identity and provisioning profile. This PR (Closes #270) adds optional signing parameters and a signed archive/export path so a macOS Citadel node can produce a distributable `.ipa`.

This stacks on #269 — base branch is `feat/140-macos-build-handlers`.

## Summary

**Signing parameters (`buildIOSArgs`)** — all optional, parsed/validated by `parseIOSSigning`:

| Payload field | xcodebuild build setting |
| --- | --- |
| `team_id` | `DEVELOPMENT_TEAM` |
| `signing_identity` | `CODE_SIGN_IDENTITY` |
| `provisioning_profile` (name or UUID) | `PROVISIONING_PROFILE_SPECIFIER` |
| `code_sign_style` (`manual`/`automatic`) | `CODE_SIGN_STYLE=Manual`/`Automatic` |

- When **no** signing fields are present, the build stays unsigned and gets `CODE_SIGNING_ALLOWED=NO`, preserving the prior simulator/compile-only behavior.
- `automatic` style adds `-allowProvisioningUpdates` so Xcode can manage profiles.
- Validation: an invalid `code_sign_style` is rejected, and manual signing requires a `team_id` (Apple requires a `DEVELOPMENT_TEAM` for manual provisioning).

**Archive + export flow** — triggered when `export_path` is present:

1. `xcodebuild archive -archivePath <archive_path> …` (signing required; `buildIOSArchiveArgs`)
2. Generate an `ExportOptions.plist` (`buildExportOptionsPlist`) — `method` (default `development`, validated against the supported export methods), `signingStyle`, `teamID`, and an optional `provisioningProfiles` bundle-id → profile mapping. All string values are XML-escaped.
3. `xcodebuild -exportArchive -archivePath … -exportPath … -exportOptionsPlist …` (`buildIOSExportArgs`) to produce a signed `.ipa`.

The plist is written to a temp file (cleaned up on return) via a stubbable `writeExportOptionsPlist` var; archive failure short-circuits before the export phase.

**Design:** all argument construction lives in pure functions (`buildIOSArgs`, `buildIOSArchiveArgs`, `buildIOSExportArgs`, `buildExportOptionsPlist`), and the exec layer (`runBuildCommand`) plus the plist writer stay stubbable — matching the existing handler's testing pattern.

## Test plan

Extended `internal/jobs/build_handlers_test.go`:

| Group | Coverage |
| --- | --- |
| `TestBuildIOSArgs` | Updated unsigned cases now assert `CODE_SIGNING_ALLOWED=NO` |
| `TestBuildIOSArgs_Signing` | Unsigned vs manual (all params) vs automatic (`-allowProvisioningUpdates`); team-id-only default; invalid style and missing-team-id validation |
| `TestBuildIOSArchiveArgs` | Missing scheme/archive_path, signing-required guard, manual + automatic archive arg vectors |
| `TestBuildIOSExportArgs` | Missing archive_path/export_path/plist-path, valid export arg vector |
| `TestBuildExportOptionsPlist` | Invalid method, default development/manual, app-store + profile mapping, XML escaping, explicit `export_signing_style` override, invalid style |
| `TestIOSBuildHandler_ArchiveExportFlow` / `_ArchiveFailureStops` | Archive-before-export ordering, plist wiring, archive failure short-circuits export (darwin-gated) |

Real signing needs an Apple Developer account, certificate, and provisioning profile on the node, so only the builders are unit-tested — no real cert/profile is required. `nix develop -c go build ./...` and `nix develop -c go test ./...` pass; the only failure is the pre-existing, unrelated `e2e.TestDeviceAuthExpiry` (needs a live `localhost:3000`).

## Related

- #269 — Phase 2 build handlers (where signing was deferred)
- #140 — macOS build server provisioning

---
*Generated by Claude*