### PR TITLE
fix(tui): wire chat device-auth credentials lazily (post-startup auth)

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -219,7 +219,14 @@ func runControlCenter() {
 			},
 		},
 		OnConnect: ccOnNetworkConnect,
-		Chat:      buildChatConfig(),
+		// Chat is seeded with the snapshot resolvable at startup, but a node that
+		// completes device authorization in-TUI persists its credentials only
+		// afterward. ChatConfigProvider lets the ChatPage re-resolve them lazily
+		// at connect() time — the same way the terminal/desktop/worker paths
+		// resolve token+org at network-connect time — so a freshly-authed node no
+		// longer shows a permanent "device authorization required" status.
+		Chat:               buildChatConfig(),
+		ChatConfigProvider: buildChatConfig,
 		Proxmox:   buildProxmoxConfig(),
 		Settings: controlcenter.SettingsCallbacks{
 			LoadTelemetry: func() *config.Telemetry {

--- a/internal/tui/controlcenter/chat_page.go
+++ b/internal/tui/controlcenter/chat_page.go
@@ -30,12 +30,28 @@ const (
 type ChatPage struct {
 	app *tview.Application
 
-	// Config (set at construction, read-only after)
+	// Config. The five fields below are seeded at construction from the initial
+	// snapshot, but are NOT necessarily final: a node that completes device
+	// authorization *after* the control center starts (the in-TUI device-auth
+	// flow, or a re-pair) writes its credentials to disk only then. To match the
+	// terminal/desktop/worker pages — which resolve their token+org lazily at
+	// network-connect time via getDeviceConfigFromFile() rather than freezing a
+	// startup snapshot — connect() re-resolves these fields through provider just
+	// before dialing whenever the credentials are still incomplete. Guarded by
+	// configMu because connect() runs on a background goroutine.
+	configMu   sync.Mutex
 	apiBaseURL string
 	apiToken   string
 	orgID      string
 	nodeID     string
 	nodeName   string
+
+	// provider, when non-nil, returns the freshest chat credentials resolved
+	// from the node's on-disk config/manifest/network state. It is consulted by
+	// connect() when the seeded snapshot is missing any required field so that a
+	// node authed after startup no longer shows a permanent "device
+	// authorization required" status.
+	provider func() ChatPageConfig
 
 	// UI components
 	root       *tview.Flex
@@ -75,6 +91,15 @@ type ChatPageConfig struct {
 	OrgID      string
 	NodeID     string
 	NodeName   string
+
+	// Provider, when set, is a lazy re-resolver for the credentials above. The
+	// control center constructs the ChatPage at startup — before the in-TUI
+	// device-auth flow can write credentials to disk — so the snapshot embedded
+	// in the fields above may be empty on a node that authorizes after launch.
+	// connect() calls Provider to pick up the freshly-written credentials,
+	// mirroring how the terminal/desktop/worker pages resolve their token+org
+	// at network-connect time. Optional: when nil, only the snapshot is used.
+	Provider func() ChatPageConfig
 }
 
 // NewChatPage creates a new chat page. The page connects lazily on first activation.
@@ -85,10 +110,58 @@ func NewChatPage(cfg ChatPageConfig) *ChatPage {
 		orgID:       cfg.OrgID,
 		nodeID:      cfg.NodeID,
 		nodeName:    cfg.NodeName,
+		provider:    cfg.Provider,
 		messages:    make([]chat.Message, 0, 200),
 		peers:       make(map[string]chat.PresenceInfo),
 		recentSends: make(map[string]time.Time),
 	}
+}
+
+// resolveConfig returns the current chat credentials, lazily re-resolving them
+// through the provider when the seeded snapshot is missing any required field.
+// A node that completes device authorization after the control center starts
+// only persists its token/org at that point; without this re-resolution the
+// ChatPage would keep the empty startup snapshot forever and show "device
+// authorization required" even though the node is fully authed.
+//
+// It is safe to call from the connect() goroutine: the read/refresh of the
+// config fields is serialized by configMu.
+func (p *ChatPage) resolveConfig() (apiBaseURL, apiToken, orgID, nodeID, nodeName string) {
+	p.configMu.Lock()
+	defer p.configMu.Unlock()
+
+	incomplete := p.apiBaseURL == "" || p.apiToken == "" || p.orgID == ""
+	if incomplete && p.provider != nil {
+		fresh := p.provider()
+		// Only overwrite a field when the provider has a non-empty value, so a
+		// transient resolution miss never clobbers a credential we already had.
+		if fresh.APIBaseURL != "" {
+			p.apiBaseURL = fresh.APIBaseURL
+		}
+		if fresh.APIToken != "" {
+			p.apiToken = fresh.APIToken
+		}
+		if fresh.OrgID != "" {
+			p.orgID = fresh.OrgID
+		}
+		if fresh.NodeID != "" {
+			p.nodeID = fresh.NodeID
+		}
+		if fresh.NodeName != "" {
+			p.nodeName = fresh.NodeName
+		}
+	}
+
+	return p.apiBaseURL, p.apiToken, p.orgID, p.nodeID, p.nodeName
+}
+
+// currentAPIBaseURL returns the currently-known API base URL under configMu,
+// for the status-bar / settings readouts. It does not trigger a provider
+// re-resolution — that happens only at connect() time.
+func (p *ChatPage) currentAPIBaseURL() string {
+	p.configMu.Lock()
+	defer p.configMu.Unlock()
+	return p.apiBaseURL
 }
 
 // Name implements Page.
@@ -212,18 +285,24 @@ func (p *ChatPage) connect() {
 		return
 	}
 
-	if p.apiBaseURL == "" || p.apiToken == "" || p.orgID == "" {
+	// Re-resolve credentials before dialing. On a node that device-authed after
+	// the control center launched, the snapshot captured at construction is
+	// empty; resolveConfig picks up the credentials device-auth wrote to disk,
+	// matching the lazy resolution the terminal/desktop/worker pages already do.
+	apiBaseURL, apiToken, orgID, nodeID, nodeName := p.resolveConfig()
+
+	if apiBaseURL == "" || apiToken == "" || orgID == "" {
 		p.clientMu.Unlock()
 		p.setStatus("[red]Not configured[white] — device authorization required")
 		return
 	}
 
 	client := chat.NewClient(chat.ClientConfig{
-		APIBaseURL: p.apiBaseURL,
-		Token:      p.apiToken,
-		OrgID:      p.orgID,
-		NodeID:     p.nodeID,
-		NodeName:   p.nodeName,
+		APIBaseURL: apiBaseURL,
+		Token:      apiToken,
+		OrgID:      orgID,
+		NodeID:     nodeID,
+		NodeName:   nodeName,
 	})
 	p.client = client
 	p.clientMu.Unlock()
@@ -401,7 +480,7 @@ func (p *ChatPage) renderStatusBar(state connState, detail string) {
 	}
 
 	p.state = state
-	endpoint := chat.SanitizeEndpoint(p.apiBaseURL)
+	endpoint := chat.SanitizeEndpoint(p.currentAPIBaseURL())
 	if endpoint == "" {
 		endpoint = "not configured"
 	}
@@ -478,7 +557,7 @@ const (
 // transport detail (Redis pub/sub) is intentionally not surfaced — callers
 // (e.g. the Settings page) should present this as a generic "connection".
 func (p *ChatPage) ConnectionStatus() (endpoint string, state ConnState) {
-	endpoint = wssEndpoint(p.apiBaseURL)
+	endpoint = wssEndpoint(p.currentAPIBaseURL())
 
 	p.clientMu.Lock()
 	client := p.client

--- a/internal/tui/controlcenter/chat_page_test.go
+++ b/internal/tui/controlcenter/chat_page_test.go
@@ -1,0 +1,111 @@
+package controlcenter
+
+import "testing"
+
+// TestChatPageResolveConfig_UsesProviderWhenSnapshotIncomplete reproduces the
+// device-auth wiring bug: the ChatPage is constructed before the node completes
+// device authorization, so its startup snapshot is empty. resolveConfig must
+// pick up the credentials the provider resolves later (mirroring how the
+// terminal/desktop/worker pages re-resolve token+org at network-connect time),
+// rather than staying stuck on the empty snapshot and reporting "device
+// authorization required".
+func TestChatPageResolveConfig_UsesProviderWhenSnapshotIncomplete(t *testing.T) {
+	// Snapshot at construction is empty (node not yet device-authed) but a
+	// provider can resolve the real credentials persisted after auth.
+	resolved := ChatPageConfig{
+		APIBaseURL: "https://aceteam.ai",
+		APIToken:   "device_api_token_xyz",
+		OrgID:      "org-123",
+		NodeID:     "node-abc",
+		NodeName:   "mini",
+	}
+	p := NewChatPage(ChatPageConfig{
+		Provider: func() ChatPageConfig { return resolved },
+	})
+
+	apiBaseURL, apiToken, orgID, nodeID, nodeName := p.resolveConfig()
+
+	if apiBaseURL != resolved.APIBaseURL {
+		t.Errorf("apiBaseURL = %q, want %q", apiBaseURL, resolved.APIBaseURL)
+	}
+	if apiToken != resolved.APIToken {
+		t.Errorf("apiToken = %q, want %q", apiToken, resolved.APIToken)
+	}
+	if orgID != resolved.OrgID {
+		t.Errorf("orgID = %q, want %q", orgID, resolved.OrgID)
+	}
+	if nodeID != resolved.NodeID {
+		t.Errorf("nodeID = %q, want %q", nodeID, resolved.NodeID)
+	}
+	if nodeName != resolved.NodeName {
+		t.Errorf("nodeName = %q, want %q", nodeName, resolved.NodeName)
+	}
+
+	// The connect() guard must now pass.
+	if apiBaseURL == "" || apiToken == "" || orgID == "" {
+		t.Fatalf("guard still trips after provider resolution: base=%q token=%q org=%q",
+			apiBaseURL, apiToken, orgID)
+	}
+}
+
+// TestChatPageResolveConfig_KeepsCompleteSnapshot verifies that when the startup
+// snapshot is already complete (node device-authed before launch — the common
+// case), resolveConfig does NOT invoke the provider and preserves the snapshot.
+func TestChatPageResolveConfig_KeepsCompleteSnapshot(t *testing.T) {
+	providerCalled := false
+	p := NewChatPage(ChatPageConfig{
+		APIBaseURL: "https://aceteam.ai",
+		APIToken:   "tok",
+		OrgID:      "org-1",
+		NodeID:     "n1",
+		NodeName:   "name1",
+		Provider: func() ChatPageConfig {
+			providerCalled = true
+			return ChatPageConfig{}
+		},
+	})
+
+	base, tok, org, _, _ := p.resolveConfig()
+	if providerCalled {
+		t.Error("provider should not be called when snapshot is already complete")
+	}
+	if base != "https://aceteam.ai" || tok != "tok" || org != "org-1" {
+		t.Errorf("snapshot not preserved: base=%q tok=%q org=%q", base, tok, org)
+	}
+}
+
+// TestChatPageResolveConfig_PartialProviderDoesNotClobber verifies that a
+// provider returning only some fields fills the missing ones without wiping a
+// credential that was already present in the snapshot.
+func TestChatPageResolveConfig_PartialProviderDoesNotClobber(t *testing.T) {
+	p := NewChatPage(ChatPageConfig{
+		// Token already known from a prior partial write; org/base missing.
+		APIToken: "existing-token",
+		Provider: func() ChatPageConfig {
+			return ChatPageConfig{
+				APIBaseURL: "https://aceteam.ai",
+				OrgID:      "org-late",
+				// APIToken intentionally empty in this resolution.
+			}
+		},
+	})
+
+	base, tok, org, _, _ := p.resolveConfig()
+	if tok != "existing-token" {
+		t.Errorf("existing token clobbered: got %q", tok)
+	}
+	if base != "https://aceteam.ai" || org != "org-late" {
+		t.Errorf("missing fields not filled: base=%q org=%q", base, org)
+	}
+}
+
+// TestChatPageResolveConfig_NoProviderNoSnapshot verifies the genuinely
+// unconfigured case still reports empty (so connect() shows the auth-required
+// status) and does not panic on a nil provider.
+func TestChatPageResolveConfig_NoProviderNoSnapshot(t *testing.T) {
+	p := NewChatPage(ChatPageConfig{})
+	base, tok, org, _, _ := p.resolveConfig()
+	if base != "" || tok != "" || org != "" {
+		t.Errorf("expected empty config, got base=%q tok=%q org=%q", base, tok, org)
+	}
+}

--- a/internal/tui/controlcenter/controlcenter.go
+++ b/internal/tui/controlcenter/controlcenter.go
@@ -420,8 +420,9 @@ type ControlCenter struct {
 	consolePage *ConsolePage
 
 	// Chat
-	chatConfig    ChatPageConfig // stored from Config; used to lazily create ChatPage
-	chatPage      *ChatPage      // nil until registered in Run
+	chatConfig     ChatPageConfig        // stored from Config; used to lazily create ChatPage
+	chatConfigProv func() ChatPageConfig // lazy re-resolver for chat credentials (post-startup device auth)
+	chatPage       *ChatPage             // nil until registered in Run
 	proxmoxConfig ProxmoxConfig  // Proxmox page config (zero = disabled)
 
 	// Settings
@@ -488,7 +489,8 @@ type Config struct {
 	Worker             WorkerCallbacks                          // Worker management callbacks
 	Permissions        PermissionsCallbacks                     // Gateway permissions callbacks
 	OnConnect          func(activityFn func(level, msg string)) // Called after VPN connects (starts terminal/VNC servers)
-	Chat               ChatPageConfig                           // Chat page configuration (empty = disabled)
+	Chat               ChatPageConfig                           // Chat page configuration (initial snapshot; may be empty pre-auth)
+	ChatConfigProvider func() ChatPageConfig                    // Lazy re-resolver for chat credentials (picks up post-startup device auth)
 	Proxmox            ProxmoxConfig                            // Proxmox page configuration (empty = disabled)
 	Settings           SettingsCallbacks                        // Settings page hooks (telemetry load/save)
 }
@@ -526,6 +528,7 @@ func New(cfg Config) *ControlCenter {
 		authServiceURL:     cfg.AuthServiceURL,
 		nexusURL:           cfg.NexusURL,
 		chatConfig:         cfg.Chat,
+		chatConfigProv:     cfg.ChatConfigProvider,
 		proxmoxConfig:      cfg.Proxmox,
 		settingsConfig:     cfg.Settings,
 	}
@@ -608,7 +611,11 @@ func (cc *ControlCenter) Run() error {
 		cc.pmgr.Register(NewPlaceholderPage("console", "Console"), false)
 	}
 
-	// Alt+3: Chat page (hidden until network is connected and org is known)
+	// Alt+3: Chat page (hidden until network is connected and org is known).
+	// Pass the lazy provider so that a node which completes device
+	// authorization *after* startup re-resolves its credentials at connect()
+	// time instead of being stuck on the empty startup snapshot.
+	cc.chatConfig.Provider = cc.chatConfigProv
 	cc.chatPage = NewChatPage(cc.chatConfig)
 	cc.pmgr.Register(cc.chatPage, false)
 


### PR DESCRIPTION
## Context

On a Linux node that is connected to the mesh and was joined via **device authorization**, the control-center Chat page (Alt+3) showed:

> `[red]Not configured[white] — device authorization required`

and stayed stuck on "connecting…", even though a valid `device_api_token` + org + API base URL exist in the node's persisted config.

The Chat `connect()` guard `if p.apiBaseURL == "" || p.apiToken == "" || p.orgID == ""` was tripping because those three fields were empty — but the credentials were not missing on disk, they were just never (re)loaded into the page.

## Root Cause

It is a **wiring/timing bug**, not a node-state bug.

`buildChatConfig()` is called exactly once, at control-center **construction** time (`cmd/controlcenter.go`, in the `controlcenter.Config{...}` literal). Its result is frozen into `ChatPage`'s fields, which were documented "set at construction, read-only after".

A node that completes the **in-TUI device-auth flow** (`ccPollDeviceAuthToken` → `saveDeviceConfigToFile`), or re-pairs, only writes its `device_api_token` / `org_id` / `api_base_url` to `~/.citadel-cli/config.yaml` **after** the control center has already started. So the snapshot captured at construction is empty, and because the fields never refresh, the Chat page reports "device authorization required" forever.

The terminal / desktop / worker pages do **not** have this bug: they re-resolve their token + org **lazily** inside `ccOnNetworkConnect` (fired after the VPN connects, on both startup auto-reconnect and post-login), calling `getDeviceConfigFromFile()` / `getOrgIDFromConfig()` at that moment. The Chat page was the only consumer freezing a startup snapshot.

This also explains why the bug does not reproduce on a node that was device-authed in a *prior* session: there the credentials are already on disk before launch, so the frozen snapshot happens to be complete.

**Scope / caveat.** This addresses the **load-order/timing** cause: the page froze an empty startup snapshot while the credentials became resolvable shortly after. It assumes that re-running `buildChatConfig()` at connect time *can* resolve the credentials — i.e. `platform.ConfigDir()` points at the config the device-auth flow actually wrote (`~/.citadel-cli/config.yaml`). If a node runs the control center as **root** with `HOME` / `SUDO_USER` not pointing at the user (e.g. a systemd-launched service), `ConfigDir()` falls through to `/etc/citadel/config.yaml`, which only contains `node_config_dir` and no device credentials; there a fresh `buildChatConfig()` is still empty and this fix is a no-op. That is a separate config-path issue (terminal/desktop/worker read the same source, so they would be equally broken) and is intentionally out of scope. Quick discriminator on an affected node: if **Terminal/Desktop work**, creds resolve correctly and this timing fix applies; if they are also broken, the node has the broader config-path problem instead.

## Changes

- `internal/tui/controlcenter/chat_page.go`
  - `ChatPageConfig` gains an optional `Provider func() ChatPageConfig` — a lazy re-resolver for the credentials.
  - New `ChatPage.resolveConfig()` re-resolves through `Provider` whenever the seeded snapshot is missing any required field (base URL / token / org), filling only empty fields so a transient resolution miss never clobbers a credential already held. Access to the config fields is serialized by a new `configMu`.
  - `connect()` now resolves via `resolveConfig()` immediately before dialing, mirroring the terminal/desktop/worker lazy resolution.
  - `renderStatusBar()` / `ConnectionStatus()` read the base URL via a locked `currentAPIBaseURL()` getter.
- `internal/tui/controlcenter/controlcenter.go`
  - `Config` gains `ChatConfigProvider func() ChatPageConfig`, stored and passed to `NewChatPage` via `ChatPageConfig.Provider`.
- `cmd/controlcenter.go`
  - Wires `ChatConfigProvider: buildChatConfig` so the page can re-read freshly-persisted device-auth credentials at connect time. The initial `Chat: buildChatConfig()` snapshot is kept for the already-authed fast path.
- `internal/tui/controlcenter/chat_page_test.go` (new) — scoped unit tests for `resolveConfig`.

## Testing

Go-only, no TUI launched. **No `go test ./...` and nothing under `internal/tmux` / `internal/terminal` was run** (those test suites crash tmux 3.4).

- `go build ./...` — clean.
- `go vet ./internal/tui/controlcenter/ ./cmd/ ./internal/chat/` — clean.
- `go test ./internal/tui/controlcenter/ -run TestChatPageResolveConfig -v` — 4/4 pass:
  - provider fills an incomplete snapshot (the bug repro);
  - a complete snapshot is preserved and the provider is **not** called;
  - a partial provider result fills missing fields without clobbering an existing token;
  - the genuinely-unconfigured case stays empty (and a nil provider does not panic).
- `go test -race ./internal/tui/controlcenter/ -run TestChatPageResolveConfig` — pass (validates `configMu`).

Diagnostic note: a throwaway in-package harness calling the real `buildChatConfig()` on a device-authed node confirmed it returns a fully-populated config there (guard does not trip) — consistent with the timing diagnosis. That harness was removed before commit.

### Manual repro / confirmation (device-authed node)

1. On a fresh node, launch the control center **before** device-authing: `citadel` → open control center.
2. Complete device authorization from inside the TUI (so the token/org are written to `~/.citadel-cli/config.yaml` only after startup).
3. Open the Chat tab (Alt+3).
   - **Before:** "Not configured — device authorization required", stuck on connecting.
   - **After:** connect() re-resolves the just-written credentials and the chat connects to `#general`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
