### PR TITLE
feat(terminal): persistent tmux sessions by default + per-user reconnect resilience

### DIFF
--- a/internal/terminal/config.go
+++ b/internal/terminal/config.go
@@ -8,6 +8,12 @@ import (
 	"time"
 )
 
+// DefaultSessionName is the base tmux session name used when
+// CITADEL_TERMINAL_SESSION is not set. Its presence is what makes terminals
+// tmux-backed (and therefore reconnect-resilient) by default. It is a valid
+// tmux session name per tmux.ValidateSessionName.
+const DefaultSessionName = "citadel"
+
 // Config holds the terminal server configuration
 type Config struct {
 	// Host is the address the WebSocket server binds to (default: 127.0.0.1)
@@ -39,6 +45,14 @@ type Config struct {
 	// the terminal state survives. Requires a resolvable tmux binary; when tmux
 	// is unavailable the server falls back to a bare shell. Configured via
 	// CITADEL_TERMINAL_SESSION.
+	//
+	// SessionName is treated as a base name. The server derives a stable,
+	// per-user session name from it (base + sanitized user ID) so each user
+	// re-attaches to their own persistent terminal across reconnects while
+	// staying isolated from other users. It defaults to DefaultSessionName so
+	// terminals are tmux-backed (and reconnect-resilient) out of the box. Set
+	// CITADEL_TERMINAL_SESSION to the disable sentinel ("none"/"off"/
+	// "disabled") to force a bare, non-persistent shell.
 	SessionName string
 
 	// AuthServiceURL is the URL of the AceTeam auth service for token validation
@@ -70,7 +84,7 @@ func DefaultConfig() *Config {
 		IdleTimeout:          time.Duration(getEnvInt("CITADEL_TERMINAL_IDLE_TIMEOUT", 30)) * time.Minute,
 		MaxConnections:       getEnvInt("CITADEL_TERMINAL_MAX_CONNECTIONS", 10),
 		Shell:                getEnvOrDefault("CITADEL_TERMINAL_SHELL", defaultShell()),
-		SessionName:          os.Getenv("CITADEL_TERMINAL_SESSION"),
+		SessionName:          getEnvOrDefault("CITADEL_TERMINAL_SESSION", DefaultSessionName),
 		AuthServiceURL:       getEnvOrDefault("CITADEL_AUTH_HOST", "https://aceteam.ai"),
 		RateLimitRPS:         1.0, // 1 connection attempt per second per IP
 		RateLimitBurst:       5,   // Allow bursts of 5

--- a/internal/terminal/server.go
+++ b/internal/terminal/server.go
@@ -356,10 +356,17 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 	// When a persistent named session is configured and tmux is available, back
 	// the PTY with `tmux new-session -A -s <name>` so the session survives
-	// reconnects; otherwise fall back to a bare shell.
-	tmuxCommand := sessionCommand(s.config.SessionName, s.config.Shell)
-	if tmuxCommand != nil {
-		s.logger.Debugf("backing session %s with persistent tmux session %q", sessionID, s.config.SessionName)
+	// reconnects; otherwise fall back to a bare shell. The tmux session name is
+	// derived per-user from the configured base name so a reconnecting client
+	// re-attaches to its own live session (running command, scrollback, cwd all
+	// preserved by the tmux server) while staying isolated from other users.
+	var tmuxCommand []string
+	if !sessionDisabled(s.config.SessionName) {
+		tmuxSessionName := sessionNameForUser(s.config.SessionName, tokenInfo.UserID)
+		tmuxCommand = sessionCommand(tmuxSessionName, s.config.Shell)
+		if tmuxCommand != nil {
+			s.logger.Debugf("backing session %s with persistent tmux session %q", sessionID, tmuxSessionName)
+		}
 	}
 
 	// Create PTY session

--- a/internal/terminal/tmux.go
+++ b/internal/terminal/tmux.go
@@ -1,7 +1,83 @@
 // internal/terminal/tmux.go
 package terminal
 
-import "github.com/aceteam-ai/citadel-cli/internal/tmux"
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+
+	"github.com/aceteam-ai/citadel-cli/internal/tmux"
+)
+
+// disableSentinels are case-insensitive values of CITADEL_TERMINAL_SESSION (or
+// Config.SessionName) that explicitly turn persistent tmux backing OFF, forcing
+// a bare, non-persistent shell.
+var disableSentinels = map[string]bool{
+	"none":     true,
+	"off":      true,
+	"disabled": true,
+	"false":    true,
+	"0":        true,
+}
+
+// sessionDisabled reports whether the configured session base name asks for
+// tmux backing to be turned off.
+func sessionDisabled(sessionName string) bool {
+	return disableSentinels[strings.ToLower(strings.TrimSpace(sessionName))]
+}
+
+// sessionNameForUser derives a stable, validated tmux session name from a base
+// name and a user ID. The same (base, userID) pair always yields the same name,
+// which is what lets a reconnecting client re-attach to the user's existing
+// persistent session. Different users get different names, so they never share
+// a terminal.
+//
+// userIDs are not guaranteed to be tmux-safe (UUIDs are fine, but emails carry
+// '@' and '.', which tmux uses to address windows/panes). We therefore keep
+// only the safe characters from the user ID and, when sanitisation would change
+// or empty it, append a short hash of the original so distinct users can never
+// collide onto the same session. The result is always within tmux's length
+// limit and passes tmux.ValidateSessionName.
+//
+// An empty userID (or a base that already fails validation) falls back to the
+// base name alone so a session is still persistent, just shared.
+func sessionNameForUser(base, userID string) string {
+	if userID == "" {
+		return base
+	}
+
+	var safe strings.Builder
+	for _, r := range userID {
+		switch {
+		case r >= 'A' && r <= 'Z', r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-', r == '_':
+			safe.WriteRune(r)
+		}
+	}
+	cleaned := safe.String()
+
+	// If sanitisation dropped any characters, the cleaned form is ambiguous
+	// (two different user IDs could clean to the same string), so disambiguate
+	// with a short hash of the original ID.
+	if cleaned != userID {
+		sum := sha256.Sum256([]byte(userID))
+		cleaned = cleaned + "-" + hex.EncodeToString(sum[:])[:8]
+	}
+
+	name := base + "-" + cleaned
+
+	// tmux session names are capped at 64 chars (see tmux.ValidateSessionName).
+	// If the combined name is too long, fall back to base + a hash so the name
+	// stays bounded and deterministic.
+	if err := tmux.ValidateSessionName(name); err != nil {
+		sum := sha256.Sum256([]byte(userID))
+		name = base + "-" + hex.EncodeToString(sum[:])[:16]
+		if err := tmux.ValidateSessionName(name); err != nil {
+			// base itself is invalid or too long; give up on per-user naming.
+			return base
+		}
+	}
+	return name
+}
 
 // sessionCommand returns the program + args the PTY should run for a connection.
 //
@@ -11,10 +87,13 @@ import "github.com/aceteam-ai/citadel-cli/internal/tmux"
 // reconnects. Otherwise it returns nil, signalling the caller to fall back to a
 // bare shell.
 //
+// A SessionName matching a disable sentinel ("none"/"off"/...) returns nil so
+// operators can opt out of persistence without unsetting the default.
+//
 // The returned command starts only a shell inside tmux; launching claude (or
 // any agent) is a separate explicit step and never coupled here.
 func sessionCommand(sessionName, shell string) []string {
-	if sessionName == "" {
+	if sessionName == "" || sessionDisabled(sessionName) {
 		return nil
 	}
 	if err := tmux.ValidateSessionName(sessionName); err != nil {

--- a/internal/terminal/tmux_test.go
+++ b/internal/terminal/tmux_test.go
@@ -4,7 +4,10 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/tmux"
 )
 
 // makeFakeTmux writes an executable stub and points CITADEL_TMUX_BIN at it so
@@ -46,5 +49,70 @@ func TestSessionCommand_BuildsAttachOrCreate(t *testing.T) {
 	want := []string{bin, "new-session", "-A", "-s", "agent", "/bin/bash"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("sessionCommand = %v, want %v", got, want)
+	}
+}
+
+func TestSessionCommand_DisableSentinel(t *testing.T) {
+	makeFakeTmux(t)
+	for _, name := range []string{"none", "off", "OFF", "disabled", "false", "0", " none "} {
+		if got := sessionCommand(name, "/bin/bash"); got != nil {
+			t.Errorf("sessionCommand(%q) = %v, want nil (disabled)", name, got)
+		}
+	}
+}
+
+func TestSessionDisabled(t *testing.T) {
+	on := []string{"", "citadel", "agent", "my-session", "nonexistent"}
+	off := []string{"none", "off", "OFF", "Disabled", "false", "0", "  off  "}
+	for _, s := range on {
+		if sessionDisabled(s) {
+			t.Errorf("sessionDisabled(%q) = true, want false", s)
+		}
+	}
+	for _, s := range off {
+		if !sessionDisabled(s) {
+			t.Errorf("sessionDisabled(%q) = false, want true", s)
+		}
+	}
+}
+
+func TestSessionNameForUser(t *testing.T) {
+	// Empty user falls back to the base name (shared but persistent).
+	if got := sessionNameForUser("citadel", ""); got != "citadel" {
+		t.Errorf("empty user: got %q, want %q", got, "citadel")
+	}
+
+	// A tmux-safe user id (e.g. a UUID without dashes, or alnum) is appended
+	// verbatim.
+	if got := sessionNameForUser("citadel", "user123"); got != "citadel-user123" {
+		t.Errorf("safe user: got %q, want %q", got, "citadel-user123")
+	}
+
+	// Deterministic: same inputs yield the same name (reconnect key stability).
+	a := sessionNameForUser("citadel", "alice@example.com")
+	b := sessionNameForUser("citadel", "alice@example.com")
+	if a != b {
+		t.Errorf("not deterministic: %q != %q", a, b)
+	}
+
+	// Distinct users that sanitise to the same cleaned string must not collide.
+	x := sessionNameForUser("citadel", "a@b.com")
+	y := sessionNameForUser("citadel", "ab.com")
+	if x == y {
+		t.Errorf("collision: both users -> %q", x)
+	}
+
+	// Every derived name must be a valid tmux session name.
+	for _, uid := range []string{
+		"user123",
+		"alice@example.com",
+		"00000000-0000-0000-0000-000000000000",
+		strings.Repeat("x", 200),
+		"@@@@",
+	} {
+		name := sessionNameForUser("citadel", uid)
+		if err := tmux.ValidateSessionName(name); err != nil {
+			t.Errorf("derived name %q for uid %q invalid: %v", name, uid, err)
+		}
 	}
 }


### PR DESCRIPTION
Closes #4181
Closes aceteam-ai/aceteam#4181 (the issue lives in the aceteam repo; the qualified form is what actually closes it from this PR)

Part of the Computer-use maturity epic (aceteam-ai/aceteam#4168), P0 item 3.

## Context

tmux session support already exists (`internal/tmux/tmux.go`, `internal/terminal/server.go`) but was effectively off: `Config.SessionName` read `CITADEL_TERMINAL_SESSION`, which is empty by default, so `sessionCommand` returned `nil` and every connection ran a **bare shell**. A bare-shell PTY is owned by the citadel `Session` object, so on any websocket disconnect the PTY is closed and the running command, scrollback, and cwd are lost.

## Root cause

`DefaultConfig()` defaulted `SessionName` to `os.Getenv("CITADEL_TERMINAL_SESSION")` (empty) → no tmux backing → no persistence.

## Solution

Make terminals tmux-backed by default and reconnect-resilient:

- **Default on:** `DefaultConfig()` now defaults `SessionName` to `DefaultSessionName` (`"citadel"`) via `getEnvOrDefault`, so connections are backed by `tmux new-session -A -s <name>` unless explicitly disabled.
- **Opt-out:** a disable sentinel (`none` / `off` / `disabled` / `false` / `0`, case/space-insensitive) in `CITADEL_TERMINAL_SESSION` forces a bare, non-persistent shell.
- **Per-user isolation + reconnect:** `SessionName` is treated as a *base* name. In `handleWebSocket` the server derives a stable, sanitized per-user session name (`sessionNameForUser(base, tokenInfo.UserID)`). The same user always maps to the same tmux session name, so a reconnect re-attaches to their existing live session; different users never share a terminal. User IDs are sanitized to tmux's safe charset (`^[A-Za-z0-9_-]{1,64}$`); when sanitization is lossy or over-length, a short SHA-256 suffix keeps names unique, bounded, and collision-free.
- **Graceful fallback:** when no tmux binary resolves, `sessionCommand` returns `nil` and the server falls back to a bare shell (existing behavior), so tmux-less nodes are unaffected.

### Why no server-side replay buffer / grace timer

State survival across a disconnect is provided by the **tmux server daemon**, not the citadel `Session`. On disconnect, `handleConnection` returns → `session.Close()` sends SIGHUP to the `tmux attach` *client* process only; the tmux *server* session (shell, running command, scrollback, cwd) survives. Reconnecting with the same name re-attaches and tmux redraws the pane. So default-name + same-name-on-reconnect satisfies the acceptance criterion without a custom replay buffer. A bounded grace window that *kills* idle tmux sessions would require running `tmux kill-session` (spawns tmux) and is **deferred** — see below.

## Files

- `internal/terminal/config.go` — `DefaultSessionName` const; default `SessionName`; doc.
- `internal/terminal/tmux.go` — `sessionDisabled`, `sessionNameForUser`, disable-sentinel handling in `sessionCommand`.
- `internal/terminal/server.go` — derive per-user tmux session name in `handleWebSocket`.
- `internal/terminal/tmux_test.go` — unit tests for the new pure helpers.

## Verification done here

This dev host runs tmux 3.4, which has a double-free bug that crashes the session when tmux is spawned, so tmux-spawning tests were **not** run here. Verified:

- `go build ./...` — OK
- `go vet ./internal/terminal/ ./internal/tmux/ ./cmd/` — OK
- `go test -c ./internal/terminal/` (compile tests without running) — OK

## How to test (run on a host with a working tmux)

Prereq: `tmux` on PATH (or `CITADEL_TMUX_BIN` set), and a citadel node initialized (`citadel init`) so an org-id and device token exist.

1. **Run the unit tests** (safe; they use a no-op tmux stub, no real tmux spawned):
   ```bash
   go test ./internal/terminal/ -run 'TestSessionCommand|TestSessionDisabled|TestSessionNameForUser' -v
   ```

2. **Default tmux backing + reconnect survival:**
   - Start the terminal server: `citadel work --terminal --terminal-port 7860` (or `citadel terminal-server --test --port 7860`).
   - Connect a websocket client to `ws://127.0.0.1:7860/terminal?token=<valid-token>` (the web/iOS terminal UI, or a wscat client speaking the JSON `input`/`output` protocol).
   - In the terminal, start a long-running command, e.g. `for i in $(seq 1 1000); do echo $i; sleep 1; done`, and `cd /tmp` to change cwd.
   - **Drop the connection** (kill the client / disconnect the network).
   - **Reconnect** with the same token. Expected: you re-attach to the same tmux session — the loop is still running and counting, scrollback is intact, and `pwd` is still `/tmp`. Before this change the command would be gone and you'd land in a fresh shell at the home dir.

3. **Per-user isolation:** connect with two tokens for different users; confirm `tmux ls` shows two distinct `citadel-*` sessions and each user sees only their own terminal.

4. **Opt-out:** set `CITADEL_TERMINAL_SESSION=off` and restart; confirm connections get a bare shell and a disconnect loses state (`tmux ls` shows no `citadel-*` session).

5. **tmux-less fallback:** on a host without tmux (and `CITADEL_TMUX_BIN` unset), confirm the server still serves a working bare shell.

## Deferred (out of scope)

- A **bounded grace window** that proactively kills idle/orphaned tmux sessions after N seconds (needs `tmux kill-session`; could not be exercised on this tmux-broken host). tmux already preserves state indefinitely until the idle-session checker closes the citadel session, so this is a cleanup nicety, not required for acceptance.
- Surfacing the active per-user session name to the client / a session-picker UI (no client protocol field exists today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
