### PR TITLE
Fix Console rendering of ESC(B charset escapes and CR (Closes #292)

### DIFF
--- a/internal/tui/controlcenter/console_filter.go
+++ b/internal/tui/controlcenter/console_filter.go
@@ -1,0 +1,98 @@
+package controlcenter
+
+// consoleFilter pre-processes raw PTY bytes before they reach tview's
+// line-oriented ANSIWriter. tview's ANSI parser understands CSI (ESC[...)
+// and OSC (ESC]...) sequences but silently drops the ESC of the
+// charset-designation family (ESC ( x, ESC ) x, ESC * x, ESC + x) without
+// consuming the trailing final byte, so the final byte (commonly "B" for
+// US-ASCII or "0" for DEC graphics) leaks into the view as literal text
+// (e.g. "BjasonB@Bubuntu-gpuB"). It also strips carriage returns, which
+// the line-oriented view would otherwise render as a stray control glyph.
+//
+// The filter is stateful across calls so that escape sequences and CRLF
+// pairs that straddle a read boundary (the PTY is read in fixed-size
+// chunks) are handled correctly. A single consoleFilter belongs to one
+// session's read loop, so no additional locking is required.
+//
+// Only CSI/OSC-style sequences relevant to coloring are passed through
+// untouched; the charset-designation family is consumed and discarded.
+type consoleFilter struct {
+	// pending holds a partial, unresolved prefix carried over from the end
+	// of the previous chunk. It is one of:
+	//   - empty: no carry
+	//   - [ESC]: a dangling escape whose next byte is not yet known
+	//   - [ESC, intermediate]: a charset designator awaiting its final byte
+	//   - ['\r']: a carriage return awaiting a possible following '\n'
+	pending []byte
+}
+
+const escByte = 0x1b
+
+// isCharsetIntermediate reports whether b is one of the charset-designation
+// intermediate bytes that follow ESC: '(' G0, ')' G1, '*' G2, '+' G3.
+func isCharsetIntermediate(b byte) bool {
+	return b == '(' || b == ')' || b == '*' || b == '+'
+}
+
+// filter processes a chunk of raw PTY bytes, stripping charset-designation
+// escape sequences and carriage returns, and returns the bytes safe to hand
+// to tview's ANSIWriter. Any trailing partial sequence is retained in the
+// filter and resolved on the next call.
+func (f *consoleFilter) filter(input []byte) []byte {
+	out := make([]byte, 0, len(input)+len(f.pending))
+
+	// Resume from any carried-over prefix by prepending it to the work.
+	work := input
+	if len(f.pending) > 0 {
+		work = append(append(make([]byte, 0, len(f.pending)+len(input)), f.pending...), input...)
+		f.pending = nil
+	}
+
+	i := 0
+	for i < len(work) {
+		b := work[i]
+
+		switch {
+		case b == '\r':
+			// Drop carriage returns. A following '\n' (the common CRLF
+			// line ending) still produces the line break on its own. If
+			// the '\r' is the final byte, carry it so we don't mistakenly
+			// emit anything before knowing what follows.
+			if i == len(work)-1 {
+				f.pending = []byte{'\r'}
+				return out
+			}
+			i++
+
+		case b == escByte:
+			// Need at least one more byte to classify the escape.
+			if i+1 >= len(work) {
+				f.pending = []byte{escByte}
+				return out
+			}
+			next := work[i+1]
+			if isCharsetIntermediate(next) {
+				// Charset designation: ESC, intermediate, final byte.
+				// Consume all three and emit nothing.
+				if i+2 >= len(work) {
+					// Final byte not yet available; carry ESC+intermediate.
+					f.pending = []byte{escByte, next}
+					return out
+				}
+				i += 3
+			} else {
+				// Any other escape (CSI '[', OSC ']', etc.) is left for
+				// tview's ANSIWriter to interpret. Emit the ESC and let
+				// normal copying continue with the next byte.
+				out = append(out, b)
+				i++
+			}
+
+		default:
+			out = append(out, b)
+			i++
+		}
+	}
+
+	return out
+}

--- a/internal/tui/controlcenter/console_filter_test.go
+++ b/internal/tui/controlcenter/console_filter_test.go
@@ -1,0 +1,106 @@
+package controlcenter
+
+import "testing"
+
+// filterString is a test helper that runs the filter over a single chunk.
+func filterString(f *consoleFilter, s string) string {
+	return string(f.filter([]byte(s)))
+}
+
+func TestConsoleFilterStripsCharsetDesignation(t *testing.T) {
+	var f consoleFilter
+	// The reported bug: ESC(B (designate G0 = US-ASCII) leaks its final "B".
+	got := filterString(&f, "\x1b(Bjason\x1b(B@host")
+	want := "jason@host"
+	if got != want {
+		t.Errorf("filter = %q, want %q", got, want)
+	}
+}
+
+func TestConsoleFilterAllCharsetIntermediates(t *testing.T) {
+	var f consoleFilter
+	// ESC ( ) * + each followed by a final byte must all be consumed.
+	got := filterString(&f, "a\x1b(Bb\x1b)0c\x1b*Ad\x1b+Be")
+	want := "abcde"
+	if got != want {
+		t.Errorf("filter = %q, want %q", got, want)
+	}
+}
+
+func TestConsoleFilterSplitAcrossChunks(t *testing.T) {
+	var f consoleFilter
+	// ESC( at the tail of one chunk, B at the head of the next.
+	if got := filterString(&f, "\x1b("); got != "" {
+		t.Errorf("first chunk = %q, want empty", got)
+	}
+	if got := filterString(&f, "Bjason"); got != "jason" {
+		t.Errorf("second chunk = %q, want %q", got, "jason")
+	}
+}
+
+func TestConsoleFilterSplitEscOnly(t *testing.T) {
+	var f consoleFilter
+	// Lone ESC at end of chunk, then intermediate+final next chunk.
+	if got := filterString(&f, "hi\x1b"); got != "hi" {
+		t.Errorf("first chunk = %q, want %q", got, "hi")
+	}
+	if got := filterString(&f, "(0world"); got != "world" {
+		t.Errorf("second chunk = %q, want %q", got, "world")
+	}
+}
+
+func TestConsoleFilterPreservesCSI(t *testing.T) {
+	var f consoleFilter
+	// CSI color sequences must pass through untouched for tview to parse.
+	in := "\x1b[31mred\x1b[0m"
+	if got := filterString(&f, in); got != in {
+		t.Errorf("filter = %q, want %q (CSI must be preserved)", got, in)
+	}
+}
+
+func TestConsoleFilterPreservesOSC(t *testing.T) {
+	var f consoleFilter
+	// OSC (ESC]) title sequences must pass through untouched.
+	in := "\x1b]0;title\x07text"
+	if got := filterString(&f, in); got != in {
+		t.Errorf("filter = %q, want %q (OSC must be preserved)", got, in)
+	}
+}
+
+func TestConsoleFilterStripsCarriageReturn(t *testing.T) {
+	var f consoleFilter
+	// CRLF collapses to LF; a stray CR is dropped.
+	if got := filterString(&f, "line1\r\nline2\r\n"); got != "line1\nline2\n" {
+		t.Errorf("filter = %q, want %q", got, "line1\nline2\n")
+	}
+}
+
+func TestConsoleFilterCarriageReturnSplit(t *testing.T) {
+	var f consoleFilter
+	// CR at end of chunk, LF at start of next: still one line break.
+	if got := filterString(&f, "abc\r"); got != "abc" {
+		t.Errorf("first chunk = %q, want %q", got, "abc")
+	}
+	if got := filterString(&f, "\ndef"); got != "\ndef" {
+		t.Errorf("second chunk = %q, want %q", got, "\ndef")
+	}
+}
+
+func TestConsoleFilterPlainText(t *testing.T) {
+	var f consoleFilter
+	in := "just some plain text 123"
+	if got := filterString(&f, in); got != in {
+		t.Errorf("filter = %q, want %q", got, in)
+	}
+}
+
+func TestConsoleFilterRealisticPrompt(t *testing.T) {
+	var f consoleFilter
+	// Approximates the prompt from the bug report:
+	// "BjasonB@Bubuntu-gpuB ~BB>" was the corrupted output.
+	in := "\x1b(Bjason\x1b(B@\x1b(Bubuntu-gpu\x1b(B ~\x1b(B\x1b(B>"
+	want := "jason@ubuntu-gpu ~>"
+	if got := filterString(&f, in); got != want {
+		t.Errorf("filter = %q, want %q", got, want)
+	}
+}

--- a/internal/tui/controlcenter/session_manager.go
+++ b/internal/tui/controlcenter/session_manager.go
@@ -108,6 +108,13 @@ func (sm *sessionManager) startSession(idx int) error {
 func (sm *sessionManager) readLoop(s *consoleSession, session *console.PTYSession) {
 	buf := make([]byte, 4096)
 	ansiW := tview.ANSIWriter(s.view)
+	// filter strips charset-designation escapes (ESC(B etc.) and carriage
+	// returns that tview's line-oriented ANSIWriter would otherwise render
+	// as literal text. It is stateful across reads so sequences split over
+	// a chunk boundary are handled correctly. The raw bytes are still
+	// broadcast unfiltered to WebSocket viewers, which use a full terminal
+	// emulator.
+	var filter consoleFilter
 
 	defer sm.onSessionEnd(s, session)
 
@@ -131,8 +138,9 @@ func (sm *sessionManager) readLoop(s *consoleSession, session *console.PTYSessio
 				s.streamer.Broadcast(chunk)
 			}
 
+			cleaned := filter.filter(chunk)
 			sm.app.QueueUpdate(func() {
-				_, _ = ansiW.Write(chunk)
+				_, _ = ansiW.Write(cleaned)
 				s.view.ScrollToEnd()
 			})
 		}


### PR DESCRIPTION
## Cause

The Alt+2 Console pane streams raw PTY bytes through tview's line-oriented `ANSIWriter` (`internal/tui/controlcenter/session_manager.go`). tview's ANSI parser understands CSI (`ESC[…`) and OSC (`ESC]…`) sequences, but for the **charset-designation family** — `ESC(x`, `ESC)x`, `ESC*x`, `ESC+x` (ESC + intermediate `(`/`)`/`*`/`+` + one final byte) — its `ansiEscape` state hits the `default: // Ignore` branch, sets state back to text, and **does not consume the trailing final byte**. The shell emits `ESC(B` (designate G0 = US-ASCII) constantly, so each trailing `B` leaked into the view as literal text:

```
BjasonB@Bubuntu-gpuB ~BB>
```

Carriage returns also reached the line-oriented view and rendered as a stray control glyph (`⏎`).

## Fix

Added a stateful `consoleFilter` (`internal/tui/controlcenter/console_filter.go`) applied to the **view-bound** byte stream in `readLoop`, just before `ansiW.Write`:

- Consumes and discards charset-designation sequences (`ESC` + `(`/`)`/`*`/`+` + one final byte).
- Strips carriage returns (`\r\n` → `\n`, lone `\r` dropped) so no glyph leaks.
- Passes CSI/OSC sequences (colors, titles) through **untouched** for tview to interpret.
- Is **stateful across reads**: the PTY is read in fixed 4096-byte chunks, so an escape (or CRLF) can straddle a boundary (`ESC(` at a chunk tail, `B` at the next head). Partial prefixes are carried into the next call. One filter per session read loop — no extra locking.

The raw bytes are still broadcast **unfiltered** to WebSocket viewers (`s.streamer.Broadcast`), which use a full terminal emulator that handles these sequences correctly.

Scope is confined to the Console panel's output rendering — no changes to pane registration, Alt-key navigation, or other panes.

## Test plan

`go build ./...`, `go test ./...`, and `go vet ./...` all clean. Added `console_filter_test.go` (10 cases, all pure-function, no live TUI needed):

| Test | Covers |
|------|--------|
| `StripsCharsetDesignation` | `"\x1b(Bjason\x1b(B@host"` → `"jason@host"` (the reported case) |
| `AllCharsetIntermediates` | `(` `)` `*` `+` all consumed |
| `SplitAcrossChunks` | `ESC(` then `Bjason` across two writes |
| `SplitEscOnly` | lone `ESC` at chunk tail, intermediate+final next chunk |
| `PreservesCSI` | `\x1b[31mred\x1b[0m` passes through |
| `PreservesOSC` | `\x1b]0;title\x07` passes through |
| `StripsCarriageReturn` | CRLF → LF |
| `CarriageReturnSplit` | CR at tail, LF next chunk |
| `RealisticPrompt` | full corrupted-prompt reproduction |
| `PlainText` | no false stripping |

Full visual confirmation requires the live TUI (Alt+2 Console).

Closes #292