### PR TITLE
feat(module): cosign signature verification + curated index/search

### DIFF
--- a/cmd/module.go
+++ b/cmd/module.go
@@ -164,6 +164,22 @@ func runModuleInstall(cmd *cobra.Command, args []string) error {
 			manifest.Name, strings.Join(crit, ", "))
 	}
 
+	// Signature gate: if the matched trust entry is a verified publisher that
+	// requires a signature, verify the image (by digest) with cosign BEFORE
+	// install. This is a hard gate -- not bypassable by --yes -- and a no-op when
+	// no signature is required (unsigned community modules still install under the
+	// risk/consent gate above). Build the same lock images we'd record so we
+	// verify exactly the digests we pin.
+	lockImages := catalog.BuildLockImages(resolved.Images)
+	verifyResult, err := catalog.VerifyModule(src, lockImages)
+	if err != nil {
+		return err
+	}
+	if verifyResult.Verified {
+		fmt.Printf("  %s %s\n", color.GreenString("✓ signature verified"), color.New(color.Faint).Sprint(verifyResult.Image))
+		lockImages = markLockImagesVerified(lockImages)
+	}
+
 	if !moduleInstallYes {
 		fmt.Print("\nProceed with install? [y/N]: ")
 		if !confirmYes() {
@@ -196,8 +212,9 @@ func runModuleInstall(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to update manifest: %w", err)
 	}
 
-	// Record provenance into the lockfile (best-effort: never fail the install).
-	recordModuleLock(src, resolved)
+	// Record provenance into the lockfile (best-effort: never fail the install),
+	// carrying the verified-signature flag computed above.
+	recordModuleLock(src, resolved, lockImages)
 
 	fmt.Printf("\nInstalled %s successfully.\n", result.Name)
 	fmt.Printf("  Compose: %s\n", result.ComposeDestPath)
@@ -214,18 +231,34 @@ func runModuleInstall(cmd *cobra.Command, args []string) error {
 
 // recordModuleLock upserts a provenance entry for a freshly resolved+installed
 // module into modules.lock. Best-effort: any failure is reported to stderr but
-// does not fail the install.
-func recordModuleLock(src catalog.Source, resolved *catalog.ResolvedModule) {
+// does not fail the install. If images is nil it is built from the resolved
+// source; callers that already verified signatures pass the verified-flagged
+// images so the result is recorded.
+func recordModuleLock(src catalog.Source, resolved *catalog.ResolvedModule, images []catalog.LockImage) {
+	if images == nil {
+		images = catalog.BuildLockImages(resolved.Images)
+	}
 	entry := catalog.LockEntry{
 		Name:   resolved.Manifest.Name,
 		Source: src.Raw,
 		Ref:    src.Ref,
 		Commit: resolved.Commit,
-		Images: catalog.BuildLockImages(resolved.Images),
+		Images: images,
 	}
 	if err := catalog.UpsertLockEntry(entry); err != nil {
 		fmt.Fprintf(os.Stderr, "  Note: could not record provenance in modules.lock: %v\n", err)
 	}
+}
+
+// markLockImagesVerified returns a copy of images with Verified set on each entry
+// (used after a successful signature verification).
+func markLockImagesVerified(images []catalog.LockImage) []catalog.LockImage {
+	out := make([]catalog.LockImage, len(images))
+	for i, im := range images {
+		im.Verified = true
+		out[i] = im
+	}
+	return out
 }
 
 // runModuleList prints the modules registered in the node manifest, merged with
@@ -614,6 +647,21 @@ func buildModuleInstallCallbacks() controlcenter.ModuleInstallCallbacks {
 			}
 			servicesDir := filepath.Join(configDir, "services")
 
+			// Signature gate (shared core): refuse before install if the matched
+			// trust entry is a verified publisher requiring a signature. No-op for
+			// sources without a signature requirement (incl. catalog/Tier 0).
+			var lockImages []catalog.LockImage
+			if resolved != nil {
+				lockImages = catalog.BuildLockImages(resolved.Images)
+			}
+			verifyResult, verr := catalog.VerifyModule(src, lockImages)
+			if verr != nil {
+				return "", verr
+			}
+			if verifyResult.Verified {
+				lockImages = markLockImagesVerified(lockImages)
+			}
+
 			// interactive=false: the TUI supplies all required config as
 			// overrides, so a missing required var is an error, never a stdin read.
 			// allowPrivileged is the user's explicit opt-in from the form; the
@@ -634,7 +682,7 @@ func buildModuleInstallCallbacks() controlcenter.ModuleInstallCallbacks {
 			}
 			// Record provenance for external sources (best-effort).
 			if resolved != nil {
-				recordModuleLock(src, resolved)
+				recordModuleLock(src, resolved, lockImages)
 			}
 			return result.Name, nil
 		},

--- a/cmd/module.go
+++ b/cmd/module.go
@@ -314,15 +314,18 @@ func formatLockImages(images []catalog.LockImage) string {
 	}
 	var parts []string
 	for _, im := range images {
+		part := im.Ref
 		if im.Digest != "" {
 			d := im.Digest
 			if len(d) > 19 { // "sha256:" + 12 hex
 				d = d[:19]
 			}
-			parts = append(parts, fmt.Sprintf("%s@%s", im.Ref, d))
-		} else {
-			parts = append(parts, im.Ref)
+			part = fmt.Sprintf("%s@%s", im.Ref, d)
 		}
+		if im.Verified {
+			part += " " + color.GreenString("✓verified")
+		}
+		parts = append(parts, part)
 	}
 	return strings.Join(parts, ", ")
 }

--- a/cmd/module_search.go
+++ b/cmd/module_search.go
@@ -1,0 +1,88 @@
+// cmd/module_search.go
+//
+// `citadel module search <query>` searches the curated central index (#347) and
+// prints matching modules with their source and current trust state. The index
+// is a YAML file (index.yaml at the catalog repo root, or CITADEL_MODULE_INDEX)
+// mapping a module name to a source repo, description, and tags.
+//
+// Curated entries inform the trusted tier: a curated source is a candidate
+// verified publisher, so each result shows whether it is already trusted (cross-
+// referenced against the local allowlist via catalog.IsTrusted). The command
+// fails soft -- if no index is published yet it prints a friendly hint rather
+// than erroring.
+//
+// Registered in this file's own init() to minimize merge conflicts.
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/aceteam-ai/citadel-cli/internal/catalog"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+var moduleSearchCmd = &cobra.Command{
+	Use:   "search [query]",
+	Short: "Search the curated module index by name, description, or tag",
+	Long: `Search the curated central index for installable modules.
+
+The index maps module names to source repos, descriptions, and tags. Results
+show the install source and whether that source is already trusted on this node
+(see 'citadel module trust'). Install a result with:
+
+  citadel module install <source>
+
+If no index has been published yet (or the catalog has not been cloned), this
+prints a friendly hint instead of an error. Run 'citadel service catalog update'
+to fetch the latest catalog (which carries the index).`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runModuleSearch,
+}
+
+func init() {
+	moduleCmd.AddCommand(moduleSearchCmd)
+}
+
+// runModuleSearch loads the curated index, matches the query, and prints results
+// with source + trust state.
+func runModuleSearch(cmd *cobra.Command, args []string) error {
+	query := ""
+	if len(args) == 1 {
+		query = args[0]
+	}
+
+	idx, err := catalog.LoadModuleIndex()
+	if err != nil {
+		return err
+	}
+	if len(idx.Modules) == 0 {
+		fmt.Println("No curated module index is available yet.")
+		fmt.Println("  Run 'citadel service catalog update' to fetch the latest catalog (which carries the index),")
+		fmt.Println("  or install a module directly: citadel module install <owner/repo | git URL>.")
+		return nil
+	}
+
+	results := catalog.SearchModuleIndex(idx, query)
+	if len(results) == 0 {
+		fmt.Printf("No modules matching '%s' in the curated index.\n", query)
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	defer w.Flush()
+	color.New(color.Bold).Fprintf(w, "MODULE\tSOURCE\tTRUST\tDESCRIPTION\n")
+	for _, e := range results {
+		trust := color.New(color.FgWhite).Sprint("untrusted")
+		// A curated entry is a candidate publisher; cross-reference the local
+		// allowlist so the operator sees what is already trusted vs. what would
+		// trigger the untrusted-source warning at install time.
+		if src, perr := catalog.ParseSource(e.Source); perr == nil && catalog.IsTrusted(src) {
+			trust = color.New(color.FgGreen).Sprint("trusted")
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", e.Name, e.Source, trust, truncate(e.Description, 50))
+	}
+	return nil
+}

--- a/cmd/module_trust.go
+++ b/cmd/module_trust.go
@@ -72,7 +72,13 @@ func init() {
 
 // runModuleTrust adds a pattern to the allowlist, or lists patterns with --list.
 func runModuleTrust(cmd *cobra.Command, args []string) error {
+	sigFlagsSet := moduleTrustRequireSig || moduleTrustIdentity != "" || moduleTrustIssuer != "" || moduleTrustKey != ""
 	if moduleTrustList || len(args) == 0 {
+		// Don't silently swallow signature flags when the pattern is missing --
+		// for a security feature, a silent misconfig is the worst failure mode.
+		if sigFlagsSet {
+			return fmt.Errorf("a pattern is required to configure a verified publisher: citadel module trust <owner/repo | owner/* | host> [--require-signature] [--identity ... --issuer ... | --key ...]")
+		}
 		return runModuleTrustedList(cmd, nil)
 	}
 	pattern := args[0]
@@ -80,7 +86,7 @@ func runModuleTrust(cmd *cobra.Command, args []string) error {
 	// Verified-publisher path: when any signature-related flag is set, store a
 	// publisher entry (a key/identity, optionally requiring a signature) instead
 	// of (in addition to) a plain trust pattern.
-	if moduleTrustRequireSig || moduleTrustIdentity != "" || moduleTrustIssuer != "" || moduleTrustKey != "" {
+	if sigFlagsSet {
 		if moduleTrustKey == "" && moduleTrustIdentity == "" {
 			return fmt.Errorf("a verified publisher needs a signing identity or key: pass --identity (with --issuer) or --key")
 		}

--- a/cmd/module_trust.go
+++ b/cmd/module_trust.go
@@ -25,7 +25,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var moduleTrustList bool
+var (
+	moduleTrustList       bool
+	moduleTrustRequireSig bool
+	moduleTrustIdentity   string
+	moduleTrustIssuer     string
+	moduleTrustKey        string
+)
 
 var moduleTrustCmd = &cobra.Command{
 	Use:   "trust [pattern]",
@@ -54,6 +60,14 @@ func init() {
 	moduleCmd.AddCommand(moduleTrustedCmd)
 
 	moduleTrustCmd.Flags().BoolVar(&moduleTrustList, "list", false, "List the trusted-source patterns instead of adding one.")
+	moduleTrustCmd.Flags().BoolVar(&moduleTrustRequireSig, "require-signature", false,
+		"Mark this source as a verified publisher and require a valid cosign image signature at install time.")
+	moduleTrustCmd.Flags().StringVar(&moduleTrustIdentity, "identity", "",
+		"Expected keyless cosign signing identity (e.g. an email or GitHub Actions workflow URI).")
+	moduleTrustCmd.Flags().StringVar(&moduleTrustIssuer, "issuer", "",
+		"Expected keyless cosign OIDC issuer (e.g. https://token.actions.githubusercontent.com). Used with --identity.")
+	moduleTrustCmd.Flags().StringVar(&moduleTrustKey, "key", "",
+		"Path/URL/KMS URI to a cosign public key for keyful signature verification.")
 }
 
 // runModuleTrust adds a pattern to the allowlist, or lists patterns with --list.
@@ -62,6 +76,42 @@ func runModuleTrust(cmd *cobra.Command, args []string) error {
 		return runModuleTrustedList(cmd, nil)
 	}
 	pattern := args[0]
+
+	// Verified-publisher path: when any signature-related flag is set, store a
+	// publisher entry (a key/identity, optionally requiring a signature) instead
+	// of (in addition to) a plain trust pattern.
+	if moduleTrustRequireSig || moduleTrustIdentity != "" || moduleTrustIssuer != "" || moduleTrustKey != "" {
+		if moduleTrustKey == "" && moduleTrustIdentity == "" {
+			return fmt.Errorf("a verified publisher needs a signing identity or key: pass --identity (with --issuer) or --key")
+		}
+		if moduleTrustKey == "" && moduleTrustIssuer == "" {
+			return fmt.Errorf("keyless verification needs an issuer: pass --issuer with --identity (or use --key)")
+		}
+		pub := catalog.VerifiedPublisher{
+			Pattern:          pattern,
+			RequireSignature: moduleTrustRequireSig,
+			Identity:         moduleTrustIdentity,
+			Issuer:           moduleTrustIssuer,
+			Key:              moduleTrustKey,
+		}
+		if err := catalog.SetVerifiedPublisher(pub); err != nil {
+			return fmt.Errorf("failed to set verified publisher '%s': %w", pattern, err)
+		}
+		fmt.Printf("Trusted verified publisher: %s\n", color.CyanString(pattern))
+		if pub.Key != "" {
+			fmt.Printf("  Verification: keyful (key %s)\n", pub.Key)
+		} else {
+			fmt.Printf("  Verification: keyless (identity %s, issuer %s)\n", pub.Identity, pub.Issuer)
+		}
+		if pub.RequireSignature {
+			fmt.Println(color.YellowString("  Signature REQUIRED at install (cosign must verify the image)."))
+		} else {
+			fmt.Println("  Signature optional (recorded, but install is not gated).")
+		}
+		fmt.Printf("  (stored in %s)\n", catalog.TrustedSourcesPath())
+		return nil
+	}
+
 	if err := catalog.AddTrustedSource(pattern); err != nil {
 		return fmt.Errorf("failed to trust '%s': %w", pattern, err)
 	}
@@ -91,11 +141,37 @@ func runModuleTrustedList(cmd *cobra.Command, args []string) error {
 		fmt.Println("Add one with: citadel module trust <owner/repo | owner/* | host>")
 		return nil
 	}
+	// Index publishers by pattern so each pattern row can show its verification.
+	pubByPattern := make(map[string]catalog.VerifiedPublisher, len(ts.Publishers))
+	for _, pub := range ts.Publishers {
+		pubByPattern[pub.Pattern] = pub
+	}
+
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	defer w.Flush()
-	color.New(color.Bold).Fprintf(w, "TRUSTED PATTERN\n")
+	color.New(color.Bold).Fprintf(w, "TRUSTED PATTERN\tVERIFICATION\n")
 	for _, p := range ts.Patterns {
-		fmt.Fprintf(w, "%s\n", p)
+		verification := "-"
+		if pub, ok := pubByPattern[p]; ok {
+			verification = describePublisher(pub)
+		}
+		fmt.Fprintf(w, "%s\t%s\n", p, verification)
 	}
 	return nil
+}
+
+// describePublisher renders a short verification descriptor for a publisher.
+func describePublisher(pub catalog.VerifiedPublisher) string {
+	var mode string
+	if pub.Key != "" {
+		mode = "keyful"
+	} else if pub.Identity != "" {
+		mode = "keyless (" + pub.Identity + ")"
+	} else {
+		mode = "declared"
+	}
+	if pub.RequireSignature {
+		return mode + ", signature required"
+	}
+	return mode + ", optional"
 }

--- a/internal/catalog/index.go
+++ b/internal/catalog/index.go
@@ -1,0 +1,126 @@
+// internal/catalog/index.go
+//
+// Curated central index for module discovery (#347). The index is a YAML file
+// mapping a module name to its source repo, a description, and tags. It lets
+// `citadel module search <query>` surface community/curated modules that live
+// outside the embedded service catalog.
+//
+// Source: by default the index lives as `index.yaml` at the root of the existing
+// citadel-services catalog repo, reusing the catalog clone/cache machinery
+// (GetCatalogPath / Update). The location is configurable via the
+// CITADEL_MODULE_INDEX env var (a path to a local YAML file).
+//
+// Fail-soft by design: if the catalog has not been cloned, or index.yaml does
+// not exist yet, the index plumbing returns a friendly empty result (never a
+// hard error) so it no-ops gracefully until an index is published.
+package catalog
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ModuleIndexEnv is the env var that overrides the index file location (a path
+// to a local YAML file). When unset, the index is read from index.yaml at the
+// catalog cache root.
+const ModuleIndexEnv = "CITADEL_MODULE_INDEX"
+
+// indexFileName is the curated index file name within the catalog repo root.
+const indexFileName = "index.yaml"
+
+// ModuleIndex is the parsed curated index.
+type ModuleIndex struct {
+	Version int                `yaml:"version"`
+	Modules []ModuleIndexEntry `yaml:"modules"`
+}
+
+// ModuleIndexEntry is one curated module: a display name, the source repo to
+// install from (owner/repo or a git URL), a description, and free-form tags.
+type ModuleIndexEntry struct {
+	Name        string   `yaml:"name"`
+	Source      string   `yaml:"source"`
+	Description string   `yaml:"description"`
+	Tags        []string `yaml:"tags,omitempty"`
+}
+
+// ModuleIndexPath returns the resolved path to the index file: the env override
+// if set, else index.yaml at the catalog cache root.
+func ModuleIndexPath() string {
+	if p := strings.TrimSpace(os.Getenv(ModuleIndexEnv)); p != "" {
+		return p
+	}
+	return filepath.Join(GetCatalogPath(), indexFileName)
+}
+
+// LoadModuleIndex reads and parses the curated index. It fails soft: a missing
+// index file (catalog not cloned, or no index published yet) yields an empty
+// index and a nil error. Only a present-but-malformed index returns an error.
+func LoadModuleIndex() (*ModuleIndex, error) {
+	path := ModuleIndexPath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &ModuleIndex{Version: 1}, nil
+		}
+		return nil, fmt.Errorf("failed to read module index %s: %w", path, err)
+	}
+	idx, err := ParseModuleIndex(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse module index %s: %w", path, err)
+	}
+	return idx, nil
+}
+
+// ParseModuleIndex parses index YAML bytes into a ModuleIndex. Pure --
+// table-tested with literals, no network/IO.
+func ParseModuleIndex(data []byte) (*ModuleIndex, error) {
+	var idx ModuleIndex
+	if err := yaml.Unmarshal(data, &idx); err != nil {
+		return nil, err
+	}
+	if idx.Version == 0 {
+		idx.Version = 1
+	}
+	return &idx, nil
+}
+
+// SearchModuleIndex returns the index entries matching query (case-insensitive)
+// against name, description, and tags. An empty query returns all entries. Pure
+// -- table-tested.
+func SearchModuleIndex(idx *ModuleIndex, query string) []ModuleIndexEntry {
+	if idx == nil {
+		return nil
+	}
+	q := strings.ToLower(strings.TrimSpace(query))
+	var out []ModuleIndexEntry
+	for _, e := range idx.Modules {
+		if q == "" || moduleIndexMatches(e, q) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// moduleIndexMatches reports whether entry matches an already-lowercased query.
+// Pure -- table-tested.
+func moduleIndexMatches(e ModuleIndexEntry, q string) bool {
+	if strings.Contains(strings.ToLower(e.Name), q) {
+		return true
+	}
+	if strings.Contains(strings.ToLower(e.Description), q) {
+		return true
+	}
+	if strings.Contains(strings.ToLower(e.Source), q) {
+		return true
+	}
+	for _, t := range e.Tags {
+		if strings.Contains(strings.ToLower(t), q) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/catalog/index_test.go
+++ b/internal/catalog/index_test.go
@@ -1,0 +1,125 @@
+package catalog
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const sampleIndex = `
+version: 1
+modules:
+  - name: whisper
+    source: acme/whisper
+    description: Speech-to-text inference service
+    tags: [audio, asr, gpu]
+  - name: bge-embed
+    source: other/bge
+    description: Text embedding engine
+    tags: [embedding, nlp]
+  - name: plainsource
+    source: https://git.example.com/x/y.git
+    description: A module with no tags
+`
+
+func TestParseModuleIndex(t *testing.T) {
+	idx, err := ParseModuleIndex([]byte(sampleIndex))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if idx.Version != 1 {
+		t.Errorf("version = %d, want 1", idx.Version)
+	}
+	if len(idx.Modules) != 3 {
+		t.Fatalf("got %d modules, want 3", len(idx.Modules))
+	}
+	if idx.Modules[0].Name != "whisper" || idx.Modules[0].Source != "acme/whisper" {
+		t.Errorf("unexpected first entry: %+v", idx.Modules[0])
+	}
+}
+
+func TestParseModuleIndex_DefaultsVersion(t *testing.T) {
+	idx, err := ParseModuleIndex([]byte("modules: []"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if idx.Version != 1 {
+		t.Errorf("expected version defaulted to 1, got %d", idx.Version)
+	}
+}
+
+func TestSearchModuleIndex(t *testing.T) {
+	idx, _ := ParseModuleIndex([]byte(sampleIndex))
+	tests := []struct {
+		query string
+		want  []string // expected names, in order
+	}{
+		{"whisper", []string{"whisper"}},
+		{"WHISPER", []string{"whisper"}},                      // case-insensitive name
+		{"embedding", []string{"bge-embed"}},                  // tag
+		{"engine", []string{"bge-embed"}},                     // description
+		{"acme", []string{"whisper"}},                         // source substring
+		{"gpu", []string{"whisper"}},                          // tag
+		{"", []string{"whisper", "bge-embed", "plainsource"}}, // empty = all
+		{"nomatch", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			got := SearchModuleIndex(idx, tt.query)
+			if len(got) != len(tt.want) {
+				t.Fatalf("query %q: got %d results, want %d (%v)", tt.query, len(got), len(tt.want), got)
+			}
+			for i, name := range tt.want {
+				if got[i].Name != name {
+					t.Errorf("query %q result[%d] = %q, want %q", tt.query, i, got[i].Name, name)
+				}
+			}
+		})
+	}
+}
+
+func TestSearchModuleIndex_NilSafe(t *testing.T) {
+	if got := SearchModuleIndex(nil, "x"); got != nil {
+		t.Errorf("expected nil for nil index, got %v", got)
+	}
+}
+
+func TestLoadModuleIndex_MissingIsFailSoft(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	// No catalog cloned, no index file -> empty index, nil error.
+	idx, err := LoadModuleIndex()
+	if err != nil {
+		t.Fatalf("expected fail-soft nil error, got %v", err)
+	}
+	if len(idx.Modules) != 0 {
+		t.Errorf("expected empty index, got %d modules", len(idx.Modules))
+	}
+}
+
+func TestLoadModuleIndex_EnvOverride(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "myindex.yaml")
+	if err := os.WriteFile(path, []byte(sampleIndex), 0644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(ModuleIndexEnv, path)
+	idx, err := LoadModuleIndex()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(idx.Modules) != 3 {
+		t.Errorf("expected 3 modules from env-override index, got %d", len(idx.Modules))
+	}
+}
+
+func TestLoadModuleIndex_MalformedErrors(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.yaml")
+	if err := os.WriteFile(path, []byte("modules: [this is : not valid"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(ModuleIndexEnv, path)
+	if _, err := LoadModuleIndex(); err == nil {
+		t.Error("expected error for malformed index")
+	}
+}

--- a/internal/catalog/lockfile.go
+++ b/internal/catalog/lockfile.go
@@ -28,6 +28,10 @@ type LockEntry struct {
 type LockImage struct {
 	Ref    string `yaml:"ref"`
 	Digest string `yaml:"digest,omitempty"` // sha256:... if resolvable, else ""
+	// Verified records that this image's signature was verified by cosign at
+	// install time (against a verified-publisher trust entry). Absent/false means
+	// no signature was required or none was verified.
+	Verified bool `yaml:"verified,omitempty"`
 }
 
 // Lockfile is the top-level modules.lock structure.

--- a/internal/catalog/trust.go
+++ b/internal/catalog/trust.go
@@ -19,6 +19,30 @@ import (
 type TrustedSources struct {
 	Version  int      `yaml:"version"`
 	Patterns []string `yaml:"patterns"`
+	// Publishers is the optional list of "verified publisher" trust entries: a
+	// source pattern plus an expected cosign signing identity/key. A publisher
+	// entry is itself a trust grant (it makes the matching source trusted) and,
+	// when RequireSignature is set, also gates install on a successful signature
+	// verification. Additive: an empty list leaves Patterns-based trust unchanged.
+	Publishers []VerifiedPublisher `yaml:"publishers,omitempty"`
+}
+
+// VerifiedPublisher declares an expected signing identity (or public key) for a
+// source pattern. The Pattern reuses the same matching semantics as Patterns
+// (owner/repo, owner/*, or a bare host -- see matchTrust). When RequireSignature
+// is true, the module's image signature must verify before install.
+type VerifiedPublisher struct {
+	// Pattern is a source pattern (owner/repo, owner/*, or a host).
+	Pattern string `yaml:"pattern"`
+	// RequireSignature gates install on a successful cosign verification.
+	RequireSignature bool `yaml:"require_signature"`
+	// Identity is the expected keyless OIDC identity (e.g. an email or a GitHub
+	// Actions workflow URI). Used with Issuer for keyless verification.
+	Identity string `yaml:"identity,omitempty"`
+	// Issuer is the expected keyless OIDC issuer (e.g. https://token.actions.githubusercontent.com).
+	Issuer string `yaml:"issuer,omitempty"`
+	// Key is a path/URL/KMS URI to a cosign public key for keyful verification.
+	Key string `yaml:"key,omitempty"`
 }
 
 // TrustedSourcesPath returns the path to the trusted-sources allowlist file.
@@ -83,7 +107,8 @@ func AddTrustedSource(pattern string) error {
 	return saveTrustedSources(ts)
 }
 
-// RemoveTrustedSource removes a pattern from the allowlist and persists it.
+// RemoveTrustedSource removes a pattern from the allowlist (both the plain
+// Patterns list and any matching verified-publisher entry) and persists it.
 // Removing a pattern that is not present is a no-op (no error).
 func RemoveTrustedSource(pattern string) error {
 	pattern = strings.TrimSpace(pattern)
@@ -98,7 +123,81 @@ func RemoveTrustedSource(pattern string) error {
 		}
 	}
 	ts.Patterns = out
+
+	pubs := ts.Publishers[:0]
+	for _, pub := range ts.Publishers {
+		if pub.Pattern != pattern {
+			pubs = append(pubs, pub)
+		}
+	}
+	ts.Publishers = pubs
 	return saveTrustedSources(ts)
+}
+
+// SetVerifiedPublisher adds or replaces a verified-publisher entry (keyed by
+// Pattern) and persists it. The pattern is also added to the plain Patterns list
+// so the source counts as trusted even before any verification runs. A blank
+// pattern is rejected.
+func SetVerifiedPublisher(pub VerifiedPublisher) error {
+	pub.Pattern = strings.TrimSpace(pub.Pattern)
+	if pub.Pattern == "" {
+		return fmt.Errorf("empty publisher pattern")
+	}
+	ts, err := LoadTrustedSources()
+	if err != nil {
+		return err
+	}
+	replaced := false
+	for i := range ts.Publishers {
+		if ts.Publishers[i].Pattern == pub.Pattern {
+			ts.Publishers[i] = pub
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		ts.Publishers = append(ts.Publishers, pub)
+	}
+	// Ensure the pattern is also in the plain allowlist (idempotent).
+	hasPattern := false
+	for _, p := range ts.Patterns {
+		if p == pub.Pattern {
+			hasPattern = true
+			break
+		}
+	}
+	if !hasPattern {
+		ts.Patterns = append(ts.Patterns, pub.Pattern)
+		sort.Strings(ts.Patterns)
+	}
+	return saveTrustedSources(ts)
+}
+
+// MatchVerifiedPublisher returns the verified-publisher entry whose pattern
+// matches src, plus true, or a zero value and false if none matches. Catalog
+// (Tier 0) sources never match a publisher entry (they are first-party and
+// exempt from signature gating).
+func MatchVerifiedPublisher(src Source) (VerifiedPublisher, bool) {
+	if src.Kind == KindCatalog {
+		return VerifiedPublisher{}, false
+	}
+	ts, err := LoadTrustedSources()
+	if err != nil {
+		return VerifiedPublisher{}, false
+	}
+	return matchPublisher(ts.Publishers, src)
+}
+
+// matchPublisher is the pure core: returns the first publisher entry whose
+// pattern trusts src (reusing matchTrust's owner/repo, owner/*, host semantics).
+// Table-tested without IO.
+func matchPublisher(pubs []VerifiedPublisher, src Source) (VerifiedPublisher, bool) {
+	for _, pub := range pubs {
+		if matchTrust([]string{pub.Pattern}, src) {
+			return pub, true
+		}
+	}
+	return VerifiedPublisher{}, false
 }
 
 // IsTrusted reports whether a parsed source is trusted. A catalog source
@@ -112,7 +211,12 @@ func IsTrusted(src Source) bool {
 	if err != nil {
 		return false
 	}
-	return matchTrust(ts.Patterns, src)
+	if matchTrust(ts.Patterns, src) {
+		return true
+	}
+	// A verified-publisher entry is itself a trust grant.
+	_, ok := matchPublisher(ts.Publishers, src)
+	return ok
 }
 
 // matchTrust is the pure matching core: reports whether any pattern trusts src.

--- a/internal/catalog/trust_test.go
+++ b/internal/catalog/trust_test.go
@@ -50,6 +50,72 @@ func TestMatchTrust_GitURLHost(t *testing.T) {
 	}
 }
 
+func TestMatchPublisher(t *testing.T) {
+	pubs := []VerifiedPublisher{
+		{Pattern: "acme/*", RequireSignature: true, Key: "/k"},
+		{Pattern: "exact/repo", Identity: "me@x", Issuer: "https://x"},
+	}
+	if pub, ok := matchPublisher(pubs, gh("acme", "widget")); !ok || !pub.RequireSignature {
+		t.Errorf("acme/widget should match acme/* publisher, got %+v ok=%v", pub, ok)
+	}
+	if _, ok := matchPublisher(pubs, gh("other", "thing")); ok {
+		t.Error("other/thing should not match any publisher")
+	}
+	// Catalog never matches a publisher.
+	if _, ok := MatchVerifiedPublisher(Source{Kind: KindCatalog, Name: "vllm"}); ok {
+		t.Error("catalog source must never match a verified publisher")
+	}
+}
+
+func TestVerifiedPublisherPersistence(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	pub := VerifiedPublisher{Pattern: "acme/*", RequireSignature: true, Key: "/k/cosign.pub"}
+	if err := SetVerifiedPublisher(pub); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	// A publisher entry is itself a trust grant.
+	if !IsTrusted(gh("acme", "widget")) {
+		t.Error("acme/widget should be trusted via the acme/* publisher entry")
+	}
+	// And it is matchable for the gate.
+	got, ok := MatchVerifiedPublisher(gh("acme", "widget"))
+	if !ok || !got.RequireSignature || got.Key != "/k/cosign.pub" {
+		t.Errorf("expected matching publisher, got %+v ok=%v", got, ok)
+	}
+
+	// Replace (same pattern) updates in place, no duplicate pattern row.
+	if err := SetVerifiedPublisher(VerifiedPublisher{Pattern: "acme/*", Identity: "me@x", Issuer: "https://x"}); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+	ts, _ := LoadTrustedSources()
+	if len(ts.Publishers) != 1 {
+		t.Errorf("expected 1 publisher after replace, got %d", len(ts.Publishers))
+	}
+	count := 0
+	for _, p := range ts.Patterns {
+		if p == "acme/*" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected pattern acme/* once in Patterns, got %d", count)
+	}
+
+	// Untrust removes both the pattern and the publisher entry.
+	if err := RemoveTrustedSource("acme/*"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	ts, _ = LoadTrustedSources()
+	if len(ts.Publishers) != 0 || len(ts.Patterns) != 0 {
+		t.Errorf("after untrust expected empty, got patterns=%v publishers=%v", ts.Patterns, ts.Publishers)
+	}
+	if IsTrusted(gh("acme", "widget")) {
+		t.Error("acme/widget should no longer be trusted after untrust")
+	}
+}
+
 func TestIsTrusted_CatalogAlways(t *testing.T) {
 	// Catalog sources are Tier-0, always trusted, no IO needed.
 	if !IsTrusted(Source{Kind: KindCatalog, Name: "vllm"}) {

--- a/internal/catalog/verify.go
+++ b/internal/catalog/verify.go
@@ -1,0 +1,191 @@
+// internal/catalog/verify.go
+//
+// Image-signature verification for module installs (#344). When a trusted source
+// is declared as a "verified publisher" with RequireSignature, the module's
+// container image must carry a valid cosign signature before it is installed.
+//
+// Verification shells out to the `cosign` binary on PATH. It supports:
+//   - keyful  verification: a configured public key (cosign verify --key ...)
+//   - keyless verification: an expected OIDC identity + issuer
+//     (cosign verify --certificate-identity ... --certificate-oidc-issuer ...)
+//
+// Images are verified BY DIGEST: we pin the image to repo@sha256:... using the
+// digest resolved in the lockfile / ResolvedModule. If a signature is required
+// but no digest can be resolved, verification refuses rather than silently
+// downgrading to a tag-only check ("never silently pass").
+//
+// When cosign is absent from PATH, a declared-but-unverifiable requirement WARNS
+// clearly and, because the publisher requires a signature, REFUSES the install.
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// VerifyResult is the outcome of attempting signature verification for one image.
+type VerifyResult struct {
+	// Image is the digest-pinned reference that was (attempted) verified.
+	Image string
+	// Verified is true only when cosign confirmed a valid signature.
+	Verified bool
+	// Skipped is true when no signature was required for this source (no-op).
+	Skipped bool
+}
+
+// CosignAvailable reports whether the cosign binary is on PATH. Pure-ish (only
+// consults PATH); table-tested by manipulating PATH.
+func CosignAvailable() bool {
+	_, err := exec.LookPath("cosign")
+	return err == nil
+}
+
+// cosignVerifyMode classifies how a publisher entry wants verification done.
+type cosignVerifyMode int
+
+const (
+	// modeNone: nothing to verify (no key, no identity).
+	modeNone cosignVerifyMode = iota
+	// modeKeyful: verify against a configured public key.
+	modeKeyful
+	// modeKeyless: verify against an expected OIDC identity + issuer.
+	modeKeyless
+)
+
+// publisherVerifyMode picks the verification mode for a publisher. Keyful takes
+// precedence when a key is set; otherwise an identity selects keyless. Pure --
+// table-tested.
+func publisherVerifyMode(pub VerifiedPublisher) cosignVerifyMode {
+	if strings.TrimSpace(pub.Key) != "" {
+		return modeKeyful
+	}
+	if strings.TrimSpace(pub.Identity) != "" {
+		return modeKeyless
+	}
+	return modeNone
+}
+
+// buildCosignArgs constructs the argv (after the leading "cosign") for verifying
+// imageRef against pub. Returns an error if the publisher has neither a key nor
+// an identity, or (for keyless) is missing an issuer. Pure -- table-tested, no
+// cosign/network needed.
+//
+// Cosign v2 flag names (verified against current sigstore docs):
+//   - keyful : verify --key <key> <imageRef>
+//   - keyless: verify --certificate-identity <id> --certificate-oidc-issuer <iss> <imageRef>
+func buildCosignArgs(pub VerifiedPublisher, imageRef string) ([]string, error) {
+	switch publisherVerifyMode(pub) {
+	case modeKeyful:
+		return []string{"verify", "--key", strings.TrimSpace(pub.Key), imageRef}, nil
+	case modeKeyless:
+		issuer := strings.TrimSpace(pub.Issuer)
+		if issuer == "" {
+			return nil, fmt.Errorf("keyless verification requires an issuer (set --issuer when trusting %q)", pub.Pattern)
+		}
+		return []string{
+			"verify",
+			"--certificate-identity", strings.TrimSpace(pub.Identity),
+			"--certificate-oidc-issuer", issuer,
+			imageRef,
+		}, nil
+	default:
+		return nil, fmt.Errorf("verified publisher %q declares no signing key or identity", pub.Pattern)
+	}
+}
+
+// pinImageToDigest returns "repo@sha256:..." when a digest is known, pinning the
+// image so verification targets an exact artifact rather than a mutable tag. If
+// ref already contains an "@sha256:" it is returned unchanged. Returns "" when no
+// digest is available. Pure -- table-tested.
+func pinImageToDigest(ref, digest string) string {
+	ref = strings.TrimSpace(ref)
+	digest = strings.TrimSpace(digest)
+	if strings.Contains(ref, "@sha256:") {
+		return ref
+	}
+	if digest == "" {
+		return ""
+	}
+	// Strip any tag (":tag") from the repo part before appending the digest. The
+	// repo may contain a registry "host:port/", so only treat a ':' after the
+	// last '/' as a tag separator.
+	repo := ref
+	if slash := strings.LastIndex(ref, "/"); slash >= 0 {
+		if colon := strings.LastIndex(ref[slash:], ":"); colon >= 0 {
+			repo = ref[:slash+colon]
+		}
+	} else if colon := strings.LastIndex(ref, ":"); colon >= 0 {
+		repo = ref[:colon]
+	}
+	return repo + "@" + digest
+}
+
+// VerifyModule verifies the resolved module's image signatures against a matched
+// verified-publisher entry. It is a NO-OP (Skipped=true, nil error) when no
+// publisher matches the source or the matched publisher does not require a
+// signature. When a signature IS required it returns an error (refusing install)
+// on any failure: cosign absent, no resolvable digest, or a failed verification.
+//
+// images maps an image reference to its best-effort resolved digest (as recorded
+// in the lockfile). Verification pins each image to its digest before calling
+// cosign.
+func VerifyModule(src Source, images []LockImage) (VerifyResult, error) {
+	pub, ok := MatchVerifiedPublisher(src)
+	if !ok || !pub.RequireSignature {
+		return VerifyResult{Skipped: true}, nil
+	}
+
+	if !CosignAvailable() {
+		return VerifyResult{}, fmt.Errorf(
+			"source %q requires a verified signature but the 'cosign' binary was not found on PATH.\n"+
+				"   Install cosign (https://docs.sigstore.dev/cosign/installation) or remove the signature\n"+
+				"   requirement with: citadel module trust %s (without --require-signature).",
+			src.Raw, pub.Pattern)
+	}
+
+	if len(images) == 0 {
+		return VerifyResult{}, fmt.Errorf("source %q requires a verified signature but no container image was found to verify", src.Raw)
+	}
+
+	var verified string
+	for _, img := range images {
+		pinned := pinImageToDigest(img.Ref, img.Digest)
+		if pinned == "" {
+			return VerifyResult{}, fmt.Errorf(
+				"source %q requires a verified signature but the digest for image %q could not be resolved.\n"+
+					"   Verification must pin the image by digest; ensure docker can resolve %q (pull it, or check registry access).",
+				src.Raw, img.Ref, img.Ref)
+		}
+		if err := runCosignVerify(pub, pinned); err != nil {
+			return VerifyResult{Image: pinned}, fmt.Errorf("signature verification failed for %s: %w", pinned, err)
+		}
+		verified = pinned
+	}
+
+	return VerifyResult{Image: verified, Verified: true}, nil
+}
+
+// runCosignVerify executes `cosign verify ...` for a single pinned image. A
+// non-nil error means the signature did not verify (or cosign errored). Bounded
+// to 60s. The seam is a package var so callers/tests can stub it.
+var runCosignVerify = func(pub VerifiedPublisher, pinnedImage string) error {
+	args, err := buildCosignArgs(pub, pinnedImage)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "cosign", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		detail := strings.TrimSpace(string(out))
+		if detail == "" {
+			detail = err.Error()
+		}
+		return fmt.Errorf("cosign rejected the signature: %s", detail)
+	}
+	return nil
+}

--- a/internal/catalog/verify.go
+++ b/internal/catalog/verify.go
@@ -77,9 +77,11 @@ func publisherVerifyMode(pub VerifiedPublisher) cosignVerifyMode {
 //   - keyful : verify --key <key> <imageRef>
 //   - keyless: verify --certificate-identity <id> --certificate-oidc-issuer <iss> <imageRef>
 func buildCosignArgs(pub VerifiedPublisher, imageRef string) ([]string, error) {
+	// A "--" separates flags from the positional image so an image reference
+	// that begins with '-' can never be parsed by cosign as an option.
 	switch publisherVerifyMode(pub) {
 	case modeKeyful:
-		return []string{"verify", "--key", strings.TrimSpace(pub.Key), imageRef}, nil
+		return []string{"verify", "--key", strings.TrimSpace(pub.Key), "--", imageRef}, nil
 	case modeKeyless:
 		issuer := strings.TrimSpace(pub.Issuer)
 		if issuer == "" {
@@ -89,7 +91,7 @@ func buildCosignArgs(pub VerifiedPublisher, imageRef string) ([]string, error) {
 			"verify",
 			"--certificate-identity", strings.TrimSpace(pub.Identity),
 			"--certificate-oidc-issuer", issuer,
-			imageRef,
+			"--", imageRef,
 		}, nil
 	default:
 		return nil, fmt.Errorf("verified publisher %q declares no signing key or identity", pub.Pattern)

--- a/internal/catalog/verify_test.go
+++ b/internal/catalog/verify_test.go
@@ -41,14 +41,14 @@ func TestBuildCosignArgs(t *testing.T) {
 			name: "keyful",
 			pub:  VerifiedPublisher{Key: "/k/cosign.pub"},
 			ref:  "ghcr.io/o/r@sha256:abc",
-			want: []string{"verify", "--key", "/k/cosign.pub", "ghcr.io/o/r@sha256:abc"},
+			want: []string{"verify", "--key", "/k/cosign.pub", "--", "ghcr.io/o/r@sha256:abc"},
 		},
 		{
 			name: "keyless",
 			pub:  VerifiedPublisher{Identity: "me@example.com", Issuer: "https://accounts.example.com"},
 			ref:  "ghcr.io/o/r@sha256:abc",
 			want: []string{"verify", "--certificate-identity", "me@example.com",
-				"--certificate-oidc-issuer", "https://accounts.example.com", "ghcr.io/o/r@sha256:abc"},
+				"--certificate-oidc-issuer", "https://accounts.example.com", "--", "ghcr.io/o/r@sha256:abc"},
 		},
 		{
 			name:    "keyless missing issuer",

--- a/internal/catalog/verify_test.go
+++ b/internal/catalog/verify_test.go
@@ -1,0 +1,197 @@
+package catalog
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+func TestPublisherVerifyMode(t *testing.T) {
+	tests := []struct {
+		name string
+		pub  VerifiedPublisher
+		want cosignVerifyMode
+	}{
+		{"key wins", VerifiedPublisher{Key: "k", Identity: "i"}, modeKeyful},
+		{"keyful", VerifiedPublisher{Key: "/path/cosign.pub"}, modeKeyful},
+		{"keyless", VerifiedPublisher{Identity: "me@example.com", Issuer: "https://x"}, modeKeyless},
+		{"none", VerifiedPublisher{}, modeNone},
+		{"blank key+id", VerifiedPublisher{Key: "  ", Identity: "  "}, modeNone},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := publisherVerifyMode(tt.pub); got != tt.want {
+				t.Errorf("publisherVerifyMode(%+v) = %v, want %v", tt.pub, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildCosignArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		pub     VerifiedPublisher
+		ref     string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "keyful",
+			pub:  VerifiedPublisher{Key: "/k/cosign.pub"},
+			ref:  "ghcr.io/o/r@sha256:abc",
+			want: []string{"verify", "--key", "/k/cosign.pub", "ghcr.io/o/r@sha256:abc"},
+		},
+		{
+			name: "keyless",
+			pub:  VerifiedPublisher{Identity: "me@example.com", Issuer: "https://accounts.example.com"},
+			ref:  "ghcr.io/o/r@sha256:abc",
+			want: []string{"verify", "--certificate-identity", "me@example.com",
+				"--certificate-oidc-issuer", "https://accounts.example.com", "ghcr.io/o/r@sha256:abc"},
+		},
+		{
+			name:    "keyless missing issuer",
+			pub:     VerifiedPublisher{Identity: "me@example.com"},
+			ref:     "img",
+			wantErr: true,
+		},
+		{
+			name:    "no key no identity",
+			pub:     VerifiedPublisher{Pattern: "o/r"},
+			ref:     "img",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildCosignArgs(tt.pub, tt.ref)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("buildCosignArgs err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("buildCosignArgs = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPinImageToDigest(t *testing.T) {
+	tests := []struct {
+		name   string
+		ref    string
+		digest string
+		want   string
+	}{
+		{"tag + digest", "ghcr.io/o/r:v1", "sha256:abc", "ghcr.io/o/r@sha256:abc"},
+		{"no tag + digest", "ghcr.io/o/r", "sha256:abc", "ghcr.io/o/r@sha256:abc"},
+		{"registry port + tag", "registry:5000/o/r:v1", "sha256:abc", "registry:5000/o/r@sha256:abc"},
+		{"already pinned", "ghcr.io/o/r@sha256:def", "sha256:abc", "ghcr.io/o/r@sha256:def"},
+		{"no digest", "ghcr.io/o/r:v1", "", ""},
+		{"bare name + tag", "redis:7", "sha256:abc", "redis@sha256:abc"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pinImageToDigest(tt.ref, tt.digest); got != tt.want {
+				t.Errorf("pinImageToDigest(%q,%q) = %q, want %q", tt.ref, tt.digest, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCosignAvailable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH/exec semantics differ on windows")
+	}
+	dir := t.TempDir()
+	t.Setenv("PATH", dir)
+	if CosignAvailable() {
+		t.Error("expected cosign unavailable with empty PATH dir")
+	}
+	// Drop a fake executable named cosign and confirm it is found.
+	fake := filepath.Join(dir, "cosign")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if !CosignAvailable() {
+		t.Error("expected cosign available after dropping a fake binary on PATH")
+	}
+}
+
+func TestVerifyModule_NoOpWhenNoPublisher(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	src := gh("acme", "widget")
+	res, err := VerifyModule(src, []LockImage{{Ref: "ghcr.io/acme/widget:v1", Digest: "sha256:abc"}})
+	if err != nil {
+		t.Fatalf("expected no-op nil error, got %v", err)
+	}
+	if !res.Skipped || res.Verified {
+		t.Errorf("expected skipped no-op, got %+v", res)
+	}
+}
+
+func TestVerifyModule_NoOpWhenNotRequired(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	// Publisher present but does NOT require a signature -> still a no-op.
+	if err := SetVerifiedPublisher(VerifiedPublisher{Pattern: "acme/widget", Key: "/k", RequireSignature: false}); err != nil {
+		t.Fatal(err)
+	}
+	res, err := VerifyModule(gh("acme", "widget"), []LockImage{{Ref: "img", Digest: "sha256:abc"}})
+	if err != nil {
+		t.Fatalf("expected no-op nil error, got %v", err)
+	}
+	if !res.Skipped {
+		t.Errorf("expected skipped, got %+v", res)
+	}
+}
+
+func TestVerifyModule_RefusesWithoutDigest(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if err := SetVerifiedPublisher(VerifiedPublisher{Pattern: "acme/widget", Key: "/k", RequireSignature: true}); err != nil {
+		t.Fatal(err)
+	}
+	// Stub cosign as available + always-pass, so the refusal can only come from
+	// the missing digest (not cosign absence).
+	defer stubCosign(t, func(VerifiedPublisher, string) error { return nil })()
+	_, err := VerifyModule(gh("acme", "widget"), []LockImage{{Ref: "img-no-digest", Digest: ""}})
+	if err == nil {
+		t.Fatal("expected refusal when a required signature has no resolvable digest")
+	}
+}
+
+func TestVerifyModule_VerifiesWithStub(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if err := SetVerifiedPublisher(VerifiedPublisher{Pattern: "acme/widget", Key: "/k", RequireSignature: true}); err != nil {
+		t.Fatal(err)
+	}
+	var got string
+	defer stubCosign(t, func(_ VerifiedPublisher, pinned string) error { got = pinned; return nil })()
+	res, err := VerifyModule(gh("acme", "widget"), []LockImage{{Ref: "ghcr.io/acme/widget:v1", Digest: "sha256:abc"}})
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if !res.Verified {
+		t.Errorf("expected Verified, got %+v", res)
+	}
+	if got != "ghcr.io/acme/widget@sha256:abc" {
+		t.Errorf("cosign verified %q, want digest-pinned ref", got)
+	}
+}
+
+// stubCosign replaces both the cosign-availability check (by prepending a temp
+// PATH dir containing a fake cosign) and the runCosignVerify seam, restoring
+// both on cleanup.
+func stubCosign(t *testing.T, fn func(VerifiedPublisher, string) error) func() {
+	t.Helper()
+	dir := t.TempDir()
+	if runtime.GOOS != "windows" {
+		_ = os.WriteFile(filepath.Join(dir, "cosign"), []byte("#!/bin/sh\nexit 0\n"), 0755)
+		t.Setenv("PATH", dir)
+	}
+	prev := runCosignVerify
+	runCosignVerify = fn
+	return func() { runCosignVerify = prev }
+}


### PR DESCRIPTION
## Context

Closes #344 and Closes #347. Builds on #342's local trusted-source allowlist (`internal/catalog/trust.go`). Both features are **additive** and gate nothing for existing unsigned community modules.

## Feature 1 — image-signature verification + verified publisher (#344)

A trusted source can now optionally be declared a **verified publisher** with an expected cosign signing identity/key. When such an entry **requires** a signature, the module's container image is verified by cosign **before install** and the install is **refused** on any failure.

- `internal/catalog/verify.go` (new): shells out to `cosign` on PATH. Supports keyful (`--key`) and keyless (`--certificate-identity` + `--certificate-oidc-issuer`) verification, **by digest** (pins `repo@sha256:...` from the digest resolved in `ResolvedModule.Images`/the lockfile). If cosign is absent, or no digest resolves, or verification fails, it refuses — never silently passes.
- `internal/catalog/trust.go`: additive `VerifiedPublisher` type + `Publishers []VerifiedPublisher` on `TrustedSources` (`omitempty`, so the on-disk format is unchanged for plain-pattern users). New `SetVerifiedPublisher` / `MatchVerifiedPublisher`; a publisher entry reuses `matchTrust` and is itself a trust grant (`IsTrusted` honours it). `RemoveTrustedSource` clears both lists.
- `cmd/module_trust.go`: `module trust <pattern> --require-signature [--identity ... --issuer ... | --key ...]`. Errors (rather than silently swallowing the flags) if a pattern is missing.
- `cmd/module.go`: one shared gate (`catalog.VerifyModule`) wired into **both** the CLI install path and the TUI install callback, placed alongside the critical-risk refuse block (a hard gate, **not** bypassable by `--yes`). The verified digest/result is recorded in the lockfile.
- `internal/catalog/lockfile.go`: single additive `LockImage.Verified` field; `module list` shows a `✓verified` marker.

**Gated vs no-op:** verification runs **only** when a matched trust entry has `RequireSignature: true`. No publisher / not required → no-op (unsigned community modules still install under the existing risk/consent gate). Catalog (Tier 0) is exempt by early-return and in `MatchVerifiedPublisher`.

## Feature 2 — curated central index + `module search` (#347)

- `internal/catalog/index.go` (new): fetch/parse a curated `index.yaml` (name → {source, description, tags}). Default location is `index.yaml` at the catalog cache root (reuses `GetCatalogPath()`/`Update()`); overridable via `CITADEL_MODULE_INDEX`. **Fails soft** — a missing/un-cloned index returns a friendly empty result, never an error, so the plumbing no-ops until an index is published.
- `cmd/module_search.go` (new, init-registered): `citadel module search <query>` matches name/description/tags (case-insensitive) and prints source + **trust state** (cross-referenced via `IsTrusted`, so a curated entry already covered by a trust/publisher pattern shows as `trusted`).

## Tests

Pure logic is table-tested under `internal/catalog/` (the only suite safe to run here): cosign-arg construction, digest pinning, mode selection, cosign-availability (via PATH), `VerifyModule` no-op/refuse/verify (cosign stubbed), index parse/search/fail-soft/env-override, and verified-publisher match/persistence/untrust.

## Testing

```
go build ./...      # clean
go vet ./...        # clean
go test ./internal/catalog/...   # pass
```
(Per repo guardrails, `go test ./...` is avoided — the tmux/terminal/TUI suites spawn tmux/pty.)

## Notes

`lockfile.go` and `trust.go` may need a trivial rebase against the sibling versioning PR (both were only extended additively here — no restructuring). Future work: a `✓` could also be surfaced in the search/TUI views.

*Generated by Claude*
