### PR TITLE
fix: use $DISPLAY env var instead of hardcoded :0 for VNC (#287)

### DIFF
--- a/internal/platform/vnc.go
+++ b/internal/platform/vnc.go
@@ -614,7 +614,8 @@ func (l *LinuxVNCManager) Start() error {
 }
 
 // buildX11VNCArgs constructs the x11vnc command-line arguments.
-// This is a pure function extracted for testability.
+// Reads $DISPLAY from the environment when an auth file is provided;
+// falls back to ":0" when $DISPLAY is unset.
 func buildX11VNCArgs(passwdFile string, port int, authFile string) []string {
 	args := []string{
 		"-rfbauth", passwdFile,
@@ -625,8 +626,13 @@ func buildX11VNCArgs(passwdFile string, port int, authFile string) []string {
 
 	if authFile != "" {
 		// An explicit auth file was found -- use it directly.
-		// Also specify -display :0 since we know the target display.
-		args = append([]string{"-display", ":0"}, args...)
+		// Use the DISPLAY env var so we target the correct X11
+		// display (e.g. :1 on GDM3 systems) instead of assuming :0.
+		display := os.Getenv("DISPLAY")
+		if display == "" {
+			display = ":0"
+		}
+		args = append([]string{"-display", display}, args...)
 		args = append(args, "-auth", authFile)
 	} else {
 		// No auth file found -- let x11vnc auto-discover the display

--- a/internal/platform/vnc_test.go
+++ b/internal/platform/vnc_test.go
@@ -323,6 +323,7 @@ func TestDefaultVNCPort(t *testing.T) {
 func TestBuildX11VNCArgs(t *testing.T) {
 	tests := []struct {
 		name       string
+		display    string // value to set for $DISPLAY (empty string clears it)
 		passwdFile string
 		port       int
 		authFile   string
@@ -330,7 +331,8 @@ func TestBuildX11VNCArgs(t *testing.T) {
 		notWant    []string
 	}{
 		{
-			name:       "with explicit auth file",
+			name:       "with explicit auth file and DISPLAY :0",
+			display:    ":0",
 			passwdFile: "/home/user/.vnc/passwd",
 			port:       5900,
 			authFile:   "/home/user/.Xauthority",
@@ -338,15 +340,26 @@ func TestBuildX11VNCArgs(t *testing.T) {
 			notWant:    []string{"-find"},
 		},
 		{
-			name:       "with DM auth file",
+			name:       "with DM auth file uses DISPLAY from env (#287)",
+			display:    ":1",
 			passwdFile: "/home/user/.vnc/passwd",
 			port:       5901,
+			authFile:   "/run/user/120/gdm/Xauthority",
+			wantArgs:   []string{"-display", ":1", "-auth", "/run/user/120/gdm/Xauthority", "-rfbport", "5901"},
+			notWant:    []string{"-find"},
+		},
+		{
+			name:       "falls back to :0 when DISPLAY is unset",
+			display:    "",
+			passwdFile: "/home/user/.vnc/passwd",
+			port:       5900,
 			authFile:   "/var/run/lightdm/root/:0",
-			wantArgs:   []string{"-display", ":0", "-auth", "/var/run/lightdm/root/:0", "-rfbport", "5901"},
+			wantArgs:   []string{"-display", ":0", "-auth", "/var/run/lightdm/root/:0"},
 			notWant:    []string{"-find"},
 		},
 		{
 			name:       "auto-discover with -find when no auth file",
+			display:    ":0",
 			passwdFile: "/home/user/.vnc/passwd",
 			port:       5900,
 			authFile:   "",
@@ -355,6 +368,7 @@ func TestBuildX11VNCArgs(t *testing.T) {
 		},
 		{
 			name:       "custom port",
+			display:    ":0",
 			passwdFile: "/root/.vnc/passwd",
 			port:       5910,
 			authFile:   "/root/.Xauthority",
@@ -364,6 +378,7 @@ func TestBuildX11VNCArgs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("DISPLAY", tt.display)
 			args := buildX11VNCArgs(tt.passwdFile, tt.port, tt.authFile)
 			argStr := strings.Join(args, " ")
 
@@ -393,6 +408,7 @@ func TestBuildX11VNCArgs(t *testing.T) {
 
 func TestBuildX11VNCArgsOrder(t *testing.T) {
 	// When using -find, it should be the first argument
+	t.Setenv("DISPLAY", ":0")
 	args := buildX11VNCArgs("/home/user/.vnc/passwd", 5900, "")
 	if len(args) == 0 {
 		t.Fatal("buildX11VNCArgs() returned empty args")


### PR DESCRIPTION
## Context

`citadel vnc enable` on Linux hardcoded `-display :0` when an X auth file was found. On Ubuntu with GDM3 (and other display managers), the display is `:1`, causing `XOpenDisplay(":0") failed`. Found during hardware testing on ubuntu-gpu (Proxmox VM).

## Summary

- **Read `$DISPLAY` from env** — `buildX11VNCArgs` now uses `os.Getenv("DISPLAY")` when an auth file is present, with `:0` fallback when unset
- **Regression test for GDM3** — new test case "with DM auth file uses DISPLAY from env (#287)" sets `DISPLAY=:1` and asserts `-display :1`
- **Deterministic tests** — all `TestBuildX11VNCArgs` subtests now use `t.Setenv` to control `$DISPLAY`

## Test plan

| Test | Coverage |
|------|----------|
| `with DM auth file uses DISPLAY from env` | DISPLAY=:1 → `-display :1` (the bug) |
| `falls back to :0 when DISPLAY is unset` | Empty DISPLAY → `-display :0` |
| `with explicit auth file and DISPLAY :0` | DISPLAY=:0 → `-display :0` (existing behavior) |
| All existing subtests | Deterministic via t.Setenv |

Closes #287.