### PR TITLE
feat(reconcile): node desired-state reconcile engine (first increment of #353)

### DIFF
--- a/internal/jobs/queue_types.go
+++ b/internal/jobs/queue_types.go
@@ -29,6 +29,18 @@ const (
 	JobTypeIOSBuild      = "IOS_BUILD"
 	JobTypeAndroidBuild  = "ANDROID_BUILD"
 	JobTypeGomobileBuild = "GOMOBILE_BUILD"
+
+	// JobTypeReconcile is the push-nudge for the node reconcile loop (issue
+	// #353, epic #352). A `reconcile` job on the node's queue triggers an
+	// immediate desired-state reconcile pass so /fabric actions feel instant
+	// (push accelerates; the periodic pull remains the source of truth).
+	//
+	// The handler is INERT unless the reconcile feature is explicitly enabled
+	// (reconcile.Config.Enabled, DISABLED BY DEFAULT) — an existing node that
+	// has not opted into remote management ignores this job. The worker dispatch
+	// is intentionally NOT wired in this increment to avoid touching the live
+	// worker path (see internal/reconcile.HandleReconcileJob).
+	JobTypeReconcile = "RECONCILE"
 )
 
 // Queue names following PR #1105 convention

--- a/internal/reconcile/apply.go
+++ b/internal/reconcile/apply.go
@@ -1,0 +1,122 @@
+package reconcile
+
+import (
+	"context"
+	"fmt"
+	"sort"
+)
+
+// StepResult records the outcome of applying a single Step.
+type StepResult struct {
+	Step Step
+	Err  error // nil on success
+}
+
+// ApplyResult is the outcome of applying a whole Plan. Per-module failure
+// isolation: a step that errors is recorded here and does NOT abort the rest of
+// the plan.
+type ApplyResult struct {
+	// Results is one entry per executed step, in execution order.
+	Results []StepResult
+	// Errors maps module name -> the error that module hit (if any). It is the
+	// per-module failure-isolation surface that feeds Health == HealthError in
+	// the actual-state report.
+	Errors map[string]error
+}
+
+// Failed reports whether any step errored.
+func (r ApplyResult) Failed() bool { return len(r.Errors) > 0 }
+
+// Apply executes a Plan via the injected ModuleOps. It applies every step,
+// isolating per-module failures: if a step errors, the error is recorded
+// against that module's name and execution CONTINUES with the remaining steps.
+// This guarantees one bad module cannot block convergence of the others.
+//
+// Apply never returns a non-nil error for a step failure (those live in
+// ApplyResult.Errors); it only returns an error for a caller-level problem such
+// as a cancelled context.
+func Apply(ctx context.Context, ops ModuleOps, plan Plan) (ApplyResult, error) {
+	res := ApplyResult{Errors: map[string]error{}}
+
+	for _, step := range plan.Steps {
+		if err := ctx.Err(); err != nil {
+			return res, err
+		}
+		// Skip further steps for a module that already failed in this pass — a
+		// later start/stop on a module whose install failed is meaningless and
+		// would only produce a confusing second error.
+		if _, alreadyFailed := res.Errors[step.Name]; alreadyFailed {
+			res.Results = append(res.Results, StepResult{
+				Step: step,
+				Err:  fmt.Errorf("skipped: earlier step for %q failed", step.Name),
+			})
+			continue
+		}
+
+		err := applyStep(ctx, ops, step)
+		res.Results = append(res.Results, StepResult{Step: step, Err: err})
+		if err != nil {
+			res.Errors[step.Name] = err
+		}
+	}
+
+	return res, nil
+}
+
+// applyStep dispatches a single step to the matching ModuleOps operation.
+func applyStep(ctx context.Context, ops ModuleOps, step Step) error {
+	switch step.Action {
+	case ActionInstall, ActionUpdate:
+		return ops.Install(ctx, step.Assignment)
+	case ActionUninstall:
+		return ops.Uninstall(ctx, step.Name)
+	case ActionStart:
+		return ops.Start(ctx, step.Name)
+	case ActionStop:
+		return ops.Stop(ctx, step.Name)
+	default:
+		return fmt.Errorf("unknown action %q for module %q", step.Action, step.Name)
+	}
+}
+
+// BuildActualState reads the node's installed modules via ListInstalled and
+// overlays any per-module errors from an ApplyResult, producing the
+// ActualState report to send back to the control plane. A module that failed to
+// converge is reported with Health == HealthError and its error string, so the
+// failure surfaces in the report without having blocked the others.
+//
+// node is the reporting node's identifier (device identity); it may be empty
+// and filled in by the transport layer.
+func BuildActualState(ctx context.Context, ops ModuleOps, applyErrs map[string]error, node string) (ActualState, error) {
+	installed, err := ops.ListInstalled(ctx)
+	if err != nil {
+		return ActualState{}, fmt.Errorf("list installed modules: %w", err)
+	}
+
+	// Index reported modules so we can attach errors and surface modules that
+	// failed before they ever became installed (e.g. a failed first install).
+	byName := make(map[string]int, len(installed))
+	out := make([]InstalledModule, 0, len(installed)+len(applyErrs))
+	for _, im := range installed {
+		byName[im.Name] = len(out)
+		out = append(out, im)
+	}
+
+	for name, e := range applyErrs {
+		if idx, ok := byName[name]; ok {
+			out[idx].Health = HealthError
+			out[idx].Error = e.Error()
+			continue
+		}
+		// A module that errored and is not in ListInstalled (failed first
+		// install) is still reported so the drift/error is visible.
+		out = append(out, InstalledModule{
+			Name:   name,
+			Health: HealthError,
+			Error:  e.Error(),
+		})
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return ActualState{Node: node, Modules: out}, nil
+}

--- a/internal/reconcile/apply_test.go
+++ b/internal/reconcile/apply_test.go
@@ -1,0 +1,187 @@
+package reconcile
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestApplyConvergesAndIsIdempotent runs Reconcile -> Apply -> Reconcile and
+// asserts the SECOND plan is empty (the heart of idempotency). The fake ops are
+// stateful, so the second ListInstalled reflects the first apply.
+func TestApplyConvergesAndIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	ops := newFakeOps(
+		// pre-existing: one stale (to uninstall), one drifted (to update),
+		// one that just needs starting.
+		InstalledModule{Name: "stale", Source: "stale", Health: HealthRunning},
+		InstalledModule{Name: "drift", Source: "drift@v1", Health: HealthRunning},
+		InstalledModule{Name: "down", Source: "down", Health: HealthStopped},
+	)
+	desired := ds(
+		ModuleAssignment{Name: "fresh", Source: "fresh", DesiredStatus: StatusRunning},
+		ModuleAssignment{Name: "drift", Source: "drift@v2", DesiredStatus: StatusRunning},
+		ModuleAssignment{Name: "down", Source: "down", DesiredStatus: StatusRunning},
+		ModuleAssignment{Name: "parked", Source: "parked", DesiredStatus: StatusStopped},
+	)
+
+	// First pass.
+	actual, _ := ops.ListInstalled(ctx)
+	plan, err := Reconcile(ctx, desired, actual)
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if plan.IsEmpty() {
+		t.Fatal("first plan should not be empty")
+	}
+	res, err := Apply(ctx, ops, plan)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if res.Failed() {
+		t.Fatalf("unexpected apply errors: %v", res.Errors)
+	}
+
+	// Verify the converged state matches desired.
+	got, _ := ops.ListInstalled(ctx)
+	gotByName := map[string]InstalledModule{}
+	for _, im := range got {
+		gotByName[im.Name] = im
+	}
+	if _, ok := gotByName["stale"]; ok {
+		t.Error("stale should have been uninstalled")
+	}
+	if gotByName["drift"].Source != "drift@v2" {
+		t.Errorf("drift source = %q, want drift@v2", gotByName["drift"].Source)
+	}
+	if gotByName["down"].Health != HealthRunning {
+		t.Errorf("down health = %q, want running", gotByName["down"].Health)
+	}
+	if gotByName["parked"].Health != HealthStopped {
+		t.Errorf("parked health = %q, want stopped", gotByName["parked"].Health)
+	}
+	if gotByName["fresh"].Health != HealthRunning {
+		t.Errorf("fresh health = %q, want running", gotByName["fresh"].Health)
+	}
+
+	// Second pass: MUST be a no-op.
+	actual2, _ := ops.ListInstalled(ctx)
+	plan2, err := Reconcile(ctx, desired, actual2)
+	if err != nil {
+		t.Fatalf("Reconcile (2nd): %v", err)
+	}
+	if !plan2.IsEmpty() {
+		t.Fatalf("second plan should be empty (idempotency), got: %v", planActions(plan2))
+	}
+}
+
+// TestApplyPerModuleFailureIsolation asserts one failing module records an error
+// and does NOT abort the others, and that the error surfaces in the actual-state
+// report (Health == HealthError with the message).
+func TestApplyPerModuleFailureIsolation(t *testing.T) {
+	ctx := context.Background()
+	ops := newFakeOps()
+	// "bad" install fails; "good1"/"good2" succeed.
+	ops.failModule("bad", "install", errf("boom: registry unreachable"))
+
+	desired := ds(
+		ModuleAssignment{Name: "good1", Source: "good1", DesiredStatus: StatusRunning},
+		ModuleAssignment{Name: "bad", Source: "bad", DesiredStatus: StatusRunning},
+		ModuleAssignment{Name: "good2", Source: "good2", DesiredStatus: StatusRunning},
+	)
+
+	actual, _ := ops.ListInstalled(ctx)
+	plan, err := Reconcile(ctx, desired, actual)
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	res, err := Apply(ctx, ops, plan)
+	if err != nil {
+		t.Fatalf("Apply returned pass-level error: %v", err)
+	}
+	if !res.Failed() {
+		t.Fatal("expected at least one per-module failure")
+	}
+	if _, ok := res.Errors["bad"]; !ok {
+		t.Error("bad module error not recorded")
+	}
+	if _, ok := res.Errors["good1"]; ok {
+		t.Error("good1 should not have errored")
+	}
+
+	// The good modules were still installed despite bad's failure.
+	got, _ := ops.ListInstalled(ctx)
+	names := map[string]bool{}
+	for _, im := range got {
+		names[im.Name] = true
+	}
+	if !names["good1"] || !names["good2"] {
+		t.Errorf("good modules not installed despite isolation; have %v", names)
+	}
+	if names["bad"] {
+		t.Error("bad module should not be installed after a failed install")
+	}
+
+	// The failure surfaces in the actual-state report.
+	report, err := BuildActualState(ctx, ops, res.Errors, "node-1")
+	if err != nil {
+		t.Fatalf("BuildActualState: %v", err)
+	}
+	var badReport *InstalledModule
+	for i := range report.Modules {
+		if report.Modules[i].Name == "bad" {
+			badReport = &report.Modules[i]
+		}
+	}
+	if badReport == nil {
+		t.Fatal("bad module missing from actual-state report")
+	}
+	if badReport.Health != HealthError {
+		t.Errorf("bad health = %q, want error", badReport.Health)
+	}
+	if !strings.Contains(badReport.Error, "registry unreachable") {
+		t.Errorf("bad error = %q, want it to mention the failure", badReport.Error)
+	}
+	if report.Node != "node-1" {
+		t.Errorf("report node = %q, want node-1", report.Node)
+	}
+}
+
+// TestApplyFailureIsolationOnExisting verifies an error on an installed module
+// (e.g. a stop that fails) is reported as HealthError while still listing the
+// module, and other modules are unaffected.
+func TestApplyFailureIsolationOnExisting(t *testing.T) {
+	ctx := context.Background()
+	ops := newFakeOps(
+		InstalledModule{Name: "stuck", Source: "stuck", Health: HealthRunning},
+		InstalledModule{Name: "fine", Source: "fine", Health: HealthRunning},
+	)
+	ops.failModule("stuck", "stop", errf("container will not stop"))
+
+	desired := ds(
+		ModuleAssignment{Name: "stuck", Source: "stuck", DesiredStatus: StatusStopped},
+		ModuleAssignment{Name: "fine", Source: "fine", DesiredStatus: StatusRunning},
+	)
+	actual, _ := ops.ListInstalled(ctx)
+	plan, _ := Reconcile(ctx, desired, actual)
+	res, err := Apply(ctx, ops, plan)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if _, ok := res.Errors["stuck"]; !ok {
+		t.Fatal("stuck stop failure not recorded")
+	}
+
+	report, _ := BuildActualState(ctx, ops, res.Errors, "")
+	byName := map[string]InstalledModule{}
+	for _, im := range report.Modules {
+		byName[im.Name] = im
+	}
+	if byName["stuck"].Health != HealthError {
+		t.Errorf("stuck health = %q, want error", byName["stuck"].Health)
+	}
+	// "fine" stays running and error-free.
+	if byName["fine"].Health == HealthError {
+		t.Error("fine should not be in error")
+	}
+}

--- a/internal/reconcile/engine.go
+++ b/internal/reconcile/engine.go
@@ -1,0 +1,212 @@
+package reconcile
+
+import (
+	"context"
+	"fmt"
+	"sort"
+)
+
+// ActionType is the kind of convergence action a Step performs.
+type ActionType string
+
+const (
+	// ActionInstall installs a module that is in desired but not in actual.
+	ActionInstall ActionType = "install"
+	// ActionUpdate re-installs a module whose source/ref or config drifted.
+	ActionUpdate ActionType = "update"
+	// ActionStart starts an installed module that should be running but isn't.
+	ActionStart ActionType = "start"
+	// ActionStop stops an installed module that should be stopped but is running.
+	ActionStop ActionType = "stop"
+	// ActionUninstall removes a module that is installed but not in desired.
+	ActionUninstall ActionType = "uninstall"
+)
+
+// Step is one idempotent convergence action in a Plan, keyed by module name.
+type Step struct {
+	Action ActionType
+	Name   string
+	// Assignment is the desired assignment driving this step (empty Source for
+	// ActionUninstall, where there is no desired entry).
+	Assignment ModuleAssignment
+	// Reason is a human-readable explanation for drift display / logs.
+	Reason string
+}
+
+// Plan is the ordered set of steps needed to converge actual -> desired. An
+// empty Plan means the node is already converged (the steady state — and the
+// proof of idempotency: reconciling a converged node yields no steps).
+type Plan struct {
+	Steps []Step
+}
+
+// IsEmpty reports whether the plan has no steps (node already converged).
+func (p Plan) IsEmpty() bool { return len(p.Steps) == 0 }
+
+// Reconcile computes the idempotent diff between the control-plane desired state
+// and the node's actual installed state. It does NOT perform any side effects;
+// it returns a Plan that Apply executes.
+//
+// Drift rules (per module, matched by Key()/Name):
+//   - in desired, not in actual            -> install (then stop if desired stopped)
+//   - in both, source/ref differs          -> update  (then start/stop to match)
+//   - in both, config differs              -> update  (then start/stop to match)
+//   - in both, run-state differs           -> start or stop
+//   - in actual, not in desired            -> uninstall
+//
+// Steps are ordered deterministically: uninstalls first (free resources),
+// then installs/updates, then start/stop transitions — and within each group
+// sorted by name so a Plan is stable and testable.
+func Reconcile(ctx context.Context, desired DesiredState, actual []InstalledModule) (Plan, error) {
+	if err := ctx.Err(); err != nil {
+		return Plan{}, err
+	}
+
+	actualByName := make(map[string]InstalledModule, len(actual))
+	for _, im := range actual {
+		actualByName[im.Name] = im
+	}
+	desiredByName := make(map[string]ModuleAssignment, len(desired.Modules))
+	for _, m := range desired.Modules {
+		desiredByName[m.Key()] = m
+	}
+
+	var uninstalls, installsUpdates, transitions []Step
+
+	// Uninstall anything installed but no longer desired.
+	for name := range actualByName {
+		if _, ok := desiredByName[name]; !ok {
+			uninstalls = append(uninstalls, Step{
+				Action: ActionUninstall,
+				Name:   name,
+				Reason: "installed but not in desired state",
+			})
+		}
+	}
+
+	// Install / update / transition for everything desired.
+	for name, want := range desiredByName {
+		cur, installed := actualByName[name]
+		if !installed {
+			installsUpdates = append(installsUpdates, Step{
+				Action:     ActionInstall,
+				Name:       name,
+				Assignment: want,
+				Reason:     "in desired state but not installed",
+			})
+			// A freshly installed module is running; if it should be stopped,
+			// queue the stop transition.
+			if want.EffectiveStatus() == StatusStopped {
+				transitions = append(transitions, Step{
+					Action:     ActionStop,
+					Name:       name,
+					Assignment: want,
+					Reason:     "desired status is stopped",
+				})
+			}
+			continue
+		}
+
+		// Installed: detect source/ref or config drift -> update.
+		if reason, drifted := updateReason(want, cur); drifted {
+			installsUpdates = append(installsUpdates, Step{
+				Action:     ActionUpdate,
+				Name:       name,
+				Assignment: want,
+				Reason:     reason,
+			})
+			// After an update the module is (re)installed and running; reconcile
+			// its run-state against desired.
+			if want.EffectiveStatus() == StatusStopped {
+				transitions = append(transitions, Step{
+					Action:     ActionStop,
+					Name:       name,
+					Assignment: want,
+					Reason:     "desired status is stopped (post-update)",
+				})
+			}
+			continue
+		}
+
+		// No content drift: only reconcile run-state.
+		if step, ok := transitionStep(want, cur); ok {
+			transitions = append(transitions, step)
+		}
+	}
+
+	sortSteps(uninstalls)
+	sortSteps(installsUpdates)
+	sortSteps(transitions)
+
+	steps := make([]Step, 0, len(uninstalls)+len(installsUpdates)+len(transitions))
+	steps = append(steps, uninstalls...)
+	steps = append(steps, installsUpdates...)
+	steps = append(steps, transitions...)
+	return Plan{Steps: steps}, nil
+}
+
+// updateReason reports whether the desired assignment differs from the current
+// installed module in a way that requires a re-install (source/ref or config),
+// and a human-readable reason.
+func updateReason(want ModuleAssignment, cur InstalledModule) (string, bool) {
+	if !sameSource(want.Source, cur) {
+		return fmt.Sprintf("source changed: %q -> %q", cur.Source, want.Source), true
+	}
+	if !sameConfig(want.Config, cur.Config) {
+		return "config changed", true
+	}
+	return "", false
+}
+
+// transitionStep returns a start/stop step if the current run-state does not
+// match desired, for an already-installed, content-matching module.
+func transitionStep(want ModuleAssignment, cur InstalledModule) (Step, bool) {
+	switch want.EffectiveStatus() {
+	case StatusRunning:
+		if cur.Health != HealthRunning {
+			return Step{
+				Action:     ActionStart,
+				Name:       cur.Name,
+				Assignment: want,
+				Reason:     "desired running, currently not running",
+			}, true
+		}
+	case StatusStopped:
+		if cur.Health == HealthRunning {
+			return Step{
+				Action:     ActionStop,
+				Name:       cur.Name,
+				Assignment: want,
+				Reason:     "desired stopped, currently running",
+			}, true
+		}
+	}
+	return Step{}, false
+}
+
+// sameSource compares a desired source string against an installed module. The
+// installed module records the normalized source; the live adapter is
+// responsible for normalizing both sides identically. We compare the raw
+// desired Source against the recorded Source.
+func sameSource(wantSource string, cur InstalledModule) bool {
+	return wantSource == cur.Source
+}
+
+// sameConfig compares two config-override maps for equality, treating nil and
+// empty as equal.
+func sameConfig(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if bv, ok := b[k]; !ok || bv != v {
+			return false
+		}
+	}
+	return true
+}
+
+// sortSteps sorts steps by name for deterministic, testable plans.
+func sortSteps(steps []Step) {
+	sort.Slice(steps, func(i, j int) bool { return steps[i].Name < steps[j].Name })
+}

--- a/internal/reconcile/engine.go
+++ b/internal/reconcile/engine.go
@@ -184,10 +184,15 @@ func transitionStep(want ModuleAssignment, cur InstalledModule) (Step, bool) {
 	return Step{}, false
 }
 
-// sameSource compares a desired source string against an installed module. The
-// installed module records the normalized source; the live adapter is
-// responsible for normalizing both sides identically. We compare the raw
-// desired Source against the recorded Source.
+// sameSource compares a desired source string against an installed module.
+//
+// It is a raw string equality on the REQUESTED source form (not a resolved
+// ref). The InstalledModule.Source canonical-form contract requires the control
+// plane and the node adapter to express Source identically (requested form) —
+// otherwise a constraint/channel like "owner/repo@^1.2" reported by the node
+// would never equal a resolved "owner/repo@v1.4.0" from the plane and the
+// engine would re-update every pass. Resolved refs live in Commit/Ref, which
+// are NOT part of this diff key.
 func sameSource(wantSource string, cur InstalledModule) bool {
 	return wantSource == cur.Source
 }

--- a/internal/reconcile/engine_test.go
+++ b/internal/reconcile/engine_test.go
@@ -1,0 +1,176 @@
+package reconcile
+
+import (
+	"context"
+	"sort"
+	"testing"
+)
+
+func ds(ms ...ModuleAssignment) DesiredState { return DesiredState{Modules: ms} }
+
+// planActions extracts (action, name) pairs from a plan for compact assertions.
+func planActions(p Plan) []string {
+	out := make([]string, 0, len(p.Steps))
+	for _, s := range p.Steps {
+		out = append(out, string(s.Action)+":"+s.Name)
+	}
+	return out
+}
+
+func eq(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestReconcileDiff(t *testing.T) {
+	tests := []struct {
+		name    string
+		desired DesiredState
+		actual  []InstalledModule
+		want    []string // sorted (action:name) pairs expected in the plan
+	}{
+		{
+			name:    "install missing",
+			desired: ds(ModuleAssignment{Name: "foo", Source: "foo", DesiredStatus: StatusRunning}),
+			actual:  nil,
+			want:    []string{"install:foo"},
+		},
+		{
+			name:    "install missing, desired stopped -> install + stop",
+			desired: ds(ModuleAssignment{Name: "foo", Source: "foo", DesiredStatus: StatusStopped}),
+			actual:  nil,
+			want:    []string{"install:foo", "stop:foo"},
+		},
+		{
+			name:    "uninstall removed",
+			desired: ds(),
+			actual:  []InstalledModule{{Name: "foo", Source: "foo", Health: HealthRunning}},
+			want:    []string{"uninstall:foo"},
+		},
+		{
+			name:    "update on source-ref change",
+			desired: ds(ModuleAssignment{Name: "foo", Source: "owner/repo@v2", DesiredStatus: StatusRunning}),
+			actual:  []InstalledModule{{Name: "foo", Source: "owner/repo@v1", Health: HealthRunning}},
+			want:    []string{"update:foo"},
+		},
+		{
+			name: "update on config change",
+			desired: ds(ModuleAssignment{Name: "foo", Source: "foo", Config: map[string]string{"PORT": "9090"},
+				DesiredStatus: StatusRunning}),
+			actual: []InstalledModule{{Name: "foo", Source: "foo", Config: map[string]string{"PORT": "8080"},
+				Health: HealthRunning}},
+			want: []string{"update:foo"},
+		},
+		{
+			name:    "start transition (desired running, currently stopped)",
+			desired: ds(ModuleAssignment{Name: "foo", Source: "foo", DesiredStatus: StatusRunning}),
+			actual:  []InstalledModule{{Name: "foo", Source: "foo", Health: HealthStopped}},
+			want:    []string{"start:foo"},
+		},
+		{
+			name:    "stop transition (desired stopped, currently running)",
+			desired: ds(ModuleAssignment{Name: "foo", Source: "foo", DesiredStatus: StatusStopped}),
+			actual:  []InstalledModule{{Name: "foo", Source: "foo", Health: HealthRunning}},
+			want:    []string{"stop:foo"},
+		},
+		{
+			name:    "already converged -> empty plan",
+			desired: ds(ModuleAssignment{Name: "foo", Source: "foo", DesiredStatus: StatusRunning}),
+			actual:  []InstalledModule{{Name: "foo", Source: "foo", Health: HealthRunning}},
+			want:    []string{},
+		},
+		{
+			name:    "default desired status is running",
+			desired: ds(ModuleAssignment{Name: "foo", Source: "foo"}),
+			actual:  []InstalledModule{{Name: "foo", Source: "foo", Health: HealthStopped}},
+			want:    []string{"start:foo"},
+		},
+		{
+			name: "mixed: install one, uninstall one, update one, leave one",
+			desired: ds(
+				ModuleAssignment{Name: "new", Source: "new", DesiredStatus: StatusRunning},
+				ModuleAssignment{Name: "drift", Source: "drift@v2", DesiredStatus: StatusRunning},
+				ModuleAssignment{Name: "ok", Source: "ok", DesiredStatus: StatusRunning},
+			),
+			actual: []InstalledModule{
+				{Name: "drift", Source: "drift@v1", Health: HealthRunning},
+				{Name: "ok", Source: "ok", Health: HealthRunning},
+				{Name: "stale", Source: "stale", Health: HealthRunning},
+			},
+			want: []string{"uninstall:stale", "update:drift", "install:new"},
+		},
+		{
+			name:    "source change AND stopped -> update + stop",
+			desired: ds(ModuleAssignment{Name: "foo", Source: "foo@v2", DesiredStatus: StatusStopped}),
+			actual:  []InstalledModule{{Name: "foo", Source: "foo@v1", Health: HealthRunning}},
+			want:    []string{"update:foo", "stop:foo"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan, err := Reconcile(context.Background(), tt.desired, tt.actual)
+			if err != nil {
+				t.Fatalf("Reconcile error: %v", err)
+			}
+			got := planActions(plan)
+			// For multi-step plans with no ordering dependency in the assertion,
+			// compare as sorted sets EXCEPT where order is part of the contract
+			// (uninstall-before-install-before-transition). We assert the exact
+			// ordered sequence the engine guarantees.
+			if !eq(got, tt.want) {
+				// Fall back to set comparison to give a clearer failure when the
+				// only difference is ordering within a group.
+				gs, ws := append([]string(nil), got...), append([]string(nil), tt.want...)
+				sort.Strings(gs)
+				sort.Strings(ws)
+				if !eq(gs, ws) {
+					t.Fatalf("plan mismatch:\n got: %v\nwant: %v", got, tt.want)
+				}
+				t.Fatalf("plan ordering mismatch:\n got: %v\nwant: %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestReconcileContextCancelled verifies Reconcile respects a cancelled context.
+func TestReconcileContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := Reconcile(ctx, ds(ModuleAssignment{Name: "foo", Source: "foo"}), nil); err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+}
+
+// TestKeyDerivation checks the name-from-source fallback used as the diff key.
+func TestKeyDerivation(t *testing.T) {
+	cases := map[string]string{
+		"embedding":                           "embedding",
+		"owner/repo@v1.2.0":                   "repo",
+		"https://host/owner/repo.git@ref":     "repo",
+		"git@github.com:owner/repo.git":       "repo",
+		"https://github.com/aceteam-ai/x.git": "x",
+	}
+	for src, want := range cases {
+		if got := NameFromSource(src); got != want {
+			t.Errorf("NameFromSource(%q) = %q, want %q", src, got, want)
+		}
+	}
+	// An assignment with no explicit Name keys off the source.
+	m := ModuleAssignment{Source: "owner/repo@v1"}
+	if m.Key() != "repo" {
+		t.Errorf("Key() = %q, want repo", m.Key())
+	}
+	// An explicit Name wins (so a ref change is not read as remove+add).
+	m2 := ModuleAssignment{Name: "fixed", Source: "owner/repo@v9"}
+	if m2.Key() != "fixed" {
+		t.Errorf("Key() = %q, want fixed", m2.Key())
+	}
+}

--- a/internal/reconcile/fakeops_test.go
+++ b/internal/reconcile/fakeops_test.go
@@ -1,0 +1,132 @@
+package reconcile
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// fakeOps is a STATEFUL in-memory ModuleOps for tests. Install/Update/Start/
+// Stop/Uninstall mutate an internal store that the next ListInstalled reflects,
+// so idempotency and update-detection tests are meaningful (a no-op stub would
+// pass a fake idempotency check while the real diff was broken).
+type fakeOps struct {
+	mu      sync.Mutex
+	store   map[string]*InstalledModule
+	calls   []string          // ordered log of operations, e.g. "install:foo"
+	failOn  map[string]error  // module name -> error to return from any op
+	failOps map[string]string // module name -> specific op ("install","start",...) to fail; empty means all
+}
+
+func newFakeOps(seed ...InstalledModule) *fakeOps {
+	f := &fakeOps{
+		store:   map[string]*InstalledModule{},
+		failOn:  map[string]error{},
+		failOps: map[string]string{},
+	}
+	for _, im := range seed {
+		cp := im
+		f.store[im.Name] = &cp
+	}
+	return f
+}
+
+// failModule makes every op on name return err. If op is non-empty, only that
+// op fails.
+func (f *fakeOps) failModule(name, op string, err error) {
+	f.failOn[name] = err
+	f.failOps[name] = op
+}
+
+func (f *fakeOps) shouldFail(name, op string) error {
+	err, ok := f.failOn[name]
+	if !ok {
+		return nil
+	}
+	if want := f.failOps[name]; want != "" && want != op {
+		return nil
+	}
+	return err
+}
+
+func (f *fakeOps) Install(ctx context.Context, m ModuleAssignment) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	name := m.Key()
+	f.calls = append(f.calls, "install:"+name)
+	if err := f.shouldFail(name, "install"); err != nil {
+		return err
+	}
+	// Fresh install => running, with the assignment's source/config recorded.
+	f.store[name] = &InstalledModule{
+		Name:   name,
+		Source: m.Source,
+		Config: cloneConfig(m.Config),
+		Health: HealthRunning,
+	}
+	return nil
+}
+
+func (f *fakeOps) Uninstall(ctx context.Context, name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, "uninstall:"+name)
+	if err := f.shouldFail(name, "uninstall"); err != nil {
+		return err
+	}
+	delete(f.store, name)
+	return nil
+}
+
+func (f *fakeOps) Start(ctx context.Context, name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, "start:"+name)
+	if err := f.shouldFail(name, "start"); err != nil {
+		return err
+	}
+	if im, ok := f.store[name]; ok {
+		im.Health = HealthRunning
+	}
+	return nil
+}
+
+func (f *fakeOps) Stop(ctx context.Context, name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, "stop:"+name)
+	if err := f.shouldFail(name, "stop"); err != nil {
+		return err
+	}
+	if im, ok := f.store[name]; ok {
+		im.Health = HealthStopped
+	}
+	return nil
+}
+
+func (f *fakeOps) ListInstalled(ctx context.Context) ([]InstalledModule, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]InstalledModule, 0, len(f.store))
+	for _, im := range f.store {
+		cp := *im
+		cp.Config = cloneConfig(im.Config)
+		out = append(out, cp)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+func cloneConfig(c map[string]string) map[string]string {
+	if c == nil {
+		return nil
+	}
+	out := make(map[string]string, len(c))
+	for k, v := range c {
+		out[k] = v
+	}
+	return out
+}
+
+func errf(format string, a ...any) error { return fmt.Errorf(format, a...) }

--- a/internal/reconcile/http_stub.go
+++ b/internal/reconcile/http_stub.go
@@ -1,0 +1,91 @@
+package reconcile
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// httpProvider is a THIN STUB implementation of DesiredStateProvider over HTTP.
+//
+// IT IS NOT WIRED INTO ANYTHING LIVE. The control-plane endpoints it talks to
+// DO NOT EXIST YET — they are owned by aceteam-ai/aceteam#4273. The routes,
+// auth (node device identity), and error/retry semantics below are PLACEHOLDERS
+// that must be finalized against that issue before this is used. It exists only
+// to (a) document the intended transport shape next to the wire-contract types
+// and (b) give the later live-provider increment a starting point. Do not
+// construct it from production code paths.
+type httpProvider struct {
+	// BaseURL is the control-plane base, e.g. "https://aceteam.ai/fabric".
+	BaseURL string
+	// NodeID identifies this node (device identity).
+	NodeID string
+	// Client is the HTTP client; nil uses http.DefaultClient.
+	Client *http.Client
+	// Authorize, if set, stamps auth headers (device-identity token) onto each
+	// request. The real device-identity auth is TBD per aceteam#4273.
+	Authorize func(*http.Request)
+}
+
+func (p *httpProvider) client() *http.Client {
+	if p.Client != nil {
+		return p.Client
+	}
+	return http.DefaultClient
+}
+
+// Fetch GETs <BaseURL>/nodes/{id}/desired-state. ENDPOINT TBD per aceteam#4273.
+func (p *httpProvider) Fetch(ctx context.Context) (DesiredState, error) {
+	url := fmt.Sprintf("%s/nodes/%s/desired-state", p.BaseURL, p.NodeID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return DesiredState{}, err
+	}
+	if p.Authorize != nil {
+		p.Authorize(req)
+	}
+	resp, err := p.client().Do(req)
+	if err != nil {
+		return DesiredState{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return DesiredState{}, fmt.Errorf("desired-state fetch: unexpected status %d", resp.StatusCode)
+	}
+	var ds DesiredState
+	if err := json.NewDecoder(resp.Body).Decode(&ds); err != nil {
+		return DesiredState{}, fmt.Errorf("decode desired-state: %w", err)
+	}
+	return ds, nil
+}
+
+// Report POSTs <BaseURL>/nodes/{id}/actual-state. ENDPOINT TBD per aceteam#4273.
+func (p *httpProvider) Report(ctx context.Context, actual ActualState) error {
+	url := fmt.Sprintf("%s/nodes/%s/actual-state", p.BaseURL, p.NodeID)
+	body, err := json.Marshal(actual)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if p.Authorize != nil {
+		p.Authorize(req)
+	}
+	resp, err := p.client().Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("actual-state report: unexpected status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// compile-time check that the stub satisfies the interface.
+var _ DesiredStateProvider = (*httpProvider)(nil)

--- a/internal/reconcile/job.go
+++ b/internal/reconcile/job.go
@@ -1,0 +1,40 @@
+package reconcile
+
+import "context"
+
+// ReconcileJobPayload is the (currently empty) payload of a push-nudge
+// `reconcile` job (jobs.JobTypeReconcile). The job carries no parameters today:
+// it simply asks the node to run an immediate reconcile pass against its
+// control-plane-assigned desired state. Fields may be added later (e.g. a
+// correlation id or a "force full re-pull" flag) without breaking the empty
+// case.
+type ReconcileJobPayload struct{}
+
+// HandleReconcileJob is the push-nudge handler skeleton for a `reconcile` job
+// on the node's queue. It is INERT unless the reconcile feature is enabled:
+//
+//   - If cfg.Enabled is false (the DEFAULT), it does nothing and returns nil —
+//     a node that has not opted into remote management ignores the job.
+//   - If a loop is provided, it Nudges the running loop (debounced) so the pass
+//     coalesces with the periodic pull.
+//   - Otherwise, with no loop but an explicit reconciler, it runs a single
+//     immediate pass synchronously.
+//
+// This handler is intentionally NOT wired into the live worker dispatch in this
+// increment; wiring (adding a case to the worker switch behind cfg.Enabled) is
+// a documented TODO to keep the live worker path untouched. See the package doc
+// and PR notes.
+func HandleReconcileJob(ctx context.Context, cfg Config, loop *Loop, rec *Reconciler) error {
+	if !cfg.Enabled {
+		return nil // inert: feature disabled
+	}
+	if loop != nil {
+		loop.Nudge()
+		return nil
+	}
+	if rec != nil {
+		_, _, err := rec.ReconcileOnce(ctx)
+		return err
+	}
+	return nil
+}

--- a/internal/reconcile/loop.go
+++ b/internal/reconcile/loop.go
@@ -1,0 +1,188 @@
+package reconcile
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// Config gates and tunes the reconcile loop. The zero value is DISABLED — a
+// node only reconciles if it explicitly opts in (Enabled == true). This keeps
+// existing nodes completely unaffected until they choose remote management.
+type Config struct {
+	// Enabled turns the reconcile loop on. DISABLED BY DEFAULT. The loop must
+	// never be started unconditionally from the worker/serve path; wiring it is
+	// gated behind this flag (see the package doc / PR notes).
+	Enabled bool
+
+	// Interval is the pull-reconcile period. Zero defaults to DefaultInterval.
+	Interval time.Duration
+
+	// MinInterval is the debounce floor: two reconcile passes (whether from the
+	// ticker or a push nudge) are never run closer together than this. Zero
+	// defaults to DefaultMinInterval.
+	MinInterval time.Duration
+
+	// Node is the reporting node identifier (device identity) stamped into the
+	// actual-state report.
+	Node string
+}
+
+const (
+	// DefaultInterval is the default pull-reconcile period.
+	DefaultInterval = 5 * time.Minute
+	// DefaultMinInterval is the default debounce floor between passes.
+	DefaultMinInterval = 10 * time.Second
+)
+
+func (c Config) interval() time.Duration {
+	if c.Interval <= 0 {
+		return DefaultInterval
+	}
+	return c.Interval
+}
+
+func (c Config) minInterval() time.Duration {
+	if c.MinInterval <= 0 {
+		return DefaultMinInterval
+	}
+	return c.MinInterval
+}
+
+// Reconciler runs one full pass: Fetch desired -> Reconcile -> Apply -> report
+// ActualState. It is the unit the Loop drives, and is independently callable
+// for a one-shot reconcile (e.g. from a push-nudge job handler).
+type Reconciler struct {
+	Provider DesiredStateProvider
+	Ops      ModuleOps
+	Node     string
+}
+
+// NewReconciler builds a Reconciler.
+func NewReconciler(p DesiredStateProvider, ops ModuleOps, node string) *Reconciler {
+	return &Reconciler{Provider: p, Ops: ops, Node: node}
+}
+
+// ReconcileOnce performs a single end-to-end pass. It returns the plan that was
+// applied and the apply result. Per-module failures are inside ApplyResult (and
+// reported back as Health == HealthError); a returned error is reserved for
+// pass-level failures (fetch failed, list failed, context cancelled).
+func (r *Reconciler) ReconcileOnce(ctx context.Context) (Plan, ApplyResult, error) {
+	desired, err := r.Provider.Fetch(ctx)
+	if err != nil {
+		return Plan{}, ApplyResult{}, err
+	}
+
+	actual, err := r.Ops.ListInstalled(ctx)
+	if err != nil {
+		return Plan{}, ApplyResult{}, err
+	}
+
+	plan, err := Reconcile(ctx, desired, actual)
+	if err != nil {
+		return Plan{}, ApplyResult{}, err
+	}
+
+	applyRes, err := Apply(ctx, r.Ops, plan)
+	if err != nil {
+		return plan, applyRes, err
+	}
+
+	// Report actual state back (best-effort: a report failure does not undo a
+	// successful converge, but it IS surfaced to the caller).
+	report, err := BuildActualState(ctx, r.Ops, applyRes.Errors, r.Node)
+	if err != nil {
+		return plan, applyRes, err
+	}
+	if err := r.Provider.Report(ctx, report); err != nil {
+		return plan, applyRes, err
+	}
+
+	return plan, applyRes, nil
+}
+
+// Loop drives a Reconciler on a configurable pull interval and accepts push
+// nudges for an immediate pass. It is DISABLED BY DEFAULT via Config.Enabled
+// and is NOT started from the live worker path in this increment (wiring is a
+// documented TODO). Build/test it in isolation.
+type Loop struct {
+	cfg  Config
+	rec  *Reconciler
+	nudg chan struct{}
+
+	mu       sync.Mutex
+	lastPass time.Time
+
+	// now is injectable for deterministic debounce tests; defaults to time.Now.
+	now func() time.Time
+}
+
+// NewLoop builds a reconcile loop. The returned loop does nothing until Run is
+// called, and Run is a no-op when cfg.Enabled is false.
+func NewLoop(cfg Config, rec *Reconciler) *Loop {
+	return &Loop{
+		cfg:  cfg,
+		rec:  rec,
+		nudg: make(chan struct{}, 1),
+		now:  time.Now,
+	}
+}
+
+// Nudge requests an immediate reconcile pass. It is non-blocking and coalescing:
+// multiple nudges before the next pass collapse into one. This is the push path
+// (a `reconcile` job on the node queue triggers Nudge).
+func (l *Loop) Nudge() {
+	select {
+	case l.nudg <- struct{}{}:
+	default:
+		// A pass is already pending; coalesce.
+	}
+}
+
+// Run drives the loop until ctx is cancelled. It returns immediately (nil) when
+// the loop is disabled, so callers can wire it unconditionally and rely on the
+// flag for the off switch. Each pass — ticker or nudge — is debounced to
+// Config.MinInterval. Per-pass errors are returned via the onPass callback if
+// set; the loop itself only stops on ctx cancellation.
+func (l *Loop) Run(ctx context.Context, onPass func(Plan, ApplyResult, error)) error {
+	if !l.cfg.Enabled {
+		return nil
+	}
+
+	ticker := time.NewTicker(l.cfg.interval())
+	defer ticker.Stop()
+
+	runPass := func() {
+		if !l.allow() {
+			return
+		}
+		plan, res, err := l.rec.ReconcileOnce(ctx)
+		if onPass != nil {
+			onPass(plan, res, err)
+		}
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			runPass()
+		case <-l.nudg:
+			runPass()
+		}
+	}
+}
+
+// allow enforces the debounce floor: it returns true (and stamps the pass time)
+// only if at least Config.MinInterval has elapsed since the last allowed pass.
+func (l *Loop) allow() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	now := l.now()
+	if !l.lastPass.IsZero() && now.Sub(l.lastPass) < l.cfg.minInterval() {
+		return false
+	}
+	l.lastPass = now
+	return true
+}

--- a/internal/reconcile/loop_test.go
+++ b/internal/reconcile/loop_test.go
@@ -1,0 +1,195 @@
+package reconcile
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestReconcileOnceFullFlow drives Fetch -> Reconcile -> Apply -> Report through
+// a FakeProvider + fakeOps and asserts the provider received an actual-state
+// report reflecting the converged node.
+func TestReconcileOnceFullFlow(t *testing.T) {
+	ctx := context.Background()
+	prov := &FakeProvider{Desired: ds(
+		ModuleAssignment{Name: "foo", Source: "foo", DesiredStatus: StatusRunning},
+	)}
+	ops := newFakeOps()
+	rec := NewReconciler(prov, ops, "node-x")
+
+	plan, res, err := rec.ReconcileOnce(ctx)
+	if err != nil {
+		t.Fatalf("ReconcileOnce: %v", err)
+	}
+	if res.Failed() {
+		t.Fatalf("apply errors: %v", res.Errors)
+	}
+	if len(plan.Steps) != 1 || plan.Steps[0].Action != ActionInstall {
+		t.Fatalf("unexpected plan: %v", planActions(plan))
+	}
+	if len(prov.Reported) != 1 {
+		t.Fatalf("expected 1 report, got %d", len(prov.Reported))
+	}
+	report := prov.Reported[0]
+	if report.Node != "node-x" {
+		t.Errorf("report node = %q, want node-x", report.Node)
+	}
+	if len(report.Modules) != 1 || report.Modules[0].Name != "foo" ||
+		report.Modules[0].Health != HealthRunning {
+		t.Errorf("unexpected report modules: %+v", report.Modules)
+	}
+
+	// Second ReconcileOnce is a no-op (idempotent) but still reports.
+	plan2, _, err := rec.ReconcileOnce(ctx)
+	if err != nil {
+		t.Fatalf("2nd ReconcileOnce: %v", err)
+	}
+	if !plan2.IsEmpty() {
+		t.Errorf("2nd pass should be empty, got %v", planActions(plan2))
+	}
+	if len(prov.Reported) != 2 {
+		t.Errorf("expected 2 reports, got %d", len(prov.Reported))
+	}
+}
+
+// TestReconcileOnceFetchError surfaces a provider fetch failure as a pass-level
+// error (and performs no ops).
+func TestReconcileOnceFetchError(t *testing.T) {
+	prov := &FakeProvider{FetchErr: errf("control plane down")}
+	ops := newFakeOps()
+	rec := NewReconciler(prov, ops, "n")
+	if _, _, err := rec.ReconcileOnce(context.Background()); err == nil {
+		t.Fatal("expected fetch error")
+	}
+	if len(ops.calls) != 0 {
+		t.Errorf("no ops should run on fetch failure, got %v", ops.calls)
+	}
+}
+
+// TestLoopDisabledByDefault asserts the zero-value Config disables the loop:
+// Run returns immediately and never reconciles.
+func TestLoopDisabledByDefault(t *testing.T) {
+	prov := &FakeProvider{Desired: ds(ModuleAssignment{Name: "foo", Source: "foo"})}
+	ops := newFakeOps()
+	rec := NewReconciler(prov, ops, "n")
+
+	loop := NewLoop(Config{}, rec) // Enabled defaults false
+	err := loop.Run(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("disabled loop Run should return nil, got %v", err)
+	}
+	if len(ops.calls) != 0 {
+		t.Errorf("disabled loop must not reconcile, got %v", ops.calls)
+	}
+	if len(prov.Reported) != 0 {
+		t.Errorf("disabled loop must not report, got %d", len(prov.Reported))
+	}
+}
+
+// TestLoopNudgeRunsPass asserts a push nudge triggers a pass when enabled, and
+// that the loop stops on context cancellation.
+func TestLoopNudgeRunsPass(t *testing.T) {
+	prov := &FakeProvider{Desired: ds(ModuleAssignment{Name: "foo", Source: "foo"})}
+	ops := newFakeOps()
+	rec := NewReconciler(prov, ops, "n")
+
+	// Long interval so the ticker never fires during the test; the pass comes
+	// only from the nudge. MinInterval tiny so debounce never blocks.
+	loop := NewLoop(Config{Enabled: true, Interval: time.Hour, MinInterval: time.Nanosecond}, rec)
+
+	done := make(chan struct{})
+	passed := make(chan struct{}, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		_ = loop.Run(ctx, func(_ Plan, _ ApplyResult, _ error) {
+			select {
+			case passed <- struct{}{}:
+			default:
+			}
+		})
+		close(done)
+	}()
+
+	loop.Nudge()
+	select {
+	case <-passed:
+	case <-time.After(2 * time.Second):
+		cancel()
+		t.Fatal("nudge did not trigger a pass")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("loop did not stop on cancel")
+	}
+	if len(prov.Reported) == 0 {
+		t.Error("expected at least one report after nudge")
+	}
+}
+
+// TestLoopDebounce uses an injectable clock to assert two passes closer than
+// MinInterval are debounced (the second allow() returns false).
+func TestLoopDebounce(t *testing.T) {
+	loop := NewLoop(Config{Enabled: true, MinInterval: time.Minute}, nil)
+	base := time.Unix(1000, 0)
+	cur := base
+	loop.now = func() time.Time { return cur }
+
+	if !loop.allow() {
+		t.Fatal("first pass should be allowed")
+	}
+	cur = base.Add(30 * time.Second) // within MinInterval
+	if loop.allow() {
+		t.Fatal("second pass within MinInterval should be debounced")
+	}
+	cur = base.Add(2 * time.Minute) // past MinInterval
+	if !loop.allow() {
+		t.Fatal("pass after MinInterval should be allowed")
+	}
+}
+
+// TestHandleReconcileJobInertWhenDisabled asserts the push-nudge handler does
+// nothing when the feature is disabled.
+func TestHandleReconcileJobInertWhenDisabled(t *testing.T) {
+	prov := &FakeProvider{Desired: ds(ModuleAssignment{Name: "foo", Source: "foo"})}
+	ops := newFakeOps()
+	rec := NewReconciler(prov, ops, "n")
+
+	if err := HandleReconcileJob(context.Background(), Config{}, nil, rec); err != nil {
+		t.Fatalf("inert handler should return nil, got %v", err)
+	}
+	if len(ops.calls) != 0 {
+		t.Errorf("disabled handler must not reconcile, got %v", ops.calls)
+	}
+}
+
+// TestHandleReconcileJobEnabledRunsOnce asserts the handler runs a single pass
+// when enabled and given a reconciler (no loop).
+func TestHandleReconcileJobEnabledRunsOnce(t *testing.T) {
+	prov := &FakeProvider{Desired: ds(ModuleAssignment{Name: "foo", Source: "foo"})}
+	ops := newFakeOps()
+	rec := NewReconciler(prov, ops, "n")
+
+	if err := HandleReconcileJob(context.Background(), Config{Enabled: true}, nil, rec); err != nil {
+		t.Fatalf("enabled handler: %v", err)
+	}
+	if len(prov.Reported) != 1 {
+		t.Errorf("expected one reconcile pass, got %d reports", len(prov.Reported))
+	}
+}
+
+// TestHandleReconcileJobEnabledNudgesLoop asserts the handler nudges a provided
+// loop instead of running synchronously.
+func TestHandleReconcileJobEnabledNudgesLoop(t *testing.T) {
+	loop := NewLoop(Config{Enabled: true}, nil)
+	if err := HandleReconcileJob(context.Background(), Config{Enabled: true}, loop, nil); err != nil {
+		t.Fatalf("handler with loop: %v", err)
+	}
+	// The nudge should be buffered in the channel.
+	select {
+	case <-loop.nudg:
+	default:
+		t.Error("expected a buffered nudge")
+	}
+}

--- a/internal/reconcile/ops.go
+++ b/internal/reconcile/ops.go
@@ -1,0 +1,49 @@
+package reconcile
+
+import "context"
+
+// ModuleOps is the narrow side-effect surface the reconcile engine drives. It
+// wraps the EXISTING module-install / run / stop / uninstall operations so the
+// engine can converge a node without importing docker, git, or the catalog
+// install internals directly — which keeps the diff/converge logic fully
+// unit-testable with a fake.
+//
+// The live adapter (a LATER increment) maps these onto:
+//   - Install  -> catalog.ParseSource + the #342 module-install path
+//     (catalog.InstallFromManifest + addServiceToManifestWithTags),
+//     then `docker compose up` for the new service.
+//   - Uninstall-> stop + remove the service from citadel.yaml / modules.lock.
+//   - Start/Stop-> `docker compose up/down` for an already-installed service.
+//   - ListInstalled -> read modules.lock (source/ref/commit/digests) joined
+//     with the live container run-state and health.
+//
+// Every method takes a context so the live adapter can honor timeouts /
+// cancellation from the reconcile loop.
+type ModuleOps interface {
+	// Install installs a module from the given assignment's Source with its
+	// Config overrides. It is the convergence action for a missing module and
+	// for an update (the engine uninstalls-then-installs, or the adapter may
+	// implement an in-place update — either is acceptable as long as the
+	// resulting ListInstalled reflects the new source/ref/config). After a
+	// successful Install the module is expected to be RUNNING; the engine
+	// issues a follow-up Stop when DesiredStatus is stopped.
+	Install(ctx context.Context, m ModuleAssignment) error
+
+	// Uninstall removes an installed module by name (stop + de-register).
+	Uninstall(ctx context.Context, name string) error
+
+	// Start brings an already-installed module up.
+	Start(ctx context.Context, name string) error
+
+	// Stop brings an already-installed module down (without uninstalling it).
+	Stop(ctx context.Context, name string) error
+
+	// ListInstalled returns the actual on-node state of every installed module.
+	//
+	// CRITICAL: each returned InstalledModule MUST carry enough to diff against
+	// the desired state — at minimum Name, Source, Ref, Config, and a Health
+	// that distinguishes running vs stopped. Without Source/Ref/Config the
+	// engine cannot detect update-on-source-change or update-on-config-change,
+	// and cannot prove idempotency.
+	ListInstalled(ctx context.Context) ([]InstalledModule, error)
+}

--- a/internal/reconcile/provider.go
+++ b/internal/reconcile/provider.go
@@ -1,0 +1,49 @@
+package reconcile
+
+import "context"
+
+// DesiredStateProvider is the control-plane transport: it fetches this node's
+// assigned desired state and reports actual state back. It is authenticated by
+// the node's existing device identity in the live implementation.
+//
+// The LIVE HTTP implementation (talking to the /fabric control plane) is a
+// SEPARATE, LATER issue and depends on the control-plane endpoints that DO NOT
+// EXIST YET (aceteam-ai/aceteam#4273). This package provides ONLY the interface
+// and an in-memory FakeProvider for tests. A thin HTTP stub is provided in
+// http_stub.go but is explicitly NOT wired to anything live.
+type DesiredStateProvider interface {
+	// Fetch returns the node's control-plane-assigned desired state.
+	Fetch(ctx context.Context) (DesiredState, error)
+	// Report posts the node's observed actual state back to the control plane.
+	Report(ctx context.Context, actual ActualState) error
+}
+
+// FakeProvider is an in-memory DesiredStateProvider for tests. It serves a
+// settable DesiredState and records every reported ActualState. It is also
+// useful as a local "static desired state from a file" provider if a node ever
+// wants to pin its state without a control plane (out of scope for #353, but
+// the type makes that trivial).
+type FakeProvider struct {
+	// Desired is the state Fetch returns.
+	Desired DesiredState
+	// FetchErr, if set, is returned by Fetch (to test fetch-failure paths).
+	FetchErr error
+	// ReportErr, if set, is returned by Report.
+	ReportErr error
+	// Reported accumulates every ActualState passed to Report, in order.
+	Reported []ActualState
+}
+
+// Fetch implements DesiredStateProvider.
+func (f *FakeProvider) Fetch(ctx context.Context) (DesiredState, error) {
+	if f.FetchErr != nil {
+		return DesiredState{}, f.FetchErr
+	}
+	return f.Desired, nil
+}
+
+// Report implements DesiredStateProvider.
+func (f *FakeProvider) Report(ctx context.Context, actual ActualState) error {
+	f.Reported = append(f.Reported, actual)
+	return f.ReportErr
+}

--- a/internal/reconcile/source.go
+++ b/internal/reconcile/source.go
@@ -1,0 +1,48 @@
+package reconcile
+
+import "strings"
+
+// NameFromSource derives a canonical module name from a source string when the
+// control plane did not provide an explicit Name. It mirrors how the module
+// install path names a service, WITHOUT importing internal/catalog (so the wire
+// contract stays decoupled):
+//
+//   - catalog name "embedding"          -> "embedding"
+//   - "owner/repo@v1.2.0"               -> "repo"
+//   - "https://host/owner/repo.git@ref" -> "repo"
+//   - "git@github.com:owner/repo.git"   -> "repo"
+//
+// Note: deriving the name from the source means a source-ref change does NOT
+// change the key (good — it reads as an update, not remove+add), but two
+// different repos with the same trailing name would collide. The control plane
+// SHOULD therefore set ModuleAssignment.Name explicitly; this is a best-effort
+// fallback.
+func NameFromSource(source string) string {
+	s := strings.TrimSpace(source)
+	if s == "" {
+		return ""
+	}
+
+	// Strip an "@ref" suffix (but not the "@" in an scp-style git URL such as
+	// "git@github.com:owner/repo.git", where "@" precedes the host).
+	if at := strings.LastIndex(s, "@"); at > 0 {
+		tail := s[at+1:]
+		// A ref never contains "/" or ":"; an scp host part does.
+		if tail != "" && !strings.ContainsAny(tail, "/:") {
+			s = s[:at]
+		}
+	}
+
+	// A bare catalog name has no path separators.
+	if !strings.ContainsAny(s, "/:") {
+		return s
+	}
+
+	// Take the last path segment, splitting on both "/" and ":" (scp form).
+	seg := s
+	if i := strings.LastIndexAny(seg, "/:"); i >= 0 {
+		seg = seg[i+1:]
+	}
+	seg = strings.TrimSuffix(seg, ".git")
+	return seg
+}

--- a/internal/reconcile/types.go
+++ b/internal/reconcile/types.go
@@ -141,6 +141,17 @@ const (
 type InstalledModule struct {
 	Name string `json:"name"`
 	// Source is the normalized source string the module was installed from.
+	//
+	// CANONICAL-FORM CONTRACT (load-bearing for idempotency): the desired
+	// ModuleAssignment.Source and this actual Source MUST be expressed in the
+	// SAME canonical form, or the engine sees drift on every pass and re-updates
+	// forever. Specifically, both sides MUST use the REQUESTED ref form, not a
+	// resolved one. A constraint/channel (e.g. "owner/repo@^1.2") is stored in
+	// the lockfile alongside its ResolvedRef (e.g. "v1.4.0"); the actual Source
+	// reported here is the REQUESTED string ("owner/repo@^1.2"), and the control
+	// plane MUST assign the same requested string — NOT the resolved tag. The
+	// resolved commit/tag is reported separately via Commit (and Ref) for drift
+	// display, and is NOT part of the source-equality diff key.
 	Source string `json:"source"`
 	// Ref is the requested ref (tag/branch/sha/constraint), if any.
 	Ref string `json:"ref,omitempty"`

--- a/internal/reconcile/types.go
+++ b/internal/reconcile/types.go
@@ -1,0 +1,174 @@
+// Package reconcile implements the node-side desired-state reconciler for
+// remote-managed nodes (issue #353, part of epic #352 — GitOps for compute).
+//
+// A node converges its installed service-modules to a control-plane-assigned
+// DesiredState: install missing modules, update changed source-ref/config,
+// start/stop to match DesiredStatus, and uninstall removed modules. The local
+// citadel.yaml / modules.lock becomes a PROJECTION of this desired state, not
+// the source of truth.
+//
+// This package is deliberately self-contained and decoupled from the live
+// docker/catalog/worker code:
+//
+//   - It identifies module sources by an opaque string (catalog name |
+//     owner/repo@ref | git URL) — the SAME grammar internal/catalog.ParseSource
+//     accepts — so the wire contract does not leak catalog struct internals.
+//   - All side effects go through the ModuleOps interface, so the diff/converge
+//     engine is unit-testable without docker, git, or a real fabric.
+//   - The control-plane transport goes through the DesiredStateProvider
+//     interface; the live HTTP implementation (authed by node device identity)
+//     is a LATER issue (aceteam-ai/aceteam#4273). Only the interface and a
+//     fake are provided here.
+package reconcile
+
+// ----------------------------------------------------------------------------
+// WIRE CONTRACT  (load-bearing across repos — keep in sync with aceteam#4273)
+//
+// These types define the JSON contract between the node reconciler and the
+// control plane (/fabric backend). The control plane MUST serve DesiredState
+// from `GET <plane>/nodes/{id}/desired-state` and accept ActualState at
+// `POST <plane>/nodes/{id}/actual-state`, both authenticated by the node's
+// existing device identity. The exact routes are owned by aceteam#4273; the
+// SHAPES below are owned jointly and must not drift silently.
+// ----------------------------------------------------------------------------
+
+// DesiredStatus is the operator-assigned target run-state of a module.
+type DesiredStatus string
+
+const (
+	// StatusRunning means the module must be installed and running.
+	StatusRunning DesiredStatus = "running"
+	// StatusStopped means the module must be installed but NOT running.
+	StatusStopped DesiredStatus = "stopped"
+)
+
+// ModuleAssignment is one entry of a node's desired state: a module the control
+// plane has assigned to this node, by source, with config overrides and a
+// target run-state.
+//
+// JSON shape (wire contract):
+//
+//	{
+//	  "name":           "embedding",          // optional canonical name; see below
+//	  "source":         "owner/repo@v1.2.0",  // catalog name | owner/repo@ref | git URL
+//	  "config":         {"PORT": "8080"},     // config overrides (key=value)
+//	  "desired_status": "running"             // "running" | "stopped"
+//	}
+type ModuleAssignment struct {
+	// Name is the canonical module name used as the reconciliation key (it is
+	// what shows up in citadel.yaml / modules.lock as the service name). When
+	// empty, the reconciler derives it from Source via NameFromSource, but the
+	// control plane SHOULD set it explicitly so the key is stable across
+	// source-ref changes (renaming a ref must not be read as remove+add).
+	Name string `json:"name,omitempty"`
+
+	// Source identifies where the module comes from. It uses the same grammar
+	// as internal/catalog.ParseSource: a bare catalog name ("embedding"), an
+	// "owner/repo@ref" GitHub reference, or a full git clone URL (optionally
+	// with "@ref"). A change to Source (including its ref) is a drift that the
+	// reconciler converges by updating the module in place.
+	Source string `json:"source"`
+
+	// Config holds config-var overrides (the same key=value pairs accepted by
+	// `citadel module install --set K=V`). A change here is drift to converge.
+	Config map[string]string `json:"config,omitempty"`
+
+	// DesiredStatus is the target run-state. Empty defaults to StatusRunning.
+	DesiredStatus DesiredStatus `json:"desired_status,omitempty"`
+}
+
+// EffectiveStatus returns DesiredStatus, defaulting an empty value to running.
+func (m ModuleAssignment) EffectiveStatus() DesiredStatus {
+	if m.DesiredStatus == "" {
+		return StatusRunning
+	}
+	return m.DesiredStatus
+}
+
+// Key returns the reconciliation key for an assignment: the explicit Name if
+// set, otherwise the name derived from Source.
+func (m ModuleAssignment) Key() string {
+	if m.Name != "" {
+		return m.Name
+	}
+	return NameFromSource(m.Source)
+}
+
+// DesiredState is the full set of modules the control plane has assigned to a
+// node. It is authoritative: anything installed locally that is not present
+// here is drift to be uninstalled.
+//
+// JSON shape (wire contract):
+//
+//	{ "modules": [ <ModuleAssignment>, ... ] }
+type DesiredState struct {
+	Modules []ModuleAssignment `json:"modules"`
+}
+
+// ----------------------------------------------------------------------------
+// Actual-state report (node -> control plane)
+// ----------------------------------------------------------------------------
+
+// ModuleHealth is the observed health of an installed module.
+type ModuleHealth string
+
+const (
+	// HealthRunning means the module is installed and its containers are up.
+	HealthRunning ModuleHealth = "running"
+	// HealthStopped means the module is installed but not running.
+	HealthStopped ModuleHealth = "stopped"
+	// HealthError means the last reconcile of this module failed; see Error.
+	HealthError ModuleHealth = "error"
+	// HealthUnknown means health could not be determined.
+	HealthUnknown ModuleHealth = "unknown"
+)
+
+// InstalledModule is the actual on-node state of a single module, as reported
+// back to the control plane for drift display.
+//
+// JSON shape (wire contract):
+//
+//	{
+//	  "name":          "embedding",
+//	  "source":        "owner/repo@v1.2.0",
+//	  "ref":           "v1.2.0",
+//	  "commit":        "abc123...",          // resolved git commit, if known
+//	  "config":        {"PORT": "8080"},
+//	  "image_digests": ["sha256:..."],
+//	  "health":        "running",            // running|stopped|error|unknown
+//	  "error":         ""                    // populated when health == error
+//	}
+type InstalledModule struct {
+	Name string `json:"name"`
+	// Source is the normalized source string the module was installed from.
+	Source string `json:"source"`
+	// Ref is the requested ref (tag/branch/sha/constraint), if any.
+	Ref string `json:"ref,omitempty"`
+	// Commit is the resolved git commit, if known.
+	Commit string `json:"commit,omitempty"`
+	// Config is the effective config-override set the module was installed with.
+	Config map[string]string `json:"config,omitempty"`
+	// ImageDigests are the deployed image digests (sha256:...), for tamper
+	// evidence / drift detection.
+	ImageDigests []string `json:"image_digests,omitempty"`
+	// Health is the observed run-state / error state.
+	Health ModuleHealth `json:"health"`
+	// Error carries the failure detail when Health == HealthError. It is the
+	// per-module failure-isolation surface: a module that failed to converge
+	// reports its error here without blocking the others.
+	Error string `json:"error,omitempty"`
+}
+
+// ActualState is the node's report of what it actually has installed, posted
+// back to the control plane so /fabric can show status and drift.
+//
+// JSON shape (wire contract):
+//
+//	{ "node": "node-id", "modules": [ <InstalledModule>, ... ] }
+type ActualState struct {
+	// Node is the reporting node's identifier (device identity). It may be left
+	// empty by the engine and filled in by the transport layer.
+	Node string `json:"node,omitempty"`
+	// Modules is the observed set of installed modules.
+	Modules []InstalledModule `json:"modules"`
+}


### PR DESCRIPTION
## Node desired-state reconcile engine — first increment of #353

Part of **#353** (node reconcile loop) / **#352** (remote-managed nodes — GitOps for compute).

This PR adds the **node-side reconcile ENGINE**: a self-contained `internal/reconcile` package that converges a node's installed service-modules to a **control-plane-assigned desired state** (install missing, update on source-ref/config drift, start/stop to match, uninstall removed), with per-module failure isolation and full idempotency. It is deliberately decoupled from live docker/catalog/worker code so the diff/converge logic is unit-testable without docker, git, or a real fabric.

### Why this scoping
The control-plane endpoints (GET desired-state / POST actual-state) **do not exist yet** — they're aceteam-ai/aceteam#4273. So this increment depends on **no live control plane**: transport is an interface with a fake, and the loop is **disabled by default** and **not wired** into the worker.

### What's included
- **Wire-contract types** (`types.go`) — `DesiredState`/`ModuleAssignment` (plane→node) and `ActualState`/`InstalledModule` (node→plane). Module sources are opaque strings using the same grammar as `catalog.ParseSource` (catalog name | `owner/repo@ref` | git URL), so the contract doesn't leak catalog internals.
- **`DesiredStateProvider` interface** (`provider.go`) — `Fetch`/`Report`, with an in-memory `FakeProvider` for tests. A thin HTTP stub (`http_stub.go`) is included but **clearly marked "endpoint TBD per aceteam#4273" and wired to nothing live**.
- **`Reconcile()`** (`engine.go`) — idempotent diff producing a deterministic, ordered `Plan` (uninstalls → installs/updates → start/stop transitions).
- **`ModuleOps` interface + `Apply()`** (`ops.go`, `apply.go`) — executes the plan through a narrow side-effect surface (`Install`/`Uninstall`/`Start`/`Stop`/`ListInstalled`). **Per-module failure isolation**: one failing module records an error and does NOT abort the others; the error surfaces in the actual-state report as `Health: error`.
- **`Loop` scaffold** (`loop.go`) — configurable pull interval + a coalescing push `Nudge()` with a debounce floor. **Gated behind `Config.Enabled`, DISABLED BY DEFAULT.** Existing nodes are unaffected; the loop is **not started** from `work.go`/`serve.go`.
- **`JobTypeReconcile`** constant (`internal/jobs/queue_types.go`) + an **inert** `HandleReconcileJob` skeleton (`job.go`) — a no-op unless the feature is enabled; worker dispatch is intentionally not wired.

### Tests (the heart of this PR) — no network, no docker, no fabric
Table-driven over a **stateful** fake `ModuleOps` + `FakeProvider`:
- install-missing, uninstall-removed, update-on-source-ref-change, update-on-config-change, start/stop transitions, mixed plans, default-status-running;
- **idempotency** — `Reconcile → Apply → Reconcile` and assert the 2nd plan is **empty**;
- **per-module failure isolation** — one module errors, the others still apply, and the error surfaces in the actual-state report;
- loop **disabled-by-default**, deterministic **nudge** + **debounce** (injectable clock, no real sleeps), inert job handler.

`go build ./cmd/citadel ./internal/reconcile/`, `go vet`, and `go test -race ./internal/reconcile/...` all pass (14 tests / 11 diff subcases).

## Wire contract (for the control-plane team — aceteam#4273)

**`GET <plane>/nodes/{id}/desired-state`** → `DesiredState`, authed by node device identity:
```json
{ "modules": [
  { "name": "embedding",
    "source": "owner/repo@v1.2.0",
    "config": { "PORT": "8080" },
    "desired_status": "running" }   // "running" | "stopped" (empty = running)
] }
```
- `source`: catalog name | `owner/repo@ref` | git URL. `name` is the stable reconciliation key — the plane SHOULD set it explicitly (a source-ref change must read as an update, not remove+add).

**`POST <plane>/nodes/{id}/actual-state`** ← `ActualState`:
```json
{ "node": "node-id", "modules": [
  { "name": "embedding", "source": "owner/repo@v1.2.0", "ref": "v1.2.0",
    "commit": "abc123…", "config": { "PORT": "8080" },
    "image_digests": ["sha256:…"],
    "health": "running",            // running|stopped|error|unknown
    "error": "" }                   // populated when health == error
] }
```

**Canonical-source-form constraint (load-bearing for idempotency):** desired `source` and reported `source` MUST be expressed in the **same requested form** (e.g. both `owner/repo@^1.2`), NOT a resolved tag. A constraint/channel resolves to a `ResolvedRef` in the node lockfile; the resolved commit/tag is reported via `commit`/`ref` for display and is **NOT** part of the source-equality diff key. If the plane assigned a resolved tag while the node reported the requested constraint, the engine would see drift every pass and re-update forever.

## Explicitly deferred (separate increments)
- **Live HTTP `DesiredStateProvider`** + the control-plane GET/POST endpoints, authed by node device identity → **aceteam-ai/aceteam#4273**.
- **Live `ModuleOps` adapter** binding the interface to the existing module path (`catalog.ParseSource` + `catalog.InstallFromManifest` + `addServiceToManifestWithTags` + `docker compose up/down`, and `ListInstalled` reading `modules.lock` joined with container run-state). The engine is fully testable against the interface today; the adapter is the next node-side increment.
- **Wiring the loop into the live worker** (`work.go`/`serve.go`) and the `JobTypeReconcile` dispatch case — left as a documented TODO behind `Config.Enabled` to keep the live worker path untouched in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
