### PR TITLE
feat: citadel provision ios|android subcommand (#140 Phase 3)

### DIFF
--- a/cmd/provision_mobile.go
+++ b/cmd/provision_mobile.go
@@ -1,0 +1,214 @@
+// cmd/provision_mobile.go
+//
+// Operator-facing `citadel provision ios` and `citadel provision android`
+// subcommands (#140 Phase 3). They prepare a fresh macOS node to run the
+// IOS_BUILD / ANDROID_BUILD job handlers added in Phase 2.
+//
+// iOS provisioning configures the code-signing keychain, imports a distribution
+// certificate, installs provisioning profiles, and checks for Xcode CLI tools.
+// Android provisioning ensures the SDK location, accepts SDK licenses, and
+// installs build components. All sensitive material (certs, passwords) is
+// supplied by the operator as paths/params; nothing is hardcoded. The
+// --dry-run flag prints every command without executing it, so the flow is
+// exercisable without real certs or a system keychain.
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
+	"github.com/aceteam-ai/citadel-cli/internal/provision/mobile"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+var (
+	provisionDryRun bool
+
+	provisionIOSKeychain     string
+	provisionIOSKeychainPass string
+	provisionIOSCertPath     string
+	provisionIOSCertPass     string
+	provisionIOSProfiles     []string
+	provisionIOSProfilesDir  string
+
+	provisionAndroidSDKRoot  string
+	provisionAndroidLicenses bool
+	provisionAndroidPackages []string
+)
+
+var provisionIOSCmd = &cobra.Command{
+	Use:          "ios",
+	Short:        "Prepare this macOS node to run iOS builds",
+	SilenceUsage: true,
+	Long: `Configure code-signing and tooling so this node can run IOS_BUILD jobs.
+
+Steps performed:
+  - Create/unlock a dedicated build keychain and set its partition list.
+  - Import a distribution certificate (.p12) when --cert is given.
+  - Install provisioning profiles into the user's Provisioning Profiles dir.
+  - Verify Xcode command-line tools are installed (hint to install if missing).
+
+Sensitive material is supplied as paths/params and never hardcoded. Use
+--dry-run to print every command without touching the keychain.
+
+Examples:
+  # Print the plan without executing anything (no certs needed)
+  citadel provision ios --dry-run \
+    --keychain citadel-build.keychain-db --keychain-password "$KC_PW"
+
+  # Real run: import a cert and install a profile
+  citadel provision ios \
+    --keychain citadel-build.keychain-db --keychain-password "$KC_PW" \
+    --cert ./dist.p12 --cert-password "$CERT_PW" \
+    --profile ./app.mobileprovision`,
+	RunE: runProvisionIOS,
+}
+
+var provisionAndroidCmd = &cobra.Command{
+	Use:          "android",
+	Short:        "Prepare this node to run Android builds",
+	SilenceUsage: true,
+	Long: `Configure the Android SDK so this node can run ANDROID_BUILD jobs.
+
+Steps performed:
+  - Resolve the SDK location (--sdk-root, else ANDROID_HOME).
+  - Accept SDK licenses via sdkmanager --licenses (with --accept-licenses).
+  - Install requested SDK packages via sdkmanager (with --package).
+
+Use --dry-run to print every command without executing it.
+
+Examples:
+  # Accept licenses and install build-tools/platform
+  citadel provision android --accept-licenses \
+    --package "platform-tools" --package "platforms;android-34" \
+    --package "build-tools;34.0.0"
+
+  # Print the plan only
+  citadel provision android --dry-run --sdk-root ~/Library/Android/sdk --accept-licenses`,
+	RunE: runProvisionAndroid,
+}
+
+func runProvisionIOS(cmd *cobra.Command, _ []string) error {
+	if !provisionDryRun && !platform.IsDarwin() {
+		return fmt.Errorf("provision ios requires macOS; this node is %s (use --dry-run to preview the plan anywhere)", platform.OS())
+	}
+
+	profilesDir := provisionIOSProfilesDir
+	if profilesDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("resolving home directory: %w", err)
+		}
+		profilesDir = mobile.DefaultProfilesDir(home)
+	}
+
+	steps, err := mobile.BuildIOSSteps(mobile.IOSOptions{
+		KeychainName:     provisionIOSKeychain,
+		KeychainPassword: provisionIOSKeychainPass,
+		CertPath:         provisionIOSCertPath,
+		CertPassword:     provisionIOSCertPass,
+		ProfilePaths:     provisionIOSProfiles,
+		ProfilesDir:      profilesDir,
+	})
+	if err != nil {
+		return err
+	}
+
+	runner := mobile.NewRunner(provisionDryRun, cmd.OutOrStdout())
+	if err := runner.Run(steps); err != nil {
+		return err
+	}
+
+	checkXcodeCLITools(cmd, provisionDryRun)
+
+	if provisionDryRun {
+		color.Yellow("Dry run complete; no changes were made.")
+	} else {
+		color.Green("iOS provisioning complete.")
+	}
+	return nil
+}
+
+func runProvisionAndroid(cmd *cobra.Command, _ []string) error {
+	sdkRoot := provisionAndroidSDKRoot
+	if sdkRoot == "" {
+		sdkRoot = androidSDKFromEnv()
+	}
+	if sdkRoot == "" {
+		return fmt.Errorf("Android SDK location not found: pass --sdk-root or set ANDROID_HOME")
+	}
+
+	if !provisionDryRun {
+		if _, err := exec.LookPath("sdkmanager"); err != nil {
+			return fmt.Errorf("sdkmanager not found on PATH; install the Android command-line tools, or use --dry-run to preview")
+		}
+	}
+
+	steps, err := mobile.BuildAndroidSteps(mobile.AndroidOptions{
+		SDKRoot:        sdkRoot,
+		AcceptLicenses: provisionAndroidLicenses,
+		Packages:       provisionAndroidPackages,
+	})
+	if err != nil {
+		return err
+	}
+
+	runner := mobile.NewRunner(provisionDryRun, cmd.OutOrStdout())
+	if err := runner.Run(steps); err != nil {
+		return err
+	}
+
+	if provisionDryRun {
+		color.Yellow("Dry run complete; no changes were made.")
+	} else {
+		color.Green("Android provisioning complete.")
+	}
+	return nil
+}
+
+// androidSDKFromEnv returns the SDK root from the standard environment
+// variables, ANDROID_HOME taking precedence over the older ANDROID_SDK_ROOT.
+func androidSDKFromEnv() string {
+	if home := os.Getenv("ANDROID_HOME"); home != "" {
+		return home
+	}
+	return os.Getenv("ANDROID_SDK_ROOT")
+}
+
+// checkXcodeCLITools reports whether the Xcode command-line tools are present
+// and prints an install hint if not. In dry-run mode on a non-macOS host the
+// check is skipped (xcode-select is unavailable there).
+func checkXcodeCLITools(cmd *cobra.Command, dryRun bool) {
+	out := cmd.OutOrStdout()
+	if dryRun && !platform.IsDarwin() {
+		fmt.Fprintln(out, "Skipping Xcode CLI tools check (not on macOS; dry-run).")
+		return
+	}
+	if path, err := exec.Command("xcode-select", "-p").Output(); err == nil && len(path) > 0 {
+		fmt.Fprintf(out, "Xcode command-line tools present at %s", string(path))
+		return
+	}
+	color.Yellow("Xcode command-line tools not found.")
+	fmt.Fprintln(out, "Install them with: xcode-select --install")
+}
+
+func init() {
+	provisionCmd.AddCommand(provisionIOSCmd)
+	provisionCmd.AddCommand(provisionAndroidCmd)
+
+	provisionIOSCmd.Flags().BoolVar(&provisionDryRun, "dry-run", false, "Print the provisioning commands without executing them")
+	provisionIOSCmd.Flags().StringVar(&provisionIOSKeychain, "keychain", "citadel-build.keychain-db", "Dedicated build keychain to create/unlock")
+	provisionIOSCmd.Flags().StringVar(&provisionIOSKeychainPass, "keychain-password", "", "Password for the build keychain (required)")
+	provisionIOSCmd.Flags().StringVar(&provisionIOSCertPath, "cert", "", "Path to a distribution certificate (.p12) to import")
+	provisionIOSCmd.Flags().StringVar(&provisionIOSCertPass, "cert-password", "", "Export password for the .p12 certificate")
+	provisionIOSCmd.Flags().StringSliceVar(&provisionIOSProfiles, "profile", nil, "Path to a .mobileprovision profile to install (repeatable)")
+	provisionIOSCmd.Flags().StringVar(&provisionIOSProfilesDir, "profiles-dir", "", "Override the provisioning profiles install directory")
+
+	provisionAndroidCmd.Flags().BoolVar(&provisionDryRun, "dry-run", false, "Print the provisioning commands without executing them")
+	provisionAndroidCmd.Flags().StringVar(&provisionAndroidSDKRoot, "sdk-root", "", "Android SDK location (defaults to ANDROID_HOME)")
+	provisionAndroidCmd.Flags().BoolVar(&provisionAndroidLicenses, "accept-licenses", false, "Accept Android SDK licenses via sdkmanager --licenses")
+	provisionAndroidCmd.Flags().StringSliceVar(&provisionAndroidPackages, "package", nil, "SDK package to install, e.g. 'platform-tools' (repeatable)")
+}

--- a/cmd/provision_mobile_test.go
+++ b/cmd/provision_mobile_test.go
@@ -1,0 +1,138 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestAndroidSDKFromEnv(t *testing.T) {
+	tests := []struct {
+		name        string
+		androidHome string
+		sdkRoot     string
+		want        string
+	}{
+		{name: "ANDROID_HOME wins", androidHome: "/home", sdkRoot: "/root", want: "/home"},
+		{name: "falls back to ANDROID_SDK_ROOT", androidHome: "", sdkRoot: "/root", want: "/root"},
+		{name: "neither set", androidHome: "", sdkRoot: "", want: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("ANDROID_HOME", tc.androidHome)
+			t.Setenv("ANDROID_SDK_ROOT", tc.sdkRoot)
+			if got := androidSDKFromEnv(); got != tc.want {
+				t.Errorf("androidSDKFromEnv() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// resetIOSFlags restores the package-level iOS flag vars between subtests so
+// state from one run does not leak into the next.
+func resetIOSFlags() {
+	provisionDryRun = false
+	provisionIOSKeychain = "citadel-build.keychain-db"
+	provisionIOSKeychainPass = ""
+	provisionIOSCertPath = ""
+	provisionIOSCertPass = ""
+	provisionIOSProfiles = nil
+	provisionIOSProfilesDir = ""
+}
+
+func TestRunProvisionIOS_DryRunPlan(t *testing.T) {
+	resetIOSFlags()
+	t.Cleanup(resetIOSFlags)
+
+	provisionDryRun = true
+	provisionIOSKeychainPass = "SECRETPW"
+	provisionIOSProfilesDir = t.TempDir()
+
+	var buf bytes.Buffer
+	provisionIOSCmd.SetOut(&buf)
+	t.Cleanup(func() { provisionIOSCmd.SetOut(nil) })
+
+	if err := runProvisionIOS(provisionIOSCmd, nil); err != nil {
+		t.Fatalf("dry-run iOS provisioning failed: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "security create-keychain") {
+		t.Errorf("expected keychain creation in plan:\n%s", out)
+	}
+	if strings.Contains(out, "SECRETPW") {
+		t.Errorf("keychain password leaked in dry-run output:\n%s", out)
+	}
+	if !strings.Contains(out, "<redacted>") {
+		t.Errorf("password not redacted:\n%s", out)
+	}
+}
+
+func TestRunProvisionIOS_RequiresKeychainPassword(t *testing.T) {
+	resetIOSFlags()
+	t.Cleanup(resetIOSFlags)
+
+	provisionDryRun = true
+	provisionIOSKeychainPass = "" // missing
+
+	var buf bytes.Buffer
+	provisionIOSCmd.SetOut(&buf)
+	t.Cleanup(func() { provisionIOSCmd.SetOut(nil) })
+
+	err := runProvisionIOS(provisionIOSCmd, nil)
+	if err == nil {
+		t.Fatal("expected error for missing keychain password")
+	}
+	if !strings.Contains(err.Error(), "keychain password is required") {
+		t.Errorf("error = %q, want keychain-password message", err)
+	}
+}
+
+func resetAndroidFlags() {
+	provisionDryRun = false
+	provisionAndroidSDKRoot = ""
+	provisionAndroidLicenses = false
+	provisionAndroidPackages = nil
+}
+
+func TestRunProvisionAndroid_DryRunPlan(t *testing.T) {
+	resetAndroidFlags()
+	t.Cleanup(resetAndroidFlags)
+
+	provisionDryRun = true
+	provisionAndroidSDKRoot = "/opt/android-sdk"
+	provisionAndroidLicenses = true
+	provisionAndroidPackages = []string{"platform-tools"}
+
+	var buf bytes.Buffer
+	provisionAndroidCmd.SetOut(&buf)
+	t.Cleanup(func() { provisionAndroidCmd.SetOut(nil) })
+
+	if err := runProvisionAndroid(provisionAndroidCmd, nil); err != nil {
+		t.Fatalf("dry-run android provisioning failed: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "sdkmanager --sdk_root=/opt/android-sdk --licenses") {
+		t.Errorf("expected licenses command:\n%s", out)
+	}
+	if !strings.Contains(out, "sdkmanager --sdk_root=/opt/android-sdk platform-tools") {
+		t.Errorf("expected package install command:\n%s", out)
+	}
+}
+
+func TestRunProvisionAndroid_NoSDKLocation(t *testing.T) {
+	resetAndroidFlags()
+	t.Cleanup(resetAndroidFlags)
+	t.Setenv("ANDROID_HOME", "")
+	t.Setenv("ANDROID_SDK_ROOT", "")
+
+	provisionDryRun = true // dry-run so sdkmanager PATH check is skipped
+
+	err := runProvisionAndroid(provisionAndroidCmd, nil)
+	if err == nil {
+		t.Fatal("expected error when no SDK location is available")
+	}
+	if !strings.Contains(err.Error(), "Android SDK location not found") {
+		t.Errorf("error = %q, want SDK-location message", err)
+	}
+}

--- a/internal/provision/mobile/mobile.go
+++ b/internal/provision/mobile/mobile.go
@@ -1,0 +1,278 @@
+// Package mobile implements operator-facing provisioning steps that prepare a
+// fresh macOS node to run iOS and Android builds (citadel provision ios|android).
+//
+// The package is deliberately split into two layers:
+//
+//   - Pure builders (BuildIOSSteps, BuildAndroidSteps) that turn user-supplied
+//     options into an ordered list of Step values describing the shell commands
+//     and filesystem operations to perform. These are platform-agnostic and have
+//     no side effects, so they are exhaustively unit-tested.
+//   - A Runner that executes (or, in dry-run mode, merely prints) those steps.
+//
+// Real keychain/cert/profile operations require Apple secrets and modify the
+// system keychain; the builders never embed secrets and accept all sensitive
+// material as caller-supplied paths/identities. Dry-run mode lets the whole
+// flow be exercised without certs or a real keychain.
+package mobile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// StepKind distinguishes the two side-effecting operations a Step can describe.
+type StepKind int
+
+const (
+	// StepExec runs an external command (Name + Args).
+	StepExec StepKind = iota
+	// StepCopyFile copies SrcPath to DstPath, creating DstPath's parent dir.
+	StepCopyFile
+)
+
+// Step is a single provisioning operation. It is intentionally data-only so the
+// builders can be tested without executing anything.
+type Step struct {
+	Kind StepKind
+	// Desc is a human-readable description printed before the step runs.
+	Desc string
+	// Name and Args apply to StepExec.
+	Name string
+	Args []string
+	// SecretArgs lists indices into Args whose values are sensitive (e.g. a
+	// keychain or certificate password) and must be redacted in dry-run output.
+	SecretArgs []int
+	// SrcPath and DstPath apply to StepCopyFile.
+	SrcPath string
+	DstPath string
+}
+
+// CommandString renders an exec step as a copy-pasteable shell command. Args at
+// SecretArgs indices are replaced with <redacted>. Only meaningful for
+// StepExec steps.
+func (s Step) CommandString() string {
+	secret := make(map[int]bool, len(s.SecretArgs))
+	for _, i := range s.SecretArgs {
+		secret[i] = true
+	}
+	parts := make([]string, 0, len(s.Args)+1)
+	parts = append(parts, s.Name)
+	for i, a := range s.Args {
+		if secret[i] {
+			parts = append(parts, "<redacted>")
+			continue
+		}
+		parts = append(parts, shellQuote(a))
+	}
+	return strings.Join(parts, " ")
+}
+
+// shellQuote wraps an argument in single quotes when it contains characters
+// that a shell would interpret, so dry-run output is copy-pasteable.
+func shellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	if strings.IndexFunc(s, func(r rune) bool {
+		switch r {
+		case ' ', '\t', '"', '\'', '$', '`', '\\', '&', '|', ';', '<', '>', '(', ')', '*', '?':
+			return true
+		}
+		return false
+	}) < 0 {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// IOSOptions configures iOS provisioning. All sensitive material is supplied by
+// the operator as paths/identities; nothing is hardcoded.
+type IOSOptions struct {
+	// KeychainName is the dedicated build keychain to create/configure
+	// (e.g. "citadel-build.keychain-db"). Required.
+	KeychainName string
+	// KeychainPassword unlocks the build keychain. Required to create/unlock.
+	KeychainPassword string
+	// CertPath is a .p12 distribution certificate to import. Optional; when
+	// empty, no certificate import step is emitted.
+	CertPath string
+	// CertPassword is the .p12 export password. Used only when CertPath is set.
+	CertPassword string
+	// ProfilePaths are .mobileprovision files to install into the user's
+	// Provisioning Profiles directory. Optional.
+	ProfilePaths []string
+	// ProfilesDir overrides the install destination directory. When empty it
+	// defaults to ~/Library/MobileDevice/Provisioning Profiles. Injectable for
+	// tests.
+	ProfilesDir string
+}
+
+// AndroidOptions configures Android provisioning.
+type AndroidOptions struct {
+	// SDKRoot is the Android SDK location (ANDROID_HOME). Required.
+	SDKRoot string
+	// AcceptLicenses emits the `sdkmanager --licenses` step.
+	AcceptLicenses bool
+	// Packages are sdkmanager package specs to install
+	// (e.g. "platform-tools", "platforms;android-34"). Optional.
+	Packages []string
+}
+
+// DefaultProfilesDir returns the standard macOS install location for
+// provisioning profiles, rooted at the supplied home directory.
+func DefaultProfilesDir(home string) string {
+	return filepath.Join(home, "Library", "MobileDevice", "Provisioning Profiles")
+}
+
+// securityBin is the macOS keychain management binary.
+const securityBin = "security"
+
+// BuildIOSSteps turns IOSOptions into an ordered provisioning plan. It performs
+// validation of required fields and existence checks for supplied paths, but it
+// does not execute anything. Returns an error for invalid input.
+//
+// The emitted plan, in order:
+//  1. create-keychain (if not asserted to exist)
+//  2. unlock-keychain
+//  3. set keychain settings (no auto-lock during build sessions)
+//  4. import distribution certificate (when CertPath is set)
+//  5. set-key-partition-list (allow codesign to use the imported key)
+//  6. install each provisioning profile (copy into ProfilesDir)
+func BuildIOSSteps(opts IOSOptions) ([]Step, error) {
+	if strings.TrimSpace(opts.KeychainName) == "" {
+		return nil, fmt.Errorf("keychain name is required (--keychain)")
+	}
+	if strings.TrimSpace(opts.KeychainPassword) == "" {
+		return nil, fmt.Errorf("keychain password is required (--keychain-password)")
+	}
+	if opts.CertPath != "" {
+		if err := mustExist(opts.CertPath, "certificate"); err != nil {
+			return nil, err
+		}
+		if strings.TrimSpace(opts.CertPassword) == "" {
+			return nil, fmt.Errorf("certificate password is required when importing a certificate (--cert-password)")
+		}
+	}
+	for _, p := range opts.ProfilePaths {
+		if err := mustExist(p, "provisioning profile"); err != nil {
+			return nil, err
+		}
+		if !strings.EqualFold(filepath.Ext(p), ".mobileprovision") {
+			return nil, fmt.Errorf("provisioning profile %q must have a .mobileprovision extension", p)
+		}
+	}
+
+	kc := opts.KeychainName
+	pw := opts.KeychainPassword
+
+	steps := []Step{
+		{
+			Kind:       StepExec,
+			Desc:       fmt.Sprintf("Create build keychain %q (ignored if it already exists)", kc),
+			Name:       securityBin,
+			Args:       []string{"create-keychain", "-p", pw, kc},
+			SecretArgs: []int{2}, // password
+		},
+		{
+			Kind:       StepExec,
+			Desc:       fmt.Sprintf("Unlock build keychain %q", kc),
+			Name:       securityBin,
+			Args:       []string{"unlock-keychain", "-p", pw, kc},
+			SecretArgs: []int{2}, // password
+		},
+		{
+			Kind: StepExec,
+			Desc: "Disable keychain auto-lock for build sessions",
+			Name: securityBin,
+			Args: []string{"set-keychain-settings", "-lut", "21600", kc},
+		},
+	}
+
+	if opts.CertPath != "" {
+		steps = append(steps, Step{
+			Kind:       StepExec,
+			Desc:       fmt.Sprintf("Import distribution certificate %q", opts.CertPath),
+			Name:       securityBin,
+			Args:       []string{"import", opts.CertPath, "-k", kc, "-P", opts.CertPassword, "-T", "/usr/bin/codesign", "-T", "/usr/bin/productsign"},
+			SecretArgs: []int{5}, // .p12 password
+		})
+		steps = append(steps, Step{
+			Kind:       StepExec,
+			Desc:       "Allow codesign to use the imported key without prompting (partition list)",
+			Name:       securityBin,
+			Args:       []string{"set-key-partition-list", "-S", "apple-tool:,apple:,codesign:", "-s", "-k", pw, kc},
+			SecretArgs: []int{5}, // keychain password
+		})
+	}
+
+	profilesDir := opts.ProfilesDir
+	for _, p := range opts.ProfilePaths {
+		dst := filepath.Join(profilesDir, filepath.Base(p))
+		steps = append(steps, Step{
+			Kind:    StepCopyFile,
+			Desc:    fmt.Sprintf("Install provisioning profile %q", filepath.Base(p)),
+			SrcPath: p,
+			DstPath: dst,
+		})
+	}
+
+	return steps, nil
+}
+
+// BuildAndroidSteps turns AndroidOptions into an ordered provisioning plan.
+//
+// The emitted plan, in order:
+//  1. accept SDK licenses (when AcceptLicenses) — `sdkmanager --licenses`
+//  2. install each requested package — `sdkmanager "<pkg>"`
+//
+// The SDK root is validated and threaded into every sdkmanager invocation via
+// --sdk_root so the command is hermetic regardless of ANDROID_HOME.
+func BuildAndroidSteps(opts AndroidOptions) ([]Step, error) {
+	root := strings.TrimSpace(opts.SDKRoot)
+	if root == "" {
+		return nil, fmt.Errorf("Android SDK root is required (--sdk-root or ANDROID_HOME)")
+	}
+
+	rootFlag := "--sdk_root=" + root
+	var steps []Step
+
+	if opts.AcceptLicenses {
+		steps = append(steps, Step{
+			Kind: StepExec,
+			Desc: "Accept Android SDK licenses",
+			Name: "sdkmanager",
+			Args: []string{rootFlag, "--licenses"},
+		})
+	}
+
+	for _, pkg := range opts.Packages {
+		pkg = strings.TrimSpace(pkg)
+		if pkg == "" {
+			continue
+		}
+		steps = append(steps, Step{
+			Kind: StepExec,
+			Desc: fmt.Sprintf("Install SDK package %q", pkg),
+			Name: "sdkmanager",
+			Args: []string{rootFlag, pkg},
+		})
+	}
+
+	return steps, nil
+}
+
+// mustExist returns a clear error if path does not exist or is unreadable.
+func mustExist(path, label string) error {
+	if strings.TrimSpace(path) == "" {
+		return fmt.Errorf("%s path is empty", label)
+	}
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("%s not found: %s", label, path)
+		}
+		return fmt.Errorf("cannot access %s %q: %w", label, path, err)
+	}
+	return nil
+}

--- a/internal/provision/mobile/mobile_test.go
+++ b/internal/provision/mobile/mobile_test.go
@@ -1,0 +1,281 @@
+package mobile
+
+import (
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// writeTemp creates a file with the given basename under a fresh temp dir and
+// returns its path. Used so existence checks in the builders pass.
+func writeTemp(t *testing.T, name string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, name)
+	if err := writeFile(p); err != nil {
+		t.Fatalf("writing temp file: %v", err)
+	}
+	return p
+}
+
+func TestBuildIOSSteps_Validation(t *testing.T) {
+	goodProfile := writeTemp(t, "app.mobileprovision")
+	goodCert := writeTemp(t, "dist.p12")
+
+	tests := []struct {
+		name    string
+		opts    IOSOptions
+		wantErr string
+	}{
+		{
+			name:    "missing keychain name",
+			opts:    IOSOptions{KeychainPassword: "pw"},
+			wantErr: "keychain name is required",
+		},
+		{
+			name:    "missing keychain password",
+			opts:    IOSOptions{KeychainName: "kc"},
+			wantErr: "keychain password is required",
+		},
+		{
+			name:    "cert path does not exist",
+			opts:    IOSOptions{KeychainName: "kc", KeychainPassword: "pw", CertPath: "/nope/missing.p12", CertPassword: "x"},
+			wantErr: "certificate not found",
+		},
+		{
+			name:    "cert without password",
+			opts:    IOSOptions{KeychainName: "kc", KeychainPassword: "pw", CertPath: goodCert},
+			wantErr: "certificate password is required",
+		},
+		{
+			name:    "profile missing on disk",
+			opts:    IOSOptions{KeychainName: "kc", KeychainPassword: "pw", ProfilePaths: []string{"/nope/x.mobileprovision"}},
+			wantErr: "provisioning profile not found",
+		},
+		{
+			name:    "profile wrong extension",
+			opts:    IOSOptions{KeychainName: "kc", KeychainPassword: "pw", ProfilePaths: []string{writeTemp(t, "wrong.txt")}},
+			wantErr: ".mobileprovision extension",
+		},
+		{
+			name: "valid minimal",
+			opts: IOSOptions{KeychainName: "kc", KeychainPassword: "pw"},
+		},
+		{
+			name: "valid full",
+			opts: IOSOptions{
+				KeychainName: "kc", KeychainPassword: "pw",
+				CertPath: goodCert, CertPassword: "cp",
+				ProfilePaths: []string{goodProfile}, ProfilesDir: "/tmp/pp",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := BuildIOSSteps(tc.opts)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error = %q, want substring %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestBuildIOSSteps_PlanOrder(t *testing.T) {
+	cert := writeTemp(t, "dist.p12")
+	profile := writeTemp(t, "app.mobileprovision")
+
+	steps, err := BuildIOSSteps(IOSOptions{
+		KeychainName:     "citadel-build.keychain-db",
+		KeychainPassword: "kcpw",
+		CertPath:         cert,
+		CertPassword:     "certpw",
+		ProfilePaths:     []string{profile},
+		ProfilesDir:      "/tmp/Provisioning Profiles",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Expected: create, unlock, settings, import, partition-list, copy-profile.
+	if len(steps) != 6 {
+		t.Fatalf("got %d steps, want 6: %+v", len(steps), steps)
+	}
+
+	wantExec := []string{"create-keychain", "unlock-keychain", "set-keychain-settings", "import", "set-key-partition-list"}
+	for i, want := range wantExec {
+		if steps[i].Kind != StepExec {
+			t.Errorf("step %d kind = %v, want StepExec", i, steps[i].Kind)
+		}
+		if steps[i].Name != securityBin {
+			t.Errorf("step %d name = %q, want %q", i, steps[i].Name, securityBin)
+		}
+		if len(steps[i].Args) == 0 || steps[i].Args[0] != want {
+			t.Errorf("step %d first arg = %v, want %q", i, steps[i].Args, want)
+		}
+	}
+
+	last := steps[5]
+	if last.Kind != StepCopyFile {
+		t.Fatalf("last step kind = %v, want StepCopyFile", last.Kind)
+	}
+	if last.SrcPath != profile {
+		t.Errorf("copy src = %q, want %q", last.SrcPath, profile)
+	}
+	wantDst := filepath.Join("/tmp/Provisioning Profiles", "app.mobileprovision")
+	if last.DstPath != wantDst {
+		t.Errorf("copy dst = %q, want %q", last.DstPath, wantDst)
+	}
+}
+
+func TestBuildIOSSteps_NoCertNoProfile(t *testing.T) {
+	steps, err := BuildIOSSteps(IOSOptions{KeychainName: "kc", KeychainPassword: "pw"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Only create/unlock/settings — no import, partition-list, or copy.
+	if len(steps) != 3 {
+		t.Fatalf("got %d steps, want 3: %+v", len(steps), steps)
+	}
+	for _, s := range steps {
+		if s.Kind != StepExec {
+			t.Errorf("unexpected non-exec step %+v", s)
+		}
+	}
+}
+
+func TestIOSSteps_RedactsSecrets(t *testing.T) {
+	cert := writeTemp(t, "dist.p12")
+	steps, err := BuildIOSSteps(IOSOptions{
+		KeychainName:     "buildkc",
+		KeychainPassword: "SUPERSECRET",
+		CertPath:         cert,
+		CertPassword:     "CERTSECRET",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, s := range steps {
+		cmd := s.CommandString()
+		if strings.Contains(cmd, "SUPERSECRET") {
+			t.Errorf("keychain password leaked in %q", cmd)
+		}
+		if strings.Contains(cmd, "CERTSECRET") {
+			t.Errorf("cert password leaked in %q", cmd)
+		}
+		// Non-secret tokens must remain visible.
+		if s.Args[0] == "create-keychain" {
+			if !strings.Contains(cmd, "buildkc") {
+				t.Errorf("keychain name redacted in %q", cmd)
+			}
+			if !strings.Contains(cmd, "<redacted>") {
+				t.Errorf("password not redacted in %q", cmd)
+			}
+		}
+	}
+}
+
+func TestBuildAndroidSteps(t *testing.T) {
+	tests := []struct {
+		name      string
+		opts      AndroidOptions
+		wantErr   string
+		wantCmds  []string
+		wantCount int
+	}{
+		{
+			name:    "missing sdk root",
+			opts:    AndroidOptions{},
+			wantErr: "Android SDK root is required",
+		},
+		{
+			name:      "licenses only",
+			opts:      AndroidOptions{SDKRoot: "/sdk", AcceptLicenses: true},
+			wantCount: 1,
+			wantCmds:  []string{"sdkmanager --sdk_root=/sdk --licenses"},
+		},
+		{
+			name: "packages with licenses",
+			opts: AndroidOptions{
+				SDKRoot:        "/sdk",
+				AcceptLicenses: true,
+				Packages:       []string{"platform-tools", "platforms;android-34"},
+			},
+			wantCount: 3,
+			wantCmds: []string{
+				"sdkmanager --sdk_root=/sdk --licenses",
+				"sdkmanager --sdk_root=/sdk platform-tools",
+				"sdkmanager --sdk_root=/sdk 'platforms;android-34'",
+			},
+		},
+		{
+			name:      "blank packages skipped",
+			opts:      AndroidOptions{SDKRoot: "/sdk", Packages: []string{"  ", "platform-tools", ""}},
+			wantCount: 1,
+			wantCmds:  []string{"sdkmanager --sdk_root=/sdk platform-tools"},
+		},
+		{
+			name:      "no licenses no packages yields empty plan",
+			opts:      AndroidOptions{SDKRoot: "/sdk"},
+			wantCount: 0,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			steps, err := BuildAndroidSteps(tc.opts)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error = %v, want substring %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(steps) != tc.wantCount {
+				t.Fatalf("got %d steps, want %d: %+v", len(steps), tc.wantCount, steps)
+			}
+			var got []string
+			for _, s := range steps {
+				got = append(got, s.CommandString())
+			}
+			if tc.wantCmds != nil && !reflect.DeepEqual(got, tc.wantCmds) {
+				t.Errorf("commands = %v, want %v", got, tc.wantCmds)
+			}
+		})
+	}
+}
+
+func TestDefaultProfilesDir(t *testing.T) {
+	got := DefaultProfilesDir("/Users/op")
+	want := filepath.Join("/Users/op", "Library", "MobileDevice", "Provisioning Profiles")
+	if got != want {
+		t.Errorf("DefaultProfilesDir = %q, want %q", got, want)
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"plain", "plain"},
+		{"platforms;android-34", "'platforms;android-34'"},
+		{"", "''"},
+		{"with space", "'with space'"},
+		{"/abs/path", "/abs/path"},
+	}
+	for _, tc := range tests {
+		if got := shellQuote(tc.in); got != tc.want {
+			t.Errorf("shellQuote(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/provision/mobile/runner.go
+++ b/internal/provision/mobile/runner.go
@@ -1,0 +1,127 @@
+package mobile
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+// stepTimeout caps a single provisioning step. sdkmanager --licenses and
+// keychain imports are quick; the cap guards against a hung interactive prompt.
+const stepTimeout = 10 * time.Minute
+
+// Runner executes a provisioning plan, or prints it in dry-run mode.
+type Runner struct {
+	// DryRun, when true, prints each step instead of executing it.
+	DryRun bool
+	// Out is the destination for human-readable progress output.
+	Out io.Writer
+
+	// execCommand is the exec hook, overridable in tests. When nil it defaults
+	// to a real command runner.
+	execCommand func(ctx context.Context, name string, args ...string) ([]byte, error)
+	// copyFile is the copy hook, overridable in tests. When nil it defaults to
+	// a real filesystem copy.
+	copyFile func(src, dst string) error
+}
+
+// NewRunner returns a Runner writing progress to out. A nil out defaults to
+// os.Stdout.
+func NewRunner(dryRun bool, out io.Writer) *Runner {
+	if out == nil {
+		out = os.Stdout
+	}
+	return &Runner{DryRun: dryRun, Out: out}
+}
+
+// Run executes (or prints) every step in order. On the first failing step it
+// stops and returns the error, leaving prior steps applied.
+func (r *Runner) Run(steps []Step) error {
+	for i, step := range steps {
+		fmt.Fprintf(r.Out, "[%d/%d] %s\n", i+1, len(steps), step.Desc)
+		if err := r.runStep(step); err != nil {
+			return fmt.Errorf("step %d (%s): %w", i+1, step.Desc, err)
+		}
+	}
+	return nil
+}
+
+func (r *Runner) runStep(step Step) error {
+	switch step.Kind {
+	case StepExec:
+		return r.runExec(step)
+	case StepCopyFile:
+		return r.runCopy(step)
+	default:
+		return fmt.Errorf("unknown step kind %d", step.Kind)
+	}
+}
+
+func (r *Runner) runExec(step Step) error {
+	if r.DryRun {
+		fmt.Fprintf(r.Out, "      $ %s\n", step.CommandString())
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), stepTimeout)
+	defer cancel()
+	out, err := r.exec(ctx, step.Name, step.Args...)
+	if len(out) > 0 {
+		fmt.Fprintf(r.Out, "%s", out)
+	}
+	if err != nil {
+		return fmt.Errorf("%s failed: %w", step.Name, err)
+	}
+	return nil
+}
+
+func (r *Runner) runCopy(step Step) error {
+	if r.DryRun {
+		fmt.Fprintf(r.Out, "      copy %s -> %s\n", step.SrcPath, step.DstPath)
+		return nil
+	}
+	if err := r.copy(step.SrcPath, step.DstPath); err != nil {
+		return fmt.Errorf("copy %s -> %s: %w", step.SrcPath, step.DstPath, err)
+	}
+	return nil
+}
+
+func (r *Runner) exec(ctx context.Context, name string, args ...string) ([]byte, error) {
+	if r.execCommand != nil {
+		return r.execCommand(ctx, name, args...)
+	}
+	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+}
+
+func (r *Runner) copy(src, dst string) error {
+	if r.copyFile != nil {
+		return r.copyFile(src, dst)
+	}
+	return defaultCopyFile(src, dst)
+}
+
+// defaultCopyFile copies src to dst, creating dst's parent directory. It
+// preserves nothing beyond the bytes; provisioning profiles are plain files.
+func defaultCopyFile(src, dst string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
+}

--- a/internal/provision/mobile/runner_test.go
+++ b/internal/provision/mobile/runner_test.go
@@ -1,0 +1,139 @@
+package mobile
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeFile creates an empty file at path, used by builder tests for existence
+// checks.
+func writeFile(path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}
+
+func TestRunner_DryRunPrintsAndDoesNotExecute(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewRunner(true, &buf)
+	executed := false
+	r.execCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		executed = true
+		return nil, nil
+	}
+	copied := false
+	r.copyFile = func(src, dst string) error {
+		copied = true
+		return nil
+	}
+
+	steps := []Step{
+		{Kind: StepExec, Desc: "exec step", Name: "security", Args: []string{"create-keychain", "-p", "pw", "kc"}, SecretArgs: []int{2}},
+		{Kind: StepCopyFile, Desc: "copy step", SrcPath: "/a/x.mobileprovision", DstPath: "/b/x.mobileprovision"},
+	}
+	if err := r.Run(steps); err != nil {
+		t.Fatalf("dry run failed: %v", err)
+	}
+	if executed {
+		t.Error("exec hook called during dry run")
+	}
+	if copied {
+		t.Error("copy hook called during dry run")
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "security create-keychain -p <redacted> kc") {
+		t.Errorf("dry-run exec line missing/unredacted:\n%s", out)
+	}
+	if strings.Contains(out, "pw") {
+		t.Errorf("password leaked in dry-run output:\n%s", out)
+	}
+	if !strings.Contains(out, "copy /a/x.mobileprovision -> /b/x.mobileprovision") {
+		t.Errorf("dry-run copy line missing:\n%s", out)
+	}
+}
+
+func TestRunner_RealRunInvokesHooks(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewRunner(false, &buf)
+
+	var gotName string
+	var gotArgs []string
+	r.execCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		gotName = name
+		gotArgs = args
+		return []byte("ok\n"), nil
+	}
+	var gotSrc, gotDst string
+	r.copyFile = func(src, dst string) error {
+		gotSrc, gotDst = src, dst
+		return nil
+	}
+
+	steps := []Step{
+		{Kind: StepExec, Desc: "run", Name: "sdkmanager", Args: []string{"--licenses"}},
+		{Kind: StepCopyFile, Desc: "install", SrcPath: "/a/p.mobileprovision", DstPath: "/b/p.mobileprovision"},
+	}
+	if err := r.Run(steps); err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	if gotName != "sdkmanager" || len(gotArgs) != 1 || gotArgs[0] != "--licenses" {
+		t.Errorf("exec got %q %v", gotName, gotArgs)
+	}
+	if gotSrc != "/a/p.mobileprovision" || gotDst != "/b/p.mobileprovision" {
+		t.Errorf("copy got %q -> %q", gotSrc, gotDst)
+	}
+	if !strings.Contains(buf.String(), "ok") {
+		t.Errorf("command output not echoed: %s", buf.String())
+	}
+}
+
+func TestRunner_StopsOnFirstError(t *testing.T) {
+	r := NewRunner(false, &bytes.Buffer{})
+	calls := 0
+	r.execCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		calls++
+		return nil, errors.New("boom")
+	}
+	steps := []Step{
+		{Kind: StepExec, Desc: "first", Name: "a"},
+		{Kind: StepExec, Desc: "second", Name: "b"},
+	}
+	err := r.Run(steps)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "step 1") || !strings.Contains(err.Error(), "first") {
+		t.Errorf("error should name failing step: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected to stop after 1 exec, got %d", calls)
+	}
+}
+
+func TestDefaultCopyFile(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.mobileprovision")
+	if err := os.WriteFile(src, []byte("PROFILE-BYTES"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(dir, "nested", "dst.mobileprovision")
+
+	if err := defaultCopyFile(src, dst); err != nil {
+		t.Fatalf("copy failed: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("reading dst: %v", err)
+	}
+	if string(got) != "PROFILE-BYTES" {
+		t.Errorf("dst content = %q, want PROFILE-BYTES", got)
+	}
+}


### PR DESCRIPTION
## Context

This is **Phase 3** of macOS mobile-build support (#140). Phase 1 (#263) added macOS capability detection; Phase 2 (#269) added the `IOS_BUILD` / `ANDROID_BUILD` / `GOMOBILE_BUILD` job handlers. A node can now *run* mobile builds — but only if its code-signing keychain, certificates, provisioning profiles, and SDK are already set up by hand. This PR adds the operator-facing `citadel provision ios|android` subcommands that automate that one-time setup, closing the gap between "node detected as Xcode-capable" and "node can actually sign and ship a build."

> **Stacking:** opens on top of #269 (base branch `feat/140-macos-build-handlers`), which itself stacks on #263. Merge oldest-first.

```
# Preview the full iOS keychain/profile plan without any secrets or a real keychain:
citadel provision ios --dry-run \
  --keychain citadel-build.keychain-db --keychain-password "$KC_PW" \
  --cert ./dist.p12 --cert-password "$CERT_PW" \
  --profile ./app.mobileprovision

[1/6] Create build keychain "citadel-build.keychain-db" (ignored if it already exists)
      $ security create-keychain -p <redacted> citadel-build.keychain-db
[2/6] Unlock build keychain "citadel-build.keychain-db"
      $ security unlock-keychain -p <redacted> citadel-build.keychain-db
...
```

## Summary

**`citadel provision ios`** (`cmd/provision_mobile.go`)
- Creates/unlocks a dedicated build keychain and disables auto-lock for build sessions.
- Imports a distribution certificate (`.p12`) when `--cert` is given, then sets the key partition list so `codesign`/`productsign` can use the key non-interactively.
- Installs `.mobileprovision` profiles into `~/Library/MobileDevice/Provisioning Profiles/`.
- Checks for Xcode CLI tools (`xcode-select -p`) and hints `xcode-select --install` if missing.
- **Darwin-gated:** real execution requires macOS; `--dry-run` previews the plan on any host.

**`citadel provision android`**
- Resolves the SDK location from `--sdk-root` or `ANDROID_HOME`/`ANDROID_SDK_ROOT`.
- Accepts SDK licenses (`sdkmanager --licenses`) with `--accept-licenses`.
- Installs requested packages (`--package "platforms;android-34"`, repeatable). Every `sdkmanager` call is threaded with `--sdk_root=...` so it is hermetic.
- Verifies `sdkmanager` is on `PATH` before a real run.

**Design: pure builders + injectable runner** (`internal/provision/mobile/`)
- `BuildIOSSteps` / `BuildAndroidSteps` are side-effect-free: they validate input and emit an ordered `[]Step` (exec or copy-file operations). This is what makes the logic exhaustively unit-testable without a keychain.
- `Runner` executes the plan, or in `--dry-run` mode prints each command. Exec and copy are injectable hooks so tests never shell out.
- **Secret handling:** no secrets are hardcoded. Passwords are passed as flags and redacted in dry-run output via explicit `SecretArgs` indices (not a fuzzy heuristic), so e.g. the keychain *name* stays visible while the password shows `<redacted>`.

## Dry-run vs. real execution

| Operation | Dry-run | Real run |
| --- | --- | --- |
| keychain create/unlock/settings, cert import, partition list | printed (passwords redacted) | `security ...` executed (macOS only) |
| profile install | printed as `copy src -> dst` | file copied into Provisioning Profiles dir |
| `sdkmanager --licenses` / package install | printed | executed (requires `sdkmanager` on PATH) |
| Xcode CLI tools check | skipped on non-macOS | `xcode-select -p`, install hint if absent |

## Test plan

| Group | Coverage |
| --- | --- |
| `internal/provision/mobile` builders | required-field validation, cert/profile existence + extension checks, plan ordering (6-step iOS plan, 3-step minimal), no-cert/no-profile short plan, Android licenses/packages/blank-skip/empty-plan |
| Secret redaction | keychain + cert passwords never appear in `CommandString`; non-secret tokens preserved; `shellQuote` of special chars |
| `Runner` | dry-run prints and does **not** invoke hooks; real run invokes exec/copy hooks with correct args; stops on first error; `defaultCopyFile` copies bytes + creates parent dir |
| `cmd` | `androidSDKFromEnv` precedence (ANDROID_HOME > ANDROID_SDK_ROOT > none); iOS dry-run plan + redaction; missing keychain password error; Android dry-run plan; missing SDK-location error |

`nix develop -c go build ./...` and `nix develop -c go test ./...` pass. The only failing test is the pre-existing `e2e.TestDeviceAuthExpiry`, which requires a server on `localhost:3000` and is unrelated to this change.

**Not unit-tested (requires an Apple developer account):** the real `security` keychain mutations, certificate import, and on-device signing. These are exercised only via `--dry-run` + the pure builders here; end-to-end verification with real certs is tracked as a follow-up (see Related).

## Related

- #140 — parent issue
- #263 — Phase 1 (capability detection)
- #269 — Phase 2 (build handlers); this PR's base branch
- #270 — iOS signing for `IOS_BUILD`; overlaps on keychain/profile setup
- Closes #271

---
*Generated by Claude*