### PR TITLE
feat(catalog): community git repos as named catalog sources (#309)

### DIFF
--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -312,14 +312,19 @@ func runCatalogInstall(cmd *cobra.Command, args []string) error {
 		overrides[parts[0]] = parts[1]
 	}
 
-	// Reject host-provisioned services (no compose.yml, e.g. the Windows-only
-	// "wechat" microservice) before doing any work. Print provisioning guidance
-	// instead of scaffolding node config and a misleading "Installing..." line.
-	if !catalog.IsInstallable(name) {
-		// Confirm the service actually exists; if not, surface the load error.
-		if _, mErr := catalog.LoadServiceManifest(name); mErr != nil {
-			return mErr
-		}
+	// Resolve manifest, compose, and owning source from a SINGLE source
+	// atomically. This is a security invariant: the trust decision must key the
+	// exact compose that gets installed, so a community source cannot shadow a
+	// default service's name to install its own compose under default privileges.
+	resolved, err := catalog.ResolveCatalogService(name)
+	if err != nil {
+		return err
+	}
+
+	// Reject host-provisioned services (no compose.yml in the owning source, e.g.
+	// the Windows-only "wechat" microservice). Print provisioning guidance instead
+	// of scaffolding node config and a misleading "Installing..." line.
+	if resolved.ComposePath == "" {
 		return printNotInstallableGuidance(name)
 	}
 
@@ -342,27 +347,20 @@ func runCatalogInstall(cmd *cobra.Command, args []string) error {
 	// (Tier 2): the install runs through the least-privilege sandbox and the
 	// un-bypassable privilege gate (overridable only with --allow-privileged),
 	// mirroring `citadel module install` of an external git source.
-	source := catalog.SourceOf(name)
-	untrusted := !catalog.IsDefaultSource(source)
+	untrusted := !catalog.IsDefaultSource(resolved.SourceName)
 
 	if untrusted {
-		fmt.Printf("Installing %s from community source '%s'...\n", name, source)
+		fmt.Printf("Installing %s from community source '%s'...\n", name, resolved.SourceName)
 	} else {
 		fmt.Printf("Installing %s from catalog...\n", name)
 	}
-
-	svcManifest, err := catalog.LoadServiceManifest(name)
-	if err != nil {
-		return err
-	}
-	composeSrc, _ := catalog.GetComposeFile(name)
 
 	// allowPrivileged: trusted (default) sources are exempt from the gate, as
 	// before. Community sources require an explicit --allow-privileged opt-in for
 	// any privileged/root-equivalent compose directive.
 	allowPrivileged := !untrusted || catalogInstallAllowPrivileged
 
-	result, err := catalog.InstallFromManifest(svcManifest, composeSrc, servicesDir, overrides, true, allowPrivileged, untrusted)
+	result, err := catalog.InstallFromManifest(resolved.Manifest, resolved.ComposePath, servicesDir, overrides, true, allowPrivileged, untrusted)
 	if err != nil {
 		// Defense-in-depth: the up-front IsInstallable check above already
 		// diverts host-provisioned services, but InstallFromManifest also guards.

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -58,13 +58,44 @@ var catalogInfoCmd = &cobra.Command{
 	RunE:  runCatalogInfo,
 }
 
-var catalogInstallConfigFlags []string
+var (
+	catalogInstallConfigFlags     []string
+	catalogInstallAllowPrivileged bool
+)
 
 var catalogInstallCmd = &cobra.Command{
 	Use:   "install <name>",
 	Short: "Install a service from the catalog onto this node",
 	Args:  cobra.ExactArgs(1),
 	RunE:  runCatalogInstall,
+}
+
+var catalogAddName string
+
+var catalogAddCmd = &cobra.Command{
+	Use:   "add <git-url>",
+	Short: "Register an additional community catalog source",
+	Long: `Register an additional catalog source -- a git repository laid out like the
+official catalog (a top-level registry.yaml and services/<name>/ subdirectories).
+After adding a source, run 'citadel service catalog update' to fetch it.
+
+The source name defaults to the repository name; override it with --name. The
+built-in official source is always present and is named "default".`,
+	Args: cobra.ExactArgs(1),
+	RunE: runCatalogAdd,
+}
+
+var catalogRemoveCmd = &cobra.Command{
+	Use:   "remove <name>",
+	Short: "Unregister a community catalog source",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runCatalogRemove,
+}
+
+var catalogListSourcesCmd = &cobra.Command{
+	Use:   "list-sources",
+	Short: "List configured catalog sources",
+	RunE:  runCatalogListSources,
 }
 
 func init() {
@@ -74,9 +105,16 @@ func init() {
 	catalogCmd.AddCommand(catalogSearchCmd)
 	catalogCmd.AddCommand(catalogInfoCmd)
 	catalogCmd.AddCommand(catalogInstallCmd)
+	catalogCmd.AddCommand(catalogAddCmd)
+	catalogCmd.AddCommand(catalogRemoveCmd)
+	catalogCmd.AddCommand(catalogListSourcesCmd)
 
 	catalogInstallCmd.Flags().StringArrayVar(&catalogInstallConfigFlags, "set", nil,
 		"Set a config value (e.g. --set MODEL=Qwen/Qwen3-8B)")
+	catalogInstallCmd.Flags().BoolVar(&catalogInstallAllowPrivileged, "allow-privileged", false,
+		"Allow a community-source service whose compose requests privileged/root-equivalent access")
+	catalogAddCmd.Flags().StringVar(&catalogAddName, "name", "",
+		"Name for the source (defaults to the repository name)")
 }
 
 // runCatalogList prints all catalog services in a table with install status.
@@ -98,7 +136,7 @@ func runCatalogList(cmd *cobra.Command, args []string) error {
 	defer w.Flush()
 
 	bold := color.New(color.Bold)
-	bold.Fprintf(w, "SERVICE\tVERSION\tCATEGORY\tGPU\tSTATUS\tDESCRIPTION\n")
+	bold.Fprintf(w, "SERVICE\tVERSION\tCATEGORY\tGPU\tSOURCE\tSTATUS\tDESCRIPTION\n")
 
 	for _, s := range reg.Services {
 		statusStr := color.New(color.FgWhite).Sprint("available")
@@ -106,10 +144,19 @@ func runCatalogList(cmd *cobra.Command, args []string) error {
 			statusStr = color.New(color.FgGreen).Sprint("installed")
 		}
 
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
-			s.Name, s.Version, s.Category, s.GPU, statusStr, truncate(s.Description, 50))
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			s.Name, s.Version, s.Category, s.GPU, sourceLabel(s.Source), statusStr, truncate(s.Description, 50))
 	}
 	return nil
+}
+
+// sourceLabel renders a registry entry's source name for table output, defaulting
+// to the built-in default source name when unset (e.g. legacy single-source).
+func sourceLabel(source string) string {
+	if source == "" {
+		return catalog.DefaultSourceName
+	}
+	return source
 }
 
 // runCatalogSearch prints services matching the query.
@@ -130,7 +177,7 @@ func runCatalogSearch(cmd *cobra.Command, args []string) error {
 	defer w.Flush()
 
 	bold := color.New(color.Bold)
-	bold.Fprintf(w, "SERVICE\tVERSION\tCATEGORY\tGPU\tSTATUS\tDESCRIPTION\n")
+	bold.Fprintf(w, "SERVICE\tVERSION\tCATEGORY\tGPU\tSOURCE\tSTATUS\tDESCRIPTION\n")
 
 	for _, s := range results {
 		statusStr := color.New(color.FgWhite).Sprint("available")
@@ -138,8 +185,8 @@ func runCatalogSearch(cmd *cobra.Command, args []string) error {
 			statusStr = color.New(color.FgGreen).Sprint("installed")
 		}
 
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
-			s.Name, s.Version, s.Category, s.GPU, statusStr, truncate(s.Description, 50))
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			s.Name, s.Version, s.Category, s.GPU, sourceLabel(s.Source), statusStr, truncate(s.Description, 50))
 	}
 	return nil
 }
@@ -155,6 +202,10 @@ func runCatalogInfo(cmd *cobra.Command, args []string) error {
 
 	bold.Print("Name:        ")
 	fmt.Println(manifest.Name)
+	if src := catalogSourceOf(manifest.Name); src != "" {
+		bold.Print("Source:      ")
+		fmt.Println(src)
+	}
 	bold.Print("Version:     ")
 	fmt.Println(manifest.Version)
 	bold.Print("Description: ")
@@ -286,16 +337,43 @@ func runCatalogInstall(cmd *cobra.Command, args []string) error {
 
 	servicesDir := filepath.Join(configDir, "services")
 
-	fmt.Printf("Installing %s from catalog...\n", name)
+	// Trust level depends on the owning source. The built-in default source is
+	// first-party (Tier 0) and installs as-is. A community source is untrusted
+	// (Tier 2): the install runs through the least-privilege sandbox and the
+	// un-bypassable privilege gate (overridable only with --allow-privileged),
+	// mirroring `citadel module install` of an external git source.
+	source := catalog.SourceOf(name)
+	untrusted := !catalog.IsDefaultSource(source)
 
-	result, err := catalog.Install(name, servicesDir, overrides)
+	if untrusted {
+		fmt.Printf("Installing %s from community source '%s'...\n", name, source)
+	} else {
+		fmt.Printf("Installing %s from catalog...\n", name)
+	}
+
+	svcManifest, err := catalog.LoadServiceManifest(name)
+	if err != nil {
+		return err
+	}
+	composeSrc, _ := catalog.GetComposeFile(name)
+
+	// allowPrivileged: trusted (default) sources are exempt from the gate, as
+	// before. Community sources require an explicit --allow-privileged opt-in for
+	// any privileged/root-equivalent compose directive.
+	allowPrivileged := !untrusted || catalogInstallAllowPrivileged
+
+	result, err := catalog.InstallFromManifest(svcManifest, composeSrc, servicesDir, overrides, true, allowPrivileged, untrusted)
 	if err != nil {
 		// Defense-in-depth: the up-front IsInstallable check above already
-		// diverts host-provisioned services, but Install also guards this.
+		// diverts host-provisioned services, but InstallFromManifest also guards.
 		if errors.Is(err, catalog.ErrNotInstallable) {
 			return printNotInstallableGuidance(name)
 		}
 		return fmt.Errorf("install failed: %w", err)
+	}
+
+	if result.Sandboxed {
+		fmt.Printf("  Applied least-privilege sandbox: %s\n", result.SandboxOverridePath)
 	}
 
 	// Register in the node manifest using existing helpers.
@@ -356,6 +434,74 @@ func installedServiceSet() map[string]bool {
 		installed[s.Name] = true
 	}
 	return installed
+}
+
+// catalogSourceOf returns the name of the source that owns service `name` (per
+// the merged registry's collision precedence), or "" if it can't be determined.
+func catalogSourceOf(name string) string {
+	reg, err := catalog.LoadRegistry()
+	if err != nil {
+		return ""
+	}
+	for _, e := range reg.Services {
+		if e.Name == name {
+			return sourceLabel(e.Source)
+		}
+	}
+	return ""
+}
+
+// runCatalogAdd registers a new community catalog source.
+func runCatalogAdd(cmd *cobra.Command, args []string) error {
+	url := args[0]
+	name := strings.TrimSpace(catalogAddName)
+	if name == "" {
+		name = catalog.DefaultSourceNameFromURL(url)
+		if name == "" {
+			return fmt.Errorf("could not derive a source name from %q; pass --name", url)
+		}
+	}
+
+	if err := catalog.AddSource(name, url); err != nil {
+		return err
+	}
+
+	fmt.Printf("Added catalog source '%s' (%s).\n", name, url)
+	fmt.Println("Run 'citadel service catalog update' to fetch it.")
+	return nil
+}
+
+// runCatalogRemove unregisters a community catalog source.
+func runCatalogRemove(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	if err := catalog.RemoveSource(name); err != nil {
+		return err
+	}
+	fmt.Printf("Removed catalog source '%s'.\n", name)
+	return nil
+}
+
+// runCatalogListSources lists every configured catalog source.
+func runCatalogListSources(cmd *cobra.Command, args []string) error {
+	sources, err := catalog.ListSources()
+	if err != nil {
+		return err
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	defer w.Flush()
+
+	bold := color.New(color.Bold)
+	bold.Fprintf(w, "NAME\tTYPE\tURL\n")
+
+	for _, s := range sources {
+		typ := "community"
+		if s.Name == catalog.DefaultSourceName {
+			typ = "default"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\n", s.Name, typ, s.URL)
+	}
+	return nil
 }
 
 // truncate is defined in mcp.go and reused here.

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -41,6 +41,10 @@ type RegistryEntry struct {
 	GPU         string   `yaml:"gpu"` // "required", "optional", "no"
 	Description string   `yaml:"description"`
 	Tags        []string `yaml:"tags,omitempty"`
+	// Source is the name of the catalog source this entry came from. It is not
+	// read from registry.yaml; the aggregation layer stamps it during a
+	// cross-source load so list/search/info can disambiguate collisions.
+	Source string `yaml:"-"`
 }
 
 // ServiceManifest is the full definition of a service (service.yaml inside a service dir).
@@ -166,24 +170,59 @@ func GetCatalogPath() string {
 	return filepath.Join(platform.ConfigDir(), catalogSubdir)
 }
 
-// IsAvailable returns true if the catalog has been cloned locally.
+// IsAvailable returns true if the default catalog has been cloned locally.
 func IsAvailable() bool {
-	info, err := os.Stat(GetCatalogPath())
+	return dirIsAvailable(GetCatalogPath())
+}
+
+// dirIsAvailable returns true if path exists and is a directory.
+func dirIsAvailable(path string) bool {
+	info, err := os.Stat(path)
 	return err == nil && info.IsDir()
 }
 
-// Update clones or pulls the catalog repository into the local cache.
+// Update clones or pulls EVERY configured catalog source: the built-in default
+// plus any user-added sources. A failure to update one source does not abort the
+// others; the first error encountered is returned after all sources are tried,
+// so a single broken community repo never blocks refreshing the rest.
 func Update() error {
-	catalogPath := GetCatalogPath()
+	sources, err := resolvedSources()
+	if err != nil {
+		return err
+	}
+
+	var firstErr error
+	for _, src := range sources {
+		if err := updateSource(src); err != nil {
+			wrapped := fmt.Errorf("catalog source %q: %w", src.Name, err)
+			if firstErr == nil {
+				firstErr = wrapped
+			}
+		}
+	}
+	return firstErr
+}
+
+// updateSource clones or pulls a single source's git repo into its cache path.
+func updateSource(src resolvedSource) error {
+	// Resolve the clone URL (expands the owner/repo shorthand for added sources).
+	cloneURL := src.URL
+	if !src.Default {
+		resolved, err := resolveSourceURL(src.URL)
+		if err != nil {
+			return err
+		}
+		cloneURL = resolved
+	}
 
 	// Ensure parent directory exists.
-	if err := os.MkdirAll(filepath.Dir(catalogPath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(src.Path), 0755); err != nil {
 		return fmt.Errorf("failed to create catalog parent directory: %w", err)
 	}
 
-	if isGitRepo(catalogPath) {
+	if isGitRepo(src.Path) {
 		// Pull latest changes.
-		cmd := exec.Command("git", "-C", catalogPath, "pull", "--ff-only")
+		cmd := exec.Command("git", "-C", src.Path, "pull", "--ff-only")
 		output, err := cmd.CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("git pull failed: %s", strings.TrimSpace(string(output)))
@@ -192,11 +231,11 @@ func Update() error {
 	}
 
 	// Fresh clone. Remove any leftover non-git directory first.
-	if err := os.RemoveAll(catalogPath); err != nil {
+	if err := os.RemoveAll(src.Path); err != nil {
 		return fmt.Errorf("failed to clean catalog directory: %w", err)
 	}
 
-	cmd := exec.Command("git", "clone", "--depth", "1", DefaultCatalogURL, catalogPath)
+	cmd := exec.Command("git", "clone", "--depth", "1", cloneURL, src.Path)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("git clone failed: %s", strings.TrimSpace(string(output)))
@@ -204,14 +243,46 @@ func Update() error {
 	return nil
 }
 
-// LoadRegistry reads the registry.yaml index file.
-// If registry.yaml is absent, it falls back to scanning service subdirectories.
+// LoadRegistry returns the merged registry across every configured catalog
+// source (the built-in default plus any user-added sources). Each entry's Source
+// field is stamped with the owning source's name. On a name collision the source
+// listed first wins -- the default source, then user-added sources in
+// registration order. If no source has been cloned yet, it returns a
+// catalog-not-found error pointing the operator at `catalog update`.
 func LoadRegistry() (*Registry, error) {
-	catalogPath := GetCatalogPath()
-	if !IsAvailable() {
+	sources, err := resolvedSources()
+	if err != nil {
+		return nil, err
+	}
+
+	var regs []sourceRegistry
+	anyAvailable := false
+	for _, src := range sources {
+		if !dirIsAvailable(src.Path) {
+			continue
+		}
+		anyAvailable = true
+		reg, err := loadRegistryFromPath(src.Path)
+		if err != nil {
+			// A single malformed community source must not take down the whole
+			// catalog (incl. the default). Skip it and warn -- mirroring the
+			// per-source resilience of Update().
+			fmt.Fprintf(os.Stderr, "warning: skipping catalog source %q: %v\n", src.Name, err)
+			continue
+		}
+		regs = append(regs, sourceRegistry{Source: src.Name, Services: reg.Services})
+	}
+
+	if !anyAvailable {
 		return nil, fmt.Errorf("catalog not found. Run 'citadel service catalog update' first")
 	}
 
+	return &Registry{Version: 1, Services: mergeRegistries(regs)}, nil
+}
+
+// loadRegistryFromPath reads the registry.yaml index from a single source's
+// cache path, falling back to scanning service subdirectories when absent.
+func loadRegistryFromPath(catalogPath string) (*Registry, error) {
 	registryPath := filepath.Join(catalogPath, "registry.yaml")
 	data, err := os.ReadFile(registryPath)
 	if err == nil {
@@ -226,15 +297,35 @@ func LoadRegistry() (*Registry, error) {
 	return scanForServices(catalogPath)
 }
 
-// LoadServiceManifest reads a specific service's service.yaml.
+// LoadServiceManifest reads a specific service's service.yaml, searching across
+// every configured catalog source. On a name collision the default source wins,
+// then user-added sources in registration order (matching LoadRegistry).
 func LoadServiceManifest(name string) (*ServiceManifest, error) {
-	catalogPath := GetCatalogPath()
-	manifestPath := filepath.Join(catalogPath, servicesSubdir, name, "service.yaml")
+	sources, err := resolvedSources()
+	if err != nil {
+		return nil, err
+	}
+	for _, src := range sources {
+		manifest, err := loadManifestFromPath(src.Path, name)
+		if err == nil {
+			return manifest, nil
+		}
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+	}
+	return nil, fmt.Errorf("service '%s' not found in catalog", name)
+}
 
+// loadManifestFromPath reads a service's service.yaml from a single source's
+// cache path. A missing manifest is reported as an os.IsNotExist error so the
+// cross-source loader can keep searching the next source.
+func loadManifestFromPath(catalogPath, name string) (*ServiceManifest, error) {
+	manifestPath := filepath.Join(catalogPath, servicesSubdir, name, "service.yaml")
 	data, err := os.ReadFile(manifestPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("service '%s' not found in catalog", name)
+			return nil, err
 		}
 		return nil, fmt.Errorf("failed to read service manifest: %w", err)
 	}
@@ -246,22 +337,26 @@ func LoadServiceManifest(name string) (*ServiceManifest, error) {
 	return &manifest, nil
 }
 
-// GetComposeFile returns the path to a service's compose.yml inside the catalog.
+// GetComposeFile returns the path to a service's compose.yml, searching across
+// every configured catalog source with the same precedence as LoadRegistry.
 func GetComposeFile(name string) (string, error) {
-	catalogPath := GetCatalogPath()
-	composePath := filepath.Join(catalogPath, servicesSubdir, name, "compose.yml")
-
-	if _, err := os.Stat(composePath); err != nil {
-		if os.IsNotExist(err) {
-			return "", fmt.Errorf("compose.yml not found for service '%s'", name)
-		}
-		return "", fmt.Errorf("failed to access compose file: %w", err)
+	sources, err := resolvedSources()
+	if err != nil {
+		return "", err
 	}
-	return composePath, nil
+	for _, src := range sources {
+		composePath := filepath.Join(src.Path, servicesSubdir, name, "compose.yml")
+		if _, err := os.Stat(composePath); err == nil {
+			return composePath, nil
+		} else if !os.IsNotExist(err) {
+			return "", fmt.Errorf("failed to access compose file: %w", err)
+		}
+	}
+	return "", fmt.Errorf("compose.yml not found for service '%s'", name)
 }
 
 // Search filters services by a query string, matching against name, tags, category,
-// and description (case-insensitive).
+// and description (case-insensitive). It searches across all configured sources.
 func Search(query string) ([]RegistryEntry, error) {
 	reg, err := LoadRegistry()
 	if err != nil {

--- a/internal/catalog/sources.go
+++ b/internal/catalog/sources.go
@@ -1,0 +1,350 @@
+// internal/catalog/sources.go
+//
+// Named catalog sources (#309). Out of the box the catalog has a single,
+// hardcoded official source (aceteam-ai/citadel-services). This file adds the
+// ability to register ADDITIONAL named sources -- community git repos laid out
+// like the official catalog (a top-level registry.yaml and services/<name>/
+// subdirs) -- so `catalog update/list/search/info/install` span every source.
+//
+// Persistence: the configured extra sources live in a small YAML file at
+// <config>/catalog-sources.yaml. Each extra source is cloned into its own
+// subdirectory under <config>/catalog-sources/<name>/. Both live OUTSIDE
+// GetCatalogPath() on purpose: Update() does an os.RemoveAll(GetCatalogPath())
+// when it re-clones the default catalog, so anything nested there would be
+// silently wiped.
+//
+// The default source is always present, is named "default", and cannot be
+// removed. Its cache stays at GetCatalogPath() so existing readers and the
+// services/<name>/ on-disk layout are unchanged (no migration needed).
+package catalog
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// DefaultSourceName is the reserved name of the built-in official source. It
+	// is always present and cannot be added or removed.
+	DefaultSourceName = "default"
+	// sourcesFileName is the YAML file (under the config dir) that persists the
+	// list of user-added catalog sources.
+	sourcesFileName = "catalog-sources.yaml"
+	// sourcesSubdir is the directory (under the config dir) that holds the cloned
+	// cache of each user-added source, one subdir per source name.
+	sourcesSubdir = "catalog-sources"
+)
+
+// CatalogSource is one configured catalog source: a unique name plus the git URL
+// to clone it from. The default source is implicit and not stored here.
+type CatalogSource struct {
+	Name string `yaml:"name"`
+	URL  string `yaml:"url"`
+}
+
+// sourcesFile is the on-disk shape of catalog-sources.yaml.
+type sourcesFile struct {
+	Version int             `yaml:"version"`
+	Sources []CatalogSource `yaml:"sources"`
+}
+
+// resolvedSource is an internal pairing of a source's identity with the local
+// cache directory its registry/manifests are read from. The default source's
+// Path is GetCatalogPath(); each added source's Path is its subdir.
+type resolvedSource struct {
+	Name    string
+	URL     string
+	Path    string
+	Default bool
+}
+
+// SourcesFilePath returns the path to the catalog-sources.yaml file.
+func SourcesFilePath() string {
+	return filepath.Join(platform.ConfigDir(), sourcesFileName)
+}
+
+// sourcesCacheDir returns the parent directory holding per-source clones.
+func sourcesCacheDir() string {
+	return filepath.Join(platform.ConfigDir(), sourcesSubdir)
+}
+
+// sourceCachePath returns the local clone directory for a named (non-default)
+// source. The name is sanitized again here as defense-in-depth even though
+// LoadSources rejects unsafe names on read.
+func sourceCachePath(name string) string {
+	return filepath.Join(sourcesCacheDir(), sanitizePathSegment(name))
+}
+
+// LoadSources reads the configured user-added sources from disk. A missing file
+// yields an empty list and a nil error (the default source is always implied).
+// Names/URLs are validated on read so a hand-edited file with an unsafe name can
+// never reach a git clone or filesystem path.
+func LoadSources() ([]CatalogSource, error) {
+	path := SourcesFilePath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read catalog sources %s: %w", path, err)
+	}
+	var sf sourcesFile
+	if err := yaml.Unmarshal(data, &sf); err != nil {
+		return nil, fmt.Errorf("failed to parse catalog sources %s: %w", path, err)
+	}
+	for _, s := range sf.Sources {
+		if err := ValidateSourceName(s.Name); err != nil {
+			return nil, fmt.Errorf("invalid source name in %s: %w", path, err)
+		}
+		if err := ValidateSourceURL(s.URL); err != nil {
+			return nil, fmt.Errorf("invalid source URL for %q in %s: %w", s.Name, path, err)
+		}
+	}
+	return sf.Sources, nil
+}
+
+// saveSources persists the given sources to catalog-sources.yaml.
+func saveSources(sources []CatalogSource) error {
+	path := SourcesFilePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+	data, err := yaml.Marshal(sourcesFile{Version: 1, Sources: sources})
+	if err != nil {
+		return fmt.Errorf("failed to marshal catalog sources: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("failed to write catalog sources %s: %w", path, err)
+	}
+	return nil
+}
+
+// ValidateSourceName checks that name is a safe, non-reserved catalog source
+// name. It must be non-empty, must not be the reserved default name, and must
+// survive path-segment sanitization unchanged (which rejects path traversal,
+// separators, and other unsafe characters since the name becomes a directory).
+func ValidateSourceName(name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("source name cannot be empty")
+	}
+	if name == DefaultSourceName {
+		return fmt.Errorf("%q is reserved for the built-in official source", DefaultSourceName)
+	}
+	if sanitizePathSegment(name) != name {
+		return fmt.Errorf("source name %q contains unsafe characters (use letters, digits, '-', '_', '.')", name)
+	}
+	return nil
+}
+
+// ValidateSourceURL checks that url is a plausible, safe git source. It reuses
+// ParseSource (the module-source parser) to accept full git URLs and the
+// owner/repo shorthand while rejecting empty/garbage input. A bare catalog name
+// (KindCatalog) is rejected: a catalog source must be a clonable repo.
+func ValidateSourceURL(url string) error {
+	url = strings.TrimSpace(url)
+	if url == "" {
+		return fmt.Errorf("source URL cannot be empty")
+	}
+	src, err := ParseSource(url)
+	if err != nil {
+		return err
+	}
+	if src.Kind == KindCatalog {
+		return fmt.Errorf("%q is not a git URL or owner/repo (a catalog source must be a git repository)", url)
+	}
+	return nil
+}
+
+// DefaultSourceNameFromURL derives a reasonable source name from a git URL or
+// owner/repo shorthand (the repository's base name, minus a trailing ".git" and
+// any ref suffix), sanitized for use as a directory. Returns "" if no usable
+// name can be derived. Used as the `add` default when --name is not supplied.
+func DefaultSourceNameFromURL(url string) string {
+	src, err := ParseSource(strings.TrimSpace(url))
+	if err != nil {
+		return ""
+	}
+	if src.Kind == KindGitHub && src.Repo != "" {
+		return sanitizePathSegment(src.Repo)
+	}
+	// Derive from the clone URL's last path segment.
+	clone := src.CloneURL
+	for _, scheme := range []string{"https://", "http://", "ssh://", "git://"} {
+		clone = strings.TrimPrefix(clone, scheme)
+	}
+	clone = strings.TrimSuffix(clone, ".git")
+	// scp-form "git@host:owner/repo" uses ':' before the path; normalize to '/'.
+	clone = strings.ReplaceAll(clone, ":", "/")
+	clone = strings.TrimRight(clone, "/")
+	if i := strings.LastIndex(clone, "/"); i >= 0 {
+		clone = clone[i+1:]
+	}
+	return sanitizePathSegment(clone)
+}
+
+// resolveSourceURL turns a user-provided source URL into the concrete git clone
+// URL, expanding the owner/repo shorthand. ValidateSourceURL must have passed.
+func resolveSourceURL(url string) (string, error) {
+	src, err := ParseSource(strings.TrimSpace(url))
+	if err != nil {
+		return "", err
+	}
+	return src.CloneURL, nil
+}
+
+// AddSource registers a new named catalog source. It validates the name and URL,
+// rejects the reserved default name, and rejects a duplicate name. It does not
+// clone the repo -- the next `catalog update` pulls all sources.
+func AddSource(name, url string) error {
+	name = strings.TrimSpace(name)
+	url = strings.TrimSpace(url)
+	if err := ValidateSourceName(name); err != nil {
+		return err
+	}
+	if err := ValidateSourceURL(url); err != nil {
+		return err
+	}
+	sources, err := LoadSources()
+	if err != nil {
+		return err
+	}
+	for _, s := range sources {
+		if s.Name == name {
+			return fmt.Errorf("a catalog source named %q already exists", name)
+		}
+	}
+	sources = append(sources, CatalogSource{Name: name, URL: url})
+	return saveSources(sources)
+}
+
+// RemoveSource unregisters a named catalog source and removes its local clone.
+// Removing the default source is an error.
+func RemoveSource(name string) error {
+	name = strings.TrimSpace(name)
+	if name == DefaultSourceName {
+		return fmt.Errorf("cannot remove the built-in %q catalog source", DefaultSourceName)
+	}
+	sources, err := LoadSources()
+	if err != nil {
+		return err
+	}
+	idx := -1
+	for i, s := range sources {
+		if s.Name == name {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return fmt.Errorf("no catalog source named %q", name)
+	}
+	sources = append(sources[:idx], sources[idx+1:]...)
+	if err := saveSources(sources); err != nil {
+		return err
+	}
+	// Best-effort: drop the cached clone so a later re-add starts fresh.
+	_ = os.RemoveAll(sourceCachePath(name))
+	return nil
+}
+
+// ListSources returns every configured source including the implicit default,
+// with the default first followed by user-added sources in registration order.
+func ListSources() ([]CatalogSource, error) {
+	added, err := LoadSources()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]CatalogSource, 0, len(added)+1)
+	out = append(out, CatalogSource{Name: DefaultSourceName, URL: DefaultCatalogURL})
+	out = append(out, added...)
+	return out, nil
+}
+
+// resolvedSources returns each source paired with the local cache path its
+// registry/manifests are read from, default first. It does not touch the
+// network; an absent clone is simply skipped by the readers.
+func resolvedSources() ([]resolvedSource, error) {
+	added, err := LoadSources()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]resolvedSource, 0, len(added)+1)
+	out = append(out, resolvedSource{
+		Name:    DefaultSourceName,
+		URL:     DefaultCatalogURL,
+		Path:    GetCatalogPath(),
+		Default: true,
+	})
+	for _, s := range added {
+		out = append(out, resolvedSource{
+			Name: s.Name,
+			URL:  s.URL,
+			Path: sourceCachePath(s.Name),
+		})
+	}
+	return out, nil
+}
+
+// SourceOf returns the name of the catalog source that owns service `name`,
+// following the same precedence the readers use (default first, then user-added
+// sources in registration order). It returns "" if the service is not found in
+// any cloned source. Used by the install path to decide a service's trust level:
+// only the built-in default source is first-party (Tier 0); community sources
+// are untrusted (Tier 2) and get the least-privilege sandbox + privilege gate.
+func SourceOf(name string) string {
+	sources, err := resolvedSources()
+	if err != nil {
+		return ""
+	}
+	for _, src := range sources {
+		manifestPath := filepath.Join(src.Path, servicesSubdir, name, "service.yaml")
+		if _, err := os.Stat(manifestPath); err == nil {
+			return src.Name
+		}
+	}
+	return ""
+}
+
+// IsDefaultSource reports whether sourceName is the built-in (trusted) default
+// source. An empty name is treated as the default for backward compatibility
+// (legacy single-source installs).
+func IsDefaultSource(sourceName string) bool {
+	return sourceName == "" || sourceName == DefaultSourceName
+}
+
+// sourceRegistry pairs a source name with the registry loaded from its cache.
+type sourceRegistry struct {
+	Source   string
+	Services []RegistryEntry
+}
+
+// mergeRegistries flattens per-source registries into a single list, deduping by
+// service name. Precedence on a name collision: the first source in the input
+// order wins (callers pass the default source first, then user-added sources in
+// registration order). Each returned entry has its Source field stamped with the
+// owning source's name. Pure -- table-tested, no IO.
+func mergeRegistries(regs []sourceRegistry) []RegistryEntry {
+	seen := make(map[string]bool)
+	var out []RegistryEntry
+	for _, sr := range regs {
+		for _, entry := range sr.Services {
+			if seen[entry.Name] {
+				continue
+			}
+			seen[entry.Name] = true
+			entry.Source = sr.Source
+			out = append(out, entry)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].Name < out[j].Name
+	})
+	return out
+}

--- a/internal/catalog/sources.go
+++ b/internal/catalog/sources.go
@@ -137,6 +137,13 @@ func ValidateSourceName(name string) error {
 	if name == DefaultSourceName {
 		return fmt.Errorf("%q is reserved for the built-in official source", DefaultSourceName)
 	}
+	// Reject dot-only names ("." / ".." / "...") explicitly: they survive
+	// sanitizePathSegment unchanged (all chars are allowed) but are path-relative
+	// specials. Used as a directory segment, ".." escapes the cache dir, so a
+	// later RemoveSource(name) -> os.RemoveAll could target a parent directory.
+	if strings.Trim(name, ".") == "" {
+		return fmt.Errorf("source name %q is not allowed", name)
+	}
 	if sanitizePathSegment(name) != name {
 		return fmt.Errorf("source name %q contains unsafe characters (use letters, digits, '-', '_', '.')", name)
 	}

--- a/internal/catalog/sources.go
+++ b/internal/catalog/sources.go
@@ -292,6 +292,61 @@ func resolvedSources() ([]resolvedSource, error) {
 	return out, nil
 }
 
+// ResolvedCatalogService is the atomic resolution of a catalog service name to a
+// single owning source: its manifest, compose path, and source name all come
+// from the SAME source. Resolving these together (rather than via three
+// independent cross-source searches) is a security invariant: the trust decision
+// (SourceName) must key the very compose that gets installed, so a community
+// source cannot shadow a default service's name to install its own compose under
+// the default's trusted privileges.
+type ResolvedCatalogService struct {
+	// Manifest is the parsed service.yaml from the owning source.
+	Manifest *ServiceManifest
+	// ComposePath is the compose.yml path in the owning source, or "" when the
+	// service is host-provisioned (no compose.yml) in that source.
+	ComposePath string
+	// SourceName is the owning source (drives the trust decision).
+	SourceName string
+}
+
+// ResolveCatalogService resolves a service name to a single owning source,
+// following the standard precedence (default first, then user-added sources in
+// registration order). The FIRST source that contains the service's service.yaml
+// wins; the manifest AND compose are read from that same source so trust and
+// compose can never come from different sources. A source whose service.yaml is
+// present but unparseable is a hard error (it is the winner -- we do not silently
+// fall through to a lower-precedence source, which would reintroduce the shadow).
+func ResolveCatalogService(name string) (*ResolvedCatalogService, error) {
+	sources, err := resolvedSources()
+	if err != nil {
+		return nil, err
+	}
+	for _, src := range sources {
+		manifestPath := filepath.Join(src.Path, servicesSubdir, name, "service.yaml")
+		if _, statErr := os.Stat(manifestPath); statErr != nil {
+			if os.IsNotExist(statErr) {
+				continue
+			}
+			return nil, fmt.Errorf("failed to access service manifest for '%s': %w", name, statErr)
+		}
+		manifest, mErr := loadManifestFromPath(src.Path, name)
+		if mErr != nil {
+			return nil, mErr
+		}
+		composePath := ""
+		cp := filepath.Join(src.Path, servicesSubdir, name, "compose.yml")
+		if _, cErr := os.Stat(cp); cErr == nil {
+			composePath = cp
+		}
+		return &ResolvedCatalogService{
+			Manifest:    manifest,
+			ComposePath: composePath,
+			SourceName:  src.Name,
+		}, nil
+	}
+	return nil, fmt.Errorf("service '%s' not found in catalog", name)
+}
+
 // SourceOf returns the name of the catalog source that owns service `name`,
 // following the same precedence the readers use (default first, then user-added
 // sources in registration order). It returns "" if the service is not found in

--- a/internal/catalog/sources_test.go
+++ b/internal/catalog/sources_test.go
@@ -1,0 +1,416 @@
+package catalog
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidateSourceName(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"simple", "community", false},
+		{"with-dash", "my-repo", false},
+		{"with-underscore-dot", "my_repo.v2", false},
+		{"empty", "", true},
+		{"reserved-default", DefaultSourceName, true},
+		{"path-traversal", "../evil", true},
+		{"slash", "a/b", true},
+		{"space", "has space", true},
+		{"semicolon", "a;b", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateSourceName(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateSourceName(%q) err = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateSourceURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"https", "https://github.com/foo/bar.git", false},
+		{"owner-repo", "foo/bar", false},
+		{"scp-form", "git@github.com:foo/bar.git", false},
+		{"empty", "", true},
+		{"bare-name", "justaname", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateSourceURL(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateSourceURL(%q) err = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDefaultSourceNameFromURL(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"https://github.com/foo/bar.git", "bar"},
+		{"foo/bar", "bar"},
+		{"foo/bar@v1.0.0", "bar"},
+		{"git@github.com:foo/baz.git", "baz"},
+		{"https://gitlab.com/group/sub/myrepo", "myrepo"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := DefaultSourceNameFromURL(tt.input); got != tt.want {
+				t.Errorf("DefaultSourceNameFromURL(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAddRemoveListSources(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	// Initially, only the implicit default source is present.
+	sources, err := ListSources()
+	if err != nil {
+		t.Fatalf("ListSources: %v", err)
+	}
+	if len(sources) != 1 || sources[0].Name != DefaultSourceName {
+		t.Fatalf("expected only the default source, got %+v", sources)
+	}
+
+	// Add a source.
+	if err := AddSource("community", "https://github.com/foo/bar.git"); err != nil {
+		t.Fatalf("AddSource: %v", err)
+	}
+
+	sources, err = ListSources()
+	if err != nil {
+		t.Fatalf("ListSources after add: %v", err)
+	}
+	if len(sources) != 2 {
+		t.Fatalf("expected 2 sources, got %d: %+v", len(sources), sources)
+	}
+	if sources[0].Name != DefaultSourceName {
+		t.Errorf("default source must be listed first, got %q", sources[0].Name)
+	}
+	if sources[1].Name != "community" {
+		t.Errorf("added source name = %q, want community", sources[1].Name)
+	}
+
+	// Persistence: a fresh LoadSources reads it back.
+	added, err := LoadSources()
+	if err != nil {
+		t.Fatalf("LoadSources: %v", err)
+	}
+	if len(added) != 1 || added[0].Name != "community" {
+		t.Errorf("LoadSources = %+v, want one 'community' entry", added)
+	}
+
+	// Duplicate name is rejected.
+	if err := AddSource("community", "https://github.com/other/repo.git"); err == nil {
+		t.Error("expected duplicate-name error, got nil")
+	}
+
+	// Adding the reserved default name is rejected.
+	if err := AddSource(DefaultSourceName, "https://github.com/x/y.git"); err == nil {
+		t.Error("expected reserved-name error, got nil")
+	}
+
+	// Invalid name / URL rejected.
+	if err := AddSource("../evil", "https://github.com/x/y.git"); err == nil {
+		t.Error("expected invalid-name error, got nil")
+	}
+	if err := AddSource("ok", "not-a-repo"); err == nil {
+		t.Error("expected invalid-url error, got nil")
+	}
+
+	// Removing the default is rejected.
+	if err := RemoveSource(DefaultSourceName); err == nil {
+		t.Error("expected error removing default source, got nil")
+	}
+
+	// Removing an unknown source is an error.
+	if err := RemoveSource("nope"); err == nil {
+		t.Error("expected error removing unknown source, got nil")
+	}
+
+	// Remove the real source.
+	if err := RemoveSource("community"); err != nil {
+		t.Fatalf("RemoveSource: %v", err)
+	}
+	sources, err = ListSources()
+	if err != nil {
+		t.Fatalf("ListSources after remove: %v", err)
+	}
+	if len(sources) != 1 {
+		t.Errorf("expected only default after remove, got %+v", sources)
+	}
+}
+
+func TestMergeRegistriesCollisionPrecedence(t *testing.T) {
+	regs := []sourceRegistry{
+		{
+			Source: DefaultSourceName,
+			Services: []RegistryEntry{
+				{Name: "vllm", Version: "1.0.0", Description: "official vllm"},
+				{Name: "shared", Version: "1.0.0", Description: "official shared"},
+			},
+		},
+		{
+			Source: "community",
+			Services: []RegistryEntry{
+				{Name: "shared", Version: "9.9.9", Description: "community shared (should lose)"},
+				{Name: "extra", Version: "2.0.0", Description: "community extra"},
+			},
+		},
+	}
+
+	merged := mergeRegistries(regs)
+
+	// Expect 3 unique services: vllm, shared, extra (sorted by name).
+	if len(merged) != 3 {
+		t.Fatalf("expected 3 merged services, got %d: %+v", len(merged), merged)
+	}
+
+	byName := make(map[string]RegistryEntry)
+	for _, e := range merged {
+		byName[e.Name] = e
+	}
+
+	// Collision: the default source wins.
+	shared, ok := byName["shared"]
+	if !ok {
+		t.Fatal("merged result missing 'shared'")
+	}
+	if shared.Source != DefaultSourceName {
+		t.Errorf("collision winner Source = %q, want %q", shared.Source, DefaultSourceName)
+	}
+	if shared.Version != "1.0.0" {
+		t.Errorf("collision winner Version = %q, want the default's 1.0.0", shared.Version)
+	}
+
+	// Non-colliding entries keep their owning source.
+	if byName["vllm"].Source != DefaultSourceName {
+		t.Errorf("vllm Source = %q, want default", byName["vllm"].Source)
+	}
+	if byName["extra"].Source != "community" {
+		t.Errorf("extra Source = %q, want community", byName["extra"].Source)
+	}
+
+	// Sorted by name.
+	if merged[0].Name != "extra" || merged[1].Name != "shared" || merged[2].Name != "vllm" {
+		t.Errorf("merged order = [%s %s %s], want [extra shared vllm]",
+			merged[0].Name, merged[1].Name, merged[2].Name)
+	}
+}
+
+func TestMergeRegistriesRegistrationOrder(t *testing.T) {
+	// Two community sources both define "dup"; the first-registered wins.
+	regs := []sourceRegistry{
+		{Source: "first", Services: []RegistryEntry{{Name: "dup", Version: "1"}}},
+		{Source: "second", Services: []RegistryEntry{{Name: "dup", Version: "2"}}},
+	}
+	merged := mergeRegistries(regs)
+	if len(merged) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(merged))
+	}
+	if merged[0].Source != "first" || merged[0].Version != "1" {
+		t.Errorf("got source=%q version=%q, want first/1", merged[0].Source, merged[0].Version)
+	}
+}
+
+// TestCrossSourceAggregationOnDisk seeds two source caches on disk (the default
+// at GetCatalogPath() and an added source at its subdir) and verifies that the
+// public readers aggregate across them with the documented collision precedence.
+func TestCrossSourceAggregationOnDisk(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	// Seed the default source: services "vllm" and "shared".
+	seedService(t, GetCatalogPath(), "vllm", "name: vllm\nversion: 1.0.0\ndescription: official vllm\ncategory: inference\n")
+	seedService(t, GetCatalogPath(), "shared", "name: shared\nversion: 1.0.0\ndescription: official shared\ncategory: misc\n")
+
+	// Register and seed a community source: services "shared" (collision) and "extra".
+	if err := AddSource("community", "https://github.com/foo/bar.git"); err != nil {
+		t.Fatalf("AddSource: %v", err)
+	}
+	communityPath := sourceCachePath("community")
+	seedService(t, communityPath, "shared", "name: shared\nversion: 9.9.9\ndescription: community shared\ncategory: misc\n")
+	seedService(t, communityPath, "extra", "name: extra\nversion: 2.0.0\ndescription: community extra\ncategory: tools\n")
+
+	reg, err := LoadRegistry()
+	if err != nil {
+		t.Fatalf("LoadRegistry: %v", err)
+	}
+	if len(reg.Services) != 3 {
+		t.Fatalf("expected 3 aggregated services, got %d: %+v", len(reg.Services), reg.Services)
+	}
+
+	byName := make(map[string]RegistryEntry)
+	for _, e := range reg.Services {
+		byName[e.Name] = e
+	}
+
+	// Collision precedence: default wins for "shared".
+	if byName["shared"].Source != DefaultSourceName {
+		t.Errorf("shared Source = %q, want default", byName["shared"].Source)
+	}
+
+	// "extra" came only from the community source.
+	if byName["extra"].Source != "community" {
+		t.Errorf("extra Source = %q, want community", byName["extra"].Source)
+	}
+
+	// LoadServiceManifest follows the same precedence (default's shared wins).
+	m, err := LoadServiceManifest("shared")
+	if err != nil {
+		t.Fatalf("LoadServiceManifest(shared): %v", err)
+	}
+	if m.Version != "1.0.0" {
+		t.Errorf("LoadServiceManifest(shared).Version = %q, want default's 1.0.0", m.Version)
+	}
+
+	// A service that exists only in the community source resolves from it.
+	if _, err := LoadServiceManifest("extra"); err != nil {
+		t.Errorf("LoadServiceManifest(extra): %v", err)
+	}
+
+	// GetComposeFile finds the community-only service's compose.
+	composePath, err := GetComposeFile("extra")
+	if err != nil {
+		t.Fatalf("GetComposeFile(extra): %v", err)
+	}
+	if filepath.Dir(filepath.Dir(filepath.Dir(composePath))) != communityPath {
+		t.Errorf("compose for extra not under community source path: %s", composePath)
+	}
+
+	// Search spans sources.
+	results, err := Search("community extra")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	found := false
+	for _, r := range results {
+		if r.Name == "extra" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("Search did not surface community-source service 'extra'")
+	}
+}
+
+func TestSourceOfAndTrust(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	seedService(t, GetCatalogPath(), "official-svc", "name: official-svc\nversion: 1.0.0\n")
+	if err := AddSource("community", "https://github.com/foo/bar.git"); err != nil {
+		t.Fatalf("AddSource: %v", err)
+	}
+	seedService(t, sourceCachePath("community"), "community-svc", "name: community-svc\nversion: 1.0.0\n")
+
+	if got := SourceOf("official-svc"); got != DefaultSourceName {
+		t.Errorf("SourceOf(official-svc) = %q, want %q", got, DefaultSourceName)
+	}
+	if got := SourceOf("community-svc"); got != "community" {
+		t.Errorf("SourceOf(community-svc) = %q, want community", got)
+	}
+	if got := SourceOf("does-not-exist"); got != "" {
+		t.Errorf("SourceOf(missing) = %q, want empty", got)
+	}
+
+	if !IsDefaultSource(SourceOf("official-svc")) {
+		t.Error("official-svc should be a default-source (trusted) service")
+	}
+	if IsDefaultSource(SourceOf("community-svc")) {
+		t.Error("community-svc should NOT be a default-source service")
+	}
+	// Empty == default for backward compatibility.
+	if !IsDefaultSource("") {
+		t.Error("empty source name should be treated as the default (trusted)")
+	}
+}
+
+// TestCommunityPrivilegedInstallRefused verifies that a community-source compose
+// requesting privileged access is refused when installed via the untrusted path
+// (allowPrivileged=false) -- the security routing this feature relies on.
+func TestCommunityPrivilegedInstallRefused(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	manifest := &ServiceManifest{Name: "evil", Version: "1.0.0"}
+	composeSrc := filepath.Join(t.TempDir(), "compose.yml")
+	if err := os.WriteFile(composeSrc, []byte("services:\n  evil:\n    image: evil:latest\n    privileged: true\n"), 0644); err != nil {
+		t.Fatalf("write compose: %v", err)
+	}
+	servicesDir := filepath.Join(t.TempDir(), "services")
+
+	// Untrusted install with allowPrivileged=false must refuse.
+	_, err := InstallFromManifest(manifest, composeSrc, servicesDir, nil, false, false, true)
+	if err == nil {
+		t.Fatal("expected refusal installing a privileged community compose, got nil")
+	}
+
+	// Same compose as a trusted (default) install is allowed (allowPrivileged=true).
+	if _, err := InstallFromManifest(manifest, composeSrc, servicesDir, nil, false, true, false); err != nil {
+		t.Errorf("trusted install of privileged compose should succeed, got %v", err)
+	}
+}
+
+// TestLoadRegistryResilientToBadSource verifies that one malformed community
+// source does not take down the whole catalog: the default source's services
+// still load.
+func TestLoadRegistryResilientToBadSource(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	seedService(t, GetCatalogPath(), "good-svc", "name: good-svc\nversion: 1.0.0\n")
+
+	if err := AddSource("broken", "https://github.com/foo/broken.git"); err != nil {
+		t.Fatalf("AddSource: %v", err)
+	}
+	// Seed the broken source dir with a malformed registry.yaml and no services dir.
+	brokenPath := sourceCachePath("broken")
+	if err := os.MkdirAll(brokenPath, 0755); err != nil {
+		t.Fatalf("mkdir broken: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(brokenPath, "registry.yaml"), []byte("::not yaml::\n  - bad"), 0644); err != nil {
+		t.Fatalf("write bad registry: %v", err)
+	}
+
+	reg, err := LoadRegistry()
+	if err != nil {
+		t.Fatalf("LoadRegistry should not hard-fail on a bad source: %v", err)
+	}
+	found := false
+	for _, e := range reg.Services {
+		if e.Name == "good-svc" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("default source's good-svc missing after a broken community source; got %+v", reg.Services)
+	}
+}
+
+// seedService writes a minimal service.yaml + compose.yml under
+// <catalogPath>/services/<name>/, mirroring the on-disk layout of a cloned source.
+func seedService(t *testing.T, catalogPath, name, manifest string) {
+	t.Helper()
+	svcDir := filepath.Join(catalogPath, servicesSubdir, name)
+	if err := os.MkdirAll(svcDir, 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", svcDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(svcDir, "service.yaml"), []byte(manifest), 0644); err != nil {
+		t.Fatalf("write service.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(svcDir, "compose.yml"), []byte("services: {}\n"), 0644); err != nil {
+		t.Fatalf("write compose.yml: %v", err)
+	}
+}

--- a/internal/catalog/sources_test.go
+++ b/internal/catalog/sources_test.go
@@ -21,6 +21,9 @@ func TestValidateSourceName(t *testing.T) {
 		{"slash", "a/b", true},
 		{"space", "has space", true},
 		{"semicolon", "a;b", true},
+		{"dot", ".", true},
+		{"dotdot", "..", true},
+		{"triple-dot", "...", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/catalog/sources_test.go
+++ b/internal/catalog/sources_test.go
@@ -339,6 +339,85 @@ func TestSourceOfAndTrust(t *testing.T) {
 	}
 }
 
+// TestResolveCatalogServiceAtomic verifies that manifest, compose, and source
+// are resolved from the SAME source, including the shadow scenario where the
+// default source has the name as host-provisioned (service.yaml, no compose) and
+// a community source defines the same name WITH a compose. The owning source for
+// trust purposes must be the default (first by precedence), and its compose must
+// be empty -- so the install path treats it as host-provisioned and never
+// installs the community compose under default privileges.
+func TestResolveCatalogServiceAtomic(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	// Default source: "wechat" host-provisioned (service.yaml only, no compose.yml).
+	hostProvDir := filepath.Join(GetCatalogPath(), servicesSubdir, "wechat")
+	if err := os.MkdirAll(hostProvDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(hostProvDir, "service.yaml"), []byte("name: wechat\nversion: 1.0.0\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Community source: "wechat" WITH a privileged compose (the attack).
+	if err := AddSource("evilcat", "https://github.com/evil/cat.git"); err != nil {
+		t.Fatalf("AddSource: %v", err)
+	}
+	evilDir := filepath.Join(sourceCachePath("evilcat"), servicesSubdir, "wechat")
+	if err := os.MkdirAll(evilDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(evilDir, "service.yaml"), []byte("name: wechat\nversion: 9.9.9\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(evilDir, "compose.yml"), []byte("services:\n  wechat:\n    privileged: true\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	resolved, err := ResolveCatalogService("wechat")
+	if err != nil {
+		t.Fatalf("ResolveCatalogService: %v", err)
+	}
+	// Owning source must be the default (precedence), NOT the community source.
+	if resolved.SourceName != DefaultSourceName {
+		t.Errorf("resolved source = %q, want %q (default wins, no shadow)", resolved.SourceName, DefaultSourceName)
+	}
+	// Compose must come from the SAME (default) source, which has none -> empty,
+	// so the install path treats it as host-provisioned (not the evil compose).
+	if resolved.ComposePath != "" {
+		t.Errorf("resolved compose = %q, want empty (default has no compose for wechat)", resolved.ComposePath)
+	}
+	if resolved.Manifest.Version != "1.0.0" {
+		t.Errorf("resolved manifest version = %q, want default's 1.0.0", resolved.Manifest.Version)
+	}
+}
+
+// TestResolveCatalogServiceCommunityRoutesUntrusted verifies that a service
+// existing ONLY in a community source resolves to that source (so the install
+// path routes it as untrusted).
+func TestResolveCatalogServiceCommunityRoutesUntrusted(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	seedService(t, GetCatalogPath(), "official-only", "name: official-only\nversion: 1.0.0\n")
+	if err := AddSource("community", "https://github.com/foo/bar.git"); err != nil {
+		t.Fatalf("AddSource: %v", err)
+	}
+	seedService(t, sourceCachePath("community"), "community-only", "name: community-only\nversion: 2.0.0\n")
+
+	resolved, err := ResolveCatalogService("community-only")
+	if err != nil {
+		t.Fatalf("ResolveCatalogService: %v", err)
+	}
+	if resolved.SourceName != "community" {
+		t.Errorf("resolved source = %q, want community", resolved.SourceName)
+	}
+	if IsDefaultSource(resolved.SourceName) {
+		t.Error("community-only must NOT route as trusted")
+	}
+	if resolved.ComposePath == "" {
+		t.Error("expected a compose path for the community service")
+	}
+}
+
 // TestCommunityPrivilegedInstallRefused verifies that a community-source compose
 // requesting privileged access is refused when installed via the untrusted path
 // (allowPrivileged=false) -- the security routing this feature relies on.


### PR DESCRIPTION
## Context

Closes #309.

Until now the catalog had exactly one source: a hardcoded `DefaultCatalogURL`
(`aceteam-ai/citadel-services`). A node could only ever browse/install from that
one official repo — there was no way to point it at a community or org-internal
catalog. This implements **Option 1** from the issue: multiple **named catalog
sources** that `update`/`list`/`search`/`info`/`install` all span, while keeping
the official repo as the always-present built-in default.

```
$ citadel service catalog add aceteam-ai/community-services --name community
Added catalog source 'community' (aceteam-ai/community-services).
Run 'citadel service catalog update' to fetch it.

$ citadel service catalog list-sources
NAME       TYPE       URL
default    default    https://github.com/aceteam-ai/citadel-services.git
community  community  aceteam-ai/community-services

$ citadel service catalog list
SERVICE  VERSION  CATEGORY   GPU       SOURCE     STATUS     DESCRIPTION
vllm     1.0.0    inference  required  default    available  ...
foo      2.0.0    tools      no        community  available  ...
```

## Summary

**Source management (`cmd/catalog.go`)**
- `catalog add <git-url> [--name foo]` — register a community source. `--name`
  defaults to the repo name. Accepts full git URLs and the `owner/repo` shorthand.
- `catalog remove <name>` — unregister and drop the local clone.
- `catalog list-sources` — list configured sources (default first).
- `--allow-privileged` flag on `catalog install` (see Security).

**Aggregation (`internal/catalog/catalog.go`, `sources.go`)**
- Sources persist in `<config>/catalog-sources.yaml`; each is cloned to
  `<config>/catalog-sources/<name>/`. Both live **outside** `GetCatalogPath()` on
  purpose: `Update()` does `os.RemoveAll(GetCatalogPath())` on a default re-clone,
  so nesting persistent state there would silently wipe configured sources.
- The default source keeps its cache at `GetCatalogPath()` — zero migration, the
  existing `services/<name>/` on-disk layout and all existing readers are unchanged.
- `Update()` pulls **every** source; one broken community repo never blocks the
  rest (first error returned after all are tried).
- `LoadRegistry`/`LoadServiceManifest`/`GetComposeFile`/`Search` aggregate across
  all sources. A malformed source is skipped + warned, never taking down the
  catalog (incl. the default). Each registry entry carries a `Source` field and a
  new SOURCE column surfaces in `list`/`search`/`info`.
- **Collision precedence:** default source wins, then user-added sources in
  registration order. `mergeRegistries` is a pure, table-tested function.

**Security — community installs are untrusted (Tier 2)**
- The default source is first-party (Tier 0) and installs as-is. A community
  source's service installs through the same untrusted path as
  `module install <git-url>`: least-privilege sandbox + an un-bypassable
  privilege gate (override with `--allow-privileged`).
- `ResolveCatalogService(name)` resolves manifest + compose + owning source from
  a **single** source atomically. This closes a name-shadow escalation: without
  it, a community source defining the same name as a default host-provisioned
  service (e.g. `wechat`) could get its compose installed under the default's
  trusted privileges.
- `--name` and the git URL become directory / `git clone` targets, so both are
  validated (reuse `ParseSource` + `sanitizePathSegment`): no path traversal, no
  dot-only names that could escape the cache dir, no cloning a bare catalog name.
  The reserved `default` name cannot be added or removed.

## Test plan

| Group | Coverage |
| --- | --- |
| Name validation | simple/dash/underscore/dot names accepted; empty, reserved `default`, traversal (`../evil`), slash, space, semicolon, and dot-only (`.`/`..`/`...`) rejected |
| URL validation | https / owner-repo / scp-form accepted; empty + bare-name rejected |
| Name derivation | `DefaultSourceNameFromURL` over https/owner-repo/`@ref`/scp/nested/empty |
| Add/remove/list | add+persist+readback, default-first ordering, reject dup name, reject reserved name, reject bad name/url, reject removing default, reject removing unknown |
| Merge precedence | default-wins on collision + registration-order tiebreak (pure) |
| On-disk aggregation | two seeded source caches; collision winner, cross-source manifest/compose/search |
| Atomic resolution | name-shadow scenario (default host-provisioned + community-with-compose) resolves to default/empty compose; community-only routes untrusted |
| Trust routing | `SourceOf` / `IsDefaultSource` |
| Install gate | community privileged compose refused (untrusted); same compose allowed when trusted |
| Resilience | malformed community `registry.yaml` → default's services still load |

`go build ./...`, `go vet ./...`, `gofmt -l`, and `go test ./...` all green.

## Related

- Closes #309.
- Reuses the module-source parser/validation from `internal/catalog/source.go`
  (the `module install <git-url>` path) and mirrors its Tier-0/Tier-2 trust model.
- Distinct from the curated module index (#347, `internal/catalog/index.go`),
  which is a name→source index for the `module` command.
