### PR TITLE
feat: detect headless/no-desktop sessions + advertise desktop capability map (#311)

### DIFF
--- a/internal/desktop/capabilities.go
+++ b/internal/desktop/capabilities.go
@@ -10,6 +10,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/session"
 )
 
 const detectionTimeout = 5 * time.Second
@@ -20,11 +22,19 @@ type Capabilities struct {
 	Display          string `json:"display"`
 	ScreenResolution string `json:"screen_resolution,omitempty"`
 	VNCPort          int    `json:"vnc_port,omitempty"`
+
+	// Session reports whether this process has an interactive desktop session
+	// and which desktop-dependent sub-capabilities (vnc/screenshot/input/
+	// terminal) are usable. Populated by the per-OS session probe. The server
+	// and frontend gate desktop affordances on this so a headless node does not
+	// advertise (or get asked to perform) VNC/screenshot/input actions.
+	Session *session.DesktopInfo `json:"session,omitempty"`
 }
 
 func DetectCapabilities() *Capabilities {
 	caps := &Capabilities{
-		OS: runtime.GOOS,
+		OS:      runtime.GOOS,
+		Session: session.DetectDesktop(),
 	}
 
 	switch runtime.GOOS {
@@ -39,15 +49,26 @@ func DetectCapabilities() *Capabilities {
 		// TODO: sw_vers for version, system_profiler SPDisplaysDataType for resolution
 		// screencapture for screenshots, cliclick for input actions
 		caps.OSVersion = "unknown"
-		caps.Display = "available"
+		caps.Display = displayFromSession(caps.Session)
 	case "windows":
 		// TODO: PowerShell Get-CimInstance Win32_OperatingSystem for version
 		// Get-CimInstance Win32_VideoController for display
 		caps.OSVersion = "unknown"
-		caps.Display = "available"
+		caps.Display = displayFromSession(caps.Session)
 	}
 
 	return caps
+}
+
+// displayFromSession derives the legacy Display string from the session probe
+// on platforms where we have no richer display detection yet. Returns
+// "available" only when an interactive desktop is present, otherwise "".
+// This makes the previously-unconditional "available" honest on headless nodes.
+func displayFromSession(s *session.DesktopInfo) string {
+	if s != nil && s.HasDesktop {
+		return "available"
+	}
+	return ""
 }
 
 func detectLinuxVersion() string {

--- a/internal/session/parse.go
+++ b/internal/session/parse.go
@@ -1,0 +1,137 @@
+package session
+
+import (
+	"bufio"
+	"fmt"
+	"strings"
+)
+
+// linuxEnv captures the environment inputs the Linux probe depends on.
+type linuxEnv struct {
+	display        string
+	waylandDisplay string
+	xdgSessionType string
+}
+
+// evaluateLinux is the pure decision function for Linux desktop detection.
+func evaluateLinux(env linuxEnv) *DesktopInfo {
+	switch {
+	case env.waylandDisplay != "":
+		return &DesktopInfo{
+			HasDesktop:  true,
+			SessionType: "wayland",
+			Reason:      "WAYLAND_DISPLAY=" + env.waylandDisplay,
+		}
+	case env.display != "":
+		return &DesktopInfo{
+			HasDesktop:  true,
+			SessionType: "x11",
+			Reason:      "DISPLAY=" + env.display,
+		}
+	default:
+		st := "headless"
+		if env.xdgSessionType != "" && env.xdgSessionType != "unspecified" {
+			st = env.xdgSessionType
+		}
+		return &DesktopInfo{
+			HasDesktop:  false,
+			SessionType: st,
+			Reason:      "headless session (no DISPLAY/WAYLAND_DISPLAY)",
+		}
+	}
+}
+
+// darwinEnv captures the env inputs the macOS probe depends on.
+type darwinEnv struct {
+	sshTTY        string
+	sshConnection string
+}
+
+// evaluateDarwin is the pure decision function for macOS desktop detection.
+// consoleUser is the username owning the GUI console session (empty if none).
+func evaluateDarwin(env darwinEnv, consoleUser string) *DesktopInfo {
+	if env.sshTTY != "" || env.sshConnection != "" {
+		return &DesktopInfo{
+			HasDesktop:  false,
+			SessionType: "ssh",
+			Reason:      "running over SSH (no Aqua GUI session)",
+		}
+	}
+	if consoleUser == "" || consoleUser == "loginwindow" {
+		return &DesktopInfo{
+			HasDesktop:  false,
+			SessionType: "headless",
+			Reason:      "no logged-in console GUI user",
+		}
+	}
+	return &DesktopInfo{
+		HasDesktop:  true,
+		SessionType: "aqua",
+		Reason:      "Aqua GUI session (console user " + consoleUser + ")",
+	}
+}
+
+// evaluateWindows is the pure decision function for Windows desktop detection.
+// procSession is the session the process runs in; consoleSession is the active
+// physical console session (0xFFFFFFFF when no one is attached).
+func evaluateWindows(procSession, consoleSession uint32) *DesktopInfo {
+	const noActiveConsole = 0xFFFFFFFF
+
+	switch {
+	case procSession == 0:
+		return &DesktopInfo{
+			HasDesktop:  false,
+			SessionType: "session0",
+			Reason:      "Session 0 isolation (service session has no interactive desktop)",
+		}
+	case consoleSession == noActiveConsole:
+		return &DesktopInfo{
+			HasDesktop:  false,
+			SessionType: "headless",
+			Reason:      "no active console session attached",
+		}
+	case procSession != consoleSession:
+		return &DesktopInfo{
+			HasDesktop:  false,
+			SessionType: "disconnected",
+			Reason: fmt.Sprintf("process session %d is not the active console session %d",
+				procSession, consoleSession),
+		}
+	default:
+		return &DesktopInfo{
+			HasDesktop:  true,
+			SessionType: "console",
+			Reason:      fmt.Sprintf("interactive console session %d", procSession),
+		}
+	}
+}
+
+// parseConsoleUser extracts the console user name from `scutil show
+// State:/Users/ConsoleUser` output. The output is a SystemConfiguration
+// dictionary dump, e.g.:
+//
+//	<dictionary> {
+//	  GID : 20
+//	  Name : jason
+//	  UID : 501
+//	}
+//
+// Returns the value of the "Name" key, or "" if absent. When no user is logged
+// in the dictionary is empty (or Name is "loginwindow"); both cases are handled
+// by the caller. This helper is pure and unit-testable on any platform.
+func parseConsoleUser(output string) string {
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(line, "Name") {
+			continue
+		}
+		rest := strings.TrimSpace(strings.TrimPrefix(line, "Name"))
+		if !strings.HasPrefix(rest, ":") {
+			continue
+		}
+		name := strings.TrimSpace(strings.TrimPrefix(rest, ":"))
+		return name
+	}
+	return ""
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1,0 +1,75 @@
+// Package session detects whether the current process has access to an
+// interactive desktop session, and which desktop-dependent sub-capabilities
+// (VNC, screenshot, input injection, desktop-attached terminal) are usable.
+//
+// The motivation: Citadel advertises desktop features unconditionally, but
+// whether they actually work depends on how the process was launched. A process
+// started over SSH, from a TTY with no DISPLAY, or as a Windows service in
+// Session 0 has no interactive desktop and will silently fail VNC/screenshot/
+// input actions. Detecting this up front lets the TUI surface the limitation
+// and lets the node advertise an honest capability map in its handshake.
+//
+// Detection is per-OS and CGO-free (env checks + golang.org/x/sys syscalls +
+// small subprocess probes), implemented in build-tagged files.
+package session
+
+// DesktopInfo is the structured result of a desktop-session probe. It answers
+// "do I have an interactive desktop session?" plus which sub-capabilities are
+// available, and a human-readable reason explaining the verdict.
+type DesktopInfo struct {
+	// HasDesktop is true when the process can drive an interactive desktop
+	// (window server / display server reachable).
+	HasDesktop bool `json:"has_desktop" yaml:"has_desktop"`
+
+	// Reason is a short human-readable explanation of the verdict, suitable for
+	// display in the TUI (e.g. "DISPLAY=:0", "headless session (no DISPLAY/WAYLAND_DISPLAY)").
+	Reason string `json:"reason" yaml:"reason"`
+
+	// SessionType describes how the process is attached to a session
+	// (e.g. "x11", "wayland", "aqua", "ssh", "console", "session0", "headless").
+	SessionType string `json:"session_type,omitempty" yaml:"session_type,omitempty"`
+
+	// Sub-capabilities derived from HasDesktop and platform support. These mirror
+	// the desktop affordances the server/frontend gate on.
+	VNC        bool `json:"vnc" yaml:"vnc"`                         // remote desktop streaming
+	Screenshot bool `json:"screenshot" yaml:"screenshot"`           // screen capture
+	Input      bool `json:"input_injection" yaml:"input_injection"` // synthetic key/pointer events
+	Terminal   bool `json:"terminal" yaml:"terminal"`               // desktop-attached terminal (always available)
+}
+
+// DetectDesktop probes the current process for interactive desktop access. It
+// never returns nil and never errors: an undetectable or headless environment
+// yields HasDesktop=false with an explanatory Reason. The per-OS implementation
+// lives in the build-tagged session_<os>.go files.
+func DetectDesktop() *DesktopInfo {
+	info := detectDesktop()
+	info.applyDerived()
+	return info
+}
+
+// applyDerived fills the sub-capability booleans from HasDesktop. A
+// desktop-attached terminal is treated as always available (the node can run a
+// PTY regardless of a window server), while VNC/screenshot/input require an
+// interactive desktop. This keeps the derivation in one place so the per-OS
+// probes only need to determine HasDesktop, SessionType, and Reason.
+func (d *DesktopInfo) applyDerived() {
+	d.Terminal = true
+	d.VNC = d.HasDesktop
+	d.Screenshot = d.HasDesktop
+	d.Input = d.HasDesktop
+}
+
+// CapabilityMap returns the desktop capabilities as a string->bool map suitable
+// for embedding in the node registration/heartbeat handshake. Keys are stable
+// wire identifiers. The map is additive: consumers that don't recognise a key
+// ignore it, and a node that never reports the map is treated as "unknown"
+// (legacy behaviour) by the server.
+func (d *DesktopInfo) CapabilityMap() map[string]bool {
+	return map[string]bool{
+		"desktop":         d.HasDesktop,
+		"vnc":             d.VNC,
+		"screenshot":      d.Screenshot,
+		"input_injection": d.Input,
+		"terminal":        d.Terminal,
+	}
+}

--- a/internal/session/session_darwin.go
+++ b/internal/session/session_darwin.go
@@ -1,0 +1,46 @@
+//go:build darwin
+
+package session
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// stringReader adapts a string to an io.Reader for command stdin.
+func stringReader(s string) *strings.Reader { return strings.NewReader(s) }
+
+// detectDesktop probes for a logged-in Aqua GUI session on macOS. A process
+// launched over SSH (SSH_TTY / SSH_CONNECTION set) has no window server, so it
+// is reported as headless even if a user is logged in at the physical console.
+//
+// CGO-free: uses env checks plus a `scutil`/`stat` subprocess to confirm a
+// console GUI user is present.
+func detectDesktop() *DesktopInfo {
+	env := darwinEnv{
+		sshTTY:        os.Getenv("SSH_TTY"),
+		sshConnection: os.Getenv("SSH_CONNECTION"),
+	}
+	consoleUser := detectConsoleUser()
+	return evaluateDarwin(env, consoleUser)
+}
+
+// detectConsoleUser returns the username of the current GUI console session, or
+// "" if none. It queries SystemConfiguration via scutil, which reports the
+// active console user (or "loginwindow" when sitting at the login screen).
+func detectConsoleUser() string {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	// `scutil` reads the dynamic store; the GUIConsoleUser script returns the
+	// console user name on stdout. This is CGO-free and present on all macOS.
+	cmd := exec.CommandContext(ctx, "/usr/sbin/scutil")
+	cmd.Stdin = stringReader("show State:/Users/ConsoleUser\n")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return parseConsoleUser(string(out))
+}

--- a/internal/session/session_linux.go
+++ b/internal/session/session_linux.go
@@ -1,0 +1,116 @@
+//go:build linux
+
+package session
+
+import (
+	"context"
+	"net"
+	"os"
+	"strings"
+	"time"
+)
+
+// detectDesktop probes for an X11/Wayland session on Linux. It reads the live
+// environment, then delegates the verdict to the pure evaluateLinux helper so
+// the logic is unit-testable without mutating process env.
+func detectDesktop() *DesktopInfo {
+	env := linuxEnv{
+		display:        os.Getenv("DISPLAY"),
+		waylandDisplay: os.Getenv("WAYLAND_DISPLAY"),
+		xdgSessionType: os.Getenv("XDG_SESSION_TYPE"),
+	}
+	info := evaluateLinux(env)
+
+	// When a DISPLAY is advertised, best-effort confirm the X server is actually
+	// reachable. A stale DISPLAY pointing at a dead server should not be reported
+	// as an available desktop. Wayland sockets are not probed here (they live
+	// under XDG_RUNTIME_DIR and absence of the var already gates them).
+	if info.HasDesktop && env.waylandDisplay == "" && env.display != "" {
+		if !x11Reachable(env.display) {
+			info.HasDesktop = false
+			info.SessionType = "headless"
+			info.Reason = "DISPLAY=" + env.display + " set but X server not reachable"
+		}
+	}
+	return info
+}
+
+// x11Reachable parses a DISPLAY string and attempts a short TCP/unix probe to
+// the X server. It returns true on a successful connect. Parsing failures or a
+// missing socket return false. This is best-effort: any positive signal that
+// the server accepts connections counts as reachable.
+func x11Reachable(display string) bool {
+	host, dpy := parseDisplay(display)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	var d net.Dialer
+
+	if host == "" {
+		// Local display uses the abstract/filesystem unix socket /tmp/.X11-unix/X<n>.
+		sock := "/tmp/.X11-unix/X" + dpy
+		if conn, err := d.DialContext(ctx, "unix", sock); err == nil {
+			conn.Close()
+			return true
+		}
+		// Some systems only expose the abstract socket; fall back to localhost TCP.
+		host = "127.0.0.1"
+	}
+	port := 6000 + atoiSafe(dpy)
+	addr := net.JoinHostPort(host, itoa(port))
+	if conn, err := d.DialContext(ctx, "tcp", addr); err == nil {
+		conn.Close()
+		return true
+	}
+	return false
+}
+
+// parseDisplay splits an X DISPLAY value "host:display.screen" into host and
+// the display number. An empty host means a local (unix-socket) display.
+func parseDisplay(display string) (host, dpy string) {
+	idx := strings.LastIndex(display, ":")
+	if idx < 0 {
+		return "", "0"
+	}
+	host = display[:idx]
+	rest := display[idx+1:]
+	if dot := strings.IndexByte(rest, '.'); dot >= 0 {
+		rest = rest[:dot]
+	}
+	if rest == "" {
+		rest = "0"
+	}
+	return host, rest
+}
+
+func atoiSafe(s string) int {
+	n := 0
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [12]byte
+	i := len(buf)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/internal/session/session_linux_test.go
+++ b/internal/session/session_linux_test.go
@@ -1,0 +1,48 @@
+//go:build linux
+
+package session
+
+import "testing"
+
+func TestParseDisplay(t *testing.T) {
+	tests := []struct {
+		display  string
+		wantHost string
+		wantDpy  string
+	}{
+		{":0", "", "0"},
+		{":1", "", "1"},
+		{":0.0", "", "0"},
+		{":10.1", "", "10"},
+		{"localhost:0", "localhost", "0"},
+		{"192.168.1.5:1.0", "192.168.1.5", "1"},
+		{"no-colon", "", "0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.display, func(t *testing.T) {
+			host, dpy := parseDisplay(tt.display)
+			if host != tt.wantHost || dpy != tt.wantDpy {
+				t.Errorf("parseDisplay(%q) = (%q, %q), want (%q, %q)",
+					tt.display, host, dpy, tt.wantHost, tt.wantDpy)
+			}
+		})
+	}
+}
+
+func TestItoaAtoiSafe(t *testing.T) {
+	cases := []struct {
+		n int
+		s string
+	}{{0, "0"}, {1, "1"}, {6000, "6000"}, {6001, "6001"}}
+	for _, c := range cases {
+		if got := itoa(c.n); got != c.s {
+			t.Errorf("itoa(%d) = %q, want %q", c.n, got, c.s)
+		}
+		if got := atoiSafe(c.s); got != c.n {
+			t.Errorf("atoiSafe(%q) = %d, want %d", c.s, got, c.n)
+		}
+	}
+	if got := atoiSafe("abc"); got != 0 {
+		t.Errorf("atoiSafe non-numeric should be 0, got %d", got)
+	}
+}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -1,0 +1,278 @@
+package session
+
+import "testing"
+
+func TestEvaluateLinux(t *testing.T) {
+	tests := []struct {
+		name        string
+		env         linuxEnv
+		wantDesktop bool
+		wantType    string
+	}{
+		{
+			name:        "x11 display set",
+			env:         linuxEnv{display: ":0"},
+			wantDesktop: true,
+			wantType:    "x11",
+		},
+		{
+			name:        "non-zero display (issue #287)",
+			env:         linuxEnv{display: ":1"},
+			wantDesktop: true,
+			wantType:    "x11",
+		},
+		{
+			name:        "wayland takes precedence",
+			env:         linuxEnv{display: ":0", waylandDisplay: "wayland-0"},
+			wantDesktop: true,
+			wantType:    "wayland",
+		},
+		{
+			name:        "headless: no display vars",
+			env:         linuxEnv{},
+			wantDesktop: false,
+			wantType:    "headless",
+		},
+		{
+			name:        "headless reports xdg session type when known",
+			env:         linuxEnv{xdgSessionType: "tty"},
+			wantDesktop: false,
+			wantType:    "tty",
+		},
+		{
+			name:        "unspecified xdg type falls back to headless",
+			env:         linuxEnv{xdgSessionType: "unspecified"},
+			wantDesktop: false,
+			wantType:    "headless",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := evaluateLinux(tt.env)
+			if got.HasDesktop != tt.wantDesktop {
+				t.Errorf("HasDesktop = %v, want %v", got.HasDesktop, tt.wantDesktop)
+			}
+			if got.SessionType != tt.wantType {
+				t.Errorf("SessionType = %q, want %q", got.SessionType, tt.wantType)
+			}
+			if got.Reason == "" {
+				t.Error("Reason should never be empty")
+			}
+		})
+	}
+}
+
+func TestEvaluateDarwin(t *testing.T) {
+	tests := []struct {
+		name        string
+		env         darwinEnv
+		consoleUser string
+		wantDesktop bool
+		wantType    string
+	}{
+		{
+			name:        "aqua gui session",
+			env:         darwinEnv{},
+			consoleUser: "jason",
+			wantDesktop: true,
+			wantType:    "aqua",
+		},
+		{
+			name:        "ssh session overrides console user",
+			env:         darwinEnv{sshTTY: "/dev/ttys000"},
+			consoleUser: "jason",
+			wantDesktop: false,
+			wantType:    "ssh",
+		},
+		{
+			name:        "ssh connection env",
+			env:         darwinEnv{sshConnection: "1.2.3.4 22 5.6.7.8 22"},
+			consoleUser: "jason",
+			wantDesktop: false,
+			wantType:    "ssh",
+		},
+		{
+			name:        "no console user is headless",
+			env:         darwinEnv{},
+			consoleUser: "",
+			wantDesktop: false,
+			wantType:    "headless",
+		},
+		{
+			name:        "loginwindow means no one logged in",
+			env:         darwinEnv{},
+			consoleUser: "loginwindow",
+			wantDesktop: false,
+			wantType:    "headless",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := evaluateDarwin(tt.env, tt.consoleUser)
+			if got.HasDesktop != tt.wantDesktop {
+				t.Errorf("HasDesktop = %v, want %v", got.HasDesktop, tt.wantDesktop)
+			}
+			if got.SessionType != tt.wantType {
+				t.Errorf("SessionType = %q, want %q", got.SessionType, tt.wantType)
+			}
+			if got.Reason == "" {
+				t.Error("Reason should never be empty")
+			}
+		})
+	}
+}
+
+func TestEvaluateWindows(t *testing.T) {
+	const noConsole = uint32(0xFFFFFFFF)
+	tests := []struct {
+		name           string
+		procSession    uint32
+		consoleSession uint32
+		wantDesktop    bool
+		wantType       string
+	}{
+		{
+			name:           "interactive console session",
+			procSession:    1,
+			consoleSession: 1,
+			wantDesktop:    true,
+			wantType:       "console",
+		},
+		{
+			name:           "session 0 isolation",
+			procSession:    0,
+			consoleSession: 1,
+			wantDesktop:    false,
+			wantType:       "session0",
+		},
+		{
+			name:           "no active console attached",
+			procSession:    2,
+			consoleSession: noConsole,
+			wantDesktop:    false,
+			wantType:       "headless",
+		},
+		{
+			name:           "process in different session than console",
+			procSession:    3,
+			consoleSession: 1,
+			wantDesktop:    false,
+			wantType:       "disconnected",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := evaluateWindows(tt.procSession, tt.consoleSession)
+			if got.HasDesktop != tt.wantDesktop {
+				t.Errorf("HasDesktop = %v, want %v", got.HasDesktop, tt.wantDesktop)
+			}
+			if got.SessionType != tt.wantType {
+				t.Errorf("SessionType = %q, want %q", got.SessionType, tt.wantType)
+			}
+			if got.Reason == "" {
+				t.Error("Reason should never be empty")
+			}
+		})
+	}
+}
+
+func TestApplyDerived(t *testing.T) {
+	t.Run("desktop available enables vnc/screenshot/input", func(t *testing.T) {
+		d := &DesktopInfo{HasDesktop: true}
+		d.applyDerived()
+		if !d.VNC || !d.Screenshot || !d.Input {
+			t.Errorf("expected vnc/screenshot/input all true, got vnc=%v screenshot=%v input=%v",
+				d.VNC, d.Screenshot, d.Input)
+		}
+		if !d.Terminal {
+			t.Error("terminal should always be true")
+		}
+	})
+	t.Run("headless disables vnc/screenshot/input but keeps terminal", func(t *testing.T) {
+		d := &DesktopInfo{HasDesktop: false}
+		d.applyDerived()
+		if d.VNC || d.Screenshot || d.Input {
+			t.Errorf("expected vnc/screenshot/input all false, got vnc=%v screenshot=%v input=%v",
+				d.VNC, d.Screenshot, d.Input)
+		}
+		if !d.Terminal {
+			t.Error("terminal should always be true even when headless")
+		}
+	})
+}
+
+func TestCapabilityMap(t *testing.T) {
+	d := &DesktopInfo{HasDesktop: false}
+	d.applyDerived()
+	m := d.CapabilityMap()
+
+	wantKeys := []string{"desktop", "vnc", "screenshot", "input_injection", "terminal"}
+	for _, k := range wantKeys {
+		if _, ok := m[k]; !ok {
+			t.Errorf("capability map missing key %q", k)
+		}
+	}
+	if m["desktop"] {
+		t.Error("headless node should report desktop=false")
+	}
+	if m["vnc"] || m["screenshot"] || m["input_injection"] {
+		t.Error("headless node should report vnc/screenshot/input_injection=false")
+	}
+	if !m["terminal"] {
+		t.Error("terminal should be true")
+	}
+}
+
+func TestDetectDesktopNeverNil(t *testing.T) {
+	got := DetectDesktop()
+	if got == nil {
+		t.Fatal("DetectDesktop must never return nil")
+	}
+	if got.Reason == "" {
+		t.Error("DetectDesktop must always set a Reason")
+	}
+	// Terminal is platform-independent and always advertised.
+	if !got.Terminal {
+		t.Error("Terminal capability should always be advertised")
+	}
+}
+
+func TestParseConsoleUser(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect string
+	}{
+		{
+			name: "standard dictionary with name",
+			input: "<dictionary> {\n" +
+				"  GID : 20\n" +
+				"  Name : jason\n" +
+				"  UID : 501\n" +
+				"}\n",
+			expect: "jason",
+		},
+		{
+			name:   "loginwindow at login screen",
+			input:  "<dictionary> {\n  Name : loginwindow\n}\n",
+			expect: "loginwindow",
+		},
+		{
+			name:   "no name key",
+			input:  "<dictionary> {\n  GID : 20\n}\n",
+			expect: "",
+		},
+		{
+			name:   "empty output",
+			input:  "",
+			expect: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseConsoleUser(tt.input); got != tt.expect {
+				t.Errorf("parseConsoleUser() = %q, want %q", got, tt.expect)
+			}
+		})
+	}
+}

--- a/internal/session/session_windows.go
+++ b/internal/session/session_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package session
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+// detectDesktop probes for interactive desktop access on Windows. A process
+// running in Session 0 (the isolated services session) or in a session other
+// than the active physical console has no access to the interactive desktop
+// (WinSta0\Default) and cannot drive VNC/screenshot/input.
+//
+// CGO-free: uses golang.org/x/sys/windows WTSGetActiveConsoleSessionId and
+// ProcessIdToSessionId.
+func detectDesktop() *DesktopInfo {
+	consoleSession := windows.WTSGetActiveConsoleSessionId()
+
+	var procSession uint32
+	if err := windows.ProcessIdToSessionId(windows.GetCurrentProcessId(), &procSession); err != nil {
+		// If we cannot resolve our own session, conservatively report headless.
+		return &DesktopInfo{
+			HasDesktop:  false,
+			SessionType: "unknown",
+			Reason:      "could not resolve process session id: " + err.Error(),
+		}
+	}
+	return evaluateWindows(procSession, consoleSession)
+}

--- a/internal/status/collector.go
+++ b/internal/status/collector.go
@@ -89,6 +89,12 @@ func (c *Collector) Collect() (*NodeStatus, error) {
 	// Collect desktop capabilities
 	status.Desktop = desktop.DetectCapabilities()
 
+	// Advertise a flat desktop capability map in the handshake so the server can
+	// gate desktop affordances per node (headless nodes report desktop=false).
+	if status.Desktop != nil && status.Desktop.Session != nil {
+		status.DesktopCapabilities = status.Desktop.Session.CapabilityMap()
+	}
+
 	// Detect VNC server status for top-level vnc_port field.
 	// Check embedded VNC server first (TUI-managed), then external (TightVNC etc).
 	if port := platform.EmbeddedVNCPort(); port > 0 {

--- a/internal/status/types.go
+++ b/internal/status/types.go
@@ -27,7 +27,13 @@ type NodeStatus struct {
 	Apps         []AppInfo             `json:"apps,omitempty"`
 	Capabilities *NodeCapabilities     `json:"capabilities,omitempty"`
 	Desktop      *desktop.Capabilities `json:"desktop,omitempty"`
-	VNCPort      int                   `json:"vnc_port"`
+	// DesktopCapabilities is a flat capability map advertised to the control
+	// plane so the server can persist it and the frontend can gate desktop
+	// affordances (VNC/screenshot/input/terminal buttons) on a per-node basis.
+	// Keys: desktop, vnc, screenshot, input_injection, terminal. Additive and
+	// backward-compatible: legacy nodes omit it and are treated as "unknown".
+	DesktopCapabilities map[string]bool `json:"desktop_capabilities,omitempty"`
+	VNCPort             int             `json:"vnc_port"`
 }
 
 // AppInfo contains information about an installed catalog app.
@@ -66,20 +72,20 @@ type GPUCapability struct {
 // NodeInfo contains basic node identification.
 type NodeInfo struct {
 	Name          string `json:"name"`
-	NetworkIP     string `json:"network_ip,omitempty"`     // Preferred: AceTeam Network IP
-	TailscaleIP   string `json:"tailscale_ip,omitempty"`   // Kept for backwards compatibility
+	NetworkIP     string `json:"network_ip,omitempty"`   // Preferred: AceTeam Network IP
+	TailscaleIP   string `json:"tailscale_ip,omitempty"` // Kept for backwards compatibility
 	UptimeSeconds int64  `json:"uptime_seconds"`
 }
 
 // SystemMetrics contains system resource utilization.
 type SystemMetrics struct {
-	CPUPercent      float64 `json:"cpu_percent"`
-	MemoryUsedGB    float64 `json:"memory_used_gb"`
-	MemoryTotalGB   float64 `json:"memory_total_gb"`
-	MemoryPercent   float64 `json:"memory_percent"`
-	DiskUsedGB      float64 `json:"disk_used_gb"`
-	DiskTotalGB     float64 `json:"disk_total_gb"`
-	DiskPercent     float64 `json:"disk_percent"`
+	CPUPercent    float64 `json:"cpu_percent"`
+	MemoryUsedGB  float64 `json:"memory_used_gb"`
+	MemoryTotalGB float64 `json:"memory_total_gb"`
+	MemoryPercent float64 `json:"memory_percent"`
+	DiskUsedGB    float64 `json:"disk_used_gb"`
+	DiskTotalGB   float64 `json:"disk_total_gb"`
+	DiskPercent   float64 `json:"disk_percent"`
 }
 
 // GPUMetrics contains GPU utilization information.
@@ -96,7 +102,7 @@ type GPUMetrics struct {
 // ServiceInfo contains information about a running service.
 type ServiceInfo struct {
 	Name   string   `json:"name"`
-	Type   string   `json:"type"` // "llm", "database", "other"
+	Type   string   `json:"type"`   // "llm", "database", "other"
 	Status string   `json:"status"` // "running", "stopped", "error"
 	Port   int      `json:"port,omitempty"`
 	Health string   `json:"health,omitempty"` // "healthy", "unhealthy", "unknown"

--- a/internal/tui/controlcenter/controlcenter.go
+++ b/internal/tui/controlcenter/controlcenter.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/network"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
 	"github.com/aceteam-ai/citadel-cli/internal/proxmox"
+	"github.com/aceteam-ai/citadel-cli/internal/session"
 	"github.com/aceteam-ai/citadel-cli/internal/telemetry"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
@@ -408,6 +409,12 @@ type ControlCenter struct {
 
 	// Device URL set after successful device auth + connect
 	deviceURL string
+
+	// desktopSession caches the interactive-desktop probe result. Lazily filled
+	// on first render via desktopInfo(); the session state is effectively static
+	// for a process lifetime, so caching avoids re-probing every refresh.
+	desktopSession   *session.DesktopInfo
+	desktopSessionMu sync.Once
 
 	// Console page (nil on Windows)
 	consolePage *ConsolePage
@@ -1518,6 +1525,15 @@ func (cc *ControlCenter) updateActionsPanel() {
 	cc.actionsView.Select(0, 0)
 }
 
+// desktopInfo returns the cached interactive-desktop probe result, running the
+// per-OS probe once on first call. Safe for repeated calls from the render loop.
+func (cc *ControlCenter) desktopInfo() *session.DesktopInfo {
+	cc.desktopSessionMu.Do(func() {
+		cc.desktopSession = session.DetectDesktop()
+	})
+	return cc.desktopSession
+}
+
 func (cc *ControlCenter) updateNodePanel() {
 	var sb strings.Builder
 
@@ -1567,6 +1583,16 @@ func (cc *ControlCenter) updateNodePanel() {
 	}
 
 	sb.WriteString(fmt.Sprintf(" [yellow]Status:[-] %s %s\n", statusIcon, statusText))
+
+	// Desktop session availability: explains up front why VNC/screenshot/input
+	// affordances may be unavailable on this node (e.g. headless/SSH session).
+	if d := cc.desktopInfo(); d != nil {
+		if d.HasDesktop {
+			sb.WriteString(" [yellow]Desktop:[-] [green]●[-] available\n")
+		} else {
+			sb.WriteString(fmt.Sprintf(" [yellow]Desktop:[-] [gray]○ unavailable (%s) — VNC/screenshot disabled[-]\n", d.Reason))
+		}
+	}
 
 	// Demo server URL
 	if cc.data.DemoServerURL != "" {


### PR DESCRIPTION
## Context

Citadel advertises desktop-dependent features (VNC remote desktop, screenshots, input injection, desktop-attached terminal) **unconditionally**, but whether they actually work depends on *how the process was launched*:

- **Windows** launched as a service lands in **Session 0** (WinSta0\Default is isolated) — no interactive desktop.
- **Linux** launched over SSH / from a TTY with no `DISPLAY`/`WAYLAND_DISPLAY` has no X/Wayland session (cf. #287 where the display was `:1`, not `:0`).
- **macOS** launched from an SSH session (vs a logged-in Aqua GUI session) has no window server.

Today the operator only finds out when a desktop action **fails after the fact** (#243 "VNC fails to start — not ready"). This PR detects desktop access **up front**, surfaces it in the TUI, and advertises an honest capability map in the node handshake so the server/frontend can gate desktop affordances instead of connecting, trying, and breaking.

Closes #311.

## Summary

**New `internal/session` package — per-OS, build-tagged, CGO-free desktop probe**
- `DetectDesktop() *DesktopInfo` returns a structured result: `HasDesktop` (bool), `Reason` (human-readable), `SessionType`, and derived sub-capabilities `VNC`/`Screenshot`/`Input`/`Terminal`. Never nil, never errors — a headless environment yields `HasDesktop=false` with an explanatory reason.
- **Linux** (`session_linux.go`): `DISPLAY`/`WAYLAND_DISPLAY` presence, best-effort X11 reachability (parse `DISPLAY` → dial unix socket / `6000+N` TCP), `XDG_SESSION_TYPE` fallback.
- **macOS** (`session_darwin.go`): SSH detection via `SSH_TTY`/`SSH_CONNECTION` env, plus a `scutil` console-user check for a logged-in Aqua session. No cgo.
- **Windows** (`session_windows.go`): `WTSGetActiveConsoleSessionId` + `ProcessIdToSessionId` via `golang.org/x/sys/windows`; detects Session 0 isolation and process-not-in-active-console-session.
- Pure decision functions (`evaluateLinux/Darwin/Windows`, `parseConsoleUser`, `parseDisplay`) live in untagged files so they unit-test on any host with injected inputs.

**Capability map in the node handshake (additive / backward-compatible)**
- `desktop.Capabilities` gains a nested `Session *session.DesktopInfo`.
- `status.NodeStatus` gains a flat `desktop_capabilities` map: `{desktop, vnc, screenshot, input_injection, terminal}` — the shape the server persists and the frontend gates on. Legacy nodes omit it and are treated as "unknown". Also makes the previously-unconditional macOS/Windows `Display="available"` honest by deriving it from the probe.

**TUI surfacing (minimal)**
- One line in the control-center node panel: `Desktop: ● available` or `Desktop: ○ unavailable (<reason>) — VNC/screenshot disabled`, backed by a `sync.Once`-cached probe.

### Wire shape (new, additive)

```json
"status": {
  "desktop_capabilities": {
    "desktop": false,
    "vnc": false,
    "screenshot": false,
    "input_injection": false,
    "terminal": true
  },
  "desktop": {
    "os": "linux",
    "session": {
      "has_desktop": false,
      "reason": "headless session (no DISPLAY/WAYLAND_DISPLAY)",
      "session_type": "headless",
      "vnc": false, "screenshot": false, "input_injection": false, "terminal": true
    }
  }
}
```

## Test plan

| Group | Coverage |
|-------|----------|
| `evaluateLinux` | DISPLAY `:0`/`:1`, Wayland precedence, headless, XDG type fallback, `unspecified` |
| `evaluateDarwin` | Aqua session, SSH override (TTY + connection), no console user, `loginwindow` |
| `evaluateWindows` | console session, Session 0, no active console (`0xFFFFFFFF`), session mismatch |
| `applyDerived` / `CapabilityMap` | sub-cap derivation; terminal always true; map keys + headless gating |
| `parseConsoleUser` | scutil dict parse, `loginwindow`, missing key, empty |
| `parseDisplay` / `itoa`/`atoiSafe` (linux) | host/display split, port arithmetic |
| `DetectDesktop` | never nil, always sets Reason, terminal always advertised |

Verified: `go build ./...`, `go vet ./...`, `go test ./...` (excl. pre-existing infra-dependent `e2e` suite), and cross-compiles `CGO_ENABLED=0` for darwin/arm64, linux/amd64, windows/amd64. `gofmt -l` clean on changed files.

## Shared files touched (for sequential merge)

- `internal/tui/controlcenter/controlcenter.go` — added import, two struct fields (`desktopSession`, `desktopSessionMu sync.Once`), a `desktopInfo()` helper, and one line in `updateNodePanel`. `cmd/work.go` was **not** touched.

## Related

- #311 (this issue), #243 / #287 (the after-the-fact desktop failures this prevents), #293/#295 (connection-status surfacing pattern).
- **Follow-up (aceteam repo):** persist the reported `desktop_capabilities` on node status and gate the desktop UI (VNC/screenshot/terminal buttons) + dispatch path on it. To be filed now that the citadel capability field has landed.

---
*Generated by Claude*
