### PR TITLE
fix(tui): answer terminal Device Attributes queries (fixes fish 2s startup hang on macOS)

### DIFF
--- a/internal/tui/controlcenter/device_attr_responder.go
+++ b/internal/tui/controlcenter/device_attr_responder.go
@@ -1,0 +1,101 @@
+package controlcenter
+
+// deviceAttrResponder answers terminal "Device Attributes" (DA) queries that a
+// shell emits at startup. The Console pane renders PTY output through tview's
+// line-oriented ANSIWriter rather than a full terminal emulator, so nothing
+// ever replies to these queries. Shells that probe terminal capabilities then
+// block waiting for a response — fish, for example, waits ~2s and prints:
+//
+//	"fish could not read response to Primary Device Attribute query after
+//	 waiting for 2 seconds ... This fish process will no longer wait for
+//	 outstanding queries, which disables some optional features."
+//
+// The fix is to detect the query in the PTY output stream and write a canned
+// reply back to the PTY (the shell's stdin), exactly as a real terminal would.
+//
+// Queries handled (both are CSI sequences terminated by the final byte 'c',
+// which no display sequence uses, so matching is unambiguous):
+//   - Primary DA   (DA1): CSI c   / CSI 0 c   -> reply CSI ? 1 ; 2 c
+//   - Secondary DA (DA2): CSI > ... c          -> reply CSI > 0 ; 0 ; 0 c
+//
+// The Primary reply is deliberately minimal — a VT100 with the Advanced Video
+// Option. Advertising more would invite the shell to enable query-driven
+// features (cursor reports, synchronized output) that the line-oriented
+// renderer cannot service. The point is only to satisfy "did the terminal
+// answer", not to claim capabilities we do not have.
+//
+// The responder is stateful across reads so a query split over a PTY read
+// boundary is still recognised. One responder belongs to a single session's
+// read loop, so no locking is required. It never modifies the display bytes;
+// tview's ANSIWriter already consumes the CSI query without rendering it.
+type deviceAttrResponder struct {
+	sawESC bool   // saw ESC, awaiting '['
+	inCSI  bool   // inside a CSI sequence, collecting parameter bytes
+	params []byte // parameter/intermediate bytes accumulated after "ESC["
+}
+
+// Replies advertise a basic terminal. See the type doc for why minimal.
+var (
+	primaryDAResponse   = []byte("\x1b[?1;2c")
+	secondaryDAResponse = []byte("\x1b[>0;0;0c")
+)
+
+// maxCSIParamBytes bounds parameter accumulation so malformed/never-terminated
+// CSI input cannot grow params without limit.
+const maxCSIParamBytes = 32
+
+// scan consumes a chunk of raw PTY output and returns the bytes (if any) to
+// write back to the PTY in reply to Device Attributes queries found in it.
+// Multiple queries in one chunk yield concatenated replies. It is purely a
+// detector: the input is never modified.
+func (r *deviceAttrResponder) scan(input []byte) []byte {
+	var resp []byte
+	for _, b := range input {
+		switch {
+		case r.inCSI:
+			if b >= 0x40 && b <= 0x7e {
+				// Final byte: the CSI sequence ends here.
+				if b == 'c' {
+					resp = append(resp, r.replyForParams()...)
+				}
+				r.inCSI = false
+				r.params = r.params[:0]
+			} else {
+				r.params = append(r.params, b)
+				if len(r.params) > maxCSIParamBytes {
+					// Give up on a runaway sequence; resync on the next ESC.
+					r.inCSI = false
+					r.params = r.params[:0]
+				}
+			}
+		case r.sawESC:
+			r.sawESC = false
+			switch b {
+			case '[':
+				r.inCSI = true
+			case escByte:
+				r.sawESC = true // ESC ESC: stay armed for the next byte
+			}
+		default:
+			if b == escByte {
+				r.sawESC = true
+			}
+		}
+	}
+	return resp
+}
+
+// replyForParams selects the reply for a CSI ... 'c' query based on its
+// leading parameter byte: '>' is Secondary DA, '=' is Tertiary DA (ignored),
+// everything else (empty or numeric, i.e. Primary DA) gets the Primary reply.
+func (r *deviceAttrResponder) replyForParams() []byte {
+	if len(r.params) > 0 {
+		switch r.params[0] {
+		case '>':
+			return secondaryDAResponse
+		case '=':
+			return nil // Tertiary DA: no meaningful reply from this renderer.
+		}
+	}
+	return primaryDAResponse
+}

--- a/internal/tui/controlcenter/device_attr_responder_test.go
+++ b/internal/tui/controlcenter/device_attr_responder_test.go
@@ -1,0 +1,97 @@
+package controlcenter
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestDeviceAttrResponder_PrimaryDA(t *testing.T) {
+	cases := map[string][]byte{
+		"bare CSI c": []byte("\x1b[c"),
+		"CSI 0 c":    []byte("\x1b[0c"),
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			var r deviceAttrResponder
+			got := r.scan(in)
+			if !bytes.Equal(got, primaryDAResponse) {
+				t.Fatalf("got %q, want primary DA %q", got, primaryDAResponse)
+			}
+		})
+	}
+}
+
+func TestDeviceAttrResponder_SecondaryDA(t *testing.T) {
+	var r deviceAttrResponder
+	got := r.scan([]byte("\x1b[>c"))
+	if !bytes.Equal(got, secondaryDAResponse) {
+		t.Fatalf("got %q, want secondary DA %q", got, secondaryDAResponse)
+	}
+}
+
+func TestDeviceAttrResponder_TertiaryDAIgnored(t *testing.T) {
+	var r deviceAttrResponder
+	if got := r.scan([]byte("\x1b[=c")); got != nil {
+		t.Fatalf("tertiary DA should yield no reply, got %q", got)
+	}
+}
+
+func TestDeviceAttrResponder_EmbeddedInOutput(t *testing.T) {
+	// A realistic startup burst: prompt text, the DA query, more text.
+	var r deviceAttrResponder
+	got := r.scan([]byte("jason@host ~> \x1b[c\x1b[0m hi"))
+	if !bytes.Equal(got, primaryDAResponse) {
+		t.Fatalf("got %q, want primary DA reply", got)
+	}
+}
+
+func TestDeviceAttrResponder_SplitAcrossChunks(t *testing.T) {
+	// The query is split at every interior byte boundary; the reply must
+	// still fire exactly once, on the chunk carrying the final 'c'.
+	full := []byte("\x1b[0c")
+	for split := 1; split < len(full); split++ {
+		t.Run("", func(t *testing.T) {
+			var r deviceAttrResponder
+			first := r.scan(full[:split])
+			if len(first) != 0 {
+				t.Fatalf("split=%d: unexpected early reply %q", split, first)
+			}
+			second := r.scan(full[split:])
+			if !bytes.Equal(second, primaryDAResponse) {
+				t.Fatalf("split=%d: got %q, want primary DA reply", split, second)
+			}
+		})
+	}
+}
+
+func TestDeviceAttrResponder_NonDASequencesIgnored(t *testing.T) {
+	// Color (SGR 'm'), cursor move ('H'), erase ('K'), and plain text must
+	// never produce a reply — only 'c'-terminated CSI is a DA query.
+	var r deviceAttrResponder
+	noise := []byte("\x1b[31mred\x1b[0m\x1b[2J\x1b[1;1H\x1b[Kplain text 0c c [c")
+	if got := r.scan(noise); got != nil {
+		t.Fatalf("non-DA sequences/text should yield no reply, got %q", got)
+	}
+}
+
+func TestDeviceAttrResponder_MultipleQueries(t *testing.T) {
+	var r deviceAttrResponder
+	got := r.scan([]byte("\x1b[c\x1b[>c"))
+	want := append(append([]byte{}, primaryDAResponse...), secondaryDAResponse...)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestDeviceAttrResponder_RunawayParamsResync(t *testing.T) {
+	// A never-terminated CSI must not grow params unbounded, and a later
+	// real DA query must still be answered after the responder resyncs.
+	var r deviceAttrResponder
+	long := append([]byte("\x1b["), bytes.Repeat([]byte("1;"), 40)...)
+	if got := r.scan(long); got != nil {
+		t.Fatalf("unterminated CSI should yield no reply, got %q", got)
+	}
+	if got := r.scan([]byte("\x1b[c")); !bytes.Equal(got, primaryDAResponse) {
+		t.Fatalf("responder should resync and answer DA, got %q", got)
+	}
+}

--- a/internal/tui/controlcenter/session_manager.go
+++ b/internal/tui/controlcenter/session_manager.go
@@ -115,6 +115,11 @@ func (sm *sessionManager) readLoop(s *consoleSession, session *console.PTYSessio
 	// broadcast unfiltered to WebSocket viewers, which use a full terminal
 	// emulator.
 	var filter consoleFilter
+	// daResponder answers terminal Device Attributes queries (e.g. fish's
+	// startup probe) that our line-oriented renderer would otherwise leave
+	// unanswered, causing the shell to block for ~2s. See
+	// device_attr_responder.go.
+	var daResponder deviceAttrResponder
 
 	defer sm.onSessionEnd(s, session)
 
@@ -136,6 +141,12 @@ func (sm *sessionManager) readLoop(s *consoleSession, session *console.PTYSessio
 			sm.mu.Unlock()
 			if isActive && s.streamer != nil {
 				s.streamer.Broadcast(chunk)
+			}
+
+			// Reply to any Device Attributes query in this chunk by writing
+			// back to the PTY (the shell's stdin), as a real terminal would.
+			if reply := daResponder.scan(chunk); len(reply) > 0 {
+				_, _ = session.Write(reply)
 			}
 
 			cleaned := filter.filter(chunk)


### PR DESCRIPTION
## Context

On macOS (where the login shell is **fish**), opening the **Alt-2 Console** tab shows a 2-second hang and this warning before the prompt appears:

```
warning: fish could not read response to Primary Device Attribute query after
waiting for 2 seconds. This is often due to a missing feature in your terminal.
... This fish process will no longer wait for outstanding queries, which
disables some optional features.
```

**Root cause:** the Console pane renders PTY output through tview's line-oriented `ANSIWriter` — a renderer, not a full terminal emulator. When a shell starts it emits **Device Attributes (DA)** queries to probe terminal capabilities and waits for a reply. Nothing in the pane ever answers, so fish blocks for ~2s, warns, and disables features. (bash/zsh don't probe as aggressively, which is why this surfaced on the mac's fish.)

## Summary

Added `deviceAttrResponder` — a small stateful scanner wired into the Console `readLoop`. It detects DA queries in the raw PTY output and writes a canned reply back to the PTY (the shell's stdin), exactly as a real terminal would:

| Query | Sequence | Reply |
| --- | --- | --- |
| Primary DA (DA1) | `CSI c` / `CSI 0 c` | `CSI ? 1 ; 2 c` (VT100 + Advanced Video Option) |
| Secondary DA (DA2) | `CSI > … c` | `CSI > 0 ; 0 ; 0 c` |
| Tertiary DA (DA3) | `CSI = … c` | ignored |

**Design notes:**
- `c` is the only CSI final byte used by DA queries (no display sequence ends in `c`), so matching is unambiguous and can't be tripped by color/cursor/erase sequences.
- The Primary reply is deliberately **minimal** — advertising more would invite the shell to enable query-driven features (cursor reports, synchronized output) that a line-oriented renderer can't service. The goal is only to satisfy "did the terminal answer."
- **Stateful across reads** (like `consoleFilter`), so a query split over a PTY read boundary still resolves. One responder per session read loop — no locking.
- **Detector only:** it never modifies the display bytes. tview's `ANSIWriter` already consumes the CSI query without rendering it, so there's no visible artifact.
- `PTYSession.Write` is a single small `os.File.Write` (< PIPE_BUF), so the 7-byte reply is atomic and can't interleave with user keystrokes.

## Test plan

`go test ./internal/tui/controlcenter/` — new `device_attr_responder_test.go` covers:

| Case | Asserts |
| --- | --- |
| Primary DA (`CSI c`, `CSI 0 c`) | replies with primary DA |
| Secondary DA | replies with secondary DA |
| Tertiary DA | no reply |
| Query embedded in prompt output | reply fires |
| Split at **every** interior byte boundary | reply fires exactly once, on the final `c` |
| Multiple queries in one chunk | concatenated replies |
| Runaway/unterminated CSI | bounded params, resyncs, later DA still answered |
| SGR/cursor/erase + plain text (incl. literal `[c`) | **never** misfire |

`go build ./...`, `go vet`, and the full `controlcenter` package suite pass; the existing `consoleFilter` tests are unaffected.

**Manual verification (needs a fish host, e.g. the M1 mac):** open Alt-2 → the fish prompt should appear immediately with no "Primary Device Attribute" warning and no 2s hang.

## Related

- Same Console-pane / line-oriented-ANSIWriter area as #292 (the `ESC(B` charset-escape leak). That fix *consumed* an escape the renderer mishandled; this one *answers* a query the renderer doesn't emulate.
