### PR TITLE
test(#351): live-TEI integration test for embedding handler

### DIFF
--- a/internal/jobs/embedding_handler_integration_test.go
+++ b/internal/jobs/embedding_handler_integration_test.go
@@ -1,0 +1,166 @@
+//go:build integration
+
+// Live-TEI integration test for the embedding handler (issue #351, code merged
+// in #357). Unlike embedding_handler_test.go, which mocks TEI with httptest,
+// this exercises EmbeddingHandler.Execute against a REAL running Text-
+// Embeddings-Inference container (gte-multilingual-base, 768-d), proving the
+// handler<->live-TEI leg end to end.
+//
+// Build-tagged `integration` so it never runs in normal CI. It is also gated to
+// t.Skip when the TEI service is unreachable, so a developer without TEI up does
+// not see spurious failures.
+//
+// Run it with TEI listening on the URL given by CITADEL_TEI_URL, e.g.:
+//
+//	CITADEL_TEI_URL=http://localhost:8085 \
+//	  go test -tags integration -run TestEmbeddingHandlerLiveTEI ./internal/jobs/ -v
+package jobs
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+// liveTEIURL resolves the TEI base URL the handler will use, honoring
+// CITADEL_TEI_URL (the same override teiBaseURL() reads) and falling back to the
+// local container's port.
+func liveTEIURL() string {
+	if v := os.Getenv("CITADEL_TEI_URL"); v != "" {
+		return v
+	}
+	return "http://localhost:8085"
+}
+
+// requireLiveTEI skips the test unless a real TEI /health responds 200 quickly.
+// It uses a short timeout so an absent service yields an immediate t.Skip rather
+// than the handler's 60s readiness poll.
+func requireLiveTEI(t *testing.T) string {
+	t.Helper()
+	base := liveTEIURL()
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(base + "/health")
+	if err != nil {
+		t.Skipf("live TEI not reachable at %s (%v); skipping integration test", base, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Skipf("live TEI health at %s returned %d; skipping integration test", base, resp.StatusCode)
+	}
+	return base
+}
+
+// TestEmbeddingHandlerLiveTEI drives EmbeddingHandler.Execute against a real TEI
+// service. It covers the canonical JSON-array input path (incl. multilingual
+// text) and the scalar-string fallback path.
+func TestEmbeddingHandlerLiveTEI(t *testing.T) {
+	base := requireLiveTEI(t)
+
+	// Point the handler at the live service. t.Setenv auto-restores on cleanup
+	// (and forbids t.Parallel, which we intentionally do not use).
+	t.Setenv("CITADEL_TEI_URL", base)
+
+	t.Run("json_array_multilingual", func(t *testing.T) {
+		job := &nexus.Job{
+			ID:   "live-embed-array",
+			Type: "embedding",
+			Payload: map[string]string{
+				"model": "gte",
+				// `input` arrives as a JSON-array string, matching the flattened
+				// map[string]string contract of the live dispatch path.
+				"input": `["hello world","你好世界"]`,
+			},
+		}
+
+		out, err := (&EmbeddingHandler{}).Execute(JobContext{}, job)
+		if err != nil {
+			t.Fatalf("Execute against live TEI failed: %v", err)
+		}
+
+		var res EmbeddingResult
+		if err := json.Unmarshal(out, &res); err != nil {
+			t.Fatalf("result did not unmarshal to EmbeddingResult: %v\nraw: %s", err, string(out))
+		}
+
+		if len(res.Embeddings) != 2 {
+			t.Fatalf("got %d embeddings, want 2", len(res.Embeddings))
+		}
+		// gte-multilingual-base is 768-d; the task pins this dimensionality.
+		const wantDim = 768
+		if res.Dimensions != wantDim {
+			t.Errorf("Dimensions = %d, want %d", res.Dimensions, wantDim)
+		}
+		for i, emb := range res.Embeddings {
+			if len(emb) == 0 {
+				t.Errorf("embedding[%d] is empty", i)
+				continue
+			}
+			if len(emb) != wantDim {
+				t.Errorf("embedding[%d] has dim %d, want %d", i, len(emb), wantDim)
+			}
+		}
+		if res.Usage.TotalTokens <= 0 {
+			t.Errorf("Usage.TotalTokens = %d, want > 0", res.Usage.TotalTokens)
+		}
+		if res.Usage.PromptTokens <= 0 {
+			t.Errorf("Usage.PromptTokens = %d, want > 0", res.Usage.PromptTokens)
+		}
+
+		t.Logf("live TEI: model=%q embeddings=%d dim=%d usage{prompt=%d total=%d} emb0[0:3]=%v",
+			res.Model, len(res.Embeddings), res.Dimensions,
+			res.Usage.PromptTokens, res.Usage.TotalTokens, head3(res.Embeddings[0]))
+	})
+
+	t.Run("scalar_fallback", func(t *testing.T) {
+		job := &nexus.Job{
+			ID:   "live-embed-scalar",
+			Type: "embedding",
+			Payload: map[string]string{
+				"model": "gte",
+				// A bare, non-JSON string: json.Unmarshal fails and the handler
+				// falls back to a single-element input. Proves the scalar path
+				// against live TEI.
+				"input": "hello world",
+			},
+		}
+
+		out, err := (&EmbeddingHandler{}).Execute(JobContext{}, job)
+		if err != nil {
+			t.Fatalf("Execute (scalar input) against live TEI failed: %v", err)
+		}
+
+		var res EmbeddingResult
+		if err := json.Unmarshal(out, &res); err != nil {
+			t.Fatalf("result did not unmarshal to EmbeddingResult: %v\nraw: %s", err, string(out))
+		}
+
+		if len(res.Embeddings) != 1 {
+			t.Fatalf("got %d embeddings, want 1 (scalar fallback)", len(res.Embeddings))
+		}
+		if len(res.Embeddings[0]) == 0 {
+			t.Fatalf("scalar embedding is empty")
+		}
+		if res.Dimensions != len(res.Embeddings[0]) {
+			t.Errorf("Dimensions = %d, but embedding has %d values", res.Dimensions, len(res.Embeddings[0]))
+		}
+		if res.Usage.TotalTokens <= 0 {
+			t.Errorf("Usage.TotalTokens = %d, want > 0", res.Usage.TotalTokens)
+		}
+
+		t.Logf("live TEI (scalar): model=%q embeddings=%d dim=%d usage{prompt=%d total=%d}",
+			res.Model, len(res.Embeddings), res.Dimensions,
+			res.Usage.PromptTokens, res.Usage.TotalTokens)
+	})
+}
+
+// head3 returns up to the first three values of v, for compact logging.
+func head3(v []float64) []float64 {
+	if len(v) > 3 {
+		return v[:3]
+	}
+	return v
+}


### PR DESCRIPTION
## What this proves

Issue #351 (embedding fabric-routing; handler code merged in #357) added `internal/jobs/embedding_handler.go`, whose `EmbeddingHandler.Execute` routes `embedding` jobs to a TEI `/v1/embeddings` upstream. The existing unit tests mock TEI with `httptest`. This PR adds a **build-tagged integration test** that exercises the handler against a **REAL running TEI** container (gte-multilingual-base, 768-d), proving the **handler ↔ live-TEI leg** end to end.

`internal/jobs/embedding_handler_integration_test.go`:
- `//go:build integration` — never runs in normal CI.
- Gated to `t.Skip` when TEI `/health` is unreachable (2s-timeout client, so no 60s readiness poll on a missing service).
- Honors `CITADEL_TEI_URL` (the same override `teiBaseURL()` reads).
- Builds a real `nexus.Job{Type:"embedding", Payload: map[string]string{...}}` (the flattened string-payload contract the live dispatch path uses) and a minimal real `JobContext`, then calls `(&EmbeddingHandler{}).Execute(...)`.
- **Case 1 — JSON-array input incl. multilingual** (`["hello world","你好世界"]`): asserts no error, result unmarshals to `EmbeddingResult`, 2 embeddings, each 768-d and non-empty, `Usage.PromptTokens`/`TotalTokens > 0`.
- **Case 2 — scalar fallback** (bare string `hello world`, not a JSON array): asserts 1 embedding via the scalar-fallback path against live TEI.

## Captured real test output

Run locally against a live TEI on `:8085`:

```
$ CITADEL_TEI_URL=http://localhost:8085 go test -tags integration -run TestEmbeddingHandlerLiveTEI ./internal/jobs/ -v

=== RUN   TestEmbeddingHandlerLiveTEI
=== RUN   TestEmbeddingHandlerLiveTEI/json_array_multilingual
     - [Job live-embed-array] Waiting for TEI embedding service to become ready...
     - [Job live-embed-array] TEI ready. Embedding 2 text(s) with model "gte"
    embedding_handler_integration_test.go:113: live TEI: model="Alibaba-NLP/gte-multilingual-base" embeddings=2 dim=768 usage{prompt=10 total=10} emb0[0:3]=[-0.033122938 0.049448732 -0.029030776]
=== RUN   TestEmbeddingHandlerLiveTEI/scalar_fallback
     - [Job live-embed-scalar] Waiting for TEI embedding service to become ready...
     - [Job live-embed-scalar] TEI ready. Embedding 1 text(s) with model "gte"
    embedding_handler_integration_test.go:154: live TEI (scalar): model="Alibaba-NLP/gte-multilingual-base" embeddings=1 dim=768 usage{prompt=5 total=5}
--- PASS: TestEmbeddingHandlerLiveTEI (0.03s)
    --- PASS: TestEmbeddingHandlerLiveTEI/json_array_multilingual (0.02s)
    --- PASS: TestEmbeddingHandlerLiveTEI/scalar_fallback (0.00s)
PASS
ok  	github.com/aceteam-ai/citadel-cli/internal/jobs	0.037s
```

Also verified: with an unreachable `CITADEL_TEI_URL` the test cleanly `--- SKIP`s (no 60s hang), and the normal `go test ./internal/jobs/` suite (no `integration` tag) still passes — the new file is excluded from default builds.

## Static gateway-routing confirmation (#351)

The gateway embedding-upstream wiring is present and consistent (verified by reading, not run against prod):

- `internal/gateway/metering.go:239` — `isMeteredPath` returns true for `"/v1/chat/completions", "/v1/completions", "/v1/embeddings"`, so `/v1/embeddings` is metered.
- `cmd/serve.go:285` — `--embedding-port` flag, default `8102`; `serve.go:171` builds `embeddingAddr = 127.0.0.1:<port>`; `serve.go:220` registers `gw.AddUpstream("/v1/embeddings", &gateway.Upstream{Address: embeddingAddr})`.
- `cmd/work.go:1881` — `--gateway-embedding-port` flag, default `8102`; `work.go:1274` registers the same `/v1/embeddings` → `embeddingAddr` upstream.

The metered `/v1/embeddings` route is registered to the local TEI embedding port in both the `serve` and `work` gateway paths. No prefix stripping (TEI exposes the same path). The gateway was NOT started against prod.

## RUNBOOK — remaining prod-fabric leg (for Jason, out of scope here)

The full dispatch loop (nexus job queue → worker picks up `task:embedding` → routes through gateway) needs the live fabric and was deliberately NOT exercised. Manual verification steps:

1. On a node, ensure TEI is reachable on the expected embedding port (default `8102`), or set `CITADEL_TEI_URL` to the actual address before starting the worker.
2. Start the node worker so it advertises the embedding capability:
   `citadel work --advertise-tags task:embedding` (with `--gateway-embedding-port` pointing at TEI; default `8102`).
3. Confirm the node registered the `task:embedding` tag in nexus (`citadel node-info` / nexus node listing).
4. Dispatch a `type=embedding` job with payload `{"model":"gte","input":"[\"hello world\",\"你好世界\"]"}` (input as a JSON-array string, matching the flattened string-payload contract).
5. Confirm the worker picks it up, `EmbeddingHandler.Execute` runs, and the job result contains 2 embeddings + usage tokens.
6. Independently confirm the gateway routes the metered `/v1/embeddings` to `--embedding-port`/`--gateway-embedding-port`: send a metered `/v1/embeddings` request through the gateway and verify it reaches TEI and is billed (metering ledger increments).

## Notes

- Do NOT merge — verification PR.
- No production behavior changed; this adds a single test file excluded from default builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)