### PR TITLE
feat(notify): send live notification from a Citadel node to a fabric phone (#323)

### DIFF
--- a/cmd/notify.go
+++ b/cmd/notify.go
@@ -1,0 +1,106 @@
+// cmd/notify.go
+// Send a live notification from this Citadel node to the org's phone(s).
+//
+// The node authenticates with its device API token (org-scoped, like every
+// other node→backend call) and POSTs a notification to the AceTeam backend,
+// which relays it to the org user's registered iOS device(s) via APNs. This
+// powers the "agent on this machine wants your attention / HITL approval" flow
+// (aceteam-ai/aceteam#4144, #4145).
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/notify"
+	"github.com/spf13/cobra"
+)
+
+var (
+	notifyTitle          string
+	notifyBody           string
+	notifyTarget         string
+	notifyConversationID string
+)
+
+var notifyCmd = &cobra.Command{
+	Use:   "notify",
+	Short: "Send a live notification to your org's phone(s)",
+	Long: `Send a push notification from this node to the org user's registered
+iOS device(s), relayed by the AceTeam backend via APNs.
+
+The node authenticates with its device API token; the org is derived
+server-side from that token (no org flag needed). Use this for the
+"agent on this machine wants your attention / HITL approval" flow.
+
+Requires a device API token (stored during 'citadel login' or 'citadel init').
+
+Note: actual push delivery depends on the paid Apple enrollment (APNs)
+clearing on the backend. Until then the backend accepts and queues the
+notification but no phone will display it. This command reports
+"accepted by backend", which is the most a node can observe.`,
+	Example: `  # Notify the org that an agent needs attention, deep-linking to a chat
+  citadel notify --title "Approval needed" \
+    --body "Agent on this machine wants to deploy" \
+    --target chat --conversation 123e4567-e89b-12d3-a456-426614174000
+
+  # Minimal notification
+  citadel notify -t "Heads up" -b "Long-running job finished"`,
+	Run: func(cmd *cobra.Command, args []string) {
+		os.Exit(runNotify())
+	},
+}
+
+// runNotify loads device auth, sends the notification, and returns a process
+// exit code (0 = accepted by backend, 1 = error).
+func runNotify() int {
+	deviceConfig := getDeviceConfigFromFile()
+	if deviceConfig == nil || deviceConfig.DeviceAPIToken == "" {
+		fmt.Fprintln(os.Stderr, "Error: No device API token found.")
+		fmt.Fprintln(os.Stderr, "Run 'citadel login' or 'citadel init' to authenticate first.")
+		return 1
+	}
+
+	apiBaseURL := deviceConfig.APIBaseURL
+	if apiBaseURL == "" {
+		apiBaseURL = authServiceURL
+	}
+
+	client := notify.NewClient(notify.Config{
+		BaseURL: apiBaseURL,
+		Token:   deviceConfig.DeviceAPIToken,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	res, err := client.Send(ctx, notify.Notification{
+		Title:          notifyTitle,
+		Body:           notifyBody,
+		Target:         notify.Target(notifyTarget),
+		ConversationID: notifyConversationID,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+
+	// A 2xx means the backend accepted/queued the push. The node cannot observe
+	// whether a phone displayed it — and real APNs delivery is gated on the
+	// paid Apple enrollment clearing on the backend (aceteam#4219).
+	fmt.Printf("Notification accepted by backend (HTTP %d).\n", res.StatusCode)
+	fmt.Println("Delivery to the phone depends on Apple APNs enrollment clearing on the backend.")
+	return 0
+}
+
+func init() {
+	rootCmd.AddCommand(notifyCmd)
+	notifyCmd.Flags().StringVarP(&notifyTitle, "title", "t", "", "Notification title (required)")
+	notifyCmd.Flags().StringVarP(&notifyBody, "body", "b", "", "Notification body (required)")
+	notifyCmd.Flags().StringVar(&notifyTarget, "target", "chat", "Deep-link surface: chat|nodes|terminal|settings")
+	notifyCmd.Flags().StringVar(&notifyConversationID, "conversation", "", "Conversation ID to deep-link into (optional)")
+	_ = notifyCmd.MarkFlagRequired("title")
+	_ = notifyCmd.MarkFlagRequired("body")
+}

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -1,0 +1,182 @@
+// Package notify lets a Citadel node emit a live notification to its org —
+// the node authenticates with its device API token (org-scoped, exactly like
+// every other node→backend call) and POSTs a notification to the AceTeam
+// backend, which relays it to the org user's registered iOS device(s) via APNs.
+//
+// This powers the "agent on this machine wants your attention / HITL approval"
+// flow (aceteam-ai/aceteam#4144, #4145): an agent running on the node can ask
+// for a human's attention on their phone.
+//
+// # Assumed backend contract (reconcile with aceteam-ai/aceteam#4219)
+//
+// As of this writing the receiving half (#4219) is being built in parallel and
+// the exact route is not yet on main. This client implements the most-likely
+// contract, grounded in the already-merged APNs send path (aceteam#3989):
+//
+//	POST {api_base_url}/api/fabric/notify
+//	Authorization: Bearer <device_api_token>
+//	X-Fabric-Source: citadel-cli
+//	Content-Type: application/json
+//
+//	{
+//	  "title": "<string, required>",
+//	  "body":  "<string, required>",
+//	  "target": "chat" | "nodes" | "terminal" | "settings",   // optional, default "chat"
+//	  "conversation_id": "<uuid>"                              // optional deep-link target
+//	}
+//
+//	-> 2xx { "success": true }   (notification accepted / queued for delivery)
+//
+// Field names mirror aceteam#3989's APNs payload builder
+// (build_apns_payload → {aps:{alert:{title,body}}, target, conversationId}).
+// The org is NOT sent in the body: it is derived server-side from the
+// device API token (the same withAuthenticatedContext → session_org_id path
+// used by /api/machines/[machineId]/manage/* node routes).
+//
+// If #4219 finalizes a different route or field names, only the constants and
+// the Notification JSON tags below need to change; the auth + send flow stays.
+package notify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// defaultNotifyPath is the assumed backend route (see package doc / aceteam#4219).
+const defaultNotifyPath = "/api/fabric/notify"
+
+// fabricSourceHeader marks the request as originating from the Citadel CLI,
+// matching the convention used by the remote-logs node route.
+const (
+	headerFabricSource = "X-Fabric-Source"
+	fabricSourceValue  = "citadel-cli"
+)
+
+// Target identifies which iOS surface a notification should deep-link into.
+// Values mirror the APNs payload "target" enum from aceteam#3989.
+type Target string
+
+const (
+	TargetChat     Target = "chat"
+	TargetNodes    Target = "nodes"
+	TargetTerminal Target = "terminal"
+	TargetSettings Target = "settings"
+)
+
+// Notification is the request body sent to the backend. Org scope is carried
+// by the auth token, not this struct (see package doc).
+type Notification struct {
+	// Title is the bold first line of the push. Required.
+	Title string `json:"title"`
+	// Body is the notification message. Required.
+	Body string `json:"body"`
+	// Target is the iOS surface to deep-link into. Optional; defaults to "chat".
+	Target Target `json:"target,omitempty"`
+	// ConversationID deep-links the notification to a specific chat/conversation.
+	// Optional.
+	ConversationID string `json:"conversation_id,omitempty"`
+}
+
+// Result is what the caller learns about a send. Because actual APNs delivery
+// is unobservable from the node, Accepted means only that the backend received
+// and queued the notification — not that a phone displayed it.
+type Result struct {
+	// Accepted is true when the backend returned a 2xx status.
+	Accepted bool
+	// StatusCode is the raw HTTP status returned by the backend.
+	StatusCode int
+}
+
+// Client sends authenticated, org-scoped notifications to the AceTeam backend.
+type Client struct {
+	baseURL    string
+	token      string
+	path       string
+	httpClient *http.Client
+}
+
+// Config configures a notify Client.
+type Config struct {
+	// BaseURL is the AceTeam API base URL (e.g. "https://aceteam.ai").
+	// Typically deviceConfig.APIBaseURL, falling back to the auth-service URL.
+	BaseURL string
+	// Token is the device_api_token from device authentication. Required.
+	Token string
+	// Path overrides the notify endpoint path (defaults to defaultNotifyPath).
+	// Exposed so it can be repointed without a code change once #4219 lands.
+	Path string
+	// HTTPClient overrides the HTTP client (mainly for tests). Optional.
+	HTTPClient *http.Client
+}
+
+// NewClient builds a notify Client from cfg.
+func NewClient(cfg Config) *Client {
+	path := cfg.Path
+	if path == "" {
+		path = defaultNotifyPath
+	}
+	hc := cfg.HTTPClient
+	if hc == nil {
+		hc = &http.Client{Timeout: 15 * time.Second}
+	}
+	return &Client{
+		baseURL:    strings.TrimRight(cfg.BaseURL, "/"),
+		token:      cfg.Token,
+		path:       path,
+		httpClient: hc,
+	}
+}
+
+// Send delivers a notification to the org via the backend. It returns a Result
+// describing whether the backend accepted the notification (a 2xx). A nil
+// error with Result.Accepted == true means the backend queued the push; the
+// node cannot observe whether the phone actually displayed it.
+func (c *Client) Send(ctx context.Context, n Notification) (*Result, error) {
+	if c.token == "" {
+		return nil, fmt.Errorf("notify: missing device API token (run 'citadel init' or 'citadel login')")
+	}
+	if c.baseURL == "" {
+		return nil, fmt.Errorf("notify: missing API base URL")
+	}
+	if strings.TrimSpace(n.Title) == "" {
+		return nil, fmt.Errorf("notify: title is required")
+	}
+	if strings.TrimSpace(n.Body) == "" {
+		return nil, fmt.Errorf("notify: body is required")
+	}
+
+	payload, err := json.Marshal(n)
+	if err != nil {
+		return nil, fmt.Errorf("notify: marshal request: %w", err)
+	}
+
+	url := c.baseURL + c.path
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("notify: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set(headerFabricSource, fabricSourceValue)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("notify: send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return &Result{Accepted: true, StatusCode: resp.StatusCode}, nil
+	}
+
+	return &Result{Accepted: false, StatusCode: resp.StatusCode},
+		fmt.Errorf("notify: backend returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+}

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -1,0 +1,159 @@
+package notify
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestSend_RequestContract locks in the assumed backend contract (aceteam#4219):
+// exact JSON body, the two auth headers, the POST method, and the route path.
+// If #4219 finalizes different field names, this test is the single place a
+// reviewer reconciles them.
+func TestSend_RequestContract(t *testing.T) {
+	var (
+		gotMethod string
+		gotPath   string
+		gotAuth   string
+		gotSource string
+		gotCT     string
+		gotBody   []byte
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotSource = r.Header.Get(headerFabricSource)
+		gotCT = r.Header.Get("Content-Type")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"success":true}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(Config{BaseURL: srv.URL, Token: "tok-123"})
+	res, err := c.Send(context.Background(), Notification{
+		Title:          "Approval needed",
+		Body:           "Agent on citadel-01 wants to deploy",
+		Target:         TargetChat,
+		ConversationID: "conv-abc",
+	})
+	if err != nil {
+		t.Fatalf("Send returned error: %v", err)
+	}
+	if !res.Accepted || res.StatusCode != http.StatusOK {
+		t.Fatalf("expected accepted 200, got %+v", res)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != defaultNotifyPath {
+		t.Errorf("path = %q, want %q", gotPath, defaultNotifyPath)
+	}
+	if gotAuth != "Bearer tok-123" {
+		t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer tok-123")
+	}
+	if gotSource != fabricSourceValue {
+		t.Errorf("%s = %q, want %q", headerFabricSource, gotSource, fabricSourceValue)
+	}
+	if gotCT != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", gotCT)
+	}
+
+	var sent map[string]any
+	if err := json.Unmarshal(gotBody, &sent); err != nil {
+		t.Fatalf("body not JSON: %v (%s)", err, gotBody)
+	}
+	want := map[string]any{
+		"title":           "Approval needed",
+		"body":            "Agent on citadel-01 wants to deploy",
+		"target":          "chat",
+		"conversation_id": "conv-abc",
+	}
+	for k, v := range want {
+		if sent[k] != v {
+			t.Errorf("body[%q] = %v, want %v", k, sent[k], v)
+		}
+	}
+	// Org must NOT be in the body — it is carried by the auth token.
+	if _, ok := sent["org_id"]; ok {
+		t.Errorf("body unexpectedly contains org_id; org scope comes from the token")
+	}
+}
+
+// TestSend_OmitsOptionalFields confirms omitempty: a minimal notification
+// sends only title+body, so the JSON surface to reconcile stays small.
+func TestSend_OmitsOptionalFields(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	c := NewClient(Config{BaseURL: srv.URL, Token: "t"})
+	if _, err := c.Send(context.Background(), Notification{Title: "Hi", Body: "There"}); err != nil {
+		t.Fatalf("Send error: %v", err)
+	}
+
+	var sent map[string]any
+	if err := json.Unmarshal(gotBody, &sent); err != nil {
+		t.Fatalf("body not JSON: %v", err)
+	}
+	if _, ok := sent["target"]; ok {
+		t.Errorf("target should be omitted when empty")
+	}
+	if _, ok := sent["conversation_id"]; ok {
+		t.Errorf("conversation_id should be omitted when empty")
+	}
+}
+
+// TestSend_BackendErrorIsNotAccepted ensures a non-2xx is surfaced as an error
+// and Accepted is false (so a HITL caller doesn't think a push went out).
+func TestSend_BackendErrorIsNotAccepted(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("revoked"))
+	}))
+	defer srv.Close()
+
+	c := NewClient(Config{BaseURL: srv.URL, Token: "t"})
+	res, err := c.Send(context.Background(), Notification{Title: "a", Body: "b"})
+	if err == nil {
+		t.Fatal("expected error on 403")
+	}
+	if res == nil || res.Accepted {
+		t.Fatalf("expected not-accepted result, got %+v", res)
+	}
+	if res.StatusCode != http.StatusForbidden {
+		t.Errorf("StatusCode = %d, want 403", res.StatusCode)
+	}
+}
+
+func TestSend_Validation(t *testing.T) {
+	c := NewClient(Config{BaseURL: "https://example.com", Token: "t"})
+	cases := []struct {
+		name string
+		n    Notification
+	}{
+		{"missing title", Notification{Body: "b"}},
+		{"missing body", Notification{Title: "a"}},
+		{"blank title", Notification{Title: "   ", Body: "b"}},
+	}
+	for _, tc := range cases {
+		if _, err := c.Send(context.Background(), tc.n); err == nil {
+			t.Errorf("%s: expected validation error", tc.name)
+		}
+	}
+
+	// Missing token is a clear, early error.
+	noTok := NewClient(Config{BaseURL: "https://example.com"})
+	if _, err := noTok.Send(context.Background(), Notification{Title: "a", Body: "b"}); err == nil {
+		t.Error("expected error when token missing")
+	}
+}


### PR DESCRIPTION
## Context

Citadel-side (SEND half) of the "Citadel chat → live push notification to a fabric phone" flow. This lets a Citadel node emit a live notification to its org so the org user's iOS device gets pushed (via APNs), powering the "agent on this machine wants your attention / HITL approval" flow.

The RECEIVE half (backend + iOS) is tracked in aceteam-ai/aceteam#4219 and is being built in parallel. This PR closes the citadel-cli send side of #323.

Refs:
- Implements citadel-cli#323
- Reconciles with aceteam-ai/aceteam#4219 (backend + iOS receive half)
- Part of the flagship epic aceteam-ai/aceteam#4144 (and #4145 Notifications/HITL)
- Contract grounded in the merged APNs send path aceteam-ai/aceteam#3989

## Changes

- **`internal/notify/notify.go`**: a small, authenticated, org-scoped notification client. It POSTs `{title, body, target?, conversation_id?}` to the backend with the node's `device_api_token` as a Bearer token plus `X-Fabric-Source: citadel-cli` (the same auth + header convention as the existing remote-logs node route). The org is **not** in the body: it is derived server-side from the token (matching `withAuthenticatedContext → session_org_id`). `Send` returns a `Result{Accepted, StatusCode}` so the HITL flow can call it programmatically as well as the CLI.
- **`cmd/notify.go`**: a thin `citadel notify` command. Loads device config, errors clearly if no token (copying the `runReconnect`/`runRemoteLogs` guard), sends, and reports backend acceptance.
- **`internal/notify/notify_test.go`**: `httptest` tests asserting the exact JSON body, both auth headers, method/path, `omitempty` behavior, non-2xx handling, and input validation.

## Assumed backend contract (reconcile with #4219)

The backend route is not yet on `main` (search for `fabric/notify` returns nothing), so this implements the most-likely contract, with field names taken from the already-merged APNs payload builder in #3989 (`build_apns_payload → {aps:{alert:{title,body}}, target, conversationId}`):

```
POST {api_base_url}/api/fabric/notify
Authorization: Bearer <device_api_token>
X-Fabric-Source: citadel-cli
Content-Type: application/json

{
  "title": "<string, required>",
  "body":  "<string, required>",
  "target": "chat" | "nodes" | "terminal" | "settings",   // optional, default "chat"
  "conversation_id": "<uuid>"                              // optional deep-link target
}

-> 2xx { "success": true }   // notification accepted / queued
```

Deliberately minimal: **no `org_id`** in the body (auth carries org), and a single deep-link representation (`conversation_id` + `target`). If #4219 finalizes a different route or field names, only the constants and JSON tags in `notify.go` change; the `notify_test.go` contract test is the single place a reviewer reconciles. The path is also overridable via `Config.Path` without a code change.

## How to test

```sh
go build ./...
go vet ./internal/notify/ ./cmd/
go test ./internal/notify/          # contract + validation tests

# CLI smoke test (no token configured → clean error, exit 1):
go run ./cmd/citadel notify --title x --body y

# Real send (requires a node authed via 'citadel init'/'citadel login'):
citadel notify --title "Approval needed" \
  --body "Agent on this machine wants to deploy" \
  --target chat --conversation <uuid>
```

## Untestable pending APNs

Real push **delivery** is gated on the paid Apple enrollment (9H93UAA9M7 / `aps-environment` entitlement) clearing on the backend, and on the #4219 route existing. Until then:
- A `2xx` from the backend means **accepted/queued**, which is the most a node can observe; the command reports that and notes delivery depends on Apple enrollment.
- The node has no way to confirm a phone displayed the push, so "delivered to phone" is intentionally **not** treated as the success condition.

## Verification

- `go build ./...`: OK
- `go vet ./internal/notify/ ./cmd/`: OK
- `go test ./internal/notify/`: OK (scoped; no tmux packages touched)
- No `go test ./...` was run; no tmux/terminal packages were tested or started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
