### PR TITLE
feat(tmux): provision Citadel-managed tmux binary when absent (#304)

### DIFF
--- a/cmd/tmux.go
+++ b/cmd/tmux.go
@@ -1,0 +1,101 @@
+// cmd/tmux.go
+package cmd
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/aceteam-ai/citadel-cli/internal/tmux"
+	"github.com/aceteam-ai/citadel-cli/internal/tmuxinstall"
+	"github.com/spf13/cobra"
+)
+
+var tmuxInstallForce bool
+
+var tmuxCmd = &cobra.Command{
+	Use:   "tmux",
+	Short: "Manage the Citadel-managed tmux binary for persistent terminal sessions",
+	Long: `Persistent, reconnect-resilient terminal sessions ("chat to a node") are
+backed by tmux. Citadel never assumes tmux is installed: it looks for tmux via
+CITADEL_TMUX_BIN, then PATH, then a Citadel-managed binary. These commands manage
+that Citadel-managed binary.
+
+If no usable tmux is found, the terminal server falls back to a bare,
+non-persistent shell.`,
+}
+
+var tmuxStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show how tmux is resolved on this node",
+	RunE:  runTmuxStatus,
+}
+
+var tmuxInstallCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Download, verify, and install a Citadel-managed tmux binary",
+	Long: `Download a Citadel-managed static tmux build for this platform, verify its
+SHA-256 checksum, and install it to the Citadel-managed path so persistent
+terminal sessions work without a system tmux.
+
+The downloaded artifact's checksum is always verified before install, and the
+binary is never executed as part of verification.
+
+Not every platform has a vetted static tmux artifact yet (macOS and Windows in
+particular). On gated platforms this command reports that no artifact is
+available; install tmux via your package manager instead (e.g. on macOS:
+'brew install tmux').`,
+	RunE: runTmuxInstall,
+}
+
+func init() {
+	rootCmd.AddCommand(tmuxCmd)
+	tmuxCmd.AddCommand(tmuxStatusCmd)
+	tmuxCmd.AddCommand(tmuxInstallCmd)
+	tmuxInstallCmd.Flags().BoolVar(&tmuxInstallForce, "force", false, "Reinstall even if a managed tmux binary already exists")
+}
+
+func runTmuxStatus(cmd *cobra.Command, args []string) error {
+	managed := tmux.ManagedBinaryPath()
+	fmt.Printf("Platform:            %s/%s\n", runtime.GOOS, runtime.GOARCH)
+	fmt.Printf("Managed binary path: %s\n", managed)
+
+	if path, err := tmux.Resolve(); err == nil {
+		fmt.Printf("Resolved tmux:       %s\n", path)
+	} else {
+		fmt.Printf("Resolved tmux:       (none) — terminals fall back to a bare shell\n")
+	}
+
+	if tmuxinstall.Available() {
+		fmt.Printf("Managed artifact:    available for this platform (run 'citadel tmux install')\n")
+	} else {
+		if src, ok := tmuxinstall.CurrentSource(); ok {
+			fmt.Printf("Managed artifact:    not available (gated) — %s\n", src.Note)
+		} else {
+			fmt.Printf("Managed artifact:    not supported on this platform\n")
+		}
+	}
+	return nil
+}
+
+func runTmuxInstall(cmd *cobra.Command, args []string) error {
+	inst := tmuxinstall.New()
+
+	if inst.AlreadyInstalled() && !tmuxInstallForce {
+		fmt.Printf("Managed tmux already installed at %s (use --force to reinstall).\n", inst.DestPath())
+		return nil
+	}
+
+	if !tmuxinstall.Available() {
+		if src, ok := tmuxinstall.CurrentSource(); ok {
+			return fmt.Errorf("no managed tmux artifact for %s/%s: %s", runtime.GOOS, runtime.GOARCH, src.Note)
+		}
+		return fmt.Errorf("managed tmux is not supported on %s/%s; install tmux via your package manager so it is found on PATH", runtime.GOOS, runtime.GOARCH)
+	}
+
+	fmt.Printf("Installing Citadel-managed tmux to %s ...\n", inst.DestPath())
+	if err := inst.Install(); err != nil {
+		return fmt.Errorf("install tmux: %w", err)
+	}
+	fmt.Printf("Installed and checksum-verified tmux at %s\n", inst.DestPath())
+	return nil
+}

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -31,6 +31,8 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/status"
 	"github.com/aceteam-ai/citadel-cli/internal/terminal"
 	"github.com/aceteam-ai/citadel-cli/internal/tlscert"
+	"github.com/aceteam-ai/citadel-cli/internal/tmux"
+	"github.com/aceteam-ai/citadel-cli/internal/tmuxinstall"
 	"github.com/aceteam-ai/citadel-cli/internal/update"
 	"github.com/aceteam-ai/citadel-cli/internal/usage"
 	"github.com/aceteam-ai/citadel-cli/internal/websockify"
@@ -1086,6 +1088,13 @@ func runWork(cmd *cobra.Command, args []string) {
 				termConfig.OrgID = orgID
 				termConfig.AuthServiceURL = baseURL
 				termConfig.Version = Version
+
+				// Best-effort: provision a Citadel-managed tmux binary so persistent
+				// terminal sessions "just work" on nodes without a system tmux. This
+				// is non-fatal — if it fails or the platform is gated, the terminal
+				// server falls back to a bare (non-persistent) shell. Skip when tmux
+				// is already resolvable or when explicitly disabled.
+				ensureManagedTmux()
 				if workTerminalHost != "" {
 					termConfig.Host = workTerminalHost
 				}
@@ -1758,6 +1767,36 @@ func permissionsToHeartbeat(p *config.Permissions) *heartbeat.PermissionState {
 		Services: p.Services,
 		SSH:      p.SSH,
 	}
+}
+
+// ensureManagedTmux best-effort provisions a Citadel-managed tmux binary so the
+// terminal server can back sessions with persistent tmux on nodes that lack a
+// system tmux. It is intentionally non-fatal and quiet:
+//   - if tmux is already resolvable (CITADEL_TMUX_BIN / PATH / managed), do
+//     nothing;
+//   - if the platform is gated/unsupported or the download/verify fails, log at
+//     debug level and return — the terminal server already falls back to a bare,
+//     non-persistent shell.
+//
+// Set CITADEL_TMUX_NO_INSTALL=1 (or true) to skip provisioning entirely.
+func ensureManagedTmux() {
+	if v := os.Getenv("CITADEL_TMUX_NO_INSTALL"); v == "1" || strings.EqualFold(v, "true") {
+		Debug("managed tmux install disabled via CITADEL_TMUX_NO_INSTALL")
+		return
+	}
+	if tmux.IsAvailable() {
+		return
+	}
+	if !tmuxinstall.Available() {
+		Debug("no managed tmux artifact for this platform; terminals use a bare shell")
+		return
+	}
+	inst := tmuxinstall.New()
+	if _, err := inst.Ensure(); err != nil {
+		Debug("managed tmux install failed (falling back to bare shell): %v", err)
+		return
+	}
+	Log("Installed Citadel-managed tmux at %s", inst.DestPath())
 }
 
 func init() {

--- a/internal/tmuxinstall/install.go
+++ b/internal/tmuxinstall/install.go
@@ -1,0 +1,363 @@
+package tmuxinstall
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/tmux"
+)
+
+// maxArtifactBytes caps how much we will download for a single tmux artifact. A
+// static tmux is a few MB; this guards against a misconfigured URL streaming an
+// unbounded body into memory/disk.
+const maxArtifactBytes = 64 << 20 // 64 MiB
+
+// defaultTimeout bounds the whole download. Provisioning is best-effort and must
+// never hang a node's startup.
+const defaultTimeout = 60 * time.Second
+
+// Installer provisions the managed tmux binary. The zero value is not usable;
+// construct it with New.
+type Installer struct {
+	httpClient *http.Client
+	// destPath is where the managed binary is written. Defaults to
+	// tmux.ManagedBinaryPath(); overridable for tests.
+	destPath string
+	// now is injectable for tests; unused in production beyond defaults.
+}
+
+// Option configures an Installer.
+type Option func(*Installer)
+
+// WithHTTPClient overrides the HTTP client (e.g. in tests).
+func WithHTTPClient(c *http.Client) Option {
+	return func(i *Installer) { i.httpClient = c }
+}
+
+// WithDestPath overrides the install destination (e.g. in tests). Production
+// callers should leave this unset so tmux.ManagedBinaryPath() is honored.
+func WithDestPath(p string) Option {
+	return func(i *Installer) { i.destPath = p }
+}
+
+// New constructs an Installer with sensible defaults.
+func New(opts ...Option) *Installer {
+	i := &Installer{
+		httpClient: &http.Client{Timeout: defaultTimeout},
+		destPath:   tmux.ManagedBinaryPath(),
+	}
+	for _, opt := range opts {
+		opt(i)
+	}
+	return i
+}
+
+// DestPath returns where the managed tmux binary will be / is installed.
+func (i *Installer) DestPath() string { return i.destPath }
+
+// AlreadyInstalled reports whether a managed tmux binary already exists at the
+// destination (a regular, non-directory file). It does not validate or execute
+// it.
+func (i *Installer) AlreadyInstalled() bool {
+	info, err := os.Stat(i.destPath)
+	return err == nil && !info.IsDir()
+}
+
+// Ensure installs the managed tmux binary for the current platform if it is not
+// already present and a vetted artifact exists. It returns:
+//   - (true, nil)  when a binary is now present (installed or already there)
+//   - (false, nil) when the platform is gated/unsupported (no error: callers
+//     should fall back to a bare shell)
+//   - (false, err) when an install was attempted and failed
+//
+// Ensure never executes the downloaded binary.
+func (i *Installer) Ensure() (installed bool, err error) {
+	if i.AlreadyInstalled() {
+		return true, nil
+	}
+	if !Available() {
+		// Gated/unsupported platform: not an error condition for best-effort
+		// callers; the terminal server falls back to a bare shell.
+		return false, nil
+	}
+	if err := i.Install(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// Install downloads, checksum-verifies, and installs the managed tmux binary for
+// the current platform, overwriting any existing managed binary. It returns a
+// descriptive error for gated/unsupported platforms (use Ensure for best-effort
+// semantics). The downloaded binary is never executed as part of verification.
+func (i *Installer) Install() error {
+	src, ok := CurrentSource()
+	if !ok || !src.vetted() {
+		return gatedError(runtime.GOOS, runtime.GOARCH)
+	}
+	return i.installFrom(src)
+}
+
+// installFrom performs the download -> verify -> extract -> place pipeline for a
+// concrete (vetted) source. Split out for testability.
+func (i *Installer) installFrom(src Source) error {
+	if !src.vetted() {
+		return fmt.Errorf("refusing to install tmux: source is not checksum-verified (gated)")
+	}
+
+	destDir := filepath.Dir(i.destPath)
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return fmt.Errorf("create managed bin dir %s: %w", destDir, err)
+	}
+
+	// Download the artifact to a temp file in the destination directory (same
+	// filesystem, so the final rename is atomic).
+	tmpArtifact, err := os.CreateTemp(destDir, ".tmux-artifact-*")
+	if err != nil {
+		return fmt.Errorf("create temp artifact: %w", err)
+	}
+	artifactPath := tmpArtifact.Name()
+	tmpArtifact.Close()
+	defer os.Remove(artifactPath)
+
+	if err := i.download(src.URL, artifactPath); err != nil {
+		return err
+	}
+
+	// Verify the checksum of the DOWNLOADED artifact BEFORE extracting or
+	// installing anything. This is the trust boundary.
+	if err := verifyChecksum(artifactPath, src.SHA256); err != nil {
+		return err
+	}
+
+	// Extract the tmux binary into a temp file next to the destination, then
+	// atomically rename it into place. We never run the binary to "verify" it.
+	tmpBin, err := os.CreateTemp(destDir, ".tmux-bin-*")
+	if err != nil {
+		return fmt.Errorf("create temp binary: %w", err)
+	}
+	tmpBinPath := tmpBin.Name()
+	tmpBin.Close()
+	defer os.Remove(tmpBinPath)
+
+	if err := extractBinary(artifactPath, tmpBinPath, src.Format); err != nil {
+		return err
+	}
+
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(tmpBinPath, 0o755); err != nil {
+			return fmt.Errorf("set executable bit: %w", err)
+		}
+	}
+
+	if err := os.Rename(tmpBinPath, i.destPath); err != nil {
+		return fmt.Errorf("install tmux to %s: %w", i.destPath, err)
+	}
+	return nil
+}
+
+// download streams url to destPath over HTTPS, enforcing a size cap.
+func (i *Installer) download(url, destPath string) error {
+	if !strings.HasPrefix(url, "https://") {
+		return fmt.Errorf("refusing to download tmux from non-HTTPS URL: %q", url)
+	}
+	resp, err := i.httpClient.Get(url)
+	if err != nil {
+		return fmt.Errorf("download tmux artifact: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download tmux artifact: unexpected status %s", resp.Status)
+	}
+
+	out, err := os.Create(destPath)
+	if err != nil {
+		return fmt.Errorf("create artifact file: %w", err)
+	}
+	defer out.Close()
+
+	// LimitReader guards against an unbounded body. +1 lets us detect overflow.
+	n, err := io.Copy(out, io.LimitReader(resp.Body, maxArtifactBytes+1))
+	if err != nil {
+		return fmt.Errorf("write artifact: %w", err)
+	}
+	if n > maxArtifactBytes {
+		return fmt.Errorf("tmux artifact exceeds size limit of %d bytes", maxArtifactBytes)
+	}
+	return nil
+}
+
+// verifyChecksum confirms the SHA-256 of the file at path equals expected
+// (lowercase hex). It returns a clear error on mismatch.
+func verifyChecksum(path, expected string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open artifact for checksum: %w", err)
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("hash artifact: %w", err)
+	}
+	got := hex.EncodeToString(h.Sum(nil))
+	if !strings.EqualFold(got, expected) {
+		return fmt.Errorf("tmux artifact checksum mismatch: expected %s, got %s", expected, got)
+	}
+	return nil
+}
+
+// tmuxBinaryName is the name of the tmux executable inside an archive for the
+// current platform.
+func tmuxBinaryName() string {
+	if runtime.GOOS == "windows" {
+		return "tmux.exe"
+	}
+	return "tmux"
+}
+
+// extractBinary writes the tmux executable from the artifact at srcPath to
+// dstPath, according to format.
+func extractBinary(srcPath, dstPath string, format archiveFormat) error {
+	switch format {
+	case formatRaw:
+		return copyFile(srcPath, dstPath)
+	case formatGzip:
+		return extractGzip(srcPath, dstPath)
+	case formatTarGz:
+		return extractTarGz(srcPath, dstPath)
+	case formatZip:
+		return extractZip(srcPath, dstPath)
+	default:
+		return fmt.Errorf("unknown tmux artifact format: %q", format)
+	}
+}
+
+func copyFile(srcPath, dstPath string) error {
+	in, err := os.Open(srcPath)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dstPath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return nil
+}
+
+func extractGzip(srcPath, dstPath string) error {
+	in, err := os.Open(srcPath)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	gzr, err := gzip.NewReader(in)
+	if err != nil {
+		return fmt.Errorf("open gzip: %w", err)
+	}
+	defer gzr.Close()
+
+	out, err := os.Create(dstPath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, io.LimitReader(gzr, maxArtifactBytes+1)); err != nil {
+		return fmt.Errorf("gunzip tmux: %w", err)
+	}
+	return nil
+}
+
+func extractTarGz(srcPath, dstPath string) error {
+	in, err := os.Open(srcPath)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	gzr, err := gzip.NewReader(in)
+	if err != nil {
+		return fmt.Errorf("open gzip: %w", err)
+	}
+	defer gzr.Close()
+
+	want := tmuxBinaryName()
+	tr := tar.NewReader(gzr)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("read tar: %w", err)
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		if filepath.Base(hdr.Name) != want {
+			continue
+		}
+		out, err := os.Create(dstPath)
+		if err != nil {
+			return err
+		}
+		if _, err := io.Copy(out, io.LimitReader(tr, maxArtifactBytes+1)); err != nil {
+			out.Close()
+			return fmt.Errorf("extract tmux from tar: %w", err)
+		}
+		out.Close()
+		return nil
+	}
+	return fmt.Errorf("%q not found in tar.gz artifact", want)
+}
+
+func extractZip(srcPath, dstPath string) error {
+	r, err := zip.OpenReader(srcPath)
+	if err != nil {
+		return fmt.Errorf("open zip: %w", err)
+	}
+	defer r.Close()
+
+	want := tmuxBinaryName()
+	for _, f := range r.File {
+		if filepath.Base(f.Name) != want {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return err
+		}
+		out, err := os.Create(dstPath)
+		if err != nil {
+			rc.Close()
+			return err
+		}
+		if _, err := io.Copy(out, io.LimitReader(rc, maxArtifactBytes+1)); err != nil {
+			rc.Close()
+			out.Close()
+			return fmt.Errorf("extract tmux from zip: %w", err)
+		}
+		rc.Close()
+		out.Close()
+		return nil
+	}
+	return fmt.Errorf("%q not found in zip artifact", want)
+}

--- a/internal/tmuxinstall/install_test.go
+++ b/internal/tmuxinstall/install_test.go
@@ -96,8 +96,9 @@ func TestInstallFrom_ChecksumMismatchRejected(t *testing.T) {
 
 func TestInstallFrom_TarGzExtraction(t *testing.T) {
 	content := []byte("tmux-binary-contents")
-	// On non-windows the wanted entry is "tmux"; include it plus a decoy.
-	archive := makeTarGz(t, "tmux", content)
+	// Use the platform's expected entry name so the test is valid on Windows
+	// runners too (where extractTarGz looks for "tmux.exe").
+	archive := makeTarGz(t, tmuxBinaryName(), content)
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write(archive)
 	}))

--- a/internal/tmuxinstall/install_test.go
+++ b/internal/tmuxinstall/install_test.go
@@ -1,0 +1,155 @@
+package tmuxinstall
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// sha256Hex returns the lowercase hex SHA-256 of b.
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// makeTarGz returns a .tar.gz containing a single regular file named entryName
+// with the given content.
+func makeTarGz(t *testing.T, entryName string, content []byte) []byte {
+	t.Helper()
+	// Build via a temp file to keep it simple.
+	f, err := os.CreateTemp(t.TempDir(), "tar-*.tgz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	gz := gzip.NewWriter(f)
+	tw := tar.NewWriter(gz)
+	hdr := &tar.Header{Name: entryName, Mode: 0o755, Size: int64(len(content)), Typeflag: tar.TypeReg}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	tw.Close()
+	gz.Close()
+	f.Close()
+	buf, err := os.ReadFile(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return buf
+}
+
+func TestInstallFromRaw_VerifiesAndInstalls(t *testing.T) {
+	content := []byte("#!/bin/sh\necho fake-tmux\n")
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(content)
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "bin", "tmux")
+	inst := New(WithHTTPClient(srv.Client()), WithDestPath(dest))
+
+	src := Source{URL: srv.URL, SHA256: sha256Hex(content), Format: formatRaw}
+	// Override the URL scheme guard: httptest TLS server uses https already.
+	if err := inst.installFrom(src); err != nil {
+		t.Fatalf("installFrom: %v", err)
+	}
+
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read installed: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("installed content mismatch")
+	}
+	if !inst.AlreadyInstalled() {
+		t.Fatal("AlreadyInstalled should be true after install")
+	}
+}
+
+func TestInstallFrom_ChecksumMismatchRejected(t *testing.T) {
+	content := []byte("real-tmux-bytes")
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(content)
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "bin", "tmux")
+	inst := New(WithHTTPClient(srv.Client()), WithDestPath(dest))
+
+	// Wrong checksum.
+	src := Source{URL: srv.URL, SHA256: sha256Hex([]byte("something-else")), Format: formatRaw}
+	if err := inst.installFrom(src); err == nil {
+		t.Fatal("expected checksum mismatch error, got nil")
+	}
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		t.Fatalf("binary must NOT be installed on checksum mismatch (stat err=%v)", err)
+	}
+}
+
+func TestInstallFrom_TarGzExtraction(t *testing.T) {
+	content := []byte("tmux-binary-contents")
+	// On non-windows the wanted entry is "tmux"; include it plus a decoy.
+	archive := makeTarGz(t, "tmux", content)
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(archive)
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "bin", "tmux")
+	inst := New(WithHTTPClient(srv.Client()), WithDestPath(dest))
+	src := Source{URL: srv.URL, SHA256: sha256Hex(archive), Format: formatTarGz}
+
+	if err := inst.installFrom(src); err != nil {
+		t.Fatalf("installFrom tar.gz: %v", err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("extracted content mismatch: %q", got)
+	}
+}
+
+func TestInstallFrom_GatedSourceRefused(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "bin", "tmux")
+	inst := New(WithDestPath(dest))
+	// Empty SHA256 => gated.
+	src := Source{URL: "https://example.invalid/tmux", SHA256: "", Format: formatRaw}
+	if err := inst.installFrom(src); err == nil {
+		t.Fatal("expected refusal to install a gated (unverified) source")
+	}
+}
+
+func TestSourceTable_AllEntriesValid(t *testing.T) {
+	// Sanity: every table entry either is fully gated (empty URL AND empty
+	// checksum) or fully vetted (both set). A URL without a checksum would be a
+	// supply-chain hazard; a checksum without a URL is meaningless.
+	for key, s := range sources {
+		urlSet := s.URL != ""
+		sumSet := s.SHA256 != ""
+		if urlSet != sumSet {
+			t.Errorf("%s: URL and SHA256 must both be set or both empty (url=%v sum=%v)", key, urlSet, sumSet)
+		}
+		if s.Note == "" {
+			t.Errorf("%s: Note must explain provenance/gating", key)
+		}
+	}
+}
+
+func TestAvailable_DefaultGated(t *testing.T) {
+	// With the shipped (fully gated) table, no platform should report available.
+	for key, s := range sources {
+		if s.vetted() {
+			t.Errorf("%s: expected gated source in shipped table, but it is vetted", key)
+		}
+	}
+}

--- a/internal/tmuxinstall/source.go
+++ b/internal/tmuxinstall/source.go
@@ -1,0 +1,168 @@
+// Package tmuxinstall provisions a Citadel-managed static tmux binary into the
+// path that the internal/tmux package resolves (tmux.ManagedBinaryPath), so that
+// persistent tmux-backed terminal sessions (aceteam EPIC #4144, issues #302/#304)
+// work on nodes that lack a system tmux, without manual setup.
+//
+// # Sourcing strategy
+//
+// tmux is not statically linkable in the trivial sense: it depends on libevent
+// and ncurses, and neither Apple's toolchain (macOS) nor stock Windows can
+// produce a genuinely static, self-contained tmux. There is also no upstream
+// "official" static tmux release to point at. To stay honest about provenance we
+// deliberately do NOT pin third-party / personal GitHub mirrors (their artifacts
+// cannot be vetted and would violate our supply-chain constraints).
+//
+// Instead, the managed binary is sourced from Citadel-org-controlled artifacts:
+// static tmux builds produced in CI and attached to citadel-cli GitHub releases
+// (or a managed mirror), fetched and SHA-256-verified with the exact same trust
+// model as the existing auto-updater (internal/update). An entry is only treated
+// as installable when it carries a real, confirmed SHA-256 checksum; an empty
+// checksum marks the platform as GATED and Resolve()/Install refuse to download
+// anything for it (so we can never install an unverified binary).
+//
+// This file is the single source table. As org-built static tmux artifacts land,
+// fill in URL + SHA256 (+ archive format) for the corresponding platform and the
+// plumbing below will provision it. Until then every platform is gated and the
+// terminal server keeps its existing, safe fallback to a bare (non-persistent)
+// shell.
+package tmuxinstall
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// archiveFormat describes how the downloaded artifact is packaged so the
+// installer knows how to extract the tmux binary from it.
+type archiveFormat string
+
+const (
+	// formatRaw means the downloaded file is the tmux executable itself, with
+	// no container. It is written directly to the managed path.
+	formatRaw archiveFormat = "raw"
+	// formatGzip means the downloaded file is a single gzip-compressed
+	// executable (e.g. tmux.gz); it is gunzipped to the managed path.
+	formatGzip archiveFormat = "gzip"
+	// formatTarGz means the downloaded file is a .tar.gz containing a "tmux"
+	// (or "tmux.exe") entry, which is extracted to the managed path.
+	formatTarGz archiveFormat = "tar.gz"
+	// formatZip means the downloaded file is a .zip containing a "tmux"
+	// (or "tmux.exe") entry, which is extracted to the managed path.
+	formatZip archiveFormat = "zip"
+)
+
+// Source describes where to obtain a Citadel-managed static tmux binary for a
+// specific OS/arch and how to verify it.
+//
+// A Source is "vetted" (installable) only when both URL and SHA256 are non-empty.
+// When SHA256 is empty the platform is GATED: no download is attempted, because
+// we never install a binary we cannot checksum-verify. This is enforced in
+// (Source).vetted and surfaced by Available / Install.
+type Source struct {
+	// URL is the download location of the artifact. Must be HTTPS and point at a
+	// Citadel-org-controlled artifact (citadel-cli release asset or managed
+	// mirror) — never an unvetted third-party / personal mirror.
+	URL string
+	// SHA256 is the lowercase hex SHA-256 of the downloaded artifact (the file at
+	// URL, before extraction). Empty means the platform is gated.
+	SHA256 string
+	// Format is how the artifact is packaged (see archiveFormat).
+	Format archiveFormat
+	// Note documents provenance / why a platform is gated. Surfaced in errors.
+	Note string
+}
+
+// vetted reports whether this source can actually be installed: it must have a
+// URL and a checksum. A missing checksum gates the platform.
+func (s Source) vetted() bool {
+	return s.URL != "" && s.SHA256 != ""
+}
+
+// platformKey is the "<goos>/<goarch>" map key for the source table.
+func platformKey(goos, goarch string) string {
+	return goos + "/" + goarch
+}
+
+// sources is the per-platform source+checksum table.
+//
+// IMPORTANT: every entry is currently GATED (empty SHA256) because no vetted,
+// Citadel-org-built static tmux artifact has been published yet. Filling in a
+// real URL + SHA256 for a platform (and confirming the checksum against the
+// actual artifact) is what flips it to installable. Do NOT invent checksums.
+//
+//	| platform        | status | source / notes                                   |
+//	|-----------------|--------|--------------------------------------------------|
+//	| linux/amd64     | GATED  | org-built static tmux (libevent+ncurses) pending |
+//	| linux/arm64     | GATED  | org-built static tmux pending                    |
+//	| darwin/amd64    | GATED  | no static macOS build; resolve via `brew tmux`   |
+//	| darwin/arm64    | GATED  | no static macOS build; resolve via `brew tmux`   |
+//	| windows/amd64   | GATED  | no native static tmux (needs Cygwin/MSYS2)       |
+//
+// linux/amd64 and linux/arm64 are the only realistically vettable targets and
+// are the intended first entries to be filled in by CI. macOS and Windows are
+// expected to remain gated; on those platforms the terminal server falls back to
+// a bare shell (and macOS users can `brew install tmux`, which Resolve picks up
+// via PATH).
+var sources = map[string]Source{
+	platformKey("linux", "amd64"): {
+		URL:    "",
+		SHA256: "",
+		Format: formatTarGz,
+		Note:   "org-built static tmux (libevent+ncurses) for linux/amd64 not yet published; gated until a CI artifact + verified SHA-256 exists (see #304)",
+	},
+	platformKey("linux", "arm64"): {
+		URL:    "",
+		SHA256: "",
+		Format: formatTarGz,
+		Note:   "org-built static tmux for linux/arm64 not yet published; gated until a CI artifact + verified SHA-256 exists (see #304)",
+	},
+	platformKey("darwin", "amd64"): {
+		URL:    "",
+		SHA256: "",
+		Format: formatTarGz,
+		Note:   "macOS cannot produce a fully static tmux; gated. Install tmux via Homebrew (`brew install tmux`) and it will be picked up on PATH",
+	},
+	platformKey("darwin", "arm64"): {
+		URL:    "",
+		SHA256: "",
+		Format: formatTarGz,
+		Note:   "macOS cannot produce a fully static tmux; gated. Install tmux via Homebrew (`brew install tmux`) and it will be picked up on PATH",
+	},
+	platformKey("windows", "amd64"): {
+		URL:    "",
+		SHA256: "",
+		Format: formatZip,
+		Note:   "Windows has no native static tmux (requires Cygwin/MSYS2); gated. Persistent sessions fall back to a bare shell on Windows",
+	},
+}
+
+// SourceFor returns the Source for the given OS/arch and whether the table has an
+// entry at all. A returned-but-gated source (ok==true, vetted()==false) means we
+// know about the platform but have no verified artifact for it yet.
+func SourceFor(goos, goarch string) (Source, bool) {
+	s, ok := sources[platformKey(goos, goarch)]
+	return s, ok
+}
+
+// CurrentSource returns the Source for the platform the binary is running on.
+func CurrentSource() (Source, bool) {
+	return SourceFor(runtime.GOOS, runtime.GOARCH)
+}
+
+// Available reports whether a vetted (checksum-verified) managed tmux artifact
+// exists for the current platform — i.e. whether Install can do anything other
+// than return a "gated"/"unsupported" error. It does not perform any network or
+// filesystem I/O.
+func Available() bool {
+	s, ok := CurrentSource()
+	return ok && s.vetted()
+}
+
+// gatedError returns a descriptive, actionable error for a platform that has no
+// installable artifact (either unknown or gated).
+func gatedError(goos, goarch string) error {
+	if s, ok := SourceFor(goos, goarch); ok {
+		return fmt.Errorf("managed tmux is not available for %s/%s: %s", goos, goarch, s.Note)
+	}
+	return fmt.Errorf("managed tmux is not supported on %s/%s: no source entry; install tmux via your package manager so it is found on PATH", goos, goarch)
+}


### PR DESCRIPTION
## Context

Follow-up to #302 / PR #303. PR #303 added the `internal/tmux` package and
persistent tmux-backed terminal sessions, resolving a tmux binary in order:
`CITADEL_TMUX_BIN` -> `tmux` on `PATH` -> a Citadel-managed binary at
`tmux.ManagedBinaryPath()` (`~/.citadel/bin/tmux`, `.exe` on Windows). When none
is found, `Resolve()` returns `ErrTmuxNotFound` and the terminal server falls
back to a bare, non-persistent shell.

The missing half (#304) was actually **provisioning** a binary into the managed
path. This PR adds the download/verify/install plumbing, a CLI command, and a
best-effort startup hook so persistent "chat to a node" sessions work on nodes
that lack a system tmux, without manual setup.

## Sourcing strategy

tmux is not trivially static: it needs libevent + ncurses, and neither Apple's
toolchain (macOS) nor stock Windows can produce a genuinely static, self-contained
tmux. There is also no upstream "official" static tmux release to pin.

To keep provenance honest, this PR **does not** pin third-party / personal GitHub
mirrors (their artifacts cannot be vetted). Instead the managed binary is sourced
from **Citadel-org-controlled artifacts** — static tmux builds produced in CI and
attached to citadel-cli releases (or a managed mirror) — fetched and
SHA-256-verified with the same trust model as the existing auto-updater
(`internal/update`).

An entry is installable **only** when it carries both a URL and a real, confirmed
SHA-256. An empty checksum **gates** the platform: no download is attempted, so we
can never install an unverified binary. **No checksums were invented.** Every
platform ships gated until a verified CI artifact exists.

### Per-platform source + checksum table

| Platform | Status | Artifact / Checksum | Notes |
|---|---|---|---|
| linux/amd64 | **GATED** | (none) | org-built static tmux (libevent+ncurses); first intended CI target |
| linux/arm64 | **GATED** | (none) | org-built static tmux; first intended CI target |
| darwin/amd64 | **GATED** | (none) | macOS can't produce a fully static tmux; use `brew install tmux` (picked up on PATH) |
| darwin/arm64 | **GATED** | (none) | macOS can't produce a fully static tmux; use `brew install tmux` (picked up on PATH) |
| windows/amd64 | **GATED** | (none) | no native static tmux (needs Cygwin/MSYS2); falls back to bare shell |

Filling in a real `URL` + `SHA256` (verified against the actual artifact) in
`internal/tmuxinstall/source.go` flips a platform to installable. linux/amd64 and
linux/arm64 are the realistically vettable targets; macOS/Windows are expected to
stay gated.

## Changes

- `internal/tmuxinstall/source.go` (new): per-platform source+checksum table,
  `Source.vetted()` gating, `Available()`, `CurrentSource()`. Documents the
  sourcing strategy in the package doc.
- `internal/tmuxinstall/install.go` (new): `Installer` with
  `Install()` / `Ensure()`. Downloads (HTTPS-only, size-capped) to a temp file,
  **SHA-256-verifies the download before doing anything else**, extracts the
  tmux binary (raw / gzip / tar.gz / zip), chmods 0755 on Unix, and atomically
  renames it into `tmux.ManagedBinaryPath()`. **Never executes the binary.**
- `internal/tmuxinstall/install_test.go` (new): scoped unit tests for
  verify/extract/gating (raw + tar.gz happy paths, checksum-mismatch refusal,
  gated-source refusal, table invariants). Lives in a separate package so it
  does not pull in the tmux test suite.
- `cmd/tmux.go` (new): `citadel tmux install` (with `--force`) and
  `citadel tmux status`.
- `cmd/work.go`: `ensureManagedTmux()` best-effort hook before the terminal
  server starts — non-fatal, skipped when tmux already resolves or when
  `CITADEL_TMUX_NO_INSTALL=1`/`true`; logs at debug on failure and falls back to
  a bare shell.

## How to test

Build + vet (no `go test` was run against the tmux/terminal suites, and no tmux
session was ever started):

```bash
go build ./...
go vet ./internal/tmuxinstall/ ./internal/tmux/ ./cmd/
```

Behavior (all platforms currently gated, so install reports unavailable):

```bash
# Shows platform, managed path, resolved tmux, and artifact availability
citadel tmux status

# On a gated platform, reports no vetted artifact (does NOT fake an install)
citadel tmux install
```

Once a verified linux artifact is added to `source.go`:
- `citadel tmux install` downloads, checksum-verifies, and installs to
  `~/.citadel/bin/tmux`.
- `citadel work --terminal` auto-provisions it via `ensureManagedTmux()` when no
  system tmux is present, so persistent sessions "just work".
- Set `CITADEL_TMUX_NO_INSTALL=1` to opt out of the startup hook.

## Notes / what's gated

- **All platforms are gated** in this PR (no faked checksums). The plumbing,
  command, and hook are complete and exercised by unit tests with synthetic
  artifacts; flipping a platform on is a one-line table edit once CI publishes a
  verified static tmux artifact.
- The unit test package imports `internal/tmux` only for the pure
  `ManagedBinaryPath()` path helper; it starts no tmux session and runs no tmux
  command.

Refs #302, #303. Closes #304.