### PR TITLE
feat(whatsapp): deploy the WhatsApp bridge as a Citadel community module (CLI + TUI)

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -235,6 +235,7 @@ func runControlCenter() {
 				return config.SaveKeepAwake(platform.ConfigDir(), k)
 			},
 		},
+		WhatsApp: buildWhatsAppCallbacks(),
 	}
 
 	cc := controlcenter.New(cfg)

--- a/cmd/whatsapp.go
+++ b/cmd/whatsapp.go
@@ -1,0 +1,397 @@
+// cmd/whatsapp.go
+//
+// `citadel whatsapp` deploys and manages the WhatsApp (Baileys) bridge as a
+// Citadel community module. The bridge is multi-tenant: one container serves
+// many tenants and the per-tenant X-API-Key is the tenant selector. This
+// command:
+//
+//   - up:      generate the admin secret (if unset), start the bridge + its
+//              Postgres sidecar via docker compose, wait for health, mint a
+//              tenant, then print the api_url / api_key / pairing QR.
+//   - status:  show whether the bridge is running and reachable.
+//   - qr:      re-fetch and print the pairing QR for the provisioned tenant.
+//   - connect: print the api_url + api_key + the whatsapp_connect hint again.
+//   - down:    stop the bridge stack (auth state survives in the named volume).
+//
+// The data-plane key handed to the aceteam `whatsapp_connect` MCP tool is the
+// per-tenant `wab_...` key minted here, NOT the admin secret.
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/network"
+	"github.com/aceteam-ai/citadel-cli/internal/whatsapp"
+	"github.com/aceteam-ai/citadel-cli/services"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+var (
+	waAPIKeyFlag    string // user-supplied ADMIN_API_KEY override
+	waPortFlag      int    // host port to publish the bridge on
+	waProxyFlag     string // optional per-tenant egress proxy
+	waTenantFlag    string // tenant name (display only)
+	waPublicURLFlag string // optional public URL for QR links
+)
+
+var whatsappCmd = &cobra.Command{
+	Use:   "whatsapp",
+	Short: "Deploy and manage the WhatsApp bridge community module",
+	Long: `Deploy the multi-tenant WhatsApp (Baileys) bridge as a Citadel-managed
+community module and link a phone by scanning a pairing QR.
+
+The bridge runs as a two-container stack (bridge + embedded Postgres for
+Baileys auth state) on this node and is reachable by the AceTeam backend over
+the secure mesh network at http://<node-network-ip>:<port>.
+
+Typical flow:
+  citadel whatsapp up           # deploy + start + mint a tenant + show QR
+  # scan the QR with WhatsApp -> Linked Devices -> Link a Device
+  # then register it from aceteam with the whatsapp_connect MCP tool`,
+}
+
+var whatsappUpCmd = &cobra.Command{
+	Use:   "up",
+	Short: "Deploy, start, and provision the WhatsApp bridge",
+	RunE:  runWhatsAppUp,
+}
+
+var whatsappStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show the WhatsApp bridge status",
+	RunE:  runWhatsAppStatus,
+}
+
+var whatsappQRCmd = &cobra.Command{
+	Use:   "qr",
+	Short: "Print the pairing QR for the provisioned tenant",
+	RunE:  runWhatsAppQR,
+}
+
+var whatsappConnectCmd = &cobra.Command{
+	Use:   "connect",
+	Short: "Print the api_url + api_key to register via whatsapp_connect",
+	RunE:  runWhatsAppConnect,
+}
+
+var whatsappDownCmd = &cobra.Command{
+	Use:   "down",
+	Short: "Stop the WhatsApp bridge (auth state is preserved)",
+	RunE:  runWhatsAppDown,
+}
+
+func init() {
+	rootCmd.AddCommand(whatsappCmd)
+	whatsappCmd.AddCommand(whatsappUpCmd)
+	whatsappCmd.AddCommand(whatsappStatusCmd)
+	whatsappCmd.AddCommand(whatsappQRCmd)
+	whatsappCmd.AddCommand(whatsappConnectCmd)
+	whatsappCmd.AddCommand(whatsappDownCmd)
+
+	whatsappUpCmd.Flags().StringVar(&waAPIKeyFlag, "api-key", "",
+		"Admin secret (ADMIN_API_KEY) for the bridge control plane. A strong one is generated if omitted.")
+	whatsappUpCmd.Flags().IntVar(&waPortFlag, "port", whatsapp.DefaultPort, "Host port to publish the bridge on.")
+	whatsappUpCmd.Flags().StringVar(&waProxyFlag, "proxy", "",
+		"Optional egress proxy for the tenant (socks5:// or http(s)://).")
+	whatsappUpCmd.Flags().StringVar(&waTenantFlag, "tenant", "default", "Tenant name (label only).")
+	whatsappUpCmd.Flags().StringVar(&waPublicURLFlag, "public-url", "",
+		"Optional public base URL of the bridge, used only for copy-pasteable QR links.")
+}
+
+// servicesDirForNode resolves the node's services directory, creating the node
+// config skeleton if needed.
+func servicesDirForNode() (string, error) {
+	_, configDir, err := findOrCreateManifest()
+	if err != nil {
+		return "", fmt.Errorf("initialize node configuration: %w", err)
+	}
+	return filepath.Join(configDir, "services"), nil
+}
+
+// bridgeBaseURL returns the loopback base URL the CLI uses to talk to the
+// locally running bridge (the CLI runs on the same host as the container).
+func bridgeBaseURL(port int) string {
+	return fmt.Sprintf("http://127.0.0.1:%d", port)
+}
+
+// meshAPIURL returns the api_url the aceteam backend should use: the node's
+// network (mesh) IP and the published port. Falls back to a placeholder hint
+// if the node is not connected to the network.
+func meshAPIURL(port int) string {
+	ip, err := network.GetGlobalIPv4()
+	if err != nil || ip == "" {
+		return ""
+	}
+	return fmt.Sprintf("http://%s:%d", ip, port)
+}
+
+func runWhatsAppUp(cmd *cobra.Command, args []string) error {
+	servicesDir, err := servicesDirForNode()
+	if err != nil {
+		return err
+	}
+
+	// 1. Materialize the embedded compose file.
+	composePath := whatsapp.ComposePath(servicesDir)
+	if err := os.MkdirAll(servicesDir, 0755); err != nil {
+		return fmt.Errorf("create services dir: %w", err)
+	}
+	if err := os.WriteFile(composePath, []byte(services.WhatsAppBridgeCompose), 0600); err != nil {
+		return fmt.Errorf("write compose file: %w", err)
+	}
+
+	// 2. Load existing env (preserves a previously generated admin key) and fill
+	//    in defaults / overrides.
+	env, err := whatsapp.LoadEnv(servicesDir)
+	if err != nil {
+		return fmt.Errorf("read bridge config: %w", err)
+	}
+
+	adminKey := waAPIKeyFlag
+	if adminKey == "" {
+		adminKey = env["ADMIN_API_KEY"]
+	}
+	if adminKey == "" {
+		adminKey, err = whatsapp.GenerateAdminKey()
+		if err != nil {
+			return err
+		}
+		fmt.Println("🔑 Generated a new admin secret for the bridge control plane.")
+	}
+	env["ADMIN_API_KEY"] = adminKey
+	env["BRIDGE_PORT"] = fmt.Sprintf("%d", waPortFlag)
+	if waProxyFlag != "" {
+		env["DEFAULT_PROXY_URL"] = waProxyFlag
+	}
+	if waPublicURLFlag != "" {
+		env["PUBLIC_URL"] = waPublicURLFlag
+	}
+	if err := whatsapp.SaveEnv(servicesDir, env); err != nil {
+		return fmt.Errorf("write bridge config: %w", err)
+	}
+
+	// 3. Start the stack. We invoke compose directly with --env-file so the
+	//    generated secret and port are sourced (docker compose does not
+	//    auto-load a service-named env file).
+	fmt.Printf("--- 🚀 Starting WhatsApp bridge on port %d ---\n", waPortFlag)
+	if err := composeUp(composePath, whatsapp.EnvPath(servicesDir)); err != nil {
+		return err
+	}
+
+	// 4. Register the service in the node manifest for tracking/lifecycle.
+	if err := addServiceToManifest(filepath.Dir(servicesDir), whatsapp.ServiceName); err != nil {
+		// Non-fatal: the container is up regardless of manifest bookkeeping.
+		fmt.Fprintf(os.Stderr, "   ⚠️ Could not record service in manifest: %v\n", err)
+	}
+
+	// 5. Wait for the bridge to answer.
+	client := whatsapp.NewClient(bridgeBaseURL(waPortFlag), adminKey)
+	fmt.Print("   ⏳ Waiting for the bridge to become ready...")
+	ctx, cancel := context.WithTimeout(cmd.Context(), 90*time.Second)
+	defer cancel()
+	if err := client.WaitReady(ctx, 90*time.Second); err != nil {
+		fmt.Println()
+		return fmt.Errorf("bridge did not become ready: %w\n   Hint: check logs with 'docker logs citadel-whatsapp-bridge'", err)
+	}
+	fmt.Println(" ready.")
+
+	// 6. Mint a tenant (the data-plane api key for whatsapp_connect).
+	tenant, err := client.CreateTenant(ctx, waTenantFlag, waProxyFlag)
+	if err != nil {
+		return fmt.Errorf("provision tenant: %w", err)
+	}
+	// Persist the tenant key locally so `status`/`qr`/`connect` can reuse it.
+	env["TENANT_API_KEY"] = tenant.APIKey
+	env["TENANT_ID"] = tenant.ID
+	env["TENANT_NAME"] = tenant.Name
+	if err := whatsapp.SaveEnv(servicesDir, env); err != nil {
+		fmt.Fprintf(os.Stderr, "   ⚠️ Could not save tenant key locally: %v\n", err)
+	}
+
+	// 7. Show the connect details + pairing QR.
+	printConnectDetails(waPortFlag, tenant.APIKey)
+	fmt.Println()
+	if err := printQR(ctx, client, tenant.APIKey); err != nil {
+		fmt.Fprintf(os.Stderr, "   ⚠️ Could not fetch pairing QR yet: %v\n", err)
+		fmt.Println("   Run 'citadel whatsapp qr' in a moment to retry.")
+	}
+	return nil
+}
+
+func runWhatsAppStatus(cmd *cobra.Command, args []string) error {
+	servicesDir, err := servicesDirForNode()
+	if err != nil {
+		return err
+	}
+	if !whatsapp.IsDeployed(servicesDir) {
+		fmt.Println("WhatsApp bridge is not deployed.")
+		fmt.Println("   Hint: run 'citadel whatsapp up' to deploy it.")
+		return nil
+	}
+	env, _ := whatsapp.LoadEnv(servicesDir)
+	port := portFromEnv(env)
+
+	bold := color.New(color.Bold)
+	bold.Println("WhatsApp bridge")
+
+	running := containerRunning("citadel-whatsapp-bridge")
+	if running {
+		fmt.Printf("  Container: %s\n", color.GreenString("running"))
+	} else {
+		fmt.Printf("  Container: %s\n", color.YellowString("stopped"))
+		fmt.Println("   Hint: run 'citadel whatsapp up' to (re)start it.")
+		return nil
+	}
+
+	client := whatsapp.NewClient(bridgeBaseURL(port), env["ADMIN_API_KEY"])
+	ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
+	defer cancel()
+	if err := client.Root(ctx); err != nil {
+		fmt.Printf("  Reachable: %s (%v)\n", color.YellowString("no"), err)
+		return nil
+	}
+	fmt.Printf("  Reachable: %s\n", color.GreenString("yes"))
+
+	if key := env["TENANT_API_KEY"]; key != "" {
+		if h, err := client.Health(ctx, key); err == nil {
+			loggedIn := color.YellowString("not linked (scan QR)")
+			if h.LoggedIn {
+				loggedIn = color.GreenString("linked")
+			}
+			fmt.Printf("  WhatsApp:  %s\n", loggedIn)
+		}
+	}
+
+	if api := meshAPIURL(port); api != "" {
+		fmt.Printf("  api_url:   %s\n", api)
+	}
+	return nil
+}
+
+func runWhatsAppQR(cmd *cobra.Command, args []string) error {
+	servicesDir, err := servicesDirForNode()
+	if err != nil {
+		return err
+	}
+	env, _ := whatsapp.LoadEnv(servicesDir)
+	key := env["TENANT_API_KEY"]
+	if key == "" {
+		return fmt.Errorf("no provisioned tenant found; run 'citadel whatsapp up' first")
+	}
+	port := portFromEnv(env)
+	client := whatsapp.NewClient(bridgeBaseURL(port), env["ADMIN_API_KEY"])
+	ctx, cancel := context.WithTimeout(cmd.Context(), 15*time.Second)
+	defer cancel()
+	return printQR(ctx, client, key)
+}
+
+func runWhatsAppConnect(cmd *cobra.Command, args []string) error {
+	servicesDir, err := servicesDirForNode()
+	if err != nil {
+		return err
+	}
+	env, _ := whatsapp.LoadEnv(servicesDir)
+	key := env["TENANT_API_KEY"]
+	if key == "" {
+		return fmt.Errorf("no provisioned tenant found; run 'citadel whatsapp up' first")
+	}
+	printConnectDetails(portFromEnv(env), key)
+	return nil
+}
+
+func runWhatsAppDown(cmd *cobra.Command, args []string) error {
+	servicesDir, err := servicesDirForNode()
+	if err != nil {
+		return err
+	}
+	composePath := whatsapp.ComposePath(servicesDir)
+	if !whatsapp.IsDeployed(servicesDir) {
+		fmt.Println("WhatsApp bridge is not deployed; nothing to stop.")
+		return nil
+	}
+	fmt.Println("--- 🛑 Stopping WhatsApp bridge ---")
+	dc := exec.Command("docker", "compose", "-f", composePath, "--env-file", whatsapp.EnvPath(servicesDir), "down")
+	out, err := dc.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("docker compose down failed:\n%s", strings.TrimSpace(string(out)))
+	}
+	fmt.Println("✅ WhatsApp bridge stopped. Auth state is preserved in the 'whatsapp_pgdata' volume.")
+	return nil
+}
+
+// composeUp runs `docker compose -f <compose> --env-file <env> up -d`.
+func composeUp(composePath, envPath string) error {
+	dc := exec.Command("docker", "compose", "-f", composePath, "--env-file", envPath, "up", "-d")
+	out, err := dc.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("docker compose up failed:\n%s\n   Hint: is Docker running? Check with 'docker info'", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// containerRunning reports whether a named container is in the running state.
+func containerRunning(name string) bool {
+	out, err := exec.Command("docker", "inspect", "--format", "{{.State.Status}}", name).Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) == "running"
+}
+
+// portFromEnv extracts the configured bridge port, defaulting to DefaultPort.
+func portFromEnv(env map[string]string) int {
+	if v := env["BRIDGE_PORT"]; v != "" {
+		var p int
+		if _, err := fmt.Sscanf(v, "%d", &p); err == nil && p > 0 {
+			return p
+		}
+	}
+	return whatsapp.DefaultPort
+}
+
+// printConnectDetails prints the api_url + api_key and the whatsapp_connect hint.
+func printConnectDetails(port int, apiKey string) {
+	bold := color.New(color.Bold)
+	fmt.Println()
+	bold.Println("Register this bridge in AceTeam:")
+
+	apiURL := meshAPIURL(port)
+	if apiURL == "" {
+		apiURL = fmt.Sprintf("http://<this-node-network-ip>:%d", port)
+		fmt.Println(color.YellowString("  (node is not connected to the AceTeam Network -- substitute its mesh IP below)"))
+	}
+	fmt.Printf("  api_url:  %s\n", color.CyanString(apiURL))
+	fmt.Printf("  api_key:  %s\n", color.CyanString(apiKey))
+	fmt.Println()
+	fmt.Println("  In AceTeam, call the whatsapp_connect MCP tool with the values above:")
+	fmt.Printf("    whatsapp_connect(api_url=%q, api_key=%q)\n", apiURL, apiKey)
+	fmt.Println()
+	fmt.Println(color.YellowString("  Note: the bridge is on the private mesh, so the AceTeam backend must run with"))
+	fmt.Println(color.YellowString("        WHATSAPP_ALLOW_PRIVATE_NETWORK=true to dial it. If you expose the bridge"))
+	fmt.Println(color.YellowString("        on a public hostname instead, that backend flag is not needed."))
+}
+
+// printQR fetches and renders the pairing QR for a tenant.
+func printQR(ctx context.Context, client *whatsapp.Client, apiKey string) error {
+	payload, err := client.QRString(ctx, apiKey)
+	if err != nil {
+		return err
+	}
+	if payload == "" {
+		fmt.Println("✅ This tenant is already linked to WhatsApp -- no QR needed.")
+		return nil
+	}
+	bold := color.New(color.Bold)
+	bold.Println("Scan this QR to link WhatsApp:")
+	fmt.Println("  (WhatsApp -> Settings -> Linked Devices -> Link a Device)")
+	fmt.Println()
+	fmt.Println(whatsapp.RenderQRANSI(payload))
+	return nil
+}

--- a/cmd/whatsapp.go
+++ b/cmd/whatsapp.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/network"
+	"github.com/aceteam-ai/citadel-cli/internal/tui/controlcenter"
 	"github.com/aceteam-ai/citadel-cli/internal/whatsapp"
 	"github.com/aceteam-ai/citadel-cli/services"
 	"github.com/fatih/color"
@@ -376,6 +377,89 @@ func printConnectDetails(port int, apiKey string) {
 	fmt.Println(color.YellowString("  Note: the bridge is on the private mesh, so the AceTeam backend must run with"))
 	fmt.Println(color.YellowString("        WHATSAPP_ALLOW_PRIVATE_NETWORK=true to dial it. If you expose the bridge"))
 	fmt.Println(color.YellowString("        on a public hostname instead, that backend flag is not needed."))
+}
+
+// buildWhatsAppCallbacks wires the WhatsApp page's lifecycle hooks to the same
+// node-config + bridge-client logic the CLI uses, so the TUI and CLI stay in
+// lockstep. All hooks are best-effort and never panic.
+func buildWhatsAppCallbacks() controlcenter.WhatsAppCallbacks {
+	return controlcenter.WhatsAppCallbacks{
+		Status: func() controlcenter.WhatsAppStatus {
+			st := controlcenter.WhatsAppStatus{}
+			servicesDir, err := servicesDirForNode()
+			if err != nil {
+				st.Err = err.Error()
+				return st
+			}
+			st.Deployed = whatsapp.IsDeployed(servicesDir)
+			if !st.Deployed {
+				return st
+			}
+			env, _ := whatsapp.LoadEnv(servicesDir)
+			port := portFromEnv(env)
+			st.APIKey = env["TENANT_API_KEY"]
+			st.APIURL = meshAPIURL(port)
+			st.Running = containerRunning("citadel-whatsapp-bridge")
+			if !st.Running {
+				return st
+			}
+			client := whatsapp.NewClient(bridgeBaseURL(port), env["ADMIN_API_KEY"])
+			ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+			defer cancel()
+			if err := client.Root(ctx); err != nil {
+				return st
+			}
+			st.Reachable = true
+			if st.APIKey != "" {
+				if h, err := client.Health(ctx, st.APIKey); err == nil {
+					st.LoggedIn = h.LoggedIn
+				}
+			}
+			return st
+		},
+		Deploy: func() (string, string, error) {
+			// Reset deploy flags to their declared defaults so a TUI-driven
+			// deploy is deterministic regardless of any prior CLI invocation.
+			waAPIKeyFlag = ""
+			waPortFlag = whatsapp.DefaultPort
+			waProxyFlag = ""
+			waTenantFlag = "default"
+			waPublicURLFlag = ""
+
+			if err := runWhatsAppUp(whatsappUpCmd, nil); err != nil {
+				return "", "", err
+			}
+			servicesDir, err := servicesDirForNode()
+			if err != nil {
+				return "", "", err
+			}
+			env, _ := whatsapp.LoadEnv(servicesDir)
+			return meshAPIURL(portFromEnv(env)), env["TENANT_API_KEY"], nil
+		},
+		Stop: func() error {
+			return runWhatsAppDown(whatsappDownCmd, nil)
+		},
+		QRBlocks: func() (string, error) {
+			servicesDir, err := servicesDirForNode()
+			if err != nil {
+				return "", err
+			}
+			env, _ := whatsapp.LoadEnv(servicesDir)
+			key := env["TENANT_API_KEY"]
+			if key == "" {
+				return "", fmt.Errorf("no provisioned tenant")
+			}
+			port := portFromEnv(env)
+			client := whatsapp.NewClient(bridgeBaseURL(port), env["ADMIN_API_KEY"])
+			ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+			defer cancel()
+			payload, err := client.QRString(ctx, key)
+			if err != nil {
+				return "", err
+			}
+			return whatsapp.RenderQRBlocks(payload), nil
+		},
+	}
 }
 
 // printQR fetches and renders the pairing QR for a tenant.

--- a/cmd/whatsapp.go
+++ b/cmd/whatsapp.go
@@ -40,6 +40,7 @@ var (
 	waProxyFlag     string // optional per-tenant egress proxy
 	waTenantFlag    string // tenant name (display only)
 	waPublicURLFlag string // optional public URL for QR links
+	waImageFlag     string // optional override for the bridge container image
 )
 
 var whatsappCmd = &cobra.Command{
@@ -104,6 +105,8 @@ func init() {
 	whatsappUpCmd.Flags().StringVar(&waTenantFlag, "tenant", "default", "Tenant name (label only).")
 	whatsappUpCmd.Flags().StringVar(&waPublicURLFlag, "public-url", "",
 		"Optional public base URL of the bridge, used only for copy-pasteable QR links.")
+	whatsappUpCmd.Flags().StringVar(&waImageFlag, "image", "",
+		"Override the bridge container image (default: ghcr.io/aceteam-ai/whatsapp-bridge:latest).")
 }
 
 // servicesDirForNode resolves the node's services directory, creating the node
@@ -123,12 +126,27 @@ func bridgeBaseURL(port int) string {
 }
 
 // meshAPIURL returns the api_url the aceteam backend should use: the node's
-// network (mesh) IP and the published port. Falls back to a placeholder hint
-// if the node is not connected to the network.
+// network (mesh) IP and the published port. Returns "" if the node is not
+// connected to the network. It primes the network singleton first (mirroring
+// status.go) so it works from a fresh process where the global server has not
+// yet been initialized.
 func meshAPIURL(port int) string {
+	if !network.HasState() {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	// VerifyOrReconnect initializes the global server if needed.
+	network.VerifyOrReconnect(ctx)
+
 	ip, err := network.GetGlobalIPv4()
 	if err != nil || ip == "" {
-		return ""
+		// Fall back to the status snapshot, which also primes the singleton.
+		if st, serr := network.GetGlobalStatus(ctx); serr == nil && st.IPv4 != "" {
+			ip = st.IPv4
+		} else {
+			return ""
+		}
 	}
 	return fmt.Sprintf("http://%s:%d", ip, port)
 }
@@ -168,6 +186,9 @@ func runWhatsAppUp(cmd *cobra.Command, args []string) error {
 	}
 	env["ADMIN_API_KEY"] = adminKey
 	env["BRIDGE_PORT"] = fmt.Sprintf("%d", waPortFlag)
+	if waImageFlag != "" {
+		env["BRIDGE_IMAGE"] = waImageFlag
+	}
 	if waProxyFlag != "" {
 		env["DEFAULT_PROXY_URL"] = waProxyFlag
 	}
@@ -186,11 +207,13 @@ func runWhatsAppUp(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// 4. Register the service in the node manifest for tracking/lifecycle.
-	if err := addServiceToManifest(filepath.Dir(servicesDir), whatsapp.ServiceName); err != nil {
-		// Non-fatal: the container is up regardless of manifest bookkeeping.
-		fmt.Fprintf(os.Stderr, "   ⚠️ Could not record service in manifest: %v\n", err)
-	}
+	// The bridge is deliberately NOT added to the node manifest. The generic
+	// `citadel run`/`citadel work` start path runs `docker compose up` without
+	// an --env-file, but this stack hard-requires ADMIN_API_KEY (and docker
+	// compose only auto-loads a file literally named ".env"). Registering it
+	// would make those commands fail. The bridge has its own lifecycle via
+	// `citadel whatsapp up/down`; status discovery uses the compose-file
+	// presence + container state, not the manifest.
 
 	// 5. Wait for the bridge to answer.
 	client := whatsapp.NewClient(bridgeBaseURL(waPortFlag), adminKey)
@@ -203,23 +226,31 @@ func runWhatsAppUp(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Println(" ready.")
 
-	// 6. Mint a tenant (the data-plane api key for whatsapp_connect).
-	tenant, err := client.CreateTenant(ctx, waTenantFlag, waProxyFlag)
-	if err != nil {
-		return fmt.Errorf("provision tenant: %w", err)
-	}
-	// Persist the tenant key locally so `status`/`qr`/`connect` can reuse it.
-	env["TENANT_API_KEY"] = tenant.APIKey
-	env["TENANT_ID"] = tenant.ID
-	env["TENANT_NAME"] = tenant.Name
-	if err := whatsapp.SaveEnv(servicesDir, env); err != nil {
-		fmt.Fprintf(os.Stderr, "   ⚠️ Could not save tenant key locally: %v\n", err)
+	// 6. Provision a tenant (the data-plane api key for whatsapp_connect). If
+	//    one was already minted on a previous `up`, reuse it -- minting a fresh
+	//    tenant would orphan the already-linked WhatsApp session and rotate the
+	//    api_key the user already registered.
+	tenantKey := env["TENANT_API_KEY"]
+	if tenantKey == "" {
+		tenant, err := client.CreateTenant(ctx, waTenantFlag, waProxyFlag)
+		if err != nil {
+			return fmt.Errorf("provision tenant: %w", err)
+		}
+		tenantKey = tenant.APIKey
+		env["TENANT_API_KEY"] = tenant.APIKey
+		env["TENANT_ID"] = tenant.ID
+		env["TENANT_NAME"] = tenant.Name
+		if err := whatsapp.SaveEnv(servicesDir, env); err != nil {
+			fmt.Fprintf(os.Stderr, "   ⚠️ Could not save tenant key locally: %v\n", err)
+		}
+	} else {
+		fmt.Println("   ℹ️  Reusing the existing tenant (its linked session and api_key are preserved).")
 	}
 
 	// 7. Show the connect details + pairing QR.
-	printConnectDetails(waPortFlag, tenant.APIKey)
+	printConnectDetails(waPortFlag, tenantKey)
 	fmt.Println()
-	if err := printQR(ctx, client, tenant.APIKey); err != nil {
+	if err := printQR(ctx, client, tenantKey); err != nil {
 		fmt.Fprintf(os.Stderr, "   ⚠️ Could not fetch pairing QR yet: %v\n", err)
 		fmt.Println("   Run 'citadel whatsapp qr' in a moment to retry.")
 	}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/hashicorp/go-version v1.8.0
 	github.com/mattn/go-runewidth v0.0.19
+	github.com/mdp/qrterminal/v3 v3.2.1
 	github.com/redis/go-redis/v9 v9.17.2
 	github.com/rivo/tview v0.42.0
 	github.com/shirou/gopsutil/v3 v3.24.5
@@ -69,7 +70,6 @@ require (
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mdlayher/netlink v1.7.3-0.20250113171957-fbb4dce95f42 // indirect
 	github.com/mdlayher/socket v0.5.0 // indirect
-	github.com/mdp/qrterminal/v3 v3.2.1 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -64,11 +64,12 @@ require (
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
-	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mdlayher/netlink v1.7.3-0.20250113171957-fbb4dce95f42 // indirect
 	github.com/mdlayher/socket v0.5.0 // indirect
+	github.com/mdp/qrterminal/v3 v3.2.1 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
@@ -107,6 +108,7 @@ require (
 	modernc.org/libc v1.67.6 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
+	rsc.io/qr v0.2.0 // indirect
 )
 
 replace github.com/gdamore/tcell/v2 => ./patches/tcell/v2

--- a/go.sum
+++ b/go.sum
@@ -179,11 +179,8 @@ github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQ
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
-github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
-github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
-github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-localereader v0.0.1 h1:ygSAOl7ZXTx4RdPYinUpg6W99U8jWvWi9Ye2JC/oIi4=
@@ -342,7 +339,6 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220817070843-5a390386f1f2/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -181,6 +181,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
+github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
+github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
@@ -196,6 +198,8 @@ github.com/mdlayher/sdnotify v1.0.0 h1:Ma9XeLVN/l0qpyx1tNeMSeTjCPH6NtuD6/N9XdTlQ
 github.com/mdlayher/sdnotify v1.0.0/go.mod h1:HQUmpM4XgYkhDLtd+Uad8ZFK1T9D5+pNxnXQjCeJlGE=
 github.com/mdlayher/socket v0.5.0 h1:ilICZmJcQz70vrWVes1MFera4jGiWNocSkykwwoy3XI=
 github.com/mdlayher/socket v0.5.0/go.mod h1:WkcBFfvyG8QENs5+hfQPl1X6Jpd2yeLIYgrGFmJiJxI=
+github.com/mdp/qrterminal/v3 v3.2.1 h1:6+yQjiiOsSuXT5n9/m60E54vdgFsw0zhADHhHLrFet4=
+github.com/mdp/qrterminal/v3 v3.2.1/go.mod h1:jOTmXvnBsMy5xqLniO0R++Jmjs2sTm9dFSuQ5kpz/SU=
 github.com/miekg/dns v1.1.58 h1:ca2Hdkz+cDg/7eNF6V56jjzuZ4aCAE+DbVkILdQWG/4=
 github.com/miekg/dns v1.1.58/go.mod h1:Ypv+3b/KadlvW9vJfXOTf300O4UqaHFzFCuHz+rPkBY=
 github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
@@ -413,6 +417,8 @@ modernc.org/strutil v1.2.1 h1:UneZBkQA+DX2Rp35KcM69cSsNES9ly8mQWD71HKlOA0=
 modernc.org/strutil v1.2.1/go.mod h1:EHkiggD70koQxjVdSBM3JKM7k6L0FbGE5eymy9i3B9A=
 modernc.org/token v1.1.0 h1:Xl7Ap9dKaEs5kLoOQeQmPWevfnk/DM5qcLcYlA8ys6Y=
 modernc.org/token v1.1.0/go.mod h1:UGzOrNV1mAFSEB63lOFHIpNRUVMvYTc6yu1SMY/XTDM=
+rsc.io/qr v0.2.0 h1:6vBLea5/NRMVTz8V66gipeLycZMl/+UlFmk8DvqQ6WY=
+rsc.io/qr v0.2.0/go.mod h1:IF+uZjkb9fqyeF/4tlBoynqmQxUoPfWEKh921coOuXs=
 software.sslmate.com/src/go-pkcs12 v0.4.0 h1:H2g08FrTvSFKUj+D309j1DPfk5APnIdAQAB8aEykJ5k=
 software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=
 tailscale.com v1.100.0 h1:nm/M/dEaW9RaRsGUjW2HsSDpsZ60Jwd9k4gNW9tTFiE=

--- a/internal/tui/controlcenter/controlcenter.go
+++ b/internal/tui/controlcenter/controlcenter.go
@@ -426,6 +426,9 @@ type ControlCenter struct {
 
 	// Settings
 	settingsConfig SettingsCallbacks // Settings page hooks (telemetry load/save)
+
+	// WhatsApp
+	whatsappConfig WhatsAppCallbacks // WhatsApp bridge page hooks (deploy/stop/status/QR)
 }
 
 // Pane focus constants
@@ -491,6 +494,7 @@ type Config struct {
 	Chat               ChatPageConfig                           // Chat page configuration (empty = disabled)
 	Proxmox            ProxmoxConfig                            // Proxmox page configuration (empty = disabled)
 	Settings           SettingsCallbacks                        // Settings page hooks (telemetry load/save)
+	WhatsApp           WhatsAppCallbacks                        // WhatsApp bridge page hooks (deploy/stop/status/QR)
 }
 
 // ProxmoxConfig holds configuration for the Proxmox TUI page.
@@ -528,6 +532,7 @@ func New(cfg Config) *ControlCenter {
 		chatConfig:         cfg.Chat,
 		proxmoxConfig:      cfg.Proxmox,
 		settingsConfig:     cfg.Settings,
+		whatsappConfig:     cfg.WhatsApp,
 	}
 }
 
@@ -630,6 +635,12 @@ func (cc *ControlCenter) Run() error {
 			NodeName:   cc.proxmoxConfig.NodeName,
 			ActivityFn: cc.AddActivity,
 		}), true)
+	}
+
+	// WhatsApp bridge page: deploy/start/stop the community module and show the
+	// pairing QR. Visible only when the host wired the lifecycle callbacks.
+	if cc.whatsappConfig.Status != nil {
+		cc.pmgr.Register(NewWhatsAppPage(cc.whatsappConfig), true)
 	}
 
 	// Settings page (Alt+5): telemetry opt-out + read-only connection status.

--- a/internal/tui/controlcenter/whatsapp_page.go
+++ b/internal/tui/controlcenter/whatsapp_page.go
@@ -1,0 +1,354 @@
+package controlcenter
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+// WhatsAppStatus is a snapshot of the bridge module state, produced by the
+// WhatsAppCallbacks.Status hook (wired from cmd so this page never imports
+// node-config/network/docker logic directly).
+type WhatsAppStatus struct {
+	// Deployed is true once the bridge compose file has been materialized.
+	Deployed bool
+	// Running is true when the bridge container is in the running state.
+	Running bool
+	// Reachable is true when GET / returns 200.
+	Reachable bool
+	// LoggedIn is true when the provisioned tenant is linked to WhatsApp.
+	LoggedIn bool
+	// APIURL is the mesh api_url the aceteam backend should register, or "".
+	APIURL string
+	// APIKey is the provisioned tenant's data-plane key, or "".
+	APIKey string
+	// Err is a human-readable error from the most recent probe, or "".
+	Err string
+}
+
+// WhatsAppCallbacks holds the lifecycle hooks for the WhatsApp page. They are
+// wired from cmd so the page stays free of platform/docker/network imports.
+type WhatsAppCallbacks struct {
+	// Status returns the current bridge state (fast, read-only).
+	Status func() WhatsAppStatus
+	// Deploy deploys+starts the bridge and provisions a tenant, returning the
+	// api_url + api_key. It may block for up to ~90s; the page calls it off the
+	// UI goroutine.
+	Deploy func() (apiURL, apiKey string, err error)
+	// Stop stops the bridge stack (auth state is preserved).
+	Stop func() error
+	// QRBlocks returns the pairing QR rendered as plain block characters (no
+	// ANSI), suitable for a TextView, or "" if the tenant is already linked.
+	QRBlocks func() (string, error)
+}
+
+// WhatsAppPage implements the Page interface for the WhatsApp bridge tab. It
+// shows deploy/start/stop controls, the connect details (api_url + api_key),
+// and the pairing QR so a phone can be linked without leaving the TUI.
+type WhatsAppPage struct {
+	app *tview.Application
+	cb  WhatsAppCallbacks
+
+	// UI
+	root      *tview.Flex
+	statusBox *tview.TextView
+	qrBox     *tview.TextView
+
+	// State
+	mu      sync.Mutex
+	status  WhatsAppStatus
+	qr      string
+	busy    bool   // an action (deploy/stop) is in flight
+	busyMsg string // label shown while busy
+	active  bool
+	stopCh  chan struct{}
+}
+
+// NewWhatsAppPage creates a WhatsApp bridge page wired to the given callbacks.
+func NewWhatsAppPage(cb WhatsAppCallbacks) *WhatsAppPage {
+	return &WhatsAppPage{cb: cb}
+}
+
+// Name implements Page.
+func (p *WhatsAppPage) Name() string { return "whatsapp" }
+
+// Title implements Page.
+func (p *WhatsAppPage) Title() string { return "WhatsApp" }
+
+// Build implements Page.
+func (p *WhatsAppPage) Build(app *tview.Application) tview.Primitive {
+	p.app = app
+
+	p.statusBox = tview.NewTextView()
+	p.statusBox.SetDynamicColors(true)
+	p.statusBox.SetScrollable(true)
+	p.statusBox.SetBorder(true)
+	p.statusBox.SetTitle(" WhatsApp Bridge ")
+	p.statusBox.SetTitleAlign(tview.AlignLeft)
+
+	p.qrBox = tview.NewTextView()
+	p.qrBox.SetDynamicColors(false)
+	p.qrBox.SetScrollable(true)
+	p.qrBox.SetBorder(true)
+	p.qrBox.SetTitle(" Pairing QR ")
+	p.qrBox.SetTitleAlign(tview.AlignLeft)
+
+	p.root = tview.NewFlex().SetDirection(tview.FlexColumn).
+		AddItem(p.statusBox, 0, 1, true).
+		AddItem(p.qrBox, 0, 1, false)
+
+	p.render()
+	return p.root
+}
+
+// OnActivate implements Page.
+func (p *WhatsAppPage) OnActivate() {
+	p.mu.Lock()
+	p.active = true
+	p.stopCh = make(chan struct{})
+	p.mu.Unlock()
+
+	go p.refresh()
+	go p.pollLoop()
+
+	if p.app != nil && p.statusBox != nil {
+		p.app.SetFocus(p.statusBox)
+	}
+}
+
+// OnDeactivate implements Page.
+func (p *WhatsAppPage) OnDeactivate() {
+	p.mu.Lock()
+	p.active = false
+	if p.stopCh != nil {
+		close(p.stopCh)
+		p.stopCh = nil
+	}
+	p.mu.Unlock()
+}
+
+// HandleInput implements Page. u=deploy/start, d=stop, q=refresh QR, r=refresh.
+func (p *WhatsAppPage) HandleInput(event *tcell.EventKey) *tcell.EventKey {
+	if event.Key() != tcell.KeyRune {
+		return event
+	}
+	switch event.Rune() {
+	case 'u', 'U':
+		p.doDeploy()
+		return nil
+	case 'd', 'D':
+		p.doStop()
+		return nil
+	case 'q', 'Q':
+		go p.refreshQR()
+		return nil
+	case 'r', 'R':
+		go p.refresh()
+		return nil
+	}
+	return event
+}
+
+// pollLoop refreshes status every 3 seconds while the page is active.
+func (p *WhatsAppPage) pollLoop() {
+	ticker := time.NewTicker(3 * time.Second)
+	defer ticker.Stop()
+	for {
+		p.mu.Lock()
+		stopCh := p.stopCh
+		p.mu.Unlock()
+		if stopCh == nil {
+			return
+		}
+		select {
+		case <-stopCh:
+			return
+		case <-ticker.C:
+			p.refresh()
+		}
+	}
+}
+
+// refresh probes status (and QR if not linked) and redraws.
+func (p *WhatsAppPage) refresh() {
+	if p.cb.Status == nil {
+		return
+	}
+	st := p.cb.Status()
+
+	p.mu.Lock()
+	p.status = st
+	busy := p.busy
+	p.mu.Unlock()
+
+	// Refresh the QR opportunistically when reachable and not yet linked.
+	if !busy && st.Reachable && !st.LoggedIn {
+		p.refreshQR()
+	} else if st.LoggedIn {
+		p.mu.Lock()
+		p.qr = ""
+		p.mu.Unlock()
+	}
+	p.queueRender()
+}
+
+// refreshQR fetches and stores the QR blocks.
+func (p *WhatsAppPage) refreshQR() {
+	if p.cb.QRBlocks == nil {
+		return
+	}
+	qr, err := p.cb.QRBlocks()
+	p.mu.Lock()
+	if err != nil {
+		p.qr = ""
+	} else {
+		p.qr = qr
+	}
+	p.mu.Unlock()
+	p.queueRender()
+}
+
+// doDeploy runs the deploy action off the UI goroutine.
+func (p *WhatsAppPage) doDeploy() {
+	p.mu.Lock()
+	if p.busy {
+		p.mu.Unlock()
+		return
+	}
+	p.busy = true
+	p.busyMsg = "Deploying bridge (this can take ~30-90s on first run)..."
+	p.mu.Unlock()
+	p.queueRender()
+
+	go func() {
+		var err error
+		if p.cb.Deploy != nil {
+			_, _, err = p.cb.Deploy()
+		}
+		p.mu.Lock()
+		p.busy = false
+		p.busyMsg = ""
+		if err != nil {
+			p.status.Err = err.Error()
+		}
+		p.mu.Unlock()
+		p.refresh()
+	}()
+}
+
+// doStop runs the stop action off the UI goroutine.
+func (p *WhatsAppPage) doStop() {
+	p.mu.Lock()
+	if p.busy {
+		p.mu.Unlock()
+		return
+	}
+	p.busy = true
+	p.busyMsg = "Stopping bridge..."
+	p.mu.Unlock()
+	p.queueRender()
+
+	go func() {
+		var err error
+		if p.cb.Stop != nil {
+			err = p.cb.Stop()
+		}
+		p.mu.Lock()
+		p.busy = false
+		p.busyMsg = ""
+		p.qr = ""
+		if err != nil {
+			p.status.Err = err.Error()
+		}
+		p.mu.Unlock()
+		p.refresh()
+	}()
+}
+
+// queueRender redraws on the UI goroutine if the page is live.
+func (p *WhatsAppPage) queueRender() {
+	if p.app == nil {
+		return
+	}
+	p.app.QueueUpdateDraw(func() { p.render() })
+}
+
+// render redraws the status and QR panes from current state.
+func (p *WhatsAppPage) render() {
+	if p.statusBox == nil || p.qrBox == nil {
+		return
+	}
+	p.mu.Lock()
+	st := p.status
+	qr := p.qr
+	busy := p.busy
+	busyMsg := p.busyMsg
+	p.mu.Unlock()
+
+	var sb strings.Builder
+	sb.WriteString("\n [yellow::b]WhatsApp Bridge[-:-:-]  [gray](community module)[-]\n\n")
+
+	// State line.
+	switch {
+	case !st.Deployed:
+		sb.WriteString("   Status:  [gray]not deployed[-]\n")
+	case st.Running && st.Reachable:
+		sb.WriteString("   Status:  [green::b]● running[-:-:-]\n")
+	case st.Running:
+		sb.WriteString("   Status:  [yellow::b]◐ starting[-:-:-]\n")
+	default:
+		sb.WriteString("   Status:  [red::b]○ stopped[-:-:-]\n")
+	}
+
+	if st.Deployed && st.Reachable {
+		if st.LoggedIn {
+			sb.WriteString("   Phone:   [green::b]linked[-:-:-]\n")
+		} else {
+			sb.WriteString("   Phone:   [yellow]not linked -- scan the QR ➜[-]\n")
+		}
+	}
+
+	// Connect details.
+	if st.APIURL != "" || st.APIKey != "" {
+		sb.WriteString("\n [white::b]Register in AceTeam[-:-:-]\n")
+		if st.APIURL != "" {
+			sb.WriteString(fmt.Sprintf("   api_url:  [aqua]%s[-]\n", st.APIURL))
+		}
+		if st.APIKey != "" {
+			sb.WriteString(fmt.Sprintf("   api_key:  [aqua]%s[-]\n", st.APIKey))
+		}
+		sb.WriteString("   [gray]Call whatsapp_connect(api_url, api_key) in AceTeam.[-]\n")
+		sb.WriteString("   [yellow]Backend needs WHATSAPP_ALLOW_PRIVATE_NETWORK=true[-]\n")
+		sb.WriteString("   [yellow]to reach the bridge over the private mesh.[-]\n")
+	}
+
+	// Busy / error.
+	if busy {
+		sb.WriteString(fmt.Sprintf("\n   [yellow]⏳ %s[-]\n", tview.Escape(busyMsg)))
+	}
+	if st.Err != "" && !busy {
+		sb.WriteString(fmt.Sprintf("\n   [red]%s[-]\n", tview.Escape(st.Err)))
+	}
+
+	// Controls.
+	sb.WriteString("\n [gray]──────────────────────────────[-]\n")
+	sb.WriteString("   [yellow::b]u[-:-:-] deploy/start    [yellow::b]d[-:-:-] stop\n")
+	sb.WriteString("   [yellow::b]q[-:-:-] refresh QR       [yellow::b]r[-:-:-] refresh\n")
+
+	p.statusBox.SetText(sb.String())
+
+	// QR pane.
+	if qr != "" {
+		p.qrBox.SetText("\n  Scan with WhatsApp ▸ Linked Devices ▸ Link a Device:\n\n" + qr)
+	} else if st.LoggedIn {
+		p.qrBox.SetText("\n  [linked] No QR needed -- this number is connected.")
+	} else if st.Deployed && st.Reachable {
+		p.qrBox.SetText("\n  Generating QR... press q to refresh.")
+	} else {
+		p.qrBox.SetText("\n  Deploy the bridge (press u) to generate a pairing QR.")
+	}
+}

--- a/internal/whatsapp/bridge.go
+++ b/internal/whatsapp/bridge.go
@@ -1,0 +1,279 @@
+// Package whatsapp manages the WhatsApp (Baileys) bridge community module:
+// generating its admin secret, talking to its REST control plane to mint a
+// tenant, polling health, and fetching the pairing QR. The logic is shared by
+// the `citadel whatsapp` CLI command and the control-center TUI page so both
+// surface an identical deploy -> pair -> connect flow.
+//
+// The bridge (sunapi386/whatsapp-bridge) is multi-tenant: one shared bridge
+// serves many tenants and the per-tenant `X-API-Key` is the tenant selector.
+// The `/admin/*` control plane is guarded by a separate `X-Admin-Key`
+// (ADMIN_API_KEY) which the operator holds. The data-plane key handed to the
+// aceteam `whatsapp_connect` MCP tool is the per-tenant `wab_...` key minted
+// here, NOT the admin key.
+package whatsapp
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/mdp/qrterminal/v3"
+)
+
+// ServiceName is the canonical catalog/service name for the bridge module.
+const ServiceName = "whatsapp-bridge"
+
+// DefaultPort is the bridge's published REST port.
+const DefaultPort = 8080
+
+// EnvFileName is the env file the CLI writes next to the compose file. It holds
+// the generated ADMIN_API_KEY and other compose variables. It is written 0600
+// because it contains the admin secret.
+const EnvFileName = "whatsapp-bridge.env"
+
+// httpTimeout bounds every bridge HTTP call so a wedged bridge never hangs the
+// CLI or the TUI's poll loop.
+const httpTimeout = 10 * time.Second
+
+// Client talks to a running bridge over HTTP. BaseURL is the bridge's reachable
+// address (e.g. http://100.64.0.5:8080); AdminKey is the X-Admin-Key for the
+// /admin/* control plane.
+type Client struct {
+	BaseURL  string
+	AdminKey string
+	HTTP     *http.Client
+}
+
+// NewClient builds a Client for a bridge at baseURL with the given admin key.
+func NewClient(baseURL, adminKey string) *Client {
+	return &Client{
+		BaseURL:  strings.TrimRight(baseURL, "/"),
+		AdminKey: adminKey,
+		HTTP:     &http.Client{Timeout: httpTimeout},
+	}
+}
+
+// Tenant is the response from minting a tenant via POST /admin/tenants. APIKey
+// is the per-tenant data-plane key (`wab_...`) the operator passes to
+// whatsapp_connect. It is shown once and not retrievable later.
+type Tenant struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	APIKey string `json:"api_key"`
+	QRURL  string `json:"qr_url"`
+	Note   string `json:"note"`
+}
+
+// Health is the response from GET /health (per-tenant, X-API-Key auth).
+type Health struct {
+	Status    string `json:"status"`
+	Connected bool   `json:"connected"`
+	LoggedIn  bool   `json:"logged_in"`
+}
+
+// GenerateAdminKey returns a strong random hex secret suitable for ADMIN_API_KEY.
+func GenerateAdminKey() (string, error) {
+	b := make([]byte, 24) // 192 bits
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate admin key: %w", err)
+	}
+	return "wab_admin_" + hex.EncodeToString(b), nil
+}
+
+// Root pings the unauthenticated GET / endpoint, which returns 200 once the
+// bridge process is up. Used as the readiness probe after `docker compose up`.
+func (c *Client) Root(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+"/", nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("bridge root returned HTTP %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// WaitReady polls GET / until it returns 200 or the timeout elapses.
+func (c *Client) WaitReady(ctx context.Context, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		callCtx, cancel := context.WithTimeout(ctx, httpTimeout)
+		err := c.Root(callCtx)
+		cancel()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+	if lastErr != nil {
+		return fmt.Errorf("bridge did not become ready within %s: %w", timeout, lastErr)
+	}
+	return fmt.Errorf("bridge did not become ready within %s", timeout)
+}
+
+// CreateTenant mints a tenant (and its data-plane API key) via the admin control
+// plane. proxyURL is optional (per-tenant egress proxy); pass "" for none.
+func (c *Client) CreateTenant(ctx context.Context, name, proxyURL string) (*Tenant, error) {
+	if c.AdminKey == "" {
+		return nil, fmt.Errorf("admin key is required to create a tenant")
+	}
+	payload := map[string]string{"name": name}
+	if proxyURL != "" {
+		payload["proxy_url"] = proxyURL
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/admin/tenants", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Admin-Key", c.AdminKey)
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	data, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("create tenant failed (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(data)))
+	}
+	var t Tenant
+	if err := json.Unmarshal(data, &t); err != nil {
+		return nil, fmt.Errorf("decode tenant response: %w", err)
+	}
+	if t.APIKey == "" {
+		return nil, fmt.Errorf("bridge returned an empty api_key")
+	}
+	return &t, nil
+}
+
+// ListTenants returns the existing tenants from GET /admin/tenants. The admin
+// list never exposes api_key, so this is for status/QR re-fetch by tenant id.
+func (c *Client) ListTenants(ctx context.Context) ([]map[string]any, error) {
+	if c.AdminKey == "" {
+		return nil, fmt.Errorf("admin key is required to list tenants")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+"/admin/tenants", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-Admin-Key", c.AdminKey)
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	data, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("list tenants failed (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(data)))
+	}
+	var out []map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("decode tenants: %w", err)
+	}
+	return out, nil
+}
+
+// Health fetches GET /health for a tenant using its data-plane api key.
+func (c *Client) Health(ctx context.Context, apiKey string) (*Health, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+"/health", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-API-Key", apiKey)
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	data, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("health failed (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(data)))
+	}
+	var h Health
+	if err := json.Unmarshal(data, &h); err != nil {
+		return nil, fmt.Errorf("decode health: %w", err)
+	}
+	return &h, nil
+}
+
+// QRString fetches the raw QR payload from GET /qr.txt for a tenant. The bridge
+// returns an empty string when the tenant is already logged in (no QR needed).
+func (c *Client) QRString(ctx context.Context, apiKey string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+"/qr.txt", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("X-API-Key", apiKey)
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	data, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("qr fetch failed (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(data)))
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+// RenderQRANSI renders a QR payload as a half-block ANSI string suitable for a
+// real terminal (used by the CLI). Returns "" for an empty payload.
+func RenderQRANSI(payload string) string {
+	if payload == "" {
+		return ""
+	}
+	var buf bytes.Buffer
+	qrterminal.GenerateWithConfig(payload, qrterminal.Config{
+		Writer:         &buf,
+		Level:          qrterminal.L,
+		HalfBlocks:     true,
+		BlackChar:      qrterminal.BLACK_BLACK,
+		WhiteChar:      qrterminal.WHITE_WHITE,
+		WhiteBlackChar: qrterminal.WHITE_BLACK,
+		BlackWhiteChar: qrterminal.BLACK_WHITE,
+		QuietZone:      2,
+	})
+	return buf.String()
+}
+
+// RenderQRBlocks renders a QR payload using plain full-block characters with no
+// ANSI escapes, so it displays correctly inside a tview TextView (the TUI).
+// Returns "" for an empty payload.
+func RenderQRBlocks(payload string) string {
+	if payload == "" {
+		return ""
+	}
+	var buf bytes.Buffer
+	qrterminal.GenerateWithConfig(payload, qrterminal.Config{
+		Writer:    &buf,
+		Level:     qrterminal.L,
+		BlackChar: "  ", // QR "black" module -> two spaces (inverted for light terminals)
+		WhiteChar: "██", // QR "white"/quiet -> filled blocks
+		QuietZone: 2,
+	})
+	return buf.String()
+}

--- a/internal/whatsapp/bridge_test.go
+++ b/internal/whatsapp/bridge_test.go
@@ -1,0 +1,151 @@
+package whatsapp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGenerateAdminKey(t *testing.T) {
+	k1, err := GenerateAdminKey()
+	if err != nil {
+		t.Fatalf("GenerateAdminKey() error = %v", err)
+	}
+	k2, _ := GenerateAdminKey()
+	if k1 == k2 {
+		t.Errorf("expected distinct keys, got identical: %s", k1)
+	}
+	if !strings.HasPrefix(k1, "wab_admin_") {
+		t.Errorf("expected wab_admin_ prefix, got %s", k1)
+	}
+	if len(k1) < 40 {
+		t.Errorf("admin key too short: %d chars", len(k1))
+	}
+}
+
+func TestEnvRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	in := map[string]string{
+		"ADMIN_API_KEY":  "wab_admin_secret",
+		"BRIDGE_PORT":    "8081",
+		"TENANT_API_KEY": "wab_tenant_xyz",
+	}
+	if err := SaveEnv(dir, in); err != nil {
+		t.Fatalf("SaveEnv() error = %v", err)
+	}
+	out, err := LoadEnv(dir)
+	if err != nil {
+		t.Fatalf("LoadEnv() error = %v", err)
+	}
+	for k, v := range in {
+		if out[k] != v {
+			t.Errorf("env[%q] = %q, want %q", k, out[k], v)
+		}
+	}
+	// File must be 0600 (holds the admin secret).
+	info, err := os.Stat(EnvPath(dir))
+	if err != nil {
+		t.Fatalf("stat env file: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("env file perm = %o, want 600", perm)
+	}
+}
+
+func TestLoadEnvMissingFile(t *testing.T) {
+	out, err := LoadEnv(filepath.Join(t.TempDir(), "does-not-exist"))
+	if err != nil {
+		t.Fatalf("LoadEnv() on missing dir error = %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("expected empty map, got %v", out)
+	}
+}
+
+func TestRenderQR(t *testing.T) {
+	if got := RenderQRANSI(""); got != "" {
+		t.Errorf("RenderQRANSI(empty) = %q, want empty", got)
+	}
+	if got := RenderQRBlocks(""); got != "" {
+		t.Errorf("RenderQRBlocks(empty) = %q, want empty", got)
+	}
+	ansi := RenderQRANSI("2@abc123,def456==")
+	if ansi == "" {
+		t.Error("RenderQRANSI returned empty for non-empty payload")
+	}
+	blocks := RenderQRBlocks("2@abc123,def456==")
+	if !strings.Contains(blocks, "█") {
+		t.Errorf("RenderQRBlocks did not contain block chars: %q", blocks)
+	}
+}
+
+func TestCreateTenant(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/admin/tenants" || r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if r.Header.Get("X-Admin-Key") != "admin-secret" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"id":"t1","name":"default","api_key":"wab_tenant_abc","qr_url":"/qr?key=wab_tenant_abc"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "admin-secret")
+	tenant, err := c.CreateTenant(context.Background(), "default", "")
+	if err != nil {
+		t.Fatalf("CreateTenant() error = %v", err)
+	}
+	if tenant.APIKey != "wab_tenant_abc" {
+		t.Errorf("api_key = %q, want wab_tenant_abc", tenant.APIKey)
+	}
+
+	// Wrong admin key must surface an error.
+	bad := NewClient(srv.URL, "wrong")
+	if _, err := bad.CreateTenant(context.Background(), "default", ""); err == nil {
+		t.Error("expected error with wrong admin key, got nil")
+	}
+}
+
+func TestQRStringAndHealth(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-API-Key") != "tenant-key" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		switch r.URL.Path {
+		case "/qr.txt":
+			w.Write([]byte("2@rawqr==\n"))
+		case "/health":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"status":"ok","connected":true,"logged_in":true}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "")
+	qr, err := c.QRString(context.Background(), "tenant-key")
+	if err != nil {
+		t.Fatalf("QRString() error = %v", err)
+	}
+	if qr != "2@rawqr==" {
+		t.Errorf("QRString() = %q, want trimmed 2@rawqr==", qr)
+	}
+	h, err := c.Health(context.Background(), "tenant-key")
+	if err != nil {
+		t.Fatalf("Health() error = %v", err)
+	}
+	if !h.LoggedIn {
+		t.Error("expected logged_in true")
+	}
+}

--- a/internal/whatsapp/config.go
+++ b/internal/whatsapp/config.go
@@ -1,0 +1,83 @@
+package whatsapp
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// EnvPath returns the absolute path of the bridge env file inside a node's
+// services directory.
+func EnvPath(servicesDir string) string {
+	return filepath.Join(servicesDir, EnvFileName)
+}
+
+// ComposePath returns the absolute path of the bridge compose file inside a
+// node's services directory.
+func ComposePath(servicesDir string) string {
+	return filepath.Join(servicesDir, ServiceName+".yml")
+}
+
+// LoadEnv reads the bridge env file into a key=value map. A missing file
+// returns an empty map and no error (the bridge has simply not been deployed
+// yet). Lines that are blank or start with '#' are ignored.
+func LoadEnv(servicesDir string) (map[string]string, error) {
+	path := EnvPath(servicesDir)
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]string{}, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	out := map[string]string{}
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		out[strings.TrimSpace(k)] = strings.TrimSpace(v)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// SaveEnv writes a key=value map to the bridge env file with 0600 permissions
+// (it holds the admin secret). Keys are sorted for stable output.
+func SaveEnv(servicesDir string, env map[string]string) error {
+	if err := os.MkdirAll(servicesDir, 0755); err != nil {
+		return fmt.Errorf("create services dir: %w", err)
+	}
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var b strings.Builder
+	b.WriteString("# whatsapp-bridge module config (written by `citadel whatsapp`).\n")
+	b.WriteString("# Contains the admin secret -- keep this file private (0600).\n")
+	for _, k := range keys {
+		fmt.Fprintf(&b, "%s=%s\n", k, env[k])
+	}
+	return os.WriteFile(EnvPath(servicesDir), []byte(b.String()), 0600)
+}
+
+// IsDeployed reports whether the bridge compose file has been materialized in
+// the services directory (i.e. the module has been deployed at least once).
+func IsDeployed(servicesDir string) bool {
+	_, err := os.Stat(ComposePath(servicesDir))
+	return err == nil
+}

--- a/services/compose/whatsapp-bridge.yml
+++ b/services/compose/whatsapp-bridge.yml
@@ -1,0 +1,74 @@
+# services/compose/whatsapp-bridge.yml
+#
+# Citadel community module: the multi-tenant WhatsApp (Baileys) bridge from
+# sunapi386/whatsapp-bridge. A two-container stack — the bridge app plus an
+# embedded Postgres sidecar that holds Baileys auth state, contacts and
+# messages so sessions survive restarts/redeploys.
+#
+# Started by `citadel whatsapp up` (or `citadel run whatsapp-bridge`), which
+# runs `docker compose -f <this> up -d`. Env values (ADMIN_API_KEY, ports,
+# proxy, log levels) are sourced from the sibling whatsapp-bridge.env file the
+# CLI writes next to this compose file.
+#
+# The container name is prefixed `citadel-` so the CLI's status check can find
+# the app, matching the convention used by the other catalog services.
+services:
+  bridge:
+    image: ghcr.io/sunapi386/whatsapp-bridge:latest
+    container_name: citadel-whatsapp-bridge
+    restart: unless-stopped
+    ports:
+      - "${BRIDGE_PORT:-8080}:8080"
+    environment:
+      HOST: 0.0.0.0
+      PORT: 8080
+      DATABASE_URL: postgres://whatsapp:${POSTGRES_PASSWORD:-whatsapp}@db:5432/whatsapp
+      # Secret for the /admin/* control plane (minting tenants, proxy config).
+      # Required — the CLI generates a strong value when the user supplies none.
+      ADMIN_API_KEY: ${ADMIN_API_KEY:?ADMIN_API_KEY is required}
+      # Public base URL, used only to print copy-pasteable QR links. Optional:
+      # the CLI fetches and renders the pairing QR directly, so this can be empty.
+      PUBLIC_URL: ${PUBLIC_URL:-}
+      # Optional per-node default egress proxy (socks5:// or http(s)://). Each
+      # Citadel node already egresses from its own mesh IP, so this is optional
+      # fine-tuning rather than required.
+      DEFAULT_PROXY_URL: ${DEFAULT_PROXY_URL:-}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      BAILEYS_LOG_LEVEL: ${BAILEYS_LOG_LEVEL:-warn}
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      # GET / is unauthenticated and returns {ok:true}; /health requires an API key.
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "require('http').get('http://localhost:8080/',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+
+  db:
+    image: postgres:16-alpine
+    container_name: citadel-whatsapp-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: whatsapp
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-whatsapp}
+      POSTGRES_DB: whatsapp
+    volumes:
+      # Named volume — Docker creates it automatically, so this needs no
+      # pre-created host directory.
+      - whatsapp_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U whatsapp"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  whatsapp_pgdata:

--- a/services/compose/whatsapp-bridge.yml
+++ b/services/compose/whatsapp-bridge.yml
@@ -14,7 +14,10 @@
 # the app, matching the convention used by the other catalog services.
 services:
   bridge:
-    image: ghcr.io/sunapi386/whatsapp-bridge:latest
+    # Image is parameterized so it can point at whichever registry publishes the
+    # community module image. The default is the aceteam-ai GHCR location; set
+    # BRIDGE_IMAGE in the env file to override (e.g. a fork's GHCR or a local tag).
+    image: ${BRIDGE_IMAGE:-ghcr.io/aceteam-ai/whatsapp-bridge:latest}
     container_name: citadel-whatsapp-bridge
     restart: unless-stopped
     ports:

--- a/services/embed.go
+++ b/services/embed.go
@@ -24,14 +24,18 @@ var SGLangCompose string
 //go:embed compose/extraction.yml
 var ExtractionCompose string
 
+//go:embed compose/whatsapp-bridge.yml
+var WhatsAppBridgeCompose string
+
 // ServiceMap provides a lookup for pre-packaged service compose files.
 var ServiceMap = map[string]string{
-	"ollama":     OllamaCompose,
-	"vllm":       VLLMCompose,
-	"llamacpp":   LlamacppCompose,
-	"lmstudio":   LMStudioCompose,
-	"sglang":     SGLangCompose,
-	"extraction": ExtractionCompose,
+	"ollama":          OllamaCompose,
+	"vllm":            VLLMCompose,
+	"llamacpp":        LlamacppCompose,
+	"lmstudio":        LMStudioCompose,
+	"sglang":          SGLangCompose,
+	"extraction":      ExtractionCompose,
+	"whatsapp-bridge": WhatsAppBridgeCompose,
 }
 
 // GetAvailableServices returns a sorted list of service names.


### PR DESCRIPTION
## Context

Ships the citadel-cli side of aceteam-ai/aceteam#4162 ("ship the WhatsApp
bridge as a Citadel community microservice module"). The bridge source lives in
sunapi386/whatsapp-bridge#1 ("Multi-tenant WhatsApp bridge + Citadel community
module") and already exposes the exact REST contract the aceteam `whatsapp_*`
MCP tools speak (`/health`, `/status`, `/contacts`, `X-API-Key` auth, Baileys QR
pairing).

This PR makes that bridge a first-class, Citadel-managed service: deploy it,
manage it, surface its `api_url` + `api_key`, and scan its pairing QR -- all
from either the CLI or the control-center TUI.

The bridge is multi-tenant: one container serves many tenants and the per-tenant
`X-API-Key` is the tenant selector. The `/admin/*` control plane is guarded by a
separate admin secret (`ADMIN_API_KEY`). The key handed to `whatsapp_connect` is
the per-tenant `wab_...` key minted via the admin API -- **not** the admin secret.

## Changes

**Service / compose**
- `services/compose/whatsapp-bridge.yml` -- embedded two-container stack (bridge
  + Postgres sidecar holding Baileys auth state) mirroring the bridge repo's
  `citadel/compose.yml`. Port 8080, Docker-managed named volume `whatsapp_pgdata`,
  `ADMIN_API_KEY` required, image parameterized via `${BRIDGE_IMAGE}`.
- `services/embed.go` -- registered `whatsapp-bridge` in `ServiceMap`.

**Shared package `internal/whatsapp`**
- `bridge.go` -- HTTP client (admin tenant provisioning, health, `/qr.txt`
  fetch), strong admin-key generation, ANSI + plain-block QR rendering.
- `config.go` -- env-file read/write (0600, holds the admin secret) and
  deployment-state helpers.

**CLI -- `citadel whatsapp <up|status|qr|connect|down>`** (`cmd/whatsapp.go`)
- `up`: generate `ADMIN_API_KEY` (if not supplied via `--api-key`), write the
  env file, `docker compose up -d` (bridge + db) via `--env-file`, wait for
  health, mint (or reuse) a tenant, then print the mesh `api_url` + the tenant
  `api_key` + the inline pairing QR + the `WHATSAPP_ALLOW_PRIVATE_NETWORK=true`
  hint. Flags: `--api-key`, `--port`, `--proxy`, `--tenant`, `--public-url`,
  `--image`.
- `status` / `qr` / `connect` / `down` for lifecycle + re-surfacing details.

**TUI -- control-center WhatsApp page** (`internal/tui/controlcenter/whatsapp_page.go`)
- New page: deploy/start (`u`), stop (`d`), refresh QR (`q`), refresh (`r`).
  Shows running/linked status, `api_url` + `api_key`, and renders the pairing
  QR inline so a phone can be linked without leaving the TUI. Lifecycle
  callbacks are wired from `cmd` so the TUI and CLI share one code path.

**Tests** -- `internal/whatsapp/bridge_test.go`: admin-key generation, env
round-trip + 0600 perms, QR rendering, and `httptest`-backed tenant/QR/health
client calls.

## How to test

> Prerequisite (deferred, see below): the module image must be published and
> pullable, e.g. `ghcr.io/aceteam-ai/whatsapp-bridge:latest`. Until then, point
> `--image` at a locally built tag (`docker build -t wa-bridge:dev .` in the
> bridge repo).

End-to-end deploy -> QR scan -> connect, on a Citadel node with Docker:

1. **Deploy + provision** (CLI):
   ```
   citadel whatsapp up                 # or: --image wa-bridge:dev
   ```
   This starts the bridge + Postgres, waits for health, mints a tenant, and
   prints `api_url`, `api_key`, and a scannable QR.

2. **Link your phone**: scan the printed QR with
   WhatsApp -> Settings -> Linked Devices -> Link a Device.
   (Re-fetch any time with `citadel whatsapp qr`; the TUI shows it live.)

3. **Register in AceTeam** with the printed values:
   ```
   whatsapp_connect(api_url="http://<node-mesh-ip>:8080", api_key="wab_...")
   whatsapp_health()   # -> logged_in: true once the QR is scanned
   ```
   The bridge is on the private mesh, so the aceteam **python-backend** must run
   with `WHATSAPP_ALLOW_PRIVATE_NETWORK=true` to dial the `100.64.0.0/10` range.
   (If you expose the bridge on a public hostname instead, that flag is not
   needed.)

4. **TUI flow**: run `citadel`, open the **WhatsApp** tab, press `u` to deploy,
   read `api_url`/`api_key` from the panel, scan the QR shown on the right.
   `d` stops it (auth state is preserved in the `whatsapp_pgdata` volume).

Local verification done (no `go test ./...`, no tmux/terminal test packages):
- `go build ./...`
- `go vet ./cmd/ ./internal/whatsapp/ ./internal/tui/controlcenter/`
- `go test ./internal/whatsapp/` (confirmed it imports no tmux/terminal pkg)

## v1 vs deferred

**In v1**
- Compose + ServiceMap registration; full `citadel whatsapp` CLI; TUI page with
  inline pairing QR; tenant reuse on re-run; mesh `api_url` surfacing; the
  `WHATSAPP_ALLOW_PRIVATE_NETWORK` hint.

**Deferred**
- **Image sourcing**: the bridge image must be published to a pullable registry.
  sunapi386/whatsapp-bridge#1 is unmerged and its publish workflow only triggers
  on `main`, so `ghcr.io/aceteam-ai/whatsapp-bridge:latest` does not exist yet.
  Use `--image <local-tag>` until then. This is the #1 prerequisite.
- **Auto-registration**: the operator still calls `whatsapp_connect` manually
  with the printed `api_url`/`api_key`. No automatic backend registration.
- **Generic `citadel run whatsapp-bridge`**: intentionally not wired -- the
  shared start path runs `docker compose up` without an `--env-file`, and this
  stack hard-requires `ADMIN_API_KEY`. Use `citadel whatsapp up`. Teaching the
  generic path to source a per-service env file touches every catalog service
  and is out of scope here.
- **Community-catalog install**: the bridge repo also ships a
  `citadel/service.yaml` for `citadel service catalog install`, but the built-in
  catalog is hardcoded to `aceteam-ai/citadel-services`; arbitrary community git
  repos as module sources are a separate change.
- **Multi-tenant per node**: one tenant per node deployment in v1 (the CLI mints
  a single "default" tenant). The bridge itself supports many.

Refs aceteam-ai/aceteam#4162, sunapi386/whatsapp-bridge#1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
