### PR TITLE
feat(desktop): relative mouse-move action + verify key coverage (#334)

### DIFF
--- a/internal/desktop/actions.go
+++ b/internal/desktop/actions.go
@@ -22,7 +22,18 @@ type Action struct {
 	Text   string `json:"text,omitempty"`
 	Key    string `json:"key,omitempty"`
 	Delta  *int   `json:"delta,omitempty"`
+	// Mode selects absolute (default, empty) or "relative" pointer movement for
+	// the "move" action. Relative moves use Dx/Dy instead of X/Y. Issue #334.
+	Mode string `json:"mode,omitempty"`
+	// Dx/Dy are signed pixel offsets for a relative "move". Negative values move
+	// left/up. Only used when Mode == "relative".
+	Dx *int `json:"dx,omitempty"`
+	Dy *int `json:"dy,omitempty"`
 }
+
+// relMoveBound caps the magnitude of a single relative move offset. Matches the
+// absolute coordinate ceiling but allows negative offsets for left/up motion.
+const relMoveBound = 32767
 
 var allowedActionTypes = map[string]bool{
 	"move":      true,
@@ -64,11 +75,23 @@ func validateAction(a Action) error {
 
 	switch a.Type {
 	case "move":
-		if a.X == nil || a.Y == nil {
-			return fmt.Errorf("move requires x and y coordinates")
-		}
-		if *a.X < 0 || *a.Y < 0 || *a.X > 32767 || *a.Y > 32767 {
-			return fmt.Errorf("coordinates out of range (0-32767)")
+		switch a.Mode {
+		case "", "absolute":
+			if a.X == nil || a.Y == nil {
+				return fmt.Errorf("absolute move requires x and y coordinates")
+			}
+			if *a.X < 0 || *a.Y < 0 || *a.X > 32767 || *a.Y > 32767 {
+				return fmt.Errorf("coordinates out of range (0-32767)")
+			}
+		case "relative":
+			if a.Dx == nil || a.Dy == nil {
+				return fmt.Errorf("relative move requires dx and dy offsets")
+			}
+			if *a.Dx < -relMoveBound || *a.Dx > relMoveBound || *a.Dy < -relMoveBound || *a.Dy > relMoveBound {
+				return fmt.Errorf("relative offsets out of range (-%d to %d)", relMoveBound, relMoveBound)
+			}
+		default:
+			return fmt.Errorf("unknown move mode %q (allowed: absolute, relative)", a.Mode)
 		}
 	case "click":
 		if a.X == nil || a.Y == nil {
@@ -126,6 +149,12 @@ func validateAction(a Action) error {
 func ActionToXdotoolArgs(a Action) (string, []string, error) {
 	switch a.Type {
 	case "move":
+		if a.Mode == "relative" {
+			// mousemove_relative shifts the pointer by a signed offset from its
+			// current position. The "--" guard lets negative dx/dy through as
+			// operands rather than being parsed as flags. Issue #334.
+			return "mousemove_relative", []string{"--", strconv.Itoa(*a.Dx), strconv.Itoa(*a.Dy)}, nil
+		}
 		return "mousemove", []string{"--", strconv.Itoa(*a.X), strconv.Itoa(*a.Y)}, nil
 	case "click":
 		button := buttonOrDefault(a.Button, 1)

--- a/internal/desktop/desktop_test.go
+++ b/internal/desktop/desktop_test.go
@@ -118,6 +118,16 @@ func TestParseActions(t *testing.T) {
 		wantErr bool
 	}{
 		{"move", `[{"type":"move","x":100,"y":200}]`, 1, false},
+		{"move absolute explicit mode", `[{"type":"move","mode":"absolute","x":100,"y":200}]`, 1, false},
+		{"move relative", `[{"type":"move","mode":"relative","dx":10,"dy":-20}]`, 1, false},
+		{"move relative negative both", `[{"type":"move","mode":"relative","dx":-5,"dy":-5}]`, 1, false},
+		{"move relative zero offset", `[{"type":"move","mode":"relative","dx":0,"dy":0}]`, 1, false},
+		{"move relative missing dx", `[{"type":"move","mode":"relative","dy":10}]`, 0, true},
+		{"move relative missing dy", `[{"type":"move","mode":"relative","dx":10}]`, 0, true},
+		{"move relative dx out of range", `[{"type":"move","mode":"relative","dx":40000,"dy":0}]`, 0, true},
+		{"move relative dy out of range", `[{"type":"move","mode":"relative","dx":0,"dy":-40000}]`, 0, true},
+		{"move unknown mode", `[{"type":"move","mode":"warp","x":1,"y":2}]`, 0, true},
+		{"move absolute missing coords", `[{"type":"move","mode":"absolute"}]`, 0, true},
 		{"click", `[{"type":"click","x":100,"y":200,"button":1}]`, 1, false},
 		{"type", `[{"type":"type","text":"hello world"}]`, 1, false},
 		{"key", `[{"type":"key","key":"Return"}]`, 1, false},
@@ -173,6 +183,24 @@ func TestActionToXdotoolArgs(t *testing.T) {
 		{
 			name:     "move",
 			action:   Action{Type: "move", X: intPtr(100), Y: intPtr(200)},
+			wantCmd:  "mousemove",
+			wantArgs: []string{"--", "100", "200"},
+		},
+		{
+			name:     "move relative",
+			action:   Action{Type: "move", Mode: "relative", Dx: intPtr(15), Dy: intPtr(-25)},
+			wantCmd:  "mousemove_relative",
+			wantArgs: []string{"--", "15", "-25"},
+		},
+		{
+			name:     "move relative negative both",
+			action:   Action{Type: "move", Mode: "relative", Dx: intPtr(-30), Dy: intPtr(-40)},
+			wantCmd:  "mousemove_relative",
+			wantArgs: []string{"--", "-30", "-40"},
+		},
+		{
+			name:     "move absolute explicit mode",
+			action:   Action{Type: "move", Mode: "absolute", X: intPtr(100), Y: intPtr(200)},
 			wantCmd:  "mousemove",
 			wantArgs: []string{"--", "100", "200"},
 		},
@@ -252,6 +280,45 @@ func TestActionToXdotoolArgs(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestKeyCoverage verifies that the "key" action accepts the full iPKVM-grade
+// keysym set the web/iOS viewers may send (issue #334). On linux these names
+// are passed verbatim to xdotool, which resolves them to X11 keysyms, so the
+// only gate is safeKeyPattern. This test pins the documented set: modifier
+// combos, F1-F12, and special keys (Ctrl+Alt+Del, PrintScreen, ScrollLock,
+// Pause, Menu, arrows, Home/End, etc.).
+func TestKeyCoverage(t *testing.T) {
+	supported := []string{
+		// Modifier combos
+		"ctrl+c", "ctrl+v", "ctrl+alt+Delete", "shift+Tab", "super+l", "alt+F4",
+		// Function keys
+		"F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10", "F11", "F12",
+		// Special keys
+		"Print", "Scroll_Lock", "Pause", "Menu", "Num_Lock", "Caps_Lock",
+		"Insert", "Delete", "Home", "End", "Page_Up", "Page_Down",
+		"Up", "Down", "Left", "Right",
+		"Return", "Escape", "BackSpace", "Tab", "space",
+	}
+	for _, k := range supported {
+		input := `[{"type":"key","key":"` + k + `"}]`
+		actions, err := ParseActions([]byte(input))
+		if err != nil {
+			t.Errorf("key %q rejected: %v", k, err)
+			continue
+		}
+		cmd, args, err := ActionToXdotoolArgs(actions[0])
+		if err != nil {
+			t.Errorf("key %q arg-gen failed: %v", k, err)
+			continue
+		}
+		if cmd != "key" {
+			t.Errorf("key %q produced cmd %q, want \"key\"", k, cmd)
+		}
+		if len(args) != 2 || args[0] != "--clearmodifiers" || args[1] != k {
+			t.Errorf("key %q produced args %v, want [--clearmodifiers %s]", k, args, k)
+		}
 	}
 }
 

--- a/internal/desktop/input_windows.go
+++ b/internal/desktop/input_windows.go
@@ -147,7 +147,12 @@ func keysymToVK(keysym uint32) (uint16, bool) {
 	case 0xff0d: return 0x0D, true  // Return -> VK_RETURN
 	case 0xff1b: return 0x1B, true  // Escape -> VK_ESCAPE
 	case 0xff63: return 0x2D, true  // Insert -> VK_INSERT
-	case 0xffff: return 0x2E, true  // Delete -> VK_DELETE
+	case 0xffff: return 0x2E, true  // Delete -> VK_DELETE (Ctrl+Alt+Del when combined)
+	case 0xff61: return 0x2C, true  // Print -> VK_SNAPSHOT (PrintScreen)
+	case 0xff14: return 0x91, true  // Scroll_Lock -> VK_SCROLL
+	case 0xff13: return 0x13, true  // Pause -> VK_PAUSE
+	case 0xff67: return 0x5D, true  // Menu -> VK_APPS (context menu)
+	case 0xff7f: return 0x90, true  // Num_Lock -> VK_NUMLOCK
 	case 0xff50: return 0x24, true  // Home -> VK_HOME
 	case 0xff57: return 0x23, true  // End -> VK_END
 	case 0xff55: return 0x21, true  // Page_Up -> VK_PRIOR


### PR DESCRIPTION
Adds iPKVM-grade pointer/key input to the desktop action layer. Part of computer-use (aceteam-ai/aceteam#4168). Web viewer reconciliation: aceteam-ai/aceteam#4242.

## Changes

**Relative mouse move (`internal/desktop/actions.go`)**
- The `move` action gains an additive `mode` field. `mode:"relative"` uses signed `dx`/`dy` offsets; empty or `"absolute"` keeps the existing `x`/`y` behavior, unchanged.
- `dx`/`dy` are validated with a signed bound (`-32767..32767`) so leftward/upward moves (negative offsets) are allowed.
- Relative moves map to xdotool `mousemove_relative -- dx dy` (the `--` guard lets negative operands through instead of being parsed as flags).
- JSON contract is fully additive (new fields are pointers with `omitempty`), so existing web/iOS viewer messages still parse and old absolute `move` is untouched.

**Key coverage**
- `TestKeyCoverage` pins the supported keysym set: modifier combos, F1-F12, and special keys (Ctrl+Alt+Del, PrintScreen, ScrollLock, Pause, Menu, Num_Lock, arrows, Home/End, Page Up/Down). On linux these names pass verbatim to xdotool, which resolves the X11 keysyms; `safeKeyPattern` already permits them all (verified, not rewritten).
- Added the previously missing keysym mappings to the Windows **VNC/RFB input path** `keysymToVK` in `internal/desktop/input_windows.go` (this is the `sendKeyEvent` subsystem, distinct from the `key` action): Print->VK_SNAPSHOT, Scroll_Lock->VK_SCROLL, Pause->VK_PAUSE, Menu->VK_APPS, Num_Lock->VK_NUMLOCK.

## Relative-move action JSON shape (for web #4242 / iOS viewers)

```json
{ "type": "move", "mode": "relative", "dx": 10, "dy": -20 }
```

- `mode` absent or `"absolute"` -> existing absolute move using `x`/`y` (unchanged).
- `mode:"relative"` -> requires `dx` and `dy` signed pixel offsets; negative = left/up.
- Range: `dx`/`dy` in `-32767..32767`.

## Supported keysym set (the `key` action)

Names are sent verbatim to xdotool on linux (which resolves X11 keysyms). Documented/tested set:

- Modifier combos: `ctrl+c`, `ctrl+alt+Delete`, `shift+Tab`, `alt+F4`, `super+l`, etc.
- Function keys: `F1`-`F12`.
- Special keys: `Print` (PrintScreen), `Scroll_Lock`, `Pause`, `Menu`, `Num_Lock`, `Caps_Lock`, `Insert`, `Delete`, `Home`, `End`, `Page_Up`, `Page_Down`, arrows (`Up`/`Down`/`Left`/`Right`), `Return`, `Escape`, `BackSpace`, `Tab`, `space`.

## Platform matrix (honest scope)

| Platform | Path | Status |
|----------|------|--------|
| linux | xdotool (`ExecuteActions`) | `key` + relative `move` execute here; needs a live X display to verify behavior |
| windows | VNC/RFB input (`keysymToVK`/`sendKeyEvent`) | New keysym mappings added, compile-checked (`GOOS=windows go build`) only; `ExecuteActions` still returns "not implemented" |
| darwin | both paths | Stubbed/unimplemented (unchanged) |

Note: on Windows, "keysym mapping present" is the claim, not "functions" - Ctrl+Alt+Del is a Secure Attention Sequence SendInput cannot synthesize, and VK_SNAPSHOT keydown is unreliable.

## How to test

Scoped, tmux-safe verification (no `go test ./...`, no tmux packages):

```bash
go build ./internal/desktop/...
GOOS=windows go build ./internal/desktop/...
go vet ./internal/desktop/...
go test ./internal/desktop/...
```

Covers relative-move parse validation (incl. negative offsets, missing dx/dy, out-of-range, unknown mode), `mousemove_relative` arg generation, and the documented key set.

## Needs a live desktop to verify

- Actual `xdotool mousemove_relative -- dx dy` motion on a real X display, including negative offsets.
- The new Windows VNC keysyms (Print/Scroll_Lock/Pause/Menu/Num_Lock) on a real Windows target via the RFB input path.