### PR TITLE
feat: stream activity feed to events log for remote debugging (Closes #294)

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
 	pmx "github.com/aceteam-ai/citadel-cli/internal/proxmox"
 	"github.com/aceteam-ai/citadel-cli/internal/status"
+	"github.com/aceteam-ai/citadel-cli/internal/telemetry"
 	"github.com/aceteam-ai/citadel-cli/internal/terminal"
 	"github.com/aceteam-ai/citadel-cli/internal/tui"
 	"github.com/aceteam-ai/citadel-cli/internal/tui/controlcenter"
@@ -1167,6 +1168,19 @@ func runTUIWorker(ctx context.Context, activityFn func(level, msg string)) error
 
 		if orgID != "" {
 			if apiSource, ok := source.(*worker.APISource); ok {
+				// Wire anonymous activity telemetry through the same
+				// authenticated Redis API client the heartbeat uses. Gated
+				// at emit time by the anon_telemetry_enabled flag; payloads
+				// carry only node/debug context, never user PII.
+				telemetry.Configure(
+					apiSource.Client(),
+					platform.ConfigDir(),
+					nodeName,
+					headscaleNodeID,
+					orgID,
+					Version,
+				)
+
 				apiPublisher, err := heartbeat.NewAPIPublisher(heartbeat.APIPublisherConfig{
 					Client:          apiSource.Client(),
 					NodeID:          nodeName,

--- a/internal/config/telemetry.go
+++ b/internal/config/telemetry.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Telemetry controls anonymous activity-event streaming used for remote
+// debugging. It follows the same opt-out (default-true) model as Permissions:
+// the node streams its operational activity feed to the AceTeam control plane
+// so operators and the platform can debug node issues remotely, and the
+// operator may turn it off.
+type Telemetry struct {
+	// AnonTelemetryEnabled gates ALL activity-event emission. When false, no
+	// activity events leave the node. Defaults to true (opt-out) so that nodes
+	// are debuggable out of the box; the settings pane (#295) and `citadel
+	// init` are responsible for disclosing this default-on behavior to the
+	// operator and offering the toggle.
+	AnonTelemetryEnabled bool `yaml:"anon_telemetry_enabled" json:"anon_telemetry_enabled"`
+}
+
+const telemetryFile = "telemetry.yaml"
+
+// DefaultTelemetry returns a Telemetry struct with anonymous telemetry enabled.
+// Default-on is intentional: the activity feed is anonymous (node/debug context
+// only, no user PII) and remote visibility into the activity log is the primary
+// mechanism for debugging field nodes we cannot SSH into.
+func DefaultTelemetry() *Telemetry {
+	return &Telemetry{
+		AnonTelemetryEnabled: true,
+	}
+}
+
+// LoadTelemetry reads telemetry settings from the config directory.
+// If the file doesn't exist, returns defaults (enabled).
+// Partial files preserve defaults for absent keys (unmarshal into a
+// pre-initialized struct), mirroring LoadPermissions.
+func LoadTelemetry(configDir string) *Telemetry {
+	t := DefaultTelemetry()
+
+	data, err := os.ReadFile(filepath.Join(configDir, telemetryFile))
+	if err != nil {
+		return t
+	}
+
+	// yaml.Unmarshal only overwrites keys present in the file, so an absent
+	// key keeps its default (true) value.
+	_ = yaml.Unmarshal(data, t)
+	return t
+}
+
+// SaveTelemetry writes telemetry settings to the config directory.
+// The settings pane (#295) calls this when the operator toggles the flag.
+func SaveTelemetry(configDir string, t *Telemetry) error {
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+
+	data, err := yaml.Marshal(t)
+	if err != nil {
+		return fmt.Errorf("marshal telemetry: %w", err)
+	}
+
+	return os.WriteFile(filepath.Join(configDir, telemetryFile), data, 0644)
+}

--- a/internal/config/telemetry_test.go
+++ b/internal/config/telemetry_test.go
@@ -1,0 +1,72 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultTelemetry(t *testing.T) {
+	tel := DefaultTelemetry()
+	if !tel.AnonTelemetryEnabled {
+		t.Errorf("DefaultTelemetry should be enabled (opt-out), got %+v", tel)
+	}
+}
+
+func TestLoadTelemetry_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	tel := LoadTelemetry(dir)
+	if !tel.AnonTelemetryEnabled {
+		t.Errorf("LoadTelemetry with no file should default to enabled, got %+v", tel)
+	}
+}
+
+func TestTelemetrySaveAndLoadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	original := &Telemetry{AnonTelemetryEnabled: false}
+
+	if err := SaveTelemetry(dir, original); err != nil {
+		t.Fatalf("SaveTelemetry: %v", err)
+	}
+
+	loaded := LoadTelemetry(dir)
+	if loaded.AnonTelemetryEnabled != original.AnonTelemetryEnabled {
+		t.Errorf("round trip mismatch: saved %+v, loaded %+v", original, loaded)
+	}
+}
+
+func TestLoadTelemetry_DisabledFromFile(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte("anon_telemetry_enabled: false\n")
+	if err := os.WriteFile(filepath.Join(dir, "telemetry.yaml"), data, 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	tel := LoadTelemetry(dir)
+	if tel.AnonTelemetryEnabled {
+		t.Error("anon_telemetry_enabled should be false from file")
+	}
+}
+
+func TestLoadTelemetry_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte("not: [valid: yaml: {{{")
+	if err := os.WriteFile(filepath.Join(dir, "telemetry.yaml"), data, 0644); err != nil {
+		t.Fatalf("write invalid yaml: %v", err)
+	}
+
+	tel := LoadTelemetry(dir)
+	if !tel.AnonTelemetryEnabled {
+		t.Errorf("invalid YAML should return defaults (enabled), got %+v", tel)
+	}
+}
+
+func TestSaveTelemetry_CreatesDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "dir")
+	if err := SaveTelemetry(dir, DefaultTelemetry()); err != nil {
+		t.Fatalf("SaveTelemetry should create nested dirs: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "telemetry.yaml")); err != nil {
+		t.Errorf("telemetry file should exist after save: %v", err)
+	}
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -1,0 +1,138 @@
+// Package telemetry streams the Citadel node's activity feed to the AceTeam
+// control plane for remote debugging.
+//
+// It reuses the same authenticated backend channel the node already uses for
+// heartbeats: events are written to a Redis stream via the device-token-authed
+// Redis API proxy (redisapi.Client.StreamAdd), NOT to Supabase directly. A
+// Python worker is expected to drain the stream into the events log.
+//
+// Design constraints (issue #294):
+//   - Anonymous: payloads carry only node/debug context, never user PII.
+//   - Opt-out: a persisted config flag (anon_telemetry_enabled, default true)
+//     gates ALL emission; the flag is re-read per emit so a runtime toggle from
+//     the settings pane (#295) takes effect without restart.
+//   - Crash-safe + fire-and-forget: emission must never block or panic the TUI.
+//     Emit() spawns a guarded goroutine with recover; failures are dropped.
+package telemetry
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/config"
+)
+
+// activityStream is the Redis stream that activity events are written to.
+// A backend consumer must drain this into the events log (see PR notes).
+const activityStream = "node:activity:stream"
+
+// streamMaxLen bounds the stream so it self-trims on the proxy side.
+const streamMaxLen = 10000
+
+// emitTimeout bounds a single emission so a slow/hung backend can never wedge
+// the emitter goroutine indefinitely.
+const emitTimeout = 5 * time.Second
+
+// eventSink is the minimal surface the emitter needs from the Redis API client.
+// *redisapi.Client satisfies it; tests inject a fake.
+type eventSink interface {
+	StreamAdd(ctx context.Context, stream string, values map[string]string, maxLen int64) error
+}
+
+// emitter holds the configured streaming context. Fields are immutable after
+// Configure; nodeID/orgID/etc. are node/debug context only (no user PII).
+type emitter struct {
+	sink            eventSink
+	configDir       string // where telemetry.yaml lives; the flag is re-read from here per emit
+	nodeID          string
+	headscaleNodeID string
+	orgID           string
+	version         string
+}
+
+var (
+	mu      sync.RWMutex
+	current *emitter
+)
+
+// Configure wires up activity streaming. Called once the Redis API client and
+// node/debug context are available (in ccStartWorker, alongside the heartbeat
+// publisher). Before Configure runs, Emit is a silent no-op, so early
+// pre-worker activity simply isn't streamed.
+func Configure(sink eventSink, configDir, nodeID, headscaleNodeID, orgID, version string) {
+	mu.Lock()
+	defer mu.Unlock()
+	if sink == nil {
+		current = nil
+		return
+	}
+	current = &emitter{
+		sink:            sink,
+		configDir:       configDir,
+		nodeID:          nodeID,
+		headscaleNodeID: headscaleNodeID,
+		orgID:           orgID,
+		version:         version,
+	}
+}
+
+// Reset clears the configured emitter. Primarily for tests.
+func Reset() {
+	mu.Lock()
+	defer mu.Unlock()
+	current = nil
+}
+
+// Emit streams a single activity entry. It is fire-and-forget and crash-safe:
+// it never blocks the caller and never panics into the caller's goroutine.
+// All work (flag check, payload build, network) happens off-thread.
+func Emit(level, message string) {
+	mu.RLock()
+	e := current
+	mu.RUnlock()
+	if e == nil {
+		return
+	}
+	go func() {
+		defer func() {
+			// Telemetry must never crash the TUI; swallow any panic.
+			_ = recover()
+		}()
+		e.emit(level, message)
+	}()
+}
+
+// emit performs one synchronous emission attempt: gate on the flag, build the
+// anonymous payload, and write to the stream. It is separated from Emit so the
+// gating and anonymization can be tested deterministically (no goroutine).
+// Failures are intentionally dropped — telemetry is best-effort.
+func (e *emitter) emit(level, message string) {
+	// Re-read the opt-out flag per emit so the settings pane (#295) toggle takes
+	// effect at runtime without a restart. The read is off the TUI thread.
+	if !config.LoadTelemetry(e.configDir).AnonTelemetryEnabled {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), emitTimeout)
+	defer cancel()
+
+	// buildPayload deliberately includes only node/debug context. There is no
+	// user-identity field (email/name) anywhere in this map.
+	_ = e.sink.StreamAdd(ctx, activityStream, e.buildPayload(level, message), streamMaxLen)
+}
+
+// buildPayload constructs the anonymous stream fields for an activity entry.
+// It is exported-for-test via emit; kept as a method so the field set is in one
+// place and obviously PII-free. Only node/debug context is included.
+func (e *emitter) buildPayload(level, message string) map[string]string {
+	return map[string]string{
+		"nodeId":          e.nodeID,
+		"headscaleNodeId": e.headscaleNodeID,
+		"orgId":           e.orgID,
+		"version":         e.version,
+		"timestamp":       time.Now().UTC().Format(time.RFC3339),
+		"level":           level,
+		"message":         message,
+	}
+}

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -1,0 +1,142 @@
+package telemetry
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/config"
+)
+
+// fakeSink records every StreamAdd call so tests can assert emit/no-emit and
+// inspect payloads for PII.
+type fakeSink struct {
+	calls []map[string]string
+}
+
+func (f *fakeSink) StreamAdd(_ context.Context, _ string, values map[string]string, _ int64) error {
+	f.calls = append(f.calls, values)
+	return nil
+}
+
+func newTestEmitter(t *testing.T, sink eventSink) (*emitter, string) {
+	t.Helper()
+	dir := t.TempDir()
+	return &emitter{
+		sink:            sink,
+		configDir:       dir,
+		nodeID:          "node-1",
+		headscaleNodeID: "758",
+		orgID:           "org-abc",
+		version:         "v2.44.0",
+	}, dir
+}
+
+func writeFlag(t *testing.T, dir string, enabled bool) {
+	t.Helper()
+	if err := config.SaveTelemetry(dir, &config.Telemetry{AnonTelemetryEnabled: enabled}); err != nil {
+		t.Fatalf("SaveTelemetry: %v", err)
+	}
+}
+
+// Gating: flag off => no emission.
+func TestEmit_FlagOff_NoEmit(t *testing.T) {
+	sink := &fakeSink{}
+	e, dir := newTestEmitter(t, sink)
+	writeFlag(t, dir, false)
+
+	e.emit("info", "node connected")
+
+	if len(sink.calls) != 0 {
+		t.Fatalf("flag off should suppress emission, got %d calls", len(sink.calls))
+	}
+}
+
+// Gating: flag on => exactly one emission.
+func TestEmit_FlagOn_Emits(t *testing.T) {
+	sink := &fakeSink{}
+	e, dir := newTestEmitter(t, sink)
+	writeFlag(t, dir, true)
+
+	e.emit("info", "node connected")
+
+	if len(sink.calls) != 1 {
+		t.Fatalf("flag on should emit once, got %d calls", len(sink.calls))
+	}
+}
+
+// Default (no file written) => enabled (opt-out), so emission happens.
+func TestEmit_DefaultEnabled_Emits(t *testing.T) {
+	sink := &fakeSink{}
+	e, _ := newTestEmitter(t, sink)
+
+	e.emit("info", "startup")
+
+	if len(sink.calls) != 1 {
+		t.Fatalf("default should be enabled and emit once, got %d calls", len(sink.calls))
+	}
+}
+
+// Anonymization: payload carries node/debug context and NO user PII.
+func TestBuildPayload_NoPII(t *testing.T) {
+	e := &emitter{
+		nodeID:          "node-1",
+		headscaleNodeID: "758",
+		orgID:           "org-abc",
+		version:         "v2.44.0",
+	}
+	payload := e.buildPayload("warning", "VPN reconnect failed")
+
+	// Required node/debug context is present.
+	for _, key := range []string{"nodeId", "headscaleNodeId", "orgId", "version", "timestamp", "level", "message"} {
+		if _, ok := payload[key]; !ok {
+			t.Errorf("payload missing expected field %q", key)
+		}
+	}
+
+	// No user-identity field is present anywhere in the payload keys.
+	for key := range payload {
+		lower := strings.ToLower(key)
+		for _, banned := range []string{"email", "username", "user_name", "password", "token", "secret"} {
+			if strings.Contains(lower, banned) {
+				t.Errorf("payload contains PII-like field %q", key)
+			}
+		}
+	}
+
+	if payload["nodeId"] != "node-1" || payload["orgId"] != "org-abc" {
+		t.Errorf("unexpected node/debug context: %+v", payload)
+	}
+}
+
+// Emit (the public goroutine wrapper) is a no-op when unconfigured and never
+// panics.
+func TestEmit_Unconfigured_NoPanic(t *testing.T) {
+	Reset()
+	Emit("info", "no emitter configured") // must not panic
+}
+
+// Configure(nil, ...) clears the emitter.
+func TestConfigure_NilSink_Clears(t *testing.T) {
+	sink := &fakeSink{}
+	Configure(sink, t.TempDir(), "n", "h", "o", "v")
+	Configure(nil, "", "", "", "", "")
+
+	mu.RLock()
+	defer mu.RUnlock()
+	if current != nil {
+		t.Error("Configure(nil) should clear the emitter")
+	}
+}
+
+// Sanity: the on-disk flag file name matches what the settings pane (#295) will
+// toggle.
+func TestFlagFileName(t *testing.T) {
+	dir := t.TempDir()
+	writeFlag(t, dir, false)
+	if _, err := os.Stat(filepath.Join(dir, "telemetry.yaml")); err != nil {
+		t.Errorf("expected telemetry.yaml flag file: %v", err)
+	}
+}

--- a/internal/tui/controlcenter/controlcenter.go
+++ b/internal/tui/controlcenter/controlcenter.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/network"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
 	"github.com/aceteam-ai/citadel-cli/internal/proxmox"
+	"github.com/aceteam-ai/citadel-cli/internal/telemetry"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
@@ -534,6 +535,12 @@ func (cc *ControlCenter) AddActivity(level, message string) {
 		cc.activities = cc.activities[:100]
 	}
 	cc.activityMu.Unlock()
+
+	// Stream the activity entry to the control plane for remote debugging.
+	// Emit is fire-and-forget, crash-safe, and gated by the anon_telemetry_enabled
+	// flag + a configured emitter, so this is a no-op until telemetry is wired up
+	// (in ccStartWorker) and never blocks or panics the TUI.
+	telemetry.Emit(level, message)
 
 	// Update UI if running
 	// Use goroutine to avoid blocking when called from input handlers


### PR DESCRIPTION
## Context

Closes #294. Related #295.

Field nodes we can't SSH into are hard to debug — the only window into what a node is doing is its on-screen **Activity** feed in the control-center TUI. This PR streams that feed to the AceTeam control plane so the activity log is visible remotely (the "Supabase events log"), turning every node into something we can debug after the fact.

The change is **anonymous** (node/debug context only, no user PII) and **opt-out** (a persisted flag the operator can flip off). Emission is **fire-and-forget and crash-safe** so it can never block or panic the TUI — directly informed by the logtail crash (#291).

## Activity source

The TUI activity feed is fed by a single chokepoint: `ControlCenter.AddActivity(level, message)` in `internal/tui/controlcenter/controlcenter.go`. Every status line (VPN connect/reconnect, worker start, job output, peer reachability, etc.) flows through it. Hooking emission there captures the entire feed without touching any TUI pane.

## Emission path — reused backend channel (no direct Supabase)

`AddActivity` now calls `telemetry.Emit(level, message)`. The new `internal/telemetry` package writes each entry to a Redis stream **via the same device-token-authenticated Redis API proxy the heartbeat already uses** (`redisapi.Client.StreamAdd` → `POST /api/fabric/redis/streams/add`). Citadel never touches Supabase directly.

- Emitter is a configured singleton, wired in `ccStartWorker` right beside the heartbeat publisher, reusing `apiSource.Client()` and the same node/org context (nodeName, headscaleNodeID, orgID, version).
- Before `Configure` runs (early pre-worker activity) `Emit` is a silent no-op.
- Stream: **`node:activity:stream`**, fields mirroring the heartbeat shape, `MAXLEN ~ 10000`.
- Uses durable `StreamAdd` (not ephemeral pub/sub) so a backend consumer can drain it reliably.

## Opt-out flag: `anon_telemetry_enabled`

`internal/config/telemetry.go` adds the flag, mirroring `permissions.go` exactly (YAML file in the config dir, opt-out/default-true semantics, partial-file-preserves-defaults).

- File: `telemetry.yaml`, key: **`anon_telemetry_enabled`**, **default `true`**.
- Default-on rationale (commented in code): the feed is anonymous and remote visibility is the primary way to debug nodes we can't reach. User-facing disclosure of the default-on behavior is #295 / `citadel init`'s job.
- `LoadTelemetry` / `SaveTelemetry` give #295's settings pane a symmetric API to toggle the flag.
- The flag is **re-read per emit** so a runtime toggle takes effect without restart (same pattern as permissions being reloaded each heartbeat). The read is off the TUI thread. _(If activity volume warrants, this could be cached with a short TTL; left simple for now.)_

## Guarantees

**Anonymity.** The payload carries only node/debug context: `nodeId`, `headscaleNodeId`, `orgId`, `version`, `timestamp`, `level`, `message`. User-identity fields (email/name) are **structurally excluded** from the payload. A call-site audit of `AddActivity` found messages are operational status lines that do not interpolate user identity; messages are free-form text, so we claim the structured fields are PII-free and the messages are operational, not that arbitrary message text is provably PII-free.

**Crash-safety / fire-and-forget.** `Emit` spawns a guarded goroutine with `recover()`; it never blocks the caller and never panics into the TUI. A single emission is bounded by a 5s context timeout. Failures are silently dropped — telemetry is best-effort, no retries/batching.

## Test plan

| Area | Coverage |
| --- | --- |
| Gating | flag off → zero emissions; flag on → exactly one; default (no file) → enabled → emits |
| Anonymization | payload contains required node/debug fields and **no** PII-like keys (email/username/token/secret/password) |
| Crash-safety | `Emit` unconfigured → no panic; `Configure(nil)` clears the emitter |
| Config flag | default-on, save/load round-trip, disabled-from-file, invalid-YAML→defaults, nested-dir create |

`go build ./...`, `go vet ./...`, and `go test ./...` are all clean. Gating/anonymization are tested against `emit()` synchronously (injected fake sink, temp config dir) to avoid goroutine flakiness.

## Backend / DB follow-up required (why this PR is a DRAFT)

The citadel side is complete, but nothing reaches the events log until the backend can accept and persist this stream. Required, owner-managed work:

1. **Allowlist the new stream name.** `app/api/fabric/redis/streams/add/route.ts` has a strict allowlist — `ALLOWED_STREAM_PATTERNS` currently only permits `^node:status:stream$`. Until `node:activity:stream` is added, every emit returns 400 and is silently dropped. (The required `device_redis:streams` scope is already on the device token via heartbeat, so no scope change is needed.)
2. **Add a Python consumer** to drain `node:activity:stream` (mirroring `worker/node_status/worker.py`, which drains `node:status:stream`).
3. **Create the events table** (DB is owner-managed — **not created here**). Suggested `node_activity_events` columns: `id` (uuid pk), `node_id` (text), `headscale_node_id` (text), `organization_id` (uuid fk → organizations, `ON UPDATE CASCADE`), `version` (text), `level` (text/enum), `message` (text), `reported_at` (timestamptz), `created_at` (timestamptz default now()). Existing `agent_activity_events` is agent-scoped (FK to agents) and not suitable; `fabric_node_status_history` is heartbeat-specific.
