### PR TITLE
fix(status): eliminate test-only data race in status server tests

### DIFF
--- a/internal/status/server.go
+++ b/internal/status/server.go
@@ -97,9 +97,11 @@ func (s *Server) AddRouteRegistrar(reg RouteRegistrar) {
 	s.routeRegistrars = append(s.routeRegistrars, reg)
 }
 
-// Start begins listening for HTTP requests.
-// This method blocks until the context is cancelled.
-func (s *Server) Start(ctx context.Context) error {
+// buildMux constructs the HTTP route multiplexer for the server, registering
+// all enabled endpoints based on the server's configuration. It reads config
+// fields but mutates no shared Server state, so it can be invoked synchronously
+// from both Start and tests without introducing data races.
+func (s *Server) buildMux() *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ping", s.handlePing)
 	mux.HandleFunc("/status", s.handleStatus)
@@ -129,6 +131,14 @@ func (s *Server) Start(ctx context.Context) error {
 	if s.extraRoutes != nil {
 		s.extraRoutes(mux)
 	}
+
+	return mux
+}
+
+// Start begins listening for HTTP requests.
+// This method blocks until the context is cancelled.
+func (s *Server) Start(ctx context.Context) error {
+	mux := s.buildMux()
 	s.httpServer = &http.Server{
 		Addr:         fmt.Sprintf(":%d", s.port),
 		Handler:      mux,

--- a/internal/status/server_test.go
+++ b/internal/status/server_test.go
@@ -204,16 +204,15 @@ func TestDesktopEndpointsRegisteredWhenEnabled(t *testing.T) {
 		EnableDesktop:  true,
 	}, collector)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-	defer cancel()
-
-	go server.Start(ctx)
-	time.Sleep(50 * time.Millisecond) // Wait for server to start
+	// Build the mux synchronously rather than starting the server in a
+	// goroutine; this exercises the real route registration without racing
+	// the server's startup goroutine over server.httpServer (issue #321).
+	handler := server.buildMux()
 
 	// Screenshot endpoint should return 401 without token (registered but auth fails)
 	req := httptest.NewRequest(http.MethodGet, "/api/screenshot", nil)
 	w := httptest.NewRecorder()
-	server.httpServer.Handler.ServeHTTP(w, req)
+	handler.ServeHTTP(w, req)
 
 	if w.Code != http.StatusUnauthorized {
 		t.Errorf("/api/screenshot without token: got %d, want %d", w.Code, http.StatusUnauthorized)
@@ -222,7 +221,7 @@ func TestDesktopEndpointsRegisteredWhenEnabled(t *testing.T) {
 	// Actions endpoint should return 401 without token
 	req = httptest.NewRequest(http.MethodPost, "/api/actions", nil)
 	w = httptest.NewRecorder()
-	server.httpServer.Handler.ServeHTTP(w, req)
+	handler.ServeHTTP(w, req)
 
 	if w.Code != http.StatusUnauthorized {
 		t.Errorf("/api/actions without token: got %d, want %d", w.Code, http.StatusUnauthorized)
@@ -241,16 +240,14 @@ func TestDesktopEndpointsNotRegisteredWithoutEnableDesktop(t *testing.T) {
 		EnableDesktop:  false,
 	}, collector)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-	defer cancel()
-
-	go server.Start(ctx)
-	time.Sleep(50 * time.Millisecond)
+	// Build the mux synchronously to avoid racing the server startup
+	// goroutine over server.httpServer (issue #321).
+	handler := server.buildMux()
 
 	// Screenshot endpoint should return 404 (not registered)
 	req := httptest.NewRequest(http.MethodGet, "/api/screenshot", nil)
 	w := httptest.NewRecorder()
-	server.httpServer.Handler.ServeHTTP(w, req)
+	handler.ServeHTTP(w, req)
 
 	if w.Code != http.StatusNotFound {
 		t.Errorf("/api/screenshot with EnableDesktop=false: got %d, want %d", w.Code, http.StatusNotFound)
@@ -266,15 +263,13 @@ func TestDesktopEndpointsNotRegisteredWithoutValidator(t *testing.T) {
 		EnableDesktop: true,
 	}, collector)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-	defer cancel()
-
-	go server.Start(ctx)
-	time.Sleep(50 * time.Millisecond)
+	// Build the mux synchronously to avoid racing the server startup
+	// goroutine over server.httpServer (issue #321).
+	handler := server.buildMux()
 
 	req := httptest.NewRequest(http.MethodGet, "/api/screenshot", nil)
 	w := httptest.NewRecorder()
-	server.httpServer.Handler.ServeHTTP(w, req)
+	handler.ServeHTTP(w, req)
 
 	if w.Code != http.StatusNotFound {
 		t.Errorf("/api/screenshot with no validator: got %d, want %d", w.Code, http.StatusNotFound)
@@ -292,17 +287,15 @@ func TestDesktopEndpointRejectsInvalidToken(t *testing.T) {
 		EnableDesktop:  true,
 	}, collector)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-	defer cancel()
-
-	go server.Start(ctx)
-	time.Sleep(50 * time.Millisecond)
+	// Build the mux synchronously to avoid racing the server startup
+	// goroutine over server.httpServer (issue #321).
+	handler := server.buildMux()
 
 	// Bad token should get 401
 	req := httptest.NewRequest(http.MethodGet, "/api/screenshot", nil)
 	req.Header.Set("Authorization", "Bearer bad-token")
 	w := httptest.NewRecorder()
-	server.httpServer.Handler.ServeHTTP(w, req)
+	handler.ServeHTTP(w, req)
 
 	if w.Code != http.StatusUnauthorized {
 		t.Errorf("/api/screenshot with bad token: got %d, want %d", w.Code, http.StatusUnauthorized)
@@ -365,16 +358,14 @@ func TestExistingEndpointsUnaffectedByDesktopConfig(t *testing.T) {
 				EnableDesktop: enableDesktop,
 			}, collector)
 
-			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-			defer cancel()
-
-			go server.Start(ctx)
-			time.Sleep(50 * time.Millisecond)
+			// Build the mux synchronously to avoid racing the server startup
+			// goroutine over server.httpServer (issue #321).
+			handler := server.buildMux()
 
 			// Health endpoint should always work
 			req := httptest.NewRequest(http.MethodGet, "/health", nil)
 			w := httptest.NewRecorder()
-			server.httpServer.Handler.ServeHTTP(w, req)
+			handler.ServeHTTP(w, req)
 
 			if w.Code != http.StatusOK {
 				t.Errorf("/health: got %d, want %d", w.Code, http.StatusOK)
@@ -383,7 +374,7 @@ func TestExistingEndpointsUnaffectedByDesktopConfig(t *testing.T) {
 			// Ping endpoint should always work
 			req = httptest.NewRequest(http.MethodGet, "/ping", nil)
 			w = httptest.NewRecorder()
-			server.httpServer.Handler.ServeHTTP(w, req)
+			handler.ServeHTTP(w, req)
 
 			if w.Code != http.StatusOK {
 				t.Errorf("/ping: got %d, want %d", w.Code, http.StatusOK)


### PR DESCRIPTION
## Context

Closes #321

`go test -race ./internal/status/...` reported a DATA RACE in `TestExistingEndpointsUnaffectedByDesktopConfig` (`server_test.go` racing `server.go`). It is pre-existing on clean `main` (unrelated to #319/#320) and test-only, but it blocks a clean `go test -race ./...`.

## Root Cause

The status server tests used this pattern:

```go
go server.Start(ctx)
time.Sleep(50 * time.Millisecond)
server.httpServer.Handler.ServeHTTP(w, req)
```

`Server.Start` writes `s.httpServer` and registers all routes on a fresh `*http.ServeMux` **concurrently** in/around its startup goroutine. The `time.Sleep` is not a synchronization primitive, so the test goroutine's read of `server.httpServer` (and the mux's internal handler map) had no happens-before relationship with `Start`'s writes. The race detector flagged:

- **Read** (test): `server.httpServer.Handler` / mux handler lookup
- **Write** (`Start`): `s.httpServer = &http.Server{...}` and `mux.HandleFunc(...)`

This is a **test-harness sequencing bug, not a production bug.** No real caller reads `server.httpServer.Handler`; production code calls `Start` and reaches the server over the network, where access is properly synchronized by the HTTP accept loop. The issue named one test, but the full-package `-race` run shows **five** tests share the identical racy pattern and fail the same way.

## Changes

- `internal/status/server.go`: extract route registration into a new unexported, side-effect-free `(*Server).buildMux() *http.ServeMux`. `Start` now calls it (`mux := s.buildMux()`). Production behavior and public API are unchanged.
- `internal/status/server_test.go`: the five affected tests now call `server.buildMux()` directly and drive requests through the returned handler — no goroutine, no sleep, no read of shared `server.httpServer`. They still exercise the real route registration (so the `EnableDesktop`/`TokenValidator` gating assertions remain meaningful). `TestServerDualListen` is left unchanged: it exercises the real network listener, which is correctly synchronized.

## Testing

```bash
go build ./...                                # clean
go vet ./...                                  # clean
go test -race -count=1 ./internal/status/...  # clean (was: DATA RACE)
go test -race -run TestExistingEndpointsUnaffectedByDesktopConfig ./internal/status/...  # ok
```

Before: `WARNING: DATA RACE` across 5 tests. After: `ok github.com/aceteam-ai/citadel-cli/internal/status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)