### PR TITLE
feat(fabric): embedding job handler + gateway route + MCP tool (#351)

### DIFF
--- a/cmd/job_handlers.go
+++ b/cmd/job_handlers.go
@@ -62,6 +62,7 @@ func init() {
 		"LLAMACPP_INFERENCE": &jobs.LlamaCppInferenceHandler{},
 		"VLLM_INFERENCE":     &jobs.VLLMInferenceHandler{},
 		"OLLAMA_INFERENCE":   &jobs.OllamaInferenceHandler{},
+		"embedding":          &jobs.EmbeddingHandler{},
 		"SANDBOX_SUSPEND":    &jobs.SandboxSuspendHandler{},
 		"SANDBOX_RESUME":     &jobs.SandboxResumeHandler{},
 		"MODEL_CACHE_PULL":   &jobs.ModelCachePullHandler{},

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -19,13 +19,14 @@ import (
 )
 
 var (
-	servePort       int
-	serveStatusPort int
-	serveTermPort   int
-	serveVNCPort    int
-	serveNoTLS      bool
-	serveCertDir    string
-	serveBind       string
+	servePort          int
+	serveStatusPort    int
+	serveTermPort      int
+	serveVNCPort       int
+	serveEmbeddingPort int
+	serveNoTLS         bool
+	serveCertDir       string
+	serveBind          string
 )
 
 var serveCmd = &cobra.Command{
@@ -154,9 +155,10 @@ func runServe(cmd *cobra.Command, args []string) error {
 
 	// Validate that gateway port does not collide with any upstream port
 	upstreamPorts := map[int]string{
-		serveStatusPort: "status-port",
-		serveTermPort:   "terminal-port",
-		serveVNCPort:    "vnc-port",
+		serveStatusPort:    "status-port",
+		serveTermPort:      "terminal-port",
+		serveVNCPort:       "vnc-port",
+		serveEmbeddingPort: "embedding-port",
 	}
 	if name, collision := upstreamPorts[servePort]; collision {
 		return fmt.Errorf("gateway port %d collides with --%s; choose a different --port", servePort, name)
@@ -166,6 +168,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	statusAddr := fmt.Sprintf("127.0.0.1:%d", serveStatusPort)
 	termAddr := fmt.Sprintf("127.0.0.1:%d", serveTermPort)
 	vncAddr := fmt.Sprintf("127.0.0.1:%d", serveVNCPort)
+	embeddingAddr := fmt.Sprintf("127.0.0.1:%d", serveEmbeddingPort)
 
 	// Add VPN listener so the gateway is reachable over the tsnet VPN.
 	// For HTTPS mode, the raw tsnet listener must be TLS-wrapped so that
@@ -210,6 +213,12 @@ func runServe(cmd *cobra.Command, args []string) error {
 	gw.AddUpstream("/ssh/authorized-keys", &gateway.Upstream{Address: statusAddr})
 	gw.AddUpstream("/provision", &gateway.Upstream{Address: statusAddr})
 
+	// Embedding upstream (issue #351): route the already-metered
+	// /v1/embeddings path to the local TEI service (default 127.0.0.1:8102).
+	// TEI exposes the OpenAI-compatible endpoint at the same path, so no prefix
+	// stripping is needed.
+	gw.AddUpstream("/v1/embeddings", &gateway.Upstream{Address: embeddingAddr})
+
 	// VNC WebSocket proxy (requires websockify running on vnc-port)
 	gw.AddUpstream("/vnc", &gateway.Upstream{
 		Address:     vncAddr,
@@ -240,6 +249,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	fmt.Printf("     /health, /status, /ping  -> %s (status server)\n", statusAddr)
 	fmt.Printf("     /api/screenshot, /api/actions -> %s\n", statusAddr)
 	fmt.Printf("     /ssh/authorized-keys     -> %s (SSH key deploy)\n", statusAddr)
+	fmt.Printf("     /v1/embeddings           -> %s (TEI embeddings)\n", embeddingAddr)
 	fmt.Printf("     /vnc/...                 -> %s (websockify)\n", vncAddr)
 	fmt.Printf("     /terminal/...            -> %s (terminal)\n", termAddr)
 
@@ -272,6 +282,7 @@ func init() {
 	serveCmd.Flags().IntVar(&serveStatusPort, "status-port", 8080, "Port of the local status server (from 'citadel work --status-port')")
 	serveCmd.Flags().IntVar(&serveTermPort, "terminal-port", 7860, "Port of the local terminal server")
 	serveCmd.Flags().IntVar(&serveVNCPort, "vnc-port", 6080, "Port of websockify (VNC WebSocket bridge)")
+	serveCmd.Flags().IntVar(&serveEmbeddingPort, "embedding-port", 8102, "Port of the local TEI embedding service (/v1/embeddings upstream)")
 
 	// Mark --no-tls as hidden (not recommended for production)
 	serveCmd.Flags().MarkHidden("no-tls")

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -102,9 +102,10 @@ var (
 	workNoGateway      bool
 	workGatewayPort    int
 	workGatewayBind    string
-	workGatewayVNC     int
-	workGatewayNoTLS   bool
-	workGatewayCertDir string
+	workGatewayVNC       int
+	workGatewayEmbedding int
+	workGatewayNoTLS     bool
+	workGatewayCertDir   string
 )
 
 var workCmd = &cobra.Command{
@@ -1163,9 +1164,10 @@ func runWork(cmd *cobra.Command, args []string) {
 	if workGateway {
 		// Validate that gateway port does not collide with upstream ports
 		upstreamPorts := map[int]string{
-			workStatusPort:   "status-port",
-			workTerminalPort: "terminal-port",
-			workGatewayVNC:   "gateway-vnc-port",
+			workStatusPort:       "status-port",
+			workTerminalPort:     "terminal-port",
+			workGatewayVNC:       "gateway-vnc-port",
+			workGatewayEmbedding: "gateway-embedding-port",
 		}
 		if name, collision := upstreamPorts[workGatewayPort]; collision {
 			fmt.Fprintf(os.Stderr, "Error: gateway port %d collides with --%s; choose a different --gateway-port\n", workGatewayPort, name)
@@ -1213,6 +1215,7 @@ func runWork(cmd *cobra.Command, args []string) {
 		statusAddr := fmt.Sprintf("127.0.0.1:%d", workStatusPort)
 		termAddr := fmt.Sprintf("127.0.0.1:%d", workTerminalPort)
 		vncAddr := fmt.Sprintf("127.0.0.1:%d", workGatewayVNC)
+		embeddingAddr := fmt.Sprintf("127.0.0.1:%d", workGatewayEmbedding)
 
 		// Start the in-process websockify bridge when desktop permissions allow.
 		// The gateway proxies "/vnc/..." to vncAddr (workGatewayVNC, e.g. 6080)
@@ -1266,6 +1269,10 @@ func runWork(cmd *cobra.Command, args []string) {
 		gw.AddUpstream("/provision", &gateway.Upstream{Address: statusAddr})
 		gw.AddUpstream("/workflow", &gateway.Upstream{Address: statusAddr})
 
+		// Embedding upstream (issue #351): route the already-metered
+		// /v1/embeddings path to the local TEI service (default 127.0.0.1:8102).
+		gw.AddUpstream("/v1/embeddings", &gateway.Upstream{Address: embeddingAddr})
+
 		gw.AddUpstream("/vnc", &gateway.Upstream{
 			Address:     vncAddr,
 			StripPrefix: true,
@@ -1311,6 +1318,7 @@ func runWork(cmd *cobra.Command, args []string) {
 		fmt.Printf("     /api/screenshot, /api/actions -> %s\n", statusAddr)
 		fmt.Printf("     /ssh/authorized-keys     -> %s (SSH key deploy)\n", statusAddr)
 		fmt.Printf("     /workflow/...             -> %s (workflow API)\n", statusAddr)
+		fmt.Printf("     /v1/embeddings           -> %s (TEI embeddings)\n", embeddingAddr)
 		fmt.Printf("     /vnc/...                 -> %s (websockify)\n", vncAddr)
 		fmt.Printf("     /terminal/...            -> %s (terminal)\n", termAddr)
 
@@ -1870,6 +1878,7 @@ func init() {
 	workCmd.Flags().IntVar(&workGatewayPort, "gateway-port", 8443, "HTTPS gateway port (default: 8443)")
 	workCmd.Flags().StringVar(&workGatewayBind, "gateway-bind", "0.0.0.0", "Gateway bind address")
 	workCmd.Flags().IntVar(&workGatewayVNC, "gateway-vnc-port", 6080, "VNC websockify port for gateway proxy")
+	workCmd.Flags().IntVar(&workGatewayEmbedding, "gateway-embedding-port", 8102, "Local TEI embedding service port (/v1/embeddings upstream)")
 	workCmd.Flags().BoolVar(&workGatewayNoTLS, "gateway-no-tls", false, "Disable TLS on the gateway (for testing only)")
 	workCmd.Flags().StringVar(&workGatewayCertDir, "gateway-cert-dir", "", "Custom directory for gateway TLS certificates")
 	workCmd.Flags().MarkHidden("gateway-no-tls")

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -34,6 +34,7 @@ claude mcp add aceteam -e ACETEAM_API_KEY=act_xxx -- citadel mcp
 | `fabric_list_nodes` | List GPU nodes in your organization or the public marketplace |
 | `fabric_node_status` | Get detailed node status: GPUs, VRAM, running services, temperature |
 | `fabric_dispatch_job` | Submit an inference or compute job to the fabric |
+| `fabric_embed_text` | Embed `texts: []string` on a node's TEI service → vectors + token usage. Args: `node_id`, `texts`, optional `model_id`, optional `dimensions` (Matryoshka; defaults to native). Dispatches an `embedding` job handled node-side by the TEI `/v1/embeddings` route. |
 | `fabric_list_models` | Browse available models across all nodes |
 | `fabric_node_earnings` | View earnings for a specific node |
 | `fabric_earnings_summary` | Aggregate earnings across all nodes |

--- a/internal/capabilities/embedding_queue_test.go
+++ b/internal/capabilities/embedding_queue_test.go
@@ -1,0 +1,37 @@
+package capabilities
+
+import "testing"
+
+// TestEmbeddingTagQueue verifies the routing contract for embedding jobs
+// (issue #351): a node carrying the `task:embedding` capability tag must
+// subscribe to the `jobs:v1:tag:task:embedding` Redis Streams queue. Queue
+// subscription is dynamic (derived from capability tags via ResolveQueues),
+// so there is no static queue list to edit — once a node installs the TEI
+// service it gains the tag (per #343 PR A serviceTags) and auto-subscribes.
+func TestEmbeddingTagQueue(t *testing.T) {
+	const embeddingTag = "task:embedding"
+	const embeddingQueue = "jobs:v1:tag:task:embedding"
+
+	if got := TagQueueName(embeddingTag); got != embeddingQueue {
+		t.Fatalf("TagQueueName(%q) = %q, want %q", embeddingTag, got, embeddingQueue)
+	}
+
+	// A TEI node typically carries engine + task + model tags.
+	caps := []Capability{
+		{Tag: "engine:tei", Category: "engine"},
+		{Tag: embeddingTag, Category: "task"},
+		{Tag: "model:gte-multilingual-base", Category: "model"},
+	}
+	queues := ResolveQueues(caps, "jobs:v1:gpu-general")
+
+	found := false
+	for _, q := range queues {
+		if q == embeddingQueue {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("ResolveQueues did not include %q; got %v", embeddingQueue, queues)
+	}
+}

--- a/internal/gateway/embedding_route_test.go
+++ b/internal/gateway/embedding_route_test.go
@@ -1,0 +1,59 @@
+package gateway
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestEmbeddingUpstreamRouting verifies that a /v1/embeddings request is routed
+// to the registered embedding (TEI) upstream and not to an unrelated backend
+// (issue #351). The path is forwarded unmodified (no prefix stripping), so TEI's
+// OpenAI-compatible /v1/embeddings handler receives it verbatim.
+func TestEmbeddingUpstreamRouting(t *testing.T) {
+	teiBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{
+			"backend": "tei",
+			"path":    r.URL.Path,
+		})
+	}))
+	defer teiBackend.Close()
+
+	statusBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"backend": "status"})
+	}))
+	defer statusBackend.Close()
+
+	teiAddr := teiBackend.URL[len("http://"):]
+	statusAddr := statusBackend.URL[len("http://"):]
+
+	gw := NewServer(Config{Port: 0, NodeName: "test-node"})
+	gw.AddUpstream("/health", &Upstream{Address: statusAddr})
+	gw.AddUpstream("/v1/embeddings", &Upstream{Address: teiAddr})
+
+	for prefix, upstream := range gw.config.Upstreams {
+		gw.registerProxy(prefix, upstream)
+	}
+	gw.mux.HandleFunc("/", gw.handleRoot)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/embeddings", nil)
+	w := httptest.NewRecorder()
+	gw.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("bad response: %v", err)
+	}
+	if resp["backend"] != "tei" {
+		t.Errorf("routed to %q backend, want tei", resp["backend"])
+	}
+	if resp["path"] != "/v1/embeddings" {
+		t.Errorf("proxied path = %q, want /v1/embeddings (no strip)", resp["path"])
+	}
+}

--- a/internal/jobs/embedding_handler.go
+++ b/internal/jobs/embedding_handler.go
@@ -1,0 +1,250 @@
+// internal/jobs/embedding_handler.go
+package jobs
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+// teiDefaultURL is the local TEI (HF Text-Embeddings-Inference) service address.
+// TEI serves an OpenAI-compatible /v1/embeddings endpoint (and a native /embed)
+// on host port 8102 (see services/compose/tei.yml from #343 PR A). Override via
+// the CITADEL_TEI_URL environment variable for non-default deployments.
+const teiDefaultURL = "http://localhost:8102"
+
+// teiReadyTimeout bounds how long the handler waits for TEI to report healthy
+// before giving up. Mirrors the vLLM/SGLang readiness budget in
+// llm_inference.go.
+const teiReadyTimeout = 60 * time.Second
+
+// EmbeddingHandler handles JobTypeEmbedding ("embedding") jobs by routing them
+// to the local TEI service's OpenAI-compatible /v1/embeddings endpoint.
+//
+// It implements the legacy jobs.JobHandler interface (Execute(JobContext,
+// *nexus.Job) ([]byte, error)) so it can be wired into the live worker dispatch
+// via worker.CreateLegacyHandlersWithOpts, exactly like VLLMInferenceHandler.
+//
+// IMPORTANT — payload contract: the live dispatch path
+// (worker.LegacyHandlerAdapter) flattens the job payload map[string]any into
+// map[string]string via fmt.Sprint before the handler sees it. A raw []string
+// would be stringified to "[a b]" and become unrecoverable. The handler
+// therefore expects `input` to arrive as a JSON-encoded array string, e.g.
+// `["hello","world"]`, which it json.Unmarshals. A bare scalar string is also
+// accepted and treated as a single-element input for convenience.
+//
+// This differs from llm_inference.go's structure-preserving signature; that
+// handler is not wired into the live worker path (see PR notes). We mirror its
+// TEI-call style while conforming to the interface the live dispatch actually
+// uses.
+type EmbeddingHandler struct{}
+
+// EmbeddingRequest is the parsed embedding job payload.
+type EmbeddingRequest struct {
+	// Model is the embedding model identifier (e.g. "gte-multilingual-base").
+	Model string
+	// Input is the list of texts to embed.
+	Input []string
+	// Dimensions optionally requests Matryoshka-truncated output dimensions.
+	// Zero means "use the model's native dimensionality".
+	Dimensions int
+}
+
+// teiEmbeddingResponse mirrors the OpenAI-compatible response TEI returns from
+// /v1/embeddings. Note: unlike chat/completions, embeddings usage carries only
+// prompt_tokens and total_tokens (no completion_tokens).
+type teiEmbeddingResponse struct {
+	Object string `json:"object"`
+	Data   []struct {
+		Object    string    `json:"object"`
+		Embedding []float64 `json:"embedding"`
+		Index     int       `json:"index"`
+	} `json:"data"`
+	Model string `json:"model"`
+	Usage struct {
+		PromptTokens int `json:"prompt_tokens"`
+		TotalTokens  int `json:"total_tokens"`
+	} `json:"usage"`
+}
+
+// EmbeddingResult is the handler's output (JSON-serialized into the job result).
+type EmbeddingResult struct {
+	Model      string      `json:"model"`
+	Embeddings [][]float64 `json:"embeddings"`
+	Dimensions int         `json:"dimensions"`
+	Usage      struct {
+		PromptTokens int `json:"prompt_tokens"`
+		TotalTokens  int `json:"total_tokens"`
+	} `json:"usage"`
+}
+
+// teiBaseURL returns the TEI service base URL, honoring CITADEL_TEI_URL.
+func teiBaseURL() string {
+	if v := os.Getenv("CITADEL_TEI_URL"); v != "" {
+		return v
+	}
+	return teiDefaultURL
+}
+
+// Execute parses the embedding job payload, waits for TEI readiness, calls the
+// OpenAI-compatible /v1/embeddings endpoint, and returns the embeddings + usage
+// as a JSON blob.
+func (h *EmbeddingHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	req, err := parseEmbeddingPayload(job.Payload)
+	if err != nil {
+		return nil, fmt.Errorf("invalid embedding payload: %w", err)
+	}
+
+	ctx.Log("info", "     - [Job %s] Waiting for TEI embedding service to become ready...", job.ID)
+	if err := waitForTEIReady(teiBaseURL(), teiReadyTimeout); err != nil {
+		return nil, err
+	}
+	ctx.Log("info", "     - [Job %s] TEI ready. Embedding %d text(s) with model %q", job.ID, len(req.Input), req.Model)
+
+	result, err := callTEIEmbeddings(teiBaseURL(), req)
+	if err != nil {
+		return nil, err
+	}
+
+	out, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal embedding result: %w", err)
+	}
+	return out, nil
+}
+
+// parseEmbeddingPayload extracts and validates the embedding request from the
+// flattened (map[string]string) job payload produced by the legacy adapter.
+//
+// `input` may be either a JSON-encoded array (e.g. `["a","b"]`) or a bare
+// scalar string (treated as a single input). `model` is required. `dimensions`
+// is optional.
+func parseEmbeddingPayload(payload map[string]string) (*EmbeddingRequest, error) {
+	model := payload["model"]
+	if model == "" {
+		return nil, fmt.Errorf("model is required")
+	}
+
+	rawInput, ok := payload["input"]
+	if !ok || rawInput == "" {
+		return nil, fmt.Errorf("input is required")
+	}
+
+	var input []string
+	// Prefer JSON array decoding (the canonical wire form for []string).
+	if err := json.Unmarshal([]byte(rawInput), &input); err != nil {
+		// Fall back: treat the whole value as a single text to embed.
+		input = []string{rawInput}
+	}
+	if len(input) == 0 {
+		return nil, fmt.Errorf("input must contain at least one text")
+	}
+
+	req := &EmbeddingRequest{
+		Model: model,
+		Input: input,
+	}
+
+	if dimStr, ok := payload["dimensions"]; ok && dimStr != "" {
+		dim, err := strconv.Atoi(dimStr)
+		if err != nil {
+			return nil, fmt.Errorf("dimensions must be an integer: %w", err)
+		}
+		if dim < 0 {
+			return nil, fmt.Errorf("dimensions must be non-negative")
+		}
+		req.Dimensions = dim
+	}
+
+	return req, nil
+}
+
+// callTEIEmbeddings POSTs the embedding request to TEI's /v1/embeddings and
+// returns the parsed result.
+func callTEIEmbeddings(baseURL string, req *EmbeddingRequest) (*EmbeddingResult, error) {
+	reqPayload := map[string]any{
+		"model": req.Model,
+		"input": req.Input,
+	}
+	// Matryoshka: forward `dimensions` only when explicitly requested, otherwise
+	// let TEI return the model's native dimensionality.
+	if req.Dimensions > 0 {
+		reqPayload["dimensions"] = req.Dimensions
+	}
+
+	reqBody, err := json.Marshal(reqPayload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal TEI request: %w", err)
+	}
+
+	resp, err := http.Post(baseURL+"/v1/embeddings", "application/json", bytes.NewBuffer(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to TEI service: %w", err)
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("TEI returned status %d: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	var teiResp teiEmbeddingResponse
+	if err := json.Unmarshal(bodyBytes, &teiResp); err != nil {
+		return nil, fmt.Errorf("failed to parse TEI response: %w", err)
+	}
+	if len(teiResp.Data) == 0 {
+		return nil, fmt.Errorf("TEI returned no embeddings")
+	}
+
+	result := &EmbeddingResult{
+		Model:      teiResp.Model,
+		Embeddings: make([][]float64, len(teiResp.Data)),
+	}
+	if result.Model == "" {
+		result.Model = req.Model
+	}
+	for _, d := range teiResp.Data {
+		// TEI returns data entries with explicit indices; place each vector at
+		// its index so output order matches the input order regardless of how
+		// the engine ordered the response.
+		if d.Index < 0 || d.Index >= len(result.Embeddings) {
+			return nil, fmt.Errorf("TEI returned out-of-range embedding index %d", d.Index)
+		}
+		result.Embeddings[d.Index] = d.Embedding
+	}
+	if len(result.Embeddings) > 0 {
+		result.Dimensions = len(result.Embeddings[0])
+	}
+	result.Usage.PromptTokens = teiResp.Usage.PromptTokens
+	result.Usage.TotalTokens = teiResp.Usage.TotalTokens
+
+	return result, nil
+}
+
+// waitForTEIReady polls TEI's /health endpoint until it reports ready or the
+// timeout elapses. Mirrors waitForVLLMReady in llm_inference.go.
+func waitForTEIReady(baseURL string, timeout time.Duration) error {
+	healthURL := baseURL + "/health"
+	pollInterval := 1 * time.Second
+	startTime := time.Now()
+
+	for time.Since(startTime) < timeout {
+		resp, err := http.Get(healthURL)
+		if err == nil && resp.StatusCode == http.StatusOK {
+			resp.Body.Close()
+			return nil
+		}
+		if resp != nil {
+			resp.Body.Close()
+		}
+		time.Sleep(pollInterval)
+	}
+	return fmt.Errorf("TEI service did not become ready within %v", timeout)
+}

--- a/internal/jobs/embedding_handler_test.go
+++ b/internal/jobs/embedding_handler_test.go
@@ -1,0 +1,225 @@
+package jobs
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+// newTEIServer returns a stub TEI server. health controls whether /health is OK;
+// the /v1/embeddings handler returns the supplied response JSON with status 200,
+// or, if respFn is set, delegates to it.
+func newTEIServer(t *testing.T, respFn func(w http.ResponseWriter, r *http.Request)) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/v1/embeddings", respFn)
+	return httptest.NewServer(mux)
+}
+
+func TestParseEmbeddingPayload(t *testing.T) {
+	tests := []struct {
+		name      string
+		payload   map[string]string
+		wantInput []string
+		wantDim   int
+		wantErr   bool
+	}{
+		{
+			name:      "json array input",
+			payload:   map[string]string{"model": "gte", "input": `["hello","world"]`},
+			wantInput: []string{"hello", "world"},
+		},
+		{
+			name:      "scalar string fallback",
+			payload:   map[string]string{"model": "gte", "input": "just one"},
+			wantInput: []string{"just one"},
+		},
+		{
+			name:      "input with spaces preserved via json",
+			payload:   map[string]string{"model": "gte", "input": `["a b c","d e"]`},
+			wantInput: []string{"a b c", "d e"},
+		},
+		{
+			name:      "dimensions parsed",
+			payload:   map[string]string{"model": "gte", "input": `["x"]`, "dimensions": "256"},
+			wantInput: []string{"x"},
+			wantDim:   256,
+		},
+		{
+			name:    "missing model",
+			payload: map[string]string{"input": `["x"]`},
+			wantErr: true,
+		},
+		{
+			name:    "missing input",
+			payload: map[string]string{"model": "gte"},
+			wantErr: true,
+		},
+		{
+			name:    "bad dimensions",
+			payload: map[string]string{"model": "gte", "input": `["x"]`, "dimensions": "notanint"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := parseEmbeddingPayload(tt.payload)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(req.Input, tt.wantInput) {
+				t.Errorf("input = %v, want %v", req.Input, tt.wantInput)
+			}
+			if req.Dimensions != tt.wantDim {
+				t.Errorf("dimensions = %d, want %d", req.Dimensions, tt.wantDim)
+			}
+		})
+	}
+}
+
+func TestCallTEIEmbeddings_Success(t *testing.T) {
+	srv := newTEIServer(t, func(w http.ResponseWriter, r *http.Request) {
+		// Verify request shape.
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("bad request body: %v", err)
+		}
+		if req["model"] != "gte" {
+			t.Errorf("model = %v, want gte", req["model"])
+		}
+		// Return two vectors, intentionally out of index order to verify
+		// the handler reorders by index.
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{
+			"object":"list",
+			"data":[
+				{"object":"embedding","index":1,"embedding":[0.3,0.4]},
+				{"object":"embedding","index":0,"embedding":[0.1,0.2]}
+			],
+			"model":"gte-multilingual-base",
+			"usage":{"prompt_tokens":5,"total_tokens":5}
+		}`))
+	})
+	defer srv.Close()
+
+	res, err := callTEIEmbeddings(srv.URL, &EmbeddingRequest{
+		Model: "gte",
+		Input: []string{"a", "b"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := [][]float64{{0.1, 0.2}, {0.3, 0.4}}
+	if !reflect.DeepEqual(res.Embeddings, want) {
+		t.Errorf("embeddings = %v, want %v (must be index-ordered)", res.Embeddings, want)
+	}
+	if res.Dimensions != 2 {
+		t.Errorf("dimensions = %d, want 2", res.Dimensions)
+	}
+	if res.Model != "gte-multilingual-base" {
+		t.Errorf("model = %q, want gte-multilingual-base", res.Model)
+	}
+	if res.Usage.PromptTokens != 5 || res.Usage.TotalTokens != 5 {
+		t.Errorf("usage = %+v, want prompt=5 total=5", res.Usage)
+	}
+}
+
+func TestCallTEIEmbeddings_ForwardsDimensions(t *testing.T) {
+	var gotDimensions any
+	var dimensionsPresent bool
+	srv := newTEIServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]any
+		_ = json.Unmarshal(body, &req)
+		gotDimensions, dimensionsPresent = req["dimensions"]
+		w.Write([]byte(`{"data":[{"index":0,"embedding":[0.1]}],"model":"gte","usage":{"prompt_tokens":1,"total_tokens":1}}`))
+	})
+	defer srv.Close()
+
+	// With dimensions set, it must be forwarded.
+	if _, err := callTEIEmbeddings(srv.URL, &EmbeddingRequest{Model: "gte", Input: []string{"x"}, Dimensions: 128}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !dimensionsPresent {
+		t.Fatalf("expected dimensions forwarded to TEI")
+	}
+	if int(gotDimensions.(float64)) != 128 {
+		t.Errorf("dimensions = %v, want 128", gotDimensions)
+	}
+
+	// Without dimensions, it must be omitted (native dims).
+	if _, err := callTEIEmbeddings(srv.URL, &EmbeddingRequest{Model: "gte", Input: []string{"x"}}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dimensionsPresent {
+		t.Errorf("dimensions should be omitted when not requested")
+	}
+}
+
+func TestCallTEIEmbeddings_UpstreamError(t *testing.T) {
+	srv := newTEIServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"error":"model not loaded"}`))
+	})
+	defer srv.Close()
+
+	_, err := callTEIEmbeddings(srv.URL, &EmbeddingRequest{Model: "gte", Input: []string{"x"}})
+	if err == nil {
+		t.Fatalf("expected error on 500, got nil")
+	}
+}
+
+func TestEmbeddingHandler_Execute(t *testing.T) {
+	srv := newTEIServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"data":[{"index":0,"embedding":[0.5,0.6,0.7]}],"model":"gte","usage":{"prompt_tokens":2,"total_tokens":2}}`))
+	})
+	defer srv.Close()
+
+	t.Setenv("CITADEL_TEI_URL", srv.URL)
+
+	h := &EmbeddingHandler{}
+	job := &nexus.Job{
+		ID:   "job-1",
+		Type: "embedding",
+		Payload: map[string]string{
+			"model": "gte",
+			"input": `["hello"]`,
+		},
+	}
+	out, err := h.Execute(JobContext{}, job)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var res EmbeddingResult
+	if err := json.Unmarshal(out, &res); err != nil {
+		t.Fatalf("result not valid JSON: %v", err)
+	}
+	if len(res.Embeddings) != 1 || res.Dimensions != 3 {
+		t.Errorf("got %d embeddings dim=%d, want 1 dim=3", len(res.Embeddings), res.Dimensions)
+	}
+}
+
+func TestEmbeddingHandler_Execute_BadPayload(t *testing.T) {
+	h := &EmbeddingHandler{}
+	job := &nexus.Job{ID: "job-2", Type: "embedding", Payload: map[string]string{"input": `["x"]`}}
+	if _, err := h.Execute(JobContext{}, job); err == nil {
+		t.Fatalf("expected error for missing model")
+	}
+}

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -131,6 +131,12 @@ func CreateLegacyHandlersWithOpts(opts LegacyHandlerOpts) []JobHandler {
 		NewLegacyHandlerAdapter(JobTypeLlamaCppInference, &jobs.LlamaCppInferenceHandler{}),
 		NewLegacyHandlerAdapter(JobTypeVLLMInference, &jobs.VLLMInferenceHandler{}),
 		NewLegacyHandlerAdapter(JobTypeOllamaInference, &jobs.OllamaInferenceHandler{}),
+		// Text-embedding jobs route to the local TEI service's OpenAI-compatible
+		// /v1/embeddings endpoint (issue #351). Registered unconditionally — like
+		// the other inference engines it needs no workspace sandbox; nodes that
+		// don't run TEI simply never receive `embedding` jobs (they only land on
+		// nodes carrying the task:embedding capability tag).
+		NewLegacyHandlerAdapter(JobTypeEmbedding, &jobs.EmbeddingHandler{}),
 		NewLegacyHandlerAdapter(JobTypeApplyDeviceConfig, jobs.NewConfigHandler("")),
 		NewLegacyHandlerAdapter(JobTypeExtraction, &jobs.ExtractionHandler{}),
 		NewLegacyHandlerAdapter(JobTypeHTTPProxy, &jobs.HTTPProxyHandler{}),


### PR DESCRIPTION
Implements **#351** — the embedding fabric-routing half of **#343**. Makes text embeddings a first-class fabric job, gateway route, and MCP tool, routed to the local TEI (HF Text-Embeddings-Inference) service that serves an OpenAI-compatible `/v1/embeddings` on port 8102.

## What's in this PR

1. **Embedding job handler** — `internal/jobs/embedding_handler.go`. `EmbeddingHandler` (legacy `jobs.JobHandler`) POSTs `{model, input, dimensions?}` to TEI's `/v1/embeddings` (default `http://localhost:8102`, overridable via `CITADEL_TEI_URL`), waits for `/health`, and returns index-ordered vectors + usage. Mirrors `llm_inference.go`'s TEI-call/health style.
2. **Worker registration** — `internal/worker/handler_adapter.go`: registers `EmbeddingHandler` for `JobTypeEmbedding` in the live dispatch (`CreateLegacyHandlersWithOpts`), alongside the other inference engines. Also added to the `cmd/job_handlers.go` diagnostic map.
3. **Gateway upstream** — `cmd/serve.go` **and** `cmd/work.go` register a `/v1/embeddings` upstream pointing at the TEI port, with new `--embedding-port` / `--gateway-embedding-port` flags (default `8102`). Both gateway commands carry duplicated upstream lists, so both were updated — `citadel work` is the primary deployment path.
4. **MCP tool** — `docs/mcp-server.md` documents `fabric_embed_text(node_id, texts[], model_id?, dimensions?)`. The MCP server (`cmd/mcp.go`) is a stdio→HTTP bridge to the aceteam backend, so the **server-side tool handler lives out of this repo**; this PR provides the node-side `embedding` handler it dispatches to.
5. **Matryoshka `dimensions`** — forwarded to TEI only when explicitly set; otherwise native dims.

## Design decision — `input` payload contract (primary review item)

The live dispatch path (`worker.LegacyHandlerAdapter`) flattens the job payload `map[string]any` → `map[string]string` via `fmt.Sprint` before the handler sees it. A raw `input []string` would stringify to `"[a b]"` and become unrecoverable. **The handler therefore expects `input` as a JSON-encoded array string** (e.g. `["hello","world"]`), which it `json.Unmarshal`s; a bare scalar string is accepted as a single text. This deviates from `llm_inference.go`'s structure-preserving signature — but that handler is **not** wired into the live worker path. **Whether the server-side dispatcher actually sends `input` in this JSON-string form is the #1 thing to verify against the live fabric.**

## Queue routing (#351 item 3)

Node queue subscription is **dynamic** via `capabilities.ResolveQueues` from the node's capability tags — there's no static queue list to edit. A node carrying the `task:embedding` tag (added by **#343 PR A**'s `serviceTags` on TEI install, not in this branch) auto-subscribes to `jobs:v1:tag:task:embedding`. Delivered here as a unit test of that contract. The `tei → task:embedding` serviceTags entry is intentionally left to PR A to avoid a duplicate-merge conflict.

## Unit-tested in this PR

- Handler against a mock TEI (`httptest`): payload parse (JSON-array + scalar + spaces-preserved + dimensions + error cases), index-based vector reordering, `dimensions` forward-vs-omit, upstream-error propagation, full `Execute`.
- `ResolveQueues([task:embedding], base)` includes `jobs:v1:tag:task:embedding`; `TagQueueName` mapping.
- Gateway `/v1/embeddings` path routes to the embedding upstream (no prefix strip).

`go build ./cmd/citadel` and `go test ./...` are green.

## Needs fabric verification at review (out of scope here, per #351)

- The real dispatched job payload shape — specifically the `input`-as-JSON-string contract above.
- End-to-end metering on `/v1/embeddings` (the path is already in the metered set; this PR adds the upstream).
- The server-side `fabric_embed_text` MCP tool handler (aceteam backend, out of this repo).
- Gated for full end-to-end use by the catalog-layout fix #350 and the `tei` service (citadel-services#2 / #343 PR A).

Part of #343.

🤖 Generated with [Claude Code](https://claude.com/claude-code)