### PR TITLE
feat: WebSocket-based job delivery source

### DIFF
--- a/internal/redisapi/client.go
+++ b/internal/redisapi/client.go
@@ -76,6 +76,11 @@ func (c *Client) debug(format string, args ...any) {
 	}
 }
 
+// BaseURL returns the API base URL.
+func (c *Client) BaseURL() string {
+	return c.baseURL
+}
+
 // WorkerID returns the unique worker identifier.
 func (c *Client) WorkerID() string {
 	return c.workerID

--- a/internal/redisapi/jobs.go
+++ b/internal/redisapi/jobs.go
@@ -31,11 +31,11 @@ func (c *Client) ConsumeJob(ctx context.Context, req ConsumeRequest) (*Job, erro
 
 	// Convert the first StreamMessage to a Job
 	msg := resp.Messages[0]
-	return parseStreamMessage(msg)
+	return ParseStreamMessage(msg)
 }
 
-// parseStreamMessage converts a StreamMessage to a Job.
-func parseStreamMessage(msg StreamMessage) (*Job, error) {
+// ParseStreamMessage converts a StreamMessage to a Job.
+func ParseStreamMessage(msg StreamMessage) (*Job, error) {
 	job := &Job{
 		MessageID: msg.ID,
 		JobID:     msg.Data.JobID,

--- a/internal/redisapi/jobs_test.go
+++ b/internal/redisapi/jobs_test.go
@@ -17,9 +17,9 @@ func TestParseStreamMessage_TopLevelType(t *testing.T) {
 		},
 	}
 
-	job, err := parseStreamMessage(msg)
+	job, err := ParseStreamMessage(msg)
 	if err != nil {
-		t.Fatalf("parseStreamMessage error: %v", err)
+		t.Fatalf("ParseStreamMessage error: %v", err)
 	}
 	if job.Type != "SHELL_COMMAND" {
 		t.Errorf("Type = %q, want %q", job.Type, "SHELL_COMMAND")
@@ -46,9 +46,9 @@ func TestParseStreamMessage_PayloadFallbackType(t *testing.T) {
 		},
 	}
 
-	job, err := parseStreamMessage(msg)
+	job, err := ParseStreamMessage(msg)
 	if err != nil {
-		t.Fatalf("parseStreamMessage error: %v", err)
+		t.Fatalf("ParseStreamMessage error: %v", err)
 	}
 	if job.Type != "llm_inference" {
 		t.Errorf("Type = %q, want %q", job.Type, "llm_inference")
@@ -69,9 +69,9 @@ func TestParseStreamMessage_TopLevelTypeWins(t *testing.T) {
 		},
 	}
 
-	job, err := parseStreamMessage(msg)
+	job, err := ParseStreamMessage(msg)
 	if err != nil {
-		t.Fatalf("parseStreamMessage error: %v", err)
+		t.Fatalf("ParseStreamMessage error: %v", err)
 	}
 	if job.Type != "FILE_READ" {
 		t.Errorf("Type = %q, want %q (top-level should win)", job.Type, "FILE_READ")
@@ -89,9 +89,9 @@ func TestParseStreamMessage_RayID(t *testing.T) {
 		},
 	}
 
-	job, err := parseStreamMessage(msg)
+	job, err := ParseStreamMessage(msg)
 	if err != nil {
-		t.Fatalf("parseStreamMessage error: %v", err)
+		t.Fatalf("ParseStreamMessage error: %v", err)
 	}
 	if job.RawData["rayId"] != "ray-test-123" {
 		t.Errorf("RawData[rayId] = %v, want %q", job.RawData["rayId"], "ray-test-123")
@@ -108,9 +108,9 @@ func TestParseStreamMessage_InvalidPayload(t *testing.T) {
 		},
 	}
 
-	_, err := parseStreamMessage(msg)
+	_, err := ParseStreamMessage(msg)
 	if err == nil {
-		t.Error("parseStreamMessage should error on invalid JSON payload")
+		t.Error("ParseStreamMessage should error on invalid JSON payload")
 	}
 }
 
@@ -123,9 +123,9 @@ func TestParseStreamMessage_EmptyPayload(t *testing.T) {
 		},
 	}
 
-	job, err := parseStreamMessage(msg)
+	job, err := ParseStreamMessage(msg)
 	if err != nil {
-		t.Fatalf("parseStreamMessage error: %v", err)
+		t.Fatalf("ParseStreamMessage error: %v", err)
 	}
 	if job.Type != "SHELL_COMMAND" {
 		t.Errorf("Type = %q, want %q", job.Type, "SHELL_COMMAND")

--- a/internal/redisapi/websocket.go
+++ b/internal/redisapi/websocket.go
@@ -39,6 +39,10 @@ type WSClient struct {
 	reconnectBackoff time.Duration
 	maxBackoff       time.Duration
 
+	// Reconnect callbacks fired after a successful reconnection
+	reconnectCallbacks   []func()
+	reconnectCallbacksMu sync.RWMutex
+
 	// Debug callback
 	debugFunc func(format string, args ...any)
 }
@@ -65,6 +69,17 @@ type WSMessage struct {
 	Channels []string       `json:"channels,omitempty"`
 	Message  map[string]any `json:"message,omitempty"`
 	Error    string         `json:"error,omitempty"`
+
+	// Consume-related fields (job delivery protocol)
+	Queue     string            `json:"queue,omitempty"`
+	Queues    []string          `json:"queues,omitempty"`
+	Group     string            `json:"group,omitempty"`
+	Consumer  string            `json:"consumer,omitempty"`
+	Count     int               `json:"count,omitempty"`
+	BlockMs   int               `json:"blockMs,omitempty"`
+	ID        string            `json:"id,omitempty"`        // Stream message ID (job delivery)
+	MessageID string            `json:"messageId,omitempty"` // Ack message ID
+	Data      map[string]string `json:"data,omitempty"`      // Job data fields from stream
 }
 
 // NewWSClient creates a new WebSocket client.
@@ -297,6 +312,18 @@ func (c *WSClient) reconnect() {
 		}
 
 		c.debug("ws: reconnected successfully")
+
+		// Fire reconnect callbacks AFTER releasing connMu to avoid
+		// deadlock (callbacks may call sendMessage which takes RLock).
+		c.reconnectCallbacksMu.RLock()
+		cbs := make([]func(), len(c.reconnectCallbacks))
+		copy(cbs, c.reconnectCallbacks)
+		c.reconnectCallbacksMu.RUnlock()
+
+		for _, cb := range cbs {
+			cb()
+		}
+
 		return
 	}
 }
@@ -401,6 +428,48 @@ func (c *WSClient) OnMessage(msgType string, handler func(WSMessage)) {
 	c.handlersMu.Lock()
 	c.handlers[msgType] = handler
 	c.handlersMu.Unlock()
+}
+
+// OnReconnect registers a callback that fires after a successful reconnection.
+// The callback is NOT called on the initial Connect -- only on reconnects.
+// Callbacks run outside of the connection lock so it is safe to call sendMessage.
+func (c *WSClient) OnReconnect(callback func()) {
+	c.reconnectCallbacksMu.Lock()
+	c.reconnectCallbacks = append(c.reconnectCallbacks, callback)
+	c.reconnectCallbacksMu.Unlock()
+}
+
+// StartConsume sends a consume message to begin receiving jobs from the server.
+// The server will start a persistent XREADGROUP BLOCK loop and push job messages.
+func (c *WSClient) StartConsume(queues []string, group, consumer string, count, blockMs int) error {
+	msg := WSMessage{
+		Type:     "consume",
+		Queues:   queues,
+		Group:    group,
+		Consumer: consumer,
+		Count:    count,
+		BlockMs:  blockMs,
+	}
+	return c.sendMessage(context.Background(), msg)
+}
+
+// StopConsume sends a stop_consume message to halt the server-side consume loop.
+func (c *WSClient) StopConsume() error {
+	msg := WSMessage{
+		Type: "stop_consume",
+	}
+	return c.sendMessage(context.Background(), msg)
+}
+
+// AckJob sends an ack message to acknowledge a processed job.
+func (c *WSClient) AckJob(queue, group, messageID string) error {
+	msg := WSMessage{
+		Type:      "ack",
+		Queue:     queue,
+		Group:     group,
+		MessageID: messageID,
+	}
+	return c.sendMessage(context.Background(), msg)
 }
 
 // IsConnected returns whether the WebSocket is currently connected.

--- a/internal/worker/ws_source.go
+++ b/internal/worker/ws_source.go
@@ -1,0 +1,384 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/aceteam-ai/citadel-cli/internal/redisapi"
+)
+
+// WSSource implements JobSource using the existing WebSocket connection for
+// server-pushed job delivery. Instead of HTTP polling, the server runs a
+// persistent XREADGROUP BLOCK loop and pushes "job" messages to the client.
+type WSSource struct {
+	client *redisapi.Client
+	config WSSourceConfig
+
+	// mu guards queueNames which may be mutated by AddQueue at runtime.
+	mu         sync.RWMutex
+	queueNames []string
+
+	// jobs is the channel that receives parsed jobs from the WebSocket handler.
+	// Buffered to avoid blocking the WSClient readLoop.
+	jobs chan *Job
+
+	// done is closed by Close to signal the handler and Next to stop.
+	done     chan struct{}
+	doneOnce sync.Once
+}
+
+// WSSourceConfig holds configuration for WSSource.
+type WSSourceConfig struct {
+	// Client is the redisapi.Client with WebSocket already enabled (or to be enabled).
+	Client *redisapi.Client
+
+	// QueueName is the Redis Stream to consume from (single queue, backwards compat).
+	QueueName string
+
+	// QueueNames is the list of Redis Streams to consume from (multi-queue mode).
+	// If set, QueueName is ignored.
+	QueueNames []string
+
+	// ConsumerGroup is the consumer group name (default: "citadel-workers").
+	ConsumerGroup string
+
+	// BlockMs is the server-side XREADGROUP BLOCK timeout (default: 5000).
+	BlockMs int
+
+	// DebugFunc is an optional callback for debug logging.
+	DebugFunc func(format string, args ...any)
+
+	// LogFn is an optional callback for logging (if nil, prints to stdout).
+	LogFn func(level, msg string)
+}
+
+// NewWSSource creates a new WebSocket-backed job source.
+func NewWSSource(cfg WSSourceConfig) *WSSource {
+	if cfg.ConsumerGroup == "" {
+		cfg.ConsumerGroup = "citadel-workers"
+	}
+	if cfg.BlockMs == 0 {
+		cfg.BlockMs = 5000
+	}
+
+	var queues []string
+	if len(cfg.QueueNames) > 0 {
+		queues = cfg.QueueNames
+	} else if cfg.QueueName != "" {
+		queues = []string{cfg.QueueName}
+	} else {
+		queues = []string{"jobs:v1:cpu-general"}
+	}
+
+	return &WSSource{
+		client:     cfg.Client,
+		config:     cfg,
+		queueNames: queues,
+		jobs:       make(chan *Job, 16),
+		done:       make(chan struct{}),
+	}
+}
+
+// Name returns the source identifier.
+func (s *WSSource) Name() string {
+	return "websocket"
+}
+
+// log outputs a message.
+func (s *WSSource) log(level, format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	if s.config.LogFn != nil {
+		s.config.LogFn(level, msg)
+	} else {
+		fmt.Printf("%s\n", msg)
+	}
+}
+
+// debug logs via the debug callback if configured.
+func (s *WSSource) debug(format string, args ...any) {
+	if s.config.DebugFunc != nil {
+		s.config.DebugFunc(format, args...)
+	}
+}
+
+// Connect enables the WebSocket on the client, registers the job handler,
+// sets up the reconnect callback, and sends the initial consume message.
+func (s *WSSource) Connect(ctx context.Context) error {
+	if s.client == nil {
+		return fmt.Errorf("WSSource requires a non-nil redisapi.Client")
+	}
+
+	// Enable WebSocket if not already connected
+	if err := s.client.EnableWebSocket(ctx); err != nil {
+		return fmt.Errorf("failed to enable WebSocket: %w", err)
+	}
+
+	ws := s.client.WebSocket()
+	if ws == nil {
+		return fmt.Errorf("WebSocket client is nil after EnableWebSocket")
+	}
+
+	// Register handler for "job" messages. The server pushes these
+	// continuously from its XREADGROUP BLOCK loop.
+	ws.OnMessage("job", func(msg redisapi.WSMessage) {
+		job, err := s.convertWSJob(msg)
+		if err != nil {
+			s.debug("ws_source: failed to convert job message: %v", err)
+			return
+		}
+
+		// Blocking send with cancel: applies backpressure if the buffer
+		// is full (runner is busy). The <-s.done case unblocks a stuck
+		// readLoop on Close so shutdown is never wedged.
+		select {
+		case s.jobs <- job:
+		case <-s.done:
+		}
+	})
+
+	// Register handler for server-side errors (e.g. rejected queue name,
+	// missing device_redis:read scope). Without this the client would
+	// silently believe it is consuming while receiving nothing — the
+	// exact failure mode #236/#3924 eliminated on the HTTP path.
+	ws.OnMessage("error", func(msg redisapi.WSMessage) {
+		s.log("error", "WebSocket server error: %s", msg.Error)
+	})
+
+	// Register handler for "consuming" confirmation from the server.
+	ws.OnMessage("consuming", func(msg redisapi.WSMessage) {
+		s.debug("ws_source: server confirmed consuming queues=%v", msg.Queues)
+	})
+
+	// Register handler for "acked" confirmation from the server.
+	ws.OnMessage("acked", func(msg redisapi.WSMessage) {
+		s.debug("ws_source: server confirmed ack messageId=%s", msg.MessageID)
+	})
+
+	// Register reconnect callback to re-send consume with current queue list.
+	ws.OnReconnect(func() {
+		s.log("info", "WebSocket reconnected, re-sending consume")
+		if err := s.sendConsume(); err != nil {
+			s.log("warning", "Failed to re-send consume after reconnect: %v", err)
+		}
+	})
+
+	// Verify connection with a ping
+	if err := s.client.Ping(ctx); err != nil {
+		return fmt.Errorf("failed to ping API: %w", err)
+	}
+
+	// Send the initial consume message
+	if err := s.sendConsume(); err != nil {
+		return fmt.Errorf("failed to start consuming: %w", err)
+	}
+
+	queues := s.snapshotQueues()
+	s.log("info", "   - Source: websocket")
+	s.log("info", "   - API: %s", s.client.BaseURL())
+	s.log("info", "   - Worker ID: %s", s.client.WorkerID())
+	if len(queues) == 1 {
+		s.log("info", "   - Queue: %s", queues[0])
+	} else {
+		s.log("info", "   - Queues (%d):", len(queues))
+		for _, q := range queues {
+			s.log("info", "     - %s", q)
+		}
+	}
+	s.log("info", "   - Consumer group: %s", s.config.ConsumerGroup)
+
+	return nil
+}
+
+// sendConsume sends the consume message with the current queue list.
+func (s *WSSource) sendConsume() error {
+	if s.client == nil {
+		return fmt.Errorf("client not initialized")
+	}
+	ws := s.client.WebSocket()
+	if ws == nil {
+		return fmt.Errorf("WebSocket not available")
+	}
+
+	queues := s.snapshotQueues()
+	return ws.StartConsume(queues, s.config.ConsumerGroup, s.client.WorkerID(), 1, s.config.BlockMs)
+}
+
+// Next blocks until a job is available or the context is cancelled.
+func (s *WSSource) Next(ctx context.Context) (*Job, error) {
+	select {
+	case job := <-s.jobs:
+		return job, nil
+	case <-s.done:
+		return nil, fmt.Errorf("WSSource closed")
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// Ack acknowledges successful job completion. Sends an ack over WebSocket
+// and also updates job status via HTTP (same as APISource).
+func (s *WSSource) Ack(ctx context.Context, job *Job) error {
+	// Update job status via HTTP
+	s.client.SetJobStatus(ctx, job.ID, "completed", nil)
+
+	queue := job.SourceQueue
+	if queue == "" {
+		if qs := s.snapshotQueues(); len(qs) > 0 {
+			queue = qs[0]
+		}
+	}
+
+	// Ack via WebSocket
+	ws := s.client.WebSocket()
+	if ws != nil && ws.IsConnected() {
+		if err := ws.AckJob(queue, s.config.ConsumerGroup, job.MessageID); err != nil {
+			s.debug("ws_source: WS ack failed, falling back to HTTP: %v", err)
+			return s.client.AcknowledgeJob(ctx, redisapi.AcknowledgeRequest{
+				Queue:     queue,
+				Group:     s.config.ConsumerGroup,
+				MessageID: job.MessageID,
+			})
+		}
+		return nil
+	}
+
+	// Fallback to HTTP ack if WebSocket is disconnected
+	return s.client.AcknowledgeJob(ctx, redisapi.AcknowledgeRequest{
+		Queue:     queue,
+		Group:     s.config.ConsumerGroup,
+		MessageID: job.MessageID,
+	})
+}
+
+// Nack indicates job failure. Updates status but does NOT ack, allowing retry.
+func (s *WSSource) Nack(ctx context.Context, job *Job, err error) error {
+	s.client.SetJobStatus(ctx, job.ID, "failed", map[string]any{
+		"error": err.Error(),
+	})
+	return nil
+}
+
+// IsJobCancelled checks whether a job has been cancelled by the producer.
+func (s *WSSource) IsJobCancelled(ctx context.Context, jobID string) bool {
+	cancelled, err := s.client.IsJobCancelled(ctx, jobID)
+	if err != nil {
+		s.log("warning", "Failed to check cancellation for %s: %v", jobID, err)
+		return false
+	}
+	return cancelled
+}
+
+// Close stops consuming and closes the jobs channel.
+func (s *WSSource) Close() error {
+	s.doneOnce.Do(func() {
+		close(s.done)
+	})
+
+	// Send stop_consume to halt the server-side loop
+	ws := s.client.WebSocket()
+	if ws != nil && ws.IsConnected() {
+		if err := ws.StopConsume(); err != nil {
+			s.debug("ws_source: failed to send stop_consume: %v", err)
+		}
+	}
+
+	if s.client != nil {
+		return s.client.Close()
+	}
+	return nil
+}
+
+// Client returns the underlying API client for stream writing.
+func (s *WSSource) Client() *redisapi.Client {
+	return s.client
+}
+
+// QueueNames returns the list of queues being consumed.
+func (s *WSSource) QueueNames() []string {
+	return s.snapshotQueues()
+}
+
+// AddQueue appends an additional queue to consume from after construction.
+// Thread-safe. After adding the queue, re-sends the consume message with the
+// updated queue list (the server stops the old loop and starts a new one).
+func (s *WSSource) AddQueue(queue string) {
+	if queue == "" {
+		return
+	}
+	s.mu.Lock()
+	for _, q := range s.queueNames {
+		if q == queue {
+			s.mu.Unlock()
+			return
+		}
+	}
+	s.queueNames = append(s.queueNames, queue)
+	s.mu.Unlock()
+
+	s.log("info", "   - Added queue: %s", queue)
+
+	// Re-send consume with updated queue list
+	if err := s.sendConsume(); err != nil {
+		s.log("warning", "Failed to re-send consume after AddQueue: %v", err)
+	}
+}
+
+// snapshotQueues returns a stable copy of the queue list.
+func (s *WSSource) snapshotQueues() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return append([]string(nil), s.queueNames...)
+}
+
+// convertWSJob converts a WebSocket "job" message to a worker.Job.
+// The server sends: { type: "job", queue: "...", id: "1234567890-0", data: { jobId, type, payload, enqueuedAt } }
+// The data fields mirror StreamMessageData, so we reuse ParseStreamMessage.
+func (s *WSSource) convertWSJob(msg redisapi.WSMessage) (*Job, error) {
+	if msg.Data == nil {
+		return nil, fmt.Errorf("job message has nil data")
+	}
+
+	// Build a StreamMessage from the WS fields to reuse ParseStreamMessage
+	streamMsg := redisapi.StreamMessage{
+		ID: msg.ID,
+		Data: redisapi.StreamMessageData{
+			JobID:      msg.Data["jobId"],
+			Type:       msg.Data["type"],
+			Payload:    msg.Data["payload"],
+			EnqueuedAt: msg.Data["enqueuedAt"],
+			RayID:      msg.Data["rayId"],
+		},
+	}
+
+	apiJob, err := redisapi.ParseStreamMessage(streamMsg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse stream message: %w", err)
+	}
+
+	job := &Job{
+		ID:          apiJob.JobID,
+		Type:        apiJob.Type,
+		Payload:     apiJob.Payload,
+		Source:      "websocket",
+		MessageID:   apiJob.MessageID,
+		SourceQueue: msg.Queue,
+	}
+
+	// Extract rayId
+	if apiJob.RawData != nil {
+		if rayID, ok := apiJob.RawData["rayId"].(string); ok && rayID != "" {
+			job.RayID = rayID
+		}
+	}
+	if job.RayID == "" && apiJob.Payload != nil {
+		if rayID, ok := apiJob.Payload["rayId"].(string); ok {
+			job.RayID = rayID
+		}
+	}
+
+	return job, nil
+}
+
+// Ensure WSSource implements JobSource at compile time.
+var _ JobSource = (*WSSource)(nil)

--- a/internal/worker/ws_source_test.go
+++ b/internal/worker/ws_source_test.go
@@ -1,0 +1,299 @@
+package worker
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/redisapi"
+)
+
+func TestWSSource_ConvertWSJob(t *testing.T) {
+	src := &WSSource{
+		config: WSSourceConfig{},
+	}
+
+	msg := redisapi.WSMessage{
+		Type:  "job",
+		Queue: "jobs:v1:cpu-general",
+		ID:    "1718000000000-0",
+		Data: map[string]string{
+			"jobId":      "test-job-uuid",
+			"type":       "SHELL_COMMAND",
+			"payload":    `{"command":"ls -la","cwd":"/tmp"}`,
+			"enqueuedAt": "2026-06-19T12:00:00Z",
+			"rayId":      "ray-abc-123",
+		},
+	}
+
+	job, err := src.convertWSJob(msg)
+	if err != nil {
+		t.Fatalf("convertWSJob error: %v", err)
+	}
+
+	if job.ID != "test-job-uuid" {
+		t.Errorf("ID = %q, want %q", job.ID, "test-job-uuid")
+	}
+	if job.Type != "SHELL_COMMAND" {
+		t.Errorf("Type = %q, want %q", job.Type, "SHELL_COMMAND")
+	}
+	if job.Source != "websocket" {
+		t.Errorf("Source = %q, want %q", job.Source, "websocket")
+	}
+	if job.SourceQueue != "jobs:v1:cpu-general" {
+		t.Errorf("SourceQueue = %q, want %q", job.SourceQueue, "jobs:v1:cpu-general")
+	}
+	if job.MessageID != "1718000000000-0" {
+		t.Errorf("MessageID = %q, want %q", job.MessageID, "1718000000000-0")
+	}
+	if job.RayID != "ray-abc-123" {
+		t.Errorf("RayID = %q, want %q", job.RayID, "ray-abc-123")
+	}
+	if cmd, ok := job.Payload["command"].(string); !ok || cmd != "ls -la" {
+		t.Errorf("Payload[command] = %v, want %q", job.Payload["command"], "ls -la")
+	}
+	if cwd, ok := job.Payload["cwd"].(string); !ok || cwd != "/tmp" {
+		t.Errorf("Payload[cwd] = %v, want %q", job.Payload["cwd"], "/tmp")
+	}
+}
+
+func TestWSSource_ConvertWSJob_PayloadFallbackType(t *testing.T) {
+	src := &WSSource{
+		config: WSSourceConfig{},
+	}
+
+	msg := redisapi.WSMessage{
+		Type:  "job",
+		Queue: "jobs:v1:gpu",
+		ID:    "1718000000001-0",
+		Data: map[string]string{
+			"jobId":   "job-uuid-456",
+			"type":    "", // Empty top-level type
+			"payload": `{"type":"llm_inference","model":"llama3"}`,
+		},
+	}
+
+	job, err := src.convertWSJob(msg)
+	if err != nil {
+		t.Fatalf("convertWSJob error: %v", err)
+	}
+
+	if job.Type != "llm_inference" {
+		t.Errorf("Type = %q, want %q (should fall back to payload type)", job.Type, "llm_inference")
+	}
+}
+
+func TestWSSource_ConvertWSJob_NilData(t *testing.T) {
+	src := &WSSource{
+		config: WSSourceConfig{},
+	}
+
+	msg := redisapi.WSMessage{
+		Type: "job",
+		ID:   "1718000000002-0",
+		Data: nil,
+	}
+
+	_, err := src.convertWSJob(msg)
+	if err == nil {
+		t.Error("convertWSJob should error on nil data")
+	}
+}
+
+func TestWSSource_ConvertWSJob_InvalidPayload(t *testing.T) {
+	src := &WSSource{
+		config: WSSourceConfig{},
+	}
+
+	msg := redisapi.WSMessage{
+		Type:  "job",
+		Queue: "jobs:v1:cpu-general",
+		ID:    "1718000000003-0",
+		Data: map[string]string{
+			"jobId":   "job-uuid-bad",
+			"type":    "SHELL_COMMAND",
+			"payload": "not-valid-json{{{",
+		},
+	}
+
+	_, err := src.convertWSJob(msg)
+	if err == nil {
+		t.Error("convertWSJob should error on invalid JSON payload")
+	}
+}
+
+func TestWSSource_AddQueue_Dedup(t *testing.T) {
+	src := NewWSSource(WSSourceConfig{
+		QueueNames: []string{"jobs:v1:cpu-general"},
+		// No client -- AddQueue will skip the sendConsume call (logged as warning)
+		LogFn: func(level, msg string) {}, // suppress output
+	})
+
+	// Add a new queue
+	src.AddQueue("jobs:v1:gpu")
+	queues := src.QueueNames()
+	if len(queues) != 2 {
+		t.Fatalf("QueueNames len = %d, want 2", len(queues))
+	}
+
+	// Add duplicate -- should be a no-op
+	src.AddQueue("jobs:v1:gpu")
+	queues = src.QueueNames()
+	if len(queues) != 2 {
+		t.Fatalf("QueueNames len = %d after dedup, want 2", len(queues))
+	}
+
+	// Add empty -- should be a no-op
+	src.AddQueue("")
+	queues = src.QueueNames()
+	if len(queues) != 2 {
+		t.Fatalf("QueueNames len = %d after empty add, want 2", len(queues))
+	}
+}
+
+func TestWSSource_AddQueue_ThreadSafe(t *testing.T) {
+	src := NewWSSource(WSSourceConfig{
+		QueueNames: []string{"jobs:v1:cpu-general"},
+		LogFn:      func(level, msg string) {},
+	})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			src.AddQueue("jobs:v1:q" + string(rune('A'+n%26)))
+		}(i)
+	}
+	wg.Wait()
+
+	queues := src.QueueNames()
+	// Should have 1 original + up to 26 unique queues (A-Z)
+	if len(queues) < 2 || len(queues) > 27 {
+		t.Errorf("QueueNames len = %d, expected between 2 and 27", len(queues))
+	}
+
+	// Verify no duplicates
+	seen := make(map[string]bool)
+	for _, q := range queues {
+		if seen[q] {
+			t.Errorf("Duplicate queue found: %s", q)
+		}
+		seen[q] = true
+	}
+}
+
+func TestWSSource_NextReturnsFromChannel(t *testing.T) {
+	src := NewWSSource(WSSourceConfig{
+		QueueNames: []string{"jobs:v1:cpu-general"},
+		LogFn:      func(level, msg string) {},
+	})
+
+	// Simulate a job arriving on the channel
+	testJob := &Job{
+		ID:          "test-123",
+		Type:        "SHELL_COMMAND",
+		Source:      "websocket",
+		SourceQueue: "jobs:v1:cpu-general",
+	}
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		src.jobs <- testJob
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	job, err := src.Next(ctx)
+	if err != nil {
+		t.Fatalf("Next error: %v", err)
+	}
+	if job == nil {
+		t.Fatal("Next returned nil job")
+	}
+	if job.ID != "test-123" {
+		t.Errorf("job.ID = %q, want %q", job.ID, "test-123")
+	}
+}
+
+func TestWSSource_NextCancelledContext(t *testing.T) {
+	src := NewWSSource(WSSourceConfig{
+		QueueNames: []string{"jobs:v1:cpu-general"},
+		LogFn:      func(level, msg string) {},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	_, err := src.Next(ctx)
+	if err == nil {
+		t.Fatal("Next should return error on cancelled context")
+	}
+}
+
+func TestWSSource_NextClosedSource(t *testing.T) {
+	src := NewWSSource(WSSourceConfig{
+		QueueNames: []string{"jobs:v1:cpu-general"},
+		LogFn:      func(level, msg string) {},
+	})
+
+	// Close the source
+	src.doneOnce.Do(func() {
+		close(src.done)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, err := src.Next(ctx)
+	if err == nil {
+		t.Fatal("Next should return error when source is closed")
+	}
+}
+
+func TestWSSource_Name(t *testing.T) {
+	src := NewWSSource(WSSourceConfig{})
+	if src.Name() != "websocket" {
+		t.Errorf("Name() = %q, want %q", src.Name(), "websocket")
+	}
+}
+
+func TestWSSource_DefaultConfig(t *testing.T) {
+	src := NewWSSource(WSSourceConfig{})
+
+	if src.config.ConsumerGroup != "citadel-workers" {
+		t.Errorf("ConsumerGroup = %q, want %q", src.config.ConsumerGroup, "citadel-workers")
+	}
+	if src.config.BlockMs != 5000 {
+		t.Errorf("BlockMs = %d, want %d", src.config.BlockMs, 5000)
+	}
+	queues := src.QueueNames()
+	if len(queues) != 1 || queues[0] != "jobs:v1:cpu-general" {
+		t.Errorf("default queue = %v, want [jobs:v1:cpu-general]", queues)
+	}
+}
+
+func TestWSSource_SingleQueueFallback(t *testing.T) {
+	src := NewWSSource(WSSourceConfig{
+		QueueName: "jobs:v1:my-queue",
+	})
+
+	queues := src.QueueNames()
+	if len(queues) != 1 || queues[0] != "jobs:v1:my-queue" {
+		t.Errorf("queue = %v, want [jobs:v1:my-queue]", queues)
+	}
+}
+
+func TestWSSource_MultiQueue(t *testing.T) {
+	src := NewWSSource(WSSourceConfig{
+		QueueName:  "ignored",
+		QueueNames: []string{"q1", "q2", "q3"},
+	})
+
+	queues := src.QueueNames()
+	if len(queues) != 3 {
+		t.Errorf("QueueNames len = %d, want 3", len(queues))
+	}
+}


### PR DESCRIPTION
## Context

Companion to aceteam-ai/aceteam#4112. Citadel HTTP polling generates ~138k requests/day from 4 devices, saturating Supabase connection pools. This adds a `WSSource` implementing the `JobSource` interface for server-pushed job delivery over the existing WebSocket connection.

## Summary

**`internal/worker/ws_source.go`** — Full `JobSource` implementation (~380 lines):
- Server pushes jobs via `consume` → `job` messages over existing WS connection
- Thread-safe queue list with `sync.RWMutex` for runtime `AddQueue`
- Buffered job channel (cap 16) for backpressure between WS readLoop and runner
- Reconnect callback re-sends `consume` with current queue list (survives connection drops)
- WebSocket-first ack with HTTP fallback when WS is disconnected
- Error/consuming/acked message handlers — no silent failures (#236/#3924 regression prevention)

**`internal/redisapi/websocket.go`** — WebSocket client extensions:
- `StartConsume`, `StopConsume`, `AckJob` methods for the consume protocol
- `OnReconnect` callback registry (fires AFTER releasing connMu to prevent deadlock)
- New `WSMessage` fields: Queue, Queues, Group, Consumer, Count, BlockMs, ID, MessageID, Data

**`internal/redisapi/jobs.go`** — Exported `ParseStreamMessage` for cross-package reuse

**Scope note**: WSSource is not yet wired into the runner selection path — that wiring is a follow-up for when the server-side consume handler is deployed.

## Test plan

- [x] 13 unit tests passing with `-race` flag
- [x] Job conversion with full field mapping
- [x] Payload fallback type (empty top-level → payload.type)
- [x] Nil data and invalid JSON rejection
- [x] AddQueue dedup + thread safety (100 goroutines)
- [x] Channel semantics: Next blocks, returns on job, cancels on context, errors on close
- [x] Default config values (consumer group, blockMs, queue)
- [x] Single-queue fallback and multi-queue mode
- [x] `go build ./...`, `go vet ./...` clean