### PR TITLE
Closes #286: bind terminal/VPN listeners to the node's VPN IP

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -387,13 +387,15 @@ func startTerminalServer(orgID string, activityFn func(level, msg string)) error
 
 	// Add VPN listener so the terminal server is reachable over the tsnet VPN.
 	// The TCP bind is localhost-only for security; external access comes through tsnet.
+	// Bind to the explicit assigned VPN IP (not ":port") so inbound connections from
+	// the platform relay are matched by tsnet. See network.ListenVPN and issue #286.
 	if network.IsGlobalConnected() {
-		vpnAddr := fmt.Sprintf(":%d", config.Port)
-		if vpnLn, err := network.Listen("tcp", vpnAddr); err != nil {
+		vpnPort := fmt.Sprintf("%d", config.Port)
+		if vpnLn, vpnIP, err := network.ListenVPN("tcp", vpnPort); err != nil {
 			Log("terminal server VPN listener failed (localhost-only): %v", err)
 		} else {
 			ccTerminalServer.AddListener(vpnLn)
-			Log("terminal server VPN listener on %s", vpnLn.Addr().String())
+			Log("terminal server VPN listener on %s:%s", vpnIP, vpnPort)
 		}
 	}
 
@@ -448,14 +450,16 @@ func startVNCServer() error {
 		FPS:  10,
 	})
 
-	// Add VPN listener so the VNC server is reachable over the tsnet VPN
+	// Add VPN listener so the VNC server is reachable over the tsnet VPN.
+	// Bind to the explicit assigned VPN IP (not ":port"); see network.ListenVPN
+	// and issue #286.
 	if network.IsGlobalConnected() {
-		vpnAddr := fmt.Sprintf(":%d", ccVNCPort)
-		if vpnLn, err := network.Listen("tcp", vpnAddr); err != nil {
+		vpnPort := fmt.Sprintf("%d", ccVNCPort)
+		if vpnLn, vpnIP, err := network.ListenVPN("tcp", vpnPort); err != nil {
 			Log("VNC server VPN listener failed (localhost-only): %v", err)
 		} else {
 			ccVNCServer.AddListener(vpnLn)
-			Log("VNC server VPN listener on %s", vpnLn.Addr().String())
+			Log("VNC server VPN listener on %s:%s", vpnIP, vpnPort)
 		}
 	}
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -172,14 +172,18 @@ func runServe(cmd *cobra.Command, args []string) error {
 	// clients connecting over the VPN get the same TLS termination.
 	var vpnGatewayListener net.Listener
 	if network.IsGlobalConnected() {
-		vpnAddr := fmt.Sprintf(":%d", servePort)
-		rawLn, err := network.Listen("tcp", vpnAddr)
+		vpnPort := fmt.Sprintf("%d", servePort)
+		rawLn, vpnIP, err := network.ListenVPN("tcp", vpnPort)
 		if err != nil {
-			Debug("gateway VPN listener failed (LAN-only): %v", err)
-		} else if tlsConfig != nil {
-			vpnGatewayListener = tls.NewListener(rawLn, tlsConfig)
+			Log("gateway VPN listener failed (LAN-only): %v", err)
+			fmt.Fprintf(os.Stderr, "   - ⚠️ Gateway VPN listener failed (LAN-only): %v\n", err)
 		} else {
-			vpnGatewayListener = rawLn
+			if tlsConfig != nil {
+				vpnGatewayListener = tls.NewListener(rawLn, tlsConfig)
+			} else {
+				vpnGatewayListener = rawLn
+			}
+			Log("gateway VPN listener on %s:%s", vpnIP, vpnPort)
 		}
 	}
 

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -20,11 +20,11 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/capabilities"
 	"github.com/aceteam-ai/citadel-cli/internal/config"
 	"github.com/aceteam-ai/citadel-cli/internal/gateway"
-	"github.com/aceteam-ai/citadel-cli/internal/provision"
 	"github.com/aceteam-ai/citadel-cli/internal/heartbeat"
 	"github.com/aceteam-ai/citadel-cli/internal/network"
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
+	"github.com/aceteam-ai/citadel-cli/internal/provision"
 	"github.com/aceteam-ai/citadel-cli/internal/redisapi"
 	internalServices "github.com/aceteam-ai/citadel-cli/internal/services"
 	"github.com/aceteam-ai/citadel-cli/internal/status"
@@ -824,14 +824,18 @@ func runWork(cmd *cobra.Command, args []string) {
 			wfServer.RegisterRoutes(mux, auth)
 		})
 
-		// Add VPN listener so the status server is reachable over the tsnet VPN
+		// Add VPN listener so the status server is reachable over the tsnet VPN.
+		// Bind to the explicit assigned VPN IP (not ":port"); see network.ListenVPN
+		// and issue #286.
 		if network.IsGlobalConnected() {
-			vpnAddr := fmt.Sprintf(":%d", workStatusPort)
-			if vpnLn, err := network.Listen("tcp", vpnAddr); err != nil {
-				Debug("status server VPN listener failed (LAN-only): %v", err)
+			vpnPort := fmt.Sprintf("%d", workStatusPort)
+			if vpnLn, vpnIP, err := network.ListenVPN("tcp", vpnPort); err != nil {
+				Log("status server VPN listener failed (LAN-only): %v", err)
+				fmt.Fprintf(os.Stderr, "   - ⚠️ Status server VPN listener failed (LAN-only): %v\n", err)
 			} else {
 				statusServer.AddListener(vpnLn)
-				fmt.Printf("   - Status server VPN: http://<vpn-ip>:%d\n", workStatusPort)
+				Log("status server VPN listener on %s:%s", vpnIP, vpnPort)
+				fmt.Printf("   - Status server VPN: http://%s:%d\n", vpnIP, workStatusPort)
 			}
 		}
 
@@ -1069,14 +1073,22 @@ func runWork(cmd *cobra.Command, args []string) {
 
 				termServer := terminal.NewServer(termConfig, cachingAuth)
 
-				// Add VPN listener so the terminal server is reachable over the tsnet VPN
+				// Add VPN listener so the terminal server is reachable over the tsnet VPN.
+				// Bind to the explicit assigned VPN IP (not ":port") so inbound
+				// connections from the platform relay (which dials ws://<vpn_ip>:7860)
+				// are matched by tsnet. See network.ListenVPN and issue #286.
 				if network.IsGlobalConnected() {
-					vpnAddr := fmt.Sprintf(":%d", termConfig.Port)
-					if vpnLn, err := network.Listen("tcp", vpnAddr); err != nil {
-						Debug("terminal server VPN listener failed (LAN-only): %v", err)
+					vpnPort := fmt.Sprintf("%d", termConfig.Port)
+					if vpnLn, vpnIP, err := network.ListenVPN("tcp", vpnPort); err != nil {
+						// Loud (not Debug): if the terminal server cannot bind to the
+						// VPN IP it is unreachable for the mobile/relay terminal even
+						// though localhost works, which is hard to diagnose otherwise.
+						Log("terminal server VPN listener failed (LAN-only): %v", err)
+						fmt.Fprintf(os.Stderr, "   - ⚠️ Terminal server VPN listener failed (LAN-only): %v\n", err)
 					} else {
 						termServer.AddListener(vpnLn)
-						fmt.Printf("   - Terminal server VPN: ws://<vpn-ip>:%d/terminal\n", termConfig.Port)
+						Log("terminal server VPN listener on %s:%s", vpnIP, vpnPort)
+						fmt.Printf("   - Terminal server VPN: ws://%s:%d/terminal\n", vpnIP, termConfig.Port)
 					}
 				}
 
@@ -1214,12 +1226,15 @@ func runWork(cmd *cobra.Command, args []string) {
 			WebSocket:   true,
 		})
 
-		// Add VPN listener (TLS-wrapped) so the gateway is reachable over tsnet
+		// Add VPN listener (TLS-wrapped) so the gateway is reachable over tsnet.
+		// Bind to the explicit assigned VPN IP (not ":port"); see network.ListenVPN
+		// and issue #286.
 		if network.IsGlobalConnected() {
-			vpnAddr := fmt.Sprintf(":%d", workGatewayPort)
-			rawLn, err := network.Listen("tcp", vpnAddr)
+			vpnPort := fmt.Sprintf("%d", workGatewayPort)
+			rawLn, vpnIP, err := network.ListenVPN("tcp", vpnPort)
 			if err != nil {
-				Debug("gateway VPN listener failed (LAN-only): %v", err)
+				Log("gateway VPN listener failed (LAN-only): %v", err)
+				fmt.Fprintf(os.Stderr, "   - ⚠️ Gateway VPN listener failed (LAN-only): %v\n", err)
 			} else {
 				var vpnGwLn net.Listener
 				if gwTLSConfig != nil {
@@ -1228,6 +1243,7 @@ func runWork(cmd *cobra.Command, args []string) {
 					vpnGwLn = rawLn
 				}
 				gw.AddListener(vpnGwLn)
+				Log("gateway VPN listener on %s:%s", vpnIP, vpnPort)
 			}
 		}
 

--- a/internal/network/singleton.go
+++ b/internal/network/singleton.go
@@ -222,6 +222,59 @@ func Listen(network, addr string) (net.Listener, error) {
 	return s.Listen(network, addr)
 }
 
+// ListenVPN creates a tsnet listener bound to this node's assigned VPN (tailnet)
+// IPv4 address on the given port, returning both the listener and the IP it bound
+// to so callers can log it.
+//
+// It must be used instead of Listen(":port") for services that need to be
+// reachable at the node's VPN IP (e.g. the terminal, status, and gateway servers
+// that the platform relay dials at ws://<vpn_ip>:<port>).
+//
+// Root cause this addresses (see issue #286): tsnet matches an inbound connection
+// to a listener by destination address. A listener opened with an empty host
+// (":port") registers under listenKey{addr: <zero>} and is only matched when the
+// connection's destination equals one of s.TailscaleIPs() *at connect time*
+// (tsnet's listenerForDstAddr conditional fallback). A listener opened with the
+// explicit assigned IP registers under listenKey{addr: <ip>} and is matched
+// unconditionally on the first lookup. tsnet's own docs instruct callers to
+// "explicitly specify the listening address." Binding explicitly makes the VPN
+// listener reliably reachable at the node's VPN IP.
+//
+// Because the tailnet IP may not be assigned the instant the backend reports
+// "Running", this waits up to a bounded timeout for GetIPv4() to return a valid
+// address before binding.
+func ListenVPN(network, port string) (net.Listener, string, error) {
+	s := Global()
+	if s == nil {
+		return nil, "", fmt.Errorf("not connected to AceTeam Network")
+	}
+
+	// Wait (bounded) for the tailnet IPv4 to be assigned. A working connection
+	// assigns the IP within a second or two; the timeout guards against a node
+	// that reported Running but has not yet received its netmap.
+	const ipWaitTimeout = 15 * time.Second
+	deadline := time.Now().Add(ipWaitTimeout)
+	var ip4 string
+	for {
+		v, err := s.GetIPv4()
+		if err == nil && v != "" {
+			ip4 = v
+			break
+		}
+		if time.Now().After(deadline) {
+			return nil, "", fmt.Errorf("timed out waiting for VPN IPv4 assignment: %w", err)
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+
+	bindAddr := net.JoinHostPort(ip4, port)
+	ln, err := s.Listen(network, bindAddr)
+	if err != nil {
+		return nil, ip4, fmt.Errorf("listen on %s: %w", bindAddr, err)
+	}
+	return ln, ip4, nil
+}
+
 // VerifyOrReconnect checks connection and reconnects if state exists but not connected.
 // Returns (connected, error). No error if simply not logged in.
 //

--- a/internal/network/singleton_test.go
+++ b/internal/network/singleton_test.go
@@ -137,6 +137,27 @@ func TestGetGlobalNodeIDWhenNotConnected(t *testing.T) {
 	}
 }
 
+// TestListenVPNWhenNotConnected verifies ListenVPN fails cleanly (no panic,
+// no nil-pointer deref) when there is no global network server. This is the
+// guarded path callers rely on before adding the VPN listener.
+func TestListenVPNWhenNotConnected(t *testing.T) {
+	ClearGlobal()
+
+	ln, ip, err := ListenVPN("tcp", "7860")
+	if err == nil {
+		if ln != nil {
+			_ = ln.Close()
+		}
+		t.Fatal("ListenVPN() = nil error, want error when not connected to network")
+	}
+	if ln != nil {
+		t.Errorf("ListenVPN() listener = %v, want nil on error", ln)
+	}
+	if ip != "" {
+		t.Errorf("ListenVPN() ip = %q, want empty string on error", ip)
+	}
+}
+
 // TestNetworkStatusNodeIDField verifies the NodeID field exists on NetworkStatus.
 func TestNetworkStatusNodeIDField(t *testing.T) {
 	status := NetworkStatus{

--- a/internal/tui/controlcenter/actions.go
+++ b/internal/tui/controlcenter/actions.go
@@ -21,7 +21,6 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/recommend"
 )
 
-
 // showListModal displays a modal with a list of items and calls onSelect when one is chosen.
 func (cc *ControlCenter) showListModal(title string, items []string, onSelect func(selected string)) {
 	if len(items) == 0 {
@@ -447,13 +446,15 @@ func (cc *ControlCenter) showExposePortModal() {
 func (cc *ControlCenter) exposePort(port int, description string) {
 	cc.AddActivity("info", fmt.Sprintf("Exposing port %d...", port))
 
-	// Create a listener on the network
-	addr := fmt.Sprintf(":%d", port)
-	listener, err := network.Listen("tcp", addr)
+	// Create a listener on the network, bound to the explicit assigned VPN IP
+	// (not ":port") so peers dialing <vpn_ip>:port are matched by tsnet.
+	// See network.ListenVPN and issue #286.
+	listener, vpnIP, err := network.ListenVPN("tcp", fmt.Sprintf("%d", port))
 	if err != nil {
 		cc.AddActivity("error", fmt.Sprintf("Failed to expose port %d: %v", port, err))
 		return
 	}
+	cc.AddActivity("info", fmt.Sprintf("Port %d exposed on %s", port, vpnIP))
 
 	// Track the forward
 	forward := PortForward{
@@ -857,7 +858,6 @@ func isServiceInstalled() bool {
 	}
 	return false
 }
-
 
 // showNetworkingModal shows a combined panel for Expose Port, Port Forwards, and SSH Access.
 func (cc *ControlCenter) showNetworkingModal() {


### PR DESCRIPTION
## Context

This unblocks the Android/iOS terminal round-trip (aceteam-ai/aceteam#4111, #3492). The platform terminal relay dials the node's **VPN IP** (`ws://<vpn_ip>:7860/terminal`). Verifying #4111 against prod surfaced the failure: on node `ubuntu-gpu-5zzi8pae` (citadel v2.42.0, VPN IP `100.64.0.18`) the terminal server answered on `127.0.0.1:7860` but **not** on `100.64.0.18:7860`, so the relay's upstream connect failed and the mobile terminal got a generic connection error after the WS upgrade.

The dual-listen code from #164/#165 (shipped v2.30.0, so present in v2.42.0) was already trying to expose the terminal over tsnet, but it was silently falling back to LAN-only.

**Live reproduction (from a mesh peer):** `100.64.0.18` is pingable over the mesh (~2–9ms, online) yet `curl http://100.64.0.18:7860/health` returns `000` (no listener). The node's own `citadel_logs`/`citadel_node_info` MCP calls also fail with a SOCKS proxy error — they proxy *into* the node's tsnet HTTP endpoint, the exact path that is broken — while DB-backed heartbeat reads (`fabric_node_status`) and control-plane reads (`nexus_get_node`) succeed. That asymmetry confirms: inbound-to-node tsnet HTTP is dead; outbound/heartbeat is fine.

## Root cause

The VPN listener was opened with an **empty host** (`network.Listen("tcp", ":7860")`). In tsnet, an inbound connection is matched to a listener by destination address (`tsnet/tsnet.go` `listenerForDstAddr`):

- An **empty-host** listener registers under `listenKey{addr: <zero>, port}` and is only matched via the **conditional fallback**: `dst.Addr()` must equal one of `s.TailscaleIPs()` at connect time.
- An **explicit-IP** listener registers under `listenKey{addr: <ip>, port}` and is matched **unconditionally on the first lookup**.

tsnet's own docs say: *"Listeners which do not specify an IP address will match for traffic for the local node ... only. ... explicitly specify the listening address."* The empty-host binding meant `Listen()` could return success (and the controlcenter path even logged "VPN listener on :7860") while the listener never actually served at the node's VPN IP. On the `citadel work` path the failure was doubly invisible because it was logged at `Debug` level (suppressed by default) — hence "silently LAN-only."

> Note: this is a *match-semantics* bug, not a startup race. A listen-time race would self-heal once the netmap populated; the failure on `.18` is persistent (`curl → 000` hours later), consistent with the empty-host listener never being matched at the dialed IP.

## Summary

- **`internal/network/singleton.go` — new `ListenVPN(network, port)`**: waits (bounded, 15s) for the tailnet IPv4 to be assigned via `GetIPv4()`, then binds to `net.JoinHostPort(ip4, port)` so the listener registers under the explicit-IP `listenKey` and is matched unconditionally. Returns the bound IP so callers can log it.
- **Wired into every VPN listener site**: `work.go` (terminal, status, gateway), `serve.go` (gateway), `controlcenter.go` (terminal, VNC), and the TUI `exposePort`.
- **No more silent failure**: the `work.go` terminal/status/gateway paths promoted their swallowed `Debug` failure log to a loud `Log` + stderr warning, and every success path now logs the **actual bound IP** (e.g. `terminal server VPN listener on 100.64.0.18:7860`). A deployed node now self-reports whether it bound the right VPN IP.
- The LAN (`127.0.0.1`) listener is unchanged and still added.

## Test plan

| Check | Result |
| --- | --- |
| `go build ./...` | pass |
| `go vet ./...` | pass |
| `go test ./...` | pass (0 failures) |
| New `TestListenVPNWhenNotConnected` | pass — `ListenVPN` fails cleanly (no panic / nil deref) when not connected |
| Live: `ping 100.64.0.18` | reachable over mesh |
| Live: `curl http://100.64.0.18:7860/health` (old binary on node) | `000` — reproduces the bug |
| tsnet source (`tailscale.com@v1.94.0`) | confirms empty-host vs explicit-IP match semantics (`tsnet.go:976` unconditional vs `tsnet.go:983` conditional) |

**Full terminal round-trip re-verification requires deploying this binary to the node.** The fix could not be bind-verified live: the reproduction was on a multi-identity box (kernel `tailscale0` at `.15` *and* a citadel tsnet identity), and rebinding the live node's tsnet would have required disrupting the running production node (kill/re-init/wipe `~/citadel-node/network/`), which was explicitly avoided. Once deployed, the new loud log line confirms the bound VPN IP, and the mobile terminal round-trip can be re-confirmed end-to-end.

## Related

- aceteam-ai/aceteam#4111 (terminal round-trip being verified when this surfaced)
- aceteam-ai/aceteam#3492 (Android/iOS terminal)
- Prior art: #164 / #165 (original dual-listen)