### PR TITLE
fix: make iOS keychain creation idempotent (#285)

### DIFF
--- a/internal/provision/mobile/mobile.go
+++ b/internal/provision/mobile/mobile.go
@@ -44,6 +44,10 @@ type Step struct {
 	// SecretArgs lists indices into Args whose values are sensitive (e.g. a
 	// keychain or certificate password) and must be redacted in dry-run output.
 	SecretArgs []int
+	// AllowedExitCodes lists non-zero exit codes that the runner should treat
+	// as success for this step. For example, `security create-keychain` returns
+	// exit code 48 when the keychain already exists.
+	AllowedExitCodes []int
 	// SrcPath and DstPath apply to StepCopyFile.
 	SrcPath string
 	DstPath string
@@ -129,6 +133,10 @@ func DefaultProfilesDir(home string) string {
 // securityBin is the macOS keychain management binary.
 const securityBin = "security"
 
+// exitCodeKeychainExists is the exit code returned by `security create-keychain`
+// when the keychain file already exists on disk.
+const exitCodeKeychainExists = 48
+
 // BuildIOSSteps turns IOSOptions into an ordered provisioning plan. It performs
 // validation of required fields and existence checks for supplied paths, but it
 // does not execute anything. Returns an error for invalid input.
@@ -169,11 +177,12 @@ func BuildIOSSteps(opts IOSOptions) ([]Step, error) {
 
 	steps := []Step{
 		{
-			Kind:       StepExec,
-			Desc:       fmt.Sprintf("Create build keychain %q (ignored if it already exists)", kc),
-			Name:       securityBin,
-			Args:       []string{"create-keychain", "-p", pw, kc},
-			SecretArgs: []int{2}, // password
+			Kind:             StepExec,
+			Desc:             fmt.Sprintf("Create build keychain %q (ignored if it already exists)", kc),
+			Name:             securityBin,
+			Args:             []string{"create-keychain", "-p", pw, kc},
+			SecretArgs:       []int{2}, // password
+			AllowedExitCodes: []int{exitCodeKeychainExists},
 		},
 		{
 			Kind:       StepExec,

--- a/internal/provision/mobile/mobile_test.go
+++ b/internal/provision/mobile/mobile_test.go
@@ -153,6 +153,27 @@ func TestBuildIOSSteps_NoCertNoProfile(t *testing.T) {
 	}
 }
 
+func TestBuildIOSSteps_CreateKeychainToleratesExitCode48(t *testing.T) {
+	steps, err := BuildIOSSteps(IOSOptions{KeychainName: "kc", KeychainPassword: "pw"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// First step is always create-keychain.
+	create := steps[0]
+	if create.Args[0] != "create-keychain" {
+		t.Fatalf("step 0 is %q, want create-keychain", create.Args[0])
+	}
+	if len(create.AllowedExitCodes) != 1 || create.AllowedExitCodes[0] != exitCodeKeychainExists {
+		t.Errorf("create-keychain AllowedExitCodes = %v, want [%d]", create.AllowedExitCodes, exitCodeKeychainExists)
+	}
+	// Other steps must not have AllowedExitCodes.
+	for i, s := range steps[1:] {
+		if len(s.AllowedExitCodes) != 0 {
+			t.Errorf("step %d (%s) has unexpected AllowedExitCodes: %v", i+1, s.Args[0], s.AllowedExitCodes)
+		}
+	}
+}
+
 func TestIOSSteps_RedactsSecrets(t *testing.T) {
 	cert := writeTemp(t, "dist.p12")
 	steps, err := BuildIOSSteps(IOSOptions{

--- a/internal/provision/mobile/runner.go
+++ b/internal/provision/mobile/runner.go
@@ -2,13 +2,19 @@ package mobile
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"time"
 )
+
+// exitCoder is satisfied by *exec.ExitError and test fakes, allowing the runner
+// to extract exit codes without depending on concrete exec types.
+type exitCoder interface{ ExitCode() int }
 
 // stepTimeout caps a single provisioning step. sdkmanager --licenses and
 // keychain imports are quick; the cap guards against a hung interactive prompt.
@@ -73,6 +79,11 @@ func (r *Runner) runExec(step Step) error {
 		fmt.Fprintf(r.Out, "%s", out)
 	}
 	if err != nil {
+		var ec exitCoder
+		if errors.As(err, &ec) && len(step.AllowedExitCodes) > 0 && slices.Contains(step.AllowedExitCodes, ec.ExitCode()) {
+			fmt.Fprintf(r.Out, "      (exit code %d tolerated)\n", ec.ExitCode())
+			return nil
+		}
 		return fmt.Errorf("%s failed: %w", step.Name, err)
 	}
 	return nil

--- a/internal/provision/mobile/runner_test.go
+++ b/internal/provision/mobile/runner_test.go
@@ -118,6 +118,85 @@ func TestRunner_StopsOnFirstError(t *testing.T) {
 	}
 }
 
+// fakeExitError is a test fake satisfying the exitCoder interface.
+type fakeExitError struct {
+	code int
+	msg  string
+}
+
+func (e *fakeExitError) Error() string { return e.msg }
+func (e *fakeExitError) ExitCode() int { return e.code }
+
+func TestRunner_ToleratesAllowedExitCode(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewRunner(false, &buf)
+	r.execCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		return []byte("keychain already exists\n"), &fakeExitError{code: 48, msg: "exit status 48"}
+	}
+
+	steps := []Step{
+		{
+			Kind:             StepExec,
+			Desc:             "Create keychain (tolerate 48)",
+			Name:             "security",
+			Args:             []string{"create-keychain", "-p", "pw", "kc"},
+			AllowedExitCodes: []int{48},
+		},
+	}
+	if err := r.Run(steps); err != nil {
+		t.Fatalf("expected success when exit code is allowed, got: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "exit code 48 tolerated") {
+		t.Errorf("expected tolerance note in output, got:\n%s", out)
+	}
+}
+
+func TestRunner_RejectsUnallowedExitCode(t *testing.T) {
+	r := NewRunner(false, &bytes.Buffer{})
+	r.execCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		return nil, &fakeExitError{code: 1, msg: "exit status 1"}
+	}
+
+	steps := []Step{
+		{
+			Kind:             StepExec,
+			Desc:             "Create keychain (only 48 allowed)",
+			Name:             "security",
+			Args:             []string{"create-keychain", "-p", "pw", "kc"},
+			AllowedExitCodes: []int{48},
+		},
+	}
+	err := r.Run(steps)
+	if err == nil {
+		t.Fatal("expected error for non-allowed exit code, got nil")
+	}
+	if !strings.Contains(err.Error(), "security failed") {
+		t.Errorf("error = %q, want substring %q", err, "security failed")
+	}
+}
+
+func TestRunner_NoAllowedExitCodesStillFails(t *testing.T) {
+	r := NewRunner(false, &bytes.Buffer{})
+	r.execCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		return nil, &fakeExitError{code: 48, msg: "exit status 48"}
+	}
+
+	steps := []Step{
+		{
+			Kind: StepExec,
+			Desc: "No allowed codes set",
+			Name: "security",
+			Args: []string{"create-keychain", "-p", "pw", "kc"},
+			// AllowedExitCodes intentionally empty
+		},
+	}
+	err := r.Run(steps)
+	if err == nil {
+		t.Fatal("expected error when AllowedExitCodes is empty, got nil")
+	}
+}
+
 func TestDefaultCopyFile(t *testing.T) {
 	dir := t.TempDir()
 	src := filepath.Join(dir, "src.mobileprovision")


### PR DESCRIPTION
## Context

`citadel provision ios` fails on re-run because `security create-keychain` returns exit code 48 when the keychain already exists. The step description says "ignored if it already exists" but the runner treats any non-zero exit as fatal. Found during hardware testing on MBP M1 Pro (macOS 26.3.1).

## Summary

- **`AllowedExitCodes` field on `Step`** — generic mechanism for tolerating known-benign exit codes without violating builder purity (builders stay data-only, no side effects)
- **Exit code 48 tolerated on create-keychain** — the runner checks `errors.As` for `exitCoder` interface, prints "(exit code 48 tolerated)" note, and continues
- **4 new tests** — builder test verifying only create-keychain has AllowedExitCodes; 3 runner tests (tolerate, reject, empty-list)

## Test plan

| Test | Coverage |
|------|----------|
| `TestBuildIOSSteps_CreateKeychainToleratesExitCode48` | Builder sets AllowedExitCodes only on create-keychain |
| `TestRunner_ToleratesAllowedExitCode` | Exit 48 + AllowedExitCodes=[48] → success |
| `TestRunner_RejectsUnallowedExitCode` | Exit 1 + AllowedExitCodes=[48] → error |
| `TestRunner_NoAllowedExitCodesStillFails` | Exit 48 + empty AllowedExitCodes → error |

Closes #285.