### PR TITLE
feat(fabric): declare FABRIC_PROTOCOL_VERSION + stamp release notes (#363 Phase 1)

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"runtime/debug"
 
+	"github.com/aceteam-ai/citadel-cli/internal/protocol"
 	"github.com/spf13/cobra"
 )
 
@@ -29,6 +30,7 @@ var versionCmd = &cobra.Command{
 	Short: "Print the version number of Citadel CLI",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Printf("Citadel CLI version %s\n", Version)
+		fmt.Printf("Fabric protocol: v%d\n", protocol.FabricProtocolVersion)
 	},
 }
 

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -1,0 +1,20 @@
+// Package protocol declares the Citadel ↔ AceTeam fabric wire-contract version.
+package protocol
+
+// FabricProtocolVersion is the version of the node↔control-plane wire contract:
+// job payloads, the reconcile desired/actual state shape, MCP tool shapes, and
+// the nexus registration handshake. It is a single integer bumped ONLY on a
+// breaking wire change.
+//
+// It is deliberately decoupled from the product/release version (vX.Y.Z): the
+// node agent (citadel-cli, git-tag + GitHub release) and the control plane
+// (aceteam, main→production + Railway) release on independent cadences, so a
+// product release must never force a counterpart release. The protocol integer
+// is the contract that lets them refuse to drift apart silently. The aceteam
+// repo declares a matching constant. See aceteam-ai/citadel-cli#363.
+//
+// Phase 1 (current): declared, surfaced in `citadel version`, and stamped into
+// release notes — no runtime negotiation/enforcement yet. Phase 2 (advertise in
+// the registration handshake, negotiate, surface incompatibility in /fabric)
+// rides the remote-managed-nodes epic (#352).
+const FabricProtocolVersion = 1

--- a/internal/protocol/protocol_test.go
+++ b/internal/protocol/protocol_test.go
@@ -1,0 +1,11 @@
+package protocol
+
+import "testing"
+
+// TestFabricProtocolVersionIsPositive guards against the constant accidentally
+// being zeroed or made negative — the wire contract starts at v1.
+func TestFabricProtocolVersionIsPositive(t *testing.T) {
+	if FabricProtocolVersion < 1 {
+		t.Fatalf("FabricProtocolVersion must be >= 1, got %d", FabricProtocolVersion)
+	}
+}

--- a/scripts/release-engine.sh
+++ b/scripts/release-engine.sh
@@ -411,10 +411,23 @@ run_release() {
     if command -v gh &>/dev/null && [[ -n "${RELEASE_GITHUB_REPO:-}" ]]; then
       step_msg "Creating GitHub Release..."
 
+      # If the project defines a release-notes preamble hook (e.g. to stamp a
+      # wire-protocol compatibility line), write it to a file and prepend it to
+      # the auto-generated notes.
+      local notes_args=("--generate-notes")
+      if declare -F hook_release_notes_preamble &>/dev/null; then
+        local preamble_file
+        preamble_file="$(mktemp)"
+        hook_release_notes_preamble >"$preamble_file" 2>/dev/null || true
+        if [[ -s "$preamble_file" ]]; then
+          notes_args=("--notes-file" "$preamble_file" "--generate-notes")
+        fi
+      fi
+
       local release_args=(
         "--repo" "$RELEASE_GITHUB_REPO"
         "--title" "${RELEASE_TAG_PREFIX}${new_version}"
-        "--generate-notes"
+        "${notes_args[@]}"
       )
 
       # Collect artifacts (hook_artifact may return multiple lines)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -47,6 +47,18 @@ hook_set_version() {
   true
 }
 
+hook_release_notes_preamble() {
+  # Stamp the fabric wire-protocol compatibility line into the release notes
+  # (issue #363). Read the integer straight from the Go constant so it is never
+  # hand-maintained.
+  local proto
+  proto=$(grep -oE 'FabricProtocolVersion[[:space:]]*=[[:space:]]*[0-9]+' \
+    "$REPO_ROOT/internal/protocol/protocol.go" 2>/dev/null | grep -oE '[0-9]+$')
+  [[ -z "$proto" ]] && return 0
+  echo "**Fabric protocol: v${proto}** — the citadel-cli ↔ aceteam node/control-plane wire-contract version (#363). Bumped only on breaking wire changes, independent of this release version."
+  echo
+}
+
 hook_test() {
   info "Running Go tests..."
   go test ./...


### PR DESCRIPTION
## Context

citadel-cli (the node agent) and the aceteam control plane (+ iOS/Android, which call the one aceteam API) share a growing wire contract — job payloads, the reconcile desired/actual state shape, MCP tool shapes, the nexus registration handshake. They release on **independent cadences** (citadel-cli = git-tag + GitHub release; aceteam = main→production + Railway), so today nothing stops them silently drifting out of compatibility. We don't want to couple release *timing*; we do want a guarantee they can't drift apart unnoticed.

This is **Phase 1** of #363 — lightweight: declare + surface the version, no runtime enforcement yet.

## Summary

- **`internal/protocol`** — `FabricProtocolVersion = 1`: a single integer for the node↔control-plane wire contract, bumped only on a breaking wire change, deliberately decoupled from the product/release version (`v2.48.0`).
- **`citadel version`** now prints `Fabric protocol: v1` — discoverable on any node, and the surface Phase 2 will advertise in the handshake.
- **Release notes** — added an optional `hook_release_notes_preamble` to the shared `release-engine.sh`; citadel-cli defines it to stamp the compat line into every GitHub release, reading the integer straight from the Go constant so it's never hand-maintained.

```
$ citadel version
Citadel CLI version 2.48.0
Fabric protocol: v1
```

## Test plan

| Check | Result |
| --- | --- |
| `go build ./cmd/citadel`, `go vet`, `gofmt -l` | clean |
| `go test ./internal/protocol/...` | pass (guards constant ≥ 1) |
| `citadel version` output | shows `Fabric protocol: v1` |
| `bash -n` on both release scripts + grep extraction | syntax OK, extracts `1` |

## Related

- Part 1 of #363; **aceteam companion** filed separately (matching constant + release-notes hook on the control-plane side).
- Phase 2 (advertise + negotiate + surface incompatibility in `/fabric`) rides the remote-managed-nodes epic #352 — the reconcile wire-contract (#353) is the first versioned surface.
