### PR TITLE
feat(status): report real node capability flags (console/desktop/files/gpu) on heartbeat

### DIFF
--- a/internal/status/capabilities_flags.go
+++ b/internal/status/capabilities_flags.go
@@ -1,0 +1,143 @@
+package status
+
+import (
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
+)
+
+// capability_flags reports the four real node-capability booleans
+// (console/desktop/files/gpu) that the AceTeam Fabric UI uses to show TRUE
+// availability instead of guessing (citadel-cli#324). The backend ingests them
+// inside the "capabilities" block of the heartbeat / node-status payload
+// (aceteam#4223, PR #4231).
+//
+// Cost discipline: these run on every heartbeat (default every 30s), so the
+// static signals (console + gpu) are detected once and cached, while only the
+// signals that can change at runtime (desktop + files) are re-probed cheaply.
+
+// staticCaps caches the console + gpu detection results, which do not change
+// over a process's lifetime (a shell/GPU does not appear or vanish while the
+// node is up). Computed once on first use via sync.Once.
+var (
+	staticCapsOnce sync.Once
+	cachedConsole  bool
+	cachedGPU      bool
+)
+
+// detectStaticCaps computes the console and gpu flags exactly once.
+func detectStaticCaps() {
+	staticCapsOnce.Do(func() {
+		cachedConsole = detectConsole()
+		cachedGPU = detectGPU()
+	})
+}
+
+// populateCapabilityFlags fills the four capability flags on caps. The desktop
+// flag is derived from vncPort (already computed by Collect, so we avoid a
+// second VNC probe). console/gpu come from the cached static detection; files
+// is a cheap stat of the workspace directory.
+func populateCapabilityFlags(caps *NodeCapabilities, vncPort int) {
+	detectStaticCaps()
+
+	console := cachedConsole
+	gpu := cachedGPU
+	desktop := vncPort > 0 || probeVNCPort(platform.DefaultVNCPort)
+	files := detectFiles()
+
+	caps.Console = &console
+	caps.Desktop = &desktop
+	caps.Files = &files
+	caps.GPU = &gpu
+}
+
+// detectConsole reports whether the node can offer a remote shell: a shell
+// interpreter is present on PATH, or an SSH daemon is available. Citadel's
+// terminal server spawns a shell, so a present shell is the meaningful signal.
+func detectConsole() bool {
+	var shells []string
+	if runtime.GOOS == "windows" {
+		shells = []string{"powershell.exe", "powershell", "cmd.exe", "cmd"}
+	} else {
+		shells = []string{"bash", "sh", "zsh"}
+	}
+	for _, sh := range shells {
+		if _, err := exec.LookPath(sh); err == nil {
+			return true
+		}
+	}
+	// Fallback: an SSH daemon also satisfies "console (shell/SSH available)".
+	if _, err := exec.LookPath("sshd"); err == nil {
+		return true
+	}
+	return false
+}
+
+// detectGPU reports whether a GPU is present / inference-capable, reusing the
+// platform GPU detector (the same one that feeds GPU metrics).
+func detectGPU() bool {
+	detector, err := platform.GetGPUDetector()
+	if err != nil {
+		return false
+	}
+	return detector.HasGPU()
+}
+
+// detectFiles reports whether node-files filesystem access is available, i.e.
+// the FILE_* job handlers have a usable workspace directory. This mirrors the
+// workspace resolution used by the worker (CITADEL_WORKSPACE, else
+// ~/citadel-node/workspace) without importing the cmd package, and confirms the
+// path is reachable.
+func detectFiles() bool {
+	dir := workspaceDir()
+	if dir == "" {
+		return false
+	}
+	// The directory must exist (or be creatable) and be a directory.
+	info, err := os.Stat(dir)
+	if err == nil {
+		return info.IsDir()
+	}
+	// Not present yet — check the parent is writable so the workspace can be
+	// created on first file job (matches resolveWorkspaceDir's MkdirAll).
+	parent := filepath.Dir(dir)
+	if pInfo, pErr := os.Stat(parent); pErr == nil && pInfo.IsDir() {
+		return true
+	}
+	return false
+}
+
+// workspaceDir resolves the node-files workspace path, matching the precedence
+// used by the worker's resolveWorkspaceDir (CITADEL_WORKSPACE, then
+// ~/citadel-node/workspace).
+func workspaceDir() string {
+	if dir := os.Getenv("CITADEL_WORKSPACE"); dir != "" {
+		return dir
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, "citadel-node", "workspace")
+}
+
+// probeVNCPort dials the local VNC port to confirm a desktop/VNC server is
+// actually reachable. Used as a fallback when Collect did not already detect a
+// running VNC server. Kept cheap with a short timeout since it runs per
+// heartbeat.
+func probeVNCPort(port int) bool {
+	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+	conn, err := net.DialTimeout("tcp", addr, 300*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}

--- a/internal/status/capabilities_flags_test.go
+++ b/internal/status/capabilities_flags_test.go
@@ -1,0 +1,86 @@
+package status
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestPopulateCapabilityFlagsAlwaysSetsAllFour verifies that all four capability
+// flags are non-nil after population, so every heartbeat emits concrete
+// true/false values rather than omitting keys (citadel-cli#324).
+func TestPopulateCapabilityFlagsAlwaysSetsAllFour(t *testing.T) {
+	caps := &NodeCapabilities{}
+	populateCapabilityFlags(caps, 0)
+
+	if caps.Console == nil {
+		t.Error("Console flag should be populated, got nil")
+	}
+	if caps.Desktop == nil {
+		t.Error("Desktop flag should be populated, got nil")
+	}
+	if caps.Files == nil {
+		t.Error("Files flag should be populated, got nil")
+	}
+	if caps.GPU == nil {
+		t.Error("GPU flag should be populated, got nil")
+	}
+}
+
+// TestCapabilityFlagsDesktopDerivedFromVNCPort verifies the desktop flag is true
+// when a VNC port was already detected, without dialing.
+func TestCapabilityFlagsDesktopDerivedFromVNCPort(t *testing.T) {
+	caps := &NodeCapabilities{}
+	populateCapabilityFlags(caps, 5900)
+	if caps.Desktop == nil || !*caps.Desktop {
+		t.Errorf("Desktop should be true when vncPort > 0, got %v", caps.Desktop)
+	}
+}
+
+// TestCapabilityFlagsJSONContract verifies the wire format matches the backend
+// contract exactly: keys console/desktop/files/gpu, boolean values, inside the
+// capabilities object (aceteam#4223, PR #4231).
+func TestCapabilityFlagsJSONContract(t *testing.T) {
+	tr := true
+	fa := false
+	caps := &NodeCapabilities{
+		Console: &tr,
+		Desktop: &fa,
+		Files:   &tr,
+		GPU:     &fa,
+	}
+	b, err := json.Marshal(caps)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	got := string(b)
+
+	for _, want := range []string{
+		`"console":true`,
+		`"desktop":false`,
+		`"files":true`,
+		`"gpu":false`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("capabilities JSON missing %q; got %s", want, got)
+		}
+	}
+}
+
+// TestNodeStatusCapabilitiesKeyPresent verifies the capabilities block is
+// emitted under the "capabilities" key on NodeStatus (the heartbeat payload),
+// matching CitadelStatus.capabilities on the backend.
+func TestNodeStatusCapabilitiesKeyPresent(t *testing.T) {
+	tr := true
+	st := &NodeStatus{
+		Version:      StatusVersion,
+		Capabilities: &NodeCapabilities{Console: &tr},
+	}
+	b, err := json.Marshal(st)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	if !strings.Contains(string(b), `"capabilities":`) {
+		t.Errorf("NodeStatus JSON missing capabilities key; got %s", string(b))
+	}
+}

--- a/internal/status/collector.go
+++ b/internal/status/collector.go
@@ -83,8 +83,14 @@ func (c *Collector) Collect() (*NodeStatus, error) {
 	// Collect installed app status
 	status.Apps = c.collectAppStatus()
 
-	// Include cached capabilities if available
-	status.Capabilities = c.capabilities
+	// Include cached capabilities if available. Copy the cached struct rather
+	// than aliasing it, so populating the per-heartbeat capability flags below
+	// does not mutate the shared cached value (Collect may run concurrently for
+	// the status server and the heartbeat publisher).
+	if c.capabilities != nil {
+		capsCopy := *c.capabilities
+		status.Capabilities = &capsCopy
+	}
 
 	// Collect desktop capabilities
 	status.Desktop = desktop.DetectCapabilities()
@@ -105,6 +111,17 @@ func (c *Collector) Collect() (*NodeStatus, error) {
 			status.VNCPort = vncMgr.Port()
 		}
 	}
+
+	// Report the four real node-capability flags (console/desktop/files/gpu) so
+	// the AceTeam Fabric UI shows true availability (citadel-cli#324). Ensure a
+	// capabilities block exists even when no pre-detected NodeCapabilities was
+	// supplied, then populate the flags. Desktop is derived from the VNCPort
+	// already computed above to avoid a redundant probe.
+	if status.Capabilities == nil {
+		status.Capabilities = &NodeCapabilities{}
+	}
+	populateCapabilityFlags(status.Capabilities, status.VNCPort)
+
 	return status, nil
 }
 

--- a/internal/status/types.go
+++ b/internal/status/types.go
@@ -44,11 +44,31 @@ type AppInfo struct {
 }
 
 // NodeCapabilities describes the GPU and inference engine capabilities of a node.
+//
+// The four boolean flags (Console/Desktop/Files/GPU) report what the node
+// ACTUALLY supports right now, so the AceTeam Fabric UI can show true
+// availability instead of guessing (citadel-cli#324). They are ingested by the
+// backend exactly as the keys "console"/"desktop"/"files"/"gpu" inside this
+// "capabilities" block (aceteam#4223, PR #4231 — CitadelStatus.capabilityFlags).
+//
+// They are *bool (pointers) so the field is omitted entirely when never set:
+// the backend treats an absent flag as "unknown" (tri-state) rather than false,
+// keeping legacy nodes that report no flags backward-compatible. The status
+// collector always populates all four on every heartbeat, so live nodes always
+// emit concrete true/false values.
 type NodeCapabilities struct {
 	GPUs       []GPUCapability `json:"gpus,omitempty"`
 	Engines    []string        `json:"engines,omitempty"`
 	Tags       []string        `json:"tags,omitempty"`
 	Hypervisor *HypervisorInfo `json:"hypervisor,omitempty"`
+
+	// Real node capability flags (citadel-cli#324). Console = shell/SSH
+	// available, Desktop = VNC reachable, Files = node-files filesystem access,
+	// GPU = GPU present / inference-capable.
+	Console *bool `json:"console,omitempty"`
+	Desktop *bool `json:"desktop,omitempty"`
+	Files   *bool `json:"files,omitempty"`
+	GPU     *bool `json:"gpu,omitempty"`
 }
 
 // HypervisorInfo describes a detected hypervisor on the node.


### PR DESCRIPTION
## What

On every heartbeat / node-status publish, citadel-cli now detects and reports
the four **real** node-capability flags so the AceTeam Fabric UI shows TRUE
availability instead of guessing:

- **console** — a shell (`bash`/`sh`/`zsh`, or `powershell`/`cmd` on Windows) or `sshd` is available
- **desktop** — a VNC server is reachable (reuses the VNC port `Collect()` already detects; falls back to a short-timeout local `:5900` dial)
- **files** — the node-files workspace directory is accessible
- **gpu** — a GPU is present / inference-capable (reuses `platform.GetGPUDetector().HasGPU()`)

## Contract (aceteam#4223 / PR #4231)

The backend ingests these **inside the existing `capabilities` block** of the
node-status payload — `CitadelStatus.capabilityFlags` reads
`capabilities.console/desktop/files/gpu`:

```jsonc
"capabilities": {
  "tags": [...], "engines": [...],   // existing
  "console": true,
  "desktop": false,
  "files": true,
  "gpu": true
}
```

The flags are `*bool` (`omitempty`) so legacy nodes that never set them are
treated as **unknown** (tri-state) by the backend rather than `false`. Live
nodes always populate all four, so they always emit concrete values.

## How it's wired

Detection lives in the status `Collector.Collect()`, so **both** publish paths
are covered automatically: the Redis publisher (`internal/heartbeat/redis.go`)
and the API publisher (`internal/heartbeat/api.go`) both call
`collector.CollectCompact()`.

## Cost discipline (runs every ~30s)

- `console` + `gpu` are static for the process lifetime → detected once and cached via `sync.Once`.
- `desktop` is derived from the VNC port `Collect()` already computes (no extra probe in the common case).
- `files` is a cheap `os.Stat` of the workspace dir.
- The cached `NodeCapabilities` is copied (not aliased) before populating per-heartbeat flags, avoiding a data race when the status server and heartbeat run concurrently.

## How to test

1. Run a node with debug logging: `citadel work --debug` (or set the debug log level).
2. Watch the heartbeat payload — `redis.go` logs `heartbeat: payload (N bytes): ...`. Confirm the `status.capabilities` object contains `console`/`desktop`/`files`/`gpu` booleans.
3. Alternatively subscribe to the Redis channel directly: `redis-cli SUBSCRIBE node:status:<nodeId>` and inspect the JSON.
4. Toggle a signal to see it flip: start/stop a VNC server (`citadel vnc enable`) → `desktop` flips true/false on the next heartbeat. On a GPU host `gpu` is true; on a CPU-only host it is false.

Unit tests in `internal/status/capabilities_flags_test.go` lock the JSON
contract (key names + boolean types) and verify all four flags are always
populated and that `desktop` is derived from the VNC port.

## Verification run

- `go build ./...` — OK
- `go vet ./internal/status/ ./internal/platform/ ./internal/desktop/` — OK (compiles the new test)
- Empirically marshalled a `Collect()` result and confirmed the exact wire shape `{"console":true,"desktop":false,"files":true,"gpu":true}`.
- Per repo tmux-safety policy, did **not** run `go test ./...` or any test under `internal/status` (it transitively imports `internal/tmux`/`internal/terminal`); the added test runs in CI.

## Not verified without live hardware / setup

- `desktop=true` against a real running VNC server (verified `false` locally with no VNC).
- `files` honors `CITADEL_WORKSPACE` + the default `~/citadel-node/workspace`, but not the `--workspace` flag (the collector has no access to it); in practice `files` is ~always true since the home dir exists.

Closes #324
