### PR TITLE
fix: self-heal VNC/terminal VPN listeners across tsnet reconnects (#317)

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -73,6 +75,66 @@ var (
 	ccVNCServer  *desktop.VNCServer
 	ccVNCPort    = 5900
 	ccVNCRunning bool
+)
+
+// vpnListener wraps a tsnet VPN listener with a liveness flag. tsnet does not
+// expose an explicit "listener torn down on reconnect" event, so we detect
+// death the only reliable way available: when the server's accept loop calls
+// Accept() and it returns a non-recoverable error (the listener was closed by
+// the tsnet teardown). The flag is set from inside Accept, so it works
+// regardless of whether the tailnet IP changed — covering the issue #317
+// same-IP blip where the node returns to the *same* address with a dead
+// listener (machine key preserved → same IP). See issue #317.
+type vpnListener struct {
+	net.Listener
+	dead   atomic.Bool
+	closed atomic.Bool // set when we deliberately Close() it (re-attach/shutdown)
+}
+
+func (l *vpnListener) Accept() (net.Conn, error) {
+	conn, err := l.Listener.Accept()
+	if err != nil && !l.closed.Load() {
+		// The accept loop saw an error we did not cause by closing the
+		// listener ourselves: treat the VPN listener as dead so the supervisor
+		// re-attaches it. (When we close it on purpose, closed is already set.)
+		l.dead.Store(true)
+	}
+	return conn, err
+}
+
+func (l *vpnListener) Close() error {
+	l.closed.Store(true)
+	return l.Listener.Close()
+}
+
+func (l *vpnListener) isDead() bool { return l.dead.Load() }
+
+// VPN-listener attachment state (issue #317).
+//
+// The VPN listener lifecycle is deliberately tracked separately from the
+// server "running" flags above. A tsnet drop+recover tears down the listener
+// bound to the tailnet IP while the localhost server keeps running, so the
+// supervisor must be able to (re)attach a VPN listener even when the server
+// object is already running. ccVPNMu guards all of the fields below and
+// serializes attach attempts so the supervisor and the startup/login paths
+// never race.
+var (
+	ccVPNMu sync.Mutex
+
+	ccVNCVPNListener *vpnListener // nil when no VNC VPN listener is attached
+	ccVNCVPNIP       string       // tailnet IP the current VNC VPN listener is bound to
+
+	ccTerminalVPNListener *vpnListener // nil when no terminal VPN listener is attached
+	ccTerminalVPNIP       string       // tailnet IP the current terminal VPN listener is bound to
+)
+
+// listenVPNFn / isConnectedFn / currentVPNIPFn are indirection points for the
+// network layer so the VPN-listener supervisor can be unit-tested without a
+// live tailnet. Production wiring uses the real network package functions.
+var (
+	listenVPNFn    = network.ListenVPN
+	isConnectedFn  = network.IsGlobalConnected
+	currentVPNIPFn = network.GetGlobalIPv4
 )
 
 // runControlCenter launches the unified control center TUI
@@ -171,6 +233,14 @@ func runControlCenter() {
 
 	// Set heartbeat callback so worker can update TUI
 	ccHeartbeatFn = cc.UpdateHeartbeat
+
+	// Supervise the VNC + terminal VPN listeners for the lifetime of the TUI so
+	// they self-heal across tsnet reconnects without relaunching citadel (issue
+	// #317). Runs independently of the one-shot auto-connect goroutine below,
+	// which only fires at startup/login.
+	supervisorCtx, supervisorCancel := context.WithCancel(context.Background())
+	defer supervisorCancel()
+	go ccSuperviseVPNListeners(supervisorCtx, cc.AddActivity)
 
 	// Auto-connect to network and start worker
 	go func() {
@@ -394,20 +464,6 @@ func startTerminalServer(orgID string, activityFn func(level, msg string)) error
 	// Create and start the server
 	ccTerminalServer = terminal.NewServer(config, ccTerminalAuth)
 
-	// Add VPN listener so the terminal server is reachable over the tsnet VPN.
-	// The TCP bind is localhost-only for security; external access comes through tsnet.
-	// Bind to the explicit assigned VPN IP (not ":port") so inbound connections from
-	// the platform relay are matched by tsnet. See network.ListenVPN and issue #286.
-	if network.IsGlobalConnected() {
-		vpnPort := fmt.Sprintf("%d", config.Port)
-		if vpnLn, vpnIP, err := network.ListenVPN("tcp", vpnPort); err != nil {
-			Log("terminal server VPN listener failed (localhost-only): %v", err)
-		} else {
-			ccTerminalServer.AddListener(vpnLn)
-			Log("terminal server VPN listener on %s:%s", vpnIP, vpnPort)
-		}
-	}
-
 	// Suppress terminal server logging in TUI mode to prevent display corruption
 	ccTerminalServer.SetSilent()
 
@@ -421,6 +477,11 @@ func startTerminalServer(orgID string, activityFn func(level, msg string)) error
 	ccTerminalOrgID = orgID
 	ccTerminalAPIToken = apiToken
 	ccTerminalRunning = true
+
+	// Attach the VPN listener so the terminal server is reachable over the
+	// tsnet VPN. This is decoupled from the server lifecycle (issue #317): the
+	// supervisor re-attaches it idempotently across tsnet reconnects.
+	attachTerminalVPNListener()
 	return nil
 }
 
@@ -443,6 +504,16 @@ func stopTerminalServer() {
 	ccTerminalRunning = false
 	ccTerminalOrgID = ""
 	ccTerminalAPIToken = ""
+
+	// Closing the server closes its listeners; reset the VPN-attach tracking
+	// so a subsequent start re-attaches cleanly (issue #317).
+	ccVPNMu.Lock()
+	if ccTerminalVPNListener != nil {
+		_ = ccTerminalVPNListener.Close()
+	}
+	ccTerminalVPNListener = nil
+	ccTerminalVPNIP = ""
+	ccVPNMu.Unlock()
 }
 
 // startVNCServer starts the embedded VNC server for remote desktop access.
@@ -458,19 +529,6 @@ func startVNCServer() error {
 		Port: ccVNCPort,
 		FPS:  10,
 	})
-
-	// Add VPN listener so the VNC server is reachable over the tsnet VPN.
-	// Bind to the explicit assigned VPN IP (not ":port"); see network.ListenVPN
-	// and issue #286.
-	if network.IsGlobalConnected() {
-		vpnPort := fmt.Sprintf("%d", ccVNCPort)
-		if vpnLn, vpnIP, err := network.ListenVPN("tcp", vpnPort); err != nil {
-			Log("VNC server VPN listener failed (localhost-only): %v", err)
-		} else {
-			ccVNCServer.AddListener(vpnLn)
-			Log("VNC server VPN listener on %s:%s", vpnIP, vpnPort)
-		}
-	}
 
 	ccVNCServer.SetSilent()
 
@@ -506,7 +564,12 @@ func startVNCServer() error {
 	}
 
 	ccVNCRunning = true
-	platform.SetEmbeddedVNCPort(ccVNCPort)
+
+	// Attach the VPN listener so the VNC server is reachable over the tsnet
+	// VPN. The heartbeat's vnc_port is set from inside the attach helper so it
+	// reflects actual VPN-listener reachability, not just localhost server
+	// state (issue #317).
+	attachVNCVPNListener()
 	return nil
 }
 
@@ -520,6 +583,201 @@ func stopVNCServer() {
 	}
 	ccVNCRunning = false
 	platform.ClearEmbeddedVNCPort()
+
+	// Closing the server closes its listeners; reset the VPN-attach tracking
+	// so a subsequent start re-attaches cleanly (issue #317).
+	ccVPNMu.Lock()
+	if ccVNCVPNListener != nil {
+		_ = ccVNCVPNListener.Close()
+	}
+	ccVNCVPNListener = nil
+	ccVNCVPNIP = ""
+	ccVPNMu.Unlock()
+}
+
+// vncVPNHealthyLocked reports whether the VNC VPN listener is currently
+// attached and live. Caller must hold ccVPNMu.
+func vncVPNHealthyLocked() bool {
+	return ccVNCVPNListener != nil && !ccVNCVPNListener.isDead()
+}
+
+// terminalVPNHealthyLocked reports whether the terminal VPN listener is
+// currently attached and live. Caller must hold ccVPNMu.
+func terminalVPNHealthyLocked() bool {
+	return ccTerminalVPNListener != nil && !ccTerminalVPNListener.isDead()
+}
+
+// attachVNCVPNListener (re)binds the VNC server's tsnet VPN listener,
+// idempotently. It is safe to call repeatedly: it no-ops when a live listener
+// is already attached, and it tears down and replaces a dead one (e.g. a
+// listener whose tsnet binding was torn down by a reconnect — including the
+// same-IP blip where the node returns to the same tailnet address). See issue
+// #317.
+//
+// The VNC server is only managed when desktop permission is enabled, so callers
+// gate on perms.Desktop before starting the server; this helper assumes the
+// server object exists (ccVNCServer != nil && ccVNCRunning).
+func attachVNCVPNListener() {
+	ccVPNMu.Lock()
+	defer ccVPNMu.Unlock()
+
+	if !ccVNCRunning || ccVNCServer == nil {
+		return
+	}
+
+	// A live listener is already attached — make sure the heartbeat reflects
+	// reachability and return.
+	if vncVPNHealthyLocked() {
+		platform.SetEmbeddedVNCPort(ccVNCPort)
+		return
+	}
+
+	// No live VPN listener: the desktop is unreachable over the tailnet, so the
+	// heartbeat's vnc_port must report 0 (issue #317 requirement). Clear it now
+	// even if we cannot rebind yet (e.g. still disconnected); a successful
+	// re-attach below sets it back.
+	platform.ClearEmbeddedVNCPort()
+
+	if !isConnectedFn() {
+		return
+	}
+
+	// Replace any dead listener before rebinding (don't leak it).
+	if ccVNCVPNListener != nil {
+		_ = ccVNCVPNListener.Close()
+		ccVNCServer.RemoveListener(ccVNCVPNListener)
+		ccVNCVPNListener = nil
+		ccVNCVPNIP = ""
+	}
+
+	vpnPort := fmt.Sprintf("%d", ccVNCPort)
+	rawLn, vpnIP, err := listenVPNFn("tcp", vpnPort)
+	if err != nil {
+		Log("VNC server VPN listener failed (localhost-only): %v", err)
+		platform.ClearEmbeddedVNCPort()
+		return
+	}
+
+	vpnLn := &vpnListener{Listener: rawLn}
+	ccVNCServer.AddListener(vpnLn)
+	ccVNCVPNListener = vpnLn
+	ccVNCVPNIP = vpnIP
+	platform.SetEmbeddedVNCPort(ccVNCPort)
+	Log("VNC server VPN listener on %s:%s", vpnIP, vpnPort)
+}
+
+// attachTerminalVPNListener (re)binds the terminal server's tsnet VPN listener,
+// idempotently. See attachVNCVPNListener for the contract. Issue #317.
+func attachTerminalVPNListener() {
+	ccVPNMu.Lock()
+	defer ccVPNMu.Unlock()
+
+	if !ccTerminalRunning || ccTerminalServer == nil {
+		return
+	}
+
+	if terminalVPNHealthyLocked() {
+		return
+	}
+
+	if !isConnectedFn() {
+		return
+	}
+
+	if ccTerminalVPNListener != nil {
+		_ = ccTerminalVPNListener.Close()
+		ccTerminalServer.RemoveListener(ccTerminalVPNListener)
+		ccTerminalVPNListener = nil
+		ccTerminalVPNIP = ""
+	}
+
+	vpnPort := fmt.Sprintf("%d", ccTerminalPort)
+	rawLn, vpnIP, err := listenVPNFn("tcp", vpnPort)
+	if err != nil {
+		Log("terminal server VPN listener failed (localhost-only): %v", err)
+		return
+	}
+
+	vpnLn := &vpnListener{Listener: rawLn}
+	ccTerminalServer.AddListener(vpnLn)
+	ccTerminalVPNListener = vpnLn
+	ccTerminalVPNIP = vpnIP
+	Log("terminal server VPN listener on %s:%s", vpnIP, vpnPort)
+}
+
+// vpnListenersHealthy reports whether the VPN listeners that should be attached
+// (given the running servers) are currently attached and live. The supervisor
+// uses it to decide whether a re-attach is needed. A listener is unhealthy if
+// it is missing or its accept loop saw the underlying tsnet listener get torn
+// down (issue #317). VNC is only considered when its server is running (which
+// itself is gated on desktop permission at start time).
+func vpnListenersHealthy() bool {
+	ccVPNMu.Lock()
+	defer ccVPNMu.Unlock()
+
+	if ccTerminalRunning && !terminalVPNHealthyLocked() {
+		return false
+	}
+	if ccVNCRunning && !vncVPNHealthyLocked() {
+		return false
+	}
+	return true
+}
+
+// ccSuperviseVPNListeners runs for the lifetime of the control center and
+// self-heals the VNC + terminal VPN listeners across tsnet reconnects (issue
+// #317).
+//
+// tsnet does not expose an explicit reconnect event: network.IsGlobalConnected
+// polls the backend state, and on the "context deadline exceeded" blip the
+// listener bound to the old tailnet IP is silently torn down while the server
+// keeps running. So instead of hooking an event, this supervisor polls and
+// reacts to the transition to connected, plus a steady-state health check that
+// also covers the issue's "display==available && vnc_port==0" self-heal
+// trigger (a VNC server that is running but has no reachable VPN listener).
+//
+// Re-attach is idempotent (see attach* helpers): a healthy listener is left
+// alone, a dead one is replaced.
+func ccSuperviseVPNListeners(ctx context.Context, activityFn func(level, msg string)) {
+	ticker := time.NewTicker(15 * time.Second)
+	defer ticker.Stop()
+
+	wasConnected := isConnectedFn()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+
+		connected := isConnectedFn()
+
+		// Nothing to manage while disconnected. Listeners bound to the old IP
+		// are already dead; we re-attach on the transition back to connected.
+		if !connected {
+			wasConnected = false
+			continue
+		}
+
+		// React to a transition into connected (startup reconnect or a
+		// mid-session tsnet recovery), or to a steady-state where a running
+		// server's VPN listener has gone unreachable (display available but
+		// vnc_port effectively 0).
+		if !wasConnected || !vpnListenersHealthy() {
+			if ccTerminalRunning {
+				attachTerminalVPNListener()
+			}
+			if ccVNCRunning {
+				before := platform.EmbeddedVNCPort()
+				attachVNCVPNListener()
+				if activityFn != nil && before == 0 && platform.EmbeddedVNCPort() != 0 {
+					activityFn("info", "Desktop VPN listener re-established after network reconnect")
+				}
+			}
+		}
+
+		wasConnected = true
+	}
 }
 
 // buildChatConfig constructs ChatPageConfig from device config and manifest.

--- a/cmd/controlcenter_vpn_test.go
+++ b/cmd/controlcenter_vpn_test.go
@@ -1,0 +1,332 @@
+package cmd
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/desktop"
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
+	"github.com/aceteam-ai/citadel-cli/internal/terminal"
+)
+
+// fakeListener is a minimal net.Listener stand-in. Its Accept() returns
+// whatever error the test has armed via setAcceptErr, letting the tests
+// simulate a tsnet VPN listener being torn down on reconnect (which surfaces as
+// an Accept error in the server's accept loop) without a real tailnet. It also
+// records whether it was closed so tests can assert no listener is leaked.
+type fakeListener struct {
+	addr string
+
+	mu        sync.Mutex
+	closed    bool
+	acceptErr error
+}
+
+func (f *fakeListener) Accept() (net.Conn, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.acceptErr != nil {
+		return nil, f.acceptErr
+	}
+	return nil, fmt.Errorf("no connections in test")
+}
+func (f *fakeListener) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closed = true
+	return nil
+}
+func (f *fakeListener) Addr() net.Addr { return fakeAddr(f.addr) }
+func (f *fakeListener) isClosed() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.closed
+}
+func (f *fakeListener) setAcceptErr(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.acceptErr = err
+}
+
+type fakeAddr string
+
+func (a fakeAddr) Network() string { return "tcp" }
+func (a fakeAddr) String() string  { return string(a) }
+
+// resetVPNState clears all package-level VPN-listener tracking and restores the
+// real network indirection hooks. Tests must call this so they don't leak state
+// into other tests in the package.
+func resetVPNState(t *testing.T) {
+	t.Helper()
+	origListen := listenVPNFn
+	origConnected := isConnectedFn
+	origIP := currentVPNIPFn
+
+	clear := func() {
+		ccVPNMu.Lock()
+		ccVNCVPNListener = nil
+		ccVNCVPNIP = ""
+		ccTerminalVPNListener = nil
+		ccTerminalVPNIP = ""
+		ccVPNMu.Unlock()
+
+		ccVNCRunning = false
+		ccVNCServer = nil
+		ccTerminalRunning = false
+		ccTerminalServer = nil
+		platform.ClearEmbeddedVNCPort()
+	}
+
+	t.Cleanup(func() {
+		listenVPNFn = origListen
+		isConnectedFn = origConnected
+		currentVPNIPFn = origIP
+		clear()
+	})
+
+	clear()
+}
+
+// TestAttachVNCVPNListenerIdempotent verifies that calling the attach helper
+// twice while connected with a live listener binds exactly one listener and
+// does not leak.
+func TestAttachVNCVPNListenerIdempotent(t *testing.T) {
+	resetVPNState(t)
+
+	var dialed int
+	currentIP := "100.64.0.30"
+	isConnectedFn = func() bool { return true }
+	currentVPNIPFn = func() (string, error) { return currentIP, nil }
+	listenVPNFn = func(network, port string) (net.Listener, string, error) {
+		dialed++
+		return &fakeListener{addr: currentIP + ":" + port}, currentIP, nil
+	}
+
+	ccVNCServer = desktop.NewVNCServer(desktop.VNCServerConfig{Host: "127.0.0.1", Port: ccVNCPort})
+	ccVNCRunning = true
+
+	attachVNCVPNListener()
+	attachVNCVPNListener() // idempotent: listener still live → no rebind
+
+	if dialed != 1 {
+		t.Fatalf("ListenVPN called %d times, want 1 (idempotent re-attach)", dialed)
+	}
+	if ccVNCVPNListener == nil {
+		t.Fatal("ccVNCVPNListener = nil, want attached after attach")
+	}
+	if platform.EmbeddedVNCPort() != ccVNCPort {
+		t.Errorf("EmbeddedVNCPort() = %d, want %d (heartbeat must reflect reachability)", platform.EmbeddedVNCPort(), ccVNCPort)
+	}
+}
+
+// TestVPNListenerReattachAfterSameIPReconnect simulates the exact issue #317
+// failure: a tsnet drop+recover where the node returns to the SAME tailnet IP
+// (machine key preserved) but the VPN listener was torn down. Detection must
+// not rely on an IP change — it keys on the listener's accept loop seeing the
+// teardown — and the supervisor must tear down the dead listener and rebind a
+// fresh one without restarting the server.
+func TestVPNListenerReattachAfterSameIPReconnect(t *testing.T) {
+	resetVPNState(t)
+
+	const sameIP = "100.64.0.30" // never changes — the reported scenario
+	connected := true
+
+	isConnectedFn = func() bool { return connected }
+	currentVPNIPFn = func() (string, error) {
+		if !connected {
+			return "", fmt.Errorf("no IPv4 address assigned")
+		}
+		return sameIP, nil
+	}
+
+	var created []*fakeListener
+	listenVPNFn = func(network, port string) (net.Listener, string, error) {
+		if !connected {
+			return nil, "", fmt.Errorf("not connected to AceTeam Network")
+		}
+		ln := &fakeListener{addr: sameIP + ":" + port}
+		created = append(created, ln)
+		return ln, sameIP, nil
+	}
+
+	// Both servers running (desktop permission assumed enabled by caller).
+	ccVNCServer = desktop.NewVNCServer(desktop.VNCServerConfig{Host: "127.0.0.1", Port: ccVNCPort})
+	ccVNCRunning = true
+	ccTerminalServer = terminal.NewServer(terminal.DefaultConfig(), nil)
+	ccTerminalRunning = true
+
+	// 1. Initial attach while connected.
+	attachVNCVPNListener()
+	attachTerminalVPNListener()
+
+	if len(created) != 2 {
+		t.Fatalf("after initial attach, ListenVPN created %d listeners, want 2 (vnc+terminal)", len(created))
+	}
+	if !vpnListenersHealthy() {
+		t.Fatal("vpnListenersHealthy() = false right after a successful attach")
+	}
+	firstVNC := created[0]
+	firstTerminal := created[1]
+
+	// 2. tsnet drops and recovers at the SAME IP, tearing down the listeners.
+	//    The server accept loops observe this as an Accept error. Simulate the
+	//    accept loop's next Accept() call by arming the underlying fake with a
+	//    teardown error and invoking the wrapper's Accept (as the loop would).
+	firstVNC.setAcceptErr(net.ErrClosed)
+	firstTerminal.setAcceptErr(net.ErrClosed)
+	ccVPNMu.Lock()
+	_, _ = ccVNCVPNListener.Accept()      // accept loop sees teardown → marks dead
+	_, _ = ccTerminalVPNListener.Accept() // ditto
+	ccVPNMu.Unlock()
+
+	// Health check must now report unhealthy even though the IP is unchanged.
+	if vpnListenersHealthy() {
+		t.Fatal("vpnListenersHealthy() = true after same-IP teardown; dead listener not detected")
+	}
+
+	// 3. Self-heal: re-attach idempotently. The dead listeners must be closed
+	//    and replaced — at the SAME IP — without restarting the server.
+	attachVNCVPNListener()
+	attachTerminalVPNListener()
+
+	if !firstVNC.isClosed() {
+		t.Error("stale VNC VPN listener was not closed on re-attach (listener leak)")
+	}
+	if !firstTerminal.isClosed() {
+		t.Error("stale terminal VPN listener was not closed on re-attach (listener leak)")
+	}
+	if len(created) != 4 {
+		t.Fatalf("after re-attach, ListenVPN created %d listeners total, want 4", len(created))
+	}
+	if ccVNCVPNIP != sameIP {
+		t.Errorf("ccVNCVPNIP = %q, want %q", ccVNCVPNIP, sameIP)
+	}
+	if !vpnListenersHealthy() {
+		t.Fatal("vpnListenersHealthy() = false after self-heal re-attach")
+	}
+	if platform.EmbeddedVNCPort() != ccVNCPort {
+		t.Errorf("EmbeddedVNCPort() = %d, want %d after re-attach (vnc_port must recover)", platform.EmbeddedVNCPort(), ccVNCPort)
+	}
+}
+
+// TestVPNSupervisorReattachOnHealthLoss drives the supervisor's decision logic
+// (without the ticker) to confirm a steady-state dead listener at the same IP
+// triggers a re-attach — the "display==available && vnc_port==0" self-heal.
+func TestVPNSupervisorReattachOnHealthLoss(t *testing.T) {
+	resetVPNState(t)
+
+	const sameIP = "100.64.0.30"
+	isConnectedFn = func() bool { return true }
+	currentVPNIPFn = func() (string, error) { return sameIP, nil }
+
+	var created []*fakeListener
+	listenVPNFn = func(network, port string) (net.Listener, string, error) {
+		ln := &fakeListener{addr: sameIP + ":" + port}
+		created = append(created, ln)
+		return ln, sameIP, nil
+	}
+
+	ccVNCServer = desktop.NewVNCServer(desktop.VNCServerConfig{Host: "127.0.0.1", Port: ccVNCPort})
+	ccVNCRunning = true
+
+	attachVNCVPNListener()
+	if platform.EmbeddedVNCPort() != ccVNCPort {
+		t.Fatalf("EmbeddedVNCPort() = %d after initial attach, want %d", platform.EmbeddedVNCPort(), ccVNCPort)
+	}
+
+	// Listener torn down at the same IP → vnc_port effectively 0.
+	created[0].setAcceptErr(net.ErrClosed)
+	ccVPNMu.Lock()
+	_, _ = ccVNCVPNListener.Accept()
+	ccVPNMu.Unlock()
+
+	// The supervisor's steady-state branch: connected, not a fresh transition,
+	// but listeners unhealthy → re-attach.
+	if vpnListenersHealthy() {
+		t.Fatal("expected unhealthy listeners after teardown")
+	}
+	attachVNCVPNListener() // what the supervisor calls on health loss
+
+	if len(created) != 2 {
+		t.Fatalf("expected a fresh listener on health-loss re-attach, created=%d", len(created))
+	}
+	if !vpnListenersHealthy() {
+		t.Fatal("vpnListenersHealthy() = false after supervisor re-attach")
+	}
+}
+
+// TestVNCPortDropsWhileListenerDeadAndDisconnected asserts the heartbeat's
+// vnc_port reports 0 (unreachable) when the VPN listener is dead and the node
+// cannot rebind because it is disconnected — i.e. vnc_port reflects actual VPN
+// reachability, not just localhost server state (issue #317 requirement #3).
+func TestVNCPortDropsWhileListenerDeadAndDisconnected(t *testing.T) {
+	resetVPNState(t)
+
+	const sameIP = "100.64.0.30"
+	connected := true
+	isConnectedFn = func() bool { return connected }
+	currentVPNIPFn = func() (string, error) {
+		if !connected {
+			return "", fmt.Errorf("disconnected")
+		}
+		return sameIP, nil
+	}
+	var created []*fakeListener
+	listenVPNFn = func(network, port string) (net.Listener, string, error) {
+		if !connected {
+			return nil, "", fmt.Errorf("not connected")
+		}
+		ln := &fakeListener{addr: sameIP + ":" + port}
+		created = append(created, ln)
+		return ln, sameIP, nil
+	}
+
+	ccVNCServer = desktop.NewVNCServer(desktop.VNCServerConfig{Host: "127.0.0.1", Port: ccVNCPort})
+	ccVNCRunning = true
+
+	attachVNCVPNListener()
+	if platform.EmbeddedVNCPort() != ccVNCPort {
+		t.Fatalf("EmbeddedVNCPort() = %d, want %d", platform.EmbeddedVNCPort(), ccVNCPort)
+	}
+
+	// Listener dies, and the node is now disconnected so it cannot rebind.
+	created[0].setAcceptErr(net.ErrClosed)
+	ccVPNMu.Lock()
+	_, _ = ccVNCVPNListener.Accept()
+	ccVPNMu.Unlock()
+	connected = false
+
+	attachVNCVPNListener() // supervisor attempt; can't rebind while disconnected
+
+	if platform.EmbeddedVNCPort() != 0 {
+		t.Errorf("EmbeddedVNCPort() = %d while listener dead and disconnected, want 0", platform.EmbeddedVNCPort())
+	}
+}
+
+// TestAttachVNCVPNListenerSkippedWhenDisconnected verifies the attach helper is
+// a no-op when not connected, leaving vnc_port at 0 (the unreachable state the
+// heartbeat should report).
+func TestAttachVNCVPNListenerSkippedWhenDisconnected(t *testing.T) {
+	resetVPNState(t)
+
+	isConnectedFn = func() bool { return false }
+	currentVPNIPFn = func() (string, error) { return "", fmt.Errorf("not connected") }
+	listenVPNFn = func(network, port string) (net.Listener, string, error) {
+		t.Fatal("ListenVPN should not be called while disconnected")
+		return nil, "", nil
+	}
+
+	ccVNCServer = desktop.NewVNCServer(desktop.VNCServerConfig{Host: "127.0.0.1", Port: ccVNCPort})
+	ccVNCRunning = true
+
+	attachVNCVPNListener()
+
+	if ccVNCVPNListener != nil {
+		t.Error("ccVNCVPNListener != nil while disconnected, want nil")
+	}
+	if platform.EmbeddedVNCPort() != 0 {
+		t.Errorf("EmbeddedVNCPort() = %d while disconnected, want 0", platform.EmbeddedVNCPort())
+	}
+}

--- a/internal/desktop/vnc_server.go
+++ b/internal/desktop/vnc_server.go
@@ -2,6 +2,7 @@ package desktop
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -81,11 +82,37 @@ func NewVNCServer(cfg VNCServerConfig) *VNCServer {
 func (s *VNCServer) SetSilent() { s.logger = &noOpLogger{} }
 
 // AddListener registers an additional net.Listener (e.g. VPN) that the server
-// will accept connections on when Start is called. Must be called before Start.
+// will accept connections on.
+//
+// If the server is already running, the listener begins accepting connections
+// immediately. This lets callers re-attach a VPN listener after a tsnet
+// reconnect without restarting the server (see issue #317). If the server is
+// not yet running, the listener is queued and served when Start is called.
 func (s *VNCServer) AddListener(ln net.Listener) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.extraListeners = append(s.extraListeners, ln)
+	running := s.running
+	s.mu.Unlock()
+
+	if running {
+		s.logger.Printf("VNC server also listening on %s (VPN, hot-attached)", ln.Addr())
+		go s.acceptLoop(ln)
+	}
+}
+
+// RemoveListener drops a previously added extra listener from the server's
+// tracking slice so a long-lived session that re-attaches a VPN listener across
+// many reconnects does not accumulate dead listener references (issue #317).
+// It does not close the listener; the caller owns its lifecycle.
+func (s *VNCServer) RemoveListener(ln net.Listener) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, l := range s.extraListeners {
+		if l == ln {
+			s.extraListeners = append(s.extraListeners[:i], s.extraListeners[i+1:]...)
+			return
+		}
+	}
 }
 
 // Start initializes the screen capturer and begins accepting VNC connections.
@@ -175,9 +202,17 @@ func (s *VNCServer) acceptLoop(ln net.Listener) {
 			case <-s.stopCh:
 				return
 			default:
-				s.logger.Printf("accept error: %v", err)
-				continue
 			}
+			// A closed listener (e.g. a tsnet VPN listener torn down on
+			// reconnect) returns a permanent error. Exiting the loop avoids a
+			// busy-spin and lets the supervisor re-attach a fresh listener
+			// (issue #317). Transient errors are retried.
+			if errors.Is(err, net.ErrClosed) {
+				s.logger.Printf("listener closed (%s), stopping accept loop", ln.Addr())
+				return
+			}
+			s.logger.Printf("accept error: %v", err)
+			continue
 		}
 		atomic.AddInt64(&s.totalConns, 1)
 		go s.handleConn(conn)

--- a/internal/terminal/server.go
+++ b/internal/terminal/server.go
@@ -107,12 +107,42 @@ func (s *Server) SetSilent() {
 }
 
 // AddListener registers an additional net.Listener that the server will also
-// serve on when Start is called. This enables dual-listen on both LAN and VPN
-// interfaces. Must be called before Start.
+// serve on. This enables dual-listen on both LAN and VPN interfaces.
+//
+// If the server is already running, the listener begins serving immediately.
+// This lets callers re-attach a VPN listener after a tsnet reconnect without
+// restarting the server (see issue #317). If the server is not yet running,
+// the listener is queued and served when Start is called.
 func (s *Server) AddListener(ln net.Listener) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.extraListeners = append(s.extraListeners, ln)
+	running := s.running
+	httpServer := s.httpServer
+	s.mu.Unlock()
+
+	if running && httpServer != nil {
+		s.logger.Printf("also listening on %s (VPN, hot-attached)", ln.Addr().String())
+		go func() {
+			if err := httpServer.Serve(ln); err != nil && err != http.ErrServerClosed {
+				s.logger.Printf("VPN listener error: %v", err)
+			}
+		}()
+	}
+}
+
+// RemoveListener drops a previously added extra listener from the server's
+// tracking slice so a long-lived session that re-attaches a VPN listener across
+// many reconnects does not accumulate dead listener references (issue #317).
+// It does not close the listener; the caller owns its lifecycle.
+func (s *Server) RemoveListener(ln net.Listener) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, l := range s.extraListeners {
+		if l == ln {
+			s.extraListeners = append(s.extraListeners[:i], s.extraListeners[i+1:]...)
+			return
+		}
+	}
 }
 
 // NewServerWithDebug creates a new terminal server with debug logging enabled


### PR DESCRIPTION
## Context

Closes #317.

Remote desktop and terminal silently die mid-session on a node that is otherwise healthy (connected, heartbeating, consuming jobs). The platform desktop/terminal tabs show "Connection Error / Session ended", the heartbeat reports `"desktop":{"display":"available"},"vnc_port":0`, and nothing is listening on `:5900` over the tailnet — yet the `citadel` control-center process is still alive. The only recovery was relaunching `citadel`.

## Root Cause (`cmd/controlcenter.go`)

The VPN-listener lifecycle was not coupled to the tsnet connection lifecycle:

1. `ccOnNetworkConnect` calls `startTerminalServer` / `startVNCServer`, which add their tsnet VPN listeners via `network.ListenVPN(...)` + `AddListener(...)`, gated on a **point-in-time** `network.IsGlobalConnected()` check.
2. Both functions early-return when already running (`if ccVNCRunning {...}` / `if ccTerminalRunning {...}`).

When tsnet drops and recovers (the "context deadline exceeded" blip), the listener bound to the tailnet IP is torn down, but `ccVNCRunning`/`ccTerminalRunning` stay `true`. So nothing ever re-attaches the VPN listener — the server keeps running on `127.0.0.1` but is unreachable over the tailnet, and the heartbeat reports `vnc_port: 0`.

Crucially, the reported failure is **same-IP**: the machine key is preserved, so the node returns to the same tailnet address (`100.64.0.30`) after the blip with a dead listener. An IP-change check would miss this.

## Solution

- **Decouple the VPN-listener lifecycle from the server "running" flag.** Each VPN listener is tracked separately and (re)attached idempotently even when the server object is already running.
- **Detect a dead listener via an IP-independent liveness signal.** A `vpnListener` wrapper marks itself dead when the server's accept loop sees the underlying tsnet listener torn down (`Accept()` returns an error we did not cause by closing it ourselves). This covers the same-IP blip.
- **Add a supervisor** (`ccSuperviseVPNListeners`) that runs for the TUI lifetime and re-establishes both VPN listeners on every transition to connected *and* whenever a running server's VPN listener has gone unhealthy (the `display==available && vnc_port==0` self-heal trigger). tsnet exposes no explicit reconnect event, so the supervisor polls (15s).
- **Hot-attach `AddListener`:** if the server is already running, a newly added listener begins serving immediately instead of only at `Start()`. Added `RemoveListener` so re-attaches across many reconnects don't accumulate dead listener references.
- **`vnc_port` now reflects actual VPN-listener reachability:** `platform.EmbeddedVNCPort` is set when a live VPN listener is attached and cleared the moment the listener is dead — not tied to localhost server state.
- VNC `acceptLoop` exits on a closed listener instead of busy-spinning.

Respects the existing `perms.Desktop` gate (VNC is only managed when its server is running, which callers gate on desktop permission).

### Files changed
- `cmd/controlcenter.go` — decoupled VPN-listener state, `vpnListener` liveness wrapper, idempotent `attach{VNC,Terminal}VPNListener`, `ccSuperviseVPNListeners`, `vnc_port` wiring.
- `internal/desktop/vnc_server.go` — hot-attach `AddListener`, `RemoveListener`, accept loop exits on closed listener.
- `internal/terminal/server.go` — hot-attach `AddListener`, `RemoveListener`.
- `cmd/controlcenter_vpn_test.go` — new unit tests.

## Testing

`go build ./...`, `go vet ./...`, and `go test ./...` for the affected packages (`cmd`, `internal/desktop`, `internal/terminal`, `internal/network`, `internal/status`) all pass. (`e2e` package failures are pre-existing and require live Redis/AceTeam services on localhost — unrelated to this change.)

New tests inject the network layer (`listenVPNFn` / `isConnectedFn` / `currentVPNIPFn`) to run offline:
- `TestVPNListenerReattachAfterSameIPReconnect` — simulates a tsnet drop+recover at the **same** tailnet IP; asserts the dead listener is detected, torn down (no leak), and replaced without restarting the server.
- `TestVPNSupervisorReattachOnHealthLoss` — steady-state dead listener triggers re-attach (the `vnc_port==0` self-heal).
- `TestVNCPortDropsWhileListenerDeadAndDisconnected` — `vnc_port` reports 0 while the listener is dead and the node can't rebind.
- `TestAttachVNCVPNListenerIdempotent`, `TestAttachVNCVPNListenerSkippedWhenDisconnected`.

## Caveats (live-tailnet verification)

The dead-listener detection rests on one tsnet behavior that **cannot be verified offline**: when tsnet tears down a listener on reconnect, the server's `Accept()` must return an error (rather than the listener dangling and `Accept` blocking forever). The issue's evidence ("torn down", `lsof` empty on `:5900`) strongly implies the listener is closed, so the signal is well-founded — but it should be confirmed on a live node by toggling connectivity mid-session and watching for the `VNC server VPN listener on <ip>:5900` re-log and `vnc_port` returning non-zero. If a future tsnet version leaves the listener dangling, `LocalClient.WatchIPNBus` is the fallback event source.

Follow-up (non-blocking): the supervisor could also rebind when `currentVPNIPFn()` differs from the bound IP as cheap insurance for the IP-change path, independent of the Accept assumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
