### PR TITLE
feat(deskstream): Tier B node-side H.264 desktop stream over mesh WS (#338)

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/aceteam-ai/citadel-cli/internal/config"
 	"github.com/aceteam-ai/citadel-cli/internal/demo"
+	"github.com/aceteam-ai/citadel-cli/internal/deskstream"
 	"github.com/aceteam-ai/citadel-cli/internal/desktop"
 	"github.com/aceteam-ai/citadel-cli/internal/heartbeat"
 	"github.com/aceteam-ai/citadel-cli/internal/instance"
@@ -89,6 +90,15 @@ var (
 	ccVNCRunning atomic.Bool
 )
 
+// H.264 desktop stream server state (citadel-cli#338). Mirrors the VNC state
+// above: atomics for concurrent supervisor access, exposed over the tsnet mesh
+// via attachH264VPNListener. Gated on the same desktop permission as VNC.
+var (
+	ccH264Server  atomic.Pointer[deskstream.Server]
+	ccH264Port    = deskstream.DefaultPort
+	ccH264Running atomic.Bool
+)
+
 // vpnListener wraps a tsnet VPN listener with a liveness flag. tsnet does not
 // expose an explicit "listener torn down on reconnect" event, so we detect
 // death the only reliable way available: when the server's accept loop calls
@@ -137,6 +147,9 @@ var (
 
 	ccVNCVPNListener *vpnListener // nil when no VNC VPN listener is attached
 	ccVNCVPNIP       string       // tailnet IP the current VNC VPN listener is bound to
+
+	ccH264VPNListener *vpnListener // nil when no H.264 VPN listener is attached
+	ccH264VPNIP       string       // tailnet IP the current H.264 VPN listener is bound to
 
 	ccTerminalVPNListener *vpnListener // nil when no terminal VPN listener is attached
 	ccTerminalVPNIP       string       // tailnet IP the current terminal VPN listener is bound to
@@ -376,6 +389,7 @@ func runControlCenter() {
 		{name: "worker", fn: func() { _ = ccStopWorker() }},
 		{name: "terminal-server", fn: stopTerminalServer},
 		{name: "vnc-server", fn: stopVNCServer},
+		{name: "h264-server", fn: stopH264Server},
 		{name: "demo-server", fn: stopDemoServer},
 		{name: "instance-server", fn: func() {
 			if instanceServer != nil {
@@ -469,6 +483,16 @@ func ccOnNetworkConnect(activityFn func(level, msg string)) {
 			activityFn("warning", fmt.Sprintf("VNC server failed: %v", err))
 		} else {
 			activityFn("info", fmt.Sprintf("VNC server listening on port %d", ccVNCPort))
+		}
+
+		// Start the H.264 desktop stream server alongside VNC when the node can
+		// encode (ffmpeg + X). Clients that support H.264 use it; others fall
+		// back to noVNC. A node without ffmpeg/X simply logs and stays on VNC
+		// only (citadel-cli#338).
+		if err := startH264Server(); err != nil {
+			activityFn("info", fmt.Sprintf("H.264 stream unavailable (using VNC only): %v", err))
+		} else {
+			activityFn("info", fmt.Sprintf("H.264 stream server listening on port %d", ccH264Port))
 		}
 	}
 
@@ -660,6 +684,102 @@ func stopVNCServer() {
 	ccVPNMu.Unlock()
 }
 
+// startH264Server starts the embedded H.264 desktop stream server for remote
+// desktop video over the mesh (citadel-cli#338). It returns an error (and does
+// not mark itself running) when the node cannot encode H.264 (no ffmpeg or X),
+// so the caller leaves the node on VNC only and clients fall back to noVNC.
+func startH264Server() error {
+	if ccH264Running.Load() {
+		return nil
+	}
+
+	srv := deskstream.NewServer(deskstream.Config{
+		Host: "127.0.0.1",
+		Port: ccH264Port,
+		FPS:  15,
+	})
+	srv.SetSilent()
+
+	if err := srv.Start(); err != nil {
+		return fmt.Errorf("failed to start H.264 server: %w", err)
+	}
+
+	ccH264Server.Store(srv)
+	ccH264Running.Store(true)
+
+	// Attach the VPN listener so the stream is reachable over the tsnet mesh,
+	// mirroring the VNC exposure (issue #317 self-healing semantics).
+	attachH264VPNListener()
+	return nil
+}
+
+// stopH264Server stops the embedded H.264 stream server.
+func stopH264Server() {
+	if !ccH264Running.Load() {
+		return
+	}
+	if srv := ccH264Server.Load(); srv != nil {
+		srv.Stop()
+	}
+	ccH264Running.Store(false)
+
+	ccVPNMu.Lock()
+	if ccH264VPNListener != nil {
+		_ = ccH264VPNListener.Close()
+	}
+	ccH264VPNListener = nil
+	ccH264VPNIP = ""
+	ccVPNMu.Unlock()
+}
+
+// h264VPNHealthyLocked reports whether the H.264 VPN listener is currently
+// attached and live. Caller must hold ccVPNMu.
+func h264VPNHealthyLocked() bool {
+	return ccH264VPNListener != nil && !ccH264VPNListener.isDead()
+}
+
+// attachH264VPNListener (re)binds the H.264 server's tsnet VPN listener
+// idempotently, mirroring attachVNCVPNListener (issue #317). Safe to call
+// repeatedly: it no-ops when a live listener is attached and replaces a dead
+// one.
+func attachH264VPNListener() {
+	ccVPNMu.Lock()
+	defer ccVPNMu.Unlock()
+
+	srv := ccH264Server.Load()
+	if !ccH264Running.Load() || srv == nil {
+		return
+	}
+
+	if h264VPNHealthyLocked() {
+		return
+	}
+
+	if !isConnectedFn() {
+		return
+	}
+
+	if ccH264VPNListener != nil {
+		_ = ccH264VPNListener.Close()
+		srv.RemoveListener(ccH264VPNListener)
+		ccH264VPNListener = nil
+		ccH264VPNIP = ""
+	}
+
+	vpnPort := fmt.Sprintf("%d", ccH264Port)
+	rawLn, vpnIP, err := listenVPNFn("tcp", vpnPort)
+	if err != nil {
+		Log("H.264 server VPN listener failed (localhost-only): %v", err)
+		return
+	}
+
+	vpnLn := &vpnListener{Listener: rawLn}
+	srv.AddListener(vpnLn)
+	ccH264VPNListener = vpnLn
+	ccH264VPNIP = vpnIP
+	Log("H.264 server VPN listener on %s:%s", vpnIP, vpnPort)
+}
+
 // vncVPNHealthyLocked reports whether the VNC VPN listener is currently
 // attached and live. Caller must hold ccVPNMu.
 func vncVPNHealthyLocked() bool {
@@ -792,6 +912,9 @@ func vpnListenersHealthy() bool {
 	if ccVNCRunning.Load() && !vncVPNHealthyLocked() {
 		return false
 	}
+	if ccH264Running.Load() && !h264VPNHealthyLocked() {
+		return false
+	}
 	return true
 }
 
@@ -844,6 +967,9 @@ func ccSuperviseVPNListeners(ctx context.Context, activityFn func(level, msg str
 				if activityFn != nil && before == 0 && platform.EmbeddedVNCPort() != 0 {
 					activityFn("info", "Desktop VPN listener re-established after network reconnect")
 				}
+			}
+			if ccH264Running.Load() {
+				attachH264VPNListener()
 			}
 		}
 

--- a/internal/deskstream/annexb.go
+++ b/internal/deskstream/annexb.go
@@ -1,0 +1,118 @@
+// Package deskstream serves the node desktop as an H.264 video stream over a
+// binary WebSocket on the node mesh listener (citadel-cli#338). It mirrors the
+// VNC server's exposure model: it listens on localhost plus any tsnet VPN
+// listeners attached via AddListener, with no application-layer auth (the tsnet
+// mesh is the trust boundary, exactly like internal/desktop's VNCServer).
+//
+// Input (mouse/keyboard) is unchanged and stays on the existing action path;
+// this package is VIDEO-ONLY.
+package deskstream
+
+// H.264 in Annex-B format is a sequence of NAL (Network Abstraction Layer)
+// units, each prefixed by a start code of either 3 bytes (00 00 01) or 4 bytes
+// (00 00 00 01). The low 5 bits of the byte after the start code give the NAL
+// unit type. We care about three types when reconstructing keyframes for a
+// broadcast stream:
+//
+//	7 = SPS (Sequence Parameter Set)
+//	8 = PPS (Picture Parameter Set)
+//	5 = IDR slice (an instantaneous decoder refresh keyframe)
+//
+// A decoder that joins a broadcast mid-GOP cannot decode P-frames (which
+// reference prior encoder state), so the wire contract requires SPS+PPS to be
+// prepended on every IDR. We parse ffmpeg's Annex-B output ourselves (rather
+// than rely on encoder-specific header-repeat flags, which differ across
+// vaapi/nvenc/libx264) so the behavior is identical regardless of encoder.
+const (
+	nalTypeIDR = 5
+	nalTypeSPS = 7
+	nalTypePPS = 8
+)
+
+// NALUnit is a single Annex-B NAL unit including its leading start code.
+type NALUnit struct {
+	// Data is the full NAL unit bytes, INCLUDING the start code prefix.
+	Data []byte
+	// Type is the NAL unit type (low 5 bits of the byte after the start code).
+	Type int
+}
+
+// IsKeyframe reports whether this NAL unit is an IDR slice (a keyframe).
+func (n NALUnit) IsKeyframe() bool { return n.Type == nalTypeIDR }
+
+// IsParameterSet reports whether this NAL unit is an SPS or PPS.
+func (n NALUnit) IsParameterSet() bool { return n.Type == nalTypeSPS || n.Type == nalTypePPS }
+
+// startCodeLen returns the length of the Annex-B start code at the beginning of
+// b (4 for 00 00 00 01, 3 for 00 00 01), or 0 if b does not begin with a start
+// code.
+func startCodeLen(b []byte) int {
+	if len(b) >= 4 && b[0] == 0 && b[1] == 0 && b[2] == 0 && b[3] == 1 {
+		return 4
+	}
+	if len(b) >= 3 && b[0] == 0 && b[1] == 0 && b[2] == 1 {
+		return 3
+	}
+	return 0
+}
+
+// findStartCode returns the index of the next Annex-B start code at or after
+// offset start, plus the length of that start code. It returns (-1, 0) if none
+// is found. A 4-byte start code is reported as a 3-byte code at index+1 only
+// when the extra leading zero is part of the previous NAL's trailing bytes;
+// callers normalize by checking the byte before the match. To keep the parser
+// simple and unambiguous we always match the minimal 00 00 01 and let the
+// caller fold a preceding zero into the start code via startCodeLen on the
+// emitted slice.
+func findStartCode(b []byte, start int) (idx int, scLen int) {
+	for i := start; i+3 <= len(b); i++ {
+		if b[i] == 0 && b[i+1] == 0 && b[i+2] == 1 {
+			// Prefer the 4-byte form when a leading zero precedes the 00 00 01.
+			if i > 0 && b[i-1] == 0 {
+				return i - 1, 4
+			}
+			return i, 3
+		}
+	}
+	return -1, 0
+}
+
+// nalType extracts the NAL unit type from a NAL unit that begins with a start
+// code. Returns -1 if the slice is too short or has no start code.
+func nalType(nal []byte) int {
+	sc := startCodeLen(nal)
+	if sc == 0 || len(nal) <= sc {
+		return -1
+	}
+	return int(nal[sc] & 0x1f)
+}
+
+// splitNALUnits splits an Annex-B byte slice into complete NAL units, each
+// retaining its leading start code. A trailing partial NAL (one not terminated
+// by a following start code) is NOT returned; instead its byte offset within b
+// is returned as remainder so the caller can carry it into the next read. This
+// makes the function safe to drive from a streaming ffmpeg stdout pipe.
+//
+// remainder is the index in b where the unconsumed tail begins (len(b) when all
+// bytes were consumed into complete NAL units). Callers retain b[remainder:].
+func splitNALUnits(b []byte) (units []NALUnit, remainder int) {
+	// Locate the first start code; anything before it is not a NAL unit.
+	first, _ := findStartCode(b, 0)
+	if first < 0 {
+		return nil, 0
+	}
+
+	pos := first
+	for {
+		// Find the start of the NEXT NAL unit, which terminates the current one.
+		next, _ := findStartCode(b, pos+3)
+		if next < 0 {
+			// No following start code: the current NAL is incomplete (its full
+			// extent is unknown until more bytes arrive). Carry it over.
+			return units, pos
+		}
+		nal := b[pos:next]
+		units = append(units, NALUnit{Data: nal, Type: nalType(nal)})
+		pos = next
+	}
+}

--- a/internal/deskstream/annexb_test.go
+++ b/internal/deskstream/annexb_test.go
@@ -1,0 +1,120 @@
+package deskstream
+
+import "testing"
+
+// nal builds a NAL unit with a 4-byte start code and the given type byte.
+func nal(typ byte, payload ...byte) []byte {
+	b := []byte{0, 0, 0, 1, typ & 0x1f}
+	return append(b, payload...)
+}
+
+// nal3 builds a NAL unit with a 3-byte start code.
+func nal3(typ byte, payload ...byte) []byte {
+	b := []byte{0, 0, 1, typ & 0x1f}
+	return append(b, payload...)
+}
+
+func concat(parts ...[]byte) []byte {
+	var out []byte
+	for _, p := range parts {
+		out = append(out, p...)
+	}
+	return out
+}
+
+func TestStartCodeLen(t *testing.T) {
+	if got := startCodeLen([]byte{0, 0, 0, 1, 0x67}); got != 4 {
+		t.Errorf("4-byte start code: got %d, want 4", got)
+	}
+	if got := startCodeLen([]byte{0, 0, 1, 0x67}); got != 3 {
+		t.Errorf("3-byte start code: got %d, want 3", got)
+	}
+	if got := startCodeLen([]byte{1, 2, 3, 4}); got != 0 {
+		t.Errorf("no start code: got %d, want 0", got)
+	}
+}
+
+func TestNalType(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []byte
+		want int
+	}{
+		{"sps", nal(nalTypeSPS), nalTypeSPS},
+		{"pps", nal(nalTypePPS), nalTypePPS},
+		{"idr", nal(nalTypeIDR), nalTypeIDR},
+		{"sps-3byte", nal3(nalTypeSPS), nalTypeSPS},
+		{"no-start-code", []byte{0x67}, -1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := nalType(c.in); got != c.want {
+				t.Errorf("nalType = %d, want %d", got, c.want)
+			}
+		})
+	}
+}
+
+func TestSplitNALUnits_CompleteAndPartial(t *testing.T) {
+	sps := nal(nalTypeSPS, 0xAA)
+	pps := nal(nalTypePPS, 0xBB)
+	idr := nal(nalTypeIDR, 0xCC, 0xDD)
+	stream := concat(sps, pps, idr)
+
+	// A trailing partial NAL (start code present but not terminated) should be
+	// carried over as remainder, not emitted.
+	partial := []byte{0, 0, 0, 1, nalTypeIDR, 0x01}
+	full := concat(stream, partial)
+
+	units, remainder := splitNALUnits(full)
+	if len(units) != 3 {
+		t.Fatalf("got %d complete units, want 3", len(units))
+	}
+	if units[0].Type != nalTypeSPS || units[1].Type != nalTypePPS || units[2].Type != nalTypeIDR {
+		t.Errorf("unexpected types: %d %d %d", units[0].Type, units[1].Type, units[2].Type)
+	}
+	if remainder != len(stream) {
+		t.Errorf("remainder = %d, want %d (start of partial)", remainder, len(stream))
+	}
+	if !equalNAL(full[remainder:], partial) {
+		t.Errorf("remainder bytes = %v, want %v", full[remainder:], partial)
+	}
+}
+
+func TestSplitNALUnits_NoStartCode(t *testing.T) {
+	units, remainder := splitNALUnits([]byte{1, 2, 3, 4, 5})
+	if units != nil {
+		t.Errorf("expected no units, got %d", len(units))
+	}
+	if remainder != 0 {
+		t.Errorf("remainder = %d, want 0", remainder)
+	}
+}
+
+func TestNALUnitClassifiers(t *testing.T) {
+	idr := NALUnit{Type: nalTypeIDR}
+	if !idr.IsKeyframe() {
+		t.Error("IDR should be a keyframe")
+	}
+	if idr.IsParameterSet() {
+		t.Error("IDR is not a parameter set")
+	}
+	sps := NALUnit{Type: nalTypeSPS}
+	if !sps.IsParameterSet() {
+		t.Error("SPS should be a parameter set")
+	}
+	if sps.IsKeyframe() {
+		t.Error("SPS is not a keyframe")
+	}
+}
+
+func TestPayloadHasKeyframe(t *testing.T) {
+	withIDR := concat(nal(nalTypeSPS), nal(nalTypePPS), nal(nalTypeIDR))
+	if !payloadHasKeyframe(withIDR) {
+		t.Error("payload with IDR should report keyframe")
+	}
+	withoutIDR := nal(1, 0x01) // a non-IDR slice
+	if payloadHasKeyframe(withoutIDR) {
+		t.Error("payload without IDR should not report keyframe")
+	}
+}

--- a/internal/deskstream/conn.go
+++ b/internal/deskstream/conn.go
@@ -47,7 +47,7 @@ func (s *Server) handleStream(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	display := resolveDisplay()
-	enc, err := selectEncoder(ffmpegHasEncoder)
+	enc, err := s.encoder()
 	if err != nil {
 		s.logger.Printf("no encoder available: %v", err)
 		return
@@ -96,7 +96,11 @@ func (s *Server) handleStream(w http.ResponseWriter, r *http.Request) {
 		s.logger.Printf("encoder start failed: %v", err)
 		return
 	}
-	defer runner.Stop()
+	// Stop the CURRENT runner at return. The closure captures the runner
+	// VARIABLE (evaluated at return time), not the value bound here, so it
+	// correctly stops whichever runner is live after a requestKeyframe restart
+	// reassigned it — otherwise the restarted ffmpeg would never be reaped.
+	defer func() { runner.Stop() }()
 
 	// Reader goroutine: handles client TEXT frames (requestKeyframe) and detects
 	// disconnects. It never writes to the socket.
@@ -131,7 +135,10 @@ func (s *Server) handleStream(w http.ResponseWriter, r *http.Request) {
 		case <-restart:
 			// On-demand keyframe: restart the encoder so the next frames begin
 			// with SPS+PPS+IDR. Drain any stale queued payloads first so the
-			// client does not briefly receive pre-restart P-frames.
+			// client does not briefly receive pre-restart P-frames. A late
+			// onPayload from the old runner's read goroutine can still slip one
+			// stale P-frame past drain before the new keyframe arrives; the
+			// decoder self-corrects within a frame, which is acceptable here.
 			runner.Stop()
 			drain(payloads)
 			runner = newEncoderRunner(cfg, enc, func(p []byte) {

--- a/internal/deskstream/conn.go
+++ b/internal/deskstream/conn.go
@@ -1,0 +1,170 @@
+package deskstream
+
+import (
+	"context"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+const (
+	// writeWait is the deadline for a single WebSocket write.
+	writeWait = 10 * time.Second
+	// pongWait / pingPeriod keep the connection alive and detect dead peers.
+	pongWait   = 60 * time.Second
+	pingPeriod = 25 * time.Second
+)
+
+// handleStream upgrades an HTTP request to a WebSocket and serves the H.264
+// stream per the wire contract:
+//
+//  1. The server sends ONE TEXT frame: the init JSON (see InitMessage).
+//  2. The server then sends BINARY frames, each a sequence of Annex-B NAL
+//     units. SPS+PPS are prepended on every IDR keyframe (see nalFramer).
+//  3. The client MAY send a TEXT frame {"type":"requestKeyframe"} to force an
+//     immediate IDR; the server restarts its encoder to honor it (a fresh
+//     ffmpeg process always begins with SPS+PPS+IDR).
+//
+// A fresh connection is treated as an implicit keyframe request: the encoder is
+// started from scratch, so the first BINARY frame already carries SPS+PPS+IDR
+// and the client can decode without waiting up to the 2s periodic interval.
+func (s *Server) handleStream(w http.ResponseWriter, r *http.Request) {
+	conn, err := s.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		s.logger.Printf("websocket upgrade failed for %s: %v", r.RemoteAddr, err)
+		return
+	}
+	atomic.AddInt64(&s.totalConns, 1)
+	atomic.AddInt64(&s.activeConns, 1)
+	remote := r.RemoteAddr
+	s.logger.Printf("client connected: %s", remote)
+	defer func() {
+		conn.Close()
+		atomic.AddInt64(&s.activeConns, -1)
+		s.logger.Printf("client disconnected: %s", remote)
+	}()
+
+	display := resolveDisplay()
+	enc, err := selectEncoder(ffmpegHasEncoder)
+	if err != nil {
+		s.logger.Printf("no encoder available: %v", err)
+		return
+	}
+	geom := detectGeometry(display)
+	gop := s.fps * 2
+
+	cfg := EncodeConfig{
+		Display:          display,
+		Width:            geom.Width,
+		Height:           geom.Height,
+		FPS:              s.fps,
+		KeyframeInterval: gop,
+	}
+
+	// Send the init TEXT frame first (wire contract step 1).
+	initMsg := NewInitMessage(geom.Width, geom.Height, s.fps, gop)
+	initBytes, err := initMsg.Marshal()
+	if err != nil {
+		s.logger.Printf("marshal init: %v", err)
+		return
+	}
+	_ = conn.SetWriteDeadline(time.Now().Add(writeWait))
+	if err := conn.WriteMessage(websocket.TextMessage, initBytes); err != nil {
+		s.logger.Printf("write init failed: %v", err)
+		return
+	}
+
+	// Single writer: all WebSocket writes happen on this goroutine via the
+	// payload/ping channels. gorilla panics on concurrent writes, so the encoder
+	// callback (a different goroutine) only ENQUEUES; it never writes directly.
+	payloads := make(chan []byte, 64)
+	restart := make(chan struct{}, 1)
+
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+
+	runner := newEncoderRunner(cfg, enc, func(p []byte) {
+		// Drop frames if the client cannot keep up rather than block ffmpeg.
+		select {
+		case payloads <- p:
+		default:
+		}
+	})
+	if err := runner.Start(ctx); err != nil {
+		s.logger.Printf("encoder start failed: %v", err)
+		return
+	}
+	defer runner.Stop()
+
+	// Reader goroutine: handles client TEXT frames (requestKeyframe) and detects
+	// disconnects. It never writes to the socket.
+	go func() {
+		conn.SetReadLimit(4096)
+		_ = conn.SetReadDeadline(time.Now().Add(pongWait))
+		conn.SetPongHandler(func(string) error {
+			return conn.SetReadDeadline(time.Now().Add(pongWait))
+		})
+		for {
+			mt, data, rerr := conn.ReadMessage()
+			if rerr != nil {
+				cancel()
+				return
+			}
+			if mt == websocket.TextMessage && parseClientMessage(data) == ClientMsgRequestKeyframe {
+				select {
+				case restart <- struct{}{}:
+				default:
+				}
+			}
+		}
+	}()
+
+	ping := time.NewTicker(pingPeriod)
+	defer ping.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-restart:
+			// On-demand keyframe: restart the encoder so the next frames begin
+			// with SPS+PPS+IDR. Drain any stale queued payloads first so the
+			// client does not briefly receive pre-restart P-frames.
+			runner.Stop()
+			drain(payloads)
+			runner = newEncoderRunner(cfg, enc, func(p []byte) {
+				select {
+				case payloads <- p:
+				default:
+				}
+			})
+			if err := runner.Start(ctx); err != nil {
+				s.logger.Printf("encoder restart failed: %v", err)
+				return
+			}
+		case p := <-payloads:
+			_ = conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if err := conn.WriteMessage(websocket.BinaryMessage, p); err != nil {
+				return
+			}
+		case <-ping.C:
+			_ = conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if err := conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
+		}
+	}
+}
+
+// drain empties a payload channel without blocking.
+func drain(ch chan []byte) {
+	for {
+		select {
+		case <-ch:
+		default:
+			return
+		}
+	}
+}

--- a/internal/deskstream/encoder.go
+++ b/internal/deskstream/encoder.go
@@ -1,0 +1,188 @@
+package deskstream
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// EncoderKind identifies which H.264 encoder ffmpeg will use.
+type EncoderKind string
+
+const (
+	// EncoderVAAPI is hardware H.264 via VA-API (Intel/AMD).
+	EncoderVAAPI EncoderKind = "h264_vaapi"
+	// EncoderNVENC is hardware H.264 via NVIDIA NVENC.
+	EncoderNVENC EncoderKind = "h264_nvenc"
+	// EncoderSoftware is software H.264 via libx264.
+	EncoderSoftware EncoderKind = "libx264"
+)
+
+// EncoderProbe is a function that reports whether ffmpeg lists the named
+// encoder. It is a variable so tests can substitute a fake without running
+// ffmpeg.
+type EncoderProbe func(name string) bool
+
+// EncodeConfig describes a capture+encode session.
+type EncodeConfig struct {
+	Display          string // X display, e.g. ":0"
+	Width            int    // capture width in pixels
+	Height           int    // capture height in pixels
+	FPS              int    // target frame rate
+	KeyframeInterval int    // forced IDR interval in frames (g)
+}
+
+// selectEncoder picks the best available H.264 encoder, preferring hardware
+// (VA-API, then NVENC) and falling back to software libx264. It returns an
+// error if NONE is available, so callers can advertise h264=false and degrade
+// to noVNC.
+//
+// The preference order is fixed: VA-API first because it is the most common
+// zero-config hardware path on Linux desktop nodes, then NVENC for NVIDIA hosts,
+// then software.
+func selectEncoder(probe EncoderProbe) (EncoderKind, error) {
+	if probe == nil {
+		probe = ffmpegHasEncoder
+	}
+	for _, enc := range []EncoderKind{EncoderVAAPI, EncoderNVENC, EncoderSoftware} {
+		if probe(string(enc)) {
+			return enc, nil
+		}
+	}
+	return "", fmt.Errorf("no H.264 encoder available in ffmpeg (need h264_vaapi, h264_nvenc, or libx264)")
+}
+
+// ffmpegHasEncoder reports whether `ffmpeg -hide_banner -encoders` lists name.
+// Returns false if ffmpeg is absent or the probe fails.
+func ffmpegHasEncoder(name string) bool {
+	path, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		return false
+	}
+	out, err := exec.Command(path, "-hide_banner", "-encoders").CombinedOutput()
+	if err != nil {
+		return false
+	}
+	// Encoder lines look like " V....D h264_nvenc   NVIDIA NVENC H.264 encoder".
+	// Match the token surrounded by whitespace to avoid substring false hits.
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		for _, fld := range fields {
+			if fld == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// buildFFmpegArgs builds the ffmpeg argument vector that captures the X display
+// via x11grab and emits raw H.264 Annex-B NAL units on stdout.
+//
+// Common invariants for all encoders:
+//   - x11grab input at the configured fps and display.
+//   - Output muxed as raw h264 (Annex-B) to stdout ("-f h264 -" / "pipe:1").
+//   - A forced IDR at least every 2 seconds AND at the keyframe interval, via
+//     -g and -force_key_frames, so a fresh broadcast viewer never waits more
+//     than ~2s for a decodable frame even without an explicit request.
+//   - zerolatency-friendly settings (no B-frames, low GOP) to minimize delay.
+//
+// The actual on-demand keyframe (client requestKeyframe) is handled OUTSIDE
+// ffmpeg by respawning the encoder, since an ffmpeg subprocess has no stdin
+// signal to force a keyframe mid-stream.
+func buildFFmpegArgs(cfg EncodeConfig, enc EncoderKind) []string {
+	fps := cfg.FPS
+	if fps <= 0 {
+		fps = 15
+	}
+	gop := cfg.KeyframeInterval
+	if gop <= 0 {
+		gop = fps * 2 // ~2s keyframe interval
+	}
+	size := fmt.Sprintf("%dx%d", cfg.Width, cfg.Height)
+
+	// Common input: grab the X display.
+	args := []string{
+		"-hide_banner",
+		"-loglevel", "error",
+		"-f", "x11grab",
+		"-framerate", strconv.Itoa(fps),
+	}
+	if cfg.Width > 0 && cfg.Height > 0 {
+		args = append(args, "-video_size", size)
+	}
+	args = append(args, "-i", cfg.Display)
+
+	// Force a keyframe at least every 2 seconds regardless of scene content.
+	forceKey := "expr:gte(t,n_forced*2)"
+
+	switch enc {
+	case EncoderVAAPI:
+		// VA-API needs the frames uploaded to the GPU; nv12 is the standard
+		// surface format. The device defaults to /dev/dri/renderD128.
+		args = append(args,
+			"-vaapi_device", "/dev/dri/renderD128",
+			"-vf", "format=nv12,hwupload",
+			"-c:v", "h264_vaapi",
+			"-g", strconv.Itoa(gop),
+			"-force_key_frames", forceKey,
+			"-bf", "0",
+		)
+	case EncoderNVENC:
+		args = append(args,
+			"-c:v", "h264_nvenc",
+			"-preset", "p1", // fastest / low-latency
+			"-tune", "ll", // low latency
+			"-g", strconv.Itoa(gop),
+			"-force_key_frames", forceKey,
+			"-bf", "0",
+		)
+	default: // software
+		args = append(args,
+			"-c:v", "libx264",
+			"-preset", "ultrafast",
+			"-tune", "zerolatency",
+			"-profile:v", "baseline",
+			"-pix_fmt", "yuv420p",
+			"-g", strconv.Itoa(gop),
+			"-force_key_frames", forceKey,
+			"-bf", "0",
+		)
+	}
+
+	// Raw Annex-B H.264 on stdout.
+	args = append(args, "-f", "h264", "pipe:1")
+	return args
+}
+
+// resolveDisplay returns the X display to capture: the DISPLAY env var, or ":0"
+// as a fallback (matching internal/desktop's screenshot path).
+func resolveDisplay() string {
+	if d := os.Getenv("DISPLAY"); d != "" {
+		return d
+	}
+	return ":0"
+}
+
+// H264Available reports whether this node can serve an H.264 desktop stream:
+// Linux, ffmpeg present with a usable H.264 encoder, and an X display set.
+// Clients use this (advertised as the "h264" capability) to decide whether to
+// stream H.264 or fall back to noVNC.
+func H264Available() bool {
+	if runtime.GOOS != "linux" {
+		return false
+	}
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		return false
+	}
+	if _, err := selectEncoder(ffmpegHasEncoder); err != nil {
+		return false
+	}
+	// An X display must be reachable; we only check the variable here (a cheap,
+	// allocation-free signal). The full reachability check happens when the
+	// encoder starts and is reported via the stream's error path.
+	return resolveDisplay() != ""
+}

--- a/internal/deskstream/encoder_test.go
+++ b/internal/deskstream/encoder_test.go
@@ -1,0 +1,102 @@
+package deskstream
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSelectEncoder_PrefersHardware(t *testing.T) {
+	// All available: VA-API wins.
+	all := func(string) bool { return true }
+	enc, err := selectEncoder(all)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if enc != EncoderVAAPI {
+		t.Errorf("got %s, want VA-API (first preference)", enc)
+	}
+}
+
+func TestSelectEncoder_FallsBackToNVENC(t *testing.T) {
+	only := func(name string) bool { return name == string(EncoderNVENC) || name == string(EncoderSoftware) }
+	enc, err := selectEncoder(only)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if enc != EncoderNVENC {
+		t.Errorf("got %s, want NVENC", enc)
+	}
+}
+
+func TestSelectEncoder_FallsBackToSoftware(t *testing.T) {
+	only := func(name string) bool { return name == string(EncoderSoftware) }
+	enc, err := selectEncoder(only)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if enc != EncoderSoftware {
+		t.Errorf("got %s, want libx264", enc)
+	}
+}
+
+func TestSelectEncoder_NoneAvailable(t *testing.T) {
+	none := func(string) bool { return false }
+	if _, err := selectEncoder(none); err == nil {
+		t.Error("expected an error when no encoder is available")
+	}
+}
+
+func TestBuildFFmpegArgs_Common(t *testing.T) {
+	cfg := EncodeConfig{Display: ":0", Width: 1920, Height: 1080, FPS: 30, KeyframeInterval: 60}
+	args := buildFFmpegArgs(cfg, EncoderSoftware)
+	joined := strings.Join(args, " ")
+
+	for _, want := range []string{
+		"-f x11grab",
+		"-framerate 30",
+		"-video_size 1920x1080",
+		"-i :0",
+		"-c:v libx264",
+		"-tune zerolatency",
+		"-g 60",
+		"-force_key_frames",
+		"-f h264",
+		"pipe:1",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("software args missing %q\nargs: %s", want, joined)
+		}
+	}
+}
+
+func TestBuildFFmpegArgs_DefaultKeyframeIsTwoSeconds(t *testing.T) {
+	// With FPS=15 and no explicit interval, GOP should default to fps*2 = 30.
+	cfg := EncodeConfig{Display: ":0", Width: 800, Height: 600, FPS: 15}
+	args := buildFFmpegArgs(cfg, EncoderSoftware)
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "-g 30") {
+		t.Errorf("expected default GOP of fps*2=30, got: %s", joined)
+	}
+}
+
+func TestBuildFFmpegArgs_VAAPI(t *testing.T) {
+	cfg := EncodeConfig{Display: ":0", Width: 1280, Height: 720, FPS: 15, KeyframeInterval: 30}
+	args := buildFFmpegArgs(cfg, EncoderVAAPI)
+	joined := strings.Join(args, " ")
+	for _, want := range []string{"-vaapi_device", "format=nv12,hwupload", "-c:v h264_vaapi"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("VA-API args missing %q\nargs: %s", want, joined)
+		}
+	}
+}
+
+func TestBuildFFmpegArgs_NVENC(t *testing.T) {
+	cfg := EncodeConfig{Display: ":0", Width: 1280, Height: 720, FPS: 15, KeyframeInterval: 30}
+	args := buildFFmpegArgs(cfg, EncoderNVENC)
+	joined := strings.Join(args, " ")
+	for _, want := range []string{"-c:v h264_nvenc", "-tune ll"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("NVENC args missing %q\nargs: %s", want, joined)
+		}
+	}
+}

--- a/internal/deskstream/framer.go
+++ b/internal/deskstream/framer.go
@@ -1,0 +1,146 @@
+package deskstream
+
+import "bytes"
+
+// nalFramer consumes a streaming Annex-B byte stream (e.g. ffmpeg stdout) and
+// produces WebSocket BINARY payloads ready to send to clients, applying the
+// wire contract's keyframe rule:
+//
+//	SPS+PPS are prepended to every IDR keyframe.
+//
+// The framer caches the most recently seen SPS and PPS so that even encoders
+// which only emit parameter sets once (at stream start) still get them in front
+// of every keyframe. This makes any single keyframe payload independently
+// decodable by a client that joined the broadcast mid-GOP.
+//
+// nalFramer is NOT safe for concurrent use; drive it from a single goroutine.
+type nalFramer struct {
+	sps []byte // latest SPS NAL unit (with start code), or nil
+	pps []byte // latest PPS NAL unit (with start code), or nil
+
+	buf []byte // carry-over bytes for a partial trailing NAL unit
+}
+
+// newNALFramer creates an empty framer.
+func newNALFramer() *nalFramer { return &nalFramer{} }
+
+// Push appends a chunk of Annex-B bytes (as read from ffmpeg stdout) and
+// returns zero or more complete WebSocket BINARY payloads. Each returned
+// payload is a self-contained sequence of one or more NAL units:
+//
+//   - A non-keyframe access unit is forwarded as-is.
+//   - A keyframe (IDR) access unit is prefixed with the cached SPS+PPS (unless
+//     the encoder already emitted them inline, in which case they are not
+//     duplicated).
+//
+// SPS/PPS NAL units that arrive on their own (not adjacent to a slice) update
+// the cache and are not emitted separately; they ride in front of the next
+// keyframe instead.
+func (f *nalFramer) Push(chunk []byte) [][]byte {
+	f.buf = append(f.buf, chunk...)
+	units, remainder := splitNALUnits(f.buf)
+	// Retain the unconsumed tail (a partial NAL) for the next Push.
+	if remainder > 0 {
+		f.buf = append(f.buf[:0], f.buf[remainder:]...)
+	}
+
+	var out [][]byte
+	// pending accumulates the NAL units of the access unit being assembled, so
+	// that SPS/PPS that immediately precede an IDR are kept together with it.
+	var pending [][]byte
+	var pendingHasKeyframe bool
+	var pendingHasSPS, pendingHasPPS bool
+
+	flush := func() {
+		if len(pending) == 0 {
+			return
+		}
+		var payload []byte
+		if pendingHasKeyframe {
+			// Prepend cached SPS/PPS unless already present inline.
+			if !pendingHasSPS && f.sps != nil {
+				payload = append(payload, f.sps...)
+			}
+			if !pendingHasPPS && f.pps != nil {
+				payload = append(payload, f.pps...)
+			}
+		}
+		for _, u := range pending {
+			payload = append(payload, u...)
+		}
+		out = append(out, payload)
+		pending = pending[:0]
+		pendingHasKeyframe = false
+		pendingHasSPS = false
+		pendingHasPPS = false
+	}
+
+	for _, u := range units {
+		switch {
+		case u.Type == nalTypeSPS:
+			f.sps = append([]byte(nil), u.Data...)
+			pending = append(pending, u.Data)
+			pendingHasSPS = true
+		case u.Type == nalTypePPS:
+			f.pps = append([]byte(nil), u.Data...)
+			pending = append(pending, u.Data)
+			pendingHasPPS = true
+		case u.Type == nalTypeIDR:
+			pending = append(pending, u.Data)
+			pendingHasKeyframe = true
+			flush()
+		default:
+			// A non-IDR slice (P-frame) or other NAL ends the access unit.
+			pending = append(pending, u.Data)
+			flush()
+		}
+	}
+	// Leave any trailing SPS/PPS-only pending bytes cached for the next keyframe;
+	// do not emit a parameter-set-only payload.
+	if pendingHasKeyframe {
+		flush()
+	}
+	return out
+}
+
+// HasParameterSets reports whether both an SPS and a PPS have been observed,
+// which is the point at which keyframes become independently decodable.
+func (f *nalFramer) HasParameterSets() bool { return f.sps != nil && f.pps != nil }
+
+// payloadHasKeyframe reports whether a marshaled BINARY payload contains an IDR
+// NAL unit. Exposed for tests and for connection bookkeeping.
+func payloadHasKeyframe(payload []byte) bool {
+	for _, u := range scanNALUnits(payload) {
+		if u.Type == nalTypeIDR {
+			return true
+		}
+	}
+	return false
+}
+
+// scanNALUnits splits a COMPLETE Annex-B payload (one already framed for the
+// wire, so fully terminated) into its NAL units. Unlike splitNALUnits it treats
+// the final NAL as complete.
+func scanNALUnits(b []byte) []NALUnit {
+	first, _ := findStartCode(b, 0)
+	if first < 0 {
+		return nil
+	}
+	var units []NALUnit
+	pos := first
+	for {
+		next, _ := findStartCode(b, pos+3)
+		if next < 0 {
+			nal := b[pos:]
+			units = append(units, NALUnit{Data: nal, Type: nalType(nal)})
+			return units
+		}
+		nal := b[pos:next]
+		units = append(units, NALUnit{Data: nal, Type: nalType(nal)})
+		pos = next
+	}
+}
+
+// equalNAL reports whether two NAL unit payloads are byte-identical. Used by
+// tests to assert SPS/PPS prepending.
+func equalNAL(a, b []byte) bool { return bytes.Equal(a, b) }

--- a/internal/deskstream/framer.go
+++ b/internal/deskstream/framer.go
@@ -39,10 +39,12 @@ func newNALFramer() *nalFramer { return &nalFramer{} }
 func (f *nalFramer) Push(chunk []byte) [][]byte {
 	f.buf = append(f.buf, chunk...)
 	units, remainder := splitNALUnits(f.buf)
-	// Retain the unconsumed tail (a partial NAL) for the next Push.
-	if remainder > 0 {
-		f.buf = append(f.buf[:0], f.buf[remainder:]...)
-	}
+	// Retain the unconsumed tail (a partial NAL) for the next Push. The NAL
+	// slices in units alias f.buf, so we must NOT compact f.buf in place here
+	// (that would overwrite bytes the pending units still point at). Snapshot
+	// the tail into a fresh backing array and replace f.buf with it.
+	tail := append([]byte(nil), f.buf[remainder:]...)
+	f.buf = tail
 
 	var out [][]byte
 	// pending accumulates the NAL units of the access unit being assembled, so

--- a/internal/deskstream/framer_test.go
+++ b/internal/deskstream/framer_test.go
@@ -1,0 +1,124 @@
+package deskstream
+
+import "testing"
+
+// TestFramer_PrependsSPSPPSOnKeyframe verifies the core wire-contract rule:
+// when SPS+PPS appear only once at stream start, every later IDR keyframe still
+// carries SPS+PPS in front of it.
+func TestFramer_PrependsSPSPPSOnKeyframe(t *testing.T) {
+	sps := nal(nalTypeSPS, 0xAA)
+	pps := nal(nalTypePPS, 0xBB)
+	idr1 := nal(nalTypeIDR, 0x11)
+	pslice := nal(1, 0x22) // P-frame
+	idr2 := nal(nalTypeIDR, 0x33)
+
+	f := newNALFramer()
+
+	// First access unit: SPS + PPS + IDR. The trailing pslice has no following
+	// start code yet, so it is buffered until the next NAL terminates it (this
+	// mirrors how ffmpeg stdout streams). So this Push emits exactly the keyframe
+	// payload; the P-frame flushes on the next Push.
+	out := f.Push(concat(sps, pps, idr1, pslice))
+	if len(out) != 1 {
+		t.Fatalf("got %d payloads, want 1 (keyframe; P-frame buffered): %v", len(out), out)
+	}
+	if !payloadHasKeyframe(out[0]) {
+		t.Fatal("first payload should contain the keyframe")
+	}
+	// The keyframe payload must begin with SPS then PPS.
+	units := scanNALUnits(out[0])
+	if len(units) < 3 || units[0].Type != nalTypeSPS || units[1].Type != nalTypePPS || units[2].Type != nalTypeIDR {
+		t.Fatalf("keyframe payload not SPS,PPS,IDR: %v", typesOf(units))
+	}
+
+	// Second keyframe arrives WITHOUT inline SPS/PPS. The framer must prepend
+	// the cached ones. (The previously buffered P-frame flushes first, then the
+	// keyframe payload; find the keyframe payload among the outputs.)
+	out2 := f.Push(concat(idr2, nal(1, 0x44)))
+	var kf []byte
+	for _, p := range out2 {
+		if payloadHasKeyframe(p) {
+			kf = p
+		}
+	}
+	if kf == nil {
+		t.Fatalf("expected a keyframe payload, got %d payloads", len(out2))
+	}
+	kunits := scanNALUnits(kf)
+	if len(kunits) < 3 || kunits[0].Type != nalTypeSPS || kunits[1].Type != nalTypePPS || kunits[2].Type != nalTypeIDR {
+		t.Fatalf("second keyframe missing prepended SPS/PPS: %v", typesOf(kunits))
+	}
+	// And the prepended SPS/PPS must be byte-identical to the originals.
+	if !equalNAL(kunits[0].Data, sps) || !equalNAL(kunits[1].Data, pps) {
+		t.Error("prepended SPS/PPS bytes differ from cached originals")
+	}
+}
+
+// TestFramer_DoesNotDuplicateInlineParamSets ensures we do not prepend cached
+// SPS/PPS when the encoder already emitted them inline with the IDR.
+func TestFramer_DoesNotDuplicateInlineParamSets(t *testing.T) {
+	sps := nal(nalTypeSPS, 0xAA)
+	pps := nal(nalTypePPS, 0xBB)
+	idr := nal(nalTypeIDR, 0x11)
+
+	f := newNALFramer()
+	out := f.Push(concat(sps, pps, idr, nal(1, 0x22)))
+	if len(out) < 1 {
+		t.Fatal("expected a keyframe payload")
+	}
+	units := scanNALUnits(out[0])
+	spsCount := 0
+	for _, u := range units {
+		if u.Type == nalTypeSPS {
+			spsCount++
+		}
+	}
+	if spsCount != 1 {
+		t.Errorf("SPS appears %d times, want exactly 1 (no duplication)", spsCount)
+	}
+}
+
+// TestFramer_PFrameNotPrefixed ensures non-keyframe payloads are NOT prefixed
+// with parameter sets.
+func TestFramer_PFrameNotPrefixed(t *testing.T) {
+	sps := nal(nalTypeSPS, 0xAA)
+	pps := nal(nalTypePPS, 0xBB)
+	idr := nal(nalTypeIDR, 0x11)
+	p1 := nal(1, 0x22)
+	p2 := nal(1, 0x33)
+
+	f := newNALFramer()
+	// prime SPS/PPS via a keyframe.
+	f.Push(concat(sps, pps, idr, p1, p2))
+	// A standalone P-frame stream.
+	out := f.Push(concat(nal(1, 0x44), nal(1, 0x55)))
+	for _, payload := range out {
+		if payloadHasKeyframe(payload) {
+			t.Fatal("P-frame payload unexpectedly flagged as keyframe")
+		}
+		for _, u := range scanNALUnits(payload) {
+			if u.IsParameterSet() {
+				t.Error("P-frame payload should not carry SPS/PPS")
+			}
+		}
+	}
+}
+
+func TestFramer_HasParameterSets(t *testing.T) {
+	f := newNALFramer()
+	if f.HasParameterSets() {
+		t.Error("fresh framer should not have parameter sets")
+	}
+	f.Push(concat(nal(nalTypeSPS, 0x01), nal(nalTypePPS, 0x02), nal(nalTypeIDR, 0x03), nal(1, 0x04)))
+	if !f.HasParameterSets() {
+		t.Error("framer should have parameter sets after a keyframe with SPS/PPS")
+	}
+}
+
+func typesOf(units []NALUnit) []int {
+	out := make([]int, len(units))
+	for i, u := range units {
+		out[i] = u.Type
+	}
+	return out
+}

--- a/internal/deskstream/runner.go
+++ b/internal/deskstream/runner.go
@@ -1,0 +1,133 @@
+package deskstream
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sync"
+)
+
+// encoderRunner owns a single ffmpeg subprocess that captures the X display and
+// emits Annex-B H.264 on stdout. It parses the stream into wire-ready BINARY
+// payloads (SPS+PPS prepended on keyframes) and pushes them to a callback.
+//
+// Because an ffmpeg subprocess has no stdin signal to force a keyframe, an
+// on-demand keyframe (client requestKeyframe, or a brand-new viewer joining) is
+// served by restarting ffmpeg: a fresh process always starts with SPS+PPS+IDR.
+// This is acceptable for the relay broadcast model (a short, ~one-frame hiccup)
+// and keeps the encoder selection logic encoder-independent.
+type encoderRunner struct {
+	cfg     EncodeConfig
+	encoder EncoderKind
+
+	onPayload func([]byte) // called with each wire-ready BINARY payload
+
+	mu      sync.Mutex
+	cmd     *exec.Cmd
+	cancel  context.CancelFunc
+	running bool
+}
+
+// newEncoderRunner creates a runner. onPayload is invoked from the runner's
+// read goroutine for every BINARY payload; it must be safe to call from that
+// goroutine and should not block for long.
+func newEncoderRunner(cfg EncodeConfig, enc EncoderKind, onPayload func([]byte)) *encoderRunner {
+	return &encoderRunner{cfg: cfg, encoder: enc, onPayload: onPayload}
+}
+
+// Start launches the ffmpeg subprocess and begins streaming payloads. It
+// returns an error if ffmpeg cannot be started (e.g. binary missing). Capture
+// errors (e.g. X display unreachable) surface asynchronously when ffmpeg exits;
+// the read goroutine simply ends.
+func (r *encoderRunner) Start(ctx context.Context) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.running {
+		return fmt.Errorf("encoder already running")
+	}
+
+	path, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		return fmt.Errorf("ffmpeg not found: %w", err)
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	args := buildFFmpegArgs(r.cfg, r.encoder)
+	cmd := exec.CommandContext(runCtx, path, args...)
+	cmd.Env = append(os.Environ(), "DISPLAY="+r.cfg.Display)
+	cmd.Stderr = os.Stderr
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return fmt.Errorf("ffmpeg stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return fmt.Errorf("start ffmpeg: %w", err)
+	}
+
+	r.cmd = cmd
+	r.cancel = cancel
+	r.running = true
+
+	go r.readLoop(stdout)
+	return nil
+}
+
+// readLoop reads Annex-B bytes from ffmpeg stdout, frames them, and forwards
+// each wire-ready payload via onPayload.
+func (r *encoderRunner) readLoop(stdout io.ReadCloser) {
+	defer func() {
+		r.mu.Lock()
+		r.running = false
+		r.mu.Unlock()
+	}()
+
+	framer := newNALFramer()
+	reader := bufio.NewReaderSize(stdout, 64*1024)
+	chunk := make([]byte, 32*1024)
+	for {
+		n, err := reader.Read(chunk)
+		if n > 0 {
+			for _, payload := range framer.Push(chunk[:n]) {
+				if r.onPayload != nil {
+					r.onPayload(payload)
+				}
+			}
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// Stop terminates the ffmpeg subprocess and waits for the read goroutine to
+// drain. It is safe to call multiple times.
+func (r *encoderRunner) Stop() {
+	r.mu.Lock()
+	cancel := r.cancel
+	cmd := r.cmd
+	r.cancel = nil
+	r.cmd = nil
+	r.running = false
+	r.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if cmd != nil {
+		_ = cmd.Wait()
+	}
+}
+
+// IsRunning reports whether the ffmpeg subprocess is currently active.
+func (r *encoderRunner) IsRunning() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.running
+}

--- a/internal/deskstream/server.go
+++ b/internal/deskstream/server.go
@@ -38,6 +38,21 @@ type Server struct {
 
 	activeConns int64
 	totalConns  int64
+
+	// encoderOnce/selectedEncoder memoize the chosen H.264 encoder so the
+	// `ffmpeg -encoders` probe runs once per server rather than on every
+	// connection.
+	encoderOnce     sync.Once
+	selectedEncoder EncoderKind
+	encoderErr      error
+}
+
+// encoder returns the memoized H.264 encoder selection for this server.
+func (s *Server) encoder() (EncoderKind, error) {
+	s.encoderOnce.Do(func() {
+		s.selectedEncoder, s.encoderErr = selectEncoder(ffmpegHasEncoder)
+	})
+	return s.selectedEncoder, s.encoderErr
 }
 
 // Logger matches the VNC/terminal server logger interface.
@@ -146,8 +161,9 @@ func (s *Server) Start() error {
 	}
 
 	// Verify an encoder is available before claiming to be up, so a node without
-	// ffmpeg/X reports a clear error and clients fall back to noVNC.
-	if _, err := selectEncoder(ffmpegHasEncoder); err != nil {
+	// ffmpeg/X reports a clear error and clients fall back to noVNC. The result
+	// is memoized for reuse by every connection.
+	if _, err := s.encoder(); err != nil {
 		s.mu.Unlock()
 		return fmt.Errorf("H.264 unavailable: %w", err)
 	}

--- a/internal/deskstream/server.go
+++ b/internal/deskstream/server.go
@@ -1,0 +1,230 @@
+package deskstream
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// Server serves the node desktop as an H.264 stream over a binary WebSocket
+// (citadel-cli#338). It mirrors the VNC server's mesh exposure: it listens on
+// localhost and on any tsnet VPN listeners attached via AddListener, with no
+// application-layer auth (the tsnet mesh is the trust boundary). Input is
+// unchanged and not handled here; this is VIDEO-ONLY.
+//
+// Each connection runs its OWN ffmpeg encoder so that a new viewer always
+// starts at an IDR and an on-demand keyframe (requestKeyframe) can be served by
+// restarting that viewer's encoder without disturbing others.
+type Server struct {
+	host string
+	port int
+	fps  int
+
+	logger   Logger
+	upgrader websocket.Upgrader
+
+	mu             sync.Mutex
+	running        bool
+	httpServer     *http.Server
+	extraListeners []net.Listener
+
+	activeConns int64
+	totalConns  int64
+}
+
+// Logger matches the VNC/terminal server logger interface.
+type Logger interface {
+	Printf(format string, v ...interface{})
+}
+
+type stdLogger struct{ l *log.Logger }
+
+func (s *stdLogger) Printf(format string, v ...interface{}) { s.l.Printf(format, v...) }
+
+type noOpLogger struct{}
+
+func (n *noOpLogger) Printf(format string, v ...interface{}) {}
+
+// Config configures the H.264 stream server.
+type Config struct {
+	Host string // bind host (default "127.0.0.1")
+	Port int    // bind port (default DefaultPort)
+	FPS  int    // target frame rate (default 15)
+}
+
+// DefaultPort is the default localhost/mesh port for the H.264 stream server.
+// Chosen adjacent to the VNC port (5900) so node operators can reason about the
+// desktop-related ports together; it is exposed over the tsnet mesh exactly
+// like VNC.
+const DefaultPort = 5910
+
+// NewServer creates an H.264 stream server.
+func NewServer(cfg Config) *Server {
+	if cfg.Host == "" {
+		cfg.Host = "127.0.0.1"
+	}
+	if cfg.Port == 0 {
+		cfg.Port = DefaultPort
+	}
+	if cfg.FPS <= 0 || cfg.FPS > 60 {
+		cfg.FPS = 15
+	}
+	s := &Server{
+		host:   cfg.Host,
+		port:   cfg.Port,
+		fps:    cfg.FPS,
+		logger: &stdLogger{l: log.New(os.Stderr, "[h264] ", log.LstdFlags)},
+	}
+	s.upgrader = websocket.Upgrader{
+		ReadBufferSize:  4096,
+		WriteBufferSize: 64 * 1024,
+		// Mesh-only exposure: like the VNC server, the tsnet listener is the
+		// trust boundary, so we accept any origin (CLI/native clients send none).
+		CheckOrigin: func(r *http.Request) bool { return true },
+	}
+	return s
+}
+
+// SetSilent switches to a no-op logger (TUI mode).
+func (s *Server) SetSilent() { s.logger = &noOpLogger{} }
+
+// Port returns the configured port.
+func (s *Server) Port() int { return s.port }
+
+// ActiveConnections returns the number of active stream sessions.
+func (s *Server) ActiveConnections() int64 { return atomic.LoadInt64(&s.activeConns) }
+
+// AddListener registers an additional net.Listener (e.g. a tsnet VPN listener)
+// that the server will also serve on. If the server is already running the
+// listener begins serving immediately, so a VPN listener can be re-attached
+// after a tsnet reconnect without restarting the server (issue #317).
+func (s *Server) AddListener(ln net.Listener) {
+	s.mu.Lock()
+	s.extraListeners = append(s.extraListeners, ln)
+	running := s.running
+	httpServer := s.httpServer
+	s.mu.Unlock()
+
+	if running && httpServer != nil {
+		s.logger.Printf("H.264 server also listening on %s (VPN, hot-attached)", ln.Addr())
+		go func() {
+			if err := httpServer.Serve(ln); err != nil && err != http.ErrServerClosed {
+				s.logger.Printf("VPN listener error: %v", err)
+			}
+		}()
+	}
+}
+
+// RemoveListener drops a previously added extra listener from tracking so a
+// long-lived session that re-attaches a VPN listener across reconnects does not
+// accumulate dead references (issue #317). It does not close the listener.
+func (s *Server) RemoveListener(ln net.Listener) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, l := range s.extraListeners {
+		if l == ln {
+			s.extraListeners = append(s.extraListeners[:i], s.extraListeners[i+1:]...)
+			return
+		}
+	}
+}
+
+// Start begins accepting H.264 stream connections.
+func (s *Server) Start() error {
+	s.mu.Lock()
+	if s.running {
+		s.mu.Unlock()
+		return fmt.Errorf("H.264 server already running")
+	}
+
+	// Verify an encoder is available before claiming to be up, so a node without
+	// ffmpeg/X reports a clear error and clients fall back to noVNC.
+	if _, err := selectEncoder(ffmpegHasEncoder); err != nil {
+		s.mu.Unlock()
+		return fmt.Errorf("H.264 unavailable: %w", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/desktop/h264", s.handleStream)
+	mux.HandleFunc("/health", s.handleHealth)
+
+	s.httpServer = &http.Server{
+		Addr:    fmt.Sprintf("%s:%d", s.host, s.port),
+		Handler: mux,
+		// No write timeout: a stream connection is long-lived. The per-message
+		// write deadline is set on each frame inside the connection handler.
+		ReadHeaderTimeout: 15 * time.Second,
+	}
+
+	addr := fmt.Sprintf("%s:%d", s.host, s.port)
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		s.running = false
+		s.httpServer = nil
+		s.mu.Unlock()
+		return fmt.Errorf("listen %s: %w", addr, err)
+	}
+
+	s.running = true
+	extras := append([]net.Listener(nil), s.extraListeners...)
+	httpServer := s.httpServer
+	s.mu.Unlock()
+
+	s.logger.Printf("H.264 server listening on %s (%d FPS)", ln.Addr(), s.fps)
+	go func() {
+		if err := httpServer.Serve(ln); err != nil && err != http.ErrServerClosed {
+			s.logger.Printf("server error: %v", err)
+		}
+	}()
+	for _, extra := range extras {
+		extra := extra
+		s.logger.Printf("H.264 server also listening on %s (VPN)", extra.Addr())
+		go func() {
+			if err := httpServer.Serve(extra); err != nil && err != http.ErrServerClosed {
+				s.logger.Printf("VPN listener error: %v", err)
+			}
+		}()
+	}
+	return nil
+}
+
+// Stop gracefully shuts down the server.
+func (s *Server) Stop() {
+	s.mu.Lock()
+	if !s.running {
+		s.mu.Unlock()
+		return
+	}
+	s.running = false
+	httpServer := s.httpServer
+	s.httpServer = nil
+	s.mu.Unlock()
+
+	if httpServer != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = httpServer.Shutdown(ctx)
+	}
+	s.logger.Printf("H.264 server stopped (total=%d)", atomic.LoadInt64(&s.totalConns))
+}
+
+// IsRunning reports whether the server is running.
+func (s *Server) IsRunning() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.running
+}
+
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintf(w, `{"status":"ok","codec":"h264","active":%d}`, atomic.LoadInt64(&s.activeConns))
+}

--- a/internal/deskstream/wire.go
+++ b/internal/deskstream/wire.go
@@ -1,0 +1,108 @@
+package deskstream
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+// InitMessage is the FIRST WebSocket frame the server sends, as a TEXT frame
+// containing this JSON. Clients (web #4254, iOS #4255) MUST read it before
+// decoding any BINARY frame, since it carries the codec and geometry needed to
+// configure their decoder. The wire contract is FIXED; do not reorder or rename
+// fields.
+type InitMessage struct {
+	Type             string `json:"type"`             // always "init"
+	Codec            string `json:"codec"`            // always "h264"
+	Width            int    `json:"width"`            // frame width in pixels
+	Height           int    `json:"height"`           // frame height in pixels
+	FPS              int    `json:"fps"`              // target frame rate
+	KeyframeInterval int    `json:"keyframeInterval"` // forced IDR interval in frames
+}
+
+// NewInitMessage builds the init message for a session.
+func NewInitMessage(width, height, fps, keyframeInterval int) InitMessage {
+	return InitMessage{
+		Type:             "init",
+		Codec:            "h264",
+		Width:            width,
+		Height:           height,
+		FPS:              fps,
+		KeyframeInterval: keyframeInterval,
+	}
+}
+
+// Marshal returns the JSON bytes for the init TEXT frame.
+func (m InitMessage) Marshal() ([]byte, error) { return json.Marshal(m) }
+
+// ClientMessage is a TEXT frame sent by a client to the server. The only
+// recognized type is "requestKeyframe", which forces the server to emit an IDR
+// (with SPS+PPS) as soon as possible.
+type ClientMessage struct {
+	Type string `json:"type"` // "requestKeyframe"
+}
+
+// ClientMsgRequestKeyframe is the value of ClientMessage.Type that requests an
+// immediate keyframe.
+const ClientMsgRequestKeyframe = "requestKeyframe"
+
+// parseClientMessage decodes a client TEXT frame. It returns the message type,
+// or "" if the frame is not valid JSON or carries no type.
+func parseClientMessage(data []byte) string {
+	var m ClientMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		return ""
+	}
+	return m.Type
+}
+
+// Geometry is the detected desktop resolution.
+type Geometry struct {
+	Width  int
+	Height int
+}
+
+// defaultGeometry is used when detection fails so the init message always
+// carries plausible dimensions.
+var defaultGeometry = Geometry{Width: 1280, Height: 720}
+
+var xdpyResolutionRe = regexp.MustCompile(`dimensions:\s+(\d+)x(\d+)`)
+
+// detectGeometry returns the X display resolution, using xdpyinfo when present.
+// It falls back to defaultGeometry when the tool is absent or parsing fails, so
+// a stream can still start (ffmpeg's x11grab will grab the real size; the init
+// message just advertises a best-effort guess that clients can correct from the
+// decoded SPS).
+func detectGeometry(display string) Geometry {
+	path, err := exec.LookPath("xdpyinfo")
+	if err != nil {
+		return defaultGeometry
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, path)
+	cmd.Env = append(os.Environ(), "DISPLAY="+display)
+	out, err := cmd.Output()
+	if err != nil {
+		return defaultGeometry
+	}
+	return parseXdpyinfoGeometry(string(out))
+}
+
+// parseXdpyinfoGeometry extracts WxH from xdpyinfo output. Exposed for testing.
+func parseXdpyinfoGeometry(out string) Geometry {
+	m := xdpyResolutionRe.FindStringSubmatch(out)
+	if len(m) != 3 {
+		return defaultGeometry
+	}
+	w, err1 := strconv.Atoi(m[1])
+	h, err2 := strconv.Atoi(m[2])
+	if err1 != nil || err2 != nil || w <= 0 || h <= 0 {
+		return defaultGeometry
+	}
+	return Geometry{Width: w, Height: h}
+}

--- a/internal/deskstream/wire_test.go
+++ b/internal/deskstream/wire_test.go
@@ -1,0 +1,79 @@
+package deskstream
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestInitMessage_WireContract pins the exact init JSON the web (#4254) and iOS
+// (#4255) clients depend on. Changing any key or value here is a wire-contract
+// break.
+func TestInitMessage_WireContract(t *testing.T) {
+	m := NewInitMessage(1920, 1080, 30, 60)
+	b, err := m.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(b)
+
+	for _, want := range []string{
+		`"type":"init"`,
+		`"codec":"h264"`,
+		`"width":1920`,
+		`"height":1080`,
+		`"fps":30`,
+		`"keyframeInterval":60`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("init JSON missing %q\ngot: %s", want, s)
+		}
+	}
+
+	// Round-trip to ensure the field names are exactly as documented.
+	var decoded map[string]any
+	if err := json.Unmarshal(b, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{"type", "codec", "width", "height", "fps", "keyframeInterval"} {
+		if _, ok := decoded[key]; !ok {
+			t.Errorf("init JSON missing key %q", key)
+		}
+	}
+}
+
+func TestParseClientMessage(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"requestKeyframe", `{"type":"requestKeyframe"}`, ClientMsgRequestKeyframe},
+		{"unknown-type", `{"type":"resize"}`, "resize"},
+		{"no-type", `{"foo":"bar"}`, ""},
+		{"invalid-json", `not json`, ""},
+		{"empty", ``, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := parseClientMessage([]byte(c.in)); got != c.want {
+				t.Errorf("parseClientMessage(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestParseXdpyinfoGeometry(t *testing.T) {
+	out := "  ...\n  dimensions:    1920x1080 pixels (508x285 millimeters)\n  ..."
+	g := parseXdpyinfoGeometry(out)
+	if g.Width != 1920 || g.Height != 1080 {
+		t.Errorf("got %dx%d, want 1920x1080", g.Width, g.Height)
+	}
+}
+
+func TestParseXdpyinfoGeometry_FallsBack(t *testing.T) {
+	g := parseXdpyinfoGeometry("no dimensions here")
+	if g != defaultGeometry {
+		t.Errorf("got %+v, want default %+v", g, defaultGeometry)
+	}
+}

--- a/internal/status/capabilities_flags.go
+++ b/internal/status/capabilities_flags.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aceteam-ai/citadel-cli/internal/deskstream"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
 )
 
@@ -30,13 +31,15 @@ var (
 	staticCapsOnce sync.Once
 	cachedConsole  bool
 	cachedGPU      bool
+	cachedH264     bool
 )
 
-// detectStaticCaps computes the console and gpu flags exactly once.
+// detectStaticCaps computes the console, gpu, and h264 flags exactly once.
 func detectStaticCaps() {
 	staticCapsOnce.Do(func() {
 		cachedConsole = detectConsole()
 		cachedGPU = detectGPU()
+		cachedH264 = deskstream.H264Available()
 	})
 }
 
@@ -49,6 +52,7 @@ func populateCapabilityFlags(caps *NodeCapabilities, vncPort int) {
 
 	console := cachedConsole
 	gpu := cachedGPU
+	h264 := cachedH264
 	desktop := vncPort > 0 || probeVNCPort(platform.DefaultVNCPort)
 	files := detectFiles()
 
@@ -56,6 +60,7 @@ func populateCapabilityFlags(caps *NodeCapabilities, vncPort int) {
 	caps.Desktop = &desktop
 	caps.Files = &files
 	caps.GPU = &gpu
+	caps.H264 = &h264
 }
 
 // detectConsole reports whether the node can offer a remote shell: a shell

--- a/internal/status/capabilities_flags_test.go
+++ b/internal/status/capabilities_flags_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 )
 
-// TestPopulateCapabilityFlagsAlwaysSetsAllFour verifies that all four capability
-// flags are non-nil after population, so every heartbeat emits concrete
-// true/false values rather than omitting keys (citadel-cli#324).
-func TestPopulateCapabilityFlagsAlwaysSetsAllFour(t *testing.T) {
+// TestPopulateCapabilityFlagsAlwaysSetsAll verifies that every capability flag
+// is non-nil after population, so every heartbeat emits concrete true/false
+// values rather than omitting keys (citadel-cli#324, plus h264 in #338).
+func TestPopulateCapabilityFlagsAlwaysSetsAll(t *testing.T) {
 	caps := &NodeCapabilities{}
 	populateCapabilityFlags(caps, 0)
 
@@ -25,6 +25,9 @@ func TestPopulateCapabilityFlagsAlwaysSetsAllFour(t *testing.T) {
 	if caps.GPU == nil {
 		t.Error("GPU flag should be populated, got nil")
 	}
+	if caps.H264 == nil {
+		t.Error("H264 flag should be populated, got nil")
+	}
 }
 
 // TestCapabilityFlagsDesktopDerivedFromVNCPort verifies the desktop flag is true
@@ -38,8 +41,8 @@ func TestCapabilityFlagsDesktopDerivedFromVNCPort(t *testing.T) {
 }
 
 // TestCapabilityFlagsJSONContract verifies the wire format matches the backend
-// contract exactly: keys console/desktop/files/gpu, boolean values, inside the
-// capabilities object (aceteam#4223, PR #4231).
+// contract exactly: keys console/desktop/files/gpu/h264, boolean values, inside
+// the capabilities object (aceteam#4223, PR #4231; h264 in citadel-cli#338).
 func TestCapabilityFlagsJSONContract(t *testing.T) {
 	tr := true
 	fa := false
@@ -48,6 +51,7 @@ func TestCapabilityFlagsJSONContract(t *testing.T) {
 		Desktop: &fa,
 		Files:   &tr,
 		GPU:     &fa,
+		H264:    &tr,
 	}
 	b, err := json.Marshal(caps)
 	if err != nil {
@@ -60,6 +64,7 @@ func TestCapabilityFlagsJSONContract(t *testing.T) {
 		`"desktop":false`,
 		`"files":true`,
 		`"gpu":false`,
+		`"h264":true`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("capabilities JSON missing %q; got %s", want, got)

--- a/internal/status/types.go
+++ b/internal/status/types.go
@@ -69,6 +69,12 @@ type NodeCapabilities struct {
 	Desktop *bool `json:"desktop,omitempty"`
 	Files   *bool `json:"files,omitempty"`
 	GPU     *bool `json:"gpu,omitempty"`
+
+	// H264 reports whether the node can serve an H.264 desktop video stream over
+	// the mesh (citadel-cli#338): ffmpeg + an H.264 encoder + an X display are
+	// available. Clients use it to choose H.264 streaming and fall back to noVNC
+	// when absent. Additive to the four flags above (aceteam#4250).
+	H264 *bool `json:"h264,omitempty"`
 }
 
 // HypervisorInfo describes a detected hypervisor on the node.


### PR DESCRIPTION
## Context

Tier B of the desktop-streaming spike (aceteam-ai/aceteam#4250, parent #4168). This is the **node-side FOUNDATION**: it streams the node desktop as **H.264** over a binary WebSocket on the existing node mesh listener, with **no WebRTC/Pion/TURN** (it reuses the same relay/mesh model as the VNC server, issue #317).

The web client (aceteam-ai/aceteam#4254) and iOS client (aceteam-ai/aceteam#4255) consume the wire contract defined below. They must implement to it exactly.

Input (mouse/keyboard) is **unchanged** and stays on the existing action path. This is **video-only**.

## Changes

New package `internal/deskstream`:
- **Encode** (`encoder.go`, `runner.go`): captures the X display via ffmpeg `x11grab` and emits H.264 **Annex-B** NAL units. Encoder selection prefers hardware `h264_vaapi`, then `h264_nvenc`, then software `libx264` (`ultrafast`/`zerolatency`/`baseline`). Detection degrades gracefully: if no encoder is available the server refuses to start with a clear error and the node stays on VNC only.
- **Annex-B framer** (`annexb.go`, `framer.go`): parses the ffmpeg byte stream into NAL units by start code, tracks NAL types (SPS=7, PPS=8, IDR=5), caches the latest SPS+PPS, and **prepends SPS+PPS to every IDR keyframe**. This is encoder-independent (vaapi/nvenc/libx264 differ in header-repeat behavior), so any keyframe payload is independently decodable by a viewer that joined the broadcast mid-GOP.
- **Serve** (`server.go`, `conn.go`): a binary WebSocket endpoint `/desktop/h264` served on localhost plus any tsnet VPN listeners attached via `AddListener` (mirrors `internal/desktop` VNCServer; tsnet mesh is the trust boundary, **no application-layer auth**). Each connection runs its **own** ffmpeg encoder so a new viewer always starts at an IDR, and an on-demand keyframe is served by restarting that connection's encoder (an ffmpeg subprocess has no stdin "keyframe now" signal). A single writer goroutine serializes all WebSocket writes (gorilla panics on concurrent writes).
- **Wire types** (`wire.go`): the `init` JSON message, `requestKeyframe` parsing, and geometry detection (`xdpyinfo`, with a 1280x720 fallback).

Capability flag (`internal/status`):
- Added an **additive** `h264 *bool json:"h264,omitempty"` to `NodeCapabilities`, alongside the existing `console/desktop/files/gpu` set (#324 / aceteam#4223). `h264` is true when `runtime.GOOS=="linux"` AND ffmpeg is on PATH AND an H.264 encoder is available AND `DISPLAY` is set. Cached statically like `console`/`gpu`. Clients use this to choose H.264 vs falling back to noVNC. Existing capability tests updated for the fifth flag.

Control center wiring (`cmd/controlcenter.go`):
- `startH264Server`/`stopH264Server`/`attachH264VPNListener` mirror the VNC functions exactly. Gated on the **same `perms.Desktop`** permission. Hooked into `ccOnNetworkConnect` (starts alongside VNC), `ccSuperviseVPNListeners`/`vpnListenersHealthy` (self-heals the VPN listener across tsnet reconnects, #317), and graceful shutdown.

## Wire contract (web #4254 / iOS #4255 implement to THIS)

Endpoint: WebSocket `ws://<node-mesh-ip>:5910/desktop/h264` (default port `5910`, adjacent to VNC's 5900; reachable over the tsnet mesh exactly like VNC).

**1. First frame -- TEXT -- init JSON (always sent before any binary frame):**
```json
{"type":"init","codec":"h264","width":1920,"height":1080,"fps":15,"keyframeInterval":30}
```
- `codec` is always `"h264"`.
- `width`/`height` are a best-effort geometry from `xdpyinfo` (fallback 1280x720); clients SHOULD trust the decoded SPS for authoritative dimensions.
- `keyframeInterval` is the forced-IDR interval in frames.

**2. Then -- BINARY frames -- H.264 Annex-B:**
- Binary frames carry a **continuous Annex-B elementary stream** (NAL units prefixed by `00 00 01` or `00 00 00 01` start codes). **A single binary frame is NOT guaranteed to be exactly one picture/access unit** -- ffmpeg may interleave AUD/SEI NALs and parameter sets across frames. Clients **MUST concatenate** binary payloads in order and feed them to an H.264 decoder as a stream; do not assume one frame == one decodable picture.
- **SPS+PPS are prepended on every IDR keyframe.** Any payload that contains an IDR begins with SPS then PPS, so a viewer joining mid-stream can begin decoding at the first keyframe payload.
- Clients SHOULD ignore binary data until the first payload containing SPS+PPS+IDR.

**3. Keyframe rules:**
- An IDR is forced **at least every 2 seconds** (`keyframeInterval` frames) regardless of scene content.
- A **fresh connection is an implicit keyframe request**: the per-connection encoder starts from scratch (a fresh ffmpeg always begins with SPS+PPS+IDR), so the first binary frames already carry a decodable keyframe -- no waiting up to 2s.
- A client MAY send a TEXT frame `{"type":"requestKeyframe"}` to force an immediate IDR. The server restarts that connection's encoder, so the next binary frames begin with SPS+PPS+IDR.

**4. Capability / fallback:**
- The node advertises `"h264": true` in its heartbeat `capabilities` block when ffmpeg + an H.264 encoder + X are available.
- When `h264` is absent or false, clients fall back to **noVNC** (the existing VNC/desktop path is unchanged).

## How to test

Automated (no live X needed) -- scoped, tmux-safe:
```
go build ./...
go vet ./internal/deskstream/ ./cmd/
go test ./internal/deskstream/ -count=1
go test ./internal/status/ -run 'TestPopulateCapabilityFlags|TestCapabilityFlags|TestNodeStatusCapabilities' -count=1
```
Tests cover: Annex-B start-code/NAL-type parsing and partial-NAL carry-over; the framer's SPS+PPS-prepend-on-keyframe rule (including no-duplication when inline and no-prefix on P-frames); the `init` JSON wire contract; `requestKeyframe` parsing; encoder selection preference + graceful no-encoder failure; ffmpeg arg building for all three encoders; geometry parsing.

Manual (needs a real Linux X display + ffmpeg) -- capture/encode path:
1. On a Linux node with `DISPLAY` set and `ffmpeg` installed, start the control center with desktop permission enabled. The activity log shows `H.264 stream server listening on port 5910`.
2. From a mesh peer: `websocat ws://<node-mesh-ip>:5910/desktop/h264 --binary > /tmp/stream` (or any WS client). Confirm the first TEXT frame is the init JSON, then binary Annex-B follows.
3. Concatenate the binary payloads to a file and verify decodability: `ffmpeg -i /tmp/stream.h264 -f null -` (no errors) and `ffprobe -show_frames /tmp/stream.h264 | grep key_frame=1` (periodic IDRs ~every 2s).
4. Send TEXT `{"type":"requestKeyframe"}` and confirm a fresh SPS/PPS/IDR appears promptly.
5. Verify the heartbeat capabilities block reports `"h264": true` on a node with ffmpeg+X, and `false`/absent without.

## Verification notes
- Per repo tmux-safety policy: NO `go test ./...` was run, and no `internal/tmux`/`internal/terminal` test packages were executed. `internal/deskstream` has no tmux/terminal imports. `cmd/` and `internal/status/` were build-verified and vetted only (their tmux-spawning test packages were not run).

Refs aceteam-ai/aceteam#4250, aceteam-ai/aceteam#4254, aceteam-ai/aceteam#4255, aceteam-ai/aceteam#4168.
