### PR TITLE
fix: add scripts/citadel.ps1 for get.aceteam.ai redirect

### DIFF
--- a/scripts/citadel.ps1
+++ b/scripts/citadel.ps1
@@ -1,11 +1,10 @@
 # Citadel CLI Installer for Windows
+#
 # Usage: irm https://get.aceteam.ai/citadel.ps1 | iex
 #
 # Or download and run:
 #   Invoke-WebRequest -Uri https://get.aceteam.ai/citadel.ps1 -OutFile citadel.ps1
 #   .\citadel.ps1
-#
-# Canonical source: scripts/citadel.ps1 (this root copy is kept for backwards compatibility)
 
 param(
     [string]$Version = "latest",
@@ -65,7 +64,7 @@ if ($existingCitadel -and -not $Force) {
     Write-Warning "Citadel is already installed at: $($existingCitadel.Source)"
     Write-Host ""
     Write-Host "To reinstall, run with -Force flag:"
-    Write-Host "  iwr -useb <url> | iex -Force"
+    Write-Host "  irm https://get.aceteam.ai/citadel.ps1 | iex -Force"
     Write-Host ""
     $continue = Read-Host "Continue anyway? (y/N)"
     if ($continue -ne 'y' -and $continue -ne 'Y') {


### PR DESCRIPTION
## Context

`https://get.aceteam.ai/citadel.ps1` 302-redirects to `raw.githubusercontent.com/aceteam-ai/citadel-cli/main/scripts/citadel.ps1`, but that file did not exist — only `install.ps1` at the repo root. Users following the Windows install command on [citadel.aceteam.ai](https://citadel.aceteam.ai/) hit a 404.

Reported in aceteam-ai/citadel#30.

## Summary

- Add `scripts/citadel.ps1` (mirrors `install.ps1`, uses current zip-based release assets)
- Update `install.ps1` header to document `get.aceteam.ai/citadel.ps1` as the canonical one-liner URL (same pattern as `scripts/install.sh` for `citadel.sh`)

## Test plan

- [x] Confirmed redirect target was 404 before fix
- [x] Confirmed `install.ps1` at repo root already works (200)
- [ ] After merge: `curl -sI https://get.aceteam.ai/citadel.ps1` should 302 → 200
- [ ] After merge: `irm https://get.aceteam.ai/citadel.ps1 | iex` on Windows installs latest release

## Related

- aceteam-ai/citadel#30