### PR TITLE
feat: gated read-only file access outside workspace sandbox (#284)

### DIFF
--- a/cmd/work.go
+++ b/cmd/work.go
@@ -91,6 +91,9 @@ var (
 	// Workspace directory for file-operation handlers
 	workWorkspaceDir string
 
+	// Allow read-only file handlers to access paths outside the workspace
+	workAllowReadOutsideWorkspace bool
+
 	// Gateway flags
 	workGateway        bool
 	workNoGateway      bool
@@ -1294,8 +1297,9 @@ func runWork(cmd *cobra.Command, args []string) {
 
 	// Create handlers with optional workspace for file-operation jobs.
 	handlers := worker.CreateLegacyHandlersWithOpts(worker.LegacyHandlerOpts{
-		WorkspaceDir: wsDir,
-		ConfigDir:    workConfigDir,
+		WorkspaceDir:              wsDir,
+		ConfigDir:                 workConfigDir,
+		AllowReadOutsideWorkspace: resolveAllowReadOutsideWorkspace(),
 	})
 	handlers = append(handlers, workflow.NewHandler(wfExec))
 
@@ -1506,6 +1510,17 @@ func resolveWorkspaceDir() string {
 		return dir
 	}
 	return abs
+}
+
+// resolveAllowReadOutsideWorkspace returns whether read-only file handlers may
+// access paths outside the workspace sandbox.
+// Priority: --allow-read-outside-workspace flag > CITADEL_ALLOW_READ_OUTSIDE_WORKSPACE env.
+func resolveAllowReadOutsideWorkspace() bool {
+	if workAllowReadOutsideWorkspace {
+		return true
+	}
+	v := os.Getenv("CITADEL_ALLOW_READ_OUTSIDE_WORKSPACE")
+	return v == "true" || v == "1"
 }
 
 // resolveConsumerGroup returns the consumer group name to use.
@@ -1768,6 +1783,7 @@ func init() {
 
 	// Workspace flags
 	workCmd.Flags().StringVar(&workWorkspaceDir, "workspace", "", "Workspace directory for file-operation jobs (or set CITADEL_WORKSPACE env)")
+	workCmd.Flags().BoolVar(&workAllowReadOutsideWorkspace, "allow-read-outside-workspace", false, "Allow read-only file ops to access paths outside the workspace sandbox (or set CITADEL_ALLOW_READ_OUTSIDE_WORKSPACE=true)")
 
 	// Gateway flags
 	workCmd.Flags().BoolVar(&workGateway, "gateway", true, "Start the HTTPS gateway in-process (enabled by default; use --no-gateway to disable)")

--- a/internal/jobs/file_list.go
+++ b/internal/jobs/file_list.go
@@ -15,6 +15,9 @@ import (
 // filtering by a glob pattern.
 type FileListHandler struct {
 	WorkspaceDir string
+	// AllowOutsideWorkspace, when true, permits listing directories outside
+	// the workspace sandbox. Bounded by OS file permissions.
+	AllowOutsideWorkspace bool
 }
 
 // NewFileListHandler creates a new FileListHandler rooted at workspace.
@@ -46,7 +49,7 @@ func (h *FileListHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error
 
 	pattern := job.Payload["pattern"] // May be empty.
 
-	validated, err := ValidatePath(h.WorkspaceDir, path)
+	validated, err := ValidateReadPath(h.WorkspaceDir, path, h.AllowOutsideWorkspace)
 	if err != nil {
 		return nil, fmt.Errorf("path validation failed: %w", err)
 	}

--- a/internal/jobs/file_path.go
+++ b/internal/jobs/file_path.go
@@ -112,6 +112,36 @@ func resolveNearestAncestor(target string) (string, error) {
 	}
 }
 
+// ValidateReadPath resolves requestedPath for read-only operations. When
+// allowOutside is false it delegates to ValidatePath (full workspace sandbox).
+// When allowOutside is true it performs basic cleaning and returns the absolute
+// path without a workspace boundary check, relying on OS file permissions and
+// the handler's own size caps for safety.
+func ValidateReadPath(workspace, requestedPath string, allowOutside bool) (string, error) {
+	if !allowOutside {
+		return ValidatePath(workspace, requestedPath)
+	}
+
+	if requestedPath == "" {
+		return "", fmt.Errorf("path is empty")
+	}
+
+	// If relative, anchor to workspace (when available) so relative paths
+	// still work in relaxed mode.
+	target := requestedPath
+	if !filepath.IsAbs(target) {
+		if workspace == "" {
+			return "", fmt.Errorf("workspace directory is not configured and path is relative")
+		}
+		resolvedWorkspace, err := filepath.EvalSymlinks(workspace)
+		if err != nil {
+			return "", fmt.Errorf("cannot resolve workspace %q: %w", workspace, err)
+		}
+		target = filepath.Join(resolvedWorkspace, target)
+	}
+	return filepath.Clean(target), nil
+}
+
 // isBinaryContent checks the first n bytes for NUL bytes, which indicate
 // binary content.
 func isBinaryContent(data []byte) bool {

--- a/internal/jobs/file_read.go
+++ b/internal/jobs/file_read.go
@@ -16,6 +16,9 @@ import (
 // with line numbers (similar to cat -n).
 type FileReadHandler struct {
 	WorkspaceDir string
+	// AllowOutsideWorkspace, when true, permits reading files outside the
+	// workspace sandbox. Bounded by OS file permissions and size caps.
+	AllowOutsideWorkspace bool
 }
 
 // NewFileReadHandler creates a new FileReadHandler rooted at workspace.
@@ -35,7 +38,7 @@ func (h *FileReadHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error
 		return nil, fmt.Errorf("job payload missing 'path' field")
 	}
 
-	validated, err := ValidatePath(h.WorkspaceDir, path)
+	validated, err := ValidateReadPath(h.WorkspaceDir, path, h.AllowOutsideWorkspace)
 	if err != nil {
 		return nil, fmt.Errorf("path validation failed: %w", err)
 	}

--- a/internal/jobs/file_read_bytes.go
+++ b/internal/jobs/file_read_bytes.go
@@ -22,6 +22,9 @@ const defaultMaxReadBytes int64 = 50 * 1024 * 1024
 // faithful bytes of PDFs/xlsx/CSV-with-NULs must cross the VPN mesh intact.
 type FileReadBytesHandler struct {
 	WorkspaceDir string
+	// AllowOutsideWorkspace, when true, permits reading files outside the
+	// workspace sandbox. Bounded by OS file permissions and size caps.
+	AllowOutsideWorkspace bool
 }
 
 // NewFileReadBytesHandler creates a new FileReadBytesHandler rooted at workspace.
@@ -45,7 +48,7 @@ func (h *FileReadBytesHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, 
 		return nil, fmt.Errorf("job payload missing 'path' field")
 	}
 
-	validated, err := ValidatePath(h.WorkspaceDir, path)
+	validated, err := ValidateReadPath(h.WorkspaceDir, path, h.AllowOutsideWorkspace)
 	if err != nil {
 		return nil, fmt.Errorf("path validation failed: %w", err)
 	}

--- a/internal/jobs/file_read_outside_test.go
+++ b/internal/jobs/file_read_outside_test.go
@@ -1,0 +1,331 @@
+package jobs
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --- ValidateReadPath unit tests ---
+
+func TestValidateReadPath_Sandboxed_DelegatesToValidatePath(t *testing.T) {
+	ws := setupWorkspace(t)
+	writeTestFile(t, ws, "hello.txt", "hello")
+
+	got, err := ValidateReadPath(ws, filepath.Join(ws, "hello.txt"), false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasSuffix(got, "hello.txt") {
+		t.Errorf("expected path ending in hello.txt, got %q", got)
+	}
+}
+
+func TestValidateReadPath_Sandboxed_RejectsOutside(t *testing.T) {
+	ws := setupWorkspace(t)
+
+	_, err := ValidateReadPath(ws, "/etc/passwd", false)
+	if err == nil {
+		t.Fatal("expected error for path outside workspace with allowOutside=false")
+	}
+}
+
+func TestValidateReadPath_Relaxed_AllowsOutside(t *testing.T) {
+	ws := setupWorkspace(t)
+	outside := t.TempDir()
+	resolved, _ := filepath.EvalSymlinks(outside)
+	target := filepath.Join(resolved, "outside.txt")
+	writeTestFile(t, resolved, "outside.txt", "data")
+
+	got, err := ValidateReadPath(ws, target, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != target {
+		t.Errorf("got %q, want %q", got, target)
+	}
+}
+
+func TestValidateReadPath_Relaxed_RelativeAnchorsToWorkspace(t *testing.T) {
+	ws := setupWorkspace(t)
+
+	got, err := ValidateReadPath(ws, "sub/file.txt", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := filepath.Join(ws, "sub", "file.txt")
+	if got != expected {
+		t.Errorf("got %q, want %q", got, expected)
+	}
+}
+
+func TestValidateReadPath_Relaxed_EmptyPath(t *testing.T) {
+	ws := setupWorkspace(t)
+
+	_, err := ValidateReadPath(ws, "", true)
+	if err == nil {
+		t.Fatal("expected error for empty path")
+	}
+}
+
+func TestValidateReadPath_Relaxed_CleansPath(t *testing.T) {
+	ws := setupWorkspace(t)
+	outside := t.TempDir()
+	resolved, _ := filepath.EvalSymlinks(outside)
+
+	// Build a dirty path with /.. that should be cleaned to the resolved dir.
+	dirty := filepath.Join(resolved, "sub", "..", "clean.txt")
+	want := filepath.Join(resolved, "clean.txt")
+
+	got, err := ValidateReadPath(ws, dirty, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("got %q, want %q (cleaned)", got, want)
+	}
+}
+
+func TestValidateReadPath_Relaxed_RelativeWithoutWorkspace(t *testing.T) {
+	_, err := ValidateReadPath("", "relative/path.txt", true)
+	if err == nil {
+		t.Fatal("expected error for relative path without workspace")
+	}
+}
+
+// --- FILE_READ with AllowOutsideWorkspace ---
+
+func TestFileRead_OutsideWorkspace_Allowed(t *testing.T) {
+	ws := setupWorkspace(t)
+	outside := t.TempDir()
+	resolved, _ := filepath.EvalSymlinks(outside)
+	path := writeTestFile(t, resolved, "external.txt", "external content\n")
+
+	h := NewFileReadHandler(ws)
+	h.AllowOutsideWorkspace = true
+	out, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path": path,
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("json unmarshal: %v", err)
+	}
+	content := result["content"].(string)
+	if !strings.Contains(content, "external content") {
+		t.Errorf("content should contain 'external content', got: %s", content)
+	}
+}
+
+func TestFileRead_OutsideWorkspace_Blocked_ByDefault(t *testing.T) {
+	ws := setupWorkspace(t)
+	outside := t.TempDir()
+	resolved, _ := filepath.EvalSymlinks(outside)
+	path := writeTestFile(t, resolved, "external.txt", "external content\n")
+
+	h := NewFileReadHandler(ws)
+	// AllowOutsideWorkspace defaults to false
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path": path,
+	}))
+	if err == nil {
+		t.Fatal("expected error for outside path with default config")
+	}
+	if !strings.Contains(err.Error(), "path validation") {
+		t.Errorf("error should mention path validation, got: %v", err)
+	}
+}
+
+// --- FILE_READ_BYTES with AllowOutsideWorkspace ---
+
+func TestFileReadBytes_OutsideWorkspace_Allowed(t *testing.T) {
+	ws := setupWorkspace(t)
+	outside := t.TempDir()
+	resolved, _ := filepath.EvalSymlinks(outside)
+	content := "binary-safe content"
+	path := writeTestFile(t, resolved, "external.bin", content)
+
+	h := NewFileReadBytesHandler(ws)
+	h.AllowOutsideWorkspace = true
+	out, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path": path,
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result fileReadBytesResult
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("json unmarshal: %v", err)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(result.Content)
+	if err != nil {
+		t.Fatalf("base64 decode: %v", err)
+	}
+	if string(decoded) != content {
+		t.Errorf("decoded = %q, want %q", string(decoded), content)
+	}
+}
+
+func TestFileReadBytes_OutsideWorkspace_Blocked_ByDefault(t *testing.T) {
+	ws := setupWorkspace(t)
+	outside := t.TempDir()
+	resolved, _ := filepath.EvalSymlinks(outside)
+	path := writeTestFile(t, resolved, "external.bin", "data")
+
+	h := NewFileReadBytesHandler(ws)
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path": path,
+	}))
+	if err == nil {
+		t.Fatal("expected error for outside path with default config")
+	}
+}
+
+// --- FILE_LIST with AllowOutsideWorkspace ---
+
+func TestFileList_OutsideWorkspace_Allowed(t *testing.T) {
+	ws := setupWorkspace(t)
+	outside := t.TempDir()
+	resolved, _ := filepath.EvalSymlinks(outside)
+	writeTestFile(t, resolved, "a.txt", "a")
+	writeTestFile(t, resolved, "b.txt", "b")
+
+	h := NewFileListHandler(ws)
+	h.AllowOutsideWorkspace = true
+	out, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path": resolved,
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("json unmarshal: %v", err)
+	}
+	count := int(result["count"].(float64))
+	if count != 2 {
+		t.Errorf("count = %d, want 2", count)
+	}
+}
+
+func TestFileList_OutsideWorkspace_Blocked_ByDefault(t *testing.T) {
+	ws := setupWorkspace(t)
+	outside := t.TempDir()
+	resolved, _ := filepath.EvalSymlinks(outside)
+
+	h := NewFileListHandler(ws)
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path": resolved,
+	}))
+	if err == nil {
+		t.Fatal("expected error for outside path with default config")
+	}
+}
+
+// --- FILE_SEARCH with AllowOutsideWorkspace ---
+
+func TestFileSearch_OutsideWorkspace_Allowed(t *testing.T) {
+	ws := setupWorkspace(t)
+	outside := t.TempDir()
+	resolved, _ := filepath.EvalSymlinks(outside)
+	writeTestFile(t, resolved, "needle.txt", "find this needle\n")
+
+	h := NewFileSearchHandler(ws)
+	h.AllowOutsideWorkspace = true
+	out, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path":  resolved,
+		"query": "needle",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(out, &result); err != nil {
+		t.Fatalf("json unmarshal: %v", err)
+	}
+	matchCount := int(result["match_count"].(float64))
+	if matchCount != 1 {
+		t.Errorf("match_count = %d, want 1", matchCount)
+	}
+
+	// Verify the match path is absolute (not ../../...) when searching outside workspace.
+	matches := result["matches"].([]any)
+	match := matches[0].(map[string]any)
+	filePath := match["file"].(string)
+	if strings.HasPrefix(filePath, "..") {
+		t.Errorf("match path should not be relative with .., got %q", filePath)
+	}
+}
+
+func TestFileSearch_OutsideWorkspace_Blocked_ByDefault(t *testing.T) {
+	ws := setupWorkspace(t)
+	outside := t.TempDir()
+	resolved, _ := filepath.EvalSymlinks(outside)
+	writeTestFile(t, resolved, "needle.txt", "find this\n")
+
+	h := NewFileSearchHandler(ws)
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path":  resolved,
+		"query": "find",
+	}))
+	if err == nil {
+		t.Fatal("expected error for outside path with default config")
+	}
+}
+
+// --- FILE_WRITE and FILE_EDIT stay sandboxed regardless ---
+
+func TestFileWrite_StaysSandboxed(t *testing.T) {
+	ws := setupWorkspace(t)
+	outside := t.TempDir()
+	resolved, _ := filepath.EvalSymlinks(outside)
+	target := filepath.Join(resolved, "should-not-exist.txt")
+
+	// FileWriteHandler has no AllowOutsideWorkspace field.
+	h := NewFileWriteHandler(ws)
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path":    target,
+		"content": "pwned",
+	}))
+	if err == nil {
+		t.Fatal("expected error: writes must always be sandboxed")
+	}
+
+	// Verify nothing was written.
+	if _, statErr := os.Stat(target); statErr == nil {
+		t.Fatal("file was created outside workspace; writes should be blocked")
+	}
+}
+
+func TestFileEdit_StaysSandboxed(t *testing.T) {
+	ws := setupWorkspace(t)
+	outside := t.TempDir()
+	resolved, _ := filepath.EvalSymlinks(outside)
+	path := writeTestFile(t, resolved, "external.txt", "original content")
+
+	// FileEditHandler has no AllowOutsideWorkspace field.
+	h := NewFileEditHandler(ws)
+	_, err := h.Execute(JobContext{}, makeJob(map[string]string{
+		"path":       path,
+		"old_string": "original",
+		"new_string": "modified",
+	}))
+	if err == nil {
+		t.Fatal("expected error: edits must always be sandboxed")
+	}
+
+	// Verify file was not modified.
+	data, _ := os.ReadFile(path)
+	if strings.Contains(string(data), "modified") {
+		t.Fatal("file was modified outside workspace; edits should be blocked")
+	}
+}

--- a/internal/jobs/file_search.go
+++ b/internal/jobs/file_search.go
@@ -17,6 +17,9 @@ import (
 // matches with line numbers and context.
 type FileSearchHandler struct {
 	WorkspaceDir string
+	// AllowOutsideWorkspace, when true, permits searching files outside the
+	// workspace sandbox. Bounded by OS file permissions and size caps.
+	AllowOutsideWorkspace bool
 }
 
 // NewFileSearchHandler creates a new FileSearchHandler rooted at workspace.
@@ -56,7 +59,7 @@ func (h *FileSearchHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, err
 
 	filePattern := job.Payload["file_pattern"] // May be empty.
 
-	validated, err := ValidatePath(h.WorkspaceDir, path)
+	validated, err := ValidateReadPath(h.WorkspaceDir, path, h.AllowOutsideWorkspace)
 	if err != nil {
 		return nil, fmt.Errorf("path validation failed: %w", err)
 	}
@@ -132,8 +135,10 @@ func (h *FileSearchHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, err
 			line := scanner.Text()
 			if strings.Contains(line, query) {
 				// Use workspace-relative path for cleaner output.
+				// When searching outside the workspace, fall back to the
+				// absolute path instead of emitting "../../../..." strings.
 				relPath, err := filepath.Rel(h.WorkspaceDir, p)
-				if err != nil {
+				if err != nil || strings.HasPrefix(relPath, "..") {
 					relPath = p
 				}
 				matches = append(matches, searchMatch{

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -103,6 +103,10 @@ type LegacyHandlerOpts struct {
 	// ConfigDir is the path to the citadel.yaml manifest directory.
 	// If empty, service-management handlers are not registered.
 	ConfigDir string
+	// AllowReadOutsideWorkspace, when true, lets read-only file handlers
+	// (FILE_READ, FILE_READ_BYTES, FILE_LIST, FILE_SEARCH) access paths
+	// outside the workspace sandbox. Write handlers are unaffected.
+	AllowReadOutsideWorkspace bool
 }
 
 // CreateLegacyHandlers creates JobHandler adapters for all existing Nexus job handlers.
@@ -141,13 +145,25 @@ func CreateLegacyHandlersWithOpts(opts LegacyHandlerOpts) []JobHandler {
 
 	// Register file-operation handlers when a workspace is configured.
 	if opts.WorkspaceDir != "" {
+		readHandler := jobs.NewFileReadHandler(opts.WorkspaceDir)
+		readHandler.AllowOutsideWorkspace = opts.AllowReadOutsideWorkspace
+
+		readBytesHandler := jobs.NewFileReadBytesHandler(opts.WorkspaceDir)
+		readBytesHandler.AllowOutsideWorkspace = opts.AllowReadOutsideWorkspace
+
+		listHandler := jobs.NewFileListHandler(opts.WorkspaceDir)
+		listHandler.AllowOutsideWorkspace = opts.AllowReadOutsideWorkspace
+
+		searchHandler := jobs.NewFileSearchHandler(opts.WorkspaceDir)
+		searchHandler.AllowOutsideWorkspace = opts.AllowReadOutsideWorkspace
+
 		handlers = append(handlers,
-			NewLegacyHandlerAdapter(JobTypeFileRead, jobs.NewFileReadHandler(opts.WorkspaceDir)),
-			NewLegacyHandlerAdapter(JobTypeFileReadBytes, jobs.NewFileReadBytesHandler(opts.WorkspaceDir)),
+			NewLegacyHandlerAdapter(JobTypeFileRead, readHandler),
+			NewLegacyHandlerAdapter(JobTypeFileReadBytes, readBytesHandler),
 			NewLegacyHandlerAdapter(JobTypeFileWrite, jobs.NewFileWriteHandler(opts.WorkspaceDir)),
 			NewLegacyHandlerAdapter(JobTypeFileEdit, jobs.NewFileEditHandler(opts.WorkspaceDir)),
-			NewLegacyHandlerAdapter(JobTypeFileList, jobs.NewFileListHandler(opts.WorkspaceDir)),
-			NewLegacyHandlerAdapter(JobTypeFileSearch, jobs.NewFileSearchHandler(opts.WorkspaceDir)),
+			NewLegacyHandlerAdapter(JobTypeFileList, listHandler),
+			NewLegacyHandlerAdapter(JobTypeFileSearch, searchHandler),
 		)
 	}
 


### PR DESCRIPTION
## Context

The MCP `upload_file` tool and File Visualizer read files from Citadel nodes over the mesh, but `ValidatePath` restricts all file ops to the workspace root (`~/citadel-node/workspace`). Users must copy files into the workspace before they can be ingested — this removes that friction for reads.

## Summary

- **`ValidateReadPath`** in `file_path.go` — new function that delegates to `ValidatePath` when the flag is off (preserving the sandbox), or does basic path cleaning when on
- **Read-only handlers** (`FILE_READ`, `FILE_READ_BYTES`, `FILE_LIST`, `FILE_SEARCH`) each gain an `AllowOutsideWorkspace` field, wired through `LegacyHandlerOpts`
- **Write handlers** (`FILE_WRITE`, `FILE_EDIT`) are **untouched** — always sandboxed
- **CLI flag** `--allow-read-outside-workspace` + env var `CITADEL_ALLOW_READ_OUTSIDE_WORKSPACE`, default **off**
- **`file_search`** fixed to emit absolute paths (not `../../../...`) when searching outside workspace
- **17 tests** covering: ValidateReadPath unit tests (7), handler allowed/blocked for all 4 read types (8), write/edit stay-sandboxed (2)

## Test plan

- `go build ./...` — clean
- `go test ./...` — all pass including 17 new tests

Closes #284