### PR TITLE
fix(controlcenter): make VPN listener globals race-free (#319 hardening)

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -61,21 +61,32 @@ var (
 	ccDemoPort   = 7777
 )
 
-// Terminal server state
+// Terminal server state.
+//
+// ccTerminalServer and ccTerminalRunning are accessed concurrently by the VPN
+// listener supervisor (ccSuperviseVPNListeners and the attach* helpers it
+// calls) and the start/stop paths, so they are atomics. They must NOT be
+// guarded by ccVPNMu: startTerminalServer sets the running flag and then calls
+// attachTerminalVPNListener, which locks ccVPNMu — a plain mutex around the
+// flag would re-enter and deadlock (issue #319). ccTerminalOrgID/APIToken are
+// only touched on the start/stop paths (never by the supervisor) so they stay
+// plain.
 var (
-	ccTerminalServer   *terminal.Server
+	ccTerminalServer   atomic.Pointer[terminal.Server]
 	ccTerminalAuth     *terminal.CachingTokenValidator
 	ccTerminalPort     = 7860
-	ccTerminalRunning  bool
+	ccTerminalRunning  atomic.Bool
 	ccTerminalOrgID    string // orgID the terminal server was started with
 	ccTerminalAPIToken string // device API token the terminal server was started with
 )
 
-// VNC server state
+// VNC server state. ccVNCServer/ccVNCRunning are atomics for the same reason as
+// the terminal globals above (concurrent supervisor access; ccVPNMu must not
+// guard them or attachVNCVPNListener would re-enter it). See issue #319.
 var (
-	ccVNCServer  *desktop.VNCServer
+	ccVNCServer  atomic.Pointer[desktop.VNCServer]
 	ccVNCPort    = 5900
-	ccVNCRunning bool
+	ccVNCRunning atomic.Bool
 )
 
 // vpnListener wraps a tsnet VPN listener with a liveness flag. tsnet does not
@@ -94,10 +105,12 @@ type vpnListener struct {
 
 func (l *vpnListener) Accept() (net.Conn, error) {
 	conn, err := l.Listener.Accept()
-	if err != nil && !l.closed.Load() {
-		// The accept loop saw an error we did not cause by closing the
-		// listener ourselves: treat the VPN listener as dead so the supervisor
-		// re-attaches it. (When we close it on purpose, closed is already set.)
+	if err != nil && !l.closed.Load() && errors.Is(err, net.ErrClosed) {
+		// Only a closed/torn-down listener is terminal — mark it dead so the
+		// supervisor re-attaches it. This mirrors the server accept loops, which
+		// treat only net.ErrClosed as terminal and continue on transient errors
+		// (issue #319): a transient Accept error must NOT trigger a needless
+		// tear-down/rebind. (When we close it on purpose, closed is already set.)
 		l.dead.Store(true)
 	}
 	return conn, err
@@ -424,7 +437,7 @@ func ccOnNetworkConnect(activityFn func(level, msg string)) {
 		if cfg := getDeviceConfigFromFile(); cfg != nil {
 			currentAPIToken = cfg.DeviceAPIToken
 		}
-		if ccTerminalRunning && (orgID != ccTerminalOrgID || currentAPIToken != ccTerminalAPIToken) {
+		if ccTerminalRunning.Load() && (orgID != ccTerminalOrgID || currentAPIToken != ccTerminalAPIToken) {
 			activityFn("info", "Credentials changed, restarting terminal server...")
 			stopTerminalServer()
 		}
@@ -459,7 +472,7 @@ func ccOnNetworkConnect(activityFn func(level, msg string)) {
 // activityFn routes log messages through the TUI activity panel. It must
 // not be nil — callers always pass one from ccOnNetworkConnect.
 func startTerminalServer(orgID string, activityFn func(level, msg string)) error {
-	if ccTerminalRunning {
+	if ccTerminalRunning.Load() {
 		return nil // Already running
 	}
 
@@ -493,22 +506,25 @@ func startTerminalServer(orgID string, activityFn func(level, msg string)) error
 		return fmt.Errorf("failed to start token cache: %w", err)
 	}
 
-	// Create and start the server
-	ccTerminalServer = terminal.NewServer(config, ccTerminalAuth)
+	// Create and start the server. Operate on a local until fully started, then
+	// publish the pointer atomically so concurrent readers (the supervisor)
+	// never observe a half-initialized server.
+	srv := terminal.NewServer(config, ccTerminalAuth)
 
 	// Suppress terminal server logging in TUI mode to prevent display corruption
-	ccTerminalServer.SetSilent()
+	srv.SetSilent()
 
-	if err := ccTerminalServer.Start(); err != nil {
+	if err := srv.Start(); err != nil {
 		ccTerminalAuth.Stop()
 		return fmt.Errorf("failed to start terminal server: %w", err)
 	}
+	ccTerminalServer.Store(srv)
 
 	// Record which credentials the server was started with, so we can
 	// detect when they change (e.g., after re-pairing) and restart.
 	ccTerminalOrgID = orgID
 	ccTerminalAPIToken = apiToken
-	ccTerminalRunning = true
+	ccTerminalRunning.Store(true)
 
 	// Attach the VPN listener so the terminal server is reachable over the
 	// tsnet VPN. This is decoupled from the server lifecycle (issue #317): the
@@ -519,7 +535,7 @@ func startTerminalServer(orgID string, activityFn func(level, msg string)) error
 
 // stopTerminalServer stops the terminal server
 func stopTerminalServer() {
-	if !ccTerminalRunning {
+	if !ccTerminalRunning.Load() {
 		return
 	}
 
@@ -527,13 +543,13 @@ func stopTerminalServer() {
 		ccTerminalAuth.Stop()
 	}
 
-	if ccTerminalServer != nil {
+	if srv := ccTerminalServer.Load(); srv != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		_ = ccTerminalServer.Stop(ctx)
+		_ = srv.Stop(ctx)
 	}
 
-	ccTerminalRunning = false
+	ccTerminalRunning.Store(false)
 	ccTerminalOrgID = ""
 	ccTerminalAPIToken = ""
 
@@ -552,17 +568,19 @@ func stopTerminalServer() {
 // It retries transient failures (e.g. screen capture init racing with display
 // server startup) up to 3 times with exponential backoff.
 func startVNCServer() error {
-	if ccVNCRunning {
+	if ccVNCRunning.Load() {
 		return nil
 	}
 
-	ccVNCServer = desktop.NewVNCServer(desktop.VNCServerConfig{
+	// Operate on a local until the server is fully started, then publish the
+	// pointer atomically so the supervisor never observes a half-built server.
+	srv := desktop.NewVNCServer(desktop.VNCServerConfig{
 		Host: "127.0.0.1",
 		Port: ccVNCPort,
 		FPS:  10,
 	})
 
-	ccVNCServer.SetSilent()
+	srv.SetSilent()
 
 	// Retry with backoff for transient failures (display not ready yet).
 	// Permanent failures (unsupported platform) bail immediately.
@@ -571,7 +589,7 @@ func startVNCServer() error {
 	var lastErr error
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
-		if err := ccVNCServer.Start(); err != nil {
+		if err := srv.Start(); err != nil {
 			lastErr = err
 			// Permanent failure: platform doesn't support screen capture
 			if strings.Contains(err.Error(), "not supported") {
@@ -582,12 +600,12 @@ func startVNCServer() error {
 				time.Sleep(interval)
 				interval *= 2
 				// Re-create server for retry since Start() sets running=false on failure
-				ccVNCServer = desktop.NewVNCServer(desktop.VNCServerConfig{
+				srv = desktop.NewVNCServer(desktop.VNCServerConfig{
 					Host: "127.0.0.1",
 					Port: ccVNCPort,
 					FPS:  10,
 				})
-				ccVNCServer.SetSilent()
+				srv.SetSilent()
 				continue
 			}
 			return fmt.Errorf("failed to start VNC server after %d attempts: %w", maxRetries+1, lastErr)
@@ -595,7 +613,8 @@ func startVNCServer() error {
 		break
 	}
 
-	ccVNCRunning = true
+	ccVNCServer.Store(srv)
+	ccVNCRunning.Store(true)
 
 	// Attach the VPN listener so the VNC server is reachable over the tsnet
 	// VPN. The heartbeat's vnc_port is set from inside the attach helper so it
@@ -607,13 +626,13 @@ func startVNCServer() error {
 
 // stopVNCServer stops the embedded VNC server
 func stopVNCServer() {
-	if !ccVNCRunning {
+	if !ccVNCRunning.Load() {
 		return
 	}
-	if ccVNCServer != nil {
-		ccVNCServer.Stop()
+	if srv := ccVNCServer.Load(); srv != nil {
+		srv.Stop()
 	}
-	ccVNCRunning = false
+	ccVNCRunning.Store(false)
 	platform.ClearEmbeddedVNCPort()
 
 	// Closing the server closes its listeners; reset the VPN-attach tracking
@@ -648,12 +667,16 @@ func terminalVPNHealthyLocked() bool {
 //
 // The VNC server is only managed when desktop permission is enabled, so callers
 // gate on perms.Desktop before starting the server; this helper assumes the
-// server object exists (ccVNCServer != nil && ccVNCRunning).
+// server object exists (ccVNCServer.Load() != nil && ccVNCRunning.Load()).
 func attachVNCVPNListener() {
 	ccVPNMu.Lock()
 	defer ccVPNMu.Unlock()
 
-	if !ccVNCRunning || ccVNCServer == nil {
+	// Load the server pointer once and use the local for every method call: a
+	// concurrent stopVNCServer could otherwise swap it between the nil-check and
+	// AddListener (issue #319 data race).
+	srv := ccVNCServer.Load()
+	if !ccVNCRunning.Load() || srv == nil {
 		return
 	}
 
@@ -677,7 +700,7 @@ func attachVNCVPNListener() {
 	// Replace any dead listener before rebinding (don't leak it).
 	if ccVNCVPNListener != nil {
 		_ = ccVNCVPNListener.Close()
-		ccVNCServer.RemoveListener(ccVNCVPNListener)
+		srv.RemoveListener(ccVNCVPNListener)
 		ccVNCVPNListener = nil
 		ccVNCVPNIP = ""
 	}
@@ -691,7 +714,7 @@ func attachVNCVPNListener() {
 	}
 
 	vpnLn := &vpnListener{Listener: rawLn}
-	ccVNCServer.AddListener(vpnLn)
+	srv.AddListener(vpnLn)
 	ccVNCVPNListener = vpnLn
 	ccVNCVPNIP = vpnIP
 	platform.SetEmbeddedVNCPort(ccVNCPort)
@@ -704,7 +727,9 @@ func attachTerminalVPNListener() {
 	ccVPNMu.Lock()
 	defer ccVPNMu.Unlock()
 
-	if !ccTerminalRunning || ccTerminalServer == nil {
+	// Load the server pointer once; see attachVNCVPNListener for why (issue #319).
+	srv := ccTerminalServer.Load()
+	if !ccTerminalRunning.Load() || srv == nil {
 		return
 	}
 
@@ -718,7 +743,7 @@ func attachTerminalVPNListener() {
 
 	if ccTerminalVPNListener != nil {
 		_ = ccTerminalVPNListener.Close()
-		ccTerminalServer.RemoveListener(ccTerminalVPNListener)
+		srv.RemoveListener(ccTerminalVPNListener)
 		ccTerminalVPNListener = nil
 		ccTerminalVPNIP = ""
 	}
@@ -731,7 +756,7 @@ func attachTerminalVPNListener() {
 	}
 
 	vpnLn := &vpnListener{Listener: rawLn}
-	ccTerminalServer.AddListener(vpnLn)
+	srv.AddListener(vpnLn)
 	ccTerminalVPNListener = vpnLn
 	ccTerminalVPNIP = vpnIP
 	Log("terminal server VPN listener on %s:%s", vpnIP, vpnPort)
@@ -747,10 +772,10 @@ func vpnListenersHealthy() bool {
 	ccVPNMu.Lock()
 	defer ccVPNMu.Unlock()
 
-	if ccTerminalRunning && !terminalVPNHealthyLocked() {
+	if ccTerminalRunning.Load() && !terminalVPNHealthyLocked() {
 		return false
 	}
-	if ccVNCRunning && !vncVPNHealthyLocked() {
+	if ccVNCRunning.Load() && !vncVPNHealthyLocked() {
 		return false
 	}
 	return true
@@ -796,10 +821,10 @@ func ccSuperviseVPNListeners(ctx context.Context, activityFn func(level, msg str
 		// server's VPN listener has gone unreachable (display available but
 		// vnc_port effectively 0).
 		if !wasConnected || !vpnListenersHealthy() {
-			if ccTerminalRunning {
+			if ccTerminalRunning.Load() {
 				attachTerminalVPNListener()
 			}
-			if ccVNCRunning {
+			if ccVNCRunning.Load() {
 				before := platform.EmbeddedVNCPort()
 				attachVNCVPNListener()
 				if activityFn != nil && before == 0 && platform.EmbeddedVNCPort() != 0 {
@@ -1032,7 +1057,7 @@ func gatherControlCenterData() (controlcenter.StatusData, error) {
 	data.DemoServerURL = fmt.Sprintf("http://localhost:%d", ccDemoPort)
 
 	// Terminal server URL (only shown when running and connected)
-	if ccTerminalRunning {
+	if ccTerminalRunning.Load() {
 		data.TerminalServerURL = fmt.Sprintf("ws://localhost:%d/terminal", ccTerminalPort)
 	}
 

--- a/cmd/controlcenter_vpn_test.go
+++ b/cmd/controlcenter_vpn_test.go
@@ -72,10 +72,10 @@ func resetVPNState(t *testing.T) {
 		ccTerminalVPNIP = ""
 		ccVPNMu.Unlock()
 
-		ccVNCRunning = false
-		ccVNCServer = nil
-		ccTerminalRunning = false
-		ccTerminalServer = nil
+		ccVNCRunning.Store(false)
+		ccVNCServer.Store(nil)
+		ccTerminalRunning.Store(false)
+		ccTerminalServer.Store(nil)
 		platform.ClearEmbeddedVNCPort()
 	}
 
@@ -104,8 +104,8 @@ func TestAttachVNCVPNListenerIdempotent(t *testing.T) {
 		return &fakeListener{addr: currentIP + ":" + port}, currentIP, nil
 	}
 
-	ccVNCServer = desktop.NewVNCServer(desktop.VNCServerConfig{Host: "127.0.0.1", Port: ccVNCPort})
-	ccVNCRunning = true
+	ccVNCServer.Store(desktop.NewVNCServer(desktop.VNCServerConfig{Host: "127.0.0.1", Port: ccVNCPort}))
+	ccVNCRunning.Store(true)
 
 	attachVNCVPNListener()
 	attachVNCVPNListener() // idempotent: listener still live → no rebind
@@ -152,10 +152,10 @@ func TestVPNListenerReattachAfterSameIPReconnect(t *testing.T) {
 	}
 
 	// Both servers running (desktop permission assumed enabled by caller).
-	ccVNCServer = desktop.NewVNCServer(desktop.VNCServerConfig{Host: "127.0.0.1", Port: ccVNCPort})
-	ccVNCRunning = true
-	ccTerminalServer = terminal.NewServer(terminal.DefaultConfig(), nil)
-	ccTerminalRunning = true
+	ccVNCServer.Store(desktop.NewVNCServer(desktop.VNCServerConfig{Host: "127.0.0.1", Port: ccVNCPort}))
+	ccVNCRunning.Store(true)
+	ccTerminalServer.Store(terminal.NewServer(terminal.DefaultConfig(), nil))
+	ccTerminalRunning.Store(true)
 
 	// 1. Initial attach while connected.
 	attachVNCVPNListener()
@@ -228,8 +228,8 @@ func TestVPNSupervisorReattachOnHealthLoss(t *testing.T) {
 		return ln, sameIP, nil
 	}
 
-	ccVNCServer = desktop.NewVNCServer(desktop.VNCServerConfig{Host: "127.0.0.1", Port: ccVNCPort})
-	ccVNCRunning = true
+	ccVNCServer.Store(desktop.NewVNCServer(desktop.VNCServerConfig{Host: "127.0.0.1", Port: ccVNCPort}))
+	ccVNCRunning.Store(true)
 
 	attachVNCVPNListener()
 	if platform.EmbeddedVNCPort() != ccVNCPort {
@@ -283,8 +283,8 @@ func TestVNCPortDropsWhileListenerDeadAndDisconnected(t *testing.T) {
 		return ln, sameIP, nil
 	}
 
-	ccVNCServer = desktop.NewVNCServer(desktop.VNCServerConfig{Host: "127.0.0.1", Port: ccVNCPort})
-	ccVNCRunning = true
+	ccVNCServer.Store(desktop.NewVNCServer(desktop.VNCServerConfig{Host: "127.0.0.1", Port: ccVNCPort}))
+	ccVNCRunning.Store(true)
 
 	attachVNCVPNListener()
 	if platform.EmbeddedVNCPort() != ccVNCPort {
@@ -318,8 +318,8 @@ func TestAttachVNCVPNListenerSkippedWhenDisconnected(t *testing.T) {
 		return nil, "", nil
 	}
 
-	ccVNCServer = desktop.NewVNCServer(desktop.VNCServerConfig{Host: "127.0.0.1", Port: ccVNCPort})
-	ccVNCRunning = true
+	ccVNCServer.Store(desktop.NewVNCServer(desktop.VNCServerConfig{Host: "127.0.0.1", Port: ccVNCPort}))
+	ccVNCRunning.Store(true)
 
 	attachVNCVPNListener()
 
@@ -329,4 +329,78 @@ func TestAttachVNCVPNListenerSkippedWhenDisconnected(t *testing.T) {
 	if platform.EmbeddedVNCPort() != 0 {
 		t.Errorf("EmbeddedVNCPort() = %d while disconnected, want 0", platform.EmbeddedVNCPort())
 	}
+}
+
+// TestVPNListenerSupervisorRaceWithStartStop exercises the issue #319 data race:
+// the VPN-listener supervisor (vpnListenersHealthy + the attach* helpers it
+// calls) reads ccVNCRunning/ccTerminalRunning/ccVNCServer/ccTerminalServer
+// concurrently with the start/stop paths that write them. Before these globals
+// were made atomic, those reads/writes were unsynchronized — a genuine data
+// race under the Go memory model — and `go test -race` flags it. Run with
+// -race; with the fix it is clean.
+//
+// The writer goroutines mirror startVNCServer/stopVNCServer and
+// startTerminalServer/stopTerminalServer: they publish a real (non-nil) server
+// pointer and flip the running flag on, then flip it off (production stop*
+// never nils the server pointer, so neither do we — that would manufacture a
+// nil-deref that cannot happen in prod). The reader goroutine drives the exact
+// supervisor decision path. The network indirection hooks are stubbed so attach
+// never touches a real tailnet.
+func TestVPNListenerSupervisorRaceWithStartStop(t *testing.T) {
+	resetVPNState(t)
+
+	const ip = "100.64.0.30"
+	isConnectedFn = func() bool { return true }
+	currentVPNIPFn = func() (string, error) { return ip, nil }
+	listenVPNFn = func(network, port string) (net.Listener, string, error) {
+		return &fakeListener{addr: ip + ":" + port}, ip, nil
+	}
+
+	// Pre-create real, non-nil servers the writers publish (mirrors what
+	// startVNCServer/startTerminalServer Store after a successful Start).
+	vncSrv := desktop.NewVNCServer(desktop.VNCServerConfig{Host: "127.0.0.1", Port: ccVNCPort})
+	termSrv := terminal.NewServer(terminal.DefaultConfig(), nil)
+
+	const iterations = 2000
+	var wg sync.WaitGroup
+
+	// Writer 1: start/stop the VNC server globals.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			ccVNCServer.Store(vncSrv)
+			ccVNCRunning.Store(true)
+			ccVNCRunning.Store(false)
+		}
+	}()
+
+	// Writer 2: start/stop the terminal server globals.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			ccTerminalServer.Store(termSrv)
+			ccTerminalRunning.Store(true)
+			ccTerminalRunning.Store(false)
+		}
+	}()
+
+	// Reader: the supervisor's steady-state decision path — health check plus
+	// both idempotent re-attaches.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_ = vpnListenersHealthy()
+			if ccTerminalRunning.Load() {
+				attachTerminalVPNListener()
+			}
+			if ccVNCRunning.Load() {
+				attachVNCVPNListener()
+			}
+		}
+	}()
+
+	wg.Wait()
 }


### PR DESCRIPTION
## Context

Hardening of the two review findings on PR #319 ("self-heal VNC/terminal VPN listeners across tsnet reconnects"). That PR was already squash-merged into `main` (`8b6642f`) before these fixes could be pushed to its branch, so they are delivered here as a follow-up PR against current `main` (which also carries the #318 shutdown changes; those do not touch the affected globals).

## Root Cause (Finding 1 — data race)

The VPN-listener supervisor (`ccSuperviseVPNListeners` and the `attachVNCVPNListener`/`attachTerminalVPNListener`/`vpnListenersHealthy` helpers it calls) reads the package globals `ccVNCRunning`, `ccTerminalRunning`, `ccVNCServer`, `ccTerminalServer` from a background goroutine, while `startVNCServer`/`stopVNCServer`/`startTerminalServer`/`stopTerminalServer` write them — without any synchronization. This is a genuine data race under the Go memory model. It went undetected because no existing test ran the supervisor concurrently with start/stop.

## Changes

- `cmd/controlcenter.go`
  - `ccVNCRunning`/`ccTerminalRunning` -> `atomic.Bool`; `ccVNCServer`/`ccTerminalServer` -> `atomic.Pointer[...]`. Updated every read/write site.
  - **Deadlock-avoidance:** `ccVPNMu` is *not* used to guard these flags, because `startVNCServer`/`startTerminalServer` set the running flag and then call `attach*`, which already locks `ccVPNMu` — a plain mutex would re-enter and deadlock. Atomics sidestep this.
  - The `attach*` helpers load each server pointer **once into a local** and use that local for the nil-check and every method call, so a concurrent stop can't slip a `nil` in between the check and `AddListener`/`RemoveListener`.
  - Server pointers are published **after** a successful `Start()` (readers gate on the running flag, so this is behaviorally identical and avoids a stale non-nil pointer on a failed start).
  - **Finding 2 (nit):** `vpnListener.Accept()` now marks the listener dead only on `errors.Is(err, net.ErrClosed)`, matching the server accept loops which treat only `net.ErrClosed` as terminal and `continue` on transient errors. A transient Accept error no longer triggers a needless tear-down/rebind.

- `cmd/controlcenter_vpn_test.go`
  - Existing tests updated to the atomic API.
  - **New `TestVPNListenerSupervisorRaceWithStartStop`:** concurrent start/stop writers vs. a supervisor-style reader (health check + both `attach*`), bounded by iteration count. Verified it reports `WARNING: DATA RACE` when a flag is reverted to a plain `bool`, and is clean with the atomics.

## Testing

```
go build ./...        # ok
go vet ./...          # ok
go test -race -count=1 ./cmd/... ./internal/desktop/... ./internal/terminal/... ./internal/network/...   # ok
```

Note: `./internal/status/...` has a **pre-existing** race in `TestExistingEndpointsUnaffectedByDesktopConfig` (httptest server start/shutdown in `internal/status/server_test.go`), independent of this change — reproduced on clean `main`. Recommend a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)