### PR TITLE
Add Settings pane: anonymous-telemetry opt-out + connection status (Closes #295)

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -151,6 +151,14 @@ func runControlCenter() {
 		OnConnect: ccOnNetworkConnect,
 		Chat:      buildChatConfig(),
 		Proxmox:   buildProxmoxConfig(),
+		Settings: controlcenter.SettingsCallbacks{
+			LoadTelemetry: func() *config.Telemetry {
+				return config.LoadTelemetry(platform.ConfigDir())
+			},
+			SaveTelemetry: func(t *config.Telemetry) error {
+				return config.SaveTelemetry(platform.ConfigDir(), t)
+			},
+		},
 	}
 
 	cc := controlcenter.New(cfg)

--- a/internal/chat/client.go
+++ b/internal/chat/client.go
@@ -156,6 +156,11 @@ func (c *Client) Send(ctx context.Context, body string) error {
 	return nil
 }
 
+// IsConnected reports whether the realtime WebSocket subscription is active.
+func (c *Client) IsConnected() bool {
+	return c.api != nil && c.api.IsWebSocketConnected()
+}
+
 // Peers returns a snapshot of currently tracked peers.
 func (c *Client) Peers() []PresenceInfo {
 	c.peersMu.RLock()

--- a/internal/config/telemetry.go
+++ b/internal/config/telemetry.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Telemetry controls anonymous debug/activity event collection.
+//
+// This follows an opt-out model: collection is enabled by default and the
+// user may disable it. The single key is shared with the telemetry emission
+// path (issue #294) so the Settings toggle and the emitter agree on whether
+// collection is permitted.
+type Telemetry struct {
+	// AnonTelemetryEnabled gates all anonymous telemetry collection. When
+	// false, no anonymous debug/activity events are collected or sent.
+	AnonTelemetryEnabled bool `yaml:"anon_telemetry_enabled" json:"anon_telemetry_enabled"`
+}
+
+const telemetryFile = "telemetry.yaml"
+
+// DefaultTelemetry returns a Telemetry struct with collection enabled (opt-out).
+func DefaultTelemetry() *Telemetry {
+	return &Telemetry{
+		AnonTelemetryEnabled: true,
+	}
+}
+
+// LoadTelemetry reads telemetry settings from the config directory.
+// If the file doesn't exist, returns the opt-out default (enabled).
+// Absent keys preserve their default value (unmarshal into a pre-initialized
+// struct), so a partial file never silently disables collection.
+func LoadTelemetry(configDir string) *Telemetry {
+	t := DefaultTelemetry()
+
+	data, err := os.ReadFile(filepath.Join(configDir, telemetryFile))
+	if err != nil {
+		return t
+	}
+
+	_ = yaml.Unmarshal(data, t)
+	return t
+}
+
+// SaveTelemetry writes telemetry settings to the config directory.
+func SaveTelemetry(configDir string, t *Telemetry) error {
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+
+	data, err := yaml.Marshal(t)
+	if err != nil {
+		return fmt.Errorf("marshal telemetry: %w", err)
+	}
+
+	return os.WriteFile(filepath.Join(configDir, telemetryFile), data, 0644)
+}

--- a/internal/config/telemetry_test.go
+++ b/internal/config/telemetry_test.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultTelemetry(t *testing.T) {
+	tel := DefaultTelemetry()
+	if !tel.AnonTelemetryEnabled {
+		t.Errorf("DefaultTelemetry should be opt-out (enabled), got %+v", tel)
+	}
+}
+
+func TestLoadTelemetry_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	tel := LoadTelemetry(dir)
+	if !tel.AnonTelemetryEnabled {
+		t.Errorf("LoadTelemetry with no file should return enabled default, got %+v", tel)
+	}
+}
+
+func TestTelemetrySaveAndLoadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	// Opt out, then verify it persists.
+	disabled := &Telemetry{AnonTelemetryEnabled: false}
+	if err := SaveTelemetry(dir, disabled); err != nil {
+		t.Fatalf("SaveTelemetry: %v", err)
+	}
+
+	loaded := LoadTelemetry(dir)
+	if loaded.AnonTelemetryEnabled {
+		t.Errorf("opt-out should persist: saved %+v, loaded %+v", disabled, loaded)
+	}
+
+	// Opt back in.
+	enabled := &Telemetry{AnonTelemetryEnabled: true}
+	if err := SaveTelemetry(dir, enabled); err != nil {
+		t.Fatalf("SaveTelemetry: %v", err)
+	}
+	if !LoadTelemetry(dir).AnonTelemetryEnabled {
+		t.Error("opt back in should persist as enabled")
+	}
+}
+
+func TestSaveTelemetry_CreatesDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "dir")
+	if err := SaveTelemetry(dir, DefaultTelemetry()); err != nil {
+		t.Fatalf("SaveTelemetry should create nested dirs: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, telemetryFile)); err != nil {
+		t.Errorf("telemetry file should exist after save: %v", err)
+	}
+}
+
+func TestLoadTelemetry_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte("not: [valid: yaml: {{{")
+	if err := os.WriteFile(filepath.Join(dir, telemetryFile), data, 0644); err != nil {
+		t.Fatalf("write invalid yaml: %v", err)
+	}
+
+	tel := LoadTelemetry(dir)
+	if !tel.AnonTelemetryEnabled {
+		t.Errorf("invalid YAML should return enabled default, got %+v", tel)
+	}
+}

--- a/internal/tui/controlcenter/chat_page.go
+++ b/internal/tui/controlcenter/chat_page.go
@@ -381,6 +381,37 @@ func (p *ChatPage) updatePeersView() {
 	p.peersBox.SetText(sb.String())
 }
 
+// ConnState describes the high-level connection state of the chat/control link.
+type ConnState string
+
+const (
+	ConnDisconnected ConnState = "disconnected"
+	ConnConnecting   ConnState = "connecting"
+	ConnConnected    ConnState = "connected"
+)
+
+// ConnectionStatus reports the user-facing connection status of the realtime
+// link: the WSS endpoint host and whether it is connected. The underlying
+// transport detail (Redis pub/sub) is intentionally not surfaced — callers
+// (e.g. the Settings page) should present this as a generic "connection".
+func (p *ChatPage) ConnectionStatus() (endpoint string, state ConnState) {
+	endpoint = wssEndpoint(p.apiBaseURL)
+
+	p.clientMu.Lock()
+	client := p.client
+	connecting := p.connected
+	p.clientMu.Unlock()
+
+	switch {
+	case client != nil && client.IsConnected():
+		return endpoint, ConnConnected
+	case connecting:
+		return endpoint, ConnConnecting
+	default:
+		return endpoint, ConnDisconnected
+	}
+}
+
 // Close shuts down the chat page and its client.
 func (p *ChatPage) Close() {
 	if p.cancel != nil {

--- a/internal/tui/controlcenter/controlcenter.go
+++ b/internal/tui/controlcenter/controlcenter.go
@@ -414,6 +414,9 @@ type ControlCenter struct {
 	chatConfig    ChatPageConfig // stored from Config; used to lazily create ChatPage
 	chatPage      *ChatPage      // nil until registered in Run
 	proxmoxConfig ProxmoxConfig  // Proxmox page config (zero = disabled)
+
+	// Settings
+	settingsConfig SettingsCallbacks // Settings page hooks (telemetry load/save)
 }
 
 // Pane focus constants
@@ -478,6 +481,7 @@ type Config struct {
 	OnConnect          func(activityFn func(level, msg string)) // Called after VPN connects (starts terminal/VNC servers)
 	Chat               ChatPageConfig                           // Chat page configuration (empty = disabled)
 	Proxmox            ProxmoxConfig                            // Proxmox page configuration (empty = disabled)
+	Settings           SettingsCallbacks                        // Settings page hooks (telemetry load/save)
 }
 
 // ProxmoxConfig holds configuration for the Proxmox TUI page.
@@ -514,6 +518,7 @@ func New(cfg Config) *ControlCenter {
 		nexusURL:           cfg.NexusURL,
 		chatConfig:         cfg.Chat,
 		proxmoxConfig:      cfg.Proxmox,
+		settingsConfig:     cfg.Settings,
 	}
 }
 
@@ -611,6 +616,9 @@ func (cc *ControlCenter) Run() error {
 			ActivityFn: cc.AddActivity,
 		}), true)
 	}
+
+	// Settings page (Alt+5): telemetry opt-out + read-only connection status.
+	cc.pmgr.Register(NewSettingsPage(cc.settingsConfig, cc.chatPage), true)
 
 	cc.rootView = cc.pmgr.Build()
 	cc.pmgr.SwitchTo(0)

--- a/internal/tui/controlcenter/settings_page.go
+++ b/internal/tui/controlcenter/settings_page.go
@@ -1,0 +1,217 @@
+package controlcenter
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/aceteam-ai/citadel-cli/internal/config"
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+// SettingsCallbacks holds the load/save hooks for the Settings page.
+// They are wired from cmd so the page never imports platform/config-dir logic.
+type SettingsCallbacks struct {
+	// LoadTelemetry returns the current persisted telemetry setting.
+	LoadTelemetry func() *config.Telemetry
+	// SaveTelemetry persists an updated telemetry setting.
+	SaveTelemetry func(*config.Telemetry) error
+}
+
+// connStatusProvider exposes the user-facing connection status. The ChatPage
+// implements this; the transport detail (Redis) is intentionally hidden.
+type connStatusProvider interface {
+	ConnectionStatus() (endpoint string, state ConnState)
+}
+
+// SettingsPage implements the Page interface for the Settings tab.
+//
+// It manages the anonymous-telemetry opt-out (persisted via SettingsCallbacks)
+// and surfaces a read-only view of the realtime connection status (which WSS
+// endpoint the control/chat link uses and whether it is healthy).
+type SettingsPage struct {
+	app *tview.Application
+
+	cb         SettingsCallbacks
+	connStatus connStatusProvider
+
+	// State
+	telemetry *config.Telemetry
+
+	// UI
+	root *tview.Flex
+	view *tview.TextView
+}
+
+// NewSettingsPage creates a Settings page. connStatus may be nil (status is
+// then reported as unavailable). The telemetry setting is loaded lazily on
+// first activation so it always reflects the latest persisted value.
+func NewSettingsPage(cb SettingsCallbacks, connStatus connStatusProvider) *SettingsPage {
+	return &SettingsPage{
+		cb:         cb,
+		connStatus: connStatus,
+	}
+}
+
+// Name implements Page.
+func (p *SettingsPage) Name() string { return "settings" }
+
+// Title implements Page.
+func (p *SettingsPage) Title() string { return "Settings" }
+
+// Build implements Page.
+func (p *SettingsPage) Build(app *tview.Application) tview.Primitive {
+	p.app = app
+
+	p.view = tview.NewTextView()
+	p.view.SetDynamicColors(true)
+	p.view.SetScrollable(true)
+	p.view.SetBorder(true)
+	p.view.SetTitle(" Settings ")
+	p.view.SetTitleAlign(tview.AlignLeft)
+
+	p.root = tview.NewFlex().SetDirection(tview.FlexRow).
+		AddItem(p.view, 0, 1, true)
+
+	return p.root
+}
+
+// OnActivate implements Page. Reloads persisted settings and re-renders.
+func (p *SettingsPage) OnActivate() {
+	p.reloadTelemetry()
+	p.render()
+	if p.app != nil && p.view != nil {
+		p.app.SetFocus(p.view)
+	}
+}
+
+// OnDeactivate implements Page.
+func (p *SettingsPage) OnDeactivate() {}
+
+// HandleInput implements Page. Space or 't' toggles the telemetry opt-out.
+func (p *SettingsPage) HandleInput(event *tcell.EventKey) *tcell.EventKey {
+	switch {
+	case event.Key() == tcell.KeyRune && (event.Rune() == ' ' || event.Rune() == 't' || event.Rune() == 'T'):
+		p.toggleTelemetry()
+		return nil
+	case event.Key() == tcell.KeyEnter:
+		p.toggleTelemetry()
+		return nil
+	}
+	return event
+}
+
+// reloadTelemetry refreshes the in-memory telemetry setting from disk.
+func (p *SettingsPage) reloadTelemetry() {
+	if p.cb.LoadTelemetry != nil {
+		p.telemetry = p.cb.LoadTelemetry()
+	}
+	if p.telemetry == nil {
+		p.telemetry = config.DefaultTelemetry()
+	}
+}
+
+// toggleTelemetry flips the opt-out setting and persists it.
+func (p *SettingsPage) toggleTelemetry() {
+	if p.telemetry == nil {
+		p.reloadTelemetry()
+	}
+
+	next := &config.Telemetry{AnonTelemetryEnabled: !p.telemetry.AnonTelemetryEnabled}
+
+	if p.cb.SaveTelemetry != nil {
+		if err := p.cb.SaveTelemetry(next); err != nil {
+			p.telemetry = next
+			p.renderWithError(fmt.Sprintf("Failed to save: %v", err))
+			return
+		}
+	}
+	p.telemetry = next
+	p.render()
+}
+
+// render redraws the settings view from current state.
+func (p *SettingsPage) render() {
+	p.renderWithError("")
+}
+
+func (p *SettingsPage) renderWithError(errMsg string) {
+	if p.view == nil {
+		return
+	}
+
+	enabled := p.telemetry != nil && p.telemetry.AnonTelemetryEnabled
+
+	var sb strings.Builder
+
+	// -- Anonymous data collection --
+	sb.WriteString("\n [yellow::b]Anonymous Data Collection[-:-:-]\n\n")
+	if enabled {
+		sb.WriteString("   Status:  [green::b]ON[-:-:-]  [gray](collecting)[-]\n\n")
+	} else {
+		sb.WriteString("   Status:  [red::b]OFF[-:-:-]  [gray](opted out)[-]\n\n")
+	}
+	sb.WriteString("   [white]What is collected:[-] anonymous debug and activity events\n")
+	sb.WriteString("   (errors, feature usage). No file contents, no message bodies,\n")
+	sb.WriteString("   no personal data.\n\n")
+	sb.WriteString("   [white]Why:[-] it helps us debug problems remotely and improve\n")
+	sb.WriteString("   Citadel. Opting out stops [white::b]all[-:-:-] anonymous collection.\n\n")
+	sb.WriteString("   [yellow::b]Space[-:-:-]/[yellow::b]Enter[-:-:-] toggle collection\n")
+
+	// -- Connection status (read-only) --
+	sb.WriteString("\n [yellow::b]Connection[-:-:-]\n\n")
+	endpoint, state := p.connectionStatus()
+	if endpoint == "" {
+		endpoint = "[gray]not configured[-]"
+	}
+	sb.WriteString(fmt.Sprintf("   Endpoint:  [white]%s[-]\n", endpoint))
+	sb.WriteString(fmt.Sprintf("   Health:    %s\n", connStateLabel(state)))
+
+	// -- Error line --
+	if errMsg != "" {
+		sb.WriteString(fmt.Sprintf("\n   [red]%s[-]\n", tview.Escape(errMsg)))
+	}
+
+	p.view.SetText(sb.String())
+}
+
+// connectionStatus returns the WSS endpoint + state, best-effort.
+func (p *SettingsPage) connectionStatus() (string, ConnState) {
+	if p.connStatus == nil {
+		return "", ConnDisconnected
+	}
+	return p.connStatus.ConnectionStatus()
+}
+
+// connStateLabel renders a colored health label for a connection state.
+func connStateLabel(state ConnState) string {
+	switch state {
+	case ConnConnected:
+		return "[green::b]● connected[-:-:-]"
+	case ConnConnecting:
+		return "[yellow::b]◐ connecting[-:-:-]"
+	default:
+		return "[red::b]○ disconnected[-:-:-]"
+	}
+}
+
+// wssEndpoint derives the user-facing WSS endpoint host from the API base URL.
+// It surfaces only the scheme+host (e.g. "wss://aceteam.ai") and deliberately
+// omits the backend path so the transport (Redis) is never exposed.
+func wssEndpoint(apiBaseURL string) string {
+	if apiBaseURL == "" {
+		return ""
+	}
+	u, err := url.Parse(apiBaseURL)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	switch u.Scheme {
+	case "https", "wss":
+		u.Scheme = "wss"
+	default:
+		u.Scheme = "ws"
+	}
+	return u.Scheme + "://" + u.Host
+}

--- a/internal/tui/controlcenter/settings_page_test.go
+++ b/internal/tui/controlcenter/settings_page_test.go
@@ -1,0 +1,111 @@
+package controlcenter
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/config"
+)
+
+var errTestSave = errors.New("save failed")
+
+// fakeConnStatus is a stub connStatusProvider for tests.
+type fakeConnStatus struct {
+	endpoint string
+	state    ConnState
+}
+
+func (f fakeConnStatus) ConnectionStatus() (string, ConnState) {
+	return f.endpoint, f.state
+}
+
+// newTestSettings wires a SettingsPage to an in-memory telemetry store.
+func newTestSettings() (*SettingsPage, *config.Telemetry) {
+	store := config.DefaultTelemetry()
+	cb := SettingsCallbacks{
+		LoadTelemetry: func() *config.Telemetry {
+			// Return a copy so the page can't mutate the store directly.
+			cp := *store
+			return &cp
+		},
+		SaveTelemetry: func(t *config.Telemetry) error {
+			store.AnonTelemetryEnabled = t.AnonTelemetryEnabled
+			return nil
+		},
+	}
+	p := NewSettingsPage(cb, fakeConnStatus{endpoint: "wss://aceteam.ai", state: ConnConnected})
+	return p, store
+}
+
+func TestSettingsToggleTelemetry_PersistsOptOut(t *testing.T) {
+	p, store := newTestSettings()
+	p.reloadTelemetry()
+
+	if !p.telemetry.AnonTelemetryEnabled {
+		t.Fatalf("expected default enabled, got %+v", p.telemetry)
+	}
+
+	// First toggle: opt out. Must persist false to the store.
+	p.toggleTelemetry()
+	if p.telemetry.AnonTelemetryEnabled {
+		t.Error("in-memory state should be disabled after toggle")
+	}
+	if store.AnonTelemetryEnabled {
+		t.Error("persisted store should be disabled after toggle (opt-out not saved)")
+	}
+
+	// Second toggle: opt back in.
+	p.toggleTelemetry()
+	if !p.telemetry.AnonTelemetryEnabled {
+		t.Error("in-memory state should be enabled after second toggle")
+	}
+	if !store.AnonTelemetryEnabled {
+		t.Error("persisted store should be enabled after second toggle")
+	}
+}
+
+func TestSettingsToggle_SaveErrorKeepsState(t *testing.T) {
+	saved := false
+	cb := SettingsCallbacks{
+		LoadTelemetry: config.DefaultTelemetry,
+		SaveTelemetry: func(*config.Telemetry) error {
+			saved = true
+			return errTestSave
+		},
+	}
+	p := NewSettingsPage(cb, nil)
+	p.Build(nil) // initialize view so renderWithError doesn't no-op silently
+	p.reloadTelemetry()
+
+	p.toggleTelemetry()
+	if !saved {
+		t.Error("SaveTelemetry should have been invoked")
+	}
+	// Even on save error, the in-memory state reflects the attempted change so
+	// the UI stays consistent with what the user pressed.
+	if p.telemetry.AnonTelemetryEnabled {
+		t.Error("in-memory state should reflect attempted toggle even on save error")
+	}
+}
+
+func TestWSSEndpoint_HidesRedisTransport(t *testing.T) {
+	cases := map[string]string{
+		"https://aceteam.ai":          "wss://aceteam.ai",
+		"http://localhost:3000":       "ws://localhost:3000",
+		"https://staging.aceteam.ai/": "wss://staging.aceteam.ai",
+		"wss://already.example":       "wss://already.example",
+		"":                            "",
+		"://bad":                      "",
+	}
+	for in, want := range cases {
+		got := wssEndpoint(in)
+		if got != want {
+			t.Errorf("wssEndpoint(%q) = %q, want %q", in, got, want)
+		}
+		// The user-facing endpoint must never reveal the Redis transport path.
+		if strings.Contains(strings.ToLower(got), "redis") {
+			t.Errorf("wssEndpoint(%q) = %q leaks redis transport detail", in, got)
+		}
+	}
+}


### PR DESCRIPTION
## Context

The control center TUI had no place to manage privacy settings or see the health of the realtime link. This PR adds a **Settings pane** that:

1. lets the operator opt out of anonymous data collection, and
2. shows the read-only connection status (which WSS endpoint the chat/control link is on, and whether it is healthy).

This is the user-facing surface for the telemetry flag that the emission work (#294) gates on, and it consumes the connection status accessor area of #293.

## Summary

**New Settings pane (`Alt+5 Settings`)** — `internal/tui/controlcenter/settings_page.go`
- Implements the existing `Page` interface, mirroring the structure of `chat_page.go`.
- Registered with one new `Config` field (`Settings SettingsCallbacks`) and one `pmgr.Register(...)` line in `controlcenter.go`, kept deliberately minimal so it rebases cleanly against the parallel pane/telemetry work. The pane logic lives entirely in the new file.

**Anonymous data collection toggle**
- Bound to the persisted citadel config key **`anon_telemetry_enabled`** (the same key #294's emitter reads, so they converge).
- New `internal/config/telemetry.go` mirrors `permissions.go`: `Telemetry` struct, `DefaultTelemetry()` (**opt-out** — enabled by default), `LoadTelemetry` / `SaveTelemetry` (YAML at `telemetry.yaml`). Absent/invalid files fall back to the enabled default; partial files preserve defaults.
- Copy explains what is collected (anonymous debug/activity events — no file contents, no message bodies, no personal data), why (remote debugging), and that opting out stops **all** collection.
- `Space`/`Enter` toggles; the change is persisted immediately via `SettingsCallbacks` wired in `cmd/controlcenter.go` to `config.{Load,Save}Telemetry(platform.ConfigDir())`.

**Connection status (read-only)**
- Surfaces the **WSS endpoint host** + health (`connected` / `connecting` / `disconnected`).
- `ChatPage.ConnectionStatus()` is a best-effort accessor backed by `chat.Client.IsConnected()` (which wraps `redisapi.IsWebSocketConnected`).
- **Redis is not exposed.** `wssEndpoint()` derives only `scheme://host` (e.g. `wss://aceteam.ai`) and strips the backend `/api/fabric/redis/ws` path. A unit test asserts the rendered endpoint never contains "redis".

**Room to grow** — the pane is a sectioned layout, so VPN/mesh status and terminal/VNC bind rows can be added later without restructuring. Not built now to keep scope tight.

## Test plan

| Area | Tests |
|------|-------|
| Telemetry config (`internal/config/telemetry_test.go`) | default opt-out, no-file default, save/load round-trip (opt out + opt back in), nested-dir create, invalid YAML falls back to enabled |
| Settings model (`internal/tui/controlcenter/settings_page_test.go`) | toggle reads + persists the config key both directions; save-error keeps in-memory state consistent; `wssEndpoint` mapping + Redis-not-leaked assertion |

`go build ./...`, `go vet ./...`, and `go test ./...` all pass clean. Full visual verification of the live TUI still needs a running terminal session.

## Related
- #294 — anonymous telemetry emission (the flag this pane toggles)
- #293 — chat/control connection status discovery (the status this pane reads)