### PR TITLE
feat(module): install service modules from any standardized git repo

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -240,7 +240,7 @@ func runControlCenter() {
 		// longer shows a permanent "device authorization required" status.
 		Chat:               buildChatConfig(),
 		ChatConfigProvider: buildChatConfig,
-		Proxmox:   buildProxmoxConfig(),
+		Proxmox:            buildProxmoxConfig(),
 		Settings: controlcenter.SettingsCallbacks{
 			LoadTelemetry: func() *config.Telemetry {
 				return config.LoadTelemetry(platform.ConfigDir())
@@ -255,7 +255,8 @@ func runControlCenter() {
 				return config.SaveKeepAwake(platform.ConfigDir(), k)
 			},
 		},
-		WhatsApp: buildWhatsAppCallbacks(),
+		WhatsApp:      buildWhatsAppCallbacks(),
+		ModuleInstall: buildModuleInstallCallbacks(),
 	}
 
 	cc := controlcenter.New(cfg)

--- a/cmd/manifest.go
+++ b/cmd/manifest.go
@@ -14,7 +14,7 @@ import (
 // Service defines a single managed service.
 type Service struct {
 	Name        string `yaml:"name"`
-	Type        string `yaml:"type,omitempty"`        // "native" or "docker" (default: auto-detect)
+	Type        string `yaml:"type,omitempty"`         // "native" or "docker" (default: auto-detect)
 	ComposeFile string `yaml:"compose_file,omitempty"` // For docker services
 	Port        int    `yaml:"port,omitempty"`         // For native services
 }
@@ -28,7 +28,7 @@ type ManifestCapabilities struct {
 
 // ManifestGPU describes a GPU declared in the manifest.
 type ManifestGPU struct {
-	Name   string `yaml:"name"`             // e.g. "NVIDIA GeForce RTX 3090"
+	Name   string `yaml:"name"`              // e.g. "NVIDIA GeForce RTX 3090"
 	VRAMMb int    `yaml:"vram_mb,omitempty"` // e.g. 24576
 	Count  int    `yaml:"count,omitempty"`   // defaults to 1
 }
@@ -216,8 +216,18 @@ func hasService(manifest *CitadelManifest, serviceName string) bool {
 	return false
 }
 
-// addServiceToManifest adds a service to the manifest and writes it to disk.
+// addServiceToManifest adds a service to the manifest and writes it to disk,
+// honoring the hardcoded capability-tag map for embedded/catalog services.
 func addServiceToManifest(configDir, serviceName string) error {
+	return addServiceToManifestWithTags(configDir, serviceName, nil)
+}
+
+// addServiceToManifestWithTags adds a service to the manifest and writes it to
+// disk. In addition to the hardcoded capability-tag map (back-compat for
+// embedded/catalog services), it merges any module-declared routing tags
+// (service.yaml's node_tags) into Node.Tags, so third-party engines become
+// routable without a CLI change. Tags are deduped via containsTag.
+func addServiceToManifestWithTags(configDir, serviceName string, nodeTags []string) error {
 	manifestPath := filepath.Join(configDir, "citadel.yaml")
 
 	// Read existing manifest
@@ -237,7 +247,7 @@ func addServiceToManifest(configDir, serviceName string) error {
 		ComposeFile: filepath.Join("./services", serviceName+".yml"),
 	})
 
-	// Auto-add capability tags for specific services
+	// Auto-add capability tags for specific embedded/catalog services (back-compat).
 	serviceTags := map[string][]string{
 		"extraction": {"extraction:gliner2", "model:gliner2-base-v1"},
 	}
@@ -246,6 +256,13 @@ func addServiceToManifest(configDir, serviceName string) error {
 			if !containsTag(manifest.Node.Tags, tag) {
 				manifest.Node.Tags = append(manifest.Node.Tags, tag)
 			}
+		}
+	}
+
+	// Merge module-declared routing tags (service.yaml node_tags).
+	for _, tag := range nodeTags {
+		if tag != "" && !containsTag(manifest.Node.Tags, tag) {
+			manifest.Node.Tags = append(manifest.Node.Tags, tag)
 		}
 	}
 

--- a/cmd/module.go
+++ b/cmd/module.go
@@ -429,9 +429,14 @@ func buildModuleInstallCallbacks() controlcenter.ModuleInstallCallbacks {
 				}
 			}
 
-			_, configDir, err := findOrCreateManifest()
+			nodeManifest, configDir, err := findOrCreateManifest()
 			if err != nil {
 				return "", err
+			}
+			// Parity with the CLI: report an already-installed module cleanly
+			// instead of letting it surface as a confusing port conflict.
+			if hasService(nodeManifest, manifest.Name) {
+				return "", fmt.Errorf("module '%s' is already in the node manifest", manifest.Name)
 			}
 			servicesDir := filepath.Join(configDir, "services")
 

--- a/cmd/module.go
+++ b/cmd/module.go
@@ -128,14 +128,20 @@ func runModuleInstall(cmd *cobra.Command, args []string) error {
 
 	// Resolve the external source: clone/update the repo and load its manifest.
 	fmt.Printf("Resolving module source %s ...\n", color.CyanString(src.Raw))
-	manifest, composeSrc, err := catalog.ResolveSource(src)
+	resolved, err := catalog.ResolveSource(src)
 	if err != nil {
 		return err
 	}
+	manifest := resolved.Manifest
 
-	// Print a summary so the operator can confirm what will be installed.
-	image := composeImage(composeSrc)
-	printModuleSummary(src, manifest, composeSrc, image, overrides)
+	// Forward-compat: warn (don't fail) on a newer manifest schema.
+	if w := catalog.SchemaWarning(manifest); w != "" {
+		fmt.Println(color.YellowString("  Warning: " + w))
+	}
+
+	// Print a summary (incl. resolved commit + image) so the operator can confirm
+	// what will be installed -- a real TOFU/provenance prompt.
+	printModuleSummary(src, resolved, overrides)
 
 	if !moduleInstallYes {
 		fmt.Print("\nProceed with install? [y/N]: ")
@@ -158,26 +164,52 @@ func runModuleInstall(cmd *cobra.Command, args []string) error {
 	servicesDir := filepath.Join(configDir, "services")
 
 	fmt.Printf("\nInstalling %s ...\n", manifest.Name)
-	result, err := catalog.InstallFromManifest(manifest, composeSrc, servicesDir, overrides, true)
+	result, err := catalog.InstallFromManifest(manifest, resolved.ComposePath, servicesDir, overrides, true)
 	if err != nil {
 		return fmt.Errorf("install failed: %w", err)
 	}
 
-	if err := addServiceToManifest(configDir, result.Name); err != nil {
+	// Register in the node manifest, merging the module's declared routing tags
+	// so a third-party engine becomes routable without a CLI change.
+	if err := addServiceToManifestWithTags(configDir, result.Name, manifest.NodeTags); err != nil {
 		return fmt.Errorf("failed to update manifest: %w", err)
 	}
+
+	// Record provenance into the lockfile (best-effort: never fail the install).
+	recordModuleLock(src, resolved)
 
 	fmt.Printf("\nInstalled %s successfully.\n", result.Name)
 	fmt.Printf("  Compose: %s\n", result.ComposeDestPath)
 	if result.EnvDestPath != "" {
 		fmt.Printf("  Config:  %s\n", result.EnvDestPath)
 	}
+	if len(manifest.NodeTags) > 0 {
+		fmt.Printf("  Routing tags: %s\n", strings.Join(manifest.NodeTags, ", "))
+	}
 	fmt.Printf("\nTo start the module:\n")
 	fmt.Printf("  citadel run %s\n", result.Name)
 	return nil
 }
 
-// runModuleList prints the modules currently registered in the node manifest.
+// recordModuleLock upserts a provenance entry for a freshly resolved+installed
+// module into modules.lock. Best-effort: any failure is reported to stderr but
+// does not fail the install.
+func recordModuleLock(src catalog.Source, resolved *catalog.ResolvedModule) {
+	entry := catalog.LockEntry{
+		Name:   resolved.Manifest.Name,
+		Source: src.Raw,
+		Ref:    src.Ref,
+		Commit: resolved.Commit,
+		Images: catalog.BuildLockImages(resolved.Images),
+	}
+	if err := catalog.UpsertLockEntry(entry); err != nil {
+		fmt.Fprintf(os.Stderr, "  Note: could not record provenance in modules.lock: %v\n", err)
+	}
+}
+
+// runModuleList prints the modules registered in the node manifest, merged with
+// provenance (source@commit, image[@digest]) from the lockfile when available.
+// Services without a lockfile entry (catalog/embedded) are still shown.
 func runModuleList(cmd *cobra.Command, args []string) error {
 	manifest, _, err := findAndReadManifest()
 	if err != nil {
@@ -189,14 +221,56 @@ func runModuleList(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	lf, _ := catalog.LoadLockfile() // best-effort; nil-safe below
+
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	defer w.Flush()
 	bold := color.New(color.Bold)
-	bold.Fprintf(w, "MODULE\tCOMPOSE\n")
+	bold.Fprintf(w, "MODULE\tSOURCE\tIMAGE\n")
 	for _, s := range manifest.Services {
-		fmt.Fprintf(w, "%s\t%s\n", s.Name, s.ComposeFile)
+		source := color.New(color.FgWhite).Sprint("catalog/embedded")
+		image := "-"
+		if lf != nil {
+			if e, ok := lf.LookupLock(s.Name); ok {
+				source = e.Source
+				if e.Commit != "" {
+					source = fmt.Sprintf("%s@%s", e.Source, shortCommit(e.Commit))
+				}
+				image = formatLockImages(e.Images)
+			}
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\n", s.Name, source, image)
 	}
 	return nil
+}
+
+// shortCommit abbreviates a git commit SHA for display.
+func shortCommit(commit string) string {
+	if len(commit) > 12 {
+		return commit[:12]
+	}
+	return commit
+}
+
+// formatLockImages renders lockfile images as "ref@digest" (digest abbreviated),
+// joined by commas, or "-" if none.
+func formatLockImages(images []catalog.LockImage) string {
+	if len(images) == 0 {
+		return "-"
+	}
+	var parts []string
+	for _, im := range images {
+		if im.Digest != "" {
+			d := im.Digest
+			if len(d) > 19 { // "sha256:" + 12 hex
+				d = d[:19]
+			}
+			parts = append(parts, fmt.Sprintf("%s@%s", im.Ref, d))
+		} else {
+			parts = append(parts, im.Ref)
+		}
+	}
+	return strings.Join(parts, ", ")
 }
 
 // runModuleInfo resolves a module source and prints its manifest details.
@@ -212,16 +286,22 @@ func runModuleInfo(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("Resolving module source %s ...\n\n", color.CyanString(src.Raw))
-	manifest, composeSrc, err := catalog.ResolveSource(src)
+	resolved, err := catalog.ResolveSource(src)
 	if err != nil {
 		return err
 	}
-	renderManifest(manifest, src, composeSrc, composeImage(composeSrc))
+	if w := catalog.SchemaWarning(resolved.Manifest); w != "" {
+		fmt.Println(color.YellowString("Warning: " + w))
+		fmt.Println()
+	}
+	renderManifest(resolved, src)
 	return nil
 }
 
-// printModuleSummary prints a concise pre-install summary for an external module.
-func printModuleSummary(src catalog.Source, manifest *catalog.ServiceManifest, composePath, image string, overrides map[string]string) {
+// printModuleSummary prints a concise pre-install summary (incl. resolved commit
+// + image) for an external module -- a TOFU/provenance prompt.
+func printModuleSummary(src catalog.Source, resolved *catalog.ResolvedModule, overrides map[string]string) {
+	manifest := resolved.Manifest
 	bold := color.New(color.Bold)
 	fmt.Println()
 	bold.Println("Module to install:")
@@ -230,8 +310,14 @@ func printModuleSummary(src catalog.Source, manifest *catalog.ServiceManifest, c
 	if manifest.Version != "" {
 		fmt.Printf("  Version: %s\n", manifest.Version)
 	}
-	if image != "" {
-		fmt.Printf("  Image:   %s\n", image)
+	if resolved.Commit != "" {
+		fmt.Printf("  Commit:  %s\n", resolved.Commit)
+	}
+	for _, img := range resolved.Images {
+		fmt.Printf("  Image:   %s\n", img)
+	}
+	if len(manifest.NodeTags) > 0 {
+		fmt.Printf("  Routing tags: %s\n", strings.Join(manifest.NodeTags, ", "))
 	}
 	if len(manifest.Ports) > 0 {
 		var ports []string
@@ -256,15 +342,20 @@ func printModuleSummary(src catalog.Source, manifest *catalog.ServiceManifest, c
 }
 
 // renderManifest prints full manifest details, mirroring runCatalogInfo's style,
-// with the resolved source + image added at the top.
-func renderManifest(manifest *catalog.ServiceManifest, src catalog.Source, composePath, image string) {
+// with the resolved source + commit + image(s) added at the top.
+func renderManifest(resolved *catalog.ResolvedModule, src catalog.Source) {
+	manifest := resolved.Manifest
 	bold := color.New(color.Bold)
 
 	bold.Print("Source:      ")
 	fmt.Println(src.Raw)
-	if image != "" {
+	if resolved.Commit != "" {
+		bold.Print("Commit:      ")
+		fmt.Println(resolved.Commit)
+	}
+	for _, img := range resolved.Images {
 		bold.Print("Image:       ")
-		fmt.Println(image)
+		fmt.Println(img)
 	}
 	bold.Print("Name:        ")
 	fmt.Println(manifest.Name)
@@ -331,6 +422,12 @@ func renderManifest(manifest *catalog.ServiceManifest, src catalog.Source, compo
 		w.Flush()
 	}
 
+	if len(manifest.NodeTags) > 0 {
+		fmt.Println()
+		bold.Print("Routing tags (node_tags): ")
+		fmt.Println(strings.Join(manifest.NodeTags, ", "))
+	}
+
 	if len(manifest.Tags) > 0 {
 		fmt.Println()
 		bold.Print("Tags: ")
@@ -380,20 +477,9 @@ func buildModuleInstallCallbacks() controlcenter.ModuleInstallCallbacks {
 			if err != nil {
 				return out, err
 			}
-
-			var manifest *catalog.ServiceManifest
-			var composeSrc string
-			if src.Kind == catalog.KindCatalog {
-				manifest, err = catalog.LoadServiceManifest(src.Name)
-				if err != nil {
-					return out, err
-				}
-				composeSrc, _ = catalog.GetComposeFile(src.Name)
-			} else {
-				manifest, composeSrc, err = catalog.ResolveSource(src)
-				if err != nil {
-					return out, err
-				}
+			manifest, composeSrc, _, err := resolveModuleForTUI(src)
+			if err != nil {
+				return out, err
 			}
 
 			out.Name = manifest.Name
@@ -413,20 +499,9 @@ func buildModuleInstallCallbacks() controlcenter.ModuleInstallCallbacks {
 			if err != nil {
 				return "", err
 			}
-
-			var manifest *catalog.ServiceManifest
-			var composeSrc string
-			if src.Kind == catalog.KindCatalog {
-				manifest, err = catalog.LoadServiceManifest(src.Name)
-				if err != nil {
-					return "", err
-				}
-				composeSrc, _ = catalog.GetComposeFile(src.Name)
-			} else {
-				manifest, composeSrc, err = catalog.ResolveSource(src)
-				if err != nil {
-					return "", err
-				}
+			manifest, composeSrc, resolved, err := resolveModuleForTUI(src)
+			if err != nil {
+				return "", err
 			}
 
 			nodeManifest, configDir, err := findOrCreateManifest()
@@ -446,10 +521,34 @@ func buildModuleInstallCallbacks() controlcenter.ModuleInstallCallbacks {
 			if err != nil {
 				return "", err
 			}
-			if err := addServiceToManifest(configDir, result.Name); err != nil {
+			// Merge the module's declared routing tags so it becomes routable.
+			if err := addServiceToManifestWithTags(configDir, result.Name, manifest.NodeTags); err != nil {
 				return "", fmt.Errorf("failed to update manifest: %w", err)
+			}
+			// Record provenance for external sources (best-effort).
+			if resolved != nil {
+				recordModuleLock(src, resolved)
 			}
 			return result.Name, nil
 		},
 	}
+}
+
+// resolveModuleForTUI resolves a source for the TUI callbacks: for a catalog name
+// it loads from the catalog cache (resolved is nil, no provenance); for an
+// external source it clones/updates the repo and returns the full ResolvedModule.
+func resolveModuleForTUI(src catalog.Source) (manifest *catalog.ServiceManifest, composeSrc string, resolved *catalog.ResolvedModule, err error) {
+	if src.Kind == catalog.KindCatalog {
+		manifest, err = catalog.LoadServiceManifest(src.Name)
+		if err != nil {
+			return nil, "", nil, err
+		}
+		composeSrc, _ = catalog.GetComposeFile(src.Name)
+		return manifest, composeSrc, nil, nil
+	}
+	resolved, err = catalog.ResolveSource(src)
+	if err != nil {
+		return nil, "", nil, err
+	}
+	return resolved.Manifest, resolved.ComposePath, resolved, nil
 }

--- a/cmd/module.go
+++ b/cmd/module.go
@@ -572,17 +572,22 @@ func buildModuleInstallCallbacks() controlcenter.ModuleInstallCallbacks {
 				})
 			}
 			// Trust state + compose risk findings for the form to surface.
+			// Catalog sources are first-party (Tier 0): always trusted and exempt
+			// from the privilege gate, so we don't scan/surface risks for them
+			// (matching the CLI catalog path) -- no scary checkbox for a built-in.
 			out.Trusted = catalog.IsTrusted(src)
-			if data, rerr := os.ReadFile(composeSrc); rerr == nil {
-				for _, r := range catalog.ScanComposeRisks(string(data)) {
-					crit := r.Severity == catalog.SeverityCritical
-					out.Risks = append(out.Risks, controlcenter.ModuleRisk{
-						Critical:  crit,
-						Directive: r.Directive,
-						Detail:    r.Detail,
-					})
-					if crit {
-						out.HasCriticalRisk = true
+			if src.Kind != catalog.KindCatalog {
+				if data, rerr := os.ReadFile(composeSrc); rerr == nil {
+					for _, r := range catalog.ScanComposeRisks(string(data)) {
+						crit := r.Severity == catalog.SeverityCritical
+						out.Risks = append(out.Risks, controlcenter.ModuleRisk{
+							Critical:  crit,
+							Directive: r.Directive,
+							Detail:    r.Detail,
+						})
+						if crit {
+							out.HasCriticalRisk = true
+						}
 					}
 				}
 			}
@@ -613,7 +618,13 @@ func buildModuleInstallCallbacks() controlcenter.ModuleInstallCallbacks {
 			// overrides, so a missing required var is an error, never a stdin read.
 			// allowPrivileged is the user's explicit opt-in from the form; the
 			// shared core still refuses a Critical compose if it is false.
-			result, err := catalog.InstallFromManifest(manifest, composeSrc, servicesDir, overrides, false, allowPrivileged)
+			// Catalog sources are first-party (Tier 0) and exempt from the gate,
+			// matching the CLI catalog path (catalog.Install passes true).
+			allow := allowPrivileged
+			if src.Kind == catalog.KindCatalog {
+				allow = true
+			}
+			result, err := catalog.InstallFromManifest(manifest, composeSrc, servicesDir, overrides, false, allow)
 			if err != nil {
 				return "", err
 			}

--- a/cmd/module.go
+++ b/cmd/module.go
@@ -37,6 +37,7 @@ import (
 var (
 	moduleInstallConfigFlags []string
 	moduleInstallYes         bool
+	moduleAllowPrivileged    bool
 )
 
 var moduleCmd = &cobra.Command{
@@ -90,7 +91,9 @@ func init() {
 	moduleInstallCmd.Flags().StringArrayVar(&moduleInstallConfigFlags, "set", nil,
 		"Set a config value (e.g. --set KEY=VALUE). Repeatable.")
 	moduleInstallCmd.Flags().BoolVar(&moduleInstallYes, "yes", false,
-		"Skip the confirmation prompt for external (non-catalog) sources.")
+		"Skip the ordinary confirmation prompt (does NOT bypass the privileged-compose gate).")
+	moduleInstallCmd.Flags().BoolVar(&moduleAllowPrivileged, "allow-privileged", false,
+		"Allow installing a module whose compose requests privileged/root-equivalent access (required when Critical risks are present).")
 }
 
 // parseSetFlags converts repeated --set KEY=VALUE flags into an overrides map.
@@ -143,6 +146,24 @@ func runModuleInstall(cmd *cobra.Command, args []string) error {
 	// what will be installed -- a real TOFU/provenance prompt.
 	printModuleSummary(src, resolved, overrides)
 
+	// Trust + risk surface: warn that this runs an arbitrary container with
+	// root-equivalent access on this node (unless the source is trusted), and
+	// list the compose risk findings.
+	trusted := catalog.IsTrusted(src)
+	risks := scanResolvedRisks(resolved)
+	printTrustAndRisks(src, trusted, risks)
+
+	// Hard gate: a Critical finding without --allow-privileged refuses the
+	// install BEFORE any confirmation (and even under --yes). This mirrors the
+	// shared-core guard in InstallFromManifest so the user sees a clear message
+	// here. Trust does NOT relax the privilege gate.
+	if crit := criticalDirectiveNames(risks); len(crit) > 0 && !moduleAllowPrivileged {
+		return fmt.Errorf("refusing to install '%s': compose requests privileged/root-equivalent access (%s).\n"+
+			"   This would grant the module Docker-level (host root) access on this node.\n"+
+			"   If you trust this source, re-run with --allow-privileged to override.",
+			manifest.Name, strings.Join(crit, ", "))
+	}
+
 	if !moduleInstallYes {
 		fmt.Print("\nProceed with install? [y/N]: ")
 		if !confirmYes() {
@@ -164,7 +185,7 @@ func runModuleInstall(cmd *cobra.Command, args []string) error {
 	servicesDir := filepath.Join(configDir, "services")
 
 	fmt.Printf("\nInstalling %s ...\n", manifest.Name)
-	result, err := catalog.InstallFromManifest(manifest, resolved.ComposePath, servicesDir, overrides, true)
+	result, err := catalog.InstallFromManifest(manifest, resolved.ComposePath, servicesDir, overrides, true, moduleAllowPrivileged)
 	if err != nil {
 		return fmt.Errorf("install failed: %w", err)
 	}
@@ -454,6 +475,64 @@ func composeImage(composePath string) string {
 	return ""
 }
 
+// scanResolvedRisks reads the resolved compose and returns its risk findings.
+func scanResolvedRisks(resolved *catalog.ResolvedModule) []catalog.ComposeRisk {
+	data, err := os.ReadFile(resolved.ComposePath)
+	if err != nil {
+		return nil
+	}
+	return catalog.ScanComposeRisks(string(data))
+}
+
+// criticalDirectiveNames returns the directive names of the Critical findings.
+func criticalDirectiveNames(risks []catalog.ComposeRisk) []string {
+	var out []string
+	for _, r := range risks {
+		if r.Severity == catalog.SeverityCritical {
+			out = append(out, r.Directive)
+		}
+	}
+	return out
+}
+
+// printTrustAndRisks prints the trust banner and the risk findings for an
+// external module source. Untrusted sources get a prominent warning that this
+// installs and runs an arbitrary container with Docker-level (host root) access.
+func printTrustAndRisks(src catalog.Source, trusted bool, risks []catalog.ComposeRisk) {
+	bold := color.New(color.Bold)
+	fmt.Println()
+	if trusted {
+		fmt.Printf("  %s %s\n", color.GreenString("✓ trusted source"), color.New(color.Faint).Sprintf("(%s)", src.Raw))
+	} else {
+		bold.Println(color.YellowString("⚠ UNTRUSTED SOURCE"))
+		fmt.Println(color.YellowString("  Installing this module runs an arbitrary container on this node with"))
+		fmt.Println(color.YellowString("  Docker-level (host root-equivalent) access. Only proceed if you trust"))
+		fmt.Printf("%s\n", color.YellowString("  the source and have reviewed its compose. "))
+		fmt.Printf("  %s\n", color.New(color.Faint).Sprintf("Trust it for next time: citadel module trust %s", trustSuggestion(src)))
+	}
+
+	if len(risks) > 0 {
+		fmt.Println()
+		bold.Println("  Compose risk findings:")
+		for _, r := range risks {
+			switch r.Severity {
+			case catalog.SeverityCritical:
+				fmt.Printf("    %s  %s — %s\n", color.RedString("CRITICAL"), r.Directive, r.Detail)
+			default:
+				fmt.Printf("    %s      %s — %s\n", color.YellowString("HIGH"), r.Directive, r.Detail)
+			}
+		}
+	}
+}
+
+// trustSuggestion returns a sensible trust pattern to suggest for a source.
+func trustSuggestion(src catalog.Source) string {
+	if src.Kind == catalog.KindGitHub {
+		return src.Owner + "/" + src.Repo
+	}
+	return src.Raw
+}
+
 // confirmYes reads a single line from stdin and reports whether it is an
 // affirmative ("y"/"yes", case-insensitive).
 func confirmYes() bool {
@@ -492,9 +571,24 @@ func buildModuleInstallCallbacks() controlcenter.ModuleInstallCallbacks {
 					Required:    cv.Required,
 				})
 			}
+			// Trust state + compose risk findings for the form to surface.
+			out.Trusted = catalog.IsTrusted(src)
+			if data, rerr := os.ReadFile(composeSrc); rerr == nil {
+				for _, r := range catalog.ScanComposeRisks(string(data)) {
+					crit := r.Severity == catalog.SeverityCritical
+					out.Risks = append(out.Risks, controlcenter.ModuleRisk{
+						Critical:  crit,
+						Directive: r.Directive,
+						Detail:    r.Detail,
+					})
+					if crit {
+						out.HasCriticalRisk = true
+					}
+				}
+			}
 			return out, nil
 		},
-		Install: func(source string, overrides map[string]string) (string, error) {
+		Install: func(source string, overrides map[string]string, allowPrivileged bool) (string, error) {
 			src, err := catalog.ParseSource(source)
 			if err != nil {
 				return "", err
@@ -517,7 +611,9 @@ func buildModuleInstallCallbacks() controlcenter.ModuleInstallCallbacks {
 
 			// interactive=false: the TUI supplies all required config as
 			// overrides, so a missing required var is an error, never a stdin read.
-			result, err := catalog.InstallFromManifest(manifest, composeSrc, servicesDir, overrides, false)
+			// allowPrivileged is the user's explicit opt-in from the form; the
+			// shared core still refuses a Critical compose if it is false.
+			result, err := catalog.InstallFromManifest(manifest, composeSrc, servicesDir, overrides, false, allowPrivileged)
 			if err != nil {
 				return "", err
 			}

--- a/cmd/module.go
+++ b/cmd/module.go
@@ -1,0 +1,450 @@
+// cmd/module.go
+//
+// `citadel module` installs and inspects Citadel service modules from any
+// standardized git repo, not just the central catalog. A module repo
+// self-describes via a top-level `citadel/` directory containing service.yaml +
+// compose.yml (the compose `image:` points at that repo's own registry); the CLI
+// never hardcodes a module's image.
+//
+// Source forms accepted by `<source>`:
+//   - a catalog name (e.g. "vllm")           -> resolved from the central catalog
+//   - "owner/repo" or "owner/repo@ref"        -> https://github.com/owner/repo.git
+//   - a full git URL (https://… or git@…:…)   -> cloned directly
+//
+// This is a separate top-level group from `citadel service install` (the systemd
+// service-install command) and from `citadel service catalog` (the central
+// catalog browser).
+//
+// Note on private repos: cloning a private source repo requires this node to have
+// git credentials (a GITHUB_TOKEN, an SSH key, or a configured git credential
+// helper). Public repos work for everyone; private repos work only for nodes with
+// credentials.
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/aceteam-ai/citadel-cli/internal/catalog"
+	"github.com/aceteam-ai/citadel-cli/internal/tui/controlcenter"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+var (
+	moduleInstallConfigFlags []string
+	moduleInstallYes         bool
+)
+
+var moduleCmd = &cobra.Command{
+	Use:   "module",
+	Short: "Install service modules from any standardized git repo",
+	Long: `Install and inspect Citadel service modules from any standardized git repo,
+not just the central catalog.
+
+A module repo self-describes via a top-level 'citadel/' directory containing
+service.yaml + compose.yml, with the compose 'image:' pointing at that repo's own
+container registry. The CLI never hardcodes a module's image.
+
+Sources can be a catalog name (e.g. vllm), an 'owner/repo' shorthand
+(optionally 'owner/repo@ref'), or a full git URL.
+
+  citadel module install owner/repo            # install from GitHub
+  citadel module install owner/repo@v1.2.0     # pin a tag/branch
+  citadel module install https://git.example/m # full git URL
+  citadel module install vllm                  # delegate to the central catalog
+
+Private source repos require this node to have git credentials (a GITHUB_TOKEN,
+an SSH key, or a configured git credential helper).`,
+}
+
+var moduleInstallCmd = &cobra.Command{
+	Use:   "install <source>",
+	Short: "Install a service module from a catalog name, owner/repo, or git URL",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runModuleInstall,
+}
+
+var moduleListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List installed modules (services in the node manifest)",
+	RunE:  runModuleList,
+}
+
+var moduleInfoCmd = &cobra.Command{
+	Use:   "info <source>",
+	Short: "Resolve a module source and print its manifest details",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runModuleInfo,
+}
+
+func init() {
+	rootCmd.AddCommand(moduleCmd)
+	moduleCmd.AddCommand(moduleInstallCmd)
+	moduleCmd.AddCommand(moduleListCmd)
+	moduleCmd.AddCommand(moduleInfoCmd)
+
+	moduleInstallCmd.Flags().StringArrayVar(&moduleInstallConfigFlags, "set", nil,
+		"Set a config value (e.g. --set KEY=VALUE). Repeatable.")
+	moduleInstallCmd.Flags().BoolVar(&moduleInstallYes, "yes", false,
+		"Skip the confirmation prompt for external (non-catalog) sources.")
+}
+
+// parseSetFlags converts repeated --set KEY=VALUE flags into an overrides map.
+func parseSetFlags(flags []string) (map[string]string, error) {
+	overrides := make(map[string]string)
+	for _, kv := range flags {
+		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid --set value '%s': expected KEY=VALUE", kv)
+		}
+		overrides[parts[0]] = parts[1]
+	}
+	return overrides, nil
+}
+
+// runModuleInstall installs a module from any source: catalog name (delegated to
+// the existing catalog flow) or an external git source resolved on the fly.
+func runModuleInstall(cmd *cobra.Command, args []string) error {
+	src, err := catalog.ParseSource(args[0])
+	if err != nil {
+		return err
+	}
+
+	// Catalog names delegate to the existing catalog install flow so that
+	// host-provisioned services and wechat-style guidance do not diverge.
+	if src.Kind == catalog.KindCatalog {
+		catalogInstallConfigFlags = moduleInstallConfigFlags
+		return runCatalogInstall(cmd, []string{src.Name})
+	}
+
+	overrides, err := parseSetFlags(moduleInstallConfigFlags)
+	if err != nil {
+		return err
+	}
+
+	// Resolve the external source: clone/update the repo and load its manifest.
+	fmt.Printf("Resolving module source %s ...\n", color.CyanString(src.Raw))
+	manifest, composeSrc, err := catalog.ResolveSource(src)
+	if err != nil {
+		return err
+	}
+
+	// Print a summary so the operator can confirm what will be installed.
+	image := composeImage(composeSrc)
+	printModuleSummary(src, manifest, composeSrc, image, overrides)
+
+	if !moduleInstallYes {
+		fmt.Print("\nProceed with install? [y/N]: ")
+		if !confirmYes() {
+			fmt.Println("Aborted.")
+			return nil
+		}
+	}
+
+	// Find or create the node manifest to get the services directory.
+	nodeManifest, configDir, err := findOrCreateManifest()
+	if err != nil {
+		return fmt.Errorf("failed to initialize configuration: %w", err)
+	}
+	if hasService(nodeManifest, manifest.Name) {
+		fmt.Printf("Module '%s' is already in the node manifest.\n", manifest.Name)
+		return nil
+	}
+
+	servicesDir := filepath.Join(configDir, "services")
+
+	fmt.Printf("\nInstalling %s ...\n", manifest.Name)
+	result, err := catalog.InstallFromManifest(manifest, composeSrc, servicesDir, overrides, true)
+	if err != nil {
+		return fmt.Errorf("install failed: %w", err)
+	}
+
+	if err := addServiceToManifest(configDir, result.Name); err != nil {
+		return fmt.Errorf("failed to update manifest: %w", err)
+	}
+
+	fmt.Printf("\nInstalled %s successfully.\n", result.Name)
+	fmt.Printf("  Compose: %s\n", result.ComposeDestPath)
+	if result.EnvDestPath != "" {
+		fmt.Printf("  Config:  %s\n", result.EnvDestPath)
+	}
+	fmt.Printf("\nTo start the module:\n")
+	fmt.Printf("  citadel run %s\n", result.Name)
+	return nil
+}
+
+// runModuleList prints the modules currently registered in the node manifest.
+func runModuleList(cmd *cobra.Command, args []string) error {
+	manifest, _, err := findAndReadManifest()
+	if err != nil {
+		fmt.Println("No node manifest found. Install a module with 'citadel module install <source>'.")
+		return nil
+	}
+	if len(manifest.Services) == 0 {
+		fmt.Println("No modules installed.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	defer w.Flush()
+	bold := color.New(color.Bold)
+	bold.Fprintf(w, "MODULE\tCOMPOSE\n")
+	for _, s := range manifest.Services {
+		fmt.Fprintf(w, "%s\t%s\n", s.Name, s.ComposeFile)
+	}
+	return nil
+}
+
+// runModuleInfo resolves a module source and prints its manifest details.
+func runModuleInfo(cmd *cobra.Command, args []string) error {
+	src, err := catalog.ParseSource(args[0])
+	if err != nil {
+		return err
+	}
+
+	// Catalog names reuse the existing catalog info renderer.
+	if src.Kind == catalog.KindCatalog {
+		return runCatalogInfo(cmd, []string{src.Name})
+	}
+
+	fmt.Printf("Resolving module source %s ...\n\n", color.CyanString(src.Raw))
+	manifest, composeSrc, err := catalog.ResolveSource(src)
+	if err != nil {
+		return err
+	}
+	renderManifest(manifest, src, composeSrc, composeImage(composeSrc))
+	return nil
+}
+
+// printModuleSummary prints a concise pre-install summary for an external module.
+func printModuleSummary(src catalog.Source, manifest *catalog.ServiceManifest, composePath, image string, overrides map[string]string) {
+	bold := color.New(color.Bold)
+	fmt.Println()
+	bold.Println("Module to install:")
+	fmt.Printf("  Source:  %s\n", src.Raw)
+	fmt.Printf("  Name:    %s\n", manifest.Name)
+	if manifest.Version != "" {
+		fmt.Printf("  Version: %s\n", manifest.Version)
+	}
+	if image != "" {
+		fmt.Printf("  Image:   %s\n", image)
+	}
+	if len(manifest.Ports) > 0 {
+		var ports []string
+		for _, p := range manifest.Ports {
+			ports = append(ports, fmt.Sprintf("%d->%d", p.Host, p.Container))
+		}
+		fmt.Printf("  Ports:   %s\n", strings.Join(ports, ", "))
+	}
+	// Required config (missing an override) -- highlight so the operator knows
+	// what must be supplied via --set.
+	var missing []string
+	for _, cv := range manifest.Config {
+		if cv.Required && cv.Default == "" {
+			if _, ok := overrides[cv.Name]; !ok {
+				missing = append(missing, cv.Name)
+			}
+		}
+	}
+	if len(missing) > 0 {
+		fmt.Printf("  %s %s\n", color.YellowString("Required config (provide via --set):"), strings.Join(missing, ", "))
+	}
+}
+
+// renderManifest prints full manifest details, mirroring runCatalogInfo's style,
+// with the resolved source + image added at the top.
+func renderManifest(manifest *catalog.ServiceManifest, src catalog.Source, composePath, image string) {
+	bold := color.New(color.Bold)
+
+	bold.Print("Source:      ")
+	fmt.Println(src.Raw)
+	if image != "" {
+		bold.Print("Image:       ")
+		fmt.Println(image)
+	}
+	bold.Print("Name:        ")
+	fmt.Println(manifest.Name)
+	bold.Print("Version:     ")
+	fmt.Println(manifest.Version)
+	bold.Print("Description: ")
+	fmt.Println(manifest.Description)
+	if manifest.Category != "" {
+		bold.Print("Category:    ")
+		fmt.Println(manifest.Category)
+	}
+	if manifest.Author != "" {
+		bold.Print("Author:      ")
+		fmt.Println(manifest.Author)
+	}
+	if manifest.Homepage != "" {
+		bold.Print("Homepage:    ")
+		fmt.Println(manifest.Homepage)
+	}
+
+	if manifest.Requires.GPU || manifest.Requires.VRAMMinGB > 0 || len(manifest.Requires.Arch) > 0 {
+		fmt.Println()
+		bold.Println("Requirements:")
+		if manifest.Requires.GPU {
+			fmt.Println("  GPU:       required")
+		}
+		if manifest.Requires.VRAMMinGB > 0 {
+			fmt.Printf("  Min VRAM:  %.0f GB\n", manifest.Requires.VRAMMinGB)
+		}
+		if len(manifest.Requires.Arch) > 0 {
+			fmt.Printf("  Arch:      %s\n", strings.Join(manifest.Requires.Arch, ", "))
+		}
+	}
+
+	if len(manifest.Ports) > 0 {
+		fmt.Println()
+		bold.Println("Ports:")
+		for _, p := range manifest.Ports {
+			proto := p.Protocol
+			if proto == "" {
+				proto = "tcp"
+			}
+			desc := ""
+			if p.Description != "" {
+				desc = "  " + p.Description
+			}
+			fmt.Printf("  %d -> %d/%s%s\n", p.Host, p.Container, proto, desc)
+		}
+	}
+
+	if len(manifest.Config) > 0 {
+		fmt.Println()
+		bold.Println("Configuration:")
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		for _, cv := range manifest.Config {
+			def := ""
+			if cv.Default != "" {
+				def = fmt.Sprintf("[default: %s]", cv.Default)
+			} else if cv.Required {
+				def = color.New(color.FgRed).Sprint("[required]")
+			}
+			fmt.Fprintf(w, "  %s\t%s\t%s\n", cv.Name, cv.Description, def)
+		}
+		w.Flush()
+	}
+
+	if len(manifest.Tags) > 0 {
+		fmt.Println()
+		bold.Print("Tags: ")
+		fmt.Println(strings.Join(manifest.Tags, ", "))
+	}
+}
+
+// composeImage extracts the first `image:` value from a compose file, for the
+// install summary. Best-effort: returns "" if it cannot be determined. The CLI
+// never hardcodes or rewrites the image -- this is display-only.
+func composeImage(composePath string) string {
+	data, err := os.ReadFile(composePath)
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "image:") {
+			val := strings.TrimSpace(strings.TrimPrefix(trimmed, "image:"))
+			val = strings.Trim(val, `"'`)
+			return val
+		}
+	}
+	return ""
+}
+
+// confirmYes reads a single line from stdin and reports whether it is an
+// affirmative ("y"/"yes", case-insensitive).
+func confirmYes() bool {
+	var resp string
+	if _, err := fmt.Scanln(&resp); err != nil {
+		return false
+	}
+	resp = strings.ToLower(strings.TrimSpace(resp))
+	return resp == "y" || resp == "yes"
+}
+
+// buildModuleInstallCallbacks wires the control center's module-install page to
+// the same source-resolution + install logic the CLI uses. The TUI collects all
+// required config up front and passes it as overrides, so the non-interactive
+// installer path is used (no stdin reads). All hooks are best-effort.
+func buildModuleInstallCallbacks() controlcenter.ModuleInstallCallbacks {
+	return controlcenter.ModuleInstallCallbacks{
+		Resolve: func(source string) (controlcenter.ModuleResolveResult, error) {
+			var out controlcenter.ModuleResolveResult
+			src, err := catalog.ParseSource(source)
+			if err != nil {
+				return out, err
+			}
+
+			var manifest *catalog.ServiceManifest
+			var composeSrc string
+			if src.Kind == catalog.KindCatalog {
+				manifest, err = catalog.LoadServiceManifest(src.Name)
+				if err != nil {
+					return out, err
+				}
+				composeSrc, _ = catalog.GetComposeFile(src.Name)
+			} else {
+				manifest, composeSrc, err = catalog.ResolveSource(src)
+				if err != nil {
+					return out, err
+				}
+			}
+
+			out.Name = manifest.Name
+			out.Image = composeImage(composeSrc)
+			for _, cv := range manifest.Config {
+				out.Config = append(out.Config, controlcenter.ConfigField{
+					Name:        cv.Name,
+					Description: cv.Description,
+					Default:     cv.Default,
+					Required:    cv.Required,
+				})
+			}
+			return out, nil
+		},
+		Install: func(source string, overrides map[string]string) (string, error) {
+			src, err := catalog.ParseSource(source)
+			if err != nil {
+				return "", err
+			}
+
+			var manifest *catalog.ServiceManifest
+			var composeSrc string
+			if src.Kind == catalog.KindCatalog {
+				manifest, err = catalog.LoadServiceManifest(src.Name)
+				if err != nil {
+					return "", err
+				}
+				composeSrc, _ = catalog.GetComposeFile(src.Name)
+			} else {
+				manifest, composeSrc, err = catalog.ResolveSource(src)
+				if err != nil {
+					return "", err
+				}
+			}
+
+			_, configDir, err := findOrCreateManifest()
+			if err != nil {
+				return "", err
+			}
+			servicesDir := filepath.Join(configDir, "services")
+
+			// interactive=false: the TUI supplies all required config as
+			// overrides, so a missing required var is an error, never a stdin read.
+			result, err := catalog.InstallFromManifest(manifest, composeSrc, servicesDir, overrides, false)
+			if err != nil {
+				return "", err
+			}
+			if err := addServiceToManifest(configDir, result.Name); err != nil {
+				return "", fmt.Errorf("failed to update manifest: %w", err)
+			}
+			return result.Name, nil
+		},
+	}
+}

--- a/cmd/module_trust.go
+++ b/cmd/module_trust.go
@@ -1,0 +1,101 @@
+// cmd/module_trust.go
+//
+// `citadel module trust` manages the local trusted-source allowlist used by the
+// module-install flow. Installing a module = `docker compose up` of arbitrary
+// compose = root-equivalent (Docker-level) access to the node, so an untrusted
+// source triggers a prominent warning at install time. Trusting a source
+// suppresses that warning (it does NOT relax the privileged-compose gate, which
+// always requires --allow-privileged for Critical findings).
+//
+// Patterns:
+//   - exact "owner/repo"     trusts that GitHub shorthand
+//   - "owner/*"              trusts any repo under that owner
+//   - a bare host "github.com" / "git.example.com" trusts any source on that host
+//
+// Catalog sources (first-party) are always trusted (Tier 0) and are not listed.
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/aceteam-ai/citadel-cli/internal/catalog"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+var moduleTrustList bool
+
+var moduleTrustCmd = &cobra.Command{
+	Use:   "trust [pattern]",
+	Short: "Trust a module source (owner/repo, owner/*, or a host), or list trusted sources with --list",
+	Args:  cobra.MaximumNArgs(1),
+	RunE:  runModuleTrust,
+}
+
+var moduleUntrustCmd = &cobra.Command{
+	Use:   "untrust <pattern>",
+	Short: "Remove a pattern from the trusted-source allowlist",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runModuleUntrust,
+}
+
+var moduleTrustedCmd = &cobra.Command{
+	Use:   "trusted",
+	Short: "List the trusted module-source patterns",
+	Args:  cobra.NoArgs,
+	RunE:  runModuleTrustedList,
+}
+
+func init() {
+	moduleCmd.AddCommand(moduleTrustCmd)
+	moduleCmd.AddCommand(moduleUntrustCmd)
+	moduleCmd.AddCommand(moduleTrustedCmd)
+
+	moduleTrustCmd.Flags().BoolVar(&moduleTrustList, "list", false, "List the trusted-source patterns instead of adding one.")
+}
+
+// runModuleTrust adds a pattern to the allowlist, or lists patterns with --list.
+func runModuleTrust(cmd *cobra.Command, args []string) error {
+	if moduleTrustList || len(args) == 0 {
+		return runModuleTrustedList(cmd, nil)
+	}
+	pattern := args[0]
+	if err := catalog.AddTrustedSource(pattern); err != nil {
+		return fmt.Errorf("failed to trust '%s': %w", pattern, err)
+	}
+	fmt.Printf("Trusted module source: %s\n", color.CyanString(pattern))
+	fmt.Printf("  (stored in %s)\n", catalog.TrustedSourcesPath())
+	return nil
+}
+
+// runModuleUntrust removes a pattern from the allowlist.
+func runModuleUntrust(cmd *cobra.Command, args []string) error {
+	pattern := args[0]
+	if err := catalog.RemoveTrustedSource(pattern); err != nil {
+		return fmt.Errorf("failed to untrust '%s': %w", pattern, err)
+	}
+	fmt.Printf("Removed trusted module source: %s\n", pattern)
+	return nil
+}
+
+// runModuleTrustedList prints the trusted-source patterns.
+func runModuleTrustedList(cmd *cobra.Command, args []string) error {
+	ts, err := catalog.LoadTrustedSources()
+	if err != nil {
+		return err
+	}
+	if len(ts.Patterns) == 0 {
+		fmt.Println("No trusted module sources. Catalog sources are always trusted (Tier 0).")
+		fmt.Println("Add one with: citadel module trust <owner/repo | owner/* | host>")
+		return nil
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	defer w.Flush()
+	color.New(color.Bold).Fprintf(w, "TRUSTED PATTERN\n")
+	for _, p := range ts.Patterns {
+		fmt.Fprintf(w, "%s\n", p)
+	}
+	return nil
+}

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -40,20 +40,35 @@ type RegistryEntry struct {
 
 // ServiceManifest is the full definition of a service (service.yaml inside a service dir).
 type ServiceManifest struct {
-	Name        string        `yaml:"name"`
-	Version     string        `yaml:"version"`
-	Description string        `yaml:"description"`
-	Category    string        `yaml:"category"`
-	Author      string        `yaml:"author"`
-	License     string        `yaml:"license"`
-	Homepage    string        `yaml:"homepage"`
-	Requires    Requirements  `yaml:"requires"`
-	Ports       []PortMapping `yaml:"ports"`
-	Config      []ConfigVar   `yaml:"config"`
-	HealthCheck HealthCheck   `yaml:"health_check"`
-	Volumes     []VolumeMount `yaml:"volumes"`
-	Tags        []string      `yaml:"tags"`
+	// SchemaVersion is the manifest schema major version. A zero/absent value
+	// means schema v1. A value newer than CurrentSchemaVersion triggers a
+	// forward-compat warning (but never a hard failure).
+	SchemaVersion int           `yaml:"schema_version"`
+	Name          string        `yaml:"name"`
+	Version       string        `yaml:"version"`
+	Description   string        `yaml:"description"`
+	Category      string        `yaml:"category"`
+	Author        string        `yaml:"author"`
+	License       string        `yaml:"license"`
+	Homepage      string        `yaml:"homepage"`
+	Requires      Requirements  `yaml:"requires"`
+	Ports         []PortMapping `yaml:"ports"`
+	Config        []ConfigVar   `yaml:"config"`
+	HealthCheck   HealthCheck   `yaml:"health_check"`
+	Volumes       []VolumeMount `yaml:"volumes"`
+	// Tags are display/search tags (free-form), used by `catalog list/search`.
+	Tags []string `yaml:"tags"`
+	// NodeTags are namespaced key:value routing tags (e.g. "engine:tei",
+	// "task:embedding", "model:gte-multilingual-base") that are merged into the
+	// node manifest's Node.Tags on install so third-party engines become
+	// routable without a CLI change. Distinct from the display Tags above.
+	NodeTags []string `yaml:"node_tags"`
 }
+
+// CurrentSchemaVersion is the highest service.yaml schema major version this CLI
+// understands. A manifest declaring a higher value is still loaded (best-effort)
+// but the operator is warned it may use fields this CLI ignores.
+const CurrentSchemaVersion = 1
 
 // Requirements describes what a service needs from the host.
 type Requirements struct {

--- a/internal/catalog/install.go
+++ b/internal/catalog/install.go
@@ -58,7 +58,11 @@ func Install(name string, servicesDir string, configOverrides map[string]string)
 	// ErrNotInstallable.
 	composeSrc, _ := GetComposeFile(name)
 
-	return InstallFromManifest(manifest, composeSrc, servicesDir, configOverrides, true)
+	// Catalog services are first-party (Tier 0) and have no --allow-privileged
+	// flag, so the privilege gate must not apply to them (it would be an
+	// un-overridable failure). Pass allowPrivileged=true. The module-source path
+	// passes the real flag value.
+	return InstallFromManifest(manifest, composeSrc, servicesDir, configOverrides, true, true)
 }
 
 // InstallFromManifest installs a service from an already-loaded manifest and a
@@ -70,9 +74,16 @@ func Install(name string, servicesDir string, configOverrides map[string]string)
 // no override and no default are prompted on os.Stdin; when false (the TUI
 // path), such a var is a returned error and stdin is never read.
 //
+// allowPrivileged is the un-bypassable privilege gate: if the resolved compose
+// contains any Critical risk (privileged mode, docker-socket mount, cap_add
+// ALL/SYS_ADMIN) and allowPrivileged is false, the install is REFUSED regardless
+// of interactive/--yes. This guard lives in the shared core so both the CLI and
+// the TUI non-interactive path are protected identically. Catalog (Tier-0)
+// installs pass allowPrivileged=true (they have no override flag).
+//
 // An empty composeSrcPath means the service is host-provisioned (no container)
 // and InstallFromManifest returns ErrNotInstallable.
-func InstallFromManifest(manifest *ServiceManifest, composeSrcPath, servicesDir string, configOverrides map[string]string, interactive bool) (*InstallResult, error) {
+func InstallFromManifest(manifest *ServiceManifest, composeSrcPath, servicesDir string, configOverrides map[string]string, interactive, allowPrivileged bool) (*InstallResult, error) {
 	name := manifest.Name
 
 	// 1. Reject host-provisioned services up front (no compose.yml).
@@ -112,16 +123,32 @@ func InstallFromManifest(manifest *ServiceManifest, composeSrcPath, servicesDir 
 		return nil, fmt.Errorf("port conflict: port(s) %v already in use", conflicts)
 	}
 
-	// 4b. Check container-name collision. A reinstall of the same module is
-	// already blocked upstream (by the manifest's hasService check), so any
-	// existing container matching this compose's container_name is a foreign
-	// collision -- refuse with a clear escape hatch. Best-effort (skipped if
-	// docker is unavailable).
+	// 4b/4c. Read the resolved compose once for the container-name collision
+	// check and the privilege gate.
 	if data, rerr := os.ReadFile(composeSrcPath); rerr == nil {
-		if cn := parseComposeContainerName(string(data)); cn != "" && ContainerNameConflict(cn) {
+		composeText := string(data)
+
+		// 4b. Container-name collision. A reinstall of the same module is already
+		// blocked upstream (by the manifest's hasService check), so any existing
+		// container matching this compose's container_name is a foreign collision
+		// -- refuse with a clear escape hatch. Best-effort (skipped if docker is
+		// unavailable).
+		if cn := parseComposeContainerName(composeText); cn != "" && ContainerNameConflict(cn) {
 			return nil, fmt.Errorf("container name '%s' is already in use by another container; "+
 				"remove it (docker rm -f %s) or override the name via the module's compose before installing '%s'",
 				cn, cn, name)
+		}
+
+		// 4c. Privilege gate (un-bypassable). Any Critical compose risk requires
+		// an explicit opt-in; without it, refuse -- even under --yes. This is the
+		// shared-core guard that protects the TUI non-interactive path too.
+		if !allowPrivileged {
+			if crit := criticalRisks(ScanComposeRisks(composeText)); len(crit) > 0 {
+				return nil, fmt.Errorf("refusing to install '%s': its compose contains privileged/root-equivalent "+
+					"directives (%s).\n   This grants the module Docker-level (host root) access on this node. "+
+					"If you trust this source, re-run with --allow-privileged to override.",
+					name, strings.Join(criticalDirectives(crit), ", "))
+			}
 		}
 	}
 

--- a/internal/catalog/install.go
+++ b/internal/catalog/install.go
@@ -112,6 +112,19 @@ func InstallFromManifest(manifest *ServiceManifest, composeSrcPath, servicesDir 
 		return nil, fmt.Errorf("port conflict: port(s) %v already in use", conflicts)
 	}
 
+	// 4b. Check container-name collision. A reinstall of the same module is
+	// already blocked upstream (by the manifest's hasService check), so any
+	// existing container matching this compose's container_name is a foreign
+	// collision -- refuse with a clear escape hatch. Best-effort (skipped if
+	// docker is unavailable).
+	if data, rerr := os.ReadFile(composeSrcPath); rerr == nil {
+		if cn := parseComposeContainerName(string(data)); cn != "" && ContainerNameConflict(cn) {
+			return nil, fmt.Errorf("container name '%s' is already in use by another container; "+
+				"remove it (docker rm -f %s) or override the name via the module's compose before installing '%s'",
+				cn, cn, name)
+		}
+	}
+
 	// 5. Resolve config values (prompt for required ones without defaults only
 	//    when interactive).
 	configValues, err := resolveConfig(manifest.Config, configOverrides, interactive)

--- a/internal/catalog/install.go
+++ b/internal/catalog/install.go
@@ -124,8 +124,18 @@ func InstallFromManifest(manifest *ServiceManifest, composeSrcPath, servicesDir 
 	}
 
 	// 4b/4c. Read the resolved compose once for the container-name collision
-	// check and the privilege gate.
-	if data, rerr := os.ReadFile(composeSrcPath); rerr == nil {
+	// check and the privilege gate. A read failure here is fatal when a gate
+	// could apply: a security gate must not fail open. (The compose is copied
+	// from this same path moments later, so a real read failure would fail the
+	// install anyway -- we just refuse earlier and explicitly.)
+	{
+		data, rerr := os.ReadFile(composeSrcPath)
+		if rerr != nil {
+			if !allowPrivileged {
+				return nil, fmt.Errorf("cannot read compose for '%s' to run the safety scan: %w", name, rerr)
+			}
+			return nil, fmt.Errorf("failed to read compose file for '%s': %w", name, rerr)
+		}
 		composeText := string(data)
 
 		// 4b. Container-name collision. A reinstall of the same module is already

--- a/internal/catalog/install.go
+++ b/internal/catalog/install.go
@@ -46,16 +46,37 @@ type InstallResult struct {
 // (e.g. ~/citadel-node/services). configOverrides are key=value pairs that
 // override config defaults.
 func Install(name string, servicesDir string, configOverrides map[string]string) (*InstallResult, error) {
-	// 1. Load service manifest from catalog.
+	// Load service manifest from catalog.
 	manifest, err := LoadServiceManifest(name)
 	if err != nil {
 		return nil, err
 	}
 
-	// 1b. Reject host-provisioned services up front. A service with no
-	// compose.yml (e.g. the Windows-only "wechat" microservice) is catalogued
-	// for discoverability only and cannot be installed/run as a container.
-	if _, err := GetComposeFile(name); err != nil {
+	// Resolve the compose source. A service with no compose.yml (e.g. the
+	// Windows-only "wechat" microservice) is host-provisioned and not
+	// installable; pass an empty composeSrcPath so InstallFromManifest returns
+	// ErrNotInstallable.
+	composeSrc, _ := GetComposeFile(name)
+
+	return InstallFromManifest(manifest, composeSrc, servicesDir, configOverrides, true)
+}
+
+// InstallFromManifest installs a service from an already-loaded manifest and a
+// compose source path. It is the shared core behind both the catalog install
+// (Install) and external "module source" installs. It checks arch/GPU/port
+// requirements, resolves config, copies the compose file, and writes an .env.
+//
+// interactive controls config resolution: when true, required config vars with
+// no override and no default are prompted on os.Stdin; when false (the TUI
+// path), such a var is a returned error and stdin is never read.
+//
+// An empty composeSrcPath means the service is host-provisioned (no container)
+// and InstallFromManifest returns ErrNotInstallable.
+func InstallFromManifest(manifest *ServiceManifest, composeSrcPath, servicesDir string, configOverrides map[string]string, interactive bool) (*InstallResult, error) {
+	name := manifest.Name
+
+	// 1. Reject host-provisioned services up front (no compose.yml).
+	if composeSrcPath == "" {
 		return nil, ErrNotInstallable
 	}
 
@@ -91,24 +112,20 @@ func Install(name string, servicesDir string, configOverrides map[string]string)
 		return nil, fmt.Errorf("port conflict: port(s) %v already in use", conflicts)
 	}
 
-	// 5. Resolve config values (prompt for required ones without defaults).
-	configValues, err := resolveConfig(manifest.Config, configOverrides)
+	// 5. Resolve config values (prompt for required ones without defaults only
+	//    when interactive).
+	configValues, err := resolveConfig(manifest.Config, configOverrides, interactive)
 	if err != nil {
 		return nil, err
 	}
 
 	// 6. Copy compose.yml to services directory.
-	composeSrc, err := GetComposeFile(name)
-	if err != nil {
-		return nil, err
-	}
-
 	if err := os.MkdirAll(servicesDir, 0755); err != nil {
 		return nil, fmt.Errorf("failed to create services directory: %w", err)
 	}
 
 	composeDest := filepath.Join(servicesDir, name+".yml")
-	if err := copyFile(composeSrc, composeDest); err != nil {
+	if err := copyFile(composeSrcPath, composeDest); err != nil {
 		return nil, fmt.Errorf("failed to copy compose file: %w", err)
 	}
 
@@ -129,9 +146,11 @@ func Install(name string, servicesDir string, configOverrides map[string]string)
 	return result, nil
 }
 
-// resolveConfig merges overrides with defaults, prompting the user for any
-// required config vars that have no default and no override.
-func resolveConfig(configVars []ConfigVar, overrides map[string]string) (map[string]string, error) {
+// resolveConfig merges overrides with defaults. When interactive is true it
+// prompts the user (os.Stdin) for any required config vars that have no default
+// and no override. When interactive is false, such a var is a returned error and
+// stdin is never read (the TUI path collects all config up front as overrides).
+func resolveConfig(configVars []ConfigVar, overrides map[string]string, interactive bool) (map[string]string, error) {
 	values := make(map[string]string)
 
 	for _, cv := range configVars {
@@ -147,8 +166,15 @@ func resolveConfig(configVars []ConfigVar, overrides map[string]string) (map[str
 			continue
 		}
 
-		// Required without default -- prompt the user.
+		// Required without default.
 		if cv.Required {
+			// Non-interactive (TUI) path: never read stdin. The caller must
+			// supply every required value as an override.
+			if !interactive {
+				return nil, fmt.Errorf("required config '%s' has no value (provide it via --set %s=...)", cv.Name, cv.Name)
+			}
+
+			// Interactive: prompt the user.
 			fmt.Printf("  %s", cv.Name)
 			if cv.Description != "" {
 				fmt.Printf(" (%s)", cv.Description)

--- a/internal/catalog/lockfile.go
+++ b/internal/catalog/lockfile.go
@@ -1,0 +1,187 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
+	"gopkg.in/yaml.v3"
+)
+
+// LockEntry records the provenance of one installed module: where it came from,
+// the resolved git commit, and the image reference(s) (with best-effort digest)
+// it deploys. This makes nodes reproducible and tamper-evident.
+type LockEntry struct {
+	Name   string      `yaml:"name"`
+	Source string      `yaml:"source"`           // normalized source string
+	Ref    string      `yaml:"ref,omitempty"`    // requested ref (tag/branch/sha), if any
+	Commit string      `yaml:"commit,omitempty"` // resolved git HEAD commit
+	Images []LockImage `yaml:"images,omitempty"`
+}
+
+// LockImage is a single image reference plus an optional resolved digest.
+type LockImage struct {
+	Ref    string `yaml:"ref"`
+	Digest string `yaml:"digest,omitempty"` // sha256:... if resolvable, else ""
+}
+
+// Lockfile is the top-level modules.lock structure.
+type Lockfile struct {
+	Version int         `yaml:"version"`
+	Modules []LockEntry `yaml:"modules"`
+}
+
+// LockfilePath returns the path to the modules lockfile.
+func LockfilePath() string {
+	return filepath.Join(platform.ConfigDir(), "modules.lock")
+}
+
+// LoadLockfile reads the modules lockfile, returning an empty (version 1)
+// lockfile if it does not yet exist.
+func LoadLockfile() (*Lockfile, error) {
+	path := LockfilePath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &Lockfile{Version: 1}, nil
+		}
+		return nil, fmt.Errorf("failed to read lockfile %s: %w", path, err)
+	}
+	var lf Lockfile
+	if err := yaml.Unmarshal(data, &lf); err != nil {
+		return nil, fmt.Errorf("failed to parse lockfile %s: %w", path, err)
+	}
+	if lf.Version == 0 {
+		lf.Version = 1
+	}
+	return &lf, nil
+}
+
+// LookupLock returns the lock entry for a module name, or (zero, false).
+func (lf *Lockfile) LookupLock(name string) (LockEntry, bool) {
+	for _, e := range lf.Modules {
+		if e.Name == name {
+			return e, true
+		}
+	}
+	return LockEntry{}, false
+}
+
+// UpsertLockEntry records (or replaces) a module's provenance in the lockfile and
+// writes it back. It is a read-modify-write upsert keyed by name; other entries
+// are preserved. Best-effort: a write failure is returned but callers should not
+// fail the install over it.
+func UpsertLockEntry(entry LockEntry) error {
+	lf, err := LoadLockfile()
+	if err != nil {
+		return err
+	}
+	replaced := false
+	for i := range lf.Modules {
+		if lf.Modules[i].Name == entry.Name {
+			lf.Modules[i] = entry
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		lf.Modules = append(lf.Modules, entry)
+	}
+
+	path := LockfilePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("failed to create lockfile directory: %w", err)
+	}
+	data, err := yaml.Marshal(lf)
+	if err != nil {
+		return fmt.Errorf("failed to marshal lockfile: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("failed to write lockfile %s: %w", path, err)
+	}
+	return nil
+}
+
+// BuildLockImages turns image references into LockImage entries, attempting a
+// best-effort digest lookup via `docker`. Any digest failure (no docker, no
+// auth, image not pulled, timeout) just omits the digest -- never an error.
+func BuildLockImages(imageRefs []string) []LockImage {
+	out := make([]LockImage, 0, len(imageRefs))
+	for _, ref := range imageRefs {
+		out = append(out, LockImage{Ref: ref, Digest: resolveImageDigest(ref)})
+	}
+	return out
+}
+
+// resolveImageDigest tries to resolve a sha256 digest for an image reference via
+// docker. It is best-effort and time-bounded: on any failure it returns "".
+func resolveImageDigest(ref string) string {
+	if _, err := exec.LookPath("docker"); err != nil {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	// Prefer a local inspect (works once the image is pulled, no registry auth).
+	local := exec.CommandContext(ctx, "docker", "image", "inspect", ref,
+		"--format", "{{index .RepoDigests 0}}")
+	if out, err := local.Output(); err == nil {
+		if d := digestFromRepoDigest(strings.TrimSpace(string(out))); d != "" {
+			return d
+		}
+	}
+
+	// Fall back to a registry manifest inspect (needs the image to be reachable;
+	// may need auth for private registries -- omitted on failure).
+	remote := exec.CommandContext(ctx, "docker", "manifest", "inspect", ref,
+		"--format", "{{.Descriptor.Digest}}")
+	if out, err := remote.Output(); err == nil {
+		d := strings.TrimSpace(string(out))
+		if strings.HasPrefix(d, "sha256:") {
+			return d
+		}
+	}
+	return ""
+}
+
+// digestFromRepoDigest extracts the "sha256:..." part from a "repo@sha256:..."
+// RepoDigests entry, or "" if absent.
+func digestFromRepoDigest(repoDigest string) string {
+	if i := strings.Index(repoDigest, "@"); i >= 0 {
+		d := repoDigest[i+1:]
+		if strings.HasPrefix(d, "sha256:") {
+			return d
+		}
+	}
+	return ""
+}
+
+// ContainerNameConflict reports whether a container with the given name already
+// exists on this host (running or stopped). Best-effort: returns false if docker
+// is unavailable or the query fails, so it never blocks an install spuriously.
+// An empty name always returns false.
+func ContainerNameConflict(name string) bool {
+	if name == "" {
+		return false
+	}
+	if _, err := exec.LookPath("docker"); err != nil {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "docker", "ps", "-a", "--format", "{{.Names}}").Output()
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.TrimSpace(line) == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/catalog/risk.go
+++ b/internal/catalog/risk.go
@@ -1,0 +1,256 @@
+package catalog
+
+import "strings"
+
+// Severity ranks a compose risk finding.
+type Severity string
+
+const (
+	// SeverityCritical marks a directive that grants host-root-equivalent access
+	// (container escape). A Critical finding gates the install behind an explicit
+	// opt-in (--allow-privileged) that --yes does NOT bypass.
+	SeverityCritical Severity = "Critical"
+	// SeverityHigh marks a directive that significantly widens the container's
+	// access to the host (host namespaces, sensitive bind mounts, device
+	// passthrough). High findings are surfaced but do not hard-gate the install.
+	SeverityHigh Severity = "High"
+)
+
+// ComposeRisk is a single dangerous directive found in a resolved compose file.
+type ComposeRisk struct {
+	Severity  Severity
+	Directive string // the directive name, e.g. "privileged"
+	Detail    string // human-readable explanation / matched value
+}
+
+// sensitiveHostPaths are host paths whose bind-mount into a container is treated
+// as High risk (read/write access to host secrets, sockets, or the whole FS).
+var sensitiveHostPaths = []string{"/etc", "/root", "/var/run", "/home", "/usr", "/boot", "/sys", "/proc"}
+
+// ScanComposeRisks scans resolved compose text for dangerous directives and
+// returns the findings. It is pure and line/substring based (like
+// parseComposeImages) -- intentionally conservative: false positives are
+// acceptable, silent misses are not. A nil/empty result means no risks found.
+func ScanComposeRisks(compose string) []ComposeRisk {
+	var risks []ComposeRisk
+	inCapAdd := false // whether we are inside a cap_add: block
+
+	for _, raw := range strings.Split(compose, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		lower := strings.ToLower(line)
+
+		// --- Critical: privileged mode ---
+		if isPrivilegedTrue(lower) {
+			risks = append(risks, ComposeRisk{
+				Severity:  SeverityCritical,
+				Directive: "privileged: true",
+				Detail:    "runs the container in privileged mode (full host device + capability access; container escape to host root)",
+			})
+		}
+
+		// --- Critical: docker socket bind mount ---
+		if strings.Contains(line, "/var/run/docker.sock") || strings.Contains(line, "/run/docker.sock") {
+			risks = append(risks, ComposeRisk{
+				Severity:  SeverityCritical,
+				Directive: "docker.sock mount",
+				Detail:    "mounts the Docker socket (control of the Docker daemon = root on the host)",
+			})
+		}
+
+		// --- cap_add tracking (Critical for ALL / SYS_ADMIN) ---
+		// Track whether we are inside a cap_add: block so a bare "- ALL" item is
+		// only flagged in that context (avoids matching unrelated "ALL" text).
+		if strings.HasPrefix(lower, "cap_add:") {
+			inCapAdd = true
+			// Inline form: "cap_add: [ALL]" or "cap_add: [SYS_ADMIN]".
+			if cap := capFromInline(line); cap != "" {
+				if r, ok := capRisk(cap); ok {
+					risks = append(risks, r)
+				}
+			}
+			continue
+		}
+		if inCapAdd {
+			if item, ok := listItem(line); ok {
+				if r, ok := capRisk(item); ok {
+					risks = append(risks, r)
+				}
+				continue
+			}
+			// A non-list line ends the cap_add block.
+			inCapAdd = false
+		}
+
+		// --- High: host namespaces ---
+		if r, ok := hostNamespaceRisk(lower); ok {
+			risks = append(risks, r)
+		}
+
+		// --- High: device passthrough (the devices: key) ---
+		// Module compose rarely needs host devices, and passthrough widens host
+		// access, so we flag the devices: directive whenever it appears.
+		if strings.HasPrefix(lower, "devices:") {
+			risks = append(risks, ComposeRisk{
+				Severity:  SeverityHigh,
+				Directive: "devices",
+				Detail:    "passes host devices into the container",
+			})
+		}
+
+		// --- High: sensitive host bind mount (a volumes list item) ---
+		if r, ok := bindMountRisk(line); ok {
+			risks = append(risks, r)
+		}
+	}
+
+	return risks
+}
+
+// isPrivilegedTrue reports whether a line sets privileged: true.
+func isPrivilegedTrue(lower string) bool {
+	if !strings.HasPrefix(lower, "privileged:") {
+		return false
+	}
+	val := strings.TrimSpace(strings.TrimPrefix(lower, "privileged:"))
+	return val == "true" || val == "yes"
+}
+
+// capFromInline extracts a capability from an inline "cap_add: [SYS_ADMIN]" form.
+func capFromInline(line string) string {
+	idx := strings.Index(line, "[")
+	if idx < 0 {
+		return ""
+	}
+	inner := line[idx+1:]
+	inner = strings.TrimSuffix(strings.TrimSpace(inner), "]")
+	inner = strings.Trim(inner, "[] ")
+	// Take the first element if comma-separated.
+	if c := strings.SplitN(inner, ",", 2); len(c) > 0 {
+		return strings.Trim(strings.TrimSpace(c[0]), `"'`)
+	}
+	return ""
+}
+
+// listItem returns the value of a YAML list item line ("- VALUE"), if it is one.
+func listItem(line string) (string, bool) {
+	if !strings.HasPrefix(line, "-") {
+		return "", false
+	}
+	val := strings.TrimSpace(strings.TrimPrefix(line, "-"))
+	val = strings.Trim(val, `"'`)
+	if val == "" {
+		return "", false
+	}
+	return val, true
+}
+
+// capRisk returns a Critical risk if cap is a dangerous Linux capability.
+func capRisk(cap string) (ComposeRisk, bool) {
+	upper := strings.ToUpper(strings.TrimSpace(cap))
+	switch upper {
+	case "ALL":
+		return ComposeRisk{
+			Severity:  SeverityCritical,
+			Directive: "cap_add: ALL",
+			Detail:    "grants ALL Linux capabilities (effectively privileged; container escape)",
+		}, true
+	case "SYS_ADMIN":
+		return ComposeRisk{
+			Severity:  SeverityCritical,
+			Directive: "cap_add: SYS_ADMIN",
+			Detail:    "grants CAP_SYS_ADMIN (mount, namespace, and many escape primitives)",
+		}, true
+	}
+	return ComposeRisk{}, false
+}
+
+// hostNamespaceRisk flags host network/pid/ipc namespace sharing.
+func hostNamespaceRisk(lower string) (ComposeRisk, bool) {
+	switch {
+	case strings.HasPrefix(lower, "network_mode:") && strings.Contains(lower, "host"):
+		return ComposeRisk{SeverityHigh, "network_mode: host", "shares the host network namespace (binds host ports, sees host traffic)"}, true
+	case strings.HasPrefix(lower, "pid:") && strings.Contains(lower, "host"):
+		return ComposeRisk{SeverityHigh, "pid: host", "shares the host PID namespace (sees and can signal host processes)"}, true
+	case strings.HasPrefix(lower, "ipc:") && strings.Contains(lower, "host"):
+		return ComposeRisk{SeverityHigh, "ipc: host", "shares the host IPC namespace"}, true
+	}
+	return ComposeRisk{}, false
+}
+
+// bindMountRisk flags a volumes list item that bind-mounts a sensitive host path.
+// It ignores named volumes (left side is not a path). Returns the finding and
+// true if risky.
+func bindMountRisk(line string) (ComposeRisk, bool) {
+	item, ok := listItem(line)
+	if !ok {
+		return ComposeRisk{}, false
+	}
+	// A bind mount is "HOST:CONTAINER[:opts]"; named volumes are "name:CONTAINER".
+	parts := strings.SplitN(item, ":", 2)
+	if len(parts) < 2 {
+		return ComposeRisk{}, false
+	}
+	host := strings.TrimSpace(parts[0])
+
+	// Only a path-like left side is a host bind mount.
+	if !looksLikeHostPath(host) {
+		return ComposeRisk{}, false
+	}
+
+	if isSensitiveHostPath(host) {
+		return ComposeRisk{
+			Severity:  SeverityHigh,
+			Directive: "volumes (host bind mount)",
+			Detail:    "bind-mounts a sensitive host path: " + host,
+		}, true
+	}
+	return ComposeRisk{}, false
+}
+
+// looksLikeHostPath reports whether s is a filesystem path (vs a named volume).
+func looksLikeHostPath(s string) bool {
+	return strings.HasPrefix(s, "/") || strings.HasPrefix(s, "~") || strings.HasPrefix(s, ".")
+}
+
+// isSensitiveHostPath reports whether host is the root, a home shortcut, or a
+// sensitive system path (boundary-aware: "/etc" matches "/etc" and "/etc/x" but
+// not "/etcetera").
+func isSensitiveHostPath(host string) bool {
+	if host == "/" {
+		return true
+	}
+	if host == "~" || strings.HasPrefix(host, "~/") {
+		return true
+	}
+	for _, p := range sensitiveHostPaths {
+		if host == p || strings.HasPrefix(host, p+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// criticalRisks returns the subset of risks at Critical severity. Pure, so the
+// install gate decision is table-testable.
+func criticalRisks(risks []ComposeRisk) []ComposeRisk {
+	var out []ComposeRisk
+	for _, r := range risks {
+		if r.Severity == SeverityCritical {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// criticalDirectives returns the directive names of the Critical findings, for
+// the refusal message.
+func criticalDirectives(risks []ComposeRisk) []string {
+	var out []string
+	for _, r := range criticalRisks(risks) {
+		out = append(out, r.Directive)
+	}
+	return out
+}

--- a/internal/catalog/risk_test.go
+++ b/internal/catalog/risk_test.go
@@ -1,6 +1,10 @@
 package catalog
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 // hasRisk reports whether risks contains a finding with the given severity whose
 // directive contains the substring.
@@ -171,5 +175,45 @@ func TestCriticalRisks(t *testing.T) {
 	dirs := criticalDirectives(risks)
 	if len(dirs) != 2 || dirs[0] != "privileged: true" {
 		t.Errorf("unexpected critical directives: %v", dirs)
+	}
+}
+
+func TestInstallFromManifest_PrivilegedGate(t *testing.T) {
+	dir := t.TempDir()
+	composePath := filepath.Join(dir, "compose.yml")
+	// A compose with a Critical risk (privileged: true), no ports/container_name.
+	if err := os.WriteFile(composePath, []byte("services:\n  app:\n    image: ghcr.io/x/y:latest\n    privileged: true\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	manifest := &ServiceManifest{Name: "risky"}
+	servicesDir := filepath.Join(dir, "services")
+
+	// allowPrivileged=false must REFUSE even though interactive=false.
+	if _, err := InstallFromManifest(manifest, composePath, servicesDir, nil, false, false); err == nil {
+		t.Fatal("expected refusal for Critical compose without allowPrivileged")
+	}
+
+	// allowPrivileged=true proceeds past the gate (install succeeds: no ports,
+	// no required config, compose copied).
+	res, err := InstallFromManifest(manifest, composePath, servicesDir, nil, false, true)
+	if err != nil {
+		t.Fatalf("expected install to proceed with allowPrivileged=true, got %v", err)
+	}
+	if res == nil || res.Name != "risky" {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+}
+
+func TestInstallFromManifest_CleanComposeNoGate(t *testing.T) {
+	dir := t.TempDir()
+	composePath := filepath.Join(dir, "compose.yml")
+	if err := os.WriteFile(composePath, []byte("services:\n  app:\n    image: ghcr.io/x/y:latest\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	manifest := &ServiceManifest{Name: "clean"}
+	servicesDir := filepath.Join(dir, "services")
+	// A clean compose installs fine even with allowPrivileged=false.
+	if _, err := InstallFromManifest(manifest, composePath, servicesDir, nil, false, false); err != nil {
+		t.Fatalf("clean compose should not be gated, got %v", err)
 	}
 }

--- a/internal/catalog/risk_test.go
+++ b/internal/catalog/risk_test.go
@@ -1,0 +1,175 @@
+package catalog
+
+import "testing"
+
+// hasRisk reports whether risks contains a finding with the given severity whose
+// directive contains the substring.
+func hasRisk(risks []ComposeRisk, sev Severity, directiveSubstr string) bool {
+	for _, r := range risks {
+		if r.Severity == sev && contains(r.Directive, directiveSubstr) {
+			return true
+		}
+	}
+	return false
+}
+
+func contains(s, sub string) bool {
+	return len(sub) == 0 || (len(s) >= len(sub) && indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestScanComposeRisks_Privileged(t *testing.T) {
+	compose := `services:
+  app:
+    image: x
+    privileged: true
+`
+	risks := ScanComposeRisks(compose)
+	if !hasRisk(risks, SeverityCritical, "privileged") {
+		t.Fatalf("expected Critical privileged risk, got %+v", risks)
+	}
+}
+
+func TestScanComposeRisks_DockerSocket(t *testing.T) {
+	for _, sock := range []string{"/var/run/docker.sock:/var/run/docker.sock", "/run/docker.sock:/run/docker.sock:ro"} {
+		compose := "services:\n  app:\n    image: x\n    volumes:\n      - " + sock + "\n"
+		risks := ScanComposeRisks(compose)
+		if !hasRisk(risks, SeverityCritical, "docker.sock") {
+			t.Errorf("expected Critical docker.sock risk for %q, got %+v", sock, risks)
+		}
+	}
+}
+
+func TestScanComposeRisks_CapAddAll(t *testing.T) {
+	compose := `services:
+  app:
+    image: x
+    cap_add:
+      - ALL
+`
+	risks := ScanComposeRisks(compose)
+	if !hasRisk(risks, SeverityCritical, "cap_add: ALL") {
+		t.Fatalf("expected Critical cap_add ALL, got %+v", risks)
+	}
+}
+
+func TestScanComposeRisks_CapAddSysAdminInline(t *testing.T) {
+	compose := "services:\n  app:\n    image: x\n    cap_add: [SYS_ADMIN]\n"
+	risks := ScanComposeRisks(compose)
+	if !hasRisk(risks, SeverityCritical, "SYS_ADMIN") {
+		t.Fatalf("expected Critical cap_add SYS_ADMIN (inline), got %+v", risks)
+	}
+}
+
+func TestScanComposeRisks_CapAddBenign(t *testing.T) {
+	// A non-dangerous cap should not be flagged.
+	compose := `services:
+  app:
+    image: x
+    cap_add:
+      - NET_ADMIN
+`
+	risks := ScanComposeRisks(compose)
+	if len(criticalRisks(risks)) != 0 {
+		t.Errorf("NET_ADMIN should not be Critical, got %+v", risks)
+	}
+}
+
+func TestScanComposeRisks_HostNamespaces(t *testing.T) {
+	cases := map[string]string{
+		"network_mode": "    network_mode: host",
+		"pid":          "    pid: host",
+		"ipc":          "    ipc: host",
+	}
+	for name, line := range cases {
+		compose := "services:\n  app:\n    image: x\n" + line + "\n"
+		risks := ScanComposeRisks(compose)
+		if !hasRisk(risks, SeverityHigh, name) {
+			t.Errorf("expected High %s risk, got %+v", name, risks)
+		}
+	}
+}
+
+func TestScanComposeRisks_SensitiveBindMounts(t *testing.T) {
+	for _, host := range []string{"/", "/etc", "/etc/passwd", "/root", "/home", "/var/run", "~", "~/secrets"} {
+		compose := "services:\n  app:\n    image: x\n    volumes:\n      - " + host + ":/mnt\n"
+		risks := ScanComposeRisks(compose)
+		if !hasRisk(risks, SeverityHigh, "bind mount") {
+			t.Errorf("expected High bind-mount risk for host %q, got %+v", host, risks)
+		}
+	}
+}
+
+func TestScanComposeRisks_NamedVolumeNotFlagged(t *testing.T) {
+	// A named volume must NOT be flagged as a host bind mount.
+	compose := `services:
+  app:
+    image: x
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+`
+	risks := ScanComposeRisks(compose)
+	if hasRisk(risks, SeverityHigh, "bind mount") {
+		t.Errorf("named volume should not be a bind-mount risk, got %+v", risks)
+	}
+}
+
+func TestScanComposeRisks_BoundaryNotSubstring(t *testing.T) {
+	// "/etcetera" must not match "/etc".
+	compose := "services:\n  app:\n    image: x\n    volumes:\n      - /etcetera/data:/mnt\n"
+	risks := ScanComposeRisks(compose)
+	if hasRisk(risks, SeverityHigh, "bind mount") {
+		t.Errorf("/etcetera should not match /etc, got %+v", risks)
+	}
+}
+
+func TestScanComposeRisks_Devices(t *testing.T) {
+	compose := "services:\n  app:\n    image: x\n    devices:\n      - /dev/snd:/dev/snd\n"
+	risks := ScanComposeRisks(compose)
+	if !hasRisk(risks, SeverityHigh, "devices") {
+		t.Errorf("expected High devices risk, got %+v", risks)
+	}
+}
+
+func TestScanComposeRisks_Clean(t *testing.T) {
+	compose := `services:
+  app:
+    image: ghcr.io/acme/app:latest
+    ports:
+      - "8080:8080"
+    volumes:
+      - appdata:/data
+    environment:
+      - FOO=bar
+volumes:
+  appdata:
+`
+	risks := ScanComposeRisks(compose)
+	if len(risks) != 0 {
+		t.Errorf("expected no risks for a clean compose, got %+v", risks)
+	}
+}
+
+func TestCriticalRisks(t *testing.T) {
+	risks := []ComposeRisk{
+		{Severity: SeverityHigh, Directive: "devices"},
+		{Severity: SeverityCritical, Directive: "privileged: true"},
+		{Severity: SeverityCritical, Directive: "docker.sock mount"},
+	}
+	crit := criticalRisks(risks)
+	if len(crit) != 2 {
+		t.Fatalf("expected 2 critical, got %d", len(crit))
+	}
+	dirs := criticalDirectives(risks)
+	if len(dirs) != 2 || dirs[0] != "privileged: true" {
+		t.Errorf("unexpected critical directives: %v", dirs)
+	}
+}

--- a/internal/catalog/source.go
+++ b/internal/catalog/source.go
@@ -78,6 +78,9 @@ func ParseSource(s string) (Source, error) {
 		if url == "" {
 			return Source{}, fmt.Errorf("invalid git URL %q", raw)
 		}
+		if err := validateRef(ref); err != nil {
+			return Source{}, fmt.Errorf("invalid ref in %q: %w", raw, err)
+		}
 		return Source{Kind: KindGitURL, Raw: raw, CloneURL: url, Ref: ref}, nil
 	}
 	if isSCPForm(raw) {
@@ -94,6 +97,12 @@ func ParseSource(s string) (Source, error) {
 			return Source{}, fmt.Errorf("invalid owner/repo source %q (expected owner/repo[@ref])", raw)
 		}
 		owner, repo := parts[0], strings.TrimSuffix(parts[1], ".git")
+		if strings.HasPrefix(owner, "-") || strings.HasPrefix(repo, "-") {
+			return Source{}, fmt.Errorf("invalid owner/repo source %q: components cannot begin with '-'", raw)
+		}
+		if err := validateRef(ref); err != nil {
+			return Source{}, fmt.Errorf("invalid ref in %q: %w", raw, err)
+		}
 		return Source{
 			Kind:     KindGitHub,
 			Raw:      raw,
@@ -164,6 +173,27 @@ func splitAtRef(s string) (repoPart, ref string) {
 		}
 	}
 	return s, ""
+}
+
+// validateRef guards against git argument injection: a ref is passed as a
+// positional argument to `git clone --branch`/`git fetch origin <ref>`, so a
+// value beginning with '-' would be parsed by git as an option (e.g.
+// `--upload-pack=<cmd>` → arbitrary command execution). Real git refnames never
+// begin with '-', so reject that (and embedded whitespace/control characters).
+// An empty ref (default branch) is allowed.
+func validateRef(ref string) error {
+	if ref == "" {
+		return nil
+	}
+	if strings.HasPrefix(ref, "-") {
+		return fmt.Errorf("a git ref cannot begin with '-'")
+	}
+	for _, r := range ref {
+		if r == ' ' || r == '\t' || r == '\n' || r == '\r' || r < 0x20 {
+			return fmt.Errorf("a git ref cannot contain whitespace or control characters")
+		}
+	}
+	return nil
 }
 
 // sanitizeCacheName turns a Source into a filesystem-safe cache directory name,

--- a/internal/catalog/source.go
+++ b/internal/catalog/source.go
@@ -1,0 +1,330 @@
+package catalog
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
+	"gopkg.in/yaml.v3"
+)
+
+// SourceKind classifies how a module source string should be resolved.
+type SourceKind int
+
+const (
+	// KindCatalog is a plain service name resolved from the central catalog
+	// (no slash, no scheme). The caller delegates to the existing catalog path.
+	KindCatalog SourceKind = iota
+	// KindGitHub is an "owner/repo" (optionally "owner/repo@ref") shorthand that
+	// expands to https://github.com/owner/repo.git.
+	KindGitHub
+	// KindGitURL is a full git URL (https://…[.git][@ref|#ref] or scp-form
+	// git@host:owner/repo.git).
+	KindGitURL
+)
+
+// String renders a SourceKind for diagnostics.
+func (k SourceKind) String() string {
+	switch k {
+	case KindCatalog:
+		return "catalog"
+	case KindGitHub:
+		return "github"
+	case KindGitURL:
+		return "git-url"
+	default:
+		return "unknown"
+	}
+}
+
+// Source is a parsed module source: where to find the module and at which ref.
+type Source struct {
+	// Kind is the resolution strategy.
+	Kind SourceKind
+	// Raw is the original, unmodified source string.
+	Raw string
+	// Name is the catalog service name (KindCatalog only).
+	Name string
+	// Owner / Repo are populated for KindGitHub (the "owner/repo" shorthand).
+	Owner string
+	Repo  string
+	// CloneURL is the git clone URL for KindGitHub / KindGitURL.
+	CloneURL string
+	// Ref is an optional tag/branch/sha to check out (empty = default branch).
+	Ref string
+}
+
+// ParseSource classifies a module source string into a Source. The classification
+// order matters: scheme is checked first and a bare catalog name is the fallback.
+//
+//   - full git URL (https://…, http://…, ssh://…, or scp-form git@host:owner/repo.git)
+//     → KindGitURL. Only the URL forms (not the scp form) accept a trailing
+//     "@ref" or "#ref" suffix.
+//   - "owner/repo" or "owner/repo@ref" (contains a slash, no scheme)
+//     → KindGitHub, clone URL https://github.com/owner/repo.git.
+//   - anything else (no slash, no scheme) → KindCatalog.
+func ParseSource(s string) (Source, error) {
+	raw := strings.TrimSpace(s)
+	if raw == "" {
+		return Source{}, fmt.Errorf("empty module source")
+	}
+
+	// 1. Full git URLs (scheme-based or scp-form).
+	if hasGitScheme(raw) {
+		url, ref := splitURLRef(raw)
+		if url == "" {
+			return Source{}, fmt.Errorf("invalid git URL %q", raw)
+		}
+		return Source{Kind: KindGitURL, Raw: raw, CloneURL: url, Ref: ref}, nil
+	}
+	if isSCPForm(raw) {
+		// scp-form (git@host:owner/repo.git) contains '@' and ':' but no ref
+		// suffix support -- splitting on '@' here would corrupt the user part.
+		return Source{Kind: KindGitURL, Raw: raw, CloneURL: raw}, nil
+	}
+
+	// 2. "owner/repo" shorthand (contains a slash, no scheme).
+	if strings.Contains(raw, "/") {
+		repoPart, ref := splitAtRef(raw)
+		parts := strings.Split(repoPart, "/")
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return Source{}, fmt.Errorf("invalid owner/repo source %q (expected owner/repo[@ref])", raw)
+		}
+		owner, repo := parts[0], strings.TrimSuffix(parts[1], ".git")
+		return Source{
+			Kind:     KindGitHub,
+			Raw:      raw,
+			Owner:    owner,
+			Repo:     repo,
+			CloneURL: fmt.Sprintf("https://github.com/%s/%s.git", owner, repo),
+			Ref:      ref,
+		}, nil
+	}
+
+	// 3. Plain catalog name.
+	if strings.ContainsAny(raw, "@:") {
+		return Source{}, fmt.Errorf("invalid catalog name %q", raw)
+	}
+	return Source{Kind: KindCatalog, Raw: raw, Name: raw}, nil
+}
+
+// hasGitScheme reports whether s starts with a recognized URL scheme.
+func hasGitScheme(s string) bool {
+	for _, scheme := range []string{"https://", "http://", "ssh://", "git://"} {
+		if strings.HasPrefix(s, scheme) {
+			return true
+		}
+	}
+	return false
+}
+
+// isSCPForm reports whether s is an scp-style git remote (git@host:owner/repo.git
+// or user@host:path). It must contain '@' before a ':' and not be a scheme URL.
+func isSCPForm(s string) bool {
+	at := strings.Index(s, "@")
+	colon := strings.Index(s, ":")
+	return at > 0 && colon > at
+}
+
+// splitURLRef splits a scheme URL into its base URL and an optional ref. The ref
+// may be appended as "#ref" (preferred for URLs) or "@ref". For "@ref" we only
+// split on an '@' that appears after the host (i.e. after the "://"), so a
+// userinfo "@" in the authority is preserved.
+func splitURLRef(s string) (url, ref string) {
+	// "#ref" suffix.
+	if i := strings.LastIndex(s, "#"); i >= 0 {
+		return s[:i], s[i+1:]
+	}
+	// "@ref" suffix: only consider an '@' that comes after the scheme's "://".
+	schemeEnd := strings.Index(s, "://")
+	if schemeEnd >= 0 {
+		rest := s[schemeEnd+3:]
+		if at := strings.LastIndex(rest, "@"); at >= 0 {
+			// Treat as a ref only if it follows a path segment (contains '/'
+			// before the '@'); otherwise it is userinfo and must be kept.
+			if strings.Contains(rest[:at], "/") {
+				return s[:schemeEnd+3+at], rest[at+1:]
+			}
+		}
+	}
+	return s, ""
+}
+
+// splitAtRef splits an "owner/repo@ref" into the repo part and the ref, splitting
+// on the last '@'. The ref must not contain a '/' that would belong to the path.
+func splitAtRef(s string) (repoPart, ref string) {
+	if at := strings.LastIndex(s, "@"); at >= 0 {
+		candidateRef := s[at+1:]
+		// A ref never contains a slash; if it does, the '@' was not a ref marker.
+		if candidateRef != "" && !strings.Contains(candidateRef, "/") {
+			return s[:at], candidateRef
+		}
+	}
+	return s, ""
+}
+
+// sanitizeCacheName turns a Source into a filesystem-safe cache directory name,
+// e.g. "owner-repo@v1.2.0" for github sources or a slug derived from the URL.
+func sanitizeCacheName(src Source) string {
+	var base string
+	switch src.Kind {
+	case KindGitHub:
+		base = src.Owner + "-" + src.Repo
+	default:
+		// Derive a slug from the clone URL: strip scheme, trailing .git, and
+		// replace path separators.
+		slug := src.CloneURL
+		for _, scheme := range []string{"https://", "http://", "ssh://", "git://"} {
+			slug = strings.TrimPrefix(slug, scheme)
+		}
+		slug = strings.TrimSuffix(slug, ".git")
+		base = slug
+	}
+	if src.Ref != "" {
+		base = base + "@" + src.Ref
+	}
+	return sanitizePathSegment(base)
+}
+
+// sanitizePathSegment replaces characters that are unsafe in a path segment.
+func sanitizePathSegment(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-', r == '_', r == '.', r == '@':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	return b.String()
+}
+
+// ModulesCacheDir returns the parent cache directory for external module sources.
+func ModulesCacheDir() string {
+	return filepath.Join(platform.ConfigDir(), "modules")
+}
+
+// ResolveSource clones (or updates) the module repo for src into a per-source
+// cache directory and loads its ServiceManifest + compose file path. For a
+// KindCatalog source it returns an error: the caller is expected to delegate
+// catalog names to the existing catalog install path.
+func ResolveSource(src Source) (manifest *ServiceManifest, composePath string, err error) {
+	if src.Kind == KindCatalog {
+		return nil, "", fmt.Errorf("source %q is a catalog name; use the catalog path", src.Raw)
+	}
+
+	cacheDir := filepath.Join(ModulesCacheDir(), sanitizeCacheName(src))
+	if err := os.MkdirAll(filepath.Dir(cacheDir), 0755); err != nil {
+		return nil, "", fmt.Errorf("failed to create modules cache directory: %w", err)
+	}
+
+	if err := cloneOrUpdate(src, cacheDir); err != nil {
+		return nil, "", err
+	}
+
+	return loadModuleManifest(cacheDir)
+}
+
+// cloneOrUpdate performs a shallow clone of the source repo into dir, or updates
+// it if dir is already a git repo. Mirrors the style of catalog.Update().
+func cloneOrUpdate(src Source, dir string) error {
+	if isGitRepo(dir) {
+		// Existing checkout: fetch + reset to the requested ref (or fast-forward
+		// the current branch when no ref is pinned).
+		if src.Ref != "" {
+			fetch := exec.Command("git", "-C", dir, "fetch", "--depth", "1", "origin", src.Ref)
+			if out, err := fetch.CombinedOutput(); err != nil {
+				return cloneError(src, fmt.Sprintf("git fetch failed: %s", strings.TrimSpace(string(out))))
+			}
+			checkout := exec.Command("git", "-C", dir, "checkout", "FETCH_HEAD")
+			if out, err := checkout.CombinedOutput(); err != nil {
+				return cloneError(src, fmt.Sprintf("git checkout failed: %s", strings.TrimSpace(string(out))))
+			}
+			return nil
+		}
+		pull := exec.Command("git", "-C", dir, "pull", "--ff-only")
+		if out, err := pull.CombinedOutput(); err != nil {
+			return cloneError(src, fmt.Sprintf("git pull failed: %s", strings.TrimSpace(string(out))))
+		}
+		return nil
+	}
+
+	// Fresh clone. Remove any leftover non-git directory first.
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("failed to clean module cache directory: %w", err)
+	}
+
+	args := []string{"clone", "--depth", "1"}
+	if src.Ref != "" {
+		// --branch accepts tags and branches (but not raw SHAs).
+		args = append(args, "--branch", src.Ref)
+	}
+	args = append(args, src.CloneURL, dir)
+
+	clone := exec.Command("git", args...)
+	if out, err := clone.CombinedOutput(); err != nil {
+		return cloneError(src, fmt.Sprintf("git clone failed: %s", strings.TrimSpace(string(out))))
+	}
+	return nil
+}
+
+// cloneError wraps a git failure with guidance about credentials, since a vanilla
+// node has no GitHub auth and cannot clone private source repos.
+func cloneError(src Source, detail string) error {
+	return fmt.Errorf("could not fetch module source %q: %s\n"+
+		"   If this is a private repository, this node needs git credentials to clone it:\n"+
+		"   set a GITHUB_TOKEN, configure an SSH key, or set up a git credential helper.",
+		src.Raw, detail)
+}
+
+// loadModuleManifest locates and parses the module's service.yaml and resolves
+// its compose file path. It prefers the standardized "citadel/" subdirectory and
+// falls back to the repo root.
+func loadModuleManifest(dir string) (*ServiceManifest, string, error) {
+	manifestPath := firstExisting(
+		filepath.Join(dir, "citadel", "service.yaml"),
+		filepath.Join(dir, "service.yaml"),
+	)
+	if manifestPath == "" {
+		return nil, "", fmt.Errorf("no service.yaml found in module repo (looked in citadel/ and repo root); "+
+			"a Citadel module must self-describe via citadel/service.yaml + citadel/compose.yml")
+	}
+
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to read module manifest %s: %w", manifestPath, err)
+	}
+	var manifest ServiceManifest
+	if err := yaml.Unmarshal(data, &manifest); err != nil {
+		return nil, "", fmt.Errorf("failed to parse module manifest %s: %w", manifestPath, err)
+	}
+	if manifest.Name == "" {
+		return nil, "", fmt.Errorf("module manifest %s has no 'name'", manifestPath)
+	}
+
+	composePath := firstExisting(
+		filepath.Join(dir, "citadel", "compose.yml"),
+		filepath.Join(dir, "compose.yml"),
+	)
+	if composePath == "" {
+		return nil, "", fmt.Errorf("no compose.yml found in module repo (looked in citadel/ and repo root)")
+	}
+
+	return &manifest, composePath, nil
+}
+
+// firstExisting returns the first path that exists, or "".
+func firstExisting(paths ...string) string {
+	for _, p := range paths {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return ""
+}

--- a/internal/catalog/source.go
+++ b/internal/catalog/source.go
@@ -210,43 +210,107 @@ func ModulesCacheDir() string {
 	return filepath.Join(platform.ConfigDir(), "modules")
 }
 
+// ResolvedModule is the result of resolving an external module source: the
+// parsed manifest, the compose path, plus provenance (cache dir, resolved git
+// commit, and the image references parsed from the compose) used for the
+// lockfile and the pre-install confirmation prompt.
+type ResolvedModule struct {
+	Manifest    *ServiceManifest
+	ComposePath string
+	CacheDir    string
+	// Commit is the resolved git HEAD of the cache checkout (or "" if unknown).
+	Commit string
+	// Images are the container image references parsed from the compose file.
+	Images []string
+}
+
 // ResolveSource clones (or updates) the module repo for src into a per-source
-// cache directory and loads its ServiceManifest + compose file path. For a
-// KindCatalog source it returns an error: the caller is expected to delegate
-// catalog names to the existing catalog install path.
-func ResolveSource(src Source) (manifest *ServiceManifest, composePath string, err error) {
+// cache directory and loads its ServiceManifest + compose file path along with
+// provenance (resolved commit + compose image refs). For a KindCatalog source it
+// returns an error: the caller is expected to delegate catalog names to the
+// existing catalog install path.
+func ResolveSource(src Source) (*ResolvedModule, error) {
 	if src.Kind == KindCatalog {
-		return nil, "", fmt.Errorf("source %q is a catalog name; use the catalog path", src.Raw)
+		return nil, fmt.Errorf("source %q is a catalog name; use the catalog path", src.Raw)
 	}
 
 	cacheDir := filepath.Join(ModulesCacheDir(), sanitizeCacheName(src))
 	if err := os.MkdirAll(filepath.Dir(cacheDir), 0755); err != nil {
-		return nil, "", fmt.Errorf("failed to create modules cache directory: %w", err)
+		return nil, fmt.Errorf("failed to create modules cache directory: %w", err)
 	}
 
 	if err := cloneOrUpdate(src, cacheDir); err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
-	return loadModuleManifest(cacheDir)
+	manifest, composePath, err := loadModuleManifest(cacheDir)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &ResolvedModule{
+		Manifest:    manifest,
+		ComposePath: composePath,
+		CacheDir:    cacheDir,
+		Commit:      gitHeadCommit(cacheDir),
+	}
+	if data, rerr := os.ReadFile(composePath); rerr == nil {
+		res.Images = parseComposeImages(string(data))
+	}
+	return res, nil
 }
 
-// cloneOrUpdate performs a shallow clone of the source repo into dir, or updates
-// it if dir is already a git repo. Mirrors the style of catalog.Update().
+// cloneStrategy classifies how a source ref must be fetched. It is pure so the
+// decision can be unit-tested without touching git.
+type cloneStrategy int
+
+const (
+	// strategyPlain: no ref pinned -- shallow clone the default branch.
+	strategyPlain cloneStrategy = iota
+	// strategyBranch: a tag/branch ref -- shallow clone with --branch <ref>.
+	strategyBranch
+	// strategyFetchSHA: a raw commit SHA -- clone default branch, then fetch +
+	// checkout the SHA (git clone --branch cannot take a raw SHA).
+	strategyFetchSHA
+)
+
+// pickCloneStrategy returns the strategy for src's ref.
+func pickCloneStrategy(src Source) cloneStrategy {
+	if src.Ref == "" {
+		return strategyPlain
+	}
+	if looksLikeSHA(src.Ref) {
+		return strategyFetchSHA
+	}
+	return strategyBranch
+}
+
+// looksLikeSHA reports whether ref is a 7-40 char hex string (an abbreviated or
+// full git commit SHA). Pure -- table-tested.
+func looksLikeSHA(ref string) bool {
+	if len(ref) < 7 || len(ref) > 40 {
+		return false
+	}
+	for _, r := range ref {
+		isHex := (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')
+		if !isHex {
+			return false
+		}
+	}
+	return true
+}
+
+// cloneOrUpdate performs a shallow clone of the source repo into dir (or updates
+// it if dir is already a git repo) and checks out the requested ref. Mirrors the
+// style of catalog.Update().
 func cloneOrUpdate(src Source, dir string) error {
+	strategy := pickCloneStrategy(src)
+
 	if isGitRepo(dir) {
-		// Existing checkout: fetch + reset to the requested ref (or fast-forward
-		// the current branch when no ref is pinned).
+		// Existing checkout: a pinned ref (branch/tag/SHA) is fetched + checked
+		// out; an unpinned source fast-forwards the current branch.
 		if src.Ref != "" {
-			fetch := exec.Command("git", "-C", dir, "fetch", "--depth", "1", "origin", src.Ref)
-			if out, err := fetch.CombinedOutput(); err != nil {
-				return cloneError(src, fmt.Sprintf("git fetch failed: %s", strings.TrimSpace(string(out))))
-			}
-			checkout := exec.Command("git", "-C", dir, "checkout", "FETCH_HEAD")
-			if out, err := checkout.CombinedOutput(); err != nil {
-				return cloneError(src, fmt.Sprintf("git checkout failed: %s", strings.TrimSpace(string(out))))
-			}
-			return nil
+			return fetchAndCheckout(src, dir)
 		}
 		pull := exec.Command("git", "-C", dir, "pull", "--ff-only")
 		if out, err := pull.CombinedOutput(); err != nil {
@@ -261,7 +325,7 @@ func cloneOrUpdate(src Source, dir string) error {
 	}
 
 	args := []string{"clone", "--depth", "1"}
-	if src.Ref != "" {
+	if strategy == strategyBranch {
 		// --branch accepts tags and branches (but not raw SHAs).
 		args = append(args, "--branch", src.Ref)
 	}
@@ -271,16 +335,127 @@ func cloneOrUpdate(src Source, dir string) error {
 	if out, err := clone.CombinedOutput(); err != nil {
 		return cloneError(src, fmt.Sprintf("git clone failed: %s", strings.TrimSpace(string(out))))
 	}
+
+	// A raw SHA cannot be selected at clone time; fetch + checkout it now.
+	if strategy == strategyFetchSHA {
+		return fetchAndCheckout(src, dir)
+	}
 	return nil
 }
 
+// fetchAndCheckout fetches src.Ref into an existing checkout at dir and checks it
+// out. It first tries a shallow fetch (works for branches/tags and, on most git
+// servers, for a SHA); if that fails it falls back to a full fetch (needed when a
+// server refuses to serve an arbitrary SHA shallowly).
+func fetchAndCheckout(src Source, dir string) error {
+	fetch := exec.Command("git", "-C", dir, "fetch", "--depth", "1", "origin", src.Ref)
+	if out, err := fetch.CombinedOutput(); err != nil {
+		// Fall back to a full fetch (drop --depth) before giving up.
+		full := exec.Command("git", "-C", dir, "fetch", "origin", src.Ref)
+		if out2, err2 := full.CombinedOutput(); err2 != nil {
+			return cloneError(src, fmt.Sprintf("git fetch failed: %s",
+				strings.TrimSpace(string(out))+"; "+strings.TrimSpace(string(out2))))
+		}
+	}
+	checkout := exec.Command("git", "-C", dir, "checkout", "FETCH_HEAD")
+	if out, err := checkout.CombinedOutput(); err != nil {
+		return cloneError(src, fmt.Sprintf("git checkout failed: %s", strings.TrimSpace(string(out))))
+	}
+	return nil
+}
+
+// gitHeadCommit returns the resolved HEAD commit of dir, or "" if it can't be
+// determined (best-effort, for provenance).
+func gitHeadCommit(dir string) string {
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// cloneErrorHost extracts a host label from a source's clone URL for the
+// credential hint (e.g. "github.com"). Pure -- table-tested.
+func cloneErrorHost(src Source) string {
+	url := src.CloneURL
+	// Strip scheme.
+	for _, scheme := range []string{"https://", "http://", "ssh://", "git://"} {
+		url = strings.TrimPrefix(url, scheme)
+	}
+	// Drop any userinfo ("git@" / "user@") that precedes the host. This covers
+	// both scp-form "git@host:owner/repo.git" and "ssh://git@host/owner/repo".
+	// Only strip an '@' that comes before the first path separator, so an '@' in
+	// a later path segment is not mistaken for userinfo.
+	sepAt := strings.IndexAny(url, "/:")
+	if at := strings.Index(url, "@"); at >= 0 && (sepAt < 0 || at < sepAt) {
+		url = url[at+1:]
+	}
+	// Take the host up to the first '/' or ':'.
+	if i := strings.IndexAny(url, "/:"); i >= 0 {
+		url = url[:i]
+	}
+	if url == "" {
+		return "the source host"
+	}
+	return url
+}
+
 // cloneError wraps a git failure with guidance about credentials, since a vanilla
-// node has no GitHub auth and cannot clone private source repos.
+// node has no auth and cannot clone private source repos.
 func cloneError(src Source, detail string) error {
+	host := cloneErrorHost(src)
 	return fmt.Errorf("could not fetch module source %q: %s\n"+
-		"   If this is a private repository, this node needs git credentials to clone it:\n"+
-		"   set a GITHUB_TOKEN, configure an SSH key, or set up a git credential helper.",
-		src.Raw, detail)
+		"   If this is a private repository, this node needs git credentials for %s.\n"+
+		"   Fix one of: set a GITHUB_TOKEN env var, configure an SSH key for %s, or\n"+
+		"   set up a git credential helper (e.g. `git credential-store` or `gh auth login`).",
+		src.Raw, detail, host, host)
+}
+
+// parseComposeImages extracts container image references from a compose file's
+// `image:` lines, in order, de-duplicated. Pure -- table-tested.
+func parseComposeImages(compose string) []string {
+	var images []string
+	seen := make(map[string]bool)
+	for _, line := range strings.Split(compose, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "image:") {
+			continue
+		}
+		val := strings.TrimSpace(strings.TrimPrefix(trimmed, "image:"))
+		val = strings.Trim(val, `"'`)
+		if val == "" || seen[val] {
+			continue
+		}
+		seen[val] = true
+		images = append(images, val)
+	}
+	return images
+}
+
+// parseComposeContainerName extracts the first `container_name:` value from a
+// compose file, or "" if none. Pure -- table-tested.
+func parseComposeContainerName(compose string) string {
+	for _, line := range strings.Split(compose, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "container_name:") {
+			continue
+		}
+		val := strings.TrimSpace(strings.TrimPrefix(trimmed, "container_name:"))
+		return strings.Trim(val, `"'`)
+	}
+	return ""
+}
+
+// SchemaWarning returns a forward-compat warning string if the manifest declares
+// a schema_version newer than this CLI understands, or "" otherwise. Pure so the
+// catalog package stays import-clean; the cmd layer prints it.
+func SchemaWarning(manifest *ServiceManifest) string {
+	if manifest != nil && manifest.SchemaVersion > CurrentSchemaVersion {
+		return fmt.Sprintf("module declares schema_version %d but this CLI understands up to %d; "+
+			"some fields may be ignored -- consider updating citadel.",
+			manifest.SchemaVersion, CurrentSchemaVersion)
+	}
+	return ""
 }
 
 // loadModuleManifest locates and parses the module's service.yaml and resolves

--- a/internal/catalog/source.go
+++ b/internal/catalog/source.go
@@ -292,7 +292,7 @@ func loadModuleManifest(dir string) (*ServiceManifest, string, error) {
 		filepath.Join(dir, "service.yaml"),
 	)
 	if manifestPath == "" {
-		return nil, "", fmt.Errorf("no service.yaml found in module repo (looked in citadel/ and repo root); "+
+		return nil, "", fmt.Errorf("no service.yaml found in module repo (looked in citadel/ and repo root); " +
 			"a Citadel module must self-describe via citadel/service.yaml + citadel/compose.yml")
 	}
 

--- a/internal/catalog/source_test.go
+++ b/internal/catalog/source_test.go
@@ -1,0 +1,239 @@
+package catalog
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseSource(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantKind SourceKind
+		wantURL  string // CloneURL (KindGitHub/KindGitURL)
+		wantRef  string
+		wantName string // KindCatalog
+		wantErr  bool
+	}{
+		{
+			name:     "plain catalog name",
+			input:    "vllm",
+			wantKind: KindCatalog,
+			wantName: "vllm",
+		},
+		{
+			name:     "catalog name with dash",
+			input:    "whatsapp-bridge",
+			wantKind: KindCatalog,
+			wantName: "whatsapp-bridge",
+		},
+		{
+			name:     "owner/repo shorthand",
+			input:    "sunapi386/whatsapp-bridge",
+			wantKind: KindGitHub,
+			wantURL:  "https://github.com/sunapi386/whatsapp-bridge.git",
+		},
+		{
+			name:     "owner/repo with ref",
+			input:    "sunapi386/whatsapp-bridge@v1.2.0",
+			wantKind: KindGitHub,
+			wantURL:  "https://github.com/sunapi386/whatsapp-bridge.git",
+			wantRef:  "v1.2.0",
+		},
+		{
+			name:     "owner/repo with .git suffix",
+			input:    "owner/repo.git",
+			wantKind: KindGitHub,
+			wantURL:  "https://github.com/owner/repo.git",
+		},
+		{
+			name:     "https url",
+			input:    "https://github.com/owner/repo.git",
+			wantKind: KindGitURL,
+			wantURL:  "https://github.com/owner/repo.git",
+		},
+		{
+			name:     "https url with #ref",
+			input:    "https://github.com/owner/repo.git#main",
+			wantKind: KindGitURL,
+			wantURL:  "https://github.com/owner/repo.git",
+			wantRef:  "main",
+		},
+		{
+			name:     "https url with @ref after path",
+			input:    "https://github.com/owner/repo@v2.0.0",
+			wantKind: KindGitURL,
+			wantURL:  "https://github.com/owner/repo",
+			wantRef:  "v2.0.0",
+		},
+		{
+			name:     "https url with userinfo is preserved (no ref)",
+			input:    "https://user@github.com/owner/repo.git",
+			wantKind: KindGitURL,
+			wantURL:  "https://user@github.com/owner/repo.git",
+			wantRef:  "",
+		},
+		{
+			name:     "scp-form git remote (ref untouched, @ preserved)",
+			input:    "git@github.com:owner/repo.git",
+			wantKind: KindGitURL,
+			wantURL:  "git@github.com:owner/repo.git",
+			wantRef:  "",
+		},
+		{
+			name:    "empty",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "whitespace only",
+			input:   "   ",
+			wantErr: true,
+		},
+		{
+			name:    "trailing slash invalid owner/repo",
+			input:   "owner/",
+			wantErr: true,
+		},
+		{
+			name:    "leading slash invalid owner/repo",
+			input:   "/repo",
+			wantErr: true,
+		},
+		{
+			name:    "too many slashes",
+			input:   "a/b/c",
+			wantErr: true,
+		},
+		{
+			name:    "catalog name with colon invalid",
+			input:   "weird:name",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseSource(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParseSource(%q) expected error, got %+v", tt.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseSource(%q) unexpected error: %v", tt.input, err)
+			}
+			if got.Kind != tt.wantKind {
+				t.Errorf("Kind = %v, want %v", got.Kind, tt.wantKind)
+			}
+			if tt.wantURL != "" && got.CloneURL != tt.wantURL {
+				t.Errorf("CloneURL = %q, want %q", got.CloneURL, tt.wantURL)
+			}
+			if got.Ref != tt.wantRef {
+				t.Errorf("Ref = %q, want %q", got.Ref, tt.wantRef)
+			}
+			if tt.wantName != "" && got.Name != tt.wantName {
+				t.Errorf("Name = %q, want %q", got.Name, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestParseSourceGitHubOwnerRepo(t *testing.T) {
+	got, err := ParseSource("acme/my-module@release-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Owner != "acme" || got.Repo != "my-module" {
+		t.Errorf("Owner/Repo = %q/%q, want acme/my-module", got.Owner, got.Repo)
+	}
+	if got.Ref != "release-1" {
+		t.Errorf("Ref = %q, want release-1", got.Ref)
+	}
+}
+
+// writeFile is a tiny test helper that creates parent dirs and writes content.
+func writeModuleFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+const sampleManifest = "name: my-module\nversion: 1.0.0\ndescription: test\n"
+const sampleCompose = "services:\n  app:\n    image: ghcr.io/acme/my-module:latest\n"
+
+func TestLoadModuleManifest_CitadelSubdir(t *testing.T) {
+	dir := t.TempDir()
+	writeModuleFile(t, filepath.Join(dir, "citadel", "service.yaml"), sampleManifest)
+	writeModuleFile(t, filepath.Join(dir, "citadel", "compose.yml"), sampleCompose)
+
+	m, composePath, err := loadModuleManifest(dir)
+	if err != nil {
+		t.Fatalf("loadModuleManifest: %v", err)
+	}
+	if m.Name != "my-module" {
+		t.Errorf("Name = %q, want my-module", m.Name)
+	}
+	if composePath != filepath.Join(dir, "citadel", "compose.yml") {
+		t.Errorf("composePath = %q, want citadel/compose.yml", composePath)
+	}
+}
+
+func TestLoadModuleManifest_RepoRootFallback(t *testing.T) {
+	dir := t.TempDir()
+	writeModuleFile(t, filepath.Join(dir, "service.yaml"), sampleManifest)
+	writeModuleFile(t, filepath.Join(dir, "compose.yml"), sampleCompose)
+
+	m, composePath, err := loadModuleManifest(dir)
+	if err != nil {
+		t.Fatalf("loadModuleManifest: %v", err)
+	}
+	if m.Name != "my-module" {
+		t.Errorf("Name = %q, want my-module", m.Name)
+	}
+	if composePath != filepath.Join(dir, "compose.yml") {
+		t.Errorf("composePath = %q, want repo-root compose.yml", composePath)
+	}
+}
+
+func TestLoadModuleManifest_CitadelPreferredOverRoot(t *testing.T) {
+	dir := t.TempDir()
+	// Both present: citadel/ should win.
+	writeModuleFile(t, filepath.Join(dir, "citadel", "service.yaml"), "name: from-citadel\nversion: 1\n")
+	writeModuleFile(t, filepath.Join(dir, "citadel", "compose.yml"), sampleCompose)
+	writeModuleFile(t, filepath.Join(dir, "service.yaml"), "name: from-root\nversion: 1\n")
+	writeModuleFile(t, filepath.Join(dir, "compose.yml"), sampleCompose)
+
+	m, composePath, err := loadModuleManifest(dir)
+	if err != nil {
+		t.Fatalf("loadModuleManifest: %v", err)
+	}
+	if m.Name != "from-citadel" {
+		t.Errorf("Name = %q, want from-citadel (citadel/ subdir preferred)", m.Name)
+	}
+	if composePath != filepath.Join(dir, "citadel", "compose.yml") {
+		t.Errorf("composePath = %q, want citadel/compose.yml", composePath)
+	}
+}
+
+func TestLoadModuleManifest_NoManifest(t *testing.T) {
+	dir := t.TempDir()
+	writeModuleFile(t, filepath.Join(dir, "README.md"), "nothing here")
+	if _, _, err := loadModuleManifest(dir); err == nil {
+		t.Fatal("expected error when no service.yaml is present")
+	}
+}
+
+func TestLoadModuleManifest_ManifestButNoCompose(t *testing.T) {
+	dir := t.TempDir()
+	writeModuleFile(t, filepath.Join(dir, "citadel", "service.yaml"), sampleManifest)
+	if _, _, err := loadModuleManifest(dir); err == nil {
+		t.Fatal("expected error when compose.yml is missing")
+	}
+}

--- a/internal/catalog/source_test.go
+++ b/internal/catalog/source_test.go
@@ -237,3 +237,167 @@ func TestLoadModuleManifest_ManifestButNoCompose(t *testing.T) {
 		t.Fatal("expected error when compose.yml is missing")
 	}
 }
+
+func TestLooksLikeSHA(t *testing.T) {
+	tests := []struct {
+		ref  string
+		want bool
+	}{
+		{"abc1234", true},  // 7 hex (min)
+		{"deadbeef", true}, // 8 hex
+		{"0123456789abcdef0123456789abcdef01234567", true}, // 40 hex (full)
+		{"ABC1234", true},    // uppercase hex
+		{"v1.2.0", false},    // tag
+		{"main", false},      // branch
+		{"release-1", false}, // branch with dash
+		{"abc123", false},    // 6 chars (too short)
+		{"abc123g", false},   // non-hex char 'g'
+		{"0123456789abcdef0123456789abcdef012345678", false}, // 41 chars (too long)
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := looksLikeSHA(tt.ref); got != tt.want {
+			t.Errorf("looksLikeSHA(%q) = %v, want %v", tt.ref, got, tt.want)
+		}
+	}
+}
+
+func TestPickCloneStrategy(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  string
+		want cloneStrategy
+	}{
+		{"no ref", "", strategyPlain},
+		{"tag", "v1.2.0", strategyBranch},
+		{"branch", "main", strategyBranch},
+		{"sha", "deadbeef", strategyFetchSHA},
+		{"full sha", "0123456789abcdef0123456789abcdef01234567", strategyFetchSHA},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pickCloneStrategy(Source{Kind: KindGitHub, Ref: tt.ref})
+			if got != tt.want {
+				t.Errorf("pickCloneStrategy(ref=%q) = %v, want %v", tt.ref, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseComposeImages(t *testing.T) {
+	compose := `services:
+  app:
+    image: ghcr.io/acme/app:latest
+    container_name: acme-app
+  db:
+    image: "postgres:16"
+  cache:
+    image: ghcr.io/acme/app:latest
+`
+	got := parseComposeImages(compose)
+	want := []string{"ghcr.io/acme/app:latest", "postgres:16"}
+	if len(got) != len(want) {
+		t.Fatalf("parseComposeImages = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("image[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestParseComposeImages_None(t *testing.T) {
+	if got := parseComposeImages("services:\n  app:\n    build: .\n"); len(got) != 0 {
+		t.Errorf("expected no images, got %v", got)
+	}
+}
+
+func TestParseComposeContainerName(t *testing.T) {
+	compose := "services:\n  app:\n    image: x\n    container_name: \"my-app\"\n"
+	if got := parseComposeContainerName(compose); got != "my-app" {
+		t.Errorf("parseComposeContainerName = %q, want my-app", got)
+	}
+	if got := parseComposeContainerName("services:\n  app:\n    image: x\n"); got != "" {
+		t.Errorf("expected empty container name, got %q", got)
+	}
+}
+
+func TestCloneErrorHost(t *testing.T) {
+	tests := []struct {
+		url  string
+		want string
+	}{
+		{"https://github.com/owner/repo.git", "github.com"},
+		{"http://git.example.com/owner/repo.git", "git.example.com"},
+		{"git@github.com:owner/repo.git", "github.com"},
+		{"ssh://git@gitlab.com/owner/repo.git", "gitlab.com"},
+	}
+	for _, tt := range tests {
+		got := cloneErrorHost(Source{CloneURL: tt.url})
+		if got != tt.want {
+			t.Errorf("cloneErrorHost(%q) = %q, want %q", tt.url, got, tt.want)
+		}
+	}
+}
+
+func TestSchemaWarning(t *testing.T) {
+	if w := SchemaWarning(&ServiceManifest{SchemaVersion: 0}); w != "" {
+		t.Errorf("schema_version 0 should be OK, got %q", w)
+	}
+	if w := SchemaWarning(&ServiceManifest{SchemaVersion: CurrentSchemaVersion}); w != "" {
+		t.Errorf("current schema_version should be OK, got %q", w)
+	}
+	if w := SchemaWarning(&ServiceManifest{SchemaVersion: CurrentSchemaVersion + 1}); w == "" {
+		t.Error("a future schema_version should produce a warning")
+	}
+}
+
+func TestLockfileUpsert(t *testing.T) {
+	// Hermetic: point ConfigDir at a temp HOME (Linux/darwin non-root path).
+	t.Setenv("HOME", t.TempDir())
+
+	// Empty lockfile when none exists.
+	lf, err := LoadLockfile()
+	if err != nil {
+		t.Fatalf("LoadLockfile (empty): %v", err)
+	}
+	if len(lf.Modules) != 0 {
+		t.Fatalf("expected empty lockfile, got %d modules", len(lf.Modules))
+	}
+
+	// Insert two entries.
+	if err := UpsertLockEntry(LockEntry{Name: "a", Source: "owner/a", Commit: "c1"}); err != nil {
+		t.Fatalf("upsert a: %v", err)
+	}
+	if err := UpsertLockEntry(LockEntry{Name: "b", Source: "owner/b", Commit: "c2"}); err != nil {
+		t.Fatalf("upsert b: %v", err)
+	}
+
+	// Replace one in place; the other must survive.
+	if err := UpsertLockEntry(LockEntry{Name: "a", Source: "owner/a", Commit: "c1-new"}); err != nil {
+		t.Fatalf("upsert a (replace): %v", err)
+	}
+
+	lf, err = LoadLockfile()
+	if err != nil {
+		t.Fatalf("LoadLockfile (after): %v", err)
+	}
+	if len(lf.Modules) != 2 {
+		t.Fatalf("expected 2 modules after replace, got %d", len(lf.Modules))
+	}
+	ea, ok := lf.LookupLock("a")
+	if !ok || ea.Commit != "c1-new" {
+		t.Errorf("entry a not replaced: %+v (ok=%v)", ea, ok)
+	}
+	eb, ok := lf.LookupLock("b")
+	if !ok || eb.Commit != "c2" {
+		t.Errorf("entry b not preserved: %+v (ok=%v)", eb, ok)
+	}
+}
+
+func TestContainerNameConflict_EmptyAndNoDocker(t *testing.T) {
+	// Empty name is never a conflict.
+	if ContainerNameConflict("") {
+		t.Error("empty container name should never conflict")
+	}
+}

--- a/internal/catalog/source_test.go
+++ b/internal/catalog/source_test.go
@@ -111,6 +111,21 @@ func TestParseSource(t *testing.T) {
 			input:   "weird:name",
 			wantErr: true,
 		},
+		{
+			name:    "ref with leading dash rejected (git arg injection)",
+			input:   "owner/repo@--upload-pack=touch /tmp/pwned",
+			wantErr: true,
+		},
+		{
+			name:    "url ref with leading dash rejected (git arg injection)",
+			input:   "https://github.com/owner/repo.git#--upload-pack=evil",
+			wantErr: true,
+		},
+		{
+			name:    "owner with leading dash rejected",
+			input:   "-flag/repo",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/catalog/trust.go
+++ b/internal/catalog/trust.go
@@ -1,0 +1,155 @@
+package catalog
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
+	"gopkg.in/yaml.v3"
+)
+
+// TrustedSources is the persisted allowlist of module source patterns the
+// operator has explicitly trusted. Patterns may be:
+//   - exact "owner/repo"            (matches that GitHub shorthand)
+//   - "owner/*"                     (any repo under that owner)
+//   - a bare host "github.com"      (any source on that host)
+type TrustedSources struct {
+	Version  int      `yaml:"version"`
+	Patterns []string `yaml:"patterns"`
+}
+
+// TrustedSourcesPath returns the path to the trusted-sources allowlist file.
+func TrustedSourcesPath() string {
+	return filepath.Join(platform.ConfigDir(), "trusted_sources.yaml")
+}
+
+// LoadTrustedSources reads the allowlist, returning an empty (version 1) list if
+// the file does not yet exist.
+func LoadTrustedSources() (*TrustedSources, error) {
+	path := TrustedSourcesPath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &TrustedSources{Version: 1}, nil
+		}
+		return nil, fmt.Errorf("failed to read trusted sources %s: %w", path, err)
+	}
+	var ts TrustedSources
+	if err := yaml.Unmarshal(data, &ts); err != nil {
+		return nil, fmt.Errorf("failed to parse trusted sources %s: %w", path, err)
+	}
+	if ts.Version == 0 {
+		ts.Version = 1
+	}
+	return &ts, nil
+}
+
+// saveTrustedSources writes the allowlist back to disk.
+func saveTrustedSources(ts *TrustedSources) error {
+	path := TrustedSourcesPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+	data, err := yaml.Marshal(ts)
+	if err != nil {
+		return fmt.Errorf("failed to marshal trusted sources: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("failed to write trusted sources %s: %w", path, err)
+	}
+	return nil
+}
+
+// AddTrustedSource adds a pattern to the allowlist (idempotent) and persists it.
+func AddTrustedSource(pattern string) error {
+	pattern = strings.TrimSpace(pattern)
+	if pattern == "" {
+		return fmt.Errorf("empty trust pattern")
+	}
+	ts, err := LoadTrustedSources()
+	if err != nil {
+		return err
+	}
+	for _, p := range ts.Patterns {
+		if p == pattern {
+			return nil // already present
+		}
+	}
+	ts.Patterns = append(ts.Patterns, pattern)
+	sort.Strings(ts.Patterns)
+	return saveTrustedSources(ts)
+}
+
+// RemoveTrustedSource removes a pattern from the allowlist and persists it.
+// Removing a pattern that is not present is a no-op (no error).
+func RemoveTrustedSource(pattern string) error {
+	pattern = strings.TrimSpace(pattern)
+	ts, err := LoadTrustedSources()
+	if err != nil {
+		return err
+	}
+	out := ts.Patterns[:0]
+	for _, p := range ts.Patterns {
+		if p != pattern {
+			out = append(out, p)
+		}
+	}
+	ts.Patterns = out
+	return saveTrustedSources(ts)
+}
+
+// IsTrusted reports whether a parsed source is trusted. A catalog source
+// (KindCatalog) is always trusted (Tier 0, first-party). External sources match
+// against the persisted allowlist patterns.
+func IsTrusted(src Source) bool {
+	if src.Kind == KindCatalog {
+		return true
+	}
+	ts, err := LoadTrustedSources()
+	if err != nil {
+		return false
+	}
+	return matchTrust(ts.Patterns, src)
+}
+
+// matchTrust is the pure matching core: reports whether any pattern trusts src.
+// Table-tested without IO.
+//
+// Matching rules by kind:
+//   - KindGitHub (owner/repo): matches exact "owner/repo", "owner/*", or the
+//     host pattern "github.com" (GitHub shorthand is always on github.com).
+//   - KindGitURL: host-level trust only -- matches a bare host pattern equal to
+//     the URL's host. (owner-level matching on arbitrary git URLs is not
+//     attempted; see note below.)
+func matchTrust(patterns []string, src Source) bool {
+	for _, raw := range patterns {
+		p := strings.TrimSpace(raw)
+		if p == "" {
+			continue
+		}
+		switch src.Kind {
+		case KindGitHub:
+			if p == "github.com" {
+				return true
+			}
+			if p == src.Owner+"/"+src.Repo {
+				return true
+			}
+			if p == src.Owner+"/*" {
+				return true
+			}
+		case KindGitURL:
+			// Host-level trust for raw git URLs. owner/repo or owner/* patterns
+			// are not matched here because a git URL's owner is not reliably
+			// parseable across hosts -- a known limitation, host trust is the
+			// realistic match.
+			if !strings.Contains(p, "/") && p == cloneErrorHost(src) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/catalog/trust_test.go
+++ b/internal/catalog/trust_test.go
@@ -1,0 +1,93 @@
+package catalog
+
+import "testing"
+
+func gh(owner, repo string) Source {
+	return Source{Kind: KindGitHub, Owner: owner, Repo: repo, CloneURL: "https://github.com/" + owner + "/" + repo + ".git"}
+}
+
+func TestMatchTrust_GitHub(t *testing.T) {
+	tests := []struct {
+		name     string
+		patterns []string
+		src      Source
+		want     bool
+	}{
+		{"exact owner/repo", []string{"acme/widget"}, gh("acme", "widget"), true},
+		{"owner wildcard", []string{"acme/*"}, gh("acme", "widget"), true},
+		{"owner wildcard other repo", []string{"acme/*"}, gh("acme", "gadget"), true},
+		{"host github.com", []string{"github.com"}, gh("anyone", "thing"), true},
+		{"no match different owner", []string{"acme/*"}, gh("evil", "thing"), false},
+		{"no match different repo", []string{"acme/widget"}, gh("acme", "gadget"), false},
+		{"empty patterns", nil, gh("acme", "widget"), false},
+		{"blank pattern ignored", []string{"  ", "acme/widget"}, gh("acme", "widget"), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchTrust(tt.patterns, tt.src); got != tt.want {
+				t.Errorf("matchTrust(%v, %s/%s) = %v, want %v", tt.patterns, tt.src.Owner, tt.src.Repo, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchTrust_GitURLHost(t *testing.T) {
+	src := Source{Kind: KindGitURL, CloneURL: "https://git.example.com/owner/repo.git"}
+	if !matchTrust([]string{"git.example.com"}, src) {
+		t.Error("expected host-level trust for git URL")
+	}
+	if matchTrust([]string{"other.example.com"}, src) {
+		t.Error("unexpected match for a different host")
+	}
+	// owner/repo patterns do not match raw git URLs (known limitation).
+	if matchTrust([]string{"owner/repo"}, src) {
+		t.Error("owner/repo should not match a raw git URL")
+	}
+
+	scp := Source{Kind: KindGitURL, CloneURL: "git@github.com:owner/repo.git"}
+	if !matchTrust([]string{"github.com"}, scp) {
+		t.Error("expected host-level trust for scp-form git URL")
+	}
+}
+
+func TestIsTrusted_CatalogAlways(t *testing.T) {
+	// Catalog sources are Tier-0, always trusted, no IO needed.
+	if !IsTrusted(Source{Kind: KindCatalog, Name: "vllm"}) {
+		t.Error("catalog source must always be trusted")
+	}
+}
+
+func TestTrustedSourcesPersistence(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	ts, err := LoadTrustedSources()
+	if err != nil {
+		t.Fatalf("load empty: %v", err)
+	}
+	if len(ts.Patterns) != 0 {
+		t.Fatalf("expected empty allowlist, got %v", ts.Patterns)
+	}
+
+	if err := AddTrustedSource("acme/*"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if err := AddTrustedSource("acme/*"); err != nil { // idempotent
+		t.Fatalf("add idempotent: %v", err)
+	}
+	if err := AddTrustedSource("github.com"); err != nil {
+		t.Fatalf("add host: %v", err)
+	}
+
+	// IsTrusted now reads the persisted file.
+	if !IsTrusted(gh("acme", "widget")) {
+		t.Error("acme/widget should be trusted via acme/*")
+	}
+
+	if err := RemoveTrustedSource("acme/*"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	ts, _ = LoadTrustedSources()
+	if len(ts.Patterns) != 1 || ts.Patterns[0] != "github.com" {
+		t.Errorf("after remove, expected [github.com], got %v", ts.Patterns)
+	}
+}

--- a/internal/tui/controlcenter/controlcenter.go
+++ b/internal/tui/controlcenter/controlcenter.go
@@ -423,13 +423,16 @@ type ControlCenter struct {
 	chatConfig     ChatPageConfig        // stored from Config; used to lazily create ChatPage
 	chatConfigProv func() ChatPageConfig // lazy re-resolver for chat credentials (post-startup device auth)
 	chatPage       *ChatPage             // nil until registered in Run
-	proxmoxConfig ProxmoxConfig  // Proxmox page config (zero = disabled)
+	proxmoxConfig  ProxmoxConfig         // Proxmox page config (zero = disabled)
 
 	// Settings
 	settingsConfig SettingsCallbacks // Settings page hooks (telemetry load/save)
 
 	// WhatsApp
 	whatsappConfig WhatsAppCallbacks // WhatsApp bridge page hooks (deploy/stop/status/QR)
+
+	// Module install (install a service module from any standardized repo)
+	moduleInstallConfig ModuleInstallCallbacks
 }
 
 // Pane focus constants
@@ -497,6 +500,7 @@ type Config struct {
 	Proxmox            ProxmoxConfig                            // Proxmox page configuration (empty = disabled)
 	Settings           SettingsCallbacks                        // Settings page hooks (telemetry load/save)
 	WhatsApp           WhatsAppCallbacks                        // WhatsApp bridge page hooks (deploy/stop/status/QR)
+	ModuleInstall      ModuleInstallCallbacks                   // Install-module page hooks (resolve source + install)
 }
 
 // ProxmoxConfig holds configuration for the Proxmox TUI page.
@@ -511,31 +515,32 @@ type ProxmoxConfig struct {
 // New creates a new control center
 func New(cfg Config) *ControlCenter {
 	return &ControlCenter{
-		stopChan:           make(chan struct{}),
-		activities:         make([]ActivityEntry, 0, 100),
-		activeForwards:     make([]PortForward, 0),
-		serviceOverrides:   make(map[string]*serviceStateOverride),
-		data:               StatusData{Version: cfg.Version},
-		refreshFn:          cfg.RefreshFn,
-		startServiceFn:     cfg.StartServiceFn,
-		stopServiceFn:      cfg.StopServiceFn,
-		restartServiceFn:   cfg.RestartServiceFn,
-		addServiceFn:       cfg.AddServiceFn,
-		getServicesFn:      cfg.GetServicesFn,
-		getConfiguredFn:    cfg.GetConfiguredFn,
-		getServiceDetailFn: cfg.GetServiceDetailFn,
-		getServiceLogsFn:   cfg.GetServiceLogsFn,
-		deviceAuth:         cfg.DeviceAuth,
-		worker:             cfg.Worker,
-		permissions:        cfg.Permissions,
-		onConnect:          cfg.OnConnect,
-		authServiceURL:     cfg.AuthServiceURL,
-		nexusURL:           cfg.NexusURL,
-		chatConfig:         cfg.Chat,
-		chatConfigProv:     cfg.ChatConfigProvider,
-		proxmoxConfig:      cfg.Proxmox,
-		settingsConfig:     cfg.Settings,
-		whatsappConfig:     cfg.WhatsApp,
+		stopChan:            make(chan struct{}),
+		activities:          make([]ActivityEntry, 0, 100),
+		activeForwards:      make([]PortForward, 0),
+		serviceOverrides:    make(map[string]*serviceStateOverride),
+		data:                StatusData{Version: cfg.Version},
+		refreshFn:           cfg.RefreshFn,
+		startServiceFn:      cfg.StartServiceFn,
+		stopServiceFn:       cfg.StopServiceFn,
+		restartServiceFn:    cfg.RestartServiceFn,
+		addServiceFn:        cfg.AddServiceFn,
+		getServicesFn:       cfg.GetServicesFn,
+		getConfiguredFn:     cfg.GetConfiguredFn,
+		getServiceDetailFn:  cfg.GetServiceDetailFn,
+		getServiceLogsFn:    cfg.GetServiceLogsFn,
+		deviceAuth:          cfg.DeviceAuth,
+		worker:              cfg.Worker,
+		permissions:         cfg.Permissions,
+		onConnect:           cfg.OnConnect,
+		authServiceURL:      cfg.AuthServiceURL,
+		nexusURL:            cfg.NexusURL,
+		chatConfig:          cfg.Chat,
+		chatConfigProv:      cfg.ChatConfigProvider,
+		proxmoxConfig:       cfg.Proxmox,
+		settingsConfig:      cfg.Settings,
+		whatsappConfig:      cfg.WhatsApp,
+		moduleInstallConfig: cfg.ModuleInstall,
 	}
 }
 
@@ -648,6 +653,13 @@ func (cc *ControlCenter) Run() error {
 	// pairing QR. Visible only when the host wired the lifecycle callbacks.
 	if cc.whatsappConfig.Status != nil {
 		cc.pmgr.Register(NewWhatsAppPage(cc.whatsappConfig), true)
+	}
+
+	// Install-module page: install a service module from any standardized repo
+	// (catalog name, owner/repo, or git URL). Visible only when the host wired
+	// the resolve/install callbacks.
+	if cc.moduleInstallConfig.Resolve != nil {
+		cc.pmgr.Register(NewModulePage(cc.moduleInstallConfig), true)
 	}
 
 	// Settings page (Alt+5): telemetry opt-out + read-only connection status.

--- a/internal/tui/controlcenter/module_page.go
+++ b/internal/tui/controlcenter/module_page.go
@@ -119,10 +119,10 @@ func (p *ModulePage) OnActivate() {
 // OnDeactivate implements Page.
 func (p *ModulePage) OnDeactivate() {}
 
-// HandleInput implements Page. The form consumes most keys; 'r' resets the flow.
+// HandleInput implements Page. The page does not steal keys: the form's text
+// inputs and buttons (Resolve / Install / Reset / Back) handle everything, so the
+// user can type a source and config values freely.
 func (p *ModulePage) HandleInput(event *tcell.EventKey) *tcell.EventKey {
-	// Let the form (text inputs, buttons) handle everything; the page does not
-	// steal keys so the user can type a source/config freely.
 	return event
 }
 

--- a/internal/tui/controlcenter/module_page.go
+++ b/internal/tui/controlcenter/module_page.go
@@ -1,0 +1,363 @@
+package controlcenter
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+// ConfigField describes a single user-configurable env var for a module, mapped
+// from catalog.ConfigVar in the cmd layer so this page never imports catalog
+// internals.
+type ConfigField struct {
+	Name        string
+	Description string
+	Default     string
+	Required    bool
+}
+
+// ModuleResolveResult is what Resolve returns: the resolved module name, the
+// container image (from the module's own compose, display-only), and the list of
+// config fields the form should collect.
+type ModuleResolveResult struct {
+	Name   string
+	Image  string
+	Config []ConfigField
+}
+
+// ModuleInstallCallbacks holds the hooks for the "Install module" page. They are
+// wired from cmd so the page stays free of catalog/network/docker imports.
+//
+// Resolve clones/updates the source repo (or loads a catalog name) and returns
+// the module name + required config; it may block on the network, so the page
+// calls it off the UI goroutine. Install performs the actual install with the
+// collected config passed as overrides (the non-interactive installer path, so
+// no stdin is read).
+type ModuleInstallCallbacks struct {
+	Resolve func(source string) (ModuleResolveResult, error)
+	Install func(source string, overrides map[string]string) (installedName string, err error)
+}
+
+// modulePhase tracks the two-phase form flow.
+type modulePhase int
+
+const (
+	phaseSource modulePhase = iota // collecting the source string
+	phaseConfig                    // source resolved, collecting config
+	phaseDone                      // install finished (success or error)
+)
+
+// ModulePage implements the Page interface for installing a service module from
+// any standardized git repo. It is a one-shot form (no polling): the user types a
+// source, presses Resolve, fills any required config, then Install.
+type ModulePage struct {
+	app *tview.Application
+	cb  ModuleInstallCallbacks
+
+	// UI
+	root   *tview.Flex
+	form   *tview.Form
+	status *tview.TextView
+
+	// State
+	mu       sync.Mutex
+	phase    modulePhase
+	source   string
+	resolved ModuleResolveResult
+	busy     bool
+	busyMsg  string
+	message  string // last success/info message
+	errMsg   string // last error message
+}
+
+// NewModulePage creates an Install-module page wired to the given callbacks.
+func NewModulePage(cb ModuleInstallCallbacks) *ModulePage {
+	return &ModulePage{cb: cb}
+}
+
+// Name implements Page.
+func (p *ModulePage) Name() string { return "module" }
+
+// Title implements Page.
+func (p *ModulePage) Title() string { return "Install Module" }
+
+// Build implements Page.
+func (p *ModulePage) Build(app *tview.Application) tview.Primitive {
+	p.app = app
+
+	p.form = tview.NewForm()
+	p.form.SetBorder(true)
+	p.form.SetTitle(" Install module ")
+	p.form.SetTitleAlign(tview.AlignLeft)
+
+	p.status = tview.NewTextView()
+	p.status.SetDynamicColors(true)
+	p.status.SetScrollable(true)
+	p.status.SetBorder(true)
+	p.status.SetTitle(" Status ")
+	p.status.SetTitleAlign(tview.AlignLeft)
+
+	p.root = tview.NewFlex().SetDirection(tview.FlexColumn).
+		AddItem(p.form, 0, 1, true).
+		AddItem(p.status, 0, 1, false)
+
+	p.buildSourceForm()
+	p.render()
+	return p.root
+}
+
+// OnActivate implements Page.
+func (p *ModulePage) OnActivate() {
+	if p.app != nil && p.form != nil {
+		p.app.SetFocus(p.form)
+	}
+}
+
+// OnDeactivate implements Page.
+func (p *ModulePage) OnDeactivate() {}
+
+// HandleInput implements Page. The form consumes most keys; 'r' resets the flow.
+func (p *ModulePage) HandleInput(event *tcell.EventKey) *tcell.EventKey {
+	// Let the form (text inputs, buttons) handle everything; the page does not
+	// steal keys so the user can type a source/config freely.
+	return event
+}
+
+// buildSourceForm builds the phase-1 form: a single source input + Resolve button.
+func (p *ModulePage) buildSourceForm() {
+	p.form.Clear(true)
+	p.form.AddInputField("Source", p.source, 40, nil, func(text string) {
+		p.mu.Lock()
+		p.source = text
+		p.mu.Unlock()
+	})
+	p.form.AddButton("Resolve", func() { p.doResolve() })
+	p.form.AddButton("Reset", func() { p.reset() })
+}
+
+// buildConfigForm builds the phase-2 form: one input per config field + Install.
+func (p *ModulePage) buildConfigForm() {
+	p.form.Clear(true)
+	for _, f := range p.resolved.Config {
+		label := f.Name
+		if f.Required && f.Default == "" {
+			label += " *"
+		}
+		p.form.AddInputField(label, f.Default, 40, nil, nil)
+	}
+	p.form.AddButton("Install", func() { p.doInstall() })
+	p.form.AddButton("Back", func() {
+		p.mu.Lock()
+		p.phase = phaseSource
+		p.errMsg = ""
+		p.mu.Unlock()
+		p.buildSourceForm()
+		p.render()
+	})
+}
+
+// collectOverrides reads the current config-form inputs into an overrides map.
+func (p *ModulePage) collectOverrides() map[string]string {
+	overrides := make(map[string]string)
+	for _, f := range p.resolved.Config {
+		label := f.Name
+		if f.Required && f.Default == "" {
+			label += " *"
+		}
+		item := p.form.GetFormItemByLabel(label)
+		input, ok := item.(*tview.InputField)
+		if !ok {
+			continue
+		}
+		val := strings.TrimSpace(input.GetText())
+		if val != "" {
+			overrides[f.Name] = val
+		}
+	}
+	return overrides
+}
+
+// doResolve resolves the source off the UI goroutine, then rebuilds the form
+// with the module's config fields.
+func (p *ModulePage) doResolve() {
+	p.mu.Lock()
+	if p.busy {
+		p.mu.Unlock()
+		return
+	}
+	src := strings.TrimSpace(p.source)
+	if src == "" {
+		p.errMsg = "Enter a module source (catalog name, owner/repo, or git URL)."
+		p.mu.Unlock()
+		p.render()
+		return
+	}
+	p.busy = true
+	p.busyMsg = "Resolving source (cloning/updating the module repo)..."
+	p.errMsg = ""
+	p.message = ""
+	p.mu.Unlock()
+	p.render()
+
+	go func() {
+		var res ModuleResolveResult
+		var err error
+		if p.cb.Resolve != nil {
+			res, err = p.cb.Resolve(src)
+		} else {
+			err = fmt.Errorf("module install is not available")
+		}
+
+		p.mu.Lock()
+		p.busy = false
+		p.busyMsg = ""
+		if err != nil {
+			p.errMsg = err.Error()
+			p.mu.Unlock()
+			p.queueRender()
+			return
+		}
+		p.resolved = res
+		p.phase = phaseConfig
+		p.mu.Unlock()
+
+		if p.app != nil {
+			p.app.QueueUpdateDraw(func() {
+				p.buildConfigForm()
+				p.render()
+			})
+		}
+	}()
+}
+
+// doInstall collects config and runs the install off the UI goroutine.
+func (p *ModulePage) doInstall() {
+	p.mu.Lock()
+	if p.busy {
+		p.mu.Unlock()
+		return
+	}
+	src := p.source
+	overrides := p.collectOverrides()
+
+	// Validate that every required field with no default has a value.
+	var missing []string
+	for _, f := range p.resolved.Config {
+		if f.Required && f.Default == "" {
+			if _, ok := overrides[f.Name]; !ok {
+				missing = append(missing, f.Name)
+			}
+		}
+	}
+	if len(missing) > 0 {
+		p.errMsg = "Missing required config: " + strings.Join(missing, ", ")
+		p.mu.Unlock()
+		p.render()
+		return
+	}
+
+	p.busy = true
+	p.busyMsg = "Installing module..."
+	p.errMsg = ""
+	p.mu.Unlock()
+	p.render()
+
+	go func() {
+		var name string
+		var err error
+		if p.cb.Install != nil {
+			name, err = p.cb.Install(src, overrides)
+		} else {
+			err = fmt.Errorf("module install is not available")
+		}
+
+		p.mu.Lock()
+		p.busy = false
+		p.busyMsg = ""
+		if err != nil {
+			p.errMsg = err.Error()
+		} else {
+			p.phase = phaseDone
+			p.message = fmt.Sprintf("Installed %s. Start it with: citadel run %s", name, name)
+		}
+		p.mu.Unlock()
+		p.queueRender()
+	}()
+}
+
+// reset returns the flow to phase 1.
+func (p *ModulePage) reset() {
+	p.mu.Lock()
+	p.phase = phaseSource
+	p.source = ""
+	p.resolved = ModuleResolveResult{}
+	p.errMsg = ""
+	p.message = ""
+	p.mu.Unlock()
+	p.buildSourceForm()
+	p.render()
+}
+
+// queueRender redraws on the UI goroutine if the page is live.
+func (p *ModulePage) queueRender() {
+	if p.app == nil {
+		return
+	}
+	p.app.QueueUpdateDraw(func() { p.render() })
+}
+
+// render redraws the status pane from current state.
+func (p *ModulePage) render() {
+	if p.status == nil {
+		return
+	}
+	p.mu.Lock()
+	phase := p.phase
+	res := p.resolved
+	busy := p.busy
+	busyMsg := p.busyMsg
+	message := p.message
+	errMsg := p.errMsg
+	p.mu.Unlock()
+
+	var sb strings.Builder
+	sb.WriteString("\n [yellow::b]Install a service module[-:-:-]\n\n")
+	sb.WriteString(" Install a module from any standardized repo.\n")
+	sb.WriteString(" [gray]A module repo self-describes via citadel/service.yaml[-]\n")
+	sb.WriteString(" [gray]+ citadel/compose.yml. Sources:[-]\n")
+	sb.WriteString("   [aqua]vllm[-]                  [gray]catalog name[-]\n")
+	sb.WriteString("   [aqua]owner/repo[-]            [gray]GitHub shorthand[-]\n")
+	sb.WriteString("   [aqua]owner/repo@v1.2.0[-]     [gray]pinned ref[-]\n")
+	sb.WriteString("   [aqua]https://git…/repo.git[-] [gray]full git URL[-]\n\n")
+	sb.WriteString(" [gray]Private repos need this node to have git[-]\n")
+	sb.WriteString(" [gray]credentials (GITHUB_TOKEN / SSH key / helper).[-]\n")
+
+	if phase == phaseConfig && res.Name != "" {
+		sb.WriteString("\n [white::b]Resolved[-:-:-]\n")
+		sb.WriteString(fmt.Sprintf("   Name:  [aqua]%s[-]\n", res.Name))
+		if res.Image != "" {
+			sb.WriteString(fmt.Sprintf("   Image: [aqua]%s[-]\n", res.Image))
+		}
+		if len(res.Config) > 0 {
+			sb.WriteString("   [gray]Fill the config fields, then Install.[-]\n")
+			sb.WriteString("   [gray]* = required[-]\n")
+		} else {
+			sb.WriteString("   [gray]No config required. Press Install.[-]\n")
+		}
+	}
+
+	if busy {
+		sb.WriteString(fmt.Sprintf("\n   [yellow]⏳ %s[-]\n", tview.Escape(busyMsg)))
+	}
+	if message != "" && !busy {
+		sb.WriteString(fmt.Sprintf("\n   [green]%s[-]\n", tview.Escape(message)))
+	}
+	if errMsg != "" && !busy {
+		sb.WriteString(fmt.Sprintf("\n   [red]%s[-]\n", tview.Escape(errMsg)))
+	}
+
+	p.status.SetText(sb.String())
+}

--- a/internal/tui/controlcenter/module_page.go
+++ b/internal/tui/controlcenter/module_page.go
@@ -19,27 +19,43 @@ type ConfigField struct {
 	Required    bool
 }
 
+// ModuleRisk is a single compose risk finding surfaced to the TUI (mapped from
+// catalog.ComposeRisk in the cmd layer so this page imports no catalog internals).
+type ModuleRisk struct {
+	Critical  bool // true = Critical severity, false = High
+	Directive string
+	Detail    string
+}
+
 // ModuleResolveResult is what Resolve returns: the resolved module name, the
-// container image (from the module's own compose, display-only), and the list of
-// config fields the form should collect.
+// container image (display-only), the config fields the form should collect, the
+// trust state of the source, and the compose risk findings.
 type ModuleResolveResult struct {
-	Name   string
-	Image  string
-	Config []ConfigField
+	Name            string
+	Image           string
+	Config          []ConfigField
+	Trusted         bool
+	Risks           []ModuleRisk
+	HasCriticalRisk bool
 }
 
 // ModuleInstallCallbacks holds the hooks for the "Install module" page. They are
 // wired from cmd so the page stays free of catalog/network/docker imports.
 //
 // Resolve clones/updates the source repo (or loads a catalog name) and returns
-// the module name + required config; it may block on the network, so the page
-// calls it off the UI goroutine. Install performs the actual install with the
-// collected config passed as overrides (the non-interactive installer path, so
-// no stdin is read).
+// the module name + required config + trust/risk info; it may block on the
+// network, so the page calls it off the UI goroutine. Install performs the actual
+// install with the collected config passed as overrides (the non-interactive
+// installer path, so no stdin is read). allowPrivileged must be true for the
+// install to proceed when the compose has a Critical risk; the page only sets it
+// when the user explicitly opts in.
 type ModuleInstallCallbacks struct {
 	Resolve func(source string) (ModuleResolveResult, error)
-	Install func(source string, overrides map[string]string) (installedName string, err error)
+	Install func(source string, overrides map[string]string, allowPrivileged bool) (installedName string, err error)
 }
+
+// allowPrivilegedLabel is the form checkbox shown when a Critical risk is found.
+const allowPrivilegedLabel = "Allow privileged (root-equivalent) access"
 
 // modulePhase tracks the two-phase form flow.
 type modulePhase int
@@ -147,6 +163,11 @@ func (p *ModulePage) buildConfigForm() {
 			label += " *"
 		}
 		p.form.AddInputField(label, f.Default, 40, nil, nil)
+	}
+	// When the compose has a Critical risk, the user must explicitly opt in to a
+	// privileged install; this checkbox is the TUI equivalent of --allow-privileged.
+	if p.resolved.HasCriticalRisk {
+		p.form.AddCheckbox(allowPrivilegedLabel, false, nil)
 	}
 	p.form.AddButton("Install", func() { p.doInstall() })
 	p.form.AddButton("Back", func() {
@@ -259,6 +280,23 @@ func (p *ModulePage) doInstall() {
 		return
 	}
 
+	// Read the privileged opt-in checkbox (only present when HasCriticalRisk).
+	allowPrivileged := false
+	if p.resolved.HasCriticalRisk {
+		if cb, ok := p.form.GetFormItemByLabel(allowPrivilegedLabel).(*tview.Checkbox); ok {
+			allowPrivileged = cb.IsChecked()
+		}
+		// Pre-gate in the UI: a Critical risk without the opt-in must not even
+		// attempt the install (the core also refuses -- belt and suspenders).
+		if !allowPrivileged {
+			p.errMsg = "This module requests privileged/root-equivalent access. Check '" +
+				allowPrivilegedLabel + "' to proceed, or pick a different module."
+			p.mu.Unlock()
+			p.render()
+			return
+		}
+	}
+
 	p.busy = true
 	p.busyMsg = "Installing module..."
 	p.errMsg = ""
@@ -269,7 +307,7 @@ func (p *ModulePage) doInstall() {
 		var name string
 		var err error
 		if p.cb.Install != nil {
-			name, err = p.cb.Install(src, overrides)
+			name, err = p.cb.Install(src, overrides, allowPrivileged)
 		} else {
 			err = fmt.Errorf("module install is not available")
 		}
@@ -341,11 +379,36 @@ func (p *ModulePage) render() {
 		if res.Image != "" {
 			sb.WriteString(fmt.Sprintf("   Image: [aqua]%s[-]\n", res.Image))
 		}
+
+		// Trust banner.
+		if res.Trusted {
+			sb.WriteString("   Source: [green]✓ trusted[-]\n")
+		} else {
+			sb.WriteString("   Source: [yellow]⚠ UNTRUSTED[-]\n")
+			sb.WriteString("   [yellow]Installs & runs an arbitrary container with[-]\n")
+			sb.WriteString("   [yellow]Docker-level (host root) access on this node.[-]\n")
+		}
+
+		// Risk findings.
+		if len(res.Risks) > 0 {
+			sb.WriteString("\n   [white::b]Compose risks[-:-:-]\n")
+			for _, r := range res.Risks {
+				if r.Critical {
+					sb.WriteString(fmt.Sprintf("   [red]CRITICAL[-] %s\n", tview.Escape(r.Directive)))
+				} else {
+					sb.WriteString(fmt.Sprintf("   [yellow]HIGH[-] %s\n", tview.Escape(r.Directive)))
+				}
+			}
+			if res.HasCriticalRisk {
+				sb.WriteString(fmt.Sprintf("   [red]Check '%s' to proceed.[-]\n", allowPrivilegedLabel))
+			}
+		}
+
 		if len(res.Config) > 0 {
-			sb.WriteString("   [gray]Fill the config fields, then Install.[-]\n")
+			sb.WriteString("\n   [gray]Fill the config fields, then Install.[-]\n")
 			sb.WriteString("   [gray]* = required[-]\n")
 		} else {
-			sb.WriteString("   [gray]No config required. Press Install.[-]\n")
+			sb.WriteString("\n   [gray]No config required. Press Install.[-]\n")
 		}
 	}
 


### PR DESCRIPTION
## Context

Today a Citadel service module can only be installed from the central `aceteam-ai/citadel-services` catalog. This PR adds a generic **module source** mechanism so a module can be installed from **any standardized git repo**, via both the CLI and the TUI control center.

A module repo self-describes via a top-level `citadel/` directory containing `service.yaml` + `compose.yml`, with the compose `image:` pointing at that repo's own container registry. The CLI never hardcodes or rewrites a module's image — the module repo owns it.

## The mechanism

A "source" is one of:

| Form | Example | Resolves to |
|------|---------|-------------|
| catalog name | `vllm` | central catalog (existing path) |
| `owner/repo` | `owner/repo` | `https://github.com/owner/repo.git` |
| `owner/repo@ref` | `owner/repo@v1.2.0`, `owner/repo@<sha>` | clone + checkout tag/branch/**SHA** |
| full git URL | `https://git.example/m.git`, `git@host:owner/repo.git` | cloned directly |

External sources are shallow-cloned into a per-source cache under `ConfigDir()/modules/<owner-repo[@ref]>/` (mirroring `catalog.Update()`'s clone/pull style). The manifest is located at `citadel/service.yaml` (preferred) or `service.yaml` (fallback); compose at `citadel/compose.yml` then `compose.yml`.

### Private-repo credentials caveat

Cloning a **private** source repo requires the node to have git credentials. The clone-failure error now names the host (e.g. `github.com`) and the concrete fixes: a `GITHUB_TOKEN` env var, an SSH key for that host, or a git credential helper (`git credential-store` / `gh auth login`). Public repos work for everyone; private repos work only for nodes with credentials.

## New command surface

```
citadel module install <source> [--set KEY=VALUE ...] [--yes]
citadel module list
citadel module info <source>
```

`citadel module` is a new **top-level** group — deliberately NOT under `citadel service install` (the systemd service-install command) nor `citadel service catalog`. Catalog-name sources delegate to the existing catalog install flow (so host-provisioned / wechat guidance does not diverge).

## Routing tags — third-party engines become routable with no CLI change

`service.yaml` gains a `node_tags` field: namespaced `key:value` routing tags (e.g. `engine:tei`, `task:embedding`, `model:gte-multilingual-base`). On install these are merged into the node manifest's `node.tags` (deduped), which is how Citadel's capability-based queue routing picks them up. This means a third-party engine module (e.g. a TEI embedding service) declares its own routing tags and becomes routable **without** editing the CLI's hardcoded tag map. `node_tags` is distinct from the existing display/search `tags`; the hardcoded `serviceTags` map is kept intact for embedded/catalog services.

## Provenance + lockfile (reproducible, tamper-evident nodes)

After a successful resolve+install, a per-module entry is recorded into `ConfigDir()/modules.lock` (YAML): `name`, normalized `source`, requested `ref`, resolved git `commit` (`git rev-parse HEAD`), and the image reference(s) parsed from the compose, each with a **best-effort** `sha256:` digest (via `docker image inspect` / `docker manifest inspect`, time-bounded to ~3s, omitted on any failure — never fails the install). `citadel module list` merges this with the node manifest to show `MODULE  SOURCE@commit  IMAGE[@digest]`; services without a lockfile entry (catalog/embedded) still appear. The non-`--yes` pre-install prompt now prints the resolved **commit + image(s)** so it is a real TOFU/provenance confirmation.

## Conflict detection on install

In addition to the existing host-port conflict check, `InstallFromManifest` now parses `container_name:` from the resolved compose and refuses the install if a container with that name already exists and is not this module (a same-module reinstall is already blocked upstream by the manifest `hasService` check), pointing at the `docker rm -f` / compose-override escape hatch. Best-effort: skipped silently if docker is unavailable. Note: this now also applies to catalog installs (consistent, low-risk behavior change).

## Schema versioning

`service.yaml` gains `schema_version` (int). A value newer than the CLI's `CurrentSchemaVersion` (1) prints a forward-compat **warning** (some fields may be ignored) but never fails — older CLIs degrade gracefully against future modules. The warning is computed by a pure `SchemaWarning()` and printed from the cmd layer (the catalog package stays import-clean).

## `requires` preflight

GPU / VRAM / arch requirements declared in the manifest are enforced for module installs via the shared `InstallFromManifest` checks (arch mismatch and missing-GPU are hard errors) — the same path catalog installs use. No new code needed here.

## TUI

A new "Install Module" page in the control center (wired only when callbacks are injected from cmd, like the WhatsApp page). Two-phase `tview.Form`: type a source → Resolve (clones off the UI goroutine) → fill required config → Install. All config is collected up front and passed as overrides, so the **non-interactive** installer path is used — the TUI never reads `os.Stdin`. The TUI path has full parity with the CLI: already-installed guard, `node_tags` merge, and lockfile provenance recording.

## Implementation notes

- `Install()` refactored into `InstallFromManifest(manifest, composeSrcPath, servicesDir, overrides, interactive)`. The old `Install(name, ...)` signature is unchanged (thin wrapper → loads from cache → `interactive=true`). `resolveConfig` only prompts on stdin when `interactive==true`; otherwise a required var with no override/default is a returned error. Empty `composeSrcPath` → `ErrNotInstallable` (preserves the host-provisioned wechat case).
- `ResolveSource` returns a `ResolvedModule{Manifest, ComposePath, CacheDir, Commit, Images}` struct.
- Pure decision logic (`looksLikeSHA`, `pickCloneStrategy`, `parseComposeImages`, `parseComposeContainerName`, `cloneErrorHost`, `SchemaWarning`) is split out and table-tested with no network.

## Files

- `internal/catalog/source.go` — `ParseSource`, `ResolveSource`, clone/update (incl. SHA fetch+checkout), pure decision helpers, schema warning
- `internal/catalog/lockfile.go` (new) — `modules.lock` load/upsert, best-effort image digest, container-name conflict check
- `internal/catalog/source_test.go` — table-driven tests (ParseSource, SHA/strategy detection, compose parsing, host extraction, lockfile upsert, schema warning) — no network
- `internal/catalog/catalog.go` — `NodeTags` + `SchemaVersion` fields on `ServiceManifest`, `CurrentSchemaVersion`
- `internal/catalog/install.go` — `InstallFromManifest`, `interactive` flag, container-name conflict check
- `cmd/module.go` — `citadel module` group, provenance recording, `buildModuleInstallCallbacks()`
- `cmd/manifest.go` — `addServiceToManifestWithTags` (wrapper keeps `addServiceToManifest`)
- `internal/tui/controlcenter/module_page.go` (new) — Install Module page + callback types
- `internal/tui/controlcenter/controlcenter.go`, `cmd/controlcenter.go` — wire the page

## Purely additive

No changes to `cmd/whatsapp.go`, `internal/whatsapp/*`, `services/embed.go`, `services/compose/*`, or any `ServiceMap` entry.

## Testing

```
go build ./...        # clean
go vet ./...          # clean
go test ./internal/catalog/...   # PASS
```

Per repo policy, the full `go test ./...` was not run from this environment (tmux/pty suites). Build + vet cover compilation of all packages.

### Manual TUI test (why this is a draft)

1. `citadel dashboard` (control center)
2. Tab to **Install Module**
3. Type a source (e.g. `owner/repo` for a public standardized repo) → **Resolve**
4. Fill any required config fields (`*` = required) → **Install**
5. Confirm success line and that `citadel module list` shows `source@commit` + image

## Trust & safety (install = root-equivalent access)

Installing a module runs `docker compose up` of arbitrary compose, which is root-equivalent (Docker-level) access to the node. Before merge, the install flow gained a trust/safety layer:

**Untrusted-source warning.** External sources are checked against a local allowlist (`citadel module trust <pattern>` → `ConfigDir()/trusted_sources.yaml`). A non-trusted source prints a prominent warning that the install runs an arbitrary container with host-root-equivalent access. Patterns: exact `owner/repo`, `owner/*`, or a bare host (`github.com`). Catalog sources are **Tier 0** (first-party, always trusted, never scanned/gated). Trust suppresses the warning **only** — it does not relax the privilege gate.

**Compose risk-scan** (`internal/catalog/risk.go`, pure + table-tested). The resolved compose is scanned for dangerous directives:
- **Critical:** `privileged: true`; a `/var/run/docker.sock` (or `/run/docker.sock`) bind mount; `cap_add` containing `ALL` or `SYS_ADMIN`.
- **High:** `network_mode: host`, `pid: host`, `ipc: host`; host bind-mounts of sensitive paths (`/`, `/etc`, `/root`, `/var/run`, `/home`, `~`, …, boundary-aware so `/etcetera` ≠ `/etc`, named volumes excluded); any `devices:` host-device passthrough.

Findings are shown at install time (Critical red, High yellow) in both the CLI and the TUI form.

**Privilege gate — `--yes` vs `--allow-privileged`.** The gate lives in the shared core (`InstallFromManifest`), so CLI and TUI are protected identically:

| Critical risk? | `--allow-privileged` | `--yes` | Result |
|---|---|---|---|
| yes | no | any | **REFUSED** (names the critical directives + how to override), even under `--yes` |
| yes | yes | no | warning + findings, ordinary `[y/N]` prompt |
| yes | yes | yes | proceeds |
| no | — | no | warning (if untrusted) + High findings, ordinary `[y/N]` prompt |
| no | — | yes | proceeds |

`--yes` bypasses only the ordinary confirmation prompt; it does **not** bypass a Critical finding. Trusted + non-critical + no `--yes` still prompts (trust silences the scary banner, not the confirmation). The TUI equivalent of `--allow-privileged` is an explicit "Allow privileged (root-equivalent) access" checkbox that only appears when a Critical risk is present; the non-interactive TUI install path hard-fails on Critical-without-opt-in (no silent privileged install, no stdin). The core gate fails **closed**: if the compose can't be read for the scan, the install is refused rather than proceeding. Catalog (Tier-0) installs pass `allowPrivileged=true` and are exempt (they have no override flag) — on both CLI and TUI.

**`citadel module trust` surface:**
```
citadel module trust <pattern>      # add owner/repo | owner/* | host to the allowlist
citadel module untrust <pattern>    # remove a pattern
citadel module trust --list         # list patterns
citadel module trusted              # list patterns
```

**Git-ref injection guard.** A source ref is passed positionally to `git clone --branch` / `git fetch origin <ref>`, so a value beginning with `-` (or containing whitespace/control chars) is rejected (`validateRef`) to prevent git-argument injection (e.g. `--upload-pack=…`).

New files: `internal/catalog/risk.go` (+ `risk_test.go`), `internal/catalog/trust.go` (+ `trust_test.go`), `cmd/module_trust.go`. `InstallFromManifest` gained an `allowPrivileged` parameter (legacy `Install` wrapper passes `true`).

## Deferred (explicit follow-ups)

- Cosign/sigstore signature verification + verified-publisher allowlist.
- Semver / channel resolution (`@^1.2`, `@stable`).
- `module update` / `module list --outdated` / cache GC / auto-rollback on failed `health_check`.
- Central index repo + `citadel module search` discovery.

*Generated by Claude*

