### PR TITLE
fix(worker): coalesce self-healing consume failures instead of warning-spamming (#370)

### DIFF
--- a/internal/worker/api_source.go
+++ b/internal/worker/api_source.go
@@ -184,6 +184,7 @@ func (s *APISource) nextMulti(ctx context.Context, queues []string) (*Job, error
 	}
 
 	var lastErr error
+	var lastQueue string
 	errCount := 0
 
 	for i := 0; i < len(queues); i++ {
@@ -204,9 +205,13 @@ func (s *APISource) nextMulti(ctx context.Context, queues []string) (*Job, error
 			BlockMs:  perQueueBlockMs,
 		})
 		if err != nil {
-			// Log and skip -- one rejected queue must not block the others.
-			s.log("warning", "consume failed on %s: %v", queue, err)
+			// Skip this queue so one rejected queue can't block the others.
+			// We deliberately do NOT log per-queue here: a transient consume
+			// failure is self-healing and logging it every poll floods the
+			// activity panel. The cycle-level outcome is coalesced by the
+			// runner instead (the queue name is carried in the wrapped error).
 			lastErr = err
+			lastQueue = queue
 			errCount++
 			continue
 		}
@@ -220,7 +225,7 @@ func (s *APISource) nextMulti(ctx context.Context, queues []string) (*Job, error
 
 	// Only propagate error (triggering backoff) if ALL queues failed.
 	if errCount == len(queues) {
-		return nil, fmt.Errorf("all queues failed: %w", lastErr)
+		return nil, fmt.Errorf("all %d queues failed (last: %s): %w", len(queues), lastQueue, lastErr)
 	}
 
 	return nil, nil // No job available on any queue

--- a/internal/worker/fetch_err_log_test.go
+++ b/internal/worker/fetch_err_log_test.go
@@ -1,0 +1,46 @@
+package worker
+
+import "testing"
+
+// TestFetchErrLogLevel verifies the coalescing policy that keeps self-healing
+// consume failures from flooding the activity log: quiet first blip, silence
+// through brief streaks, one warning when sustained, then sparse re-warns.
+func TestFetchErrLogLevel(t *testing.T) {
+	const threshold, repeat = 5, 10
+
+	cases := []struct {
+		consecutive int
+		wantLevel   string
+		wantLog     bool
+	}{
+		{1, "info", true},     // first blip: quiet info
+		{2, "", false},        // brief streak: silent
+		{3, "", false},        // silent
+		{4, "", false},        // silent
+		{5, "warning", true},  // sustained: escalate once
+		{6, "", false},        // silent again
+		{14, "", false},       // silent
+		{15, "warning", true}, // threshold(5) + repeat(10): re-warn
+		{16, "", false},       // silent
+		{25, "warning", true}, // next re-warn
+	}
+
+	for _, c := range cases {
+		level, ok := fetchErrLogLevel(c.consecutive, threshold, repeat)
+		if ok != c.wantLog || level != c.wantLevel {
+			t.Errorf("fetchErrLogLevel(%d) = (%q,%v), want (%q,%v)",
+				c.consecutive, level, ok, c.wantLevel, c.wantLog)
+		}
+	}
+}
+
+// TestFetchErrLogLevelZeroRepeat ensures a zero repeat never divides by zero
+// and simply stops re-warning after the initial escalation.
+func TestFetchErrLogLevelZeroRepeat(t *testing.T) {
+	if _, ok := fetchErrLogLevel(100, 5, 0); ok {
+		t.Error("expected no log when repeat is 0 and past threshold")
+	}
+	if level, ok := fetchErrLogLevel(5, 5, 0); !ok || level != "warning" {
+		t.Errorf("threshold escalation should still fire with repeat=0; got (%q,%v)", level, ok)
+	}
+}

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -109,6 +109,24 @@ type consumeStatusReporter interface {
 	LastConsumeStatus() int
 }
 
+// fetchErrLogLevel decides whether (and how loudly) a job-fetch failure on the
+// Nth consecutive cycle should be surfaced to the activity log. It returns
+// ("", false) to stay silent. The policy: announce the first blip quietly
+// (info), escalate to a single warning once failures are sustained (== threshold),
+// then re-warn sparingly (every `repeat` cycles) while it keeps failing.
+func fetchErrLogLevel(consecutive, threshold, repeat int) (level string, shouldLog bool) {
+	switch {
+	case consecutive == 1:
+		return "info", true
+	case consecutive == threshold:
+		return "warning", true
+	case consecutive > threshold && repeat > 0 && (consecutive-threshold)%repeat == 0:
+		return "warning", true
+	default:
+		return "", false
+	}
+}
+
 // recordConsumeStatus copies the source's last consume HTTP status and error
 // into the introspection state after each poll cycle.
 func (r *Runner) recordConsumeStatus(pollErr error) {
@@ -200,6 +218,18 @@ func (r *Runner) Run(ctx context.Context) error {
 	backoff := time.Second
 	const maxBackoff = 30 * time.Second
 
+	// Job-fetch failures (consume timeouts, transient 5xx during a backend
+	// deploy/failover) are normal and self-healing: the loop just backs off and
+	// retries. Logging each one as a warning floods the activity panel and reads
+	// like the node is broken. Coalesce instead — stay quiet through brief blips,
+	// escalate to a single warning only once failures are sustained, then repeat
+	// sparingly with a running count, and announce recovery.
+	const (
+		sustainedFetchErrThreshold = 5  // cycles before a transient blip becomes a warning
+		sustainedFetchErrRepeat    = 10 // re-warn every N cycles while still failing
+	)
+	consecutiveFetchErrs := 0
+
 runLoop:
 	for {
 		select {
@@ -232,7 +262,16 @@ runLoop:
 				if ctx.Err() != nil {
 					break runLoop // Context cancelled
 				}
-				r.log("warning", "Error fetching job: %v (retry in %s)", err, backoff)
+				consecutiveFetchErrs++
+				if level, ok := fetchErrLogLevel(consecutiveFetchErrs, sustainedFetchErrThreshold, sustainedFetchErrRepeat); ok {
+					if consecutiveFetchErrs == 1 {
+						// First blip in a streak: record quietly (persisted to the
+						// log, info-level so it doesn't alarm) and let backoff retry.
+						r.log(level, "Job fetch retrying (backoff %s): %v", backoff, err)
+					} else {
+						r.log(level, "Job fetching has failed %d cycles in a row: %v", consecutiveFetchErrs, err)
+					}
+				}
 				select {
 				case <-time.After(backoff):
 				case <-ctx.Done():
@@ -246,7 +285,12 @@ runLoop:
 				continue
 			}
 
-			// Reset backoff on success
+			// Reset backoff on success, and announce recovery if we had
+			// previously escalated to a sustained-failure warning.
+			if consecutiveFetchErrs >= sustainedFetchErrThreshold {
+				r.log("success", "Job fetching recovered after %d failed cycles", consecutiveFetchErrs)
+			}
+			consecutiveFetchErrs = 0
 			backoff = time.Second
 
 			if job == nil {


### PR DESCRIPTION
## Context

While investigating the failures an operator pasted from a live node:

```
⚠ consume failed on jobs:v1:shell:org_…:node:1036: ... context deadline exceeded
⚠ consume failed on jobs:v1:cpu-general: request failed with status 502: upstream error
```

…it turned out the node wasn't broken. These are **self-healing transients** the run loop already recovers from:

- **`context deadline exceeded`** — the per-request consume deadline is `BlockMs + 5s` (~10s); when the backend long-poll holds longer (or the edge is briefly slow), the node's own deadline fires. Ordinary idle long-poll / transient latency.
- **`502 upstream error`** — clustered in tight windows, i.e. the backend `/jobs/consume` route was briefly unhealthy during a deploy / Redis-Sentinel failover. Recovers on its own.

The defect was the **logging**, not the node: every failed cycle emitted **two** warnings — a per-queue `consume failed on …` (in `nextMulti`) plus the runner's `Error fetching job` — so the Activity Log filled with scary `⚠` lines that read like an outage when nothing needed action.

## Summary

| File | Change |
| --- | --- |
| `internal/worker/api_source.go` | Drop the per-queue warning; carry the queue name in the wrapped cycle-level error so detail isn't lost. |
| `internal/worker/runner.go` | Coalesce fetch-error logging: quiet `info` on the first blip → silent through brief streaks → a single `warning` once sustained (5 cycles) → sparse re-warn every 10 cycles with a running count → a `success` "recovered after N cycles" line when it clears. |
| `fetchErrLogLevel()` (new, pure) | The coalescing policy, unit-tested in isolation. |

Net: a one-cycle blip that recovers is now **silent at warning level** (still persisted to the dated log per #369 for forensics); a genuine sustained outage produces exactly one warning, then a count every 10 cycles, then a recovery line.

## Test plan

| Group | Coverage |
| --- | --- |
| `TestFetchErrLogLevel` | first blip → info; cycles 2–4 silent; cycle 5 warning; 6–14 silent; 15/25 re-warn (evenly spaced after escalation) |
| `TestFetchErrLogLevelZeroRepeat` | divide-by-zero guard; threshold escalation still fires with `repeat=0` |
| Build / vet / gofmt / `go test ./...` | all clean, no regressions |

## Related

- Closes #370
- Sibling #369 (PR #371): always-on dated logging — these transients are now persisted to `citadel-YYYY-MM-DD.log` even though they no longer alarm the panel.
- Out of scope: the `502` originates from the aceteam `/api/fabric/redis/jobs/consume` route during deploy/failover; if it recurs, a backend issue to return a graceful `503 Retry-After` is the follow-up. The `Stream add failed … deadline exceeded` line is the same transient class on the telemetry path and can get the same treatment later.
