### PR TITLE
fix(tui): bound control-center shutdown so SIGINT/Ctrl+C exits cleanly (#312)

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -167,17 +168,10 @@ func runControlCenter() {
 	instanceServer, _ := instance.Listen(configDir)
 	if instanceServer != nil {
 		_ = instance.WritePID(configDir)
-		defer func() {
-			instanceServer.Close()
-			instance.RemovePID(configDir)
-		}()
 	}
 
 	// Start the demo server in the background
 	startDemoServer()
-	defer stopDemoServer()
-	defer stopTerminalServer()
-	defer stopVNCServer()
 
 	cfg := controlcenter.Config{
 		Version:            Version,
@@ -241,6 +235,20 @@ func runControlCenter() {
 	supervisorCtx, supervisorCancel := context.WithCancel(context.Background())
 	defer supervisorCancel()
 	go ccSuperviseVPNListeners(supervisorCtx, cc.AddActivity)
+
+	// Handle OS signals (SIGINT/SIGTERM) so the TUI exits cleanly even when
+	// Ctrl+C is delivered as a signal rather than a tcell key event, or when
+	// the process is sent SIGTERM by a service manager. cc.Stop() is guarded by
+	// sync.Once and stops the tview event loop first, so calling it from this
+	// goroutine unblocks cc.Run() and triggers the teardown path below. Without
+	// this, a real SIGINT had no handler at all and the process hung forever
+	// (issue #312).
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigs
+		cc.Stop()
+	}()
 
 	// Auto-connect to network and start worker
 	go func() {
@@ -326,8 +334,32 @@ func runControlCenter() {
 		}
 	}()
 
-	if err := cc.Run(); err != nil {
-		fmt.Fprintf(os.Stderr, "Control center error: %v\n", err)
+	runErr := cc.Run()
+
+	// Tear down all long-lived subsystems once the TUI event loop has exited.
+	// Each step is bounded internally, but we run them through gracefulShutdown
+	// so that a regression in any one teardown can never hang the process: after
+	// a short grace period the watchdog force-exits, logging what was still
+	// pending (issue #312). The background worker started by ccOnNetworkConnect
+	// uses its own context.Background()-derived context and is NOT tied to the
+	// TUI, so it must be cancelled explicitly here or its goroutines (Redis API
+	// poll, heartbeat) would leak past exit.
+	gracefulShutdown([]shutdownStep{
+		{name: "tui-cleanup", fn: cc.Cleanup},
+		{name: "worker", fn: func() { _ = ccStopWorker() }},
+		{name: "terminal-server", fn: stopTerminalServer},
+		{name: "vnc-server", fn: stopVNCServer},
+		{name: "demo-server", fn: stopDemoServer},
+		{name: "instance-server", fn: func() {
+			if instanceServer != nil {
+				instanceServer.Close()
+				instance.RemovePID(configDir)
+			}
+		}},
+	})
+
+	if runErr != nil {
+		fmt.Fprintf(os.Stderr, "Control center error: %v\n", runErr)
 		os.Exit(1)
 	}
 }

--- a/cmd/shutdown.go
+++ b/cmd/shutdown.go
@@ -1,0 +1,92 @@
+// cmd/shutdown.go
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"time"
+)
+
+// shutdownStep is a single named teardown action run during a graceful shutdown.
+// Each step is run in its own goroutine so a misbehaving (blocking) step cannot
+// stall the others or the overall deadline.
+type shutdownStep struct {
+	name string
+	fn   func()
+}
+
+// runShutdownSequence runs all steps concurrently and waits up to grace for them
+// to complete. It returns the names of any steps that had NOT finished when the
+// grace period elapsed (empty slice means a clean shutdown).
+//
+// This is the bounded safety net for issue #312: shutdown must never block
+// indefinitely. The caller decides what to do with a non-empty result (the TUI
+// path force-exits via os.Exit). Keeping the timeout logic here — pure and
+// side-effect free apart from running the steps — makes it unit-testable with a
+// deliberately-stuck stub step.
+func runShutdownSequence(grace time.Duration, steps []shutdownStep) []string {
+	if len(steps) == 0 {
+		return nil
+	}
+
+	var mu sync.Mutex
+	pending := make(map[string]struct{}, len(steps))
+	for _, s := range steps {
+		pending[s.name] = struct{}{}
+	}
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(len(steps))
+	for _, s := range steps {
+		go func(step shutdownStep) {
+			defer wg.Done()
+			if step.fn != nil {
+				step.fn()
+			}
+			mu.Lock()
+			delete(pending, step.name)
+			mu.Unlock()
+		}(s)
+	}
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-time.After(grace):
+		mu.Lock()
+		stuck := make([]string, 0, len(pending))
+		for name := range pending {
+			stuck = append(stuck, name)
+		}
+		mu.Unlock()
+		return stuck
+	}
+}
+
+// gracefulShutdown runs the teardown steps with a bounded grace period and, if
+// any step is still pending when the period elapses, logs the stragglers and
+// force-exits the process so a wedged goroutine can never leave an orphaned
+// node holding the VPN identity / terminal port (issue #312).
+//
+// The grace period is intentionally short (seconds) because every individual
+// subsystem teardown is itself bounded; the watchdog only fires if something
+// regresses.
+const shutdownGracePeriod = 5 * time.Second
+
+func gracefulShutdown(steps []shutdownStep) {
+	stuck := runShutdownSequence(shutdownGracePeriod, steps)
+	if len(stuck) == 0 {
+		return
+	}
+	for _, name := range stuck {
+		Log("shutdown: step %q did not complete within %s; force-exiting", name, shutdownGracePeriod)
+		fmt.Fprintf(os.Stderr, "   - Warning: shutdown step %q timed out; force-exiting\n", name)
+	}
+	os.Exit(1)
+}

--- a/cmd/shutdown_test.go
+++ b/cmd/shutdown_test.go
@@ -1,0 +1,75 @@
+// cmd/shutdown_test.go
+package cmd
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestRunShutdownSequenceAllComplete verifies that when every step finishes
+// well within the grace period, the sequence reports no stragglers and all
+// steps actually ran.
+func TestRunShutdownSequenceAllComplete(t *testing.T) {
+	var ran int32
+	steps := []shutdownStep{
+		{name: "a", fn: func() { atomic.AddInt32(&ran, 1) }},
+		{name: "b", fn: func() { atomic.AddInt32(&ran, 1) }},
+		{name: "c", fn: func() { atomic.AddInt32(&ran, 1) }},
+	}
+
+	stuck := runShutdownSequence(time.Second, steps)
+	if len(stuck) != 0 {
+		t.Fatalf("expected no stuck steps, got %v", stuck)
+	}
+	if got := atomic.LoadInt32(&ran); got != 3 {
+		t.Fatalf("expected 3 steps to run, got %d", got)
+	}
+}
+
+// TestRunShutdownSequenceStuckStep is the core safety-net test: a deliberately
+// blocking step must NOT prevent the sequence from returning after the grace
+// period, and the stuck step must be reported by name so the caller can log it
+// and force-exit (issue #312).
+func TestRunShutdownSequenceStuckStep(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release) // unblock the stuck goroutine so the test doesn't leak it
+
+	var fastRan int32
+	steps := []shutdownStep{
+		{name: "fast", fn: func() { atomic.AddInt32(&fastRan, 1) }},
+		{name: "stuck", fn: func() { <-release }},
+	}
+
+	start := time.Now()
+	stuck := runShutdownSequence(50*time.Millisecond, steps)
+	elapsed := time.Since(start)
+
+	if elapsed >= time.Second {
+		t.Fatalf("sequence did not return promptly after grace period: %s", elapsed)
+	}
+	if len(stuck) != 1 || stuck[0] != "stuck" {
+		t.Fatalf("expected [stuck], got %v", stuck)
+	}
+	if got := atomic.LoadInt32(&fastRan); got != 1 {
+		t.Fatalf("expected fast step to have run, got %d", got)
+	}
+}
+
+// TestRunShutdownSequenceEmpty verifies the empty-input fast path.
+func TestRunShutdownSequenceEmpty(t *testing.T) {
+	if stuck := runShutdownSequence(time.Second, nil); stuck != nil {
+		t.Fatalf("expected nil for empty steps, got %v", stuck)
+	}
+}
+
+// TestRunShutdownSequenceNilFn verifies a step with a nil fn is treated as an
+// instantly-completing no-op rather than panicking.
+func TestRunShutdownSequenceNilFn(t *testing.T) {
+	steps := []shutdownStep{
+		{name: "noop", fn: nil},
+	}
+	if stuck := runShutdownSequence(time.Second, steps); len(stuck) != 0 {
+		t.Fatalf("expected no stuck steps, got %v", stuck)
+	}
+}

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -152,13 +152,29 @@ func runWork(cmd *cobra.Command, args []string) {
 		workTerminal = false
 	}
 
-	// Setup signal handling
+	// Setup signal handling. The first signal cancels the root context so every
+	// subsystem (worker runner, status/terminal/gateway servers, heartbeat,
+	// auto-updater, usage syncer) observes cancellation and unwinds. As a
+	// bounded safety net (issue #312), a watchdog force-exits if graceful
+	// shutdown does not complete within the grace period, and a second signal
+	// force-exits immediately — so a misbehaving goroutine can never leave an
+	// orphaned node holding the VPN identity or the terminal-server port.
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-sigs
 		fmt.Println("\n   - Received shutdown signal...")
 		cancel()
+		go func() {
+			select {
+			case <-sigs:
+				fmt.Fprintln(os.Stderr, "   - Second signal received; force-exiting")
+				os.Exit(1)
+			case <-time.After(shutdownGracePeriod):
+				fmt.Fprintf(os.Stderr, "   - Shutdown did not complete within %s; force-exiting\n", shutdownGracePeriod)
+				os.Exit(1)
+			}
+		}()
 	}()
 
 	// Note: Update check is now handled by root.go's PersistentPreRun

--- a/internal/redisapi/websocket.go
+++ b/internal/redisapi/websocket.go
@@ -490,6 +490,12 @@ func (c *WSClient) Close() error {
 
 	c.connected = false
 	if c.conn != nil {
+		// Bound the close-handshake write: WriteMessage has no deadline by
+		// default, so on a half-dead connection (e.g. after macOS sleep or a
+		// network change) it can block indefinitely. That stalls shutdown via
+		// chat.Client.Close() (issue #312). A short deadline makes the write
+		// fail fast; we then close the underlying TCP conn regardless.
+		_ = c.conn.SetWriteDeadline(time.Now().Add(2 * time.Second))
 		err := c.conn.WriteMessage(
 			websocket.CloseMessage,
 			websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),

--- a/internal/tui/controlcenter/controlcenter.go
+++ b/internal/tui/controlcenter/controlcenter.go
@@ -386,6 +386,7 @@ type ControlCenter struct {
 	activities     []ActivityEntry
 	activityMu     sync.Mutex
 	stopChan       chan struct{}
+	stopOnce       sync.Once
 	running        bool
 	lastRefresh    time.Time
 	inModal        bool          // Track if we're in a modal (help, quit, etc.)
@@ -667,17 +668,46 @@ func (cc *ControlCenter) ShowChat() {
 	}
 }
 
-// Stop stops the control center
+// Stop signals the control center to exit.
+//
+// It does ONLY two things — close stopChan (to halt background loops) and call
+// tview's Application.Stop() — because Stop() is invoked from the tview
+// event-loop goroutine (the Ctrl+C key handler at HandleGlobalInput, and the
+// quit-confirm modal). Any blocking teardown done here would wedge the event
+// loop: a PTY read-loop's app.QueueUpdate() could never drain, and a chat
+// WebSocket Close() does a synchronous network write with no deadline that can
+// block forever on a half-dead connection (the macOS sleep/network-change case
+// in issue #312). Either one leaves Run() blocked and the process hung on exit.
+//
+// The actual subsystem teardown (console PTYs, chat client) is performed by
+// Cleanup() AFTER Run() returns, under the cmd-layer watchdog, so it can never
+// block the event loop and can never block indefinitely.
+//
+// Guarded by sync.Once so it is safe to call from multiple paths (the Ctrl+C
+// handler, the quit-confirm modal, and the OS signal handler) without
+// double-closing stopChan.
 func (cc *ControlCenter) Stop() {
-	close(cc.stopChan)
+	cc.stopOnce.Do(func() {
+		close(cc.stopChan)
+		if cc.app != nil {
+			cc.app.Stop()
+		}
+	})
+}
+
+// Cleanup tears down the control center's owned subsystems (console PTY
+// sessions and the chat client). It MUST be called only after Run() has
+// returned — once the tview event loop has exited, page Close()s no longer
+// race app.QueueUpdate() callers, and each page's internal closed-mutex makes
+// the call safe and idempotent. The cmd layer runs this under a bounded
+// shutdown watchdog so a blocking Close (e.g. a stuck WebSocket write) cannot
+// hang exit (issue #312).
+func (cc *ControlCenter) Cleanup() {
 	if cc.consolePage != nil {
 		cc.consolePage.Close()
 	}
 	if cc.chatPage != nil {
 		cc.chatPage.Close()
-	}
-	if cc.app != nil {
-		cc.app.Stop()
 	}
 }
 

--- a/internal/tui/controlcenter/stop_test.go
+++ b/internal/tui/controlcenter/stop_test.go
@@ -1,0 +1,24 @@
+package controlcenter
+
+import "testing"
+
+// TestStopIdempotent verifies that Stop() can be called multiple times without
+// panicking on a double-close of stopChan. Stop() is reachable from three
+// concurrent paths during shutdown (the Ctrl+C key handler, the quit-confirm
+// modal, and the OS signal handler), so it must be safe to invoke more than
+// once (issue #312). With app/consolePage/chatPage nil on a freshly-built
+// control center, Stop() only closes stopChan, which is exactly the path the
+// sync.Once guard protects.
+func TestStopIdempotent(t *testing.T) {
+	cc := New(Config{Version: "test"})
+
+	cc.Stop()
+	cc.Stop() // second call must not panic (double-close of stopChan)
+
+	select {
+	case <-cc.stopChan:
+		// closed as expected
+	default:
+		t.Fatal("stopChan was not closed by Stop()")
+	}
+}


### PR DESCRIPTION
## Context

Running the Citadel control center — the `citadel work` / bare `citadel` TUI — and then hitting Ctrl+C (or sending SIGINT) **never terminated the process**. It hung and had to be force-killed, leaving an orphaned node holding the VPN identity and the terminal-server port, which blocks clean restarts. Reported on macOS (#312).

```
^C   (nothing happens; process never exits)
```

## Root cause

With tcell in raw mode, Ctrl+C is delivered as a `KeyCtrlC` **event**, not a signal, and runs `cc.Stop()` on the **tview event-loop goroutine** (`HandleGlobalInput`, controlcenter.go:799). The old `cc.Stop()` called `consolePage.Close()` and `chatPage.Close()` inline:

- `chatPage.Close()` → `chat.Client.Close()` → `redisapi.WSClient.Close()` performs a **synchronous WebSocket close-handshake write with no deadline**. On a half-dead connection (the classic macOS sleep / network-change case) that write blocks forever.
- That wedges the event loop, so `app.Stop()` is never reached and `cc.Run()` never returns.

Compounding factors: `runControlCenter` had **no OS signal handler** at all (a real SIGINT was unhandled), the TUI worker ran on a `context.Background()`-derived context that was **never cancelled** on exit, and there was **no force-exit safety net**.

## Summary

| Change | File | Why |
| --- | --- | --- |
| `cc.Stop()` now only `close(stopChan)` + `app.Stop()`, guarded by `sync.Once` | `internal/tui/controlcenter/controlcenter.go` *(shared — TUI file, kept minimal)* | These are the only two event-loop-safe actions; blocking teardown must not run on the event loop. Once-guard makes it safe to call from the Ctrl+C handler, quit modal, and signal handler. |
| New `cc.Cleanup()` does the blocking page teardown (console PTYs, chat client) | `internal/tui/controlcenter/controlcenter.go` *(shared)* | Runs **after** `Run()` returns, off the event loop, under the watchdog. |
| `runControlCenter`: SIGINT/SIGTERM handler + bounded shutdown sequencer + worker cancellation | `cmd/controlcenter.go` | Real signals now exit cleanly; every subsystem (tui-cleanup, worker, terminal/vnc/demo/instance) is torn down through a 5s-bounded sequencer that force-exits if any step hangs, logging it. The leaked TUI worker is now cancelled. |
| Bounded shutdown sequencer + watchdog | `cmd/shutdown.go` (new) | Pure, testable timeout logic: runs steps concurrently, returns the names of any not finished within the grace period; caller force-exits. |
| `runWork` (headless) gains the same safety net | `cmd/work.go` | A second signal or a 5s timeout force-exits, so the headless path can't hang either. |
| `WSClient.Close()` sets a 2s write deadline on the close handshake | `internal/redisapi/websocket.go` | The actual unbounded blocker — makes `tui-cleanup` complete fast rather than relying on the force-exit every chat session. |

**Shutdown ordering principle:** the event-loop goroutine does the minimum (signal stop + `app.Stop()`); all blocking teardown happens after `Run()` returns, under a bounded watchdog that can never hang the process.

## Test plan

| Test | Coverage |
| --- | --- |
| `TestRunShutdownSequenceStuckStep` | Core safety net: a deliberately-stuck stub step does **not** prevent the sequence from returning after the grace period; the stuck step is reported by name. |
| `TestRunShutdownSequenceAllComplete` / `Empty` / `NilFn` | Clean completion, empty fast-path, nil-fn no-op. |
| `TestStopIdempotent` | `cc.Stop()` is safe to call multiple times (no double-close panic) across the three concurrent shutdown paths. |
| `go build ./...`, `go vet ./...`, `gofmt -l` (clean) | — |
| Cross-compile `CGO_ENABLED=0` for `darwin/arm64`, `linux/amd64`, `windows/amd64` | All pass. |
| `go test ./...` | All pass except the pre-existing `e2e` package, which requires live Redis (6379) + HTTP (3000) and is environmental, not from this change. |

**Verified by code inspection** for the live event-loop deadlock (the TUI hang cannot be reproduced headlessly).

**Manual test (please run):** start `citadel work`, open the chat tab, then send SIGINT / press Ctrl+C → the process should exit within a couple of seconds instead of hanging.

## Related

- Closes #312
- Touches the shared TUI file `internal/tui/controlcenter/controlcenter.go` (minimal: `Stop()` rework + new `Cleanup()` + one struct field) — a parallel agent edits TUI files.
