### PR TITLE
fix(catalog): read catalog services under services/<name>/ (#350)

### DIFF
--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -20,6 +20,11 @@ const (
 	DefaultCatalogURL = "https://github.com/aceteam-ai/citadel-services.git"
 	// catalogSubdir is the subdirectory within the config dir for the catalog cache.
 	catalogSubdir = "catalog"
+	// servicesSubdir is the subdirectory within the catalog repo that holds the
+	// per-service directories (e.g. services/vllm/service.yaml). The catalog repo
+	// (aceteam-ai/citadel-services) stores services here, alongside a top-level
+	// registry.yaml index.
+	servicesSubdir = "services"
 )
 
 // Registry is the top-level index of available services (registry.yaml).
@@ -179,7 +184,7 @@ func LoadRegistry() (*Registry, error) {
 // LoadServiceManifest reads a specific service's service.yaml.
 func LoadServiceManifest(name string) (*ServiceManifest, error) {
 	catalogPath := GetCatalogPath()
-	manifestPath := filepath.Join(catalogPath, name, "service.yaml")
+	manifestPath := filepath.Join(catalogPath, servicesSubdir, name, "service.yaml")
 
 	data, err := os.ReadFile(manifestPath)
 	if err != nil {
@@ -199,7 +204,7 @@ func LoadServiceManifest(name string) (*ServiceManifest, error) {
 // GetComposeFile returns the path to a service's compose.yml inside the catalog.
 func GetComposeFile(name string) (string, error) {
 	catalogPath := GetCatalogPath()
-	composePath := filepath.Join(catalogPath, name, "compose.yml")
+	composePath := filepath.Join(catalogPath, servicesSubdir, name, "compose.yml")
 
 	if _, err := os.Stat(composePath); err != nil {
 		if os.IsNotExist(err) {
@@ -311,10 +316,12 @@ func matchesQuery(entry RegistryEntry, query string) bool {
 	return false
 }
 
-// scanForServices scans the catalog directory for service.yaml files when registry.yaml
-// is absent. Each immediate subdirectory containing a service.yaml becomes an entry.
+// scanForServices scans the catalog's services directory for service.yaml files
+// when registry.yaml is absent. Each immediate subdirectory of <catalog>/services
+// containing a service.yaml becomes an entry.
 func scanForServices(catalogPath string) (*Registry, error) {
-	entries, err := os.ReadDir(catalogPath)
+	servicesPath := filepath.Join(catalogPath, servicesSubdir)
+	entries, err := os.ReadDir(servicesPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to scan catalog directory: %w", err)
 	}
@@ -327,7 +334,7 @@ func scanForServices(catalogPath string) (*Registry, error) {
 			continue
 		}
 
-		manifestPath := filepath.Join(catalogPath, entry.Name(), "service.yaml")
+		manifestPath := filepath.Join(servicesPath, entry.Name(), "service.yaml")
 		data, err := os.ReadFile(manifestPath)
 		if err != nil {
 			continue // skip directories without service.yaml

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -1,0 +1,64 @@
+package catalog
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCatalogServicesLayout verifies that the readers resolve services stored
+// under the catalog repo's services/<name>/ layout (matching
+// aceteam-ai/citadel-services), not a flat <catalog>/<name>/ layout. Regression
+// test for #350.
+func TestCatalogServicesLayout(t *testing.T) {
+	// Hermetic: point ConfigDir at a temp HOME (Linux/darwin non-root path),
+	// mirroring TestLockfileUpsert.
+	t.Setenv("HOME", t.TempDir())
+
+	// Seed a service under <catalog>/services/<name>/ as the real repo does.
+	svcDir := filepath.Join(GetCatalogPath(), "services", "vllm")
+	if err := os.MkdirAll(svcDir, 0755); err != nil {
+		t.Fatalf("mkdir services dir: %v", err)
+	}
+	manifest := "name: vllm\nversion: 1.0.0\ndescription: vLLM inference server\ncategory: inference\n"
+	if err := os.WriteFile(filepath.Join(svcDir, "service.yaml"), []byte(manifest), 0644); err != nil {
+		t.Fatalf("write service.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(svcDir, "compose.yml"), []byte("services: {}\n"), 0644); err != nil {
+		t.Fatalf("write compose.yml: %v", err)
+	}
+
+	// LoadServiceManifest must resolve the services/<name>/ manifest.
+	m, err := LoadServiceManifest("vllm")
+	if err != nil {
+		t.Fatalf("LoadServiceManifest(vllm): %v", err)
+	}
+	if m.Name != "vllm" {
+		t.Errorf("manifest name = %q, want vllm", m.Name)
+	}
+
+	// GetComposeFile must resolve the services/<name>/compose.yml.
+	if _, err := GetComposeFile("vllm"); err != nil {
+		t.Errorf("GetComposeFile(vllm): %v", err)
+	}
+
+	// scanForServices (registry.yaml-absent fallback) must find it too.
+	reg, err := scanForServices(GetCatalogPath())
+	if err != nil {
+		t.Fatalf("scanForServices: %v", err)
+	}
+	var found bool
+	for _, e := range reg.Services {
+		if e.Name == "vllm" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("scanForServices did not return vllm; got %d services", len(reg.Services))
+	}
+
+	// A flat <catalog>/<name>/service.yaml must NOT resolve.
+	if _, err := LoadServiceManifest("nonexistent"); err == nil {
+		t.Error("expected error for missing service, got nil")
+	}
+}


### PR DESCRIPTION
## What changed

The CLI read catalog services flat at `<catalog>/<name>/service.yaml`, but the central catalog repo (`aceteam-ai/citadel-services`) stores them at `services/<name>/{service.yaml,compose.yml}` with a top-level `registry.yaml` index. As a result, catalog-name module sources resolved **zero** services — only the embedded ServiceMap worked.

This updates the three readers in `internal/catalog/catalog.go` to look under `services/`:
- `LoadServiceManifest(name)` → `<catalog>/services/<name>/service.yaml`
- `GetComposeFile(name)` → `<catalog>/services/<name>/compose.yml`
- `scanForServices(catalogPath)` → scans `<catalog>/services/` (registry.yaml-absent fallback; also naturally skips sibling `schema/` and `templates/` dirs)

`registry.yaml` (top-level index), `IsAvailable`, and the `Update()` clone target correctly stay at the repo root. Added a `services/<name>/` introduced via a `servicesSubdir` const for consistency.

A regression test (`internal/catalog/catalog_test.go`) seeds a `services/<name>/` fixture under a hermetic temp HOME and asserts it resolves via `LoadServiceManifest`, `GetComposeFile`, and `scanForServices`.

Fixes #350.

## Verification

- `go test ./internal/catalog/...` → ok
- `go build ./cmd/citadel` → ok
- Empirical: cloned the real catalog to `~/.citadel-cli/catalog` and ran the built binary:

```
$ citadel module info vllm
Name:        vllm
Version:     0.23.0
Description: High-performance LLM inference with PagedAttention
Category:    inference
...
```

`module info vllm` now **resolves and renders the manifest** instead of `service 'vllm' not found in catalog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)