### PR TITLE
feat(worker): node-side screenshot + VNC handlers (#4179) + drag actions (#4180)

### DIFF
--- a/internal/desktop/actions.go
+++ b/internal/desktop/actions.go
@@ -25,11 +25,13 @@ type Action struct {
 }
 
 var allowedActionTypes = map[string]bool{
-	"move":   true,
-	"click":  true,
-	"type":   true,
-	"key":    true,
-	"scroll": true,
+	"move":      true,
+	"click":     true,
+	"type":      true,
+	"key":       true,
+	"scroll":    true,
+	"mousedown": true, // press a button without releasing (drag start; issue #4180)
+	"mouseup":   true, // release a held button (drag end; issue #4180)
 }
 
 var safeKeyPattern = regexp.MustCompile(`^[a-zA-Z0-9_+\- ]+$`)
@@ -57,7 +59,7 @@ func ParseActions(data []byte) ([]Action, error) {
 
 func validateAction(a Action) error {
 	if !allowedActionTypes[a.Type] {
-		return fmt.Errorf("unknown action type %q (allowed: move, click, type, key, scroll)", a.Type)
+		return fmt.Errorf("unknown action type %q (allowed: move, click, type, key, scroll, mousedown, mouseup)", a.Type)
 	}
 
 	switch a.Type {
@@ -98,6 +100,13 @@ func validateAction(a Action) error {
 		if !safeKeyPattern.MatchString(a.Key) {
 			return fmt.Errorf("key name contains invalid characters")
 		}
+	case "mousedown", "mouseup":
+		// Press/release a button at the current pointer position. Coordinates
+		// are not required: drag sequences emit a preceding "move" action to
+		// position the pointer (see python translate_action left_click_drag).
+		if a.Button != nil && (*a.Button < 1 || *a.Button > 5) {
+			return fmt.Errorf("button must be 1-5")
+		}
 	case "scroll":
 		if a.Delta == nil {
 			return fmt.Errorf("scroll requires delta")
@@ -124,6 +133,12 @@ func ActionToXdotoolArgs(a Action) (string, []string, error) {
 			"--", strconv.Itoa(*a.X), strconv.Itoa(*a.Y),
 			"click", strconv.Itoa(button),
 		}, nil
+	case "mousedown":
+		// Press and hold a button at the current pointer position (drag start).
+		return "mousedown", []string{strconv.Itoa(buttonOrDefault(a.Button, 1))}, nil
+	case "mouseup":
+		// Release a held button at the current pointer position (drag end).
+		return "mouseup", []string{strconv.Itoa(buttonOrDefault(a.Button, 1))}, nil
 	case "type":
 		return "type", []string{"--clearmodifiers", "--", a.Text}, nil
 	case "key":

--- a/internal/desktop/desktop_test.go
+++ b/internal/desktop/desktop_test.go
@@ -122,6 +122,11 @@ func TestParseActions(t *testing.T) {
 		{"type", `[{"type":"type","text":"hello world"}]`, 1, false},
 		{"key", `[{"type":"key","key":"Return"}]`, 1, false},
 		{"scroll", `[{"type":"scroll","delta":-3}]`, 1, false},
+		{"mousedown", `[{"type":"mousedown","button":1}]`, 1, false},
+		{"mouseup", `[{"type":"mouseup","button":1}]`, 1, false},
+		{"mousedown no button", `[{"type":"mousedown"}]`, 1, false},
+		{"drag sequence", `[{"type":"move","x":10,"y":20},{"type":"mousedown","button":1},{"type":"move","x":90,"y":80},{"type":"mouseup","button":1}]`, 4, false},
+		{"mousedown invalid button", `[{"type":"mousedown","button":9}]`, 0, true},
 		{"multiple", `[{"type":"move","x":10,"y":20},{"type":"click","x":10,"y":20},{"type":"type","text":"hi"}]`, 3, false},
 		{"empty array", `[]`, 0, true},
 		{"invalid json", `not json`, 0, true},
@@ -206,6 +211,24 @@ func TestActionToXdotoolArgs(t *testing.T) {
 			action:   Action{Type: "scroll", Delta: intPtr(2)},
 			wantCmd:  "click",
 			wantArgs: []string{"4", "4"},
+		},
+		{
+			name:     "mousedown default button",
+			action:   Action{Type: "mousedown"},
+			wantCmd:  "mousedown",
+			wantArgs: []string{"1"},
+		},
+		{
+			name:     "mousedown explicit button",
+			action:   Action{Type: "mousedown", Button: intPtr(3)},
+			wantCmd:  "mousedown",
+			wantArgs: []string{"3"},
+		},
+		{
+			name:     "mouseup default button",
+			action:   Action{Type: "mouseup"},
+			wantCmd:  "mouseup",
+			wantArgs: []string{"1"},
 		},
 	}
 

--- a/internal/jobs/desktop.go
+++ b/internal/jobs/desktop.go
@@ -1,0 +1,191 @@
+// internal/jobs/desktop.go
+package jobs
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"image"
+	_ "image/png" // register PNG decoder for image.DecodeConfig
+	"strings"
+
+	"github.com/aceteam-ai/citadel-cli/internal/desktop"
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+// ScreenshotHandler captures the node's display and returns a base64-encoded
+// PNG. It backs the FILE_SCREENSHOT and VNC_SCREENSHOT job types, which the
+// aceteam `desktop_screenshot` / `vnc_screenshot` MCP tools dispatch over the
+// Redis mesh (issue #4179). Without this handler those tools time out (~15s)
+// despite the UI looking production-grade -- the "demo trap" the epic #4168
+// scoping pass identified.
+//
+// Both job types capture the same X11 framebuffer via the existing
+// internal/desktop capture path; there is no separate VNC-framebuffer source.
+type ScreenshotHandler struct{}
+
+// Execute captures a screenshot and returns it base64-encoded.
+//
+// Payload fields (advisory; capture is always PNG):
+//   - format:  requested image format (ignored; always PNG)
+//   - quality: requested JPEG quality (ignored; PNG is lossless)
+//
+// Response JSON:
+//   - image:    standard base64 of the raw PNG bytes (the field the
+//     coordinator/MCP tool reads as result["image"])
+//   - encoding: always "base64"
+//   - format:   always "png"
+//   - width:    decoded pixel width as a string (best-effort)
+//   - height:   decoded pixel height as a string (best-effort)
+func (h *ScreenshotHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	// JobContext carries no context.Context; CaptureScreenshot applies its own
+	// internal timeout, so Background is safe here.
+	png, err := desktop.CaptureScreenshot(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("screenshot capture failed: %w", err)
+	}
+	if len(png) == 0 {
+		return nil, fmt.Errorf("screenshot capture returned no image data")
+	}
+
+	ctx.Log("info", "     - [Job %s] %s captured (%d bytes)", job.ID, job.Type, len(png))
+
+	result := map[string]any{
+		"image":    base64.StdEncoding.EncodeToString(png),
+		"encoding": "base64",
+		"format":   "png",
+	}
+
+	// Best-effort dimensions to match the documented wire contract
+	// ({"image","width","height"}). DecodeConfig reads only the header, so this
+	// is cheap and never fails the job if the format is unexpected.
+	if cfg, _, derr := image.DecodeConfig(bytes.NewReader(png)); derr == nil {
+		result["width"] = fmt.Sprintf("%d", cfg.Width)
+		result["height"] = fmt.Sprintf("%d", cfg.Height)
+	}
+
+	return json.Marshal(result)
+}
+
+// Ensure ScreenshotHandler implements JobHandler.
+var _ JobHandler = (*ScreenshotHandler)(nil)
+
+// TypeHandler types literal text on the node's display. It backs the VNC_TYPE
+// job type behind the aceteam `vnc_type` MCP tool (issue #4179), reusing the
+// existing internal/desktop input path.
+type TypeHandler struct{}
+
+// Execute types the payload's `text` field on the display.
+//
+// Payload fields:
+//   - text: the literal text to type (required, non-empty)
+//
+// Response JSON: {"ok": true, "typed": <char-count>}.
+func (h *TypeHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	text, ok := job.Payload["text"]
+	if !ok || text == "" {
+		return nil, fmt.Errorf("job payload missing 'text' field")
+	}
+
+	actions, err := buildTypeActions(text)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx.Log("info", "     - [Job %s] VNC_TYPE typing %d chars", job.ID, len(text))
+
+	if err := desktop.ExecuteActions(context.Background(), actions); err != nil {
+		return nil, fmt.Errorf("type failed: %w", err)
+	}
+
+	return json.Marshal(map[string]any{"ok": true, "typed": len(text)})
+}
+
+// Ensure TypeHandler implements JobHandler.
+var _ JobHandler = (*TypeHandler)(nil)
+
+// KeysHandler sends a key combination to the node's display. It backs the
+// VNC_KEYS job type behind the aceteam `vnc_keys` MCP tool (issue #4179).
+type KeysHandler struct{}
+
+// Execute sends a key combo to the display.
+//
+// Payload fields (the MCP tool sends both; `keys` is authoritative):
+//   - keys:  JSON array of X keysym names, e.g. `["ctrl","c"]` (preferred)
+//   - combo: original human combo string, e.g. "Ctrl+C" (fallback/diagnostic)
+//
+// The keys are joined with '+' into a single xdotool `key` action
+// (e.g. "ctrl+c").
+//
+// Response JSON: {"ok": true, "keys": "<combo>"}.
+func (h *KeysHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	combo, err := buildKeyCombo(job.Payload["keys"], job.Payload["combo"])
+	if err != nil {
+		return nil, err
+	}
+
+	actions, err := buildKeyActions(combo)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx.Log("info", "     - [Job %s] VNC_KEYS sending %q", job.ID, combo)
+
+	if err := desktop.ExecuteActions(context.Background(), actions); err != nil {
+		return nil, fmt.Errorf("keys failed: %w", err)
+	}
+
+	return json.Marshal(map[string]any{"ok": true, "keys": combo})
+}
+
+// Ensure KeysHandler implements JobHandler.
+var _ JobHandler = (*KeysHandler)(nil)
+
+// buildTypeActions translates literal text into a validated type action.
+// Kept as a pure function so it can be unit-tested without a live display.
+func buildTypeActions(text string) ([]desktop.Action, error) {
+	payload, err := json.Marshal([]desktop.Action{{Type: "type", Text: text}})
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode type action: %w", err)
+	}
+	return desktop.ParseActions(payload)
+}
+
+// buildKeyCombo resolves the key combo from the job payload. It prefers the
+// `keys` JSON array (what the MCP tool computes) and falls back to the raw
+// `combo` string. The result is a '+'-joined xdotool combo like "ctrl+c".
+// Pure function: unit-testable without a display.
+func buildKeyCombo(keysJSON, combo string) (string, error) {
+	if keysJSON != "" {
+		var keys []string
+		if err := json.Unmarshal([]byte(keysJSON), &keys); err != nil {
+			return "", fmt.Errorf("invalid 'keys' JSON array: %w", err)
+		}
+		cleaned := make([]string, 0, len(keys))
+		for _, k := range keys {
+			k = strings.TrimSpace(k)
+			if k != "" {
+				cleaned = append(cleaned, k)
+			}
+		}
+		if len(cleaned) > 0 {
+			return strings.Join(cleaned, "+"), nil
+		}
+	}
+	if strings.TrimSpace(combo) != "" {
+		return strings.TrimSpace(combo), nil
+	}
+	return "", fmt.Errorf("job payload missing 'keys' (or 'combo') field")
+}
+
+// buildKeyActions translates a key combo into a validated key action.
+// Pure function: unit-testable without a live display.
+func buildKeyActions(combo string) ([]desktop.Action, error) {
+	payload, err := json.Marshal([]desktop.Action{{Type: "key", Key: combo}})
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode key action: %w", err)
+	}
+	return desktop.ParseActions(payload)
+}

--- a/internal/jobs/desktop_test.go
+++ b/internal/jobs/desktop_test.go
@@ -1,0 +1,75 @@
+// internal/jobs/desktop_test.go
+package jobs
+
+import "testing"
+
+func TestBuildKeyCombo(t *testing.T) {
+	tests := []struct {
+		name     string
+		keysJSON string
+		combo    string
+		want     string
+		wantErr  bool
+	}{
+		{"keys array", `["ctrl","c"]`, "Ctrl+C", "ctrl+c", false},
+		{"keys array single", `["Return"]`, "Enter", "Return", false},
+		{"keys array trims blanks", `["ctrl","","alt","del"]`, "", "ctrl+alt+del", false},
+		{"falls back to combo", "", "ctrl+v", "ctrl+v", false},
+		{"empty keys uses combo", `[]`, "Escape", "Escape", false},
+		{"invalid keys json", `not json`, "", "", true},
+		{"both empty", "", "", "", true},
+		{"keys whitespace only falls back", `["  "]`, "Tab", "Tab", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildKeyCombo(tt.keysJSON, tt.combo)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (got %q)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("buildKeyCombo() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildKeyActions(t *testing.T) {
+	actions, err := buildKeyActions("ctrl+c")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(actions) != 1 {
+		t.Fatalf("got %d actions, want 1", len(actions))
+	}
+	if actions[0].Type != "key" || actions[0].Key != "ctrl+c" {
+		t.Errorf("got %+v, want key=ctrl+c", actions[0])
+	}
+
+	// An unsafe combo must be rejected by the desktop action validator.
+	if _, err := buildKeyActions("a;rm -rf /"); err == nil {
+		t.Error("expected validation error for injection combo, got nil")
+	}
+}
+
+func TestBuildTypeActions(t *testing.T) {
+	actions, err := buildTypeActions("hello world")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(actions) != 1 {
+		t.Fatalf("got %d actions, want 1", len(actions))
+	}
+	if actions[0].Type != "type" || actions[0].Text != "hello world" {
+		t.Errorf("got %+v, want type=hello world", actions[0])
+	}
+
+	if _, err := buildTypeActions(""); err == nil {
+		t.Error("expected error for empty text, got nil")
+	}
+}

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -141,6 +141,17 @@ func CreateLegacyHandlersWithOpts(opts LegacyHandlerOpts) []JobHandler {
 		NewLegacyHandlerAdapter(JobTypeIOSBuild, jobs.NewIOSBuildHandler(opts.WorkspaceDir)),
 		NewLegacyHandlerAdapter(JobTypeAndroidBuild, jobs.NewAndroidBuildHandler(opts.WorkspaceDir)),
 		NewLegacyHandlerAdapter(JobTypeGomobileBuild, jobs.NewGomobileBuildHandler(opts.WorkspaceDir)),
+		// Desktop capture/input handlers (issue #4179). Registered
+		// unconditionally: screenshot/type/keys need no workspace sandbox, and
+		// gating them behind WorkspaceDir would leave the desktop_screenshot /
+		// vnc_* MCP tools timing out on any node without a configured workspace.
+		// FILE_SCREENSHOT and VNC_SCREENSHOT share one capture path (the
+		// existing internal/desktop X11 capture); there is no separate VNC
+		// framebuffer source.
+		NewLegacyHandlerAdapter(JobTypeFileScreenshot, &jobs.ScreenshotHandler{}),
+		NewLegacyHandlerAdapter(JobTypeVNCScreenshot, &jobs.ScreenshotHandler{}),
+		NewLegacyHandlerAdapter(JobTypeVNCType, &jobs.TypeHandler{}),
+		NewLegacyHandlerAdapter(JobTypeVNCKeys, &jobs.KeysHandler{}),
 	}
 
 	// Register file-operation handlers when a workspace is configured.

--- a/internal/worker/job.go
+++ b/internal/worker/job.go
@@ -123,4 +123,8 @@ const (
 	JobTypeIOSBuild          = "IOS_BUILD"           // Build an iOS app via xcodebuild (macOS only)
 	JobTypeAndroidBuild      = "ANDROID_BUILD"       // Build an Android app via the Gradle wrapper
 	JobTypeGomobileBuild     = "GOMOBILE_BUILD"      // Cross-compile a Go package via gomobile bind
+	JobTypeFileScreenshot    = "FILE_SCREENSHOT"     // Capture the node's display, return base64 PNG (issue #4179)
+	JobTypeVNCScreenshot     = "VNC_SCREENSHOT"      // Capture the node's display via the VNC tool path (issue #4179)
+	JobTypeVNCType           = "VNC_TYPE"            // Type text on the node's display (issue #4179)
+	JobTypeVNCKeys           = "VNC_KEYS"            // Send a key combo to the node's display (issue #4179)
 )


### PR DESCRIPTION
Closes aceteam-ai/aceteam#4179
Advances aceteam-ai/aceteam#4180

Part of epic aceteam-ai/aceteam#4168 (P0, "demo-trap"). Companion docs PR: aceteam-ai/aceteam#4196.

## Summary

The `desktop_screenshot` / `vnc_*` MCP tools (and the web `NodeDesktop.tsx` + iOS VNC UIs) dispatch Redis jobs that **no Citadel node handler implemented**, so every call silently timed out (~15s) despite production-looking UI. This registers the missing handlers, backed by the existing `internal/desktop` X11 capture/input.

### #4179 — node-side handlers
- New job-type constants in `internal/worker/job.go`: `FILE_SCREENSHOT`, `VNC_SCREENSHOT`, `VNC_TYPE`, `VNC_KEYS`.
- New handlers in `internal/jobs/desktop.go`:
  - `ScreenshotHandler` → `desktop.CaptureScreenshot`, returns `{"image","encoding","format","width","height"}` (the `image` field the MCP tool reads; width/height via `image.DecodeConfig` to match the documented wire contract). Backs both `FILE_SCREENSHOT` and `VNC_SCREENSHOT` — both capture the same X11 framebuffer; there is no separate VNC framebuffer source.
  - `TypeHandler` (`VNC_TYPE`) → types the `text` payload.
  - `KeysHandler` (`VNC_KEYS`) → joins the `keys` JSON array (e.g. `["ctrl","c"]`) into an xdotool combo (`ctrl+c`); falls back to `combo`.
- Registered **unconditionally** in `CreateLegacyHandlersWithOpts` (the base slice, not gated on `WorkspaceDir`): screenshot/type/keys need no workspace sandbox, and gating them would leave the tools timing out on any node without a configured workspace.
- `format`/`quality` are treated as advisory; capture is always PNG (lossless).

### #4180 (partial) — drag contract in `internal/desktop/actions.go`
- Implemented the `mousedown` / `mouseup` action types and the `left_click_drag` contract. The python `translate_action` already emits `move → mousedown → move → mouseup` for drags; the node now honors it via xdotool `mousedown`/`mouseup`. This makes drag live immediately at the existing `/api/actions` status-server endpoint.
- `mousedown`/`mouseup` take an optional button (default 1) and no coordinates — the pointer is positioned by a preceding `move`, matching the drag sequence.

## What is NOT in this PR (deferred — see #4180 follow-up)
The python half of #4180 (wiring `ComputerUseTool` into a real agent/MCP path) is **deferred and documented as follow-up**, because it is not verifiable on the current dev host and needs new infrastructure:
- `ComputerUseTool` uses the node's HTTP status-server endpoints (`/api/screenshot`, `/api/actions`), but the python backend reaches nodes only via the Redis job path (`_dispatch_file_job`). There is no node→(ip, status_port, auth_token) resolver, and tool registration is not yet unified (the `ToolContext` factory in #3269 is unfinished).
- There is also **no coordinate mouse-click/move MCP tool** today (only screenshot/type/keys), so "agent can screenshot AND click" via MCP needs a new job type + handler + tool. Both fulfillment paths exceed what can be verified here.

## How to test

⚠️ This host runs tmux 3.4 with a double-free bug; `go test ./...` was **not** run (it would spawn tmux). Verified with `go build ./...`, `go vet ./...`, and targeted `go test` on changed non-tmux packages.

Automated (already run, all green):
```
go build ./...
go vet ./...
go test ./internal/worker/... ./internal/desktop/... ./internal/jobs/...
```

Manual screenshot/input round-trip (run on a node with a real X11 display + `imagemagick`/`scrot` + `xdotool`, on a fixed-tmux host):
1. Install/register a Citadel node with a desktop (`$DISPLAY` set).
2. From an agent / MCP client against the org, call `desktop_screenshot(node_id)` → expect JSON with a non-empty base64 PNG in `image` (decode and view it), not a ~15s timeout.
3. Call `vnc_type(node_id, "hello")` and `vnc_keys(node_id, "ctrl+a")` → expect `{"success": true, ...}` and observe the text/keystrokes on the node.
4. Drag: POST `[{"type":"move","x":100,"y":100},{"type":"mousedown","button":1},{"type":"move","x":300,"y":300},{"type":"mouseup","button":1}]` to the node status server `/api/actions` → expect a drag from (100,100) to (300,300).
