### PR TITLE
feat(desktop): Tier A — ZRLE + dirty-rect encoding for embedded RFB server

### DIFF
--- a/internal/desktop/vnc_encode.go
+++ b/internal/desktop/vnc_encode.go
@@ -1,0 +1,267 @@
+package desktop
+
+import (
+	"bytes"
+	"compress/zlib"
+	"encoding/binary"
+	"image"
+	"io"
+)
+
+// RFB encoding numbers we care about.
+const (
+	encodingRaw  int32 = 0
+	encodingZRLE int32 = 16
+)
+
+// zrleTileSize is the fixed tile dimension used by the ZRLE encoding (RFC 6143
+// section 7.7.6). Tiles are 64x64, with partial tiles at the right/bottom edges.
+const zrleTileSize = 64
+
+// extractRect copies the pixels of the sub-rectangle (x, y, w, h) out of a
+// full-frame capture into a contiguous, row-major RGBX buffer.
+//
+// The capture stores pixels in native BGRX byte order (GDI). This helper swaps
+// B<->R as it copies so the returned buffer is in the RGBX order advertised in
+// ServerInit. It is the single source of pixel bytes for both the Raw sub-rect
+// path and the ZRLE tiler (which takes the first 3 bytes of each pixel as a
+// compressed pixel / CPIXEL).
+//
+// The full frame is assumed to be frameW pixels wide and 4 bytes per pixel.
+func extractRect(pix []byte, frameW, x, y, w, h int) []byte {
+	out := make([]byte, w*h*4)
+	for row := 0; row < h; row++ {
+		srcStart := ((y+row)*frameW + x) * 4
+		dstStart := row * w * 4
+		src := pix[srcStart : srcStart+w*4]
+		dst := out[dstStart : dstStart+w*4]
+		// Copy with B<->R swap (BGRX -> RGBX).
+		for i := 0; i < len(src); i += 4 {
+			dst[i] = src[i+2]
+			dst[i+1] = src[i+1]
+			dst[i+2] = src[i]
+			dst[i+3] = src[i+3]
+		}
+	}
+	return out
+}
+
+// writeRawRectHeader writes the 12-byte rectangle header (x, y, w, h, encoding).
+func writeRawRectHeader(buf *bytes.Buffer, x, y, w, h int, encoding int32) {
+	var hdr [12]byte
+	binary.BigEndian.PutUint16(hdr[0:2], uint16(x))
+	binary.BigEndian.PutUint16(hdr[2:4], uint16(y))
+	binary.BigEndian.PutUint16(hdr[4:6], uint16(w))
+	binary.BigEndian.PutUint16(hdr[6:8], uint16(h))
+	binary.BigEndian.PutUint32(hdr[8:12], uint32(encoding))
+	buf.Write(hdr[:])
+}
+
+// encodeRawRect appends a Raw-encoded rectangle (header + RGBX pixel bytes) for
+// the sub-rectangle (x, y, w, h) of the frame to buf.
+func encodeRawRect(buf *bytes.Buffer, pix []byte, frameW, x, y, w, h int) {
+	writeRawRectHeader(buf, x, y, w, h, encodingRaw)
+	buf.Write(extractRect(pix, frameW, x, y, w, h))
+}
+
+// zrleEncoder holds the per-connection zlib stream that ZRLE rectangles are
+// written to. RFB requires ONE continuous zlib stream for the lifetime of the
+// connection (the dictionary carries across rects and frames), so this must be
+// created once per client and reused, never per frame.
+type zrleEncoder struct {
+	zbuf bytes.Buffer
+	zw   *zlib.Writer
+}
+
+func newZRLEEncoder() *zrleEncoder {
+	e := &zrleEncoder{}
+	e.zw = zlib.NewWriter(&e.zbuf)
+	return e
+}
+
+// Close releases the underlying zlib writer.
+func (e *zrleEncoder) Close() {
+	if e.zw != nil {
+		_ = e.zw.Close()
+		e.zw = nil
+	}
+}
+
+// encodeZRLERect appends a ZRLE-encoded rectangle for the sub-rectangle
+// (x, y, w, h) of the frame to buf.
+//
+// The rectangle is split into 64x64 tiles (partial at edges). Each tile is
+// encoded with subencoding 0 (raw CPIXELs): a single 0 byte followed by the
+// tile's pixels in compressed-pixel form (3 bytes each, the unused 4th byte of
+// the 32bpp RGBX format is dropped). The concatenated tile bytes are written to
+// the connection's continuous zlib stream and flushed; the resulting deflated
+// bytes form the rect payload, prefixed with a u32 length.
+//
+// Using only subencoding 0 keeps the implementation simple and robust: zlib
+// provides the compression. Every standard VNC client decodes this.
+func (e *zrleEncoder) encodeZRLERect(buf *bytes.Buffer, pix []byte, frameW, x, y, w, h int) error {
+	writeRawRectHeader(buf, x, y, w, h, encodingZRLE)
+
+	// Build the uncompressed ZRLE tile stream for this rect.
+	tiles := buildZRLETiles(pix, frameW, x, y, w, h)
+
+	// Write tiles to the continuous zlib stream and flush so the client can
+	// decode this rect immediately. Flush emits a Z_SYNC_FLUSH boundary.
+	e.zbuf.Reset()
+	if _, err := e.zw.Write(tiles); err != nil {
+		return err
+	}
+	if err := e.zw.Flush(); err != nil {
+		return err
+	}
+	compressed := e.zbuf.Bytes()
+
+	var lenBuf [4]byte
+	binary.BigEndian.PutUint32(lenBuf[:], uint32(len(compressed)))
+	buf.Write(lenBuf[:])
+	buf.Write(compressed)
+	return nil
+}
+
+// buildZRLETiles produces the uncompressed ZRLE tile byte stream for the
+// sub-rectangle (x, y, w, h). Each tile is subencoding 0 (raw) followed by its
+// CPIXELs (3 bytes/pixel). Exported indirectly via tests.
+func buildZRLETiles(pix []byte, frameW, x, y, w, h int) []byte {
+	var out bytes.Buffer
+	for ty := 0; ty < h; ty += zrleTileSize {
+		th := zrleTileSize
+		if ty+th > h {
+			th = h - ty
+		}
+		for tx := 0; tx < w; tx += zrleTileSize {
+			tw := zrleTileSize
+			if tx+tw > w {
+				tw = w - tx
+			}
+			// Subencoding 0 = raw CPIXELs.
+			out.WriteByte(0)
+			// CPIXELs: for each pixel in the tile, 3 bytes (R, G, B), dropping
+			// the unused 4th byte of the RGBX format.
+			for row := 0; row < th; row++ {
+				srcY := y + ty + row
+				rowStart := (srcY*frameW + x + tx) * 4
+				for col := 0; col < tw; col++ {
+					p := rowStart + col*4
+					// Source is native BGRX; CPIXEL order must match the
+					// advertised RGBX format, so emit R, G, B = pix[p+2],
+					// pix[p+1], pix[p].
+					out.WriteByte(pix[p+2])
+					out.WriteByte(pix[p+1])
+					out.WriteByte(pix[p])
+				}
+			}
+		}
+	}
+	return out.Bytes()
+}
+
+// dirtyTiles compares the previous and current frames (both native BGRX,
+// same dimensions) on a 64-aligned grid and returns the bounding rectangles of
+// the changed tiles, coalesced row by row.
+//
+// prev may be nil (or a different size), in which case the whole frame is
+// reported as a single dirty rectangle (a full update). This is the correct
+// behaviour for the first frame of a connection and for non-incremental
+// FramebufferUpdateRequests.
+func dirtyTiles(prev, cur []byte, frameW, frameH int) []image.Rectangle {
+	full := []image.Rectangle{image.Rect(0, 0, frameW, frameH)}
+	if prev == nil || len(prev) != len(cur) {
+		return full
+	}
+
+	var rects []image.Rectangle
+	for ty := 0; ty < frameH; ty += zrleTileSize {
+		th := zrleTileSize
+		if ty+th > frameH {
+			th = frameH - ty
+		}
+		// Track a run of contiguous changed tile-columns to coalesce into one
+		// rectangle per band.
+		runStart := -1
+		for tx := 0; tx <= frameW; tx += zrleTileSize {
+			changed := false
+			if tx < frameW {
+				tw := zrleTileSize
+				if tx+tw > frameW {
+					tw = frameW - tx
+				}
+				changed = tileChanged(prev, cur, frameW, tx, ty, tw, th)
+			}
+			if changed {
+				if runStart < 0 {
+					runStart = tx
+				}
+			} else if runStart >= 0 {
+				rects = append(rects, image.Rect(runStart, ty, tx, ty+th))
+				runStart = -1
+			}
+		}
+	}
+	return rects
+}
+
+// tileChanged reports whether any pixel in the tile (tx, ty, tw, th) differs
+// between prev and cur.
+func tileChanged(prev, cur []byte, frameW, tx, ty, tw, th int) bool {
+	for row := 0; row < th; row++ {
+		start := ((ty+row)*frameW + tx) * 4
+		end := start + tw*4
+		if !bytes.Equal(prev[start:end], cur[start:end]) {
+			return true
+		}
+	}
+	return false
+}
+
+// writeFramebufferUpdateRects writes a complete FramebufferUpdate message
+// containing the given rectangles, encoded with the chosen encoding (ZRLE when
+// zEnc is non-nil and the client negotiated it, else Raw). The pixel source is
+// the native-BGRX frame; extraction handles the byte-order swap.
+//
+// rects must already be clamped to the frame bounds.
+func writeFramebufferUpdateRects(w io.Writer, pix []byte, frameW int, rects []image.Rectangle, zEnc *zrleEncoder) error {
+	var buf bytes.Buffer
+
+	// FramebufferUpdate header: type(0) + padding(1) + number-of-rects(u16).
+	buf.WriteByte(0)
+	buf.WriteByte(0)
+	var nrects [2]byte
+	binary.BigEndian.PutUint16(nrects[:], uint16(len(rects)))
+	buf.Write(nrects[:])
+
+	for _, r := range rects {
+		x, y := r.Min.X, r.Min.Y
+		rw, rh := r.Dx(), r.Dy()
+		if rw <= 0 || rh <= 0 {
+			continue
+		}
+		if zEnc != nil {
+			if err := zEnc.encodeZRLERect(&buf, pix, frameW, x, y, rw, rh); err != nil {
+				return err
+			}
+		} else {
+			encodeRawRect(&buf, pix, frameW, x, y, rw, rh)
+		}
+	}
+
+	_, err := w.Write(buf.Bytes())
+	return err
+}
+
+// clientSupportsZRLE scans a SetEncodings list (big-endian s32 values) and
+// reports whether the client advertised ZRLE (16). Pseudo-encodings (negative
+// values) are ignored.
+func clientSupportsZRLE(encodings []byte) bool {
+	for i := 0; i+4 <= len(encodings); i += 4 {
+		enc := int32(binary.BigEndian.Uint32(encodings[i : i+4]))
+		if enc == encodingZRLE {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/desktop/vnc_encode.go
+++ b/internal/desktop/vnc_encode.go
@@ -227,19 +227,26 @@ func tileChanged(prev, cur []byte, frameW, tx, ty, tw, th int) bool {
 func writeFramebufferUpdateRects(w io.Writer, pix []byte, frameW int, rects []image.Rectangle, zEnc *zrleEncoder) error {
 	var buf bytes.Buffer
 
+	// Drop any degenerate rectangles up front so the number-of-rects header
+	// always matches the rectangles actually written (a mismatch desyncs the
+	// RFB stream).
+	valid := rects[:0:0]
+	for _, r := range rects {
+		if r.Dx() > 0 && r.Dy() > 0 {
+			valid = append(valid, r)
+		}
+	}
+
 	// FramebufferUpdate header: type(0) + padding(1) + number-of-rects(u16).
 	buf.WriteByte(0)
 	buf.WriteByte(0)
 	var nrects [2]byte
-	binary.BigEndian.PutUint16(nrects[:], uint16(len(rects)))
+	binary.BigEndian.PutUint16(nrects[:], uint16(len(valid)))
 	buf.Write(nrects[:])
 
-	for _, r := range rects {
+	for _, r := range valid {
 		x, y := r.Min.X, r.Min.Y
 		rw, rh := r.Dx(), r.Dy()
-		if rw <= 0 || rh <= 0 {
-			continue
-		}
 		if zEnc != nil {
 			if err := zEnc.encodeZRLERect(&buf, pix, frameW, x, y, rw, rh); err != nil {
 				return err

--- a/internal/desktop/vnc_encode_test.go
+++ b/internal/desktop/vnc_encode_test.go
@@ -1,0 +1,307 @@
+package desktop
+
+import (
+	"bytes"
+	"compress/zlib"
+	"encoding/binary"
+	"image"
+	"io"
+	"testing"
+)
+
+// makeBGRXFrame builds a w*h frame in native BGRX byte order where each pixel's
+// R,G,B are derived from its position, so byte-order handling is observable.
+func makeBGRXFrame(w, h int) []byte {
+	pix := make([]byte, w*h*4)
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			p := (y*w + x) * 4
+			r := byte((x * 7) & 0xff)
+			g := byte((y * 11) & 0xff)
+			b := byte((x + y) & 0xff)
+			// Native BGRX order.
+			pix[p] = b
+			pix[p+1] = g
+			pix[p+2] = r
+			pix[p+3] = 0
+		}
+	}
+	return pix
+}
+
+func TestExtractRectSwapsToRGBX(t *testing.T) {
+	w, h := 4, 3
+	pix := makeBGRXFrame(w, h)
+	// Extract a 2x2 sub-rect at (1,1).
+	out := extractRect(pix, w, 1, 1, 2, 2)
+	if len(out) != 2*2*4 {
+		t.Fatalf("len = %d, want 16", len(out))
+	}
+	// Verify the top-left pixel of the sub-rect (source pixel (1,1)).
+	srcP := (1*w + 1) * 4
+	wantR, wantG, wantB := pix[srcP+2], pix[srcP+1], pix[srcP]
+	if out[0] != wantR || out[1] != wantG || out[2] != wantB {
+		t.Errorf("pixel = (%d,%d,%d), want RGB (%d,%d,%d)", out[0], out[1], out[2], wantR, wantG, wantB)
+	}
+}
+
+func TestEncodeRawRectHeaderAndPixels(t *testing.T) {
+	w, h := 8, 8
+	pix := makeBGRXFrame(w, h)
+	var buf bytes.Buffer
+	encodeRawRect(&buf, pix, w, 2, 1, 3, 4)
+
+	data := buf.Bytes()
+	// 12-byte rect header.
+	if x := binary.BigEndian.Uint16(data[0:2]); x != 2 {
+		t.Errorf("x = %d, want 2", x)
+	}
+	if y := binary.BigEndian.Uint16(data[2:4]); y != 1 {
+		t.Errorf("y = %d, want 1", y)
+	}
+	if rw := binary.BigEndian.Uint16(data[4:6]); rw != 3 {
+		t.Errorf("w = %d, want 3", rw)
+	}
+	if rh := binary.BigEndian.Uint16(data[6:8]); rh != 4 {
+		t.Errorf("h = %d, want 4", rh)
+	}
+	if enc := binary.BigEndian.Uint32(data[8:12]); enc != 0 {
+		t.Errorf("encoding = %d, want 0 (Raw)", enc)
+	}
+	// Payload length = w*h*4.
+	if got, want := len(data)-12, 3*4*4; got != want {
+		t.Errorf("payload len = %d, want %d", got, want)
+	}
+}
+
+func TestBuildZRLETilesSingleTileCPIXEL(t *testing.T) {
+	// 2x2 frame -> one tile, 4 pixels, subencoding byte + 4*3 CPIXEL bytes.
+	w, h := 2, 2
+	pix := makeBGRXFrame(w, h)
+	tiles := buildZRLETiles(pix, w, 0, 0, w, h)
+
+	wantLen := 1 + (w*h)*3
+	if len(tiles) != wantLen {
+		t.Fatalf("tiles len = %d, want %d", len(tiles), wantLen)
+	}
+	if tiles[0] != 0 {
+		t.Errorf("subencoding = %d, want 0 (raw)", tiles[0])
+	}
+	// First CPIXEL should be the top-left pixel in R,G,B order (3 bytes, no 4th).
+	srcP := 0
+	wantR, wantG, wantB := pix[srcP+2], pix[srcP+1], pix[srcP]
+	if tiles[1] != wantR || tiles[2] != wantG || tiles[3] != wantB {
+		t.Errorf("CPIXEL = (%d,%d,%d), want (%d,%d,%d)", tiles[1], tiles[2], tiles[3], wantR, wantG, wantB)
+	}
+}
+
+func TestBuildZRLETilesPartialEdgeTiles(t *testing.T) {
+	// 65x65 frame -> 2x2 tile grid: 64,64 | 64,1 | 1,64 | 1,1 (partial edges).
+	w, h := zrleTileSize+1, zrleTileSize+1
+	pix := makeBGRXFrame(w, h)
+	tiles := buildZRLETiles(pix, w, 0, 0, w, h)
+
+	// Four tiles: pixel counts 64*64, 1*64, 64*1, 1*1 = 4096+64+64+1 = 4225 px.
+	// Plus 4 subencoding bytes. Each pixel = 3 CPIXEL bytes.
+	totalPx := w * h // 65*65 = 4225 = sum above
+	wantLen := 4 /*subenc bytes*/ + totalPx*3
+	if len(tiles) != wantLen {
+		t.Fatalf("tiles len = %d, want %d", len(tiles), wantLen)
+	}
+}
+
+// TestEncodeZRLERectRoundTrip encodes a rect, then decompresses the zlib stream
+// and verifies the tile bytes match what buildZRLETiles produced. This is a
+// byte-level check that needs no display.
+func TestEncodeZRLERectRoundTrip(t *testing.T) {
+	w, h := 70, 50 // spans 2 tile columns, 1 tile row (partial)
+	pix := makeBGRXFrame(w, h)
+
+	enc := newZRLEEncoder()
+	defer enc.Close()
+
+	var buf bytes.Buffer
+	if err := enc.encodeZRLERect(&buf, pix, w, 0, 0, w, h); err != nil {
+		t.Fatalf("encodeZRLERect: %v", err)
+	}
+
+	data := buf.Bytes()
+	// 12-byte rect header.
+	if enc := binary.BigEndian.Uint32(data[8:12]); int32(enc) != encodingZRLE {
+		t.Errorf("encoding = %d, want %d (ZRLE)", enc, encodingZRLE)
+	}
+	// u32 length prefix.
+	zlen := binary.BigEndian.Uint32(data[12:16])
+	if int(zlen) != len(data)-16 {
+		t.Fatalf("zlib length prefix = %d, but %d bytes follow", zlen, len(data)-16)
+	}
+
+	// Decompress and compare against the expected tile stream.
+	zr, err := zlib.NewReader(bytes.NewReader(data[16:]))
+	if err != nil {
+		t.Fatalf("zlib.NewReader: %v", err)
+	}
+	got, err := io.ReadAll(zr)
+	if err != nil && err != io.ErrUnexpectedEOF {
+		// A flushed (not closed) zlib stream may surface ErrUnexpectedEOF at the
+		// flush boundary; the decoded payload before it is still valid.
+		t.Fatalf("read zlib: %v", err)
+	}
+	want := buildZRLETiles(pix, w, 0, 0, w, h)
+	if !bytes.Equal(got, want) {
+		t.Errorf("decoded tiles mismatch: got %d bytes, want %d bytes", len(got), len(want))
+	}
+}
+
+// TestZRLEContinuousStream verifies that two rects encoded on the same encoder
+// share one continuous zlib stream (the second is decoded by continuing the
+// first reader), which is what RFB requires.
+func TestZRLEContinuousStream(t *testing.T) {
+	w, h := 16, 16
+	pix := makeBGRXFrame(w, h)
+
+	enc := newZRLEEncoder()
+	defer enc.Close()
+
+	var buf1, buf2 bytes.Buffer
+	if err := enc.encodeZRLERect(&buf1, pix, w, 0, 0, w, h); err != nil {
+		t.Fatalf("rect1: %v", err)
+	}
+	if err := enc.encodeZRLERect(&buf2, pix, w, 0, 0, w, h); err != nil {
+		t.Fatalf("rect2: %v", err)
+	}
+
+	// Concatenate both rects' zlib payloads and decode as a single stream.
+	payload1 := buf1.Bytes()[16:]
+	payload2 := buf2.Bytes()[16:]
+	combined := append(append([]byte{}, payload1...), payload2...)
+
+	zr, err := zlib.NewReader(bytes.NewReader(combined))
+	if err != nil {
+		t.Fatalf("zlib.NewReader: %v", err)
+	}
+	got, err := io.ReadAll(zr)
+	if err != nil && err != io.ErrUnexpectedEOF {
+		t.Fatalf("read: %v", err)
+	}
+	tile := buildZRLETiles(pix, w, 0, 0, w, h)
+	want := append(append([]byte{}, tile...), tile...)
+	if !bytes.Equal(got, want) {
+		t.Errorf("continuous stream decode mismatch: got %d bytes, want %d", len(got), len(want))
+	}
+}
+
+func TestClientSupportsZRLE(t *testing.T) {
+	// Build a SetEncodings list: [Tight(7), ZRLE(16), Cursor pseudo(-239)].
+	list := make([]byte, 0, 12)
+	for _, e := range []int32{7, encodingZRLE, -239} {
+		var b [4]byte
+		binary.BigEndian.PutUint32(b[:], uint32(e))
+		list = append(list, b[:]...)
+	}
+	if !clientSupportsZRLE(list) {
+		t.Error("expected ZRLE to be detected")
+	}
+
+	// List without ZRLE.
+	var raw [4]byte
+	binary.BigEndian.PutUint32(raw[:], 0)
+	if clientSupportsZRLE(raw[:]) {
+		t.Error("did not expect ZRLE in a Raw-only list")
+	}
+
+	// Truncated trailing bytes must not panic or false-positive.
+	if clientSupportsZRLE([]byte{0, 0, 0}) {
+		t.Error("truncated list should not report ZRLE")
+	}
+}
+
+func TestDirtyTilesNilPrevReturnsFull(t *testing.T) {
+	cur := makeBGRXFrame(100, 100)
+	rects := dirtyTiles(nil, cur, 100, 100)
+	if len(rects) != 1 || rects[0] != image.Rect(0, 0, 100, 100) {
+		t.Errorf("nil prev should yield one full rect, got %v", rects)
+	}
+}
+
+func TestDirtyTilesSizeMismatchReturnsFull(t *testing.T) {
+	prev := makeBGRXFrame(50, 50)
+	cur := makeBGRXFrame(100, 100)
+	rects := dirtyTiles(prev, cur, 100, 100)
+	if len(rects) != 1 || rects[0] != image.Rect(0, 0, 100, 100) {
+		t.Errorf("size mismatch should yield one full rect, got %v", rects)
+	}
+}
+
+func TestDirtyTilesNoChange(t *testing.T) {
+	frame := makeBGRXFrame(130, 130)
+	prev := append([]byte{}, frame...)
+	rects := dirtyTiles(prev, frame, 130, 130)
+	if len(rects) != 0 {
+		t.Errorf("identical frames should yield no dirty rects, got %v", rects)
+	}
+}
+
+func TestDirtyTilesSingleTileChange(t *testing.T) {
+	w, h := 200, 200 // 4x4 tile grid (last tiles partial: 200 = 3*64 + 8)
+	frame := makeBGRXFrame(w, h)
+	prev := append([]byte{}, frame...)
+
+	// Mutate one pixel inside the tile at column index 1 (x in [64,128)),
+	// row index 2 (y in [128,192)).
+	px, py := 70, 130
+	frame[(py*w+px)*4] ^= 0xff
+
+	rects := dirtyTiles(prev, frame, w, h)
+	if len(rects) != 1 {
+		t.Fatalf("expected 1 dirty rect, got %d: %v", len(rects), rects)
+	}
+	r := rects[0]
+	// The dirty rect must contain the mutated pixel.
+	if !(image.Point{X: px, Y: py}).In(r) {
+		t.Errorf("dirty rect %v does not contain mutated pixel (%d,%d)", r, px, py)
+	}
+	// And it must be within a single tile band (height 64 starting at y=128).
+	if r.Min.Y != 128 || r.Max.Y != 192 {
+		t.Errorf("dirty rect y-band = [%d,%d), want [128,192)", r.Min.Y, r.Max.Y)
+	}
+}
+
+func TestDirtyTilesCoalescesRowRun(t *testing.T) {
+	w, h := 200, 70 // tile rows: [0,64),[64,70); cols at 0,64,128,192
+	frame := makeBGRXFrame(w, h)
+	prev := append([]byte{}, frame...)
+
+	// Change two adjacent tile columns in the top band: x=10 (col0) and x=70 (col1).
+	frame[(5*w+10)*4] ^= 0xff
+	frame[(5*w+70)*4] ^= 0xff
+
+	rects := dirtyTiles(prev, frame, w, h)
+	if len(rects) != 1 {
+		t.Fatalf("expected adjacent changed columns to coalesce into 1 rect, got %d: %v", len(rects), rects)
+	}
+	r := rects[0]
+	if r.Min.X != 0 || r.Max.X != 128 {
+		t.Errorf("coalesced rect x-span = [%d,%d), want [0,128)", r.Min.X, r.Max.X)
+	}
+}
+
+func TestWriteFramebufferUpdateRectsRawNrects(t *testing.T) {
+	w, h := 64, 64
+	pix := makeBGRXFrame(w, h)
+	rects := []image.Rectangle{
+		image.Rect(0, 0, 32, 32),
+		image.Rect(32, 0, 64, 32),
+	}
+	var buf bytes.Buffer
+	if err := writeFramebufferUpdateRects(&buf, pix, w, rects, nil); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	data := buf.Bytes()
+	if data[0] != 0 {
+		t.Errorf("message type = %d, want 0", data[0])
+	}
+	if n := binary.BigEndian.Uint16(data[2:4]); n != 2 {
+		t.Errorf("nrects = %d, want 2", n)
+	}
+}

--- a/internal/desktop/vnc_server.go
+++ b/internal/desktop/vnc_server.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"image"
 	"io"
 	"log"
 	"net"
@@ -338,8 +339,17 @@ func (s *VNCServer) writeServerInit(w io.Writer, width, height int) error {
 // rfbSession runs the main client message loop and frame-sending goroutine.
 func (s *VNCServer) rfbSession(conn net.Conn) {
 	var writeMu sync.Mutex
-	updateRequested := make(chan struct{}, 1)
+	// updateRequested carries the incremental flag of a FramebufferUpdateRequest
+	// (true = incremental, false = full). Buffered to 1; a pending full request
+	// wins over a later incremental one.
+	updateRequested := make(chan bool, 1)
 	done := make(chan struct{})
+
+	// Per-connection encoding negotiation state. zrleEnabled is set when the
+	// client advertises ZRLE (16) via SetEncodings. Protected by encMu because
+	// it is written by the reader loop and read by the sender goroutine.
+	var encMu sync.Mutex
+	zrleEnabled := false
 
 	// Frame sender goroutine
 	go func() {
@@ -348,30 +358,61 @@ func (s *VNCServer) rfbSession(conn net.Conn) {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 
+		// Per-connection state: the previous captured frame (native BGRX) for
+		// dirty-rectangle diffing, and the continuous ZRLE zlib stream.
+		var prevFrame []byte
+		var zEnc *zrleEncoder
+		defer func() {
+			if zEnc != nil {
+				zEnc.Close()
+			}
+		}()
+
 		for {
 			select {
 			case <-s.stopCh:
 				return
-			case <-ticker.C:
-				// Only send a frame if the client has requested one.
-				select {
-				case <-updateRequested:
-				default:
-					continue
-				}
-
+			case incremental := <-updateRequested:
 				frame, err := s.capturer.Capture()
 				if err != nil {
 					s.logger.Printf("capture error: %v", err)
 					continue
 				}
 
+				encMu.Lock()
+				useZRLE := zrleEnabled
+				encMu.Unlock()
+
+				if useZRLE && zEnc == nil {
+					zEnc = newZRLEEncoder()
+				}
+
+				// Determine the rectangles to send. A non-incremental request,
+				// or the first frame of a connection, sends the full frame.
+				// Otherwise diff against the previous frame on a 64x64 tile grid.
+				frameW, frameH := frame.Width(), frame.Height()
+				var rects []image.Rectangle
+				if !incremental || prevFrame == nil {
+					rects = []image.Rectangle{image.Rect(0, 0, frameW, frameH)}
+				} else {
+					rects = dirtyTiles(prevFrame, frame.Pix, frameW, frameH)
+				}
+
+				activeEnc := zEnc
+				if !useZRLE {
+					activeEnc = nil
+				}
+
 				writeMu.Lock()
-				err = writeFramebufferUpdate(conn, frame)
+				err = writeFramebufferUpdateRects(conn, frame.Pix, frameW, rects, activeEnc)
 				writeMu.Unlock()
 				if err != nil {
 					return // connection dead
 				}
+
+				// Stash a copy of this frame as the diff baseline. Capture
+				// returns a fresh buffer each call, so we can retain it.
+				prevFrame = frame.Pix
 			}
 		}
 	}()
@@ -415,7 +456,14 @@ func (s *VNCServer) rfbSession(conn net.Conn) {
 			if _, err := io.ReadFull(conn, encodings); err != nil {
 				return
 			}
-			// We only support Raw encoding (0), ignore the rest.
+			// Negotiate ZRLE (16) if the client advertises it; otherwise we
+			// fall back to Raw (0), which every client supports.
+			if clientSupportsZRLE(encodings) {
+				encMu.Lock()
+				zrleEnabled = true
+				encMu.Unlock()
+				s.logger.Printf("client negotiated ZRLE encoding")
+			}
 
 		case 3: // FramebufferUpdateRequest
 			// type(1) + incremental(1) + x(2) + y(2) + w(2) + h(2) = 10, already read 1
@@ -423,10 +471,25 @@ func (s *VNCServer) rfbSession(conn net.Conn) {
 			if _, err := io.ReadFull(conn, buf[:]); err != nil {
 				return
 			}
-			// Signal the frame sender that the client wants a frame.
+			incremental := buf[0] != 0
+			// Signal the frame sender that the client wants a frame, passing
+			// the incremental flag. A pending full request (false) is not
+			// downgraded by a later incremental one.
 			select {
-			case updateRequested <- struct{}{}:
+			case updateRequested <- incremental:
 			default:
+				if !incremental {
+					// Ensure a full-update request is not lost behind a queued
+					// incremental one: drain and re-send as full.
+					select {
+					case <-updateRequested:
+					default:
+					}
+					select {
+					case updateRequested <- false:
+					default:
+					}
+				}
 			}
 
 		case 4: // KeyEvent


### PR DESCRIPTION
## Context

The embedded Go RFB server (`internal/desktop/vnc_server.go`) sent one
**full-frame, uncompressed Raw** `FramebufferUpdate` every frame. On a 1080p
desktop that is ~8 MB per frame, which is wasteful over the mesh/VPN. This is
Tier A of the desktop-streaming efficiency work.

Refs aceteam-ai/aceteam#4250 (spike) / aceteam-ai/aceteam#4168.

## Changes

- **`internal/desktop/vnc_encode.go`** (new, untagged pure Go):
  - `dirtyTiles` — diffs the previous vs current frame on a 64-aligned tile
    grid and returns the changed rectangles, coalesced per tile row. Returns a
    single full-frame rect when there is no prior frame or a size mismatch.
  - `zrleEncoder` — holds **one continuous zlib stream per connection** (RFB
    requires the dictionary to carry across rects and frames). `encodeZRLERect`
    tiles the rect into 64x64 tiles, emits subencoding 0 (raw CPIXELs), writes
    them to the stream, `Flush()`es, and prefixes the deflated bytes with a u32
    length.
  - `extractRect` — single source of sub-rect pixels for both paths; copies
    row-by-row and swaps BGRX (GDI native) to RGBX (advertised format). CPIXEL
    is 3 bytes (the unused 4th byte of the 32bpp format is dropped).
  - `encodeRawRect` / `writeFramebufferUpdateRects` — multi-rect update writer
    that routes each rect through ZRLE or Raw.
  - `clientSupportsZRLE` — scans a `SetEncodings` list for encoding 16, ignores
    pseudo-encodings (negatives).
- **`internal/desktop/vnc_server.go`**:
  - `SetEncodings` handler now negotiates ZRLE per connection.
  - `FramebufferUpdateRequest` now honors the **incremental** flag (previously
    discarded); a non-incremental request forces a full update.
  - The frame sender keeps per-connection state (prev frame + zlib stream),
    diffs incremental frames, and sends only changed rects.
  - The original `writeFramebufferUpdate` (full-frame Raw) is kept unchanged so
    existing tests stay green; it serves as the documented fallback shape.

### Which encoding and why

**ZRLE** (RFB encoding 16). A single zlib stream plus raw-CPIXEL tiles is the
simplest robust choice and every standard VNC client (noVNC included) decodes
it. Tight would need multiple zlib streams, a compression-control byte, and
JPEG/gradient/copy filters for no benefit at this stage. Uses stdlib
`compress/zlib`; **no new dependencies**.

### Negotiation + Raw fallback

ZRLE is enabled for a connection only when the client advertises 16 in
`SetEncodings`. If it does not, the server falls back to **Raw (0)**, which all
clients support. Dirty-rect diffing applies to both encodings.

### Which platform paths benefit

The embedded server's capturer is **GDI (Windows-only)** — confirmed: it is
started from `cmd/controlcenter.go:startVNCServer()`, and Linux/macOS nodes
stream via external **x11vnc** (`internal/platform/vnc.go`), which is already
compressed. So this primarily benefits the **Windows embedded-server path**.
The encoder itself is platform-agnostic Go and builds for all targets.

### Client path / negotiation reality check

The embedded server is reached through `internal/websockify/bridge.go`
(WebSocket-to-TCP) by the **browser noVNC** client. Verified against current
noVNC (`core/decoders/zrle.js` plus `_sendEncodings()` in `core/rfb.js`):
noVNC ships a ZRLE decoder and advertises encoding 16, so the negotiation
fires and the browser path gets real compression. Caveat: this assumes a noVNC
build that advertises ZRLE. If a very old noVNC (or any Raw-only client) is in
use, negotiation simply does not fire and the server falls back to dirty-rect
**Raw** -- still a bandwidth win on idle/partial-change frames, just
uncompressed.

## How to test

Automated (no display needed):
```bash
go build ./...
GOOS=windows go build ./...
go vet ./internal/desktop/...
go test ./internal/desktop/...
```
The tests cover: BGRX->RGBX extraction, Raw rect header/payload, ZRLE tile
CPIXEL layout, partial edge tiles, a zlib round-trip decode of an encoded rect,
the continuous-stream property across two rects, `SetEncodings` ZRLE detection
(including truncated/pseudo-encoding cases), and dirty-tile detection
(nil/size-mismatch -> full, no-change -> empty, single-tile change, row-run
coalescing).

Manual repro (needs a real Windows display):
1. Run the Citadel control center on a Windows node so the embedded VNC server
   starts.
2. Connect with a ZRLE-capable client (noVNC, TigerVNC). Confirm the image
   renders correctly and that idle screens send near-zero bytes (dirty-rect)
   while changes stream as compressed ZRLE rects.
3. Connect with a Raw-only client and confirm it still renders (fallback path).

## Notes

What needs a live display to verify: the actual GDI capture loop and end-to-end
rendering in a real VNC client. The encoding/diff logic is fully covered by
byte-level unit tests.
