### PR TITLE
feat(cobrowse): add stealth (anti-bot-detection) launch mode

### DIFF
--- a/internal/platform/cobrowse.go
+++ b/internal/platform/cobrowse.go
@@ -47,6 +47,115 @@ import (
 // existing tunnels, never bound to a public interface.
 const DefaultCobrowseDebugPort = 9222
 
+// EnvCobrowseStealth toggles the anti-bot-detection ("stealth") launch flags.
+// Stealth is ON by default for co-browse; set this env var to "0" / "false" /
+// "off" to launch a plain automation-flavored Chromium instead (useful for
+// debugging or for parity with the pre-stealth behavior).
+const EnvCobrowseStealth = "CITADEL_COBROWSE_STEALTH"
+
+// EnvCobrowseUserAgent optionally overrides the browser User-Agent. By default
+// we leave the UA UNSET so real headed Chrome reports its own (correct, current)
+// UA -- a hardcoded UA pins a Chrome version that drifts out of sync with the
+// actual binary, and that mismatch is itself a bot-detection signal. Only set
+// this when you deliberately want to spoof a specific UA.
+const EnvCobrowseUserAgent = "CITADEL_COBROWSE_USER_AGENT"
+
+// cobrowseLaunchOptions is the full input to buildChromeArgs. Keeping it a plain
+// struct (rather than an interface/registry) is deliberate: a future full
+// CloakBrowser launcher swaps in by constructing different options or by calling
+// a different builder, without any plugin abstraction to maintain here.
+type cobrowseLaunchOptions struct {
+	debugPort  int
+	profileDir string
+	startURL   string
+	// stealth enables the anti-bot-detection launch flags (see buildChromeArgs).
+	stealth bool
+	// lang is the UI/Accept-Language locale (e.g. "en-US"). Defaults applied by
+	// buildChromeArgs when empty.
+	lang string
+	// userAgent, when non-empty, overrides the browser User-Agent. Empty means
+	// "use real Chrome's own UA" (recommended -- see EnvCobrowseUserAgent).
+	userAgent string
+}
+
+// stealthEnabled resolves whether stealth launch flags should be applied,
+// reading EnvCobrowseStealth. Stealth is ON unless explicitly disabled.
+func stealthEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(EnvCobrowseStealth))) {
+	case "0", "false", "off", "no":
+		return false
+	default:
+		return true
+	}
+}
+
+// buildChromeArgs constructs the Chromium command-line for a co-browse launch.
+// It is a pure function (no I/O, no globals beyond its inputs) so the flag set
+// is unit-testable without launching a browser or touching a display.
+//
+// Stealth (anti-bot-detection) notes -- this is the citadel-side, launch-flag
+// layer of the team's stealth-Chromium approach (CloakBrowser), which is the
+// intended long-term replacement for this plain launch:
+//   - --disable-blink-features=AutomationControlled removes the headless/automation
+//     Blink feature so navigator.webdriver is not forced true. This is the single
+//     most load-bearing stealth flag.
+//   - We deliberately NEVER pass --enable-automation. Launching raw via exec means
+//     Chrome does not add the automation switches or the "Chrome is being controlled
+//     by automated test software" infobar unless we ask for them -- so simply not
+//     emitting that flag satisfies the "no infobar / exclude enable-automation"
+//     requirement. (--exclude-switches / excludeSwitches is a chromedriver
+//     capability, not a Chrome CLI flag, so there is intentionally no such arg.
+//     --disable-infobars was removed from modern Chrome and is intentionally
+//     omitted too.)
+//   - --lang pins a realistic locale.
+//   - --user-data-dir gives a persistent stealth profile so cookies, history, and
+//     the resulting fingerprint stay consistent across jobs.
+//
+// What stealth flags CANNOT do (and therefore needs the full CloakBrowser
+// wrapper, tracked as follow-up): CDP-level
+// Page.addScriptToEvaluateOnNewDocument fingerprint patches (navigator.webdriver /
+// plugins / languages, window.chrome.runtime, permissions.query, WebGL
+// vendor/renderer, canvas/audio noise), per-identity consistent fingerprints,
+// and proxy/TLS (JA3) alignment.
+func buildChromeArgs(opts cobrowseLaunchOptions) []string {
+	// disableFeatures is built as a single slice and emitted as ONE
+	// --disable-features flag. Chrome only honors the last --disable-features
+	// occurrence, so appending a second flag would silently drop earlier values
+	// (e.g. Translate). Future stealth additions go in this slice, not a new flag.
+	disableFeatures := []string{"Translate"}
+
+	args := []string{
+		fmt.Sprintf("--remote-debugging-port=%d", opts.debugPort),
+		"--remote-debugging-address=127.0.0.1",
+		"--user-data-dir=" + opts.profileDir,
+		"--no-first-run",
+		"--no-default-browser-check",
+		"--start-maximized",
+	}
+
+	if opts.stealth {
+		// Core anti-automation signal: drop the AutomationControlled Blink
+		// feature so navigator.webdriver is not forced true.
+		args = append(args, "--disable-blink-features=AutomationControlled")
+		lang := opts.lang
+		if lang == "" {
+			lang = "en-US"
+		}
+		args = append(args, "--lang="+lang)
+		if opts.userAgent != "" {
+			args = append(args, "--user-agent="+opts.userAgent)
+		}
+	}
+
+	// Emit the merged disable-features exactly once (see note above).
+	args = append(args, "--disable-features="+strings.Join(disableFeatures, ","))
+
+	if opts.startURL != "" {
+		args = append(args, opts.startURL)
+	}
+	return args
+}
+
 // CobrowseDriver identifies who currently controls the session.
 type CobrowseDriver string
 
@@ -181,18 +290,16 @@ func (m *CobrowseManager) Start(profileDir, startURL string, debugPort int) (Cob
 		return CobrowseStatus{}, err
 	}
 
-	args := []string{
-		fmt.Sprintf("--remote-debugging-port=%d", debugPort),
-		"--remote-debugging-address=127.0.0.1",
-		"--user-data-dir=" + profileDir,
-		"--no-first-run",
-		"--no-default-browser-check",
-		"--disable-features=Translate",
-		"--start-maximized",
-	}
-	if startURL != "" {
-		args = append(args, startURL)
-	}
+	// Stealth (anti-bot-detection) is ON by default for co-browse; this is the
+	// first citadel-side step toward the full CloakBrowser launch replacing this
+	// plain Chromium launch. Disable via EnvCobrowseStealth for plain behavior.
+	args := buildChromeArgs(cobrowseLaunchOptions{
+		debugPort:  debugPort,
+		profileDir: profileDir,
+		startURL:   startURL,
+		stealth:    stealthEnabled(),
+		userAgent:  os.Getenv(EnvCobrowseUserAgent),
+	})
 
 	cmd := exec.Command(chrome, args...)
 	// The browser must render on the SAME X display the node's VNC server

--- a/internal/platform/cobrowse_test.go
+++ b/internal/platform/cobrowse_test.go
@@ -3,9 +3,163 @@ package platform
 import (
 	"os/exec"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
+
+// containsArg reports whether args contains an exact match for want.
+func containsArg(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+// hasPrefixArg reports whether any arg starts with prefix.
+func hasPrefixArg(args []string, prefix string) bool {
+	for _, a := range args {
+		if strings.HasPrefix(a, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// countPrefixArg counts args starting with prefix.
+func countPrefixArg(args []string, prefix string) int {
+	n := 0
+	for _, a := range args {
+		if strings.HasPrefix(a, prefix) {
+			n++
+		}
+	}
+	return n
+}
+
+// TestBuildChromeArgs_Invariants checks the flags that must hold in BOTH stealth
+// modes: the CDP debug wiring, the persistent profile, the single merged
+// --disable-features (Chrome only honors the last one), and that the automation
+// switch is never emitted (no "controlled by automated test software" infobar).
+func TestBuildChromeArgs_Invariants(t *testing.T) {
+	for _, stealth := range []bool{true, false} {
+		args := buildChromeArgs(cobrowseLaunchOptions{
+			debugPort:  9222,
+			profileDir: "/tmp/profile",
+			stealth:    stealth,
+		})
+		if !containsArg(args, "--remote-debugging-port=9222") {
+			t.Errorf("stealth=%v: missing --remote-debugging-port=9222 in %v", stealth, args)
+		}
+		if !containsArg(args, "--remote-debugging-address=127.0.0.1") {
+			t.Errorf("stealth=%v: missing --remote-debugging-address=127.0.0.1", stealth)
+		}
+		if !containsArg(args, "--user-data-dir=/tmp/profile") {
+			t.Errorf("stealth=%v: missing persistent --user-data-dir", stealth)
+		}
+		// Exactly one --disable-features, and it must still carry Translate.
+		if n := countPrefixArg(args, "--disable-features="); n != 1 {
+			t.Errorf("stealth=%v: want exactly 1 --disable-features=, got %d in %v", stealth, n, args)
+		}
+		if !hasPrefixArg(args, "--disable-features=") {
+			t.Errorf("stealth=%v: missing --disable-features=", stealth)
+		}
+		for _, a := range args {
+			if strings.HasPrefix(a, "--disable-features=") && !strings.Contains(a, "Translate") {
+				t.Errorf("stealth=%v: --disable-features dropped Translate: %q", stealth, a)
+			}
+		}
+		// Never emit the automation switch (would re-add the infobar / webdriver).
+		if containsArg(args, "--enable-automation") {
+			t.Errorf("stealth=%v: --enable-automation must never be emitted", stealth)
+		}
+		// excludeSwitches is a chromedriver capability, not a CLI flag.
+		if hasPrefixArg(args, "--exclude-switches") {
+			t.Errorf("stealth=%v: --exclude-switches is not a valid Chrome flag", stealth)
+		}
+	}
+}
+
+// TestBuildChromeArgs_StealthToggle checks the stealth-only flags appear when on
+// and are absent when off.
+func TestBuildChromeArgs_StealthToggle(t *testing.T) {
+	on := buildChromeArgs(cobrowseLaunchOptions{debugPort: 9222, profileDir: "/p", stealth: true})
+	if !containsArg(on, "--disable-blink-features=AutomationControlled") {
+		t.Errorf("stealth on: missing --disable-blink-features=AutomationControlled in %v", on)
+	}
+	if !containsArg(on, "--lang=en-US") {
+		t.Errorf("stealth on: missing default --lang=en-US in %v", on)
+	}
+
+	off := buildChromeArgs(cobrowseLaunchOptions{debugPort: 9222, profileDir: "/p", stealth: false})
+	if containsArg(off, "--disable-blink-features=AutomationControlled") {
+		t.Errorf("stealth off: --disable-blink-features must be absent in %v", off)
+	}
+	if hasPrefixArg(off, "--lang=") {
+		t.Errorf("stealth off: --lang must be absent in %v", off)
+	}
+}
+
+// TestBuildChromeArgs_UserAgentAndLang checks optional overrides: a custom UA is
+// emitted only when set, and an empty UA leaves real Chrome's own UA in place.
+func TestBuildChromeArgs_UserAgentAndLang(t *testing.T) {
+	withUA := buildChromeArgs(cobrowseLaunchOptions{
+		debugPort: 9222, profileDir: "/p", stealth: true,
+		lang: "fr-FR", userAgent: "Mozilla/5.0 Custom",
+	})
+	if !containsArg(withUA, "--user-agent=Mozilla/5.0 Custom") {
+		t.Errorf("expected custom --user-agent in %v", withUA)
+	}
+	if !containsArg(withUA, "--lang=fr-FR") {
+		t.Errorf("expected custom --lang=fr-FR in %v", withUA)
+	}
+
+	noUA := buildChromeArgs(cobrowseLaunchOptions{debugPort: 9222, profileDir: "/p", stealth: true})
+	if hasPrefixArg(noUA, "--user-agent=") {
+		t.Errorf("expected no --user-agent when unset (use real Chrome UA), got %v", noUA)
+	}
+}
+
+// TestBuildChromeArgs_StartURL checks the start URL is the last arg when set and
+// omitted when empty.
+func TestBuildChromeArgs_StartURL(t *testing.T) {
+	args := buildChromeArgs(cobrowseLaunchOptions{
+		debugPort: 9222, profileDir: "/p", stealth: true, startURL: "https://example.com",
+	})
+	if got := args[len(args)-1]; got != "https://example.com" {
+		t.Errorf("expected start URL last, got %q in %v", got, args)
+	}
+
+	none := buildChromeArgs(cobrowseLaunchOptions{debugPort: 9222, profileDir: "/p", stealth: true})
+	for _, a := range none {
+		if strings.HasPrefix(a, "http://") || strings.HasPrefix(a, "https://") {
+			t.Errorf("expected no URL arg when startURL empty, found %q", a)
+		}
+	}
+}
+
+// TestStealthEnabled checks the env toggle: ON by default, OFF for known
+// falsey values.
+func TestStealthEnabled(t *testing.T) {
+	t.Setenv(EnvCobrowseStealth, "")
+	if !stealthEnabled() {
+		t.Error("stealth should default ON when env unset")
+	}
+	for _, v := range []string{"0", "false", "off", "no", "OFF", " false "} {
+		t.Setenv(EnvCobrowseStealth, v)
+		if stealthEnabled() {
+			t.Errorf("stealth should be OFF for %q", v)
+		}
+	}
+	for _, v := range []string{"1", "true", "on", "yes", "anything"} {
+		t.Setenv(EnvCobrowseStealth, v)
+		if !stealthEnabled() {
+			t.Errorf("stealth should be ON for %q", v)
+		}
+	}
+}
 
 // TestCobrowse_StopWhenNotRunning verifies Stop is a safe no-op with no session
 // and that calling it twice does not panic. The shutdown hook in cmd/work.go


### PR DESCRIPTION
## Context

First citadel-side step toward the goal that the team's stealth Chromium
approach (CloakBrowser) eventually replaces the plain Chromium launch used by
co-browse. The full CloakBrowser wrapper lives elsewhere and is out of scope
here; this PR adds the buildable, launch-flag layer now and makes it pluggable
so a future full-CloakBrowser launcher can swap in.

Refs aceteam-ai/aceteam#4168.

## Changes

- Extracted the Chromium command-line into a pure, unit-testable builder
  `buildChromeArgs(cobrowseLaunchOptions)` in `internal/platform/cobrowse.go`.
  `Start` now constructs options and calls it; its signature is unchanged, so
  `internal/jobs/cobrowse.go` keeps calling `mgr.Start(profile, url, 0)` as-is
  and the existing debug-port / persistent-profile behavior is preserved.
- Added a stealth (anti-bot-detection) mode, ON by default for co-browse,
  toggled via `CITADEL_COBROWSE_STEALTH` (set `0`/`false`/`off`/`no` to disable).
- Optional UA override via `CITADEL_COBROWSE_USER_AGENT`.
- Scoped tests for the flag construction and the env toggle
  (`internal/platform/cobrowse_test.go`).

### Stealth flag set (applied when stealth is on)

- `--disable-blink-features=AutomationControlled` — the load-bearing flag; drops
  the automation Blink feature so `navigator.webdriver` is not forced true.
- `--lang=en-US` (configurable) — realistic locale.
- Persistent `--user-data-dir` stealth profile — cookies/history/fingerprint stay
  consistent across jobs (already present; reused).
- `--start-maximized` — realistic window (already present; reused).

### Handled correctly by NOT emitting a flag

- We never pass `--enable-automation`. Launching raw via `exec` means Chrome does
  not add the automation switches or the "Chrome is being controlled by automated
  test software" infobar unless asked, so simply not emitting it satisfies the
  "no infobar / exclude enable-automation" requirement.
- `--exclude-switches` / `excludeSwitches` is a chromedriver capability, NOT a
  Chrome CLI flag, so there is intentionally no such arg.
- `--disable-infobars` was removed from modern Chrome and is intentionally omitted.

### Deliberate non-changes

- `--disable-features` is built as a single merged flag (currently `Translate`).
  Chrome honors only the last `--disable-features` occurrence, so future stealth
  additions go into that slice rather than a second flag that would silently drop
  `Translate`. A test asserts exactly one `--disable-features=`.
- User-Agent is left unset by default so real headed Chrome reports its own
  current UA. A hardcoded UA pins a Chrome version that drifts out of sync with
  the actual binary, and that mismatch is itself a detection signal. Override only
  when deliberately spoofing.

## How to test

```
go build ./...
go vet ./internal/platform/...
go test ./internal/platform/ -run 'TestBuildChromeArgs|TestStealthEnabled|TestCobrowse'
```

Tests cover: stealth on adds `--disable-blink-features=AutomationControlled` and
`--lang`; stealth off omits them; both modes keep the CDP wiring and persistent
profile; exactly one `--disable-features=` (with `Translate`); `--enable-automation`
never emitted; start URL last when set / omitted when empty; env toggle defaults on.

## What still needs the full CloakBrowser wrapper (follow-up)

Launch flags cannot reach these; they require CDP-level injection / wrapper
support and are tracked as follow-up:

- `Page.addScriptToEvaluateOnNewDocument` fingerprint patches: `navigator.webdriver`,
  `navigator.plugins` / `navigator.languages`, `window.chrome.runtime`,
  `permissions.query`.
- WebGL vendor/renderer spoofing and canvas/audio fingerprint noise.
- Per-identity consistent fingerprint profiles.
- Proxy / TLS (JA3) alignment.

Do NOT merge.
