### PR TITLE
feat(source): assigned-source resolution + private-source credentials (#354)

### DIFF
--- a/internal/catalog/source.go
+++ b/internal/catalog/source.go
@@ -464,9 +464,15 @@ func gitHeadCommit(dir string) string {
 	return strings.TrimSpace(string(out))
 }
 
-// cloneErrorHost extracts a host label from a source's clone URL for the
-// credential hint (e.g. "github.com"). Pure -- table-tested.
-func cloneErrorHost(src Source) string {
+// SourceHost extracts the bare host (e.g. "github.com") from a parsed source's
+// clone URL. It handles scheme URLs, scp-form remotes, and userinfo ("git@host")
+// uniformly. It returns "" when no host can be determined (e.g. a KindCatalog
+// source, which has no CloneURL).
+//
+// This is the canonical host-parsing routine; callers that need a host to key
+// credentials by (see internal/source) MUST use this rather than re-deriving it,
+// so the scp/userinfo edge cases stay handled in exactly one place.
+func SourceHost(src Source) string {
 	url := src.CloneURL
 	// Strip scheme.
 	for _, scheme := range []string{"https://", "http://", "ssh://", "git://"} {
@@ -484,10 +490,17 @@ func cloneErrorHost(src Source) string {
 	if i := strings.IndexAny(url, "/:"); i >= 0 {
 		url = url[:i]
 	}
-	if url == "" {
-		return "the source host"
-	}
 	return url
+}
+
+// cloneErrorHost extracts a host label from a source's clone URL for the
+// credential hint (e.g. "github.com"), falling back to a friendly phrase when
+// the host is unknown. Pure -- table-tested.
+func cloneErrorHost(src Source) string {
+	if host := SourceHost(src); host != "" {
+		return host
+	}
+	return "the source host"
 }
 
 // cloneError wraps a git failure with guidance about credentials, since a vanilla

--- a/internal/catalog/source_test.go
+++ b/internal/catalog/source_test.go
@@ -355,6 +355,23 @@ func TestCloneErrorHost(t *testing.T) {
 	}
 }
 
+func TestSourceHost(t *testing.T) {
+	tests := []struct {
+		url  string
+		want string
+	}{
+		{"https://github.com/owner/repo.git", "github.com"},
+		{"git@github.com:owner/repo.git", "github.com"},
+		{"ssh://git@gitlab.com/owner/repo.git", "gitlab.com"},
+		{"", ""}, // a catalog source has no clone URL and so no host
+	}
+	for _, tt := range tests {
+		if got := SourceHost(Source{CloneURL: tt.url}); got != tt.want {
+			t.Errorf("SourceHost(%q) = %q, want %q", tt.url, got, tt.want)
+		}
+	}
+}
+
 func TestSchemaWarning(t *testing.T) {
 	if w := SchemaWarning(&ServiceManifest{SchemaVersion: 0}); w != "" {
 		t.Errorf("schema_version 0 should be OK, got %q", w)

--- a/internal/source/apply.go
+++ b/internal/source/apply.go
@@ -1,0 +1,183 @@
+package source
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aceteam-ai/citadel-cli/internal/catalog"
+)
+
+// AuthenticatedClone is the result of applying a credential to a source: the
+// concrete clone URL plus any extra environment the git process needs.
+//
+// SECURITY: for an HTTPS-token credential the CloneURL embeds the token
+// (`https://x-access-token:<token>@host/...`) and is therefore ITSELF A SECRET.
+// It must be used transiently to launch git and NEVER logged, persisted to
+// .git/config, reported to the control plane, or placed in an error. Use
+// Redacted() for any diagnostic output.
+type AuthenticatedClone struct {
+	// CloneURL is the URL git should clone from. For a token credential this
+	// contains the secret; for ssh/none it is the plain URL.
+	CloneURL string
+	// Env is extra environment for the git process (e.g. GIT_SSH_COMMAND for an
+	// ssh-key credential). Never contains the token.
+	Env []string
+	// kind records how auth was applied, for Redacted().
+	kind CredentialKind
+	// plainURL is the non-secret URL, for Redacted().
+	plainURL string
+}
+
+// Redacted returns a log-safe description that never contains the token.
+func (a AuthenticatedClone) Redacted() string {
+	return fmt.Sprintf("AuthenticatedClone{auth=%s url=%s env=%d}", a.kind, a.plainURL, len(a.Env))
+}
+
+// String implements fmt.Stringer with the redacted form.
+func (a AuthenticatedClone) String() string { return a.Redacted() }
+
+// GoString implements fmt.GoStringer so %#v cannot dump the token-bearing URL.
+func (a AuthenticatedClone) GoString() string { return a.Redacted() }
+
+// ApplyCredential is the PURE, testable heart of credential application: given a
+// resolved Descriptor and the Credential selected for it, it produces the
+// concrete clone URL + git environment, without performing any I/O or clone.
+//
+//   - CredNone  -> plain CloneURL, no env (public clone).
+//   - CredHTTPSToken over an https:// URL -> token injected into the URL
+//     authority as `https://<user>:<token>@host/...`.
+//   - CredSSHKey -> plain URL + GIT_SSH_COMMAND pinning the key (and disabling
+//     agent/known-host prompts that would hang an unattended node clone).
+func ApplyCredential(d Descriptor, cred Credential) (AuthenticatedClone, error) {
+	if d.Kind == KindCatalog {
+		return AuthenticatedClone{}, fmt.Errorf("apply credential: %q is a catalog name and is not git-cloned", d.Raw)
+	}
+	if d.CloneURL == "" {
+		return AuthenticatedClone{}, fmt.Errorf("apply credential: source %q has no clone URL", d.Raw)
+	}
+
+	switch cred.Kind {
+	case CredNone:
+		return AuthenticatedClone{CloneURL: d.CloneURL, kind: CredNone, plainURL: d.CloneURL}, nil
+
+	case CredHTTPSToken:
+		authURL, err := injectHTTPSToken(d.CloneURL, cred.Username, cred.Secret())
+		if err != nil {
+			return AuthenticatedClone{}, err
+		}
+		return AuthenticatedClone{CloneURL: authURL, kind: CredHTTPSToken, plainURL: d.CloneURL}, nil
+
+	case CredSSHKey:
+		// IdentitiesOnly forces git to use only the provided key; BatchMode +
+		// StrictHostKeyChecking=accept-new keep an unattended node clone from
+		// blocking on an interactive prompt.
+		sshCmd := fmt.Sprintf(
+			"ssh -i %s -o IdentitiesOnly=yes -o BatchMode=yes -o StrictHostKeyChecking=accept-new",
+			cred.KeyPath)
+		return AuthenticatedClone{
+			CloneURL: d.CloneURL,
+			Env:      []string{"GIT_SSH_COMMAND=" + sshCmd},
+			kind:     CredSSHKey,
+			plainURL: d.CloneURL,
+		}, nil
+
+	default:
+		return AuthenticatedClone{}, fmt.Errorf("apply credential: unknown credential kind %d", cred.Kind)
+	}
+}
+
+// injectHTTPSToken rewrites an https:// (or http://) URL to carry basic-auth
+// credentials in its authority: scheme://user:token@host/path. It refuses any
+// non-http(s) scheme (a token must not be injected into an ssh/git URL) and any
+// URL that already contains userinfo.
+func injectHTTPSToken(cloneURL, user, token string) (string, error) {
+	var scheme string
+	switch {
+	case strings.HasPrefix(cloneURL, "https://"):
+		scheme = "https://"
+	case strings.HasPrefix(cloneURL, "http://"):
+		scheme = "http://"
+	default:
+		return "", fmt.Errorf("cannot inject an HTTPS token into a non-http(s) source URL")
+	}
+	rest := strings.TrimPrefix(cloneURL, scheme)
+	if strings.Contains(rest[:hostEnd(rest)], "@") {
+		return "", fmt.Errorf("source URL already carries userinfo; refusing to inject a token")
+	}
+	if user == "" {
+		user = defaultHTTPSUser
+	}
+	// NOTE: the token is not URL-encoded. GitHub deploy tokens / PATs (the
+	// x-access-token convention) are URL-safe (alphanumeric + '_'), so this is
+	// correct for the supported case. A non-GitHub token containing reserved
+	// authority characters ('@', '/', ':') would need percent-encoding; that is
+	// out of scope until a non-GitHub private host is actually supported.
+	return scheme + user + ":" + token + "@" + rest, nil
+}
+
+// hostEnd returns the index in rest (the part after the scheme) at which the
+// authority ends (first '/' '?' or '#'), or len(rest) if none.
+func hostEnd(rest string) int {
+	if i := strings.IndexAny(rest, "/?#"); i >= 0 {
+		return i
+	}
+	return len(rest)
+}
+
+// Cloner performs the actual clone+manifest-load for a resolved source. It is
+// the SEAM that keeps the real git clone injectable: the live adapter wires it
+// to catalog.ResolveSource (CatalogCloner below) while tests substitute a fake
+// so NO real clone runs against a private repo in CI.
+type Cloner interface {
+	// Clone fetches the module for the given catalog source — already
+	// credential-applied via the provided AuthenticatedClone — and returns the
+	// loaded module. Implementations MUST treat auth.CloneURL as a secret.
+	Clone(ctx context.Context, src catalog.Source, auth AuthenticatedClone) (*catalog.ResolvedModule, error)
+}
+
+// CatalogCloner is the LIVE Cloner: it delegates to catalog.ResolveSource, which
+// owns the real clone/update + manifest load. It is a thin adapter so the
+// existing #342 install path stays the single place a clone actually happens.
+//
+// NOTE: catalog.ResolveSource currently derives auth from the ambient git
+// environment (GITHUB_TOKEN / ssh / credential helper — see catalog.cloneError).
+// Threading an explicit per-source AuthenticatedClone (the rewritten URL +
+// GIT_SSH_COMMAND) through ResolveSource is the next increment; until then this
+// adapter relies on that ambient path and the AuthenticatedClone documents the
+// intended wiring. This is why the SCOPE defers LIVE private clones to a follow-
+// up — no real private clone is exercised here or in tests.
+type CatalogCloner struct{}
+
+// Clone implements Cloner by delegating to catalog.ResolveSource.
+func (CatalogCloner) Clone(_ context.Context, src catalog.Source, _ AuthenticatedClone) (*catalog.ResolvedModule, error) {
+	return catalog.ResolveSource(src)
+}
+
+// Fetch is the end-to-end node-side resolution helper, wiring resolution +
+// credential selection + application + the (injected) clone seam together. It is
+// what the live reconcile ModuleOps adapter calls; in tests a fake Cloner makes
+// it exercisable WITHOUT a real clone.
+//
+// It never logs the credential or the authenticated URL.
+func Fetch(ctx context.Context, rawSource string, provider CredentialProvider, cloner Cloner) (*catalog.ResolvedModule, error) {
+	d, err := Resolve(rawSource)
+	if err != nil {
+		return nil, err
+	}
+	if d.IsCatalog() {
+		// Catalog names are installed via the existing catalog path, not cloned
+		// here; the live adapter handles that branch.
+		return nil, fmt.Errorf("source %q is a catalog name; install via the catalog path", rawSource)
+	}
+
+	cred, err := provider.CredentialFor(d)
+	if err != nil {
+		return nil, err
+	}
+	auth, err := ApplyCredential(d, cred)
+	if err != nil {
+		return nil, err
+	}
+	return cloner.Clone(ctx, d.CatalogSource(), auth)
+}

--- a/internal/source/apply_test.go
+++ b/internal/source/apply_test.go
@@ -1,0 +1,184 @@
+package source
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/catalog"
+)
+
+// httpsTokenCred builds an https-token Credential with the obvious fake token.
+func httpsTokenCred(host string) Credential {
+	return Credential{Kind: CredHTTPSToken, Host: host, Username: defaultHTTPSUser, token: fakeToken}
+}
+
+// TestCredential_RedactionAllVerbs proves the token never leaks through any of
+// the common fmt verbs — %v, %+v, %#v, %s — nor through String()/GoString().
+func TestCredential_RedactionAllVerbs(t *testing.T) {
+	cred := httpsTokenCred("github.com")
+
+	checks := map[string]string{
+		"%v":          fmt.Sprintf("%v", cred),
+		"%+v":         fmt.Sprintf("%+v", cred),
+		"%#v":         fmt.Sprintf("%#v", cred),
+		"%s":          fmt.Sprintf("%s", cred),
+		"String()":    cred.String(),
+		"GoString()":  cred.GoString(),
+		"Redacted()":  cred.Redacted(),
+		"in-slice %v": fmt.Sprintf("%v", []Credential{cred}),
+		"pointer %v":  fmt.Sprintf("%v", &cred),
+	}
+	for verb, out := range checks {
+		if strings.Contains(out, fakeToken) {
+			t.Errorf("%s leaked the token: %q", verb, out)
+		}
+		if !strings.Contains(out, "REDACTED") && verb != "in-slice %v" && verb != "pointer %v" {
+			// in-slice/pointer formatting may elide the marker; the no-leak
+			// assertion above is the load-bearing one.
+			t.Errorf("%s did not contain REDACTED marker: %q", verb, out)
+		}
+	}
+
+	// The secret IS retrievable via the explicit accessor (and only that).
+	if cred.Secret() != fakeToken {
+		t.Errorf("Secret() = %q, want the token", cred.Secret())
+	}
+}
+
+func TestApplyCredential(t *testing.T) {
+	t.Run("none -> plain url", func(t *testing.T) {
+		d := mustResolve(t, "https://git.example.com/a/b.git")
+		auth, err := ApplyCredential(d, NoCredential)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if auth.CloneURL != d.CloneURL {
+			t.Errorf("CloneURL = %q, want plain %q", auth.CloneURL, d.CloneURL)
+		}
+		if len(auth.Env) != 0 {
+			t.Errorf("Env = %v, want empty", auth.Env)
+		}
+	})
+
+	t.Run("https token injected into authority", func(t *testing.T) {
+		d := mustResolve(t, "https://git.example.com/a/b.git")
+		auth, err := ApplyCredential(d, httpsTokenCred("git.example.com"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := "https://x-access-token:" + fakeToken + "@git.example.com/a/b.git"
+		if auth.CloneURL != want {
+			t.Errorf("CloneURL = %q, want %q", auth.CloneURL, want)
+		}
+	})
+
+	t.Run("ssh key -> GIT_SSH_COMMAND, plain url", func(t *testing.T) {
+		d := mustResolve(t, "ssh://git@git.example.com/a/b.git")
+		cred := Credential{Kind: CredSSHKey, Host: "git.example.com", KeyPath: "/keys/deploy"}
+		auth, err := ApplyCredential(d, cred)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if auth.CloneURL != d.CloneURL {
+			t.Errorf("CloneURL = %q, want plain %q", auth.CloneURL, d.CloneURL)
+		}
+		if len(auth.Env) != 1 || !strings.Contains(auth.Env[0], "GIT_SSH_COMMAND=") ||
+			!strings.Contains(auth.Env[0], "/keys/deploy") {
+			t.Errorf("Env = %v, want GIT_SSH_COMMAND with the key path", auth.Env)
+		}
+	})
+
+	t.Run("catalog source is not cloneable", func(t *testing.T) {
+		d := mustResolve(t, "embedding")
+		if _, err := ApplyCredential(d, NoCredential); err == nil {
+			t.Fatal("expected error applying credential to a catalog name")
+		}
+	})
+
+	t.Run("token refused on non-https url", func(t *testing.T) {
+		d := mustResolve(t, "ssh://git@git.example.com/a/b.git")
+		if _, err := ApplyCredential(d, httpsTokenCred("git.example.com")); err == nil {
+			t.Fatal("expected error injecting an HTTPS token into an ssh url")
+		}
+	})
+}
+
+// TestAuthenticatedClone_Redaction proves the token-bearing clone URL never
+// leaks through the AuthenticatedClone's stringification.
+func TestAuthenticatedClone_Redaction(t *testing.T) {
+	d := mustResolve(t, "https://git.example.com/a/b.git")
+	auth, err := ApplyCredential(d, httpsTokenCred("git.example.com"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Sanity: the raw struct field does carry the secret (it must, to clone).
+	if !strings.Contains(auth.CloneURL, fakeToken) {
+		t.Fatal("test precondition: authenticated URL should carry the token")
+	}
+	for _, out := range []string{
+		fmt.Sprintf("%v", auth),
+		fmt.Sprintf("%+v", auth),
+		fmt.Sprintf("%#v", auth),
+		fmt.Sprintf("%s", auth),
+		auth.String(),
+		auth.Redacted(),
+	} {
+		if strings.Contains(out, fakeToken) {
+			t.Errorf("AuthenticatedClone stringification leaked the token: %q", out)
+		}
+	}
+}
+
+// fakeCloner records the auth it was handed without performing a real clone.
+type fakeCloner struct {
+	gotURL string
+	gotEnv []string
+}
+
+func (f *fakeCloner) Clone(_ context.Context, src catalog.Source, auth AuthenticatedClone) (*catalog.ResolvedModule, error) {
+	f.gotURL = auth.CloneURL
+	f.gotEnv = auth.Env
+	return &catalog.ResolvedModule{CacheDir: src.CloneURL}, nil
+}
+
+// TestFetch_WiresThroughSeam proves Fetch resolves + selects a credential +
+// applies it + hands the authenticated clone to the injected Cloner — WITHOUT a
+// real clone (the fake stands in).
+func TestFetch_WiresThroughSeam(t *testing.T) {
+	content := `{"type":"https-token","token":"` + fakeToken + `"}`
+	dir := writeCred(t, "git.example.com", content, 0o600)
+	provider := FileProvider{Dir: dir}
+	cloner := &fakeCloner{}
+
+	res, err := Fetch(context.Background(), "https://git.example.com/a/b.git", provider, cloner)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if res == nil {
+		t.Fatal("Fetch returned nil module")
+	}
+	want := "https://x-access-token:" + fakeToken + "@git.example.com/a/b.git"
+	if cloner.gotURL != want {
+		t.Errorf("cloner got URL %q, want authenticated %q", cloner.gotURL, want)
+	}
+}
+
+func TestFetch_CatalogSourceRejected(t *testing.T) {
+	cloner := &fakeCloner{}
+	if _, err := Fetch(context.Background(), "embedding", NoCredentials{}, cloner); err == nil {
+		t.Fatal("Fetch of a catalog name should return an error (use the catalog path)")
+	}
+}
+
+func TestFetch_PublicSourceNoCreds(t *testing.T) {
+	cloner := &fakeCloner{}
+	_, err := Fetch(context.Background(), "https://git.example.com/a/b.git", NoCredentials{}, cloner)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if cloner.gotURL != "https://git.example.com/a/b.git" {
+		t.Errorf("public clone URL = %q, want plain", cloner.gotURL)
+	}
+}

--- a/internal/source/credentials.go
+++ b/internal/source/credentials.go
@@ -1,0 +1,256 @@
+package source
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// CredentialKind discriminates the auth mechanism a Credential carries.
+type CredentialKind int
+
+const (
+	// CredNone means no credential — a PUBLIC source cloned anonymously.
+	CredNone CredentialKind = iota
+	// CredHTTPSToken is an HTTPS access token (deploy token / PAT) cloned over
+	// https as `https://x-access-token:<token>@host/...`.
+	CredHTTPSToken
+	// CredSSHKey is a path to a private SSH key used via GIT_SSH_COMMAND.
+	CredSSHKey
+)
+
+// String renders a CredentialKind for diagnostics. It never reveals a secret.
+func (k CredentialKind) String() string {
+	switch k {
+	case CredNone:
+		return "none"
+	case CredHTTPSToken:
+		return "https-token"
+	case CredSSHKey:
+		return "ssh-key"
+	default:
+		return "unknown"
+	}
+}
+
+// Credential is a git credential the node clones a private source with.
+//
+// SECURITY: the secret value (token) is held in an UNEXPORTED field and is never
+// rendered by String() / Redacted() / %v / %+v / %#v. Retrieve it explicitly via
+// Secret() only at the point of use (building an authenticated clone URL). The
+// SSH key path is NOT itself a secret (the key material on disk is), so the path
+// is shown; the key file is never read into this struct.
+type Credential struct {
+	// Kind is the auth mechanism.
+	Kind CredentialKind
+	// Host is the host this credential authenticates to (e.g. "github.com").
+	Host string
+	// Username is the HTTPS basic-auth username. Defaults to "x-access-token"
+	// (GitHub's convention for token-as-password) when empty. Not a secret.
+	Username string
+	// KeyPath is the SSH private-key path for CredSSHKey. Not a secret itself.
+	KeyPath string
+
+	// token is the HTTPS access token. UNEXPORTED so struct stringification
+	// (%v/%+v/%#v) cannot leak it; access only via Secret().
+	token string
+}
+
+// NoCredential is the zero credential: a public source cloned anonymously.
+var NoCredential = Credential{Kind: CredNone}
+
+// IsNone reports whether the credential carries no auth (public source).
+func (c Credential) IsNone() bool { return c.Kind == CredNone }
+
+// Secret returns the raw token for an HTTPS-token credential. This is the ONLY
+// accessor for the secret; callers must use the value transiently (e.g. to build
+// an authenticated clone URL at apply time) and never log or persist it.
+func (c Credential) Secret() string { return c.token }
+
+// Redacted returns a log-safe one-line summary that never includes the token.
+func (c Credential) Redacted() string {
+	switch c.Kind {
+	case CredNone:
+		return "Credential{none}"
+	case CredHTTPSToken:
+		user := c.Username
+		if user == "" {
+			user = defaultHTTPSUser
+		}
+		return fmt.Sprintf("Credential{https-token host=%s user=%s token=REDACTED}", c.Host, user)
+	case CredSSHKey:
+		return fmt.Sprintf("Credential{ssh-key host=%s key=%s}", c.Host, c.KeyPath)
+	default:
+		return "Credential{unknown}"
+	}
+}
+
+// String implements fmt.Stringer with the redacted form so the token never
+// leaks through %v / %s formatting.
+func (c Credential) String() string { return c.Redacted() }
+
+// GoString implements fmt.GoStringer so even %#v (which would otherwise dump the
+// unexported field via reflection) renders the redacted form.
+func (c Credential) GoString() string { return c.Redacted() }
+
+const defaultHTTPSUser = "x-access-token"
+
+// CredentialProvider supplies the git credential a node should clone a given
+// source with, keyed by the resolved Descriptor (its Host / CloneURL). A public
+// source yields NoCredential; an unknown/unscoped private source also yields
+// NoCredential (the clone then fails with catalog's credential-hint error,
+// which is the correct, non-leaking behavior).
+//
+// Implementations MUST NOT log secrets and MUST NOT place secrets in returned
+// errors.
+type CredentialProvider interface {
+	// CredentialFor returns the credential to clone d with, or NoCredential when
+	// the source is public or no scoped credential is configured for its host.
+	CredentialFor(d Descriptor) (Credential, error)
+}
+
+// NoCredentials is the default provider: it supplies no auth, so only PUBLIC
+// sources can be cloned. It is the safe baseline for a vanilla node.
+type NoCredentials struct{}
+
+// CredentialFor implements CredentialProvider. It always returns NoCredential.
+func (NoCredentials) CredentialFor(Descriptor) (Credential, error) {
+	return NoCredential, nil
+}
+
+// fileCredential is the on-disk JSON shape of one host-scoped credential. The
+// token is read transiently and copied into Credential.token; it is never logged.
+type fileCredential struct {
+	// Host is the host this credential authenticates to (matched against the
+	// Descriptor's Host). Optional; defaults to the filename's host slug.
+	Host string `json:"host"`
+	// Type is "https-token" or "ssh-key".
+	Type string `json:"type"`
+	// Username is the HTTPS basic-auth username (optional).
+	Username string `json:"username,omitempty"`
+	// Token is the HTTPS access token (for type=https-token). A SECRET.
+	Token string `json:"token,omitempty"`
+	// KeyPath is the SSH private-key path (for type=ssh-key).
+	KeyPath string `json:"key_path,omitempty"`
+}
+
+// FileProvider is a local, file-backed CredentialProvider. It reads scoped git
+// credentials from a secure node directory (default ~/citadel-node/credentials/),
+// one JSON file per host. Files MUST be 0600; the mode is enforced on READ and a
+// too-permissive file is REJECTED before its contents are read, so a rejection
+// error can never contain the secret.
+//
+// This is the node's secure local secret store. The control-plane-PROVISIONED
+// path (the plane mints a scoped deploy token / SSH key per node and rotates it)
+// is DEFERRED — see ControlPlaneProvider below and aceteam-ai/aceteam#4273.
+type FileProvider struct {
+	// Dir is the credentials directory. When empty, DefaultCredentialsDir() is
+	// used. Injectable so tests can point it at a temp dir.
+	Dir string
+}
+
+// DefaultCredentialsDir returns the default node credentials directory,
+// ~/citadel-node/credentials/. Kept separate from the catalog/config dir so the
+// node's git secrets have a single, locked-down home.
+func DefaultCredentialsDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		// Fall back to a relative path rather than a guessable absolute one; the
+		// caller will fail to read and fall back to NoCredential.
+		return filepath.Join("citadel-node", "credentials")
+	}
+	return filepath.Join(home, "citadel-node", "credentials")
+}
+
+func (p FileProvider) dir() string {
+	if p.Dir != "" {
+		return p.Dir
+	}
+	return DefaultCredentialsDir()
+}
+
+// CredentialFor implements CredentialProvider. It looks up a credential file
+// named "<host>.json" (host slugified to a filesystem-safe name) in the
+// provider's directory. A missing file or a catalog/public source yields
+// NoCredential (not an error): the source is treated as public.
+func (p FileProvider) CredentialFor(d Descriptor) (Credential, error) {
+	host := d.Host
+	if host == "" {
+		// Catalog name or unknown host: nothing to authenticate.
+		return NoCredential, nil
+	}
+
+	path := filepath.Join(p.dir(), hostFileName(host))
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// No scoped credential for this host: treat as public.
+			return NoCredential, nil
+		}
+		return NoCredential, fmt.Errorf("stat credential for host %q: %w", host, err)
+	}
+
+	// Enforce 0600 BEFORE reading, so a rejection can never echo the secret.
+	// (Permission bits are not meaningful on Windows; skip the check there.)
+	if runtime.GOOS != "windows" {
+		if perm := info.Mode().Perm(); perm&0o077 != 0 {
+			return NoCredential, fmt.Errorf(
+				"credential file for host %q has insecure permissions %#o (must be 0600); refusing to read",
+				host, perm)
+		}
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return NoCredential, fmt.Errorf("read credential for host %q: %w", host, err)
+	}
+
+	cred, err := parseFileCredential(host, data)
+	if err != nil {
+		// parseFileCredential is written to never include the token in its error.
+		return NoCredential, err
+	}
+	return cred, nil
+}
+
+// hostFileName maps a host to its credential filename, slugifying characters
+// that are unsafe in a path segment so a malicious host string cannot escape the
+// credentials directory.
+func hostFileName(host string) string {
+	var b strings.Builder
+	for _, r := range host {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-', r == '_', r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	return b.String() + ".json"
+}
+
+// ControlPlaneProvider is the DEFERRED control-plane-provisioned credential
+// path: the plane mints a scoped deploy token / SSH key per node (the #342
+// private-repo caveat) and rotates it, and this provider fetches/refreshes it
+// over the node's authenticated device identity.
+//
+// It is intentionally a stub — implementing it requires control-plane endpoints
+// that DO NOT EXIST YET. See aceteam-ai/aceteam#4273.
+//
+// TODO(aceteam#4273): implement live provisioning + rotation against the control
+// plane, authenticated by node device identity; persist the scoped credential to
+// the FileProvider directory (0600) so reconcile can clone private sources.
+type ControlPlaneProvider struct{}
+
+// CredentialFor implements CredentialProvider. DEFERRED: it returns an explicit
+// not-implemented error referencing aceteam#4273 rather than silently returning
+// NoCredential, so a misconfiguration is visible instead of masquerading as a
+// public source.
+func (ControlPlaneProvider) CredentialFor(Descriptor) (Credential, error) {
+	return NoCredential, fmt.Errorf(
+		"control-plane-provisioned credentials are not implemented yet (deferred to aceteam-ai/aceteam#4273)")
+}

--- a/internal/source/credentials_test.go
+++ b/internal/source/credentials_test.go
@@ -1,0 +1,195 @@
+package source
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// fakeToken is an OBVIOUS fake — never a real secret in a fixture.
+const fakeToken = "tok_FAKE_do_not_use_1234567890"
+
+func mustResolve(t *testing.T, raw string) Descriptor {
+	t.Helper()
+	d, err := Resolve(raw)
+	if err != nil {
+		t.Fatalf("Resolve(%q): %v", raw, err)
+	}
+	return d
+}
+
+// writeCred writes a credential file with the given perms and returns its dir.
+func writeCred(t *testing.T, host, content string, perm os.FileMode) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, hostFileName(host))
+	if err := os.WriteFile(path, []byte(content), perm); err != nil {
+		t.Fatalf("write cred: %v", err)
+	}
+	// os.WriteFile is subject to umask; force the exact mode.
+	if err := os.Chmod(path, perm); err != nil {
+		t.Fatalf("chmod cred: %v", err)
+	}
+	return dir
+}
+
+func TestNoCredentials_AlwaysNone(t *testing.T) {
+	p := NoCredentials{}
+	for _, raw := range []string{"embedding", "acme/widgets@v1", "https://git.example.com/a/b.git"} {
+		cred, err := p.CredentialFor(mustResolve(t, raw))
+		if err != nil {
+			t.Fatalf("CredentialFor(%q): %v", raw, err)
+		}
+		if !cred.IsNone() {
+			t.Errorf("CredentialFor(%q) = %v, want none", raw, cred.Kind)
+		}
+	}
+}
+
+func TestFileProvider_Selection(t *testing.T) {
+	httpsCred := `{"type":"https-token","token":"` + fakeToken + `"}`
+	sshCred := `{"type":"ssh-key","key_path":"/home/citadel/.ssh/deploy_key"}`
+
+	tests := []struct {
+		name     string
+		host     string // host the cred file is written for ("" = no file)
+		content  string
+		query    string // source string to resolve+query
+		wantKind CredentialKind
+	}{
+		{
+			name:     "public catalog source -> none",
+			query:    "embedding",
+			wantKind: CredNone,
+		},
+		{
+			name:     "private host with matching https token",
+			host:     "git.example.com",
+			content:  httpsCred,
+			query:    "https://git.example.com/acme/widgets.git",
+			wantKind: CredHTTPSToken,
+		},
+		{
+			name:     "private host with matching ssh key",
+			host:     "git.example.com",
+			content:  sshCred,
+			query:    "ssh://git@git.example.com/acme/widgets.git",
+			wantKind: CredSSHKey,
+		},
+		{
+			name:     "unknown host (no cred file) -> none",
+			host:     "git.example.com",
+			content:  httpsCred,
+			query:    "https://other.example.org/acme/widgets.git",
+			wantKind: CredNone,
+		},
+		{
+			name:     "github owner/repo matches github.com cred",
+			host:     "github.com",
+			content:  httpsCred,
+			query:    "acme/widgets@v1.2.0",
+			wantKind: CredHTTPSToken,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var dir string
+			if tt.host != "" {
+				dir = writeCred(t, tt.host, tt.content, 0o600)
+			} else {
+				dir = t.TempDir()
+			}
+			p := FileProvider{Dir: dir}
+			cred, err := p.CredentialFor(mustResolve(t, tt.query))
+			if err != nil {
+				t.Fatalf("CredentialFor(%q): %v", tt.query, err)
+			}
+			if cred.Kind != tt.wantKind {
+				t.Errorf("Kind = %v, want %v", cred.Kind, tt.wantKind)
+			}
+		})
+	}
+}
+
+func TestFileProvider_Rejects0600Violation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits not enforced on Windows")
+	}
+	content := `{"type":"https-token","token":"` + fakeToken + `"}`
+	dir := writeCred(t, "git.example.com", content, 0o644) // world-readable: too open
+
+	p := FileProvider{Dir: dir}
+	cred, err := p.CredentialFor(mustResolve(t, "https://git.example.com/a/b.git"))
+	if err == nil {
+		t.Fatal("expected an error for insecure (0644) credential file, got nil")
+	}
+	if !cred.IsNone() {
+		t.Errorf("on rejection cred should be none, got %v", cred.Kind)
+	}
+	// The rejection error must NOT contain the secret (it is reported before read).
+	if strings.Contains(err.Error(), fakeToken) {
+		t.Fatalf("rejection error leaked the token: %q", err.Error())
+	}
+}
+
+func TestFileProvider_MissingFileIsPublic(t *testing.T) {
+	p := FileProvider{Dir: t.TempDir()}
+	cred, err := p.CredentialFor(mustResolve(t, "https://git.example.com/a/b.git"))
+	if err != nil {
+		t.Fatalf("CredentialFor: %v", err)
+	}
+	if !cred.IsNone() {
+		t.Errorf("missing cred file should yield none, got %v", cred.Kind)
+	}
+}
+
+func TestParseFileCredential_Errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{"not json", `not json at all`},
+		{"missing type", `{"token":"` + fakeToken + `"}`},
+		{"unknown type", `{"type":"oauth","token":"` + fakeToken + `"}`},
+		{"empty https token", `{"type":"https-token","token":""}`},
+		{"empty ssh key path", `{"type":"ssh-key","key_path":""}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cred, err := parseFileCredential("github.com", []byte(tt.content))
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !cred.IsNone() {
+				t.Errorf("error path should return none, got %v", cred.Kind)
+			}
+			if strings.Contains(err.Error(), fakeToken) {
+				t.Fatalf("parse error leaked the token: %q", err.Error())
+			}
+		})
+	}
+}
+
+func TestControlPlaneProvider_Deferred(t *testing.T) {
+	cred, err := ControlPlaneProvider{}.CredentialFor(mustResolve(t, "https://git.example.com/a/b.git"))
+	if err == nil {
+		t.Fatal("ControlPlaneProvider should return a not-implemented error")
+	}
+	if !strings.Contains(err.Error(), "4273") {
+		t.Errorf("deferred error should reference aceteam#4273, got %q", err.Error())
+	}
+	if !cred.IsNone() {
+		t.Errorf("deferred cred should be none, got %v", cred.Kind)
+	}
+}
+
+func TestHostFileName_NoTraversal(t *testing.T) {
+	// A malicious host must not escape the credentials directory.
+	got := hostFileName("../../etc/passwd")
+	if strings.Contains(got, "/") || strings.Contains(got, "\\") {
+		t.Fatalf("hostFileName leaked a path separator: %q", got)
+	}
+}

--- a/internal/source/parse.go
+++ b/internal/source/parse.go
@@ -1,0 +1,55 @@
+package source
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// parseFileCredential decodes one on-disk credential file into a Credential.
+//
+// SECURITY: every error path here is written to describe WHAT is wrong without
+// echoing the token value, so a parse failure can never leak the secret into a
+// log or job payload.
+func parseFileCredential(host string, data []byte) (Credential, error) {
+	var fc fileCredential
+	if err := json.Unmarshal(data, &fc); err != nil {
+		// json.Unmarshal errors reference offsets/types, never field values, but
+		// wrap with a fixed message to be certain no value is surfaced.
+		return NoCredential, fmt.Errorf("credential for host %q is not valid JSON", host)
+	}
+
+	credHost := fc.Host
+	if credHost == "" {
+		credHost = host
+	}
+
+	switch fc.Type {
+	case "https-token":
+		if fc.Token == "" {
+			return NoCredential, fmt.Errorf("credential for host %q (https-token) has an empty token", host)
+		}
+		user := fc.Username
+		if user == "" {
+			user = defaultHTTPSUser
+		}
+		return Credential{
+			Kind:     CredHTTPSToken,
+			Host:     credHost,
+			Username: user,
+			token:    fc.Token,
+		}, nil
+	case "ssh-key":
+		if fc.KeyPath == "" {
+			return NoCredential, fmt.Errorf("credential for host %q (ssh-key) has an empty key_path", host)
+		}
+		return Credential{
+			Kind:    CredSSHKey,
+			Host:    credHost,
+			KeyPath: fc.KeyPath,
+		}, nil
+	case "":
+		return NoCredential, fmt.Errorf("credential for host %q is missing its \"type\" field", host)
+	default:
+		return NoCredential, fmt.Errorf("credential for host %q has unknown type %q (want \"https-token\" or \"ssh-key\")", host, fc.Type)
+	}
+}

--- a/internal/source/resolve.go
+++ b/internal/source/resolve.go
@@ -1,0 +1,132 @@
+// Package source resolves a control-plane-assigned module source string into an
+// installable descriptor and supplies git credentials for PRIVATE sources, for
+// the remote-managed-node path (issue #354, part of epic #352).
+//
+// It is the node-side companion to internal/reconcile: a reconcile
+// ModuleAssignment.Source is an opaque string (catalog name | owner/repo[@ref] |
+// git URL); this package classifies it (REUSING internal/catalog's parser — it
+// is not re-implemented here), then, for a private source, selects the git
+// credential the node should clone with.
+//
+// Dependency direction (deliberate, no cycles):
+//
+//	internal/reconcile  ->  internal/source  ->  internal/catalog
+//
+// reconcile stays pure and does NOT import this package or catalog; the LIVE
+// ModuleOps adapter (a later increment, see internal/reconcile/ops.go) is what
+// wires reconcile to this resolution+credential path and to the actual clone.
+//
+// SECURITY POSTURE (hard requirements, see credentials.go):
+//   - Credentials are NEVER logged, committed, or placed in error messages /
+//     job payloads.
+//   - The resolution Descriptor produced here is log-safe: it carries the
+//     PLAIN clone URL and never an authenticated (token-bearing) URL. The
+//     authenticated URL is produced only at apply time (apply.go) and is itself
+//     treated as a secret.
+//   - File-backed credentials are stored 0600 and the mode is enforced on READ.
+package source
+
+import (
+	"fmt"
+
+	"github.com/aceteam-ai/citadel-cli/internal/catalog"
+)
+
+// Kind classifies how a source string is resolved. It mirrors
+// catalog.SourceKind so callers of this package do not need to import catalog
+// just to switch on the kind.
+type Kind int
+
+const (
+	// KindCatalog is a bare catalog service name (resolved from the central
+	// catalog; it has no clone URL of its own).
+	KindCatalog Kind = iota
+	// KindGitHub is an "owner/repo[@ref]" shorthand (clones from github.com).
+	KindGitHub
+	// KindGitURL is a full git URL (scheme or scp form).
+	KindGitURL
+)
+
+// String renders a Kind for diagnostics.
+func (k Kind) String() string {
+	switch k {
+	case KindCatalog:
+		return "catalog"
+	case KindGitHub:
+		return "github"
+	case KindGitURL:
+		return "git-url"
+	default:
+		return "unknown"
+	}
+}
+
+// Descriptor is a normalized, LOG-SAFE resolution of an assigned source string:
+// what kind it is, where to clone it from, and at which ref. It intentionally
+// carries only non-secret data — never a token, never an authenticated URL — so
+// it can be logged, reported back to the control plane, or embedded in an error
+// without leaking a credential. Authentication is applied separately and only at
+// clone time (see ApplyCredential).
+type Descriptor struct {
+	// Kind is the resolution strategy.
+	Kind Kind
+	// Raw is the original assigned source string.
+	Raw string
+	// CloneURL is the PLAIN (unauthenticated) git clone URL for KindGitHub /
+	// KindGitURL. Empty for KindCatalog.
+	CloneURL string
+	// Ref is the requested tag/branch/sha/constraint (empty = default branch).
+	Ref string
+	// Host is the bare host the source clones from (e.g. "github.com"), used as
+	// the credential lookup key. Empty for KindCatalog.
+	Host string
+
+	// catalogSrc is the underlying parsed catalog.Source, retained so the live
+	// install adapter can hand it straight to catalog.ResolveSource without
+	// re-parsing. Unexported: it is an internal detail, not part of the
+	// log-safe surface.
+	catalogSrc catalog.Source
+}
+
+// CatalogSource returns the underlying parsed catalog.Source. The live module
+// adapter passes this to catalog.ResolveSource for the actual clone/load, so the
+// classification is parsed exactly once.
+func (d Descriptor) CatalogSource() catalog.Source { return d.catalogSrc }
+
+// IsCatalog reports whether the source is a bare catalog name (and so is
+// installed via the existing catalog path rather than a git clone).
+func (d Descriptor) IsCatalog() bool { return d.Kind == KindCatalog }
+
+// Resolve classifies an assigned source string into a log-safe Descriptor by
+// delegating to catalog.ParseSource (the single source of truth for the
+// catalog | owner/repo@ref | git-URL grammar, including the scp/userinfo/ref
+// edge cases). It does NOT clone or touch the network.
+func Resolve(rawSource string) (Descriptor, error) {
+	src, err := catalog.ParseSource(rawSource)
+	if err != nil {
+		return Descriptor{}, fmt.Errorf("resolve source: %w", err)
+	}
+
+	d := Descriptor{
+		Raw:        src.Raw,
+		CloneURL:   src.CloneURL,
+		Ref:        src.Ref,
+		catalogSrc: src,
+	}
+	switch src.Kind {
+	case catalog.KindCatalog:
+		d.Kind = KindCatalog
+	case catalog.KindGitHub:
+		d.Kind = KindGitHub
+	case catalog.KindGitURL:
+		d.Kind = KindGitURL
+	default:
+		return Descriptor{}, fmt.Errorf("resolve source %q: unknown source kind", rawSource)
+	}
+
+	// A catalog name has no clone host; everything else is keyed by its host.
+	if d.Kind != KindCatalog {
+		d.Host = catalog.SourceHost(src)
+	}
+	return d, nil
+}

--- a/internal/source/resolve_test.go
+++ b/internal/source/resolve_test.go
@@ -1,0 +1,112 @@
+package source
+
+import "testing"
+
+func TestResolve_Classification(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      string
+		wantKind Kind
+		wantURL  string
+		wantRef  string
+		wantHost string
+		wantErr  bool
+	}{
+		{
+			name:     "bare catalog name",
+			raw:      "embedding",
+			wantKind: KindCatalog,
+			wantURL:  "",
+			wantHost: "",
+		},
+		{
+			name:     "owner/repo no ref",
+			raw:      "acme/widgets",
+			wantKind: KindGitHub,
+			wantURL:  "https://github.com/acme/widgets.git",
+			wantHost: "github.com",
+		},
+		{
+			name:     "owner/repo with ref",
+			raw:      "acme/widgets@v1.2.0",
+			wantKind: KindGitHub,
+			wantURL:  "https://github.com/acme/widgets.git",
+			wantRef:  "v1.2.0",
+			wantHost: "github.com",
+		},
+		{
+			name:     "https git url with .git",
+			raw:      "https://git.example.com/acme/widgets.git",
+			wantKind: KindGitURL,
+			wantURL:  "https://git.example.com/acme/widgets.git",
+			wantHost: "git.example.com",
+		},
+		{
+			name:     "https git url with #ref",
+			raw:      "https://git.example.com/acme/widgets.git#main",
+			wantKind: KindGitURL,
+			wantURL:  "https://git.example.com/acme/widgets.git",
+			wantRef:  "main",
+			wantHost: "git.example.com",
+		},
+		{
+			name:     "scp-form git url",
+			raw:      "git@github.com:acme/widgets.git",
+			wantKind: KindGitURL,
+			wantURL:  "git@github.com:acme/widgets.git",
+			wantHost: "github.com",
+		},
+		{
+			name:     "ssh url with userinfo",
+			raw:      "ssh://git@git.example.com/acme/widgets.git",
+			wantKind: KindGitURL,
+			wantURL:  "ssh://git@git.example.com/acme/widgets.git",
+			wantHost: "git.example.com",
+		},
+		{
+			name:    "empty source",
+			raw:     "",
+			wantErr: true,
+		},
+		{
+			name:    "catalog name with illegal @",
+			raw:     "embedding@v1",
+			wantErr: true,
+		},
+		{
+			name:    "owner/repo ref beginning with dash (injection guard)",
+			raw:     "acme/widgets@-bad",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d, err := Resolve(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Resolve(%q) = nil error, want error", tt.raw)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Resolve(%q) error: %v", tt.raw, err)
+			}
+			if d.Kind != tt.wantKind {
+				t.Errorf("Kind = %v, want %v", d.Kind, tt.wantKind)
+			}
+			if d.CloneURL != tt.wantURL {
+				t.Errorf("CloneURL = %q, want %q", d.CloneURL, tt.wantURL)
+			}
+			if d.Ref != tt.wantRef {
+				t.Errorf("Ref = %q, want %q", d.Ref, tt.wantRef)
+			}
+			if d.Host != tt.wantHost {
+				t.Errorf("Host = %q, want %q", d.Host, tt.wantHost)
+			}
+			if d.IsCatalog() != (tt.wantKind == KindCatalog) {
+				t.Errorf("IsCatalog() = %v, want %v", d.IsCatalog(), tt.wantKind == KindCatalog)
+			}
+		})
+	}
+}


### PR DESCRIPTION
First increment of **#354** ("Catalog/module source assignment + private-source credentials"), the **node side** of epic **#352** (remote-managed nodes) and the companion to **#353**'s reconcile engine. Code + tests only; no live network, no control plane, no prod.

## What's included

A new self-contained `internal/source` package that turns a control-plane-assigned `reconcile.ModuleAssignment.Source` into something installable and supplies git credentials for **private** sources.

Dependency direction stays clean — `reconcile → source → catalog` — and `reconcile` keeps **zero** `catalog`/`source` imports, so the wire contract stays decoupled. The live `ModuleOps` adapter (deferred) is what wires them.

**Source resolution (`resolve.go`)** — `Resolve(rawSource)` wraps `catalog.ParseSource` (the single source of truth for the `catalog | owner/repo@ref | git-URL` grammar, including the scp/userinfo/ref edge cases — **not** re-implemented) into a **log-safe** `Descriptor{Kind, CloneURL, Ref, Host}`. The descriptor carries only the **plain** clone URL, never a token-bearing one.

**Credential provider (`credentials.go`, `parse.go`)** — the heart of #354:
- `CredentialProvider` interface: `CredentialFor(Descriptor) (Credential, error)`.
- `NoCredentials` — safe default, public sources only.
- `FileProvider` — local file-backed store at an **injectable** `Dir` (default `~/citadel-node/credentials/`), one JSON file per host. `0600` enforced **on read**, rejecting a too-permissive file **before** its contents are read. Missing file / catalog source → `NoCredential` (treated as public). Host slugified to prevent path traversal.
- `ControlPlaneProvider` — **deferred** stub returning an explicit not-implemented error referencing `aceteam-ai/aceteam#4273` (the plane provisions + rotates a scoped deploy token / SSH key per node — the #342 private-repo caveat).

**Credential application + clone seam (`apply.go`)**:
- `ApplyCredential(Descriptor, Credential)` — pure, testable: builds the authenticated clone URL (`https://x-access-token:<tok>@host/...`) or the `GIT_SSH_COMMAND` for an ssh-key, with no I/O.
- `Cloner` seam keeps the real git clone injectable: `CatalogCloner` delegates to `catalog.ResolveSource`; tests substitute a fake so **no real clone runs**.

Plus a minimal `catalog.SourceHost` export (extracted from `cloneErrorHost`) so credential host-keying reuses the existing scp/userinfo parsing rather than forking it.

## Security properties

- Token held in an **unexported** field; redacted across `%v` / `%+v` / `%#v` / `%s` and via `String()`/`GoString()` (tested, incl. slice/pointer).
- The authenticated (token-bearing) clone URL is itself treated as a secret and redacted in `AuthenticatedClone`'s stringification (tested).
- Credentials never logged, never committed, never in error messages / job payloads; cred files `0600`, enforced **before** the secret is read so a rejection error can't echo it.
- No secret values in fixtures — obvious fakes like `tok_FAKE`.

## Deferred (out of scope here → `aceteam-ai/aceteam#4273`)

- Control-plane-provisioned credentials (mint + rotate a scoped per-node deploy token / SSH key over device identity).
- **Live private clones / live reconcile wiring.** The file-backed credential is selected and an auth URL / `GIT_SSH_COMMAND` is built, but `CatalogCloner` still delegates to `catalog.ResolveSource`, which uses **ambient** git auth. So `~/citadel-node/credentials/` is **inert in a live clone** until the explicit-auth threading lands in the follow-up — this increment delivers the resolution + credential-selection + redaction machinery and the injectable seam, not a working private clone.

## Tests

Table-driven, no network / docker / real git / prod: source classification (catalog / owner-repo@ref / git-URL incl. edge cases + injection guard), credential selection (public→none, private host→matching cred, unknown→none), `0600` enforcement, parse-error no-leak, redaction across all fmt verbs, and the `Fetch` seam wiring through a fake cloner.

```
ok  github.com/aceteam-ai/citadel-cli/internal/source
ok  github.com/aceteam-ai/citadel-cli/internal/catalog
```

Part of #354 / #352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)