### PR TITLE
fix(run): accept module-installed services in `citadel run <name>` (#358)

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/aceteam-ai/citadel-cli/internal/compose"
@@ -119,19 +120,55 @@ func runAllServices() {
 	syncSSHKeysIfConfigured(configDir)
 }
 
+// serviceIsKnown reports whether a service name is runnable: it is either an
+// embedded/catalog service (in services.ServiceMap) or a module-installed
+// service already tracked in the node manifest. The manifest is the source of
+// truth for installed/module services, so checking both lets `citadel run
+// <name>` accept services added via `citadel module install`.
+func serviceIsKnown(serviceName string, manifest *CitadelManifest) bool {
+	if _, ok := services.ServiceMap[serviceName]; ok {
+		return true
+	}
+	return hasService(manifest, serviceName)
+}
+
+// knownServiceNames returns a sorted, deduplicated list of runnable service
+// names: the embedded/catalog services plus any module-installed services from
+// the manifest. Used for the "Available services" hint on an unknown name.
+func knownServiceNames(manifest *CitadelManifest) []string {
+	names := services.GetAvailableServices() // already sorted
+	seen := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		seen[n] = struct{}{}
+	}
+	extra := make([]string, 0)
+	for _, s := range manifest.Services {
+		if _, ok := seen[s.Name]; ok {
+			continue
+		}
+		seen[s.Name] = struct{}{}
+		extra = append(extra, s.Name)
+	}
+	sort.Strings(extra)
+	return append(names, extra...)
+}
+
 // runSingleService adds a service to the manifest (if needed) and starts it.
 func runSingleService(serviceName string) {
-	// Validate service name
-	if _, ok := services.ServiceMap[serviceName]; !ok {
-		fmt.Fprintf(os.Stderr, "❌ Unknown service '%s'.\n", serviceName)
-		fmt.Printf("Available services: %s\n", strings.Join(services.GetAvailableServices(), ", "))
-		os.Exit(1)
-	}
-
-	// Find or create manifest
+	// Find or create manifest first: the manifest is the source of truth for
+	// module-installed services, and it must be created on a fresh node so a
+	// valid embedded service can be started on first run.
 	manifest, configDir, err := findOrCreateManifest()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "❌ Failed to initialize configuration: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Validate service name against both the embedded catalog and the manifest
+	// (which tracks module-installed services).
+	if !serviceIsKnown(serviceName, manifest) {
+		fmt.Fprintf(os.Stderr, "❌ Unknown service '%s'.\n", serviceName)
+		fmt.Printf("Available services: %s\n", strings.Join(knownServiceNames(manifest), ", "))
 		os.Exit(1)
 	}
 

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,0 +1,84 @@
+// cmd/run_test.go
+package cmd
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/services"
+)
+
+// TestServiceIsKnown verifies the validation gate used by `citadel run <name>`
+// accepts both embedded/catalog services (services.ServiceMap) and
+// module-installed services tracked in the manifest, while rejecting unknown
+// names. This is the regression guard for issue #358, where the gate only
+// consulted ServiceMap and rejected module-installed services like "tei".
+func TestServiceIsKnown(t *testing.T) {
+	// "tei" is a stand-in for a module-installed service: it is NOT in
+	// services.ServiceMap but is present in the manifest after
+	// `citadel module install tei`.
+	manifest := &CitadelManifest{
+		Services: []Service{
+			{Name: "tei", ComposeFile: "./services/tei.yml"},
+		},
+	}
+
+	// Sanity check: the module-installed name must not be an embedded service,
+	// otherwise case (b) would not actually exercise the manifest fallback.
+	if _, ok := services.ServiceMap["tei"]; ok {
+		t.Fatal("test assumption broken: 'tei' should not be in services.ServiceMap")
+	}
+
+	tests := []struct {
+		name        string
+		serviceName string
+		want        bool
+	}{
+		{"embedded service only (ServiceMap)", "vllm", true},
+		{"module-installed service only (manifest)", "tei", true},
+		{"unknown service", "definitely-not-a-service", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := serviceIsKnown(tt.serviceName, manifest); got != tt.want {
+				t.Errorf("serviceIsKnown(%q) = %v, want %v", tt.serviceName, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestKnownServiceNames verifies the "Available services" hint includes both
+// embedded services and module-installed services from the manifest, deduped
+// and in a stable (sorted) order.
+func TestKnownServiceNames(t *testing.T) {
+	manifest := &CitadelManifest{
+		Services: []Service{
+			{Name: "tei", ComposeFile: "./services/tei.yml"},
+			// vllm is also embedded; it must not be duplicated.
+			{Name: "vllm", ComposeFile: "./services/vllm.yml"},
+		},
+	}
+
+	got := knownServiceNames(manifest)
+
+	// Expect all embedded services (sorted) followed by the unique manifest-only
+	// names (sorted), with no duplicates.
+	want := append([]string{}, services.GetAvailableServices()...)
+	want = append(want, "tei")
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("knownServiceNames() = %v, want %v", got, want)
+	}
+
+	// Explicit dedup check: "vllm" should appear exactly once.
+	count := 0
+	for _, n := range got {
+		if n == "vllm" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("knownServiceNames() contains 'vllm' %d times, want 1", count)
+	}
+}


### PR DESCRIPTION
## Root cause

`runSingleService` in `cmd/run.go` validated the service name **only** against the embedded `services.ServiceMap`:

```go
if _, ok := services.ServiceMap[serviceName]; !ok {
    fmt.Fprintf(os.Stderr, "❌ Unknown service '%s'.\n", serviceName)
    ...
    os.Exit(1)
}
```

So after `citadel module install tei` — which writes a `tei` entry into the node manifest (`citadel.yaml`) and `services/tei.yml` on disk — `citadel run tei` still printed `Unknown service 'tei'`, even though the install output tells the user to run it. No-arg `citadel run` already worked for installed services because it iterates `manifest.Services`.

## Why the fix is small

Everything downstream of the validation gate already handled module-installed services correctly:
- `ensureComposeFile(configDir, serviceName)` returns early when `services/<name>.yml` already exists (an installed module's file does), only falling back to `services.ServiceMap` when the file is missing.
- `hasService(manifest, serviceName)` is true for installed services, so `addServiceToManifest` is skipped.
- `startService(serviceName, composePath)` just runs `docker compose` on the compose path.

The **only** thing blocking `citadel run tei` was the ServiceMap-only validation gate. The node manifest is the source of truth for installed/module services.

## The fix (manifest-aware validation)

- Reordered `runSingleService` to call `findOrCreateManifest()` **first**, then validate. This is required: on a fresh node, starting a valid embedded service must still bootstrap the config/manifest, so a read-only manifest check would wrongly error on first run. The reorder keeps first-run behavior intact.
- Extracted the validation decision into a small, testable helper:
  ```go
  func serviceIsKnown(serviceName string, manifest *CitadelManifest) bool {
      if _, ok := services.ServiceMap[serviceName]; ok {
          return true
      }
      return hasService(manifest, serviceName)
  }
  ```
- Improved the `Available services:` hint to also include module-installed services from the manifest (deduped, stable/sorted order) via `knownServiceNames`.

For a **new** embedded service (in `ServiceMap`, not yet in the manifest) the downstream flow is unchanged: `ensureComposeFile`, `hasService`, `addServiceToManifest`, and `startService` all receive the same arguments as before.

## Tests

Added `cmd/run_test.go`:
- `TestServiceIsKnown` (table-driven): (a) a name only in `ServiceMap` (`vllm`) is accepted; (b) a name only in the manifest (`tei`, module-installed, not in `ServiceMap`) is accepted; (c) an unknown name is rejected. The helper is tested directly — the `os.Exit` paths are not exercised.
- `TestKnownServiceNames`: the hint includes embedded + manifest-only names, deduped (`vllm` appears once) and in stable sorted order.

## Verification

```
go build ./cmd/citadel   # ok
go test ./cmd/...         # ok
go test ./services/...    # ok
gofmt -w cmd/run.go cmd/run_test.go
```

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)