### PR TITLE
test(e2e): skip TestDeviceAuthExpiry when AceTeam API is unreachable

### DIFF
--- a/e2e/device_auth_test.go
+++ b/e2e/device_auth_test.go
@@ -121,6 +121,13 @@ func TestDeviceAuthExpiry(t *testing.T) {
 
 	aceteam := harness.NewAceTeamHarness(aceteamURL)
 
+	// Skip when the AceTeam API isn't reachable (e.g. running the suite without
+	// the platform up — including release.sh's `go test ./...` gate), matching
+	// TestDeviceAuthFlow above rather than hard-failing on connection refused.
+	if err := aceteam.WaitForReady(ctx, 10*time.Second); err != nil {
+		t.Skipf("AceTeam API not ready: %v", err)
+	}
+
 	// Poll with a fake/expired device code
 	tokenResp, tokenErr, err := aceteam.PollForToken(ctx, "fake-expired-code-12345")
 	if err != nil {


### PR DESCRIPTION
## Context
`scripts/release.sh` runs `go test ./...` as a release gate. On any machine without the full AceTeam platform + Redis running locally, the release failed here:

```
--- FAIL: TestDeviceAuthExpiry (0.00s)
    device_auth_test.go:127: Poll request failed: ... dial tcp [::1]:3000: connect: connection refused
```

## Root Cause
`TestDeviceAuthExpiry` called `aceteam.PollForToken` and `t.Fatalf`'d on connection-refused — unlike its sibling `TestDeviceAuthFlow` (and the `job_distribution`/`heartbeat` tests), which probe service readiness and `t.Skipf` when it's unavailable. So the one test hard-failed the whole `e2e` package off-platform.

## Changes
- `e2e/device_auth_test.go`: added a `WaitForReady`-then-`t.Skipf` guard (short 10s probe) to `TestDeviceAuthExpiry`, matching the existing pattern. Skips gracefully off-platform; still runs normally in CI where the API is up.

## Testing
```
go vet ./e2e/...                                  # clean
go test ./e2e/... -run '^TestDeviceAuthExpiry$' -v # --- SKIP (was --- FAIL)
```
Unblocks `./scripts/release.sh` on machines without the platform running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)