### PR TITLE
Closes #293: chat connection status + broker-less discovery

### DIFF
--- a/docs/chat-brokerless-discovery.md
+++ b/docs/chat-brokerless-discovery.md
@@ -1,0 +1,105 @@
+# Chat: connection status & broker-less peer discovery
+
+This document covers the Control Center **Chat** pane (Alt+3): how it connects,
+the connection-status indicator, and the design for broker-less peer discovery
+over the Headscale/nexus mesh.
+
+## Background: the "connecting…" bug (issue #293)
+
+The Chat pane connects lazily on first activation. The original lifecycle
+optimistically set the message view to `Connected` **before** the blocking
+`chat.Client.Connect()` call, and then discarded that call's error
+(`_ = client.Connect(ctx)`). The peers sidebar was seeded with a static
+`connecting…` placeholder that was only ever cleared by a presence callback.
+
+The result: if the real-time handshake failed (endpoint unreachable, auth
+rejected, subscribe error) no presence ever arrived, so the sidebar stayed on
+`connecting…` forever while the main view falsely claimed `Connected`. The user
+saw a permanent, silent half-connected state.
+
+### Fix
+
+The chat client now exposes a real connected signal:
+
+- `chat.Client.OnConnect(fn)` — fired exactly once, **after** the WebSocket
+  handshake and channel subscribe both succeed (`internal/chat/client.go`).
+- `chat.Client.IsConnected()` — read-only passthrough to the transport.
+
+The Chat pane (`internal/tui/controlcenter/chat_page.go`) drives a three-state
+machine — `connecting → connected | error`:
+
+- It stays in **connecting** until `OnConnect` fires.
+- On `OnConnect` it flips to **connected**, clears the sidebar placeholder, and
+  marks the page connected.
+- If `Connect()` returns an error before a successful connect, it flips to
+  **error**, shows the real error message in the message view and a red
+  `offline` sidebar, instead of an eternal `connecting…`.
+
+## Connection status indicator
+
+A one-line status bar sits between the message view and the input box. It shows
+the **WSS endpoint** the chat is using and its health:
+
+```
+● connecting…  wss://aceteam.ai
+● connected    wss://aceteam.ai
+● error        wss://aceteam.ai   <real error>
+```
+
+The endpoint label is produced by `chat.SanitizeEndpoint`, which converts the
+API base URL to `scheme://host` (https→wss, http→ws) and **deliberately drops
+the path**. The underlying transport (a Redis pub/sub proxy reached at an
+internal path) is never surfaced to the user — the status line shows only the
+public host, not how messages are carried. This is enforced by a unit test that
+asserts the sanitized output never contains the transport path.
+
+## Broker-less peer discovery (design + stub)
+
+Today chat is **broker-mediated**: every node subscribes to an org-scoped
+channel on a central WSS endpoint, and that broker fans messages out. This is
+simple but couples chat liveness to a single hosted service — the same coupling
+that produced the stuck `connecting…` state when the endpoint was unreachable.
+
+**Broker-less discovery** removes the central directory. Every node in an org is
+already a member of the same Headscale/nexus mesh, so a node can:
+
+1. **Enumerate** its org peers directly from the local tailnet — no central
+   directory. Headscale scopes peers by Headscale user, and each org maps to
+   user `org_<organization_id>`, so `network.GetGlobalPeers` already returns
+   only same-org nodes.
+2. **Probe** each peer over the VPN mesh.
+3. (future) Exchange messages **peer-to-peer** over the mesh.
+
+`internal/chat/discovery.go` implements the enumerate + probe half:
+
+```go
+results, err := chat.DiscoverPeers(ctx)
+// each ProbeResult: NodeName, IP, Online, Reachable, LatencyMs, SpeaksChat
+```
+
+### What is real vs. stubbed
+
+| Step              | Status        | Notes                                                                 |
+| ----------------- | ------------- | --------------------------------------------------------------------- |
+| Enumerate         | Implemented   | `network.GetGlobalPeers` (org-scoped via Headscale user).             |
+| Reachability probe| Implemented   | `network.PingPeer` over the mesh; proves routable, **not** chat-able. |
+| Protocol probe    | Not yet       | No per-node chat listener exists to probe against.                    |
+
+`ProbeResult.SpeaksChat` is therefore **always false** today and is asserted as
+such in tests. Reachability is not proof a peer speaks chat.
+
+### Completing it
+
+To make chat genuinely broker-less, a follow-up needs to:
+
+1. Add a small per-node chat listener (placeholder port `chatProbePort` in
+   `discovery.go`).
+2. Replace `probeReachable` with a real protocol handshake against that
+   listener, setting `SpeaksChat` truthfully.
+3. Route outbound messages to peers returned by `DiscoverPeers` (direct mesh
+   dial via `network.Dial`) instead of the central channel, falling back to the
+   broker when a peer has no listener.
+
+`DiscoverPeers` is currently informational; the chat client still uses the
+central WSS transport. The discovery primitive ships now so the enumerate/probe
+plumbing is in place for that follow-up.

--- a/internal/chat/client.go
+++ b/internal/chat/client.go
@@ -20,14 +20,16 @@ import (
 // messages received while the client is subscribed are displayed. A future
 // backend endpoint will enable loading the last N messages on connect.
 type Client struct {
-	api      *redisapi.Client
-	orgID    string
-	nodeID   string
-	nodeName string
+	api        *redisapi.Client
+	apiBaseURL string
+	orgID      string
+	nodeID     string
+	nodeName   string
 
 	// Callbacks
 	onMessage  func(Message)
 	onPresence func(PresenceInfo)
+	onConnect  func()
 	mu         sync.RWMutex
 
 	// Presence tracking
@@ -62,12 +64,13 @@ func NewClient(cfg ClientConfig) *Client {
 	})
 
 	return &Client{
-		api:      apiClient,
-		orgID:    cfg.OrgID,
-		nodeID:   cfg.NodeID,
-		nodeName: cfg.NodeName,
-		peers:    make(map[string]PresenceInfo),
-		done:     make(chan struct{}),
+		api:        apiClient,
+		apiBaseURL: cfg.APIBaseURL,
+		orgID:      cfg.OrgID,
+		nodeID:     cfg.NodeID,
+		nodeName:   cfg.NodeName,
+		peers:      make(map[string]PresenceInfo),
+		done:       make(chan struct{}),
 	}
 }
 
@@ -83,6 +86,28 @@ func (c *Client) OnPresence(fn func(PresenceInfo)) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.onPresence = fn
+}
+
+// OnConnect sets the callback invoked once the underlying WebSocket
+// subscription is established. Used by the UI to flip a status line from
+// "connecting" to "connected" only after the real handshake succeeds.
+func (c *Client) OnConnect(fn func()) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.onConnect = fn
+}
+
+// IsConnected reports whether the underlying real-time transport is currently
+// connected. It is a read-only passthrough to the transport client.
+func (c *Client) IsConnected() bool {
+	return c.api != nil && c.api.IsWebSocketConnected()
+}
+
+// EndpointURL returns a user-facing, sanitized address of the real-time
+// endpoint (scheme + host only, never the internal transport path). Returns
+// an empty string if no base URL is configured.
+func (c *Client) EndpointURL() string {
+	return SanitizeEndpoint(c.apiBaseURL)
 }
 
 // Connect establishes the WebSocket subscription for real-time messages
@@ -116,6 +141,14 @@ func (c *Client) Connect(ctx context.Context) error {
 	if err := ws.Subscribe(ctx, chatCh, presCh); err != nil {
 		cancel()
 		return fmt.Errorf("subscribe: %w", err)
+	}
+
+	// Real-time transport is now live: notify the UI to flip its status.
+	c.mu.RLock()
+	onConnect := c.onConnect
+	c.mu.RUnlock()
+	if onConnect != nil {
+		onConnect()
 	}
 
 	// Start presence heartbeat

--- a/internal/chat/discovery.go
+++ b/internal/chat/discovery.go
@@ -1,0 +1,120 @@
+package chat
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/network"
+)
+
+// Broker-less peer discovery.
+//
+// Today, chat messages flow through a central WSS endpoint (the AceTeam Redis
+// API proxy): every node subscribes to an org-scoped channel and the broker
+// fans messages out. This is simple but couples chat liveness to a single
+// hosted service — exactly the dependency that left the chat pane stuck on
+// "connecting…" when the endpoint was unreachable.
+//
+// Broker-less discovery is the alternative: because every node in an org is
+// already a member of the same Headscale/nexus mesh, a node can enumerate its
+// org peers directly from the local tailnet (no central directory) and probe
+// each one for a chat listener, then exchange messages peer-to-peer over the
+// VPN mesh. This file implements the enumerate + probe half of that design.
+//
+// Status of each step:
+//   - Enumerate (DiscoverPeers): IMPLEMENTED. Uses network.GetGlobalPeers, which
+//     returns only same-org peers (Headscale filters by Headscale user, and
+//     each org maps to user "org_<organization_id>").
+//   - Reachability probe (probeReachable): IMPLEMENTED as a stub. It pings the
+//     peer over the mesh to confirm it is reachable. Reachability is NOT proof
+//     that the peer speaks the chat protocol.
+//   - Protocol probe: NOT YET IMPLEMENTED. There is no per-node chat listener
+//     today (chat is broker-mediated), so there is no endpoint to probe for
+//     "speaks chat". Wiring a small per-node chat listener and replacing the
+//     reachability probe with a real protocol handshake is the follow-up that
+//     completes broker-less chat. See ProbeResult.SpeaksChat (always false for
+//     now) and the chatProbePort placeholder below.
+
+// chatProbePort is the (future) TCP port a node would expose for a local chat
+// listener. It is a placeholder: no listener binds it yet, so the protocol
+// probe is intentionally not performed.
+const chatProbePort = 8473
+
+// probeTimeout bounds how long we wait when probing a single peer.
+const probeTimeout = 2 * time.Second
+
+// ProbeResult captures what we learned about one peer during discovery.
+type ProbeResult struct {
+	// NodeName is the peer's mesh hostname.
+	NodeName string
+	// IP is the peer's tailnet IPv4 address, if known.
+	IP string
+	// Online reflects the peer's last-known mesh presence.
+	Online bool
+	// Reachable is true if the peer responded to a mesh ping.
+	Reachable bool
+	// LatencyMs is the ping round-trip time when Reachable is true.
+	LatencyMs float64
+	// SpeaksChat is whether the peer was confirmed to speak the chat protocol.
+	// Always false until a per-node chat listener exists to probe against.
+	SpeaksChat bool
+}
+
+// DiscoverPeers enumerates the org-scoped peers visible on the Headscale mesh
+// and probes each for reachability. It does NOT use a central broker: the peer
+// list comes from the local tailnet and probes go directly over the VPN.
+//
+// This is the broker-less discovery primitive. It is currently informational
+// (the chat client still uses the central WSS transport); a future change can
+// route messages to peers returned here once they expose a chat listener.
+func DiscoverPeers(ctx context.Context) ([]ProbeResult, error) {
+	peers, err := network.GetGlobalPeers(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]ProbeResult, 0, len(peers))
+	for _, peer := range peers {
+		r := ProbeResult{
+			NodeName: peer.Hostname,
+			IP:       peer.IP,
+			Online:   peer.Online,
+		}
+
+		// Only probe peers we have an address for and that the mesh reports
+		// as online — probing offline nodes just burns the timeout.
+		if peer.IP != "" && peer.Online {
+			reachable, latency := probeReachable(ctx, peer.IP)
+			r.Reachable = reachable
+			r.LatencyMs = latency
+			// SpeaksChat stays false: no per-node chat listener to probe yet.
+		}
+
+		results = append(results, r)
+	}
+
+	// Stable ordering: reachable first, then by name.
+	sort.SliceStable(results, func(i, j int) bool {
+		if results[i].Reachable != results[j].Reachable {
+			return results[i].Reachable
+		}
+		return results[i].NodeName < results[j].NodeName
+	})
+
+	return results, nil
+}
+
+// probeReachable pings a peer over the mesh to confirm basic reachability.
+// This is the reachability stub: it proves the peer is on the VPN and routable,
+// not that it speaks chat. Returns (reachable, latencyMs).
+func probeReachable(ctx context.Context, ip string) (bool, float64) {
+	pctx, cancel := context.WithTimeout(ctx, probeTimeout)
+	defer cancel()
+
+	latency, _, _, err := network.PingPeer(pctx, ip)
+	if err != nil {
+		return false, 0
+	}
+	return true, latency
+}

--- a/internal/chat/discovery_test.go
+++ b/internal/chat/discovery_test.go
@@ -1,0 +1,65 @@
+package chat
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeEndpoint(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"https to wss", "https://aceteam.ai", "wss://aceteam.ai"},
+		{"http to ws", "http://localhost:8000", "ws://localhost:8000"},
+		{"strips path", "https://aceteam.ai/api/fabric/redis/ws", "wss://aceteam.ai"},
+		{"keeps port", "https://staging.aceteam.ai:8443/foo", "wss://staging.aceteam.ai:8443"},
+		{"already wss", "wss://aceteam.ai/x", "wss://aceteam.ai"},
+		{"empty", "", ""},
+		{"no host", "not a url", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizeEndpoint(tt.in)
+			if got != tt.want {
+				t.Fatalf("SanitizeEndpoint(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSanitizeEndpointNeverLeaksTransport guards the issue #293 requirement
+// that the user-facing endpoint label must not reveal the Redis transport.
+func TestSanitizeEndpointNeverLeaksTransport(t *testing.T) {
+	inputs := []string{
+		"https://aceteam.ai/api/fabric/redis/ws",
+		"http://localhost:8000/api/fabric/redis/ws",
+		"https://aceteam.ai/redis",
+	}
+	for _, in := range inputs {
+		got := SanitizeEndpoint(in)
+		if strings.Contains(strings.ToLower(got), "redis") {
+			t.Fatalf("SanitizeEndpoint(%q) = %q leaks transport path", in, got)
+		}
+		if strings.Contains(got, "/") && !strings.Contains(got, "://") {
+			t.Fatalf("SanitizeEndpoint(%q) = %q unexpectedly contains a path", in, got)
+		}
+	}
+}
+
+func TestEndpointURLPassthrough(t *testing.T) {
+	c := NewClient(ClientConfig{APIBaseURL: "https://aceteam.ai", Token: "t", OrgID: "o"})
+	if got := c.EndpointURL(); got != "wss://aceteam.ai" {
+		t.Fatalf("EndpointURL() = %q, want wss://aceteam.ai", got)
+	}
+}
+
+// TestProbeResultSpeaksChatStub documents the design invariant: until a
+// per-node chat listener exists, discovery never claims a peer speaks chat.
+func TestProbeResultSpeaksChatStub(t *testing.T) {
+	r := ProbeResult{NodeName: "n", Reachable: true}
+	if r.SpeaksChat {
+		t.Fatal("SpeaksChat must default to false; no per-node listener exists yet")
+	}
+}

--- a/internal/chat/message.go
+++ b/internal/chat/message.go
@@ -7,8 +7,32 @@ package chat
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"time"
 )
+
+// SanitizeEndpoint derives a user-facing real-time endpoint label from the API
+// base URL. It returns scheme + host only (https -> wss, http -> ws) and
+// deliberately omits the internal transport path, so the underlying transport
+// (e.g. the Redis pub/sub proxy path) is never surfaced to the user.
+func SanitizeEndpoint(apiBaseURL string) string {
+	if apiBaseURL == "" {
+		return ""
+	}
+	u, err := url.Parse(apiBaseURL)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	switch u.Scheme {
+	case "https", "wss":
+		u.Scheme = "wss"
+	case "http", "ws":
+		u.Scheme = "ws"
+	default:
+		u.Scheme = "wss"
+	}
+	return u.Scheme + "://" + u.Host
+}
 
 // Message represents a chat message exchanged between nodes.
 type Message struct {

--- a/internal/tui/controlcenter/chat_page.go
+++ b/internal/tui/controlcenter/chat_page.go
@@ -16,6 +16,15 @@ import (
 // presenceTimeout is how long since last heartbeat before a node is considered offline.
 const presenceTimeout = 90 * time.Second
 
+// connState describes the chat transport connection lifecycle.
+type connState int
+
+const (
+	connConnecting connState = iota
+	connConnected
+	connError
+)
+
 // ChatPage implements the Page interface for the Chat tab.
 // It provides org-scoped node-to-node messaging over the Redis API proxy.
 type ChatPage struct {
@@ -34,6 +43,7 @@ type ChatPage struct {
 	channelBox *tview.TextView
 	peersBox   *tview.TextView
 	msgView    *tview.TextView
+	statusBar  *tview.TextView
 	input      *tview.InputField
 
 	// Chat client
@@ -54,6 +64,7 @@ type ChatPage struct {
 
 	// Lifecycle
 	connected bool
+	state     connState
 	cancel    context.CancelFunc
 }
 
@@ -120,6 +131,11 @@ func (p *ChatPage) Build(app *tview.Application) tview.Primitive {
 	p.msgView.SetTitleAlign(tview.AlignLeft)
 	p.msgView.SetText(" [gray]Connecting to chat...[white]\n")
 
+	// Status bar: shows which WSS endpoint the chat is connected to + health.
+	p.statusBar = tview.NewTextView()
+	p.statusBar.SetDynamicColors(true)
+	p.statusBar.SetTextAlign(tview.AlignLeft)
+
 	p.input = tview.NewInputField()
 	p.input.SetLabel("> ")
 	p.input.SetFieldBackgroundColor(tcell.ColorDarkSlateGray)
@@ -134,7 +150,11 @@ func (p *ChatPage) Build(app *tview.Application) tview.Primitive {
 
 	rightPanel := tview.NewFlex().SetDirection(tview.FlexRow).
 		AddItem(p.msgView, 0, 1, false).
+		AddItem(p.statusBar, 1, 0, false).
 		AddItem(p.input, 1, 0, true)
+
+	// Render the initial "connecting" status line.
+	p.renderStatusBar(connConnecting, "")
 
 	// -- Root layout --
 
@@ -208,6 +228,11 @@ func (p *ChatPage) connect() {
 	p.client = client
 	p.clientMu.Unlock()
 
+	// Show the (sanitized) endpoint we are dialing while connecting.
+	p.app.QueueUpdateDraw(func() {
+		p.renderStatusBar(connConnecting, "")
+	})
+
 	// Wire up callbacks
 	client.OnMessage(func(msg chat.Message) {
 		// Suppress echo of own messages (already rendered via local echo)
@@ -245,17 +270,46 @@ func (p *ChatPage) connect() {
 		})
 	})
 
-	p.setStatus("[green]Connected[white] to #general")
+	// OnConnect fires only after the real-time transport handshake + subscribe
+	// succeed. Until then the UI stays in the "connecting" state, so a failed
+	// handshake no longer renders as a false "Connected".
+	client.OnConnect(func() {
+		p.clientMu.Lock()
+		p.connected = true
+		p.clientMu.Unlock()
 
-	p.clientMu.Lock()
-	p.connected = true
-	p.clientMu.Unlock()
+		p.app.QueueUpdateDraw(func() {
+			p.renderStatusBar(connConnected, "")
+			p.setStatus("[green]Connected[white] to #general")
+			// Clear the "connecting..." placeholder in the peers sidebar.
+			p.updatePeersView()
+		})
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	p.cancel = cancel
 
-	// This blocks until ctx is cancelled
-	_ = client.Connect(ctx)
+	// Connect blocks until ctx is cancelled on success, or returns quickly with
+	// an error if the handshake/subscribe fails. Surface the real error instead
+	// of leaving the UI stuck on "connecting...".
+	if err := client.Connect(ctx); err != nil {
+		p.clientMu.Lock()
+		wasConnected := p.connected
+		p.connected = false
+		p.clientMu.Unlock()
+
+		// A nil-cancel context error (context.Canceled) on a clean shutdown is
+		// not a real failure — only report errors that occurred before/without
+		// a successful connect.
+		if !wasConnected && ctx.Err() == nil {
+			errMsg := err.Error()
+			p.app.QueueUpdateDraw(func() {
+				p.renderStatusBar(connError, errMsg)
+				p.setStatus(fmt.Sprintf("[red]Connection failed[white]: %s", errMsg))
+				p.peersBox.SetText(" [red]offline[white]")
+			})
+		}
+	}
 }
 
 // sendMessage sends the current input as a chat message.
@@ -335,6 +389,35 @@ func (p *ChatPage) appendMessage(msg chat.Message) {
 	fmt.Fprintf(p.msgView, " [gray]%s[white] [%s]%s[white]: %s\n",
 		ts, nameColor, tview.Escape(name), tview.Escape(msg.Body))
 	p.msgView.ScrollToEnd()
+}
+
+// renderStatusBar updates the one-line connection status indicator beneath the
+// message view. It surfaces which WSS endpoint the chat is using and its health
+// (connecting / connected / error). The endpoint is sanitized to scheme + host
+// so the underlying transport path is never exposed to the user.
+func (p *ChatPage) renderStatusBar(state connState, detail string) {
+	if p.statusBar == nil {
+		return
+	}
+
+	p.state = state
+	endpoint := chat.SanitizeEndpoint(p.apiBaseURL)
+	if endpoint == "" {
+		endpoint = "not configured"
+	}
+
+	switch state {
+	case connConnected:
+		p.statusBar.SetText(fmt.Sprintf(" [green]●[white] connected  [gray]%s[white]", tview.Escape(endpoint)))
+	case connError:
+		msg := fmt.Sprintf(" [red]●[white] error  [gray]%s[white]", tview.Escape(endpoint))
+		if detail != "" {
+			msg += fmt.Sprintf("  [red]%s[white]", tview.Escape(detail))
+		}
+		p.statusBar.SetText(msg)
+	default:
+		p.statusBar.SetText(fmt.Sprintf(" [yellow]●[white] connecting…  [gray]%s[white]", tview.Escape(endpoint)))
+	}
 }
 
 // setStatus updates the message view with a status line.


### PR DESCRIPTION
## Context

The Control Center **Chat** pane (Alt+3) was stuck on `connecting…` indefinitely. Issue #293 asks to (1) diagnose the stuck state, (2) surface which **WSS** endpoint the chat uses + its health **without** revealing that the transport is Redis, and (3) design broker-less peer discovery over the Headscale/nexus mesh.

## Connecting diagnosis & fix

**Root cause (in-scope, fixed):** `ChatPage.connect()` set the message view to `[green]Connected` *before* the blocking `chat.Client.Connect()` call and then discarded that call's error with `_ = client.Connect(ctx)`. The peers sidebar was seeded with a static `connecting…` placeholder that was only ever cleared by a presence callback. So whenever the real-time handshake failed (endpoint unreachable, auth rejected, or subscribe error), no presence ever arrived: the sidebar stayed on `connecting…` forever while the main view falsely showed `Connected`. A silent, permanent half-connected state.

**External unknown (why this is a DRAFT):** whether the WSS endpoint (`/api/fabric/redis/ws` on the API host) is actually deployed and reachable in a given environment can't be verified from here — that requires the running TUI + backend. The fix makes the UI tell the truth about whatever the handshake actually does, rather than masking it.

### Changes

- `chat.Client` gains a real connected signal: `OnConnect(fn)` fires **once, after** the WebSocket handshake **and** channel subscribe succeed; `IsConnected()` is a read-only transport passthrough. *(Touches `internal/chat/client.go` — a third file beyond the two TUI files in scope. This is non-TUI, so there's no collision with parallel TUI agents; calling it out explicitly. A pure time-based heuristic was rejected because the 10s handshake timeout makes a timer report "connected" mid-dial.)*
- `chat_page.go` now drives a `connecting → connected | error` state machine: stays in **connecting** until `OnConnect`; on error from `Connect()` it shows the **real error message** and a red `offline` sidebar instead of an eternal `connecting…`.

## WSS status UI (Redis not exposed)

A one-line status bar between the message view and input shows the endpoint + health:

```
● connecting…  wss://aceteam.ai
● connected    wss://aceteam.ai
● error        wss://aceteam.ai   <real error>
```

The label comes from `chat.SanitizeEndpoint`, which returns `scheme://host` only (https→wss, http→ws) and **drops the path**. The internal Redis pub/sub transport path is never surfaced. A unit test asserts the sanitized output never contains `redis` or a path.

## Broker-less discovery (design + stub)

`internal/chat/discovery.go` + `docs/chat-brokerless-discovery.md`. Chat is broker-mediated today (central WSS fan-out). Broker-less discovery removes the central directory: every org node is already on the same Headscale mesh, so a node can enumerate org peers locally and probe them.

| Step               | Status      | Notes |
| ------------------ | ----------- | ----- |
| Enumerate          | Implemented | `network.GetGlobalPeers` — org-scoped via Headscale user `org_<id>`. |
| Reachability probe | Implemented | `network.PingPeer` over the mesh; proves routable, **not** chat-able. |
| Protocol probe     | Stub        | No per-node chat listener exists yet to probe against; `ProbeResult.SpeaksChat` is always false (asserted by test). |

`DiscoverPeers(ctx)` ships the enumerate+probe plumbing; the doc spells out the follow-up (per-node listener, real protocol handshake, direct mesh routing with broker fallback).

## Test plan

| Area | Coverage |
| ---- | -------- |
| `SanitizeEndpoint` | https/http/wss conversion, path stripping, port retention, empty/invalid input |
| No-transport-leak guard | sanitized output never contains `redis` or a path |
| `EndpointURL` passthrough | client returns sanitized host |
| Discovery invariant | `SpeaksChat` defaults false (no listener yet) |

`go build ./...`, `go vet ./...`, `go test ./...` all clean. **Live verification of the connecting fix needs the running TUI + backend** and is not done here.

## Scope

Edits confined to `internal/tui/controlcenter/chat_page.go` and the `internal/chat` helpers (`client.go`, `message.go`, new `discovery.go`/`discovery_test.go`) plus a design doc. No pane registration, other panes, or settings pane touched.

## Related

Closes #293.