### PR TITLE
feat(logging): always-on date-based logs + reliable debug copy (#369)

### DIFF
--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -1,0 +1,76 @@
+// cmd/debug.go
+/*
+Copyright © 2025 AceTeam <dev@aceteam.ai>
+*/
+package cmd
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/clilog"
+	"github.com/spf13/cobra"
+)
+
+var debugTailLines int
+
+// debugCmd prints a copy-pasteable debug bundle to stdout. On a headless node
+// reached over SSH, copying out of the TUI's clipboard is unreliable, so this
+// dumps everything an operator needs to paste into a bug report — version,
+// host, the dated log path, and a tail of the always-on activity log — to
+// stdout where the terminal can copy it normally.
+var debugCmd = &cobra.Command{
+	Use:   "debug",
+	Short: "Print a copy-pasteable debug bundle (version, host, recent logs)",
+	Long: `Print a debug bundle to stdout: citadel version, host/OS, the path to the
+date-based append-only log, and the last N lines of activity.
+
+Designed for headless nodes over SSH where the TUI clipboard does not reach
+your machine. Pipe or redirect it to share:
+
+  citadel debug                # print to terminal
+  citadel debug > debug.txt    # save to a file you can scp
+  citadel debug -n 500         # include more log lines`,
+	Args: cobra.NoArgs,
+	RunE: runDebug,
+}
+
+func runDebug(cmd *cobra.Command, args []string) error {
+	var sb strings.Builder
+
+	fmt.Fprintln(&sb, "=== citadel debug bundle ===")
+	fmt.Fprintf(&sb, "version:  %s\n", Version)
+	fmt.Fprintf(&sb, "time:     %s\n", time.Now().Format(time.RFC3339))
+	fmt.Fprintf(&sb, "os/arch:  %s/%s\n", runtime.GOOS, runtime.GOARCH)
+	fmt.Fprintf(&sb, "log dir:  %s\n", clilog.Dir())
+	fmt.Fprintf(&sb, "log file: %s\n", clilog.Path())
+	fmt.Fprintln(&sb)
+
+	fmt.Fprintf(&sb, "--- last %d activity log lines ---\n", debugTailLines)
+	tail, err := agentTailLogs(struct {
+		Lines int
+		Level string
+		Grep  string
+		Since string
+	}{Lines: debugTailLines})
+	if err != nil {
+		fmt.Fprintf(&sb, "(could not read activity log: %v)\n", err)
+	} else if strings.TrimSpace(tail) == "" {
+		fmt.Fprintln(&sb, "(no activity logged yet)")
+	} else {
+		sb.WriteString(tail)
+		if !strings.HasSuffix(tail, "\n") {
+			sb.WriteByte('\n')
+		}
+	}
+
+	fmt.Print(sb.String())
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(debugCmd)
+	debugCmd.Flags().IntVarP(&debugTailLines, "lines", "n", 200, "Number of recent log lines to include")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,11 +7,10 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
+	"github.com/aceteam-ai/citadel-cli/internal/clilog"
 	"github.com/aceteam-ai/citadel-cli/internal/tui"
 	"github.com/aceteam-ai/citadel-cli/internal/update"
 	"github.com/fatih/color"
@@ -41,64 +40,18 @@ var debugToStderr bool
 // deferredUpdateNotification stores update info when TUI will handle the display
 var deferredUpdateNotification string
 
-// logFile is the file handle for logging
-var logFile *os.File
-var logMu sync.Mutex
-var logInitOnce sync.Once
-var logDir string
-
-// initLogFile initializes the log file with timestamp naming and symlink
-func initLogFile() {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return
-	}
-
-	logDir = filepath.Join(homeDir, ".citadel-cli", "logs")
-	if err := os.MkdirAll(logDir, 0755); err != nil {
-		return
-	}
-
-	// Create timestamped log file: citadel-2026-01-22T11-04-47.log
-	timestamp := time.Now().Format("2006-01-02T15-04-05")
-	logFileName := fmt.Sprintf("citadel-%s.log", timestamp)
-	logPath := filepath.Join(logDir, logFileName)
-
-	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
-	if err != nil {
-		return
-	}
-
-	logFile = f
-
-	// Create/update symlink to latest log
-	latestLink := filepath.Join(logDir, "latest.log")
-	// Remove existing symlink if present
-	os.Remove(latestLink)
-	// Create new symlink (use relative path for portability)
-	os.Symlink(logFileName, latestLink)
-
-	// Write session header
-	sessionTime := time.Now().Format("15:04:05")
-	fmt.Fprintf(logFile, "[%s] [CITADEL] === Session started ===\n", sessionTime)
-}
-
-// Log writes a message to the log file and optionally to console if debug mode is enabled.
-// This function always writes to the log file, but only prints to console with --debug.
+// Log writes a message to the date-based log file and optionally to the console
+// if debug mode is enabled. It always persists to file (see internal/clilog),
+// but only prints to console with --debug.
 func Log(format string, args ...interface{}) {
-	timeStr := time.Now().Format("15:04:05")
 	msg := fmt.Sprintf(format, args...)
 
-	// Always write to file
-	logMu.Lock()
-	logInitOnce.Do(initLogFile)
-	if logFile != nil {
-		fmt.Fprintf(logFile, "[%s] [CITADEL] %s\n", timeStr, msg)
-	}
-	logMu.Unlock()
+	// Always persist to the dated, append-only log file.
+	clilog.Write("", msg)
 
-	// Print to console only if debug mode is enabled
+	// Print to console only if debug mode is enabled.
 	if debugMode {
+		timeStr := time.Now().Format("15:04:05")
 		if debugToStderr {
 			fmt.Fprintf(os.Stderr, "[%s] [CITADEL] %s\n", timeStr, msg)
 		} else {

--- a/internal/clilog/clilog.go
+++ b/internal/clilog/clilog.go
@@ -1,0 +1,123 @@
+// Package clilog provides citadel-cli's always-on, date-based, append-only
+// file logging. It is a small dependency-free sink shared by the cobra
+// commands (package cmd) and the control-center TUI (package
+// internal/tui/controlcenter) so that every activity entry is persisted to
+// disk as it happens — not only when the operator presses a key.
+//
+// Logs live in ~/.citadel-cli/logs/citadel-YYYY-MM-DD.log. All sessions on a
+// given day append to the same file (one file per date, not one per process
+// start), and a `latest.log` symlink always points at the current day's file.
+// The file rotates automatically when the date rolls over for a long-running
+// daemon.
+package clilog
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+var (
+	mu         sync.Mutex
+	file       *os.File
+	fileDate   string // YYYY-MM-DD of the currently open file
+	headerOnce sync.Once
+
+	// dirOverride lets tests redirect the log directory. When empty, the
+	// real ~/.citadel-cli/logs directory is used.
+	dirOverride string
+	// nowFn is the clock, overridable in tests.
+	nowFn = time.Now
+)
+
+const dateLayout = "2006-01-02"
+
+// Dir returns the directory where citadel logs are written.
+func Dir() string {
+	if dirOverride != "" {
+		return dirOverride
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".citadel-cli", "logs")
+}
+
+// fileNameFor returns the log filename for a given day.
+func fileNameFor(t time.Time) string {
+	return fmt.Sprintf("citadel-%s.log", t.Format(dateLayout))
+}
+
+// Path returns the absolute path of the current day's log file.
+func Path() string {
+	return filepath.Join(Dir(), fileNameFor(nowFn()))
+}
+
+// ensureFileLocked opens (or rotates to) the log file for the current date.
+// The caller must hold mu. It is best-effort: on any error the file handle is
+// left nil and writes become no-ops rather than crashing the process.
+func ensureFileLocked() {
+	today := nowFn().Format(dateLayout)
+	if file != nil && fileDate == today {
+		return
+	}
+
+	d := Dir()
+	if d == "" {
+		return
+	}
+	if err := os.MkdirAll(d, 0o755); err != nil {
+		return
+	}
+
+	if file != nil {
+		_ = file.Close()
+		file = nil
+	}
+
+	name := fileNameFor(nowFn())
+	f, err := os.OpenFile(filepath.Join(d, name), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	file = f
+	fileDate = today
+
+	// Point latest.log at today's file (relative target for portability).
+	latest := filepath.Join(d, "latest.log")
+	_ = os.Remove(latest)
+	_ = os.Symlink(name, latest)
+}
+
+// Write appends a single timestamped line to today's log file. A level of ""
+// is written under the generic [CITADEL] tag; otherwise the level (e.g.
+// "warning") is recorded so the on-disk log mirrors the TUI activity panel.
+func Write(level, msg string) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	ensureFileLocked()
+	if file == nil {
+		return
+	}
+
+	// One session header per process, written via whichever path logs first.
+	headerOnce.Do(func() {
+		fmt.Fprintf(file, "[%s] [CITADEL] === Session started ===\n", nowFn().Format("15:04:05"))
+	})
+
+	ts := nowFn().Format("15:04:05")
+	if level == "" {
+		fmt.Fprintf(file, "[%s] [CITADEL] %s\n", ts, msg)
+	} else {
+		fmt.Fprintf(file, "[%s] [%s] %s\n", ts, level, msg)
+	}
+}
+
+// Writef is a printf-style convenience wrapper around Write.
+func Writef(level, format string, args ...interface{}) {
+	Write(level, fmt.Sprintf(format, args...))
+}

--- a/internal/clilog/clilog_test.go
+++ b/internal/clilog/clilog_test.go
@@ -1,0 +1,122 @@
+package clilog
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// reset returns the package to a clean state and points it at a temp dir with
+// a fixed clock. It returns the temp dir.
+func reset(t *testing.T, now time.Time) string {
+	t.Helper()
+	mu.Lock()
+	if file != nil {
+		_ = file.Close()
+	}
+	file = nil
+	fileDate = ""
+	headerOnce = sync.Once{}
+	dir := t.TempDir()
+	dirOverride = dir
+	nowFn = func() time.Time { return now }
+	mu.Unlock()
+	t.Cleanup(func() {
+		mu.Lock()
+		if file != nil {
+			_ = file.Close()
+			file = nil
+		}
+		dirOverride = ""
+		nowFn = time.Now
+		fileDate = ""
+		mu.Unlock()
+	})
+	return dir
+}
+
+func TestPathIsDateBased(t *testing.T) {
+	day := time.Date(2026, 6, 29, 10, 0, 0, 0, time.UTC)
+	reset(t, day)
+	got := filepath.Base(Path())
+	if got != "citadel-2026-06-29.log" {
+		t.Fatalf("Path basename = %q, want citadel-2026-06-29.log", got)
+	}
+}
+
+func TestSameDayAppendsToOneFile(t *testing.T) {
+	day := time.Date(2026, 6, 29, 10, 0, 0, 0, time.UTC)
+	dir := reset(t, day)
+
+	Write("", "first")
+	Write("warning", "second")
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var logs []string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "citadel-") {
+			logs = append(logs, e.Name())
+		}
+	}
+	if len(logs) != 1 {
+		t.Fatalf("expected exactly one dated log file, got %v", logs)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "citadel-2026-06-29.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(data)
+	if !strings.Contains(s, "=== Session started ===") {
+		t.Errorf("missing session header in:\n%s", s)
+	}
+	if !strings.Contains(s, "[CITADEL] first") {
+		t.Errorf("missing plain entry in:\n%s", s)
+	}
+	if !strings.Contains(s, "[warning] second") {
+		t.Errorf("missing leveled entry in:\n%s", s)
+	}
+	if strings.Count(s, "Session started") != 1 {
+		t.Errorf("expected exactly one session header, got:\n%s", s)
+	}
+}
+
+func TestRotatesAcrossMidnight(t *testing.T) {
+	day1 := time.Date(2026, 6, 29, 23, 59, 0, 0, time.UTC)
+	dir := reset(t, day1)
+
+	Write("", "before midnight")
+
+	// Advance the clock to the next day and write again.
+	mu.Lock()
+	nowFn = func() time.Time { return time.Date(2026, 6, 30, 0, 1, 0, 0, time.UTC) }
+	mu.Unlock()
+	Write("", "after midnight")
+
+	if _, err := os.Stat(filepath.Join(dir, "citadel-2026-06-29.log")); err != nil {
+		t.Errorf("day-1 file missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "citadel-2026-06-30.log")); err != nil {
+		t.Errorf("day-2 file missing (no rotation): %v", err)
+	}
+}
+
+func TestLatestSymlinkPointsAtToday(t *testing.T) {
+	day := time.Date(2026, 6, 29, 10, 0, 0, 0, time.UTC)
+	dir := reset(t, day)
+	Write("", "hi")
+
+	target, err := os.Readlink(filepath.Join(dir, "latest.log"))
+	if err != nil {
+		t.Fatalf("latest.log not a symlink: %v", err)
+	}
+	if target != "citadel-2026-06-29.log" {
+		t.Errorf("latest.log -> %q, want citadel-2026-06-29.log", target)
+	}
+}

--- a/internal/tui/controlcenter/controlcenter.go
+++ b/internal/tui/controlcenter/controlcenter.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aceteam-ai/citadel-cli/internal/clilog"
 	"github.com/aceteam-ai/citadel-cli/internal/config"
 	"github.com/aceteam-ai/citadel-cli/internal/network"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
@@ -567,6 +568,10 @@ func (cc *ControlCenter) AddActivity(level, message string) {
 	// flag + a configured emitter, so this is a no-op until telemetry is wired up
 	// (in ccStartWorker) and never blocks or panics the TUI.
 	telemetry.Emit(level, message)
+
+	// Persist every activity entry to the dated, append-only log file so the
+	// node is always logging — not only when the operator presses a key.
+	clilog.Write(level, message)
 
 	// Update UI if running
 	// Use goroutine to avoid blocking when called from input handlers
@@ -2464,8 +2469,8 @@ func (cc *ControlCenter) showActivityFullScreen() {
 	cc.activityMu.Lock()
 	var sb strings.Builder
 	sb.WriteString("[yellow::b]Activity Log[-:-:-]\n\n")
-	sb.WriteString(fmt.Sprintf("[gray]Session logs are kept in memory (up to 100 entries)[-]\n"))
-	sb.WriteString(fmt.Sprintf("[gray]Press 'l' to copy logs to /tmp/citadel-activity.log[-]\n\n"))
+	sb.WriteString(fmt.Sprintf("[gray]All activity is logged to %s (append-only, one file per day).[-]\n", clilog.Path()))
+	sb.WriteString(fmt.Sprintf("[gray]Press 'l' to save a snapshot of the lines below; run '[white]citadel debug[gray]' for a copy-pasteable bundle.[-]\n\n"))
 
 	if len(cc.activities) == 0 {
 		sb.WriteString("[gray]No activity yet[-]\n")
@@ -2495,7 +2500,7 @@ func (cc *ControlCenter) showActivityFullScreen() {
 	}
 	cc.activityMu.Unlock()
 
-	sb.WriteString("\n[gray]Press Esc to close, 'l' to copy logs[-]")
+	sb.WriteString("\n[gray]Press Esc to close, 'l' to save a snapshot[-]")
 	textView.SetText(sb.String())
 	textView.SetBorder(true).SetTitle(" Activity Log (Full Screen) ")
 
@@ -2519,33 +2524,31 @@ func (cc *ControlCenter) showActivityFullScreen() {
 	cc.app.SetFocus(textView)
 }
 
-// copyActivityLogs copies recent log lines to clipboard
+// copyActivityLogs writes a snapshot of the on-screen activity to a file under
+// the log directory. It deliberately does NOT report "copied to clipboard":
+// on a headless node reached over SSH, the system clipboard (xclip/xsel)
+// writes to the node's X selection, which the operator can never reach. A file
+// path the operator can cat/scp is the only reliable handoff. The full
+// append-only log already lives next to it (see clilog).
 func (cc *ControlCenter) copyActivityLogs() {
-	// Use in-memory activity entries (same source as the 'c' key copy).
-	// This ensures what the user sees on screen is what gets copied.
 	cc.activityMu.Lock()
 	lineCount := len(cc.activities)
 	cc.activityMu.Unlock()
 
 	if lineCount == 0 {
-		cc.AddActivity("info", "No logs to copy")
+		cc.AddActivity("info", "No activity to save")
 		return
 	}
 
 	content := cc.getActivityText()
 
-	// Copy to clipboard
-	if err := cc.copyToClipboard(content); err != nil {
-		// Fall back to file
-		filePath := "/tmp/citadel-logs.txt"
-		if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
-			cc.AddActivity("error", fmt.Sprintf("Failed to copy logs: %v", err))
-			return
-		}
-		cc.AddActivity("success", fmt.Sprintf("%d lines saved to %s", lineCount, filePath))
-	} else {
-		cc.AddActivity("success", fmt.Sprintf("%d lines copied to clipboard", lineCount))
+	snapPath := filepath.Join(clilog.Dir(), "activity-snapshot.txt")
+	if err := os.WriteFile(snapPath, []byte(content), 0o644); err != nil {
+		cc.AddActivity("error", fmt.Sprintf("Failed to save activity: %v", err))
+		return
 	}
+
+	cc.AddActivity("success", fmt.Sprintf("Saved %d lines to %s (full log: %s)", lineCount, snapPath, clilog.Path()))
 }
 
 // getNodeText returns plain text representation of node info


### PR DESCRIPTION
## Context

On a headless node reached over SSH (`ubuntu-gpu`), the Activity Log full-screen panel told the operator to "Press 'l' to copy logs" and then reported `✓ N lines copied to clipboard` — but nothing landed anywhere reachable. `copyToClipboard` shells out to `xclip`/`xsel`, which (when present) exits 0 by writing to the *node's* X selection, invisible to whoever is SSH'd in. The success toast lied, the help text named a file the code never wrote, and only the 100-entry in-memory ring was captured. Meanwhile logs were written to a fresh `citadel-<process-timestamp>.log` on every restart (hundreds of tiny files), and activity that didn't also route through `cmd.Log()` never hit disk at all.

Net: there was no reliable "give me the debug info" path on exactly the machines that need it. Operator ask: *"I hate pasting into chat — make it easy to copy debug info."*

## Summary

| Component | Change | Why |
| --- | --- | --- |
| `internal/clilog` (new) | Date-based, append-only file logging with midnight rotation + `latest.log` symlink | One file per day (`citadel-YYYY-MM-DD.log`), not one per process start. Dependency-free sink shared by `cmd` and the TUI with no import cycle. |
| `cmd/root.go` | `Log()` delegates to `clilog` | Single source of truth; date-based naming. |
| `controlcenter.AddActivity` | Persists every entry via `clilog.Write` | The node is **always logging** — including the `⚠ consume failed` warnings — not only when `l` is pressed. |
| `controlcenter` `l` + help text | Writes a snapshot to a **shown path**; never claims a clipboard success it didn't achieve; help text matches reality | Honest, reliable handoff over SSH. |
| `cmd/debug.go` (new) | `citadel debug` prints version + host + log path + recent activity to **stdout** | The dependable "copy over SSH" path — pipe/redirect it, no clipboard needed. |

```
$ citadel debug -n 5
=== citadel debug bundle ===
version:  2.46.0
os/arch:  linux/amd64
log file: ~/.citadel-cli/logs/citadel-2026-06-29.log

--- last 5 activity log lines ---
[10:00:02] [warning] consume failed on q: deadline
...
```

## Test plan

| Group | Coverage |
| --- | --- |
| `internal/clilog` unit tests | date-based filename, same-day append (one file, one session header), midnight rotation, `latest.log` symlink target |
| Build / vet / gofmt | `go build ./...`, `go vet`, `gofmt -l` all clean |
| Full suite | `go test ./...` green (no regressions in `agent_tools_test`, which reads `latest.log`) |
| Manual smoke | built binary; `citadel debug` renders the bundle and tails the dated log; invoking it logged its own `command: citadel debug` line (proving always-on logging) |

## Related

- Closes #369
- Sibling: #370 (the consume warnings themselves are self-healing transients but logged as scary `⚠` — downgrade + coalesce). Investigated here; fix tracked separately.
- The panel copies (`c`/`C`) share the same clipboard-on-headless caveat; left as a follow-up to keep this PR focused on the `l`/logging path.

## Notes

OSC52 terminal-clipboard (paste-over-SSH) was considered but deferred: injecting OSC52 from inside a `tview` modal is fragile (tcell owns the terminal). The file path + `citadel debug` are the dependable primitives; OSC52 can be layered on later.
