### PR TITLE
feat(worker): expose desktop click/drag over the fabric transport (VNC_ACTIONS)

### DIFF
--- a/internal/jobs/desktop.go
+++ b/internal/jobs/desktop.go
@@ -143,6 +143,55 @@ func (h *KeysHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
 // Ensure KeysHandler implements JobHandler.
 var _ JobHandler = (*KeysHandler)(nil)
 
+// ActionsHandler executes a sequence of pointer/keyboard actions (move, click,
+// mousedown, mouseup, scroll, type, key) on the node's display. It backs the
+// VNC_ACTIONS job type behind the aceteam `desktop_click` / `desktop_drag` MCP
+// tools (issue #4180), reusing the existing internal/desktop input path -- the
+// same path the HTTP /api/actions endpoint uses. This is what makes the
+// computer_use click and drag primitives reachable over the fabric transport.
+type ActionsHandler struct{}
+
+// Execute runs the payload's `actions` array on the display.
+//
+// Payload fields:
+//   - actions: a JSON array of action objects (required, non-empty), e.g.
+//     `[{"type":"move","x":10,"y":20},{"type":"mousedown","button":1},
+//     {"type":"move","x":90,"y":80},{"type":"mouseup","button":1}]`.
+//     The aceteam side builds this with python_tools.computer_use.translate_action,
+//     so the wire format matches desktop.ParseActions exactly.
+//
+// Response JSON: {"ok": true, "count": <number-of-actions>}.
+func (h *ActionsHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	actions, err := buildActions(job.Payload["actions"])
+	if err != nil {
+		return nil, err
+	}
+
+	ctx.Log("info", "     - [Job %s] VNC_ACTIONS executing %d action(s)", job.ID, len(actions))
+
+	if err := desktop.ExecuteActions(context.Background(), actions); err != nil {
+		return nil, fmt.Errorf("actions failed: %w", err)
+	}
+
+	return json.Marshal(map[string]any{"ok": true, "count": len(actions)})
+}
+
+// Ensure ActionsHandler implements JobHandler.
+var _ JobHandler = (*ActionsHandler)(nil)
+
+// buildActions parses and validates the `actions` JSON array from a VNC_ACTIONS
+// payload. Pure function: unit-testable without a live display.
+func buildActions(raw string) ([]desktop.Action, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, fmt.Errorf("job payload missing 'actions' field")
+	}
+	actions, err := desktop.ParseActions([]byte(raw))
+	if err != nil {
+		return nil, fmt.Errorf("invalid actions: %w", err)
+	}
+	return actions, nil
+}
+
 // buildTypeActions translates literal text into a validated type action.
 // Kept as a pure function so it can be unit-tested without a live display.
 func buildTypeActions(text string) ([]desktop.Action, error) {

--- a/internal/jobs/desktop_test.go
+++ b/internal/jobs/desktop_test.go
@@ -57,6 +57,46 @@ func TestBuildKeyActions(t *testing.T) {
 	}
 }
 
+func TestBuildActions(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		wantLen int
+		wantErr bool
+	}{
+		{"single click", `[{"type":"click","x":100,"y":200,"button":1}]`, 1, false},
+		{
+			"drag sequence",
+			`[{"type":"move","x":10,"y":20},{"type":"mousedown","button":1},{"type":"move","x":90,"y":80},{"type":"mouseup","button":1}]`,
+			4,
+			false,
+		},
+		{"empty payload", "", 0, true},
+		{"whitespace payload", "   ", 0, true},
+		{"empty array", `[]`, 0, true},
+		{"invalid json", `not json`, 0, true},
+		{"unknown action rejected", `[{"type":"exec","text":"rm -rf /"}]`, 0, true},
+		{"click out of range rejected", `[{"type":"click","x":-1,"y":100}]`, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actions, err := buildActions(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (got %d actions)", len(actions))
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(actions) != tt.wantLen {
+				t.Errorf("got %d actions, want %d", len(actions), tt.wantLen)
+			}
+		})
+	}
+}
+
 func TestBuildTypeActions(t *testing.T) {
 	actions, err := buildTypeActions("hello world")
 	if err != nil {

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -152,6 +152,12 @@ func CreateLegacyHandlersWithOpts(opts LegacyHandlerOpts) []JobHandler {
 		NewLegacyHandlerAdapter(JobTypeVNCScreenshot, &jobs.ScreenshotHandler{}),
 		NewLegacyHandlerAdapter(JobTypeVNCType, &jobs.TypeHandler{}),
 		NewLegacyHandlerAdapter(JobTypeVNCKeys, &jobs.KeysHandler{}),
+		// VNC_ACTIONS exposes the pointer/keyboard primitives shipped in #314
+		// (move/click/mousedown/mouseup/scroll, including the drag sequence) over
+		// the fabric Redis transport so the aceteam desktop_click / desktop_drag
+		// MCP tools can drive a node end to end (issue #4180). Same unconditional
+		// registration rationale as the screenshot/type/keys handlers above.
+		NewLegacyHandlerAdapter(JobTypeVNCActions, &jobs.ActionsHandler{}),
 	}
 
 	// Register file-operation handlers when a workspace is configured.

--- a/internal/worker/job.go
+++ b/internal/worker/job.go
@@ -127,4 +127,5 @@ const (
 	JobTypeVNCScreenshot     = "VNC_SCREENSHOT"      // Capture the node's display via the VNC tool path (issue #4179)
 	JobTypeVNCType           = "VNC_TYPE"            // Type text on the node's display (issue #4179)
 	JobTypeVNCKeys           = "VNC_KEYS"            // Send a key combo to the node's display (issue #4179)
+	JobTypeVNCActions        = "VNC_ACTIONS"         // Execute pointer/keyboard actions (click, move, drag) on the node's display (issue #4180)
 )


### PR DESCRIPTION
## Context

Part of aceteam-ai/aceteam epic #4168 (computer-use, P0) and issue aceteam-ai/aceteam#4180. The pointer/keyboard primitives the issue calls out (move, click, mousedown, mouseup, scroll — including the `move → mousedown → move → mouseup` drag sequence) **already landed in #314** (`internal/desktop/actions.go`: `mousedown`/`mouseup` action types + `validateAction` + `ActionToXdotoolArgs` + tests). The Python `translate_action("left_click_drag", ...)` already emits that exact sequence.

What was missing: those primitives were only reachable over the HTTP `/api/actions` status-server endpoint, which the aceteam MCP path does not call. The canonical fabric path (used by the `desktop_screenshot` / `vnc_*` tools) is a Redis Streams job dispatched to a node handler — and there was **no node handler for actions** (only screenshot/type/keys). So an agent could not click or drag a node over the MCP path.

This PR exposes the existing drag/click primitives through the fabric transport.

## Root Cause

`internal/jobs/desktop.go` had `ScreenshotHandler`, `TypeHandler`, `KeysHandler` (backing `FILE_SCREENSHOT`/`VNC_SCREENSHOT`/`VNC_TYPE`/`VNC_KEYS`) but no handler for arbitrary pointer/keyboard actions. The drag primitives in `actions.go` were live only on the HTTP endpoint, not on the Redis mesh the MCP tools use.

## Changes

- `internal/worker/job.go` — add `JobTypeVNCActions = "VNC_ACTIONS"`.
- `internal/jobs/desktop.go` — add `ActionsHandler`: reads the payload `actions` JSON array → `desktop.ParseActions` (same validator the HTTP path uses) → `desktop.ExecuteActions` (the same xdotool path). The array includes the `move/mousedown/move/mouseup` drag sequence. `buildActions` extracted as a pure, unit-testable helper. Returns `{"ok": true, "count": n}`.
- `internal/worker/handler_adapter.go` — register `VNC_ACTIONS` unconditionally in `CreateLegacyHandlersWithOpts`, same rationale as the #314 screenshot/type/keys handlers (no workspace sandbox needed; gating would leave the tool timing out).

The aceteam side (companion PR) builds the action array with `python_tools.computer_use.translate_action` and dispatches it as `VNC_ACTIONS` via `desktop_click` / `desktop_drag`, so the Python loop's vocabulary stays the single source of truth.

## Testing

```bash
go build ./...
go vet ./internal/desktop/... ./internal/jobs/... ./internal/worker/...
go test ./internal/desktop/...   # scoped; tmux/terminal suites NOT run
```

All clean. New unit test `TestBuildActions` (in `internal/jobs/desktop_test.go`) covers the payload parsing: single click, the full drag sequence, empty/whitespace/invalid payloads, and validator rejections (unknown action, out-of-range coords).

**Not run** (intentional, repo-wide test hazard): `go test ./...` and any `internal/tmux` / `internal/terminal` suite, which spawn real tmux sessions. `internal/jobs` contains `tmux_session_test.go`, so its tests were **not executed** — `internal/jobs` was verified via `go build` + `go vet` only. The new `TestBuildActions` lives in `internal/jobs` and was therefore validated by build + vet, not by a test run. The closely-related `internal/desktop` package is tmux-free, so `go test ./internal/desktop/...` was run and passes (covers `ParseActions`, including the drag sequence, which `buildActions` delegates to).

**Cannot be verified here:** a true click/drag needs a live X11 desktop + xdotool node. This PR verifies action translation, parsing, and handler registration; the actual on-screen effect is manual e2e.

## How to test (end-to-end)

On a node with a desktop session (X11 + `xdotool`) running `citadel work`:

1. From the aceteam MCP server: `desktop_screenshot(node_id)` → live PNG.
2. `desktop_click(node_id, x, y)` → dispatches `VNC_ACTIONS`; node runs `xdotool mousemove x y click 1`.
3. `desktop_drag(node_id, sx, sy, ex, ey)` → node runs `mousemove → mousedown → mousemove → mouseup`.
4. `desktop_screenshot(node_id)` again to confirm the UI reacted.

## Related

- aceteam-ai/aceteam#4180, epic aceteam-ai/aceteam#4168
- Builds on #314 (drag primitives + screenshot/VNC handlers)
- Companion aceteam PR adds `desktop_click` / `desktop_drag` MCP tools

---
*Generated by Claude*
