### PR TITLE
feat(module): least-privilege sandbox for untrusted modules (#348)

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -1224,7 +1224,13 @@ func ccStartService(name string) error {
 	for _, service := range manifest.Services {
 		if service.Name == name {
 			fullComposePath := filepath.Join(configDir, service.ComposeFile)
-			cmd := exec.Command("docker", "compose", "-f", fullComposePath, "-p", "citadel-"+name, "up", "-d")
+			// Include the least-privilege sandbox override when present so a
+			// TUI-installed untrusted module also starts hardened here (the
+			// override would otherwise be bypassed by this start site).
+			args := []string{"compose"}
+			args = append(args, composeFileArgs(fullComposePath, fullComposePath)...)
+			args = append(args, "-p", "citadel-"+name, "up", "-d")
+			cmd := exec.Command("docker", args...)
 			return cmd.Run()
 		}
 	}

--- a/cmd/module.go
+++ b/cmd/module.go
@@ -200,8 +200,16 @@ func runModuleInstall(cmd *cobra.Command, args []string) error {
 
 	servicesDir := filepath.Join(configDir, "services")
 
+	// Untrusted (Tier-2) sources get the least-privilege sandbox: bind-mount
+	// confinement + a generated hardening override. Trusted (Tier 0/1) run as-is.
+	untrusted := !trusted
+	if untrusted {
+		fmt.Printf("\n%s\n", color.YellowString("Applying least-privilege sandbox (drop caps, no-new-privileges, "+
+			"read-only rootfs, resource limits)."))
+	}
+
 	fmt.Printf("\nInstalling %s ...\n", manifest.Name)
-	result, err := catalog.InstallFromManifest(manifest, resolved.ComposePath, servicesDir, overrides, true, moduleAllowPrivileged)
+	result, err := catalog.InstallFromManifest(manifest, resolved.ComposePath, servicesDir, overrides, true, moduleAllowPrivileged, untrusted)
 	if err != nil {
 		return fmt.Errorf("install failed: %w", err)
 	}
@@ -213,13 +221,17 @@ func runModuleInstall(cmd *cobra.Command, args []string) error {
 	}
 
 	// Record provenance into the lockfile (best-effort: never fail the install),
-	// carrying the verified-signature flag computed above.
-	recordModuleLock(src, resolved, lockImages)
+	// carrying the verified-signature flag computed above and whether a sandbox
+	// override was written.
+	recordModuleLock(src, resolved, lockImages, result.Sandboxed)
 
 	fmt.Printf("\nInstalled %s successfully.\n", result.Name)
 	fmt.Printf("  Compose: %s\n", result.ComposeDestPath)
 	if result.EnvDestPath != "" {
 		fmt.Printf("  Config:  %s\n", result.EnvDestPath)
+	}
+	if result.Sandboxed {
+		fmt.Printf("  Sandbox: %s\n", result.SandboxOverridePath)
 	}
 	if len(manifest.NodeTags) > 0 {
 		fmt.Printf("  Routing tags: %s\n", strings.Join(manifest.NodeTags, ", "))
@@ -234,7 +246,7 @@ func runModuleInstall(cmd *cobra.Command, args []string) error {
 // does not fail the install. If images is nil it is built from the resolved
 // source; callers that already verified signatures pass the verified-flagged
 // images so the result is recorded.
-func recordModuleLock(src catalog.Source, resolved *catalog.ResolvedModule, images []catalog.LockImage) {
+func recordModuleLock(src catalog.Source, resolved *catalog.ResolvedModule, images []catalog.LockImage, sandboxed bool) {
 	if images == nil {
 		images = catalog.BuildLockImages(resolved.Images)
 	}
@@ -245,6 +257,7 @@ func recordModuleLock(src catalog.Source, resolved *catalog.ResolvedModule, imag
 		ResolvedRef: resolved.ResolvedRef,
 		Commit:      resolved.Commit,
 		Images:      images,
+		Sandboxed:   sandboxed,
 	}
 	if err := catalog.UpsertLockEntry(entry); err != nil {
 		fmt.Fprintf(os.Stderr, "  Note: could not record provenance in modules.lock: %v\n", err)
@@ -287,10 +300,11 @@ func runModuleList(cmd *cobra.Command, args []string) error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	defer w.Flush()
 	bold := color.New(color.Bold)
-	bold.Fprintf(w, "MODULE\tSOURCE\tIMAGE\n")
+	bold.Fprintf(w, "MODULE\tSOURCE\tIMAGE\tSANDBOX\n")
 	for _, s := range manifest.Services {
 		source := color.New(color.FgWhite).Sprint("catalog/embedded")
 		image := "-"
+		sandbox := "-"
 		if lf != nil {
 			if e, ok := lf.LookupLock(s.Name); ok {
 				source = e.Source
@@ -298,9 +312,12 @@ func runModuleList(cmd *cobra.Command, args []string) error {
 					source = fmt.Sprintf("%s@%s", e.Source, shortCommit(e.Commit))
 				}
 				image = formatLockImages(e.Images)
+				if e.Sandboxed {
+					sandbox = color.GreenString("sandboxed")
+				}
 			}
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\n", s.Name, source, image)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", s.Name, source, image, sandbox)
 	}
 	return nil
 }
@@ -682,7 +699,10 @@ func buildModuleInstallCallbacks() controlcenter.ModuleInstallCallbacks {
 			if src.Kind == catalog.KindCatalog {
 				allow = true
 			}
-			result, err := catalog.InstallFromManifest(manifest, composeSrc, servicesDir, overrides, false, allow)
+			// Untrusted (Tier-2) sources get the least-privilege sandbox in the
+			// shared core, matching the CLI path. Catalog/trusted run as-is.
+			untrusted := !catalog.IsTrusted(src)
+			result, err := catalog.InstallFromManifest(manifest, composeSrc, servicesDir, overrides, false, allow, untrusted)
 			if err != nil {
 				return "", err
 			}
@@ -692,7 +712,7 @@ func buildModuleInstallCallbacks() controlcenter.ModuleInstallCallbacks {
 			}
 			// Record provenance for external sources (best-effort).
 			if resolved != nil {
-				recordModuleLock(src, resolved, lockImages)
+				recordModuleLock(src, resolved, lockImages, result.Sandboxed)
 			}
 			return result.Name, nil
 		},

--- a/cmd/module_update.go
+++ b/cmd/module_update.go
@@ -163,7 +163,11 @@ func updateOne(entry catalog.LockEntry, src catalog.Source, servicesDir string) 
 	// still refuses a newly-introduced Critical compose unless allowed. We pass
 	// false so a module that *becomes* privileged on update is refused, which is
 	// the safe default; the operator can re-run `module install` with the flag.
-	if _, err := catalog.InstallFromManifest(resolved.Manifest, resolved.ComposePath, servicesDir, nil, false, false); err != nil {
+	// Preserve the recorded sandbox posture across an update: if the module was
+	// installed as untrusted/sandboxed, regenerate its hardening override from the
+	// (possibly changed) new compose so the override never goes stale.
+	res, err := catalog.InstallFromManifest(resolved.Manifest, resolved.ComposePath, servicesDir, nil, false, false, entry.Sandboxed)
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "  re-install failed for %s: %v\n", entry.Name, err)
 		return false
 	}
@@ -175,6 +179,7 @@ func updateOne(entry catalog.LockEntry, src catalog.Source, servicesDir string) 
 		ResolvedRef: resolved.ResolvedRef,
 		Commit:      resolved.Commit,
 		Images:      catalog.BuildLockImages(resolved.Images),
+		Sandboxed:   res.Sandboxed,
 	}
 	if err := catalog.UpsertLockEntry(newEntry); err != nil {
 		fmt.Fprintf(os.Stderr, "  could not update lockfile for %s: %v\n", entry.Name, err)
@@ -214,7 +219,7 @@ func rollback(prev catalog.LockEntry, servicesDir string) {
 		fmt.Fprintf(os.Stderr, "  rollback failed to re-resolve previous version: %v\n", err)
 		return
 	}
-	if _, err := catalog.InstallFromManifest(resolved.Manifest, resolved.ComposePath, servicesDir, nil, false, true); err != nil {
+	if _, err := catalog.InstallFromManifest(resolved.Manifest, resolved.ComposePath, servicesDir, nil, false, true, prev.Sandboxed); err != nil {
 		fmt.Fprintf(os.Stderr, "  rollback re-install failed: %v\n", err)
 		return
 	}
@@ -270,7 +275,12 @@ func composeUpDetached(name, composePath string) error {
 	if _, err := os.Stat(composePath); err != nil {
 		return fmt.Errorf("compose file not found: %s", composePath)
 	}
-	c := exec.Command("docker", "compose", "-f", composePath, "-p", "citadel-"+name, "up", "-d")
+	// Include the least-privilege sandbox override when present (untrusted/Tier-2
+	// modules) so an updated/rolled-back sandboxed module restarts hardened.
+	args := []string{"compose"}
+	args = append(args, composeFileArgs(composePath, composePath)...)
+	args = append(args, "-p", "citadel-"+name, "up", "-d")
+	c := exec.Command("docker", args...)
 	if out, err := c.CombinedOutput(); err != nil {
 		return fmt.Errorf("docker compose up failed: %s", strings.TrimSpace(string(out)))
 	}

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -127,12 +127,50 @@ func startService(serviceName, composeFilePath string) error {
 		}
 	}
 
-	composeCmd := exec.Command("docker", "compose", "-f", actualComposePath, "up", "-d")
+	// Include the per-module least-privilege sandbox override when a sibling
+	// <name>.sandbox.yml exists (written at install time for untrusted/Tier-2
+	// modules). A no-op for every existing (non-sandboxed) service. The sibling is
+	// derived from the ORIGINAL compose path, not actualComposePath -- on non-Linux
+	// the latter may be a GPU-stripped temp file in a different directory.
+	args := []string{"compose"}
+	args = append(args, composeFileArgs(composeFilePath, actualComposePath)...)
+	args = append(args, "up", "-d")
+	composeCmd := exec.Command("docker", args...)
 	output, err = composeCmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("docker compose failed: %s", string(output))
 	}
 	return nil
+}
+
+// composeFileArgs returns the ordered "-f <file>" arguments for a docker compose
+// invocation: the base compose, followed by the per-module least-privilege
+// sandbox override (<name>.sandbox.yml) when that sibling file exists. The
+// sandbox sibling is resolved from origComposePath (the installed compose, whose
+// directory holds the override), while the base file passed to docker is
+// actualComposePath (which may be a platform-stripped temp copy). When no
+// override exists, only the base file is returned -- additive and a no-op for
+// every pre-sandbox service.
+func composeFileArgs(origComposePath, actualComposePath string) []string {
+	args := []string{"-f", actualComposePath}
+	if override := sandboxOverridePathFor(origComposePath); override != "" {
+		args = append(args, "-f", override)
+	}
+	return args
+}
+
+// sandboxOverridePathFor returns the path of the sandbox override that sits next
+// to a service's compose file (<dir>/<name>.sandbox.yml), or "" if it does not
+// exist. The compose file is "<name>.yml"; the override shares the same <name>.
+func sandboxOverridePathFor(composePath string) string {
+	dir := filepath.Dir(composePath)
+	base := filepath.Base(composePath)
+	name := strings.TrimSuffix(base, filepath.Ext(base))
+	override := filepath.Join(dir, name+".sandbox.yml")
+	if _, err := os.Stat(override); err == nil {
+		return override
+	}
+	return ""
 }
 
 // determineServiceType decides whether to use native or docker for a service.

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aceteam-ai/citadel-cli/internal/catalog"
 	"github.com/aceteam-ai/citadel-cli/internal/compose"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
 	"github.com/aceteam-ai/citadel-cli/internal/services"
@@ -162,15 +163,13 @@ func composeFileArgs(origComposePath, actualComposePath string) []string {
 // sandboxOverridePathFor returns the path of the sandbox override that sits next
 // to a service's compose file (<dir>/<name>.sandbox.yml), or "" if it does not
 // exist. The compose file is "<name>.yml"; the override shares the same <name>.
+// Delegates to catalog.ExistingSandboxOverride (the single source of truth for
+// the override filename).
 func sandboxOverridePathFor(composePath string) string {
 	dir := filepath.Dir(composePath)
 	base := filepath.Base(composePath)
 	name := strings.TrimSuffix(base, filepath.Ext(base))
-	override := filepath.Join(dir, name+".sandbox.yml")
-	if _, err := os.Stat(override); err == nil {
-		return override
-	}
-	return ""
+	return catalog.ExistingSandboxOverride(dir, name)
 }
 
 // determineServiceType decides whether to use native or docker for a service.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/aceteam-ai/citadel-cli
 go 1.26.4
 
 require (
+	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/UserExistsError/conpty v0.1.4
 	github.com/alicebob/miniredis/v2 v2.36.1
 	github.com/charmbracelet/bubbles v0.21.0
@@ -32,7 +33,6 @@ require (
 
 require (
 	filippo.io/edwards25519 v1.2.0 // indirect
-	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/akutz/memconn v0.1.0 // indirect
 	github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,7 +6,6 @@ filippo.io/mkcert v1.4.4 h1:8eVbbwfVlaqUM7OwuftKc2nuYOoTDQWqsoXmzoXZdbc=
 filippo.io/mkcert v1.4.4/go.mod h1:VyvOchVuAye3BoUsPUOOofKygVwLV2KQMVFJNRq+1dA=
 github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/UserExistsError/conpty v0.1.4 h1:+3FhJhiqhyEJa+K5qaK3/w6w+sN3Nh9O9VbJyBS02to=

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -63,12 +63,57 @@ type ServiceManifest struct {
 	// node manifest's Node.Tags on install so third-party engines become
 	// routable without a CLI change. Distinct from the display Tags above.
 	NodeTags []string `yaml:"node_tags"`
+	// Sandbox declares the least-privilege needs of an untrusted (Tier 2) module.
+	// It is OPTIONAL: a module with no sandbox: block gets the strict defaults
+	// (all caps dropped, no-new-privileges, read-only rootfs, conservative
+	// resource limits). The installer grants exactly what is declared here and
+	// drops everything else. Trusted (Tier 0/1) modules ignore this entirely and
+	// run as-is. See internal/catalog/sandbox.go.
+	Sandbox SandboxSpec `yaml:"sandbox"`
 }
 
 // CurrentSchemaVersion is the highest service.yaml schema major version this CLI
 // understands. A manifest declaring a higher value is still loaded (best-effort)
 // but the operator is warned it may use fields this CLI ignores.
-const CurrentSchemaVersion = 1
+//
+// v2 adds the optional `sandbox:` block (declarative least-privilege needs for
+// untrusted modules). It is purely additive -- a v1 manifest is fully valid.
+const CurrentSchemaVersion = 2
+
+// SandboxSpec is the optional declarative least-privilege block of a module
+// manifest. Every field is optional; an absent field means "strict default".
+type SandboxSpec struct {
+	// Capabilities are the Linux capabilities to KEEP (added back via cap_add
+	// after cap_drop: ALL). Names may be given with or without the "CAP_" prefix
+	// (e.g. "NET_BIND_SERVICE" or "CAP_NET_BIND_SERVICE"); they are emitted
+	// verbatim. Empty means no capabilities are kept.
+	Capabilities []string `yaml:"capabilities"`
+	// Devices are host devices the module legitimately needs (compose `devices:`
+	// entries, e.g. "/dev/snd"). Empty means none.
+	Devices []string `yaml:"devices"`
+	// WritablePaths are in-container paths that must be writable. With a read-only
+	// rootfs, each becomes a tmpfs mount so the module can write there. "/tmp" is
+	// always writable regardless.
+	WritablePaths []string `yaml:"writable_paths"`
+	// HostNetwork opts the module into host networking. Default false: host
+	// networking is NOT granted unless explicitly declared (and it independently
+	// trips the #342 risk scan).
+	HostNetwork bool `yaml:"host_network"`
+	// Resources declares cgroup limits. Unset fields fall back to conservative
+	// defaults in GenerateHardeningOverride.
+	Resources SandboxResources `yaml:"resources"`
+}
+
+// SandboxResources declares per-module cgroup limits. Zero/empty values fall
+// back to conservative defaults.
+type SandboxResources struct {
+	// CPU is the cpus limit (compose `cpus:`, e.g. "2.0"). Empty -> default.
+	CPU string `yaml:"cpu"`
+	// Memory is the memory limit (compose `mem_limit:`, e.g. "2g"). Empty -> default.
+	Memory string `yaml:"memory"`
+	// PIDs is the pids_limit. Zero -> default.
+	PIDs int `yaml:"pids"`
+}
 
 // Requirements describes what a service needs from the host.
 type Requirements struct {

--- a/internal/catalog/install.go
+++ b/internal/catalog/install.go
@@ -36,6 +36,13 @@ type InstallResult struct {
 	ComposeDestPath string
 	// EnvDestPath is the absolute path where the .env file was written, or empty.
 	EnvDestPath string
+	// Sandboxed is true when a least-privilege hardening override was generated
+	// and written (untrusted/Tier-2 installs only). When true,
+	// SandboxOverridePath points at the override file.
+	Sandboxed bool
+	// SandboxOverridePath is the absolute path of the <name>.sandbox.yml override,
+	// or empty when not sandboxed.
+	SandboxOverridePath string
 }
 
 // Install copies a catalog service's compose.yml (and optional .env) into the
@@ -60,9 +67,10 @@ func Install(name string, servicesDir string, configOverrides map[string]string)
 
 	// Catalog services are first-party (Tier 0) and have no --allow-privileged
 	// flag, so the privilege gate must not apply to them (it would be an
-	// un-overridable failure). Pass allowPrivileged=true. The module-source path
-	// passes the real flag value.
-	return InstallFromManifest(manifest, composeSrc, servicesDir, configOverrides, true, true)
+	// un-overridable failure). Pass allowPrivileged=true. They are trusted, so
+	// untrusted=false: no sandbox hardening is applied. The module-source path
+	// passes the real flag + trust values.
+	return InstallFromManifest(manifest, composeSrc, servicesDir, configOverrides, true, true, false)
 }
 
 // InstallFromManifest installs a service from an already-loaded manifest and a
@@ -81,9 +89,19 @@ func Install(name string, servicesDir string, configOverrides map[string]string)
 // the TUI non-interactive path are protected identically. Catalog (Tier-0)
 // installs pass allowPrivileged=true (they have no override flag).
 //
+// untrusted marks a Tier-2 (untrusted-source) install. When true, two extra
+// containment layers run in the shared core so BOTH the CLI and the TUI
+// non-interactive path are protected identically (mirroring the privilege gate):
+//   - bind-mount confinement: a host bind-mount outside the per-module sandbox
+//     data dir is REFUSED unless allowPrivileged is set.
+//   - a least-privilege hardening override (<name>.sandbox.yml) is generated and
+//     written next to the compose; the run path includes it automatically.
+//
+// Trusted (Tier 0/1) installs pass untrusted=false and are unaffected.
+//
 // An empty composeSrcPath means the service is host-provisioned (no container)
 // and InstallFromManifest returns ErrNotInstallable.
-func InstallFromManifest(manifest *ServiceManifest, composeSrcPath, servicesDir string, configOverrides map[string]string, interactive, allowPrivileged bool) (*InstallResult, error) {
+func InstallFromManifest(manifest *ServiceManifest, composeSrcPath, servicesDir string, configOverrides map[string]string, interactive, allowPrivileged, untrusted bool) (*InstallResult, error) {
 	name := manifest.Name
 
 	// 1. Reject host-provisioned services up front (no compose.yml).
@@ -160,6 +178,21 @@ func InstallFromManifest(manifest *ServiceManifest, composeSrcPath, servicesDir 
 					name, strings.Join(criticalDirectives(crit), ", "))
 			}
 		}
+
+		// 4d. Bind-mount confinement (untrusted/Tier-2 only). Enforce the #342
+		// risk-scan warning: an untrusted module may only bind-mount host paths
+		// within its per-module sandbox data dir (<servicesDir>/<name>-data).
+		// Anything outside is refused unless the operator opted into privileged
+		// installs. Trusted (Tier 0/1) installs skip this entirely.
+		if untrusted && !allowPrivileged {
+			if v := BindMountViolations(composeText, servicesDir, name); len(v) > 0 {
+				return nil, fmt.Errorf("refusing to install untrusted module '%s': its compose bind-mounts host "+
+					"path(s) outside the module sandbox dir (%s): %s.\n   "+
+					"Untrusted modules may only mount within their sandbox data dir. "+
+					"If you trust this source, re-run with --allow-privileged to override.",
+					name, SandboxDataDir(servicesDir, name), strings.Join(v, ", "))
+			}
+		}
 	}
 
 	// 5. Resolve config values (prompt for required ones without defaults only
@@ -182,6 +215,32 @@ func InstallFromManifest(manifest *ServiceManifest, composeSrcPath, servicesDir 
 	result := &InstallResult{
 		Name:            name,
 		ComposeDestPath: composeDest,
+	}
+
+	// 6b. Least-privilege sandbox (untrusted/Tier-2 only). Generate a hardening
+	// override from the manifest's declared needs and write it next to the
+	// compose as <name>.sandbox.yml; the run path includes it automatically when
+	// present. Also create the per-module sandbox data dir so the one allowed
+	// bind-mount root exists. Trusted (Tier 0/1) installs skip all of this.
+	if untrusted {
+		baseData, rerr := os.ReadFile(composeDest)
+		if rerr != nil {
+			return nil, fmt.Errorf("failed to read copied compose for sandbox hardening: %w", rerr)
+		}
+		override, gerr := GenerateHardeningOverride(string(baseData), manifest)
+		if gerr != nil {
+			return nil, fmt.Errorf("failed to generate sandbox override for '%s': %w", name, gerr)
+		}
+		overridePath := filepath.Join(servicesDir, name+".sandbox.yml")
+		if werr := os.WriteFile(overridePath, []byte(override), 0600); werr != nil {
+			return nil, fmt.Errorf("failed to write sandbox override: %w", werr)
+		}
+		// Best-effort: create the per-module sandbox data dir (the only host path
+		// an untrusted module is allowed to bind-mount). A failure here is not
+		// fatal -- the module may not use a bind mount at all.
+		_ = os.MkdirAll(SandboxDataDir(servicesDir, name), 0755)
+		result.Sandboxed = true
+		result.SandboxOverridePath = overridePath
 	}
 
 	// 7. Write .env file if there are config values.

--- a/internal/catalog/install.go
+++ b/internal/catalog/install.go
@@ -231,7 +231,7 @@ func InstallFromManifest(manifest *ServiceManifest, composeSrcPath, servicesDir 
 		if gerr != nil {
 			return nil, fmt.Errorf("failed to generate sandbox override for '%s': %w", name, gerr)
 		}
-		overridePath := filepath.Join(servicesDir, name+".sandbox.yml")
+		overridePath := SandboxOverridePath(servicesDir, name)
 		if werr := os.WriteFile(overridePath, []byte(override), 0600); werr != nil {
 			return nil, fmt.Errorf("failed to write sandbox override: %w", werr)
 		}

--- a/internal/catalog/lockfile.go
+++ b/internal/catalog/lockfile.go
@@ -23,6 +23,10 @@ type LockEntry struct {
 	ResolvedRef string      `yaml:"resolved_ref,omitempty"` // concrete tag a constraint/channel resolved to (e.g. "^1.2" -> "v1.4.0")
 	Commit      string      `yaml:"commit,omitempty"`       // resolved git HEAD commit
 	Images      []LockImage `yaml:"images,omitempty"`
+	// Sandboxed records that a least-privilege hardening override was generated
+	// for this (untrusted/Tier-2) module at install time. Absent/false means the
+	// module runs without an override (trusted/curated, or pre-sandbox installs).
+	Sandboxed bool `yaml:"sandboxed,omitempty"`
 }
 
 // LockImage is a single image reference plus an optional resolved digest.

--- a/internal/catalog/risk_test.go
+++ b/internal/catalog/risk_test.go
@@ -189,13 +189,13 @@ func TestInstallFromManifest_PrivilegedGate(t *testing.T) {
 	servicesDir := filepath.Join(dir, "services")
 
 	// allowPrivileged=false must REFUSE even though interactive=false.
-	if _, err := InstallFromManifest(manifest, composePath, servicesDir, nil, false, false); err == nil {
+	if _, err := InstallFromManifest(manifest, composePath, servicesDir, nil, false, false, false); err == nil {
 		t.Fatal("expected refusal for Critical compose without allowPrivileged")
 	}
 
 	// allowPrivileged=true proceeds past the gate (install succeeds: no ports,
 	// no required config, compose copied).
-	res, err := InstallFromManifest(manifest, composePath, servicesDir, nil, false, true)
+	res, err := InstallFromManifest(manifest, composePath, servicesDir, nil, false, true, false)
 	if err != nil {
 		t.Fatalf("expected install to proceed with allowPrivileged=true, got %v", err)
 	}
@@ -213,7 +213,7 @@ func TestInstallFromManifest_CleanComposeNoGate(t *testing.T) {
 	manifest := &ServiceManifest{Name: "clean"}
 	servicesDir := filepath.Join(dir, "services")
 	// A clean compose installs fine even with allowPrivileged=false.
-	if _, err := InstallFromManifest(manifest, composePath, servicesDir, nil, false, false); err != nil {
+	if _, err := InstallFromManifest(manifest, composePath, servicesDir, nil, false, false, false); err != nil {
 		t.Fatalf("clean compose should not be gated, got %v", err)
 	}
 }

--- a/internal/catalog/sandbox.go
+++ b/internal/catalog/sandbox.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -212,6 +213,25 @@ func dedupeStrings(in []string) []string {
 // within this directory unless --allow-privileged is set.
 func SandboxDataDir(servicesDir, name string) string {
 	return filepath.Join(servicesDir, name+"-data")
+}
+
+// SandboxOverridePath returns the path of a module's hardening override
+// (<servicesDir>/<name>.sandbox.yml). It is the single source of truth for the
+// override filename so every docker-compose start site (across packages) can
+// resolve and stat the same file. It does NOT check existence.
+func SandboxOverridePath(servicesDir, name string) string {
+	return filepath.Join(servicesDir, name+".sandbox.yml")
+}
+
+// ExistingSandboxOverride returns SandboxOverridePath if that file exists, else
+// "". Start sites append it as a second `-f` when non-empty -- a no-op for every
+// non-sandboxed (trusted/pre-sandbox) service.
+func ExistingSandboxOverride(servicesDir, name string) string {
+	p := SandboxOverridePath(servicesDir, name)
+	if _, err := os.Stat(p); err == nil {
+		return p
+	}
+	return ""
 }
 
 // BindMountViolations returns the host bind-mount paths in a compose that an

--- a/internal/catalog/sandbox.go
+++ b/internal/catalog/sandbox.go
@@ -1,0 +1,285 @@
+package catalog
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Conservative default cgroup limits applied to an untrusted (Tier 2) module
+// when its manifest does not declare an override. They are intentionally modest:
+// a module declares what it actually needs via the manifest `sandbox.resources`
+// block, and anything bigger is an explicit operator decision.
+const (
+	defaultSandboxCPUs   = "2.0"
+	defaultSandboxMemory = "2g"
+	defaultSandboxPIDs   = 512
+)
+
+// minimalGPUCaps are the capabilities kept for a GPU module even when the
+// manifest declares none. cap_drop: ALL is generally safe for NVIDIA-runtime
+// containers (GPU access goes through the runtime, not Linux caps), so the
+// default GPU cap set is empty; the NVIDIA device reservation in the BASE
+// compose is what grants the GPU, and the override never touches it. This slice
+// is the documented hook for keeping a known-required cap should a GPU image
+// turn out to need one -- today it is empty by design.
+var minimalGPUCaps = []string{}
+
+// composeRoot is the minimal shape we parse from a base compose to enumerate its
+// service names. A compose may define several services (an app + a db sidecar);
+// the hardening override must target each by name.
+type composeRoot struct {
+	Services map[string]yaml.Node `yaml:"services"`
+}
+
+// GenerateHardeningOverride builds a docker-compose override (a second `-f`
+// file) that applies manifest-declared least-privilege to EVERY service defined
+// in the base compose. It is PURE (string in, string out) and table-tested.
+//
+// Per compose service it sets:
+//   - security_opt: ["no-new-privileges:true"]
+//   - cap_drop: ["ALL"] then cap_add: only the manifest-declared capabilities
+//     (plus a minimal set for GPU modules, currently empty by design)
+//   - read_only: true plus tmpfs: ["/tmp"] and a tmpfs entry per declared
+//     writable_path (so a read-only rootfs module can still write where it must)
+//   - pids_limit, mem_limit, cpus from sandbox.resources (or conservative
+//     defaults)
+//   - devices: only the manifest-declared host devices (omitted if none)
+//   - network_mode: "host" ONLY if sandbox.host_network is true (never otherwise)
+//
+// GPU safety: the override deliberately emits NO GPU/device-reservation block.
+// The base compose owns the NVIDIA `deploy.resources.reservations.devices`
+// reservation; the override only adds hardening keys, so a legit GPU module
+// (e.g. the TEI embedding service, #343) still starts. Note that docker-compose
+// list-merges sequences, so a base `cap_add` survives this override's
+// `cap_drop: ALL` -- the override mechanism cannot subtract a base directive.
+// That residual escalation is already covered by the #342 privilege gate
+// (cap_add ALL/SYS_ADMIN is Critical and refused without --allow-privileged).
+func GenerateHardeningOverride(baseComposeYAML string, manifest *ServiceManifest) (string, error) {
+	var root composeRoot
+	if err := yaml.Unmarshal([]byte(baseComposeYAML), &root); err != nil {
+		return "", fmt.Errorf("failed to parse base compose to enumerate services: %w", err)
+	}
+	if len(root.Services) == 0 {
+		return "", fmt.Errorf("base compose declares no services: cannot generate a hardening override")
+	}
+
+	spec := SandboxSpec{}
+	gpu := false
+	if manifest != nil {
+		spec = manifest.Sandbox
+		gpu = manifest.Requires.GPU
+	}
+
+	// Resolve the per-service hardening once (identical for every service).
+	svc := buildServiceHardening(spec, gpu)
+
+	// Stable, deterministic output: sort service names.
+	names := make([]string, 0, len(root.Services))
+	for name := range root.Services {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	out := map[string]map[string]any{}
+	for _, name := range names {
+		out[name] = svc
+	}
+
+	doc := map[string]any{"services": out}
+	data, err := yaml.Marshal(doc)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal hardening override: %w", err)
+	}
+
+	header := "# Citadel least-privilege sandbox override (auto-generated).\n" +
+		"# Applied to untrusted (Tier 2) modules on top of the base compose via\n" +
+		"#   docker compose -f <name>.yml -f <name>.sandbox.yml up\n" +
+		"# Drops all Linux capabilities, forbids privilege escalation, makes the\n" +
+		"# root filesystem read-only, and caps resources. Edit the module manifest's\n" +
+		"# sandbox: block (then reinstall) to declare additional needs.\n"
+	return header + string(data), nil
+}
+
+// buildServiceHardening returns the per-service hardening map applied to every
+// compose service. Pure helper so GenerateHardeningOverride stays small.
+func buildServiceHardening(spec SandboxSpec, gpu bool) map[string]any {
+	svc := map[string]any{
+		"security_opt": []string{"no-new-privileges:true"},
+		"cap_drop":     []string{"ALL"},
+		"read_only":    true,
+	}
+
+	// Capabilities to keep: declared caps, plus the minimal GPU set for GPU
+	// modules. cap_add is only emitted when there is something to add (an empty
+	// cap_add list is meaningless and noisy).
+	caps := normalizeCaps(spec.Capabilities)
+	if gpu {
+		caps = append(caps, minimalGPUCaps...)
+	}
+	caps = dedupeStrings(caps)
+	if len(caps) > 0 {
+		svc["cap_add"] = caps
+	}
+
+	// Read-only rootfs: provide writable tmpfs mounts. /tmp is always writable;
+	// declared writable_paths are added (deduped, /tmp not duplicated).
+	tmpfs := []string{"/tmp"}
+	for _, p := range spec.WritablePaths {
+		p = strings.TrimSpace(p)
+		if p == "" || p == "/tmp" {
+			continue
+		}
+		tmpfs = append(tmpfs, p)
+	}
+	svc["tmpfs"] = dedupeStrings(tmpfs)
+
+	// Resource limits: declared or conservative defaults.
+	cpus := strings.TrimSpace(spec.Resources.CPU)
+	if cpus == "" {
+		cpus = defaultSandboxCPUs
+	}
+	mem := strings.TrimSpace(spec.Resources.Memory)
+	if mem == "" {
+		mem = defaultSandboxMemory
+	}
+	pids := spec.Resources.PIDs
+	if pids <= 0 {
+		pids = defaultSandboxPIDs
+	}
+	svc["cpus"] = cpus
+	svc["mem_limit"] = mem
+	svc["pids_limit"] = pids
+
+	// Host devices: only what the manifest declares.
+	if devs := dedupeStrings(trimAll(spec.Devices)); len(devs) > 0 {
+		svc["devices"] = devs
+	}
+
+	// Host networking: opt-in only.
+	if spec.HostNetwork {
+		svc["network_mode"] = "host"
+	}
+
+	return svc
+}
+
+// normalizeCaps trims and uppercases declared capability names, dropping empties.
+// Names are emitted verbatim (with or without a CAP_ prefix as declared); docker
+// accepts both forms.
+func normalizeCaps(caps []string) []string {
+	out := make([]string, 0, len(caps))
+	for _, c := range caps {
+		c = strings.ToUpper(strings.TrimSpace(c))
+		if c == "" {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+func trimAll(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if s = strings.TrimSpace(s); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func dedupeStrings(in []string) []string {
+	seen := make(map[string]bool, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
+}
+
+// --- bind-mount confinement (enforcement on top of the #342 risk-scan warning) ---
+
+// SandboxDataDir returns the per-module sandbox data directory for a module
+// installed into servicesDir. Host bind-mounts of an untrusted module must stay
+// within this directory unless --allow-privileged is set.
+func SandboxDataDir(servicesDir, name string) string {
+	return filepath.Join(servicesDir, name+"-data")
+}
+
+// BindMountViolations returns the host bind-mount paths in a compose that an
+// untrusted module is NOT permitted to mount: any host bind-mount whose host
+// side resolves outside the per-module sandbox data dir. Named volumes and
+// non-path mounts are ignored. It is PURE (compose text + dirs in, slice out)
+// and table-tested. Parsing is line-based, consistent with risk.go.
+//
+// Relative host paths (e.g. "./data") are resolved against servicesDir, the
+// directory the compose file is copied into -- matching how docker-compose
+// resolves a relative bind path against the compose file's directory.
+func BindMountViolations(compose, servicesDir, name string) []string {
+	allowedRoot := SandboxDataDir(servicesDir, name)
+	var violations []string
+
+	for _, raw := range strings.Split(compose, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		item, ok := listItem(line)
+		if !ok {
+			continue
+		}
+		// A bind mount is "HOST:CONTAINER[:opts]"; a named volume is
+		// "name:CONTAINER" (left side is not a path).
+		parts := strings.SplitN(item, ":", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		host := strings.TrimSpace(parts[0])
+		if !looksLikeHostPath(host) {
+			continue // named volume, not a host bind mount
+		}
+
+		resolved := resolveHostBindPath(host, servicesDir)
+		if !withinDir(allowedRoot, resolved) {
+			violations = append(violations, host)
+		}
+	}
+	return violations
+}
+
+// resolveHostBindPath resolves a compose host bind path for confinement checks.
+// Absolute paths are cleaned as-is; "~"/"~/..." is left as a literal absolute-ish
+// marker (a home mount is always outside the sandbox dir); relative paths are
+// resolved against servicesDir (the compose file's directory).
+func resolveHostBindPath(host, servicesDir string) string {
+	switch {
+	case host == "~" || strings.HasPrefix(host, "~/"):
+		// Home shortcut: always outside the per-module sandbox dir. Return a
+		// sentinel that cannot be within allowedRoot.
+		return filepath.Clean("/__home__" + strings.TrimPrefix(host, "~"))
+	case filepath.IsAbs(host):
+		return filepath.Clean(host)
+	default:
+		return filepath.Clean(filepath.Join(servicesDir, host))
+	}
+}
+
+// withinDir reports whether path is dir itself or nested under it. Boundary-aware
+// (cleans both, then checks for equality or a "dir/" prefix) so "/a/b-data" is
+// not considered within "/a/b".
+func withinDir(dir, path string) bool {
+	dir = filepath.Clean(dir)
+	path = filepath.Clean(path)
+	if path == dir {
+		return true
+	}
+	return strings.HasPrefix(path, dir+string(filepath.Separator))
+}

--- a/internal/catalog/sandbox_test.go
+++ b/internal/catalog/sandbox_test.go
@@ -1,0 +1,486 @@
+package catalog
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func writeFileTest(t *testing.T, path, body string) error {
+	t.Helper()
+	return os.WriteFile(path, []byte(body), 0600)
+}
+
+func fileExistsTest(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// parseOverride unmarshals a generated override into a generic map so tests can
+// assert structure without depending on key order or formatting.
+func parseOverride(t *testing.T, yml string) map[string]map[string]any {
+	t.Helper()
+	var doc struct {
+		Services map[string]map[string]any `yaml:"services"`
+	}
+	if err := yaml.Unmarshal([]byte(yml), &doc); err != nil {
+		t.Fatalf("override is not valid YAML: %v\n---\n%s", err, yml)
+	}
+	return doc.Services
+}
+
+func strSlice(t *testing.T, v any) []string {
+	t.Helper()
+	raw, ok := v.([]any)
+	if !ok {
+		t.Fatalf("expected a list, got %T (%v)", v, v)
+	}
+	out := make([]string, 0, len(raw))
+	for _, e := range raw {
+		s, ok := e.(string)
+		if !ok {
+			t.Fatalf("expected string list element, got %T", e)
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+func contains2(list []string, want string) bool {
+	for _, s := range list {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestGenerateHardeningOverride_Defaults(t *testing.T) {
+	base := `services:
+  app:
+    image: ghcr.io/x/y:latest
+`
+	out, err := GenerateHardeningOverride(base, &ServiceManifest{Name: "x"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	svcs := parseOverride(t, out)
+	app, ok := svcs["app"]
+	if !ok {
+		t.Fatalf("override missing service 'app'; got %v", svcs)
+	}
+
+	// security_opt: no-new-privileges
+	if so := strSlice(t, app["security_opt"]); !contains2(so, "no-new-privileges:true") {
+		t.Errorf("security_opt missing no-new-privileges: %v", so)
+	}
+	// cap_drop: ALL
+	if cd := strSlice(t, app["cap_drop"]); !contains2(cd, "ALL") {
+		t.Errorf("cap_drop should contain ALL: %v", cd)
+	}
+	// No cap_add by default (nothing declared, non-GPU).
+	if _, present := app["cap_add"]; present {
+		t.Errorf("cap_add should be absent when no caps declared: %v", app["cap_add"])
+	}
+	// read_only true
+	if ro, _ := app["read_only"].(bool); !ro {
+		t.Errorf("read_only should be true, got %v", app["read_only"])
+	}
+	// tmpfs contains /tmp
+	if tm := strSlice(t, app["tmpfs"]); !contains2(tm, "/tmp") {
+		t.Errorf("tmpfs should contain /tmp: %v", tm)
+	}
+	// resource defaults present
+	if app["cpus"] != defaultSandboxCPUs {
+		t.Errorf("cpus default = %v, want %v", app["cpus"], defaultSandboxCPUs)
+	}
+	if app["mem_limit"] != defaultSandboxMemory {
+		t.Errorf("mem_limit default = %v, want %v", app["mem_limit"], defaultSandboxMemory)
+	}
+	if app["pids_limit"] != defaultSandboxPIDs {
+		t.Errorf("pids_limit default = %v, want %v", app["pids_limit"], defaultSandboxPIDs)
+	}
+	// No host networking unless declared.
+	if _, present := app["network_mode"]; present {
+		t.Errorf("network_mode should be absent by default: %v", app["network_mode"])
+	}
+	// No devices unless declared.
+	if _, present := app["devices"]; present {
+		t.Errorf("devices should be absent by default: %v", app["devices"])
+	}
+}
+
+func TestGenerateHardeningOverride_MultiService(t *testing.T) {
+	base := `services:
+  web:
+    image: ghcr.io/x/web:latest
+  db:
+    image: postgres:16
+`
+	out, err := GenerateHardeningOverride(base, &ServiceManifest{Name: "x"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	svcs := parseOverride(t, out)
+	for _, name := range []string{"web", "db"} {
+		svc, ok := svcs[name]
+		if !ok {
+			t.Fatalf("override missing service %q; got %v", name, svcs)
+		}
+		if cd := strSlice(t, svc["cap_drop"]); !contains2(cd, "ALL") {
+			t.Errorf("service %q cap_drop should contain ALL: %v", name, cd)
+		}
+		if ro, _ := svc["read_only"].(bool); !ro {
+			t.Errorf("service %q read_only should be true", name)
+		}
+	}
+}
+
+func TestGenerateHardeningOverride_DeclaredCapsAndWritablePaths(t *testing.T) {
+	base := `services:
+  app:
+    image: ghcr.io/x/y:latest
+`
+	m := &ServiceManifest{
+		Name: "x",
+		Sandbox: SandboxSpec{
+			Capabilities:  []string{"net_bind_service", "CAP_CHOWN", " "},
+			WritablePaths: []string{"/var/cache", "/tmp", "/data"},
+			Devices:       []string{"/dev/snd"},
+			Resources:     SandboxResources{CPU: "4.0", Memory: "8g", PIDs: 1024},
+		},
+	}
+	out, err := GenerateHardeningOverride(base, m)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	app := parseOverride(t, out)["app"]
+
+	caps := strSlice(t, app["cap_add"])
+	if !contains2(caps, "NET_BIND_SERVICE") {
+		t.Errorf("cap_add should contain NET_BIND_SERVICE (uppercased): %v", caps)
+	}
+	if !contains2(caps, "CAP_CHOWN") {
+		t.Errorf("cap_add should contain CAP_CHOWN verbatim: %v", caps)
+	}
+	if len(caps) != 2 {
+		t.Errorf("blank cap should be dropped; got %v", caps)
+	}
+
+	tm := strSlice(t, app["tmpfs"])
+	if !contains2(tm, "/var/cache") || !contains2(tm, "/data") {
+		t.Errorf("tmpfs should include declared writable paths: %v", tm)
+	}
+	// /tmp present exactly once (declared duplicate de-duped).
+	count := 0
+	for _, p := range tm {
+		if p == "/tmp" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("/tmp should appear exactly once, got %d: %v", count, tm)
+	}
+
+	if devs := strSlice(t, app["devices"]); !contains2(devs, "/dev/snd") {
+		t.Errorf("devices should contain declared /dev/snd: %v", devs)
+	}
+	if app["cpus"] != "4.0" || app["mem_limit"] != "8g" || app["pids_limit"] != 1024 {
+		t.Errorf("declared resources not honored: cpus=%v mem=%v pids=%v",
+			app["cpus"], app["mem_limit"], app["pids_limit"])
+	}
+}
+
+func TestGenerateHardeningOverride_HostNetworkOptIn(t *testing.T) {
+	base := "services:\n  app:\n    image: x\n"
+
+	// Default: no host networking.
+	out, _ := GenerateHardeningOverride(base, &ServiceManifest{Name: "x"})
+	if _, present := parseOverride(t, out)["app"]["network_mode"]; present {
+		t.Errorf("network_mode must be absent unless host_network declared")
+	}
+
+	// Opt-in.
+	m := &ServiceManifest{Name: "x", Sandbox: SandboxSpec{HostNetwork: true}}
+	out, _ = GenerateHardeningOverride(base, m)
+	if got := parseOverride(t, out)["app"]["network_mode"]; got != "host" {
+		t.Errorf("network_mode = %v, want host", got)
+	}
+}
+
+// TestGenerateHardeningOverride_GPU encodes the TEI (#343) shape: a GPU module
+// with a NVIDIA device reservation, a model-cache writable path, and a declared
+// device. The override must still be valid, must NOT emit any GPU/deploy block,
+// and must keep cap_drop ALL with an empty (or empty-by-design) cap set.
+func TestGenerateHardeningOverride_GPU(t *testing.T) {
+	base := `services:
+  tei:
+    image: ghcr.io/huggingface/text-embeddings-inference:latest
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+`
+	m := &ServiceManifest{
+		Name:     "tei",
+		Requires: Requirements{GPU: true},
+		Sandbox: SandboxSpec{
+			WritablePaths: []string{"/data"},
+		},
+	}
+	out, err := GenerateHardeningOverride(base, m)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Override must not introduce any GPU/deploy reservation (base owns it).
+	if strings.Contains(out, "deploy:") || strings.Contains(out, "reservations") || strings.Contains(out, "nvidia") {
+		t.Errorf("override must not emit a GPU/deploy block:\n%s", out)
+	}
+	tei := parseOverride(t, out)["tei"]
+	if cd := strSlice(t, tei["cap_drop"]); !contains2(cd, "ALL") {
+		t.Errorf("GPU module should still cap_drop ALL: %v", cd)
+	}
+	// minimalGPUCaps is empty by design -> no cap_add for a GPU module with no
+	// declared caps.
+	if _, present := tei["cap_add"]; present {
+		t.Errorf("GPU module with no declared caps should have no cap_add: %v", tei["cap_add"])
+	}
+	if tm := strSlice(t, tei["tmpfs"]); !contains2(tm, "/data") {
+		t.Errorf("GPU module writable path /data missing from tmpfs: %v", tm)
+	}
+}
+
+func TestGenerateHardeningOverride_NoServicesError(t *testing.T) {
+	if _, err := GenerateHardeningOverride("name: not-a-compose\n", &ServiceManifest{Name: "x"}); err == nil {
+		t.Error("expected an error for a compose with no services")
+	}
+	if _, err := GenerateHardeningOverride(":::not yaml:::", &ServiceManifest{Name: "x"}); err == nil {
+		t.Error("expected an error for invalid YAML")
+	}
+}
+
+func TestGenerateHardeningOverride_Deterministic(t *testing.T) {
+	base := "services:\n  b:\n    image: x\n  a:\n    image: y\n"
+	a, _ := GenerateHardeningOverride(base, &ServiceManifest{Name: "x"})
+	b, _ := GenerateHardeningOverride(base, &ServiceManifest{Name: "x"})
+	if a != b {
+		t.Errorf("override generation should be deterministic:\n%s\n---\n%s", a, b)
+	}
+}
+
+// --- bind-mount confinement ---
+
+func TestBindMountViolations(t *testing.T) {
+	servicesDir := "/home/u/citadel-node/services"
+	name := "mod"
+	allowed := SandboxDataDir(servicesDir, name) // /home/u/citadel-node/services/mod-data
+
+	tests := []struct {
+		desc       string
+		compose    string
+		wantViols  []string
+		wantNoViol bool
+	}{
+		{
+			desc: "named volume is fine",
+			compose: `services:
+  app:
+    image: x
+    volumes:
+      - mydata:/var/lib/data
+`,
+			wantNoViol: true,
+		},
+		{
+			desc: "bind mount inside sandbox data dir is fine",
+			compose: `services:
+  app:
+    image: x
+    volumes:
+      - ` + filepath.Join(allowed, "sub") + `:/data
+`,
+			wantNoViol: true,
+		},
+		{
+			desc: "relative bind resolving into sandbox data dir is fine",
+			compose: `services:
+  app:
+    image: x
+    volumes:
+      - ./mod-data/cache:/cache
+`,
+			wantNoViol: true,
+		},
+		{
+			desc: "absolute bind outside is a violation",
+			compose: `services:
+  app:
+    image: x
+    volumes:
+      - /etc:/host-etc
+`,
+			wantViols: []string{"/etc"},
+		},
+		{
+			desc: "home bind is a violation",
+			compose: `services:
+  app:
+    image: x
+    volumes:
+      - ~/secrets:/secrets
+`,
+			wantViols: []string{"~/secrets"},
+		},
+		{
+			desc: "sibling dir with shared prefix is NOT within sandbox dir",
+			compose: `services:
+  app:
+    image: x
+    volumes:
+      - ` + servicesDir + `/mod-data-evil:/x
+`,
+			wantViols: []string{servicesDir + "/mod-data-evil"},
+		},
+		{
+			desc: "multiple binds, mixed",
+			compose: `services:
+  app:
+    image: x
+    volumes:
+      - ` + filepath.Join(allowed, "ok") + `:/ok
+      - /var/run/foo:/bad
+`,
+			wantViols: []string{"/var/run/foo"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := BindMountViolations(tc.compose, servicesDir, name)
+			if tc.wantNoViol {
+				if len(got) != 0 {
+					t.Errorf("expected no violations, got %v", got)
+				}
+				return
+			}
+			if len(got) != len(tc.wantViols) {
+				t.Fatalf("violations = %v, want %v", got, tc.wantViols)
+			}
+			for i, w := range tc.wantViols {
+				if got[i] != w {
+					t.Errorf("violation[%d] = %q, want %q", i, got[i], w)
+				}
+			}
+		})
+	}
+}
+
+// --- InstallFromManifest sandbox wiring ---
+
+func TestInstallFromManifest_UntrustedWritesSandboxOverride(t *testing.T) {
+	dir := t.TempDir()
+	composePath := filepath.Join(dir, "compose.yml")
+	if err := writeFileTest(t, composePath, "services:\n  app:\n    image: ghcr.io/x/y:latest\n"); err != nil {
+		t.Fatal(err)
+	}
+	servicesDir := filepath.Join(dir, "services")
+	manifest := &ServiceManifest{Name: "mod"}
+
+	// untrusted=true must generate the override and flag the result.
+	res, err := InstallFromManifest(manifest, composePath, servicesDir, nil, false, false, true)
+	if err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+	if !res.Sandboxed {
+		t.Fatal("result.Sandboxed should be true for an untrusted install")
+	}
+	want := filepath.Join(servicesDir, "mod.sandbox.yml")
+	if res.SandboxOverridePath != want {
+		t.Errorf("override path = %q, want %q", res.SandboxOverridePath, want)
+	}
+	if !fileExistsTest(want) {
+		t.Errorf("override file %q was not written", want)
+	}
+	// The per-module sandbox data dir must be created.
+	if !fileExistsTest(SandboxDataDir(servicesDir, "mod")) {
+		t.Errorf("sandbox data dir %q was not created", SandboxDataDir(servicesDir, "mod"))
+	}
+}
+
+func TestInstallFromManifest_TrustedNoSandboxOverride(t *testing.T) {
+	dir := t.TempDir()
+	composePath := filepath.Join(dir, "compose.yml")
+	if err := writeFileTest(t, composePath, "services:\n  app:\n    image: ghcr.io/x/y:latest\n"); err != nil {
+		t.Fatal(err)
+	}
+	servicesDir := filepath.Join(dir, "services")
+	manifest := &ServiceManifest{Name: "mod"}
+
+	// untrusted=false (Tier 0/1): no override, not flagged.
+	res, err := InstallFromManifest(manifest, composePath, servicesDir, nil, false, true, false)
+	if err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+	if res.Sandboxed {
+		t.Error("trusted install must not be sandboxed")
+	}
+	if fileExistsTest(filepath.Join(servicesDir, "mod.sandbox.yml")) {
+		t.Error("trusted install must not write a sandbox override")
+	}
+}
+
+func TestInstallFromManifest_BindMountConfinement(t *testing.T) {
+	dir := t.TempDir()
+	composePath := filepath.Join(dir, "compose.yml")
+	// A bind-mount of /etc (outside the sandbox data dir).
+	body := "services:\n  app:\n    image: x\n    volumes:\n      - /etc:/host-etc\n"
+	if err := writeFileTest(t, composePath, body); err != nil {
+		t.Fatal(err)
+	}
+	servicesDir := filepath.Join(dir, "services")
+	manifest := &ServiceManifest{Name: "mod"}
+
+	// untrusted + !allowPrivileged: must REFUSE.
+	if _, err := InstallFromManifest(manifest, composePath, servicesDir, nil, false, false, true); err == nil {
+		t.Fatal("expected refusal for untrusted module bind-mounting outside sandbox dir")
+	}
+
+	// allowPrivileged overrides the confinement.
+	if _, err := InstallFromManifest(manifest, composePath, servicesDir, nil, false, true, true); err != nil {
+		t.Fatalf("allow-privileged should bypass bind-mount confinement, got %v", err)
+	}
+
+	// A trusted install (untrusted=false) is not confined either.
+	dir2 := t.TempDir()
+	composePath2 := filepath.Join(dir2, "compose.yml")
+	if err := writeFileTest(t, composePath2, body); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InstallFromManifest(manifest, composePath2, filepath.Join(dir2, "services"), nil, false, true, false); err != nil {
+		t.Fatalf("trusted install should not be bind-confined, got %v", err)
+	}
+}
+
+func TestWithinDir(t *testing.T) {
+	cases := []struct {
+		dir, path string
+		want      bool
+	}{
+		{"/a/b", "/a/b", true},
+		{"/a/b", "/a/b/c", true},
+		{"/a/b", "/a/bc", false},
+		{"/a/b", "/a/b-data", false},
+		{"/a/b", "/a", false},
+	}
+	for _, c := range cases {
+		if got := withinDir(c.dir, c.path); got != c.want {
+			t.Errorf("withinDir(%q,%q) = %v, want %v", c.dir, c.path, got, c.want)
+		}
+	}
+}

--- a/internal/jobs/service_handler.go
+++ b/internal/jobs/service_handler.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/aceteam-ai/citadel-cli/internal/catalog"
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
 	"github.com/aceteam-ai/citadel-cli/internal/services"
@@ -56,7 +57,7 @@ func NewServiceHandlerWithWorkspace(configDir, workspaceDir string) *ServiceHand
 type serviceResult struct {
 	Name    string `json:"name"`
 	Running bool   `json:"running"`
-	Kind    string `json:"kind"`              // "docker" or "native"
+	Kind    string `json:"kind"` // "docker" or "native"
 	Error   string `json:"error,omitempty"`
 	Action  string `json:"action,omitempty"`  // "start", "stop", "status"
 	Message string `json:"message,omitempty"` // human-readable summary
@@ -144,7 +145,16 @@ func (h *ServiceHandler) serviceStart(ctx JobContext, svc manifestService) ([]by
 		if pathErr != nil {
 			return nil, pathErr
 		}
-		cmd := exec.Command("docker", "compose", "-f", composePath, "up", "-d")
+		// Include the least-privilege sandbox override when present (untrusted/
+		// Tier-2 modules) so a remotely-started module also runs hardened -- the
+		// override would otherwise be bypassed by this start site.
+		composeArgs := []string{"compose", "-f", composePath}
+		if override := catalog.ExistingSandboxOverride(filepath.Dir(composePath),
+			strings.TrimSuffix(filepath.Base(composePath), filepath.Ext(filepath.Base(composePath)))); override != "" {
+			composeArgs = append(composeArgs, "-f", override)
+		}
+		composeArgs = append(composeArgs, "up", "-d")
+		cmd := exec.Command("docker", composeArgs...)
 		cmd.Env = h.composeEnv()
 		out, cmdErr := cmd.CombinedOutput()
 		if cmdErr != nil {


### PR DESCRIPTION
## Context

Closes the containment half of the module trust model (#348), the follow-up to
#342's risk-scan + `--allow-privileged` gate + trust tiers. Installing a module
is `docker compose up` of an arbitrary compose = root-equivalent access to the
node. This PR adds the runtime least-privilege layer.

The design is the **locked decision** in #348.

## Posture (manifest-declared least-privilege, untrusted-only)

- **Scope:** applies ONLY to **untrusted (Tier 2)** modules
  (`catalog.IsTrusted(src) == false`). Curated (Tier 0) and trusted (Tier 1)
  modules run as-is, completely untouched.
- **Principle:** the module's `service.yaml` declares the privileges it needs;
  the installer grants exactly those and drops the rest. Anything beyond what's
  declared still trips the existing `--allow-privileged` gate (unchanged).

## What changed

**1. Manifest `sandbox:` block (additive, `CurrentSchemaVersion` 1 → 2).**
New optional `SandboxSpec` on `ServiceManifest`:
```yaml
sandbox:
  capabilities: []      # Linux caps to KEEP (added back after cap_drop: ALL)
  devices: []           # host devices the module legitimately needs
  writable_paths: []    # in-container paths that must be writable (read-only rootfs otherwise)
  host_network: false   # opt into host networking
  resources: { cpu: "", memory: "", pids: 0 }   # cgroup limits; sane defaults if unset
```
A module with no `sandbox:` block gets the strict defaults. Schema v2 is purely
additive; v1 manifests stay valid.

**2. `internal/catalog/sandbox.go` — `GenerateHardeningOverride` (PURE).**
Parses the base compose with `yaml.v3` to enumerate **every** compose service
(app + db sidecar etc.) and emits a docker-compose override (`-f base.yml -f
<name>.sandbox.yml`) that, per service, sets:
`security_opt: [no-new-privileges:true]`; `cap_drop: [ALL]` then `cap_add:` only
the declared caps; `read_only: true` + `tmpfs: [/tmp, …writable_paths]`;
`pids_limit` + `mem_limit` + `cpus` (declared or conservative defaults);
`devices:` only when declared; `network_mode: host` only when `host_network:
true`. Deterministic output (sorted service names). Heavily table-tested.

**3. Bind-mount confinement (enforcement on top of #342's warning).**
`BindMountViolations` (PURE, line-based per `risk.go`) rejects any host
bind-mount whose host side resolves outside the per-module sandbox data dir
(`<servicesDir>/<name>-data/`), for untrusted modules, unless
`--allow-privileged` is set.

**4. Wiring — shared core, so CLI + TUI + update/rollback are covered identically.**
`InstallFromManifest` gained an `untrusted bool` param (threaded through every
caller: catalog `Install` → false, CLI install → `!trusted`, TUI install →
`!IsTrusted`, update → `entry.Sandboxed`, rollback → `prev.Sandboxed`). When
untrusted it runs the bind-mount gate, generates + writes `<name>.sandbox.yml`,
creates the sandbox data dir, sets `InstallResult.Sandboxed`, and records
`sandboxed: true` (additive `LockEntry` field) in `modules.lock`.

At **run/start**, every site that starts an *installed module* now appends
`-f <name>.sandbox.yml` when that sibling exists (a no-op for every existing,
non-sandboxed service): `startService` (the `citadel run` path),
`composeUpDetached` (module update/rollback restart), the TUI control-center
start, and the remote `SERVICE_START` job handler. A single source of truth
(`catalog.SandboxOverridePath` / `ExistingSandboxOverride`) backs all of them.

**5. Surfacing.** Tier-2 install prints "applying least-privilege sandbox …" and
the override path; `module list` shows a `SANDBOX` column.

## GPU safety (TEI #343 stays working)

The override deliberately emits **no** GPU/`deploy`/device-reservation block: the
base compose owns the NVIDIA reservation and the override only *adds* hardening
keys, so a legit GPU module still starts. `cap_drop: ALL` is safe for
NVIDIA-runtime containers (GPU access is via the runtime, not Linux caps), so the
default GPU cap set is empty (`minimalGPUCaps`, a documented hook). Encoded as a
TEI-shaped test (GPU + model-cache writable path + reservation) asserting the
override is still valid and touches nothing GPU-related.

## How to override

- Declare needs in the manifest `sandbox:` block (caps, devices, writable_paths,
  host_network, resources), then reinstall.
- `--allow-privileged` bypasses the bind-mount confinement and the Critical
  privilege gate (unchanged from #342).

## Known limitations / deferred

- **List-merge is additive:** a base compose `cap_add` survives the override's
  `cap_drop: ALL` (docker-compose merges sequences). The override mechanism
  cannot *subtract* a base directive; that residual is already covered by the
  #342 Critical privilege gate (`cap_add ALL`/`SYS_ADMIN` is refused without
  `--allow-privileged`). Documented, not "fixed".
- A `writable_paths` entry that collides with a base `volumes:` mount would have
  its tmpfs shadow the volume (breaks persistence) — modules should not declare a
  writable_path the base already mounts.
- Blanket `read_only: true` breaks images that write outside `/tmp`; such modules
  must declare `writable_paths`.
- The `config_handler` (onboarding-wizard) and `llamacpp_inference` start sites
  start **built-in Tier-0 engines**, not installed untrusted modules, so they are
  intentionally not wired. `cmd/whatsapp.go` is out of scope.

## Testing

`go build ./...` + `go vet ./...` clean; `go test ./internal/catalog/...` passes
(table tests for `GenerateHardeningOverride` — multi-service, GPU/non-GPU,
declared caps/writable_paths/devices/host-network, determinism — and
`BindMountViolations` + `InstallFromManifest` sandbox wiring/confinement).
Per repo policy `go test ./...` was NOT run (tmux/pty suites). **Needs real-docker
manual testing** (compose merge semantics, `read_only`/`tmpfs`, string
`cpus`/`mem_limit`) — hence draft.

*Generated by Claude*
