### PR TITLE
feat(module): trust-tiered runtime sandboxing (podman-rootless preferred) (#348)

### DIFF
--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -360,7 +360,10 @@ func runCatalogInstall(cmd *cobra.Command, args []string) error {
 	// any privileged/root-equivalent compose directive.
 	allowPrivileged := !untrusted || catalogInstallAllowPrivileged
 
-	result, err := catalog.InstallFromManifest(resolved.Manifest, resolved.ComposePath, servicesDir, overrides, true, allowPrivileged, untrusted)
+	// skipHardening is always false here: the catalog-install path has no
+	// --no-harden escape hatch, so untrusted community installs are always
+	// hardened (the safe default for the primary untrusted surface).
+	result, err := catalog.InstallFromManifest(resolved.Manifest, resolved.ComposePath, servicesDir, overrides, true, allowPrivileged, untrusted, false)
 	if err != nil {
 		// Defense-in-depth: the up-front IsInstallable check above already
 		// diverts host-provisioned services, but InstallFromManifest also guards.

--- a/cmd/module.go
+++ b/cmd/module.go
@@ -38,6 +38,7 @@ var (
 	moduleInstallConfigFlags []string
 	moduleInstallYes         bool
 	moduleAllowPrivileged    bool
+	moduleNoHarden           bool
 )
 
 var moduleCmd = &cobra.Command{
@@ -94,6 +95,8 @@ func init() {
 		"Skip the ordinary confirmation prompt (does NOT bypass the privileged-compose gate).")
 	moduleInstallCmd.Flags().BoolVar(&moduleAllowPrivileged, "allow-privileged", false,
 		"Allow installing a module whose compose requests privileged/root-equivalent access (required when Critical risks are present).")
+	moduleInstallCmd.Flags().BoolVar(&moduleNoHarden, "no-harden", false,
+		"Skip generating the least-privilege sandbox override for an untrusted module (bind-mount confinement still applies). Use only if the hardening defaults break the module.")
 }
 
 // parseSetFlags converts repeated --set KEY=VALUE flags into an overrides map.
@@ -202,14 +205,20 @@ func runModuleInstall(cmd *cobra.Command, args []string) error {
 
 	// Untrusted (Tier-2) sources get the least-privilege sandbox: bind-mount
 	// confinement + a generated hardening override. Trusted (Tier 0/1) run as-is.
+	// --no-harden opts out of the override (not the bind-mount confinement).
 	untrusted := !trusted
 	if untrusted {
-		fmt.Printf("\n%s\n", color.YellowString("Applying least-privilege sandbox (drop caps, no-new-privileges, "+
-			"read-only rootfs, resource limits)."))
+		if moduleNoHarden {
+			fmt.Printf("\n%s\n", color.YellowString("--no-harden: skipping the least-privilege sandbox override "+
+				"(bind-mount confinement still applies). GPU/inference services are exempt regardless."))
+		} else {
+			fmt.Printf("\n%s\n", color.YellowString("Applying least-privilege sandbox (drop caps, no-new-privileges, "+
+				"read-only rootfs, resource limits). GPU/inference services are exempt."))
+		}
 	}
 
 	fmt.Printf("\nInstalling %s ...\n", manifest.Name)
-	result, err := catalog.InstallFromManifest(manifest, resolved.ComposePath, servicesDir, overrides, true, moduleAllowPrivileged, untrusted)
+	result, err := catalog.InstallFromManifest(manifest, resolved.ComposePath, servicesDir, overrides, true, moduleAllowPrivileged, untrusted, moduleNoHarden)
 	if err != nil {
 		return fmt.Errorf("install failed: %w", err)
 	}
@@ -702,7 +711,7 @@ func buildModuleInstallCallbacks() controlcenter.ModuleInstallCallbacks {
 			// Untrusted (Tier-2) sources get the least-privilege sandbox in the
 			// shared core, matching the CLI path. Catalog/trusted run as-is.
 			untrusted := !catalog.IsTrusted(src)
-			result, err := catalog.InstallFromManifest(manifest, composeSrc, servicesDir, overrides, false, allow, untrusted)
+			result, err := catalog.InstallFromManifest(manifest, composeSrc, servicesDir, overrides, false, allow, untrusted, false)
 			if err != nil {
 				return "", err
 			}

--- a/cmd/module_update.go
+++ b/cmd/module_update.go
@@ -166,7 +166,7 @@ func updateOne(entry catalog.LockEntry, src catalog.Source, servicesDir string) 
 	// Preserve the recorded sandbox posture across an update: if the module was
 	// installed as untrusted/sandboxed, regenerate its hardening override from the
 	// (possibly changed) new compose so the override never goes stale.
-	res, err := catalog.InstallFromManifest(resolved.Manifest, resolved.ComposePath, servicesDir, nil, false, false, entry.Sandboxed)
+	res, err := catalog.InstallFromManifest(resolved.Manifest, resolved.ComposePath, servicesDir, nil, false, false, entry.Sandboxed, false)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "  re-install failed for %s: %v\n", entry.Name, err)
 		return false
@@ -219,7 +219,7 @@ func rollback(prev catalog.LockEntry, servicesDir string) {
 		fmt.Fprintf(os.Stderr, "  rollback failed to re-resolve previous version: %v\n", err)
 		return
 	}
-	if _, err := catalog.InstallFromManifest(resolved.Manifest, resolved.ComposePath, servicesDir, nil, false, true, prev.Sandboxed); err != nil {
+	if _, err := catalog.InstallFromManifest(resolved.Manifest, resolved.ComposePath, servicesDir, nil, false, true, prev.Sandboxed, false); err != nil {
 		fmt.Fprintf(os.Stderr, "  rollback re-install failed: %v\n", err)
 		return
 	}

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -70,8 +70,17 @@ func startService(serviceName, composeFilePath string) error {
 
 	containerName := "citadel-" + serviceName
 
+	// Resolve the container runtime once (podman rootless preferred over docker;
+	// see catalog.SelectContainerRuntime) and drive every sub-command below
+	// through it, so module containers run under the hardened runtime when
+	// available and fall back to docker otherwise (#348). Engine sub-commands
+	// (inspect/rm) use rt.EngineBin (never the podman-compose wrapper); the
+	// compose-up below uses rt.Bin + rt.ComposePrefix.
+	rt := catalog.SelectContainerRuntime()
+	fmt.Printf("   Container runtime: %s\n", rt.Label())
+
 	// Check if container already exists and its state
-	inspectCmd := exec.Command("docker", "inspect", "--format", "{{.State.Status}}", containerName)
+	inspectCmd := exec.Command(rt.EngineBin, "inspect", "--format", "{{.State.Status}}", containerName)
 	output, err := inspectCmd.Output()
 
 	if err == nil {
@@ -87,7 +96,7 @@ func startService(serviceName, composeFilePath string) error {
 		if forceRecreate {
 			// Force mode: remove the old container and recreate
 			fmt.Printf("   ♻️  Removing stale container %s...\n", containerName)
-			rmCmd := exec.Command("docker", "rm", "-f", containerName)
+			rmCmd := exec.Command(rt.EngineBin, "rm", "-f", containerName)
 			rmCmd.Run() // Ignore errors - container might already be gone
 		} else {
 			// Interactive mode: prompt user
@@ -103,7 +112,7 @@ func startService(serviceName, composeFilePath string) error {
 
 			// Remove the old container before recreating
 			fmt.Printf("   ♻️  Removing stale container %s...\n", containerName)
-			rmCmd := exec.Command("docker", "rm", "-f", containerName)
+			rmCmd := exec.Command(rt.EngineBin, "rm", "-f", containerName)
 			rmCmd.Run() // Ignore errors
 		}
 	}
@@ -133,13 +142,13 @@ func startService(serviceName, composeFilePath string) error {
 	// modules). A no-op for every existing (non-sandboxed) service. The sibling is
 	// derived from the ORIGINAL compose path, not actualComposePath -- on non-Linux
 	// the latter may be a GPU-stripped temp file in a different directory.
-	args := []string{"compose"}
-	args = append(args, composeFileArgs(composeFilePath, actualComposePath)...)
-	args = append(args, "up", "-d")
-	composeCmd := exec.Command("docker", args...)
+	composeArgs := composeFileArgs(composeFilePath, actualComposePath)
+	composeArgs = append(composeArgs, "up", "-d")
+	args := rt.ComposeArgs(composeArgs...)
+	composeCmd := exec.Command(rt.Bin, args...)
 	output, err = composeCmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("docker compose failed: %s", string(output))
+		return fmt.Errorf("%s compose failed: %s", rt.Bin, string(output))
 	}
 	return nil
 }

--- a/internal/catalog/gpu_compose.go
+++ b/internal/catalog/gpu_compose.go
@@ -1,0 +1,98 @@
+package catalog
+
+import (
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// serviceRequestsGPU reports whether a single compose service (decoded into a
+// generic map) requests a GPU. This is the authoritative per-service signal that
+// drives the #348 GPU exemption: a GPU/inference service (vLLM, TEI, ...) must
+// NOT receive the read-only / cap-drop / resource-limit hardening, because those
+// defaults break it (the 2g memory default alone OOMs an inference container).
+//
+// Detection is fail-safe in the security direction: only a POSITIVE GPU signal
+// exempts a service. An ambiguous service is treated as non-GPU and hardened.
+//
+// Signals, any of which mark the service as GPU:
+//   - deploy.resources.reservations.devices contains an NVIDIA driver entry or a
+//     "gpu" capability (the canonical Compose GPU reservation, mirrors
+//     compose.StripGPUDevices' navigation).
+//   - a top-level `gpus:` shorthand (e.g. `gpus: all`).
+//   - `runtime: nvidia` (legacy nvidia-docker runtime selection).
+func serviceRequestsGPU(svc map[string]any) bool {
+	if svc == nil {
+		return false
+	}
+
+	// `gpus:` shorthand (string or list form -- presence is enough).
+	if _, ok := svc["gpus"]; ok {
+		return true
+	}
+
+	// `runtime: nvidia`.
+	if rt, ok := svc["runtime"].(string); ok && strings.EqualFold(strings.TrimSpace(rt), "nvidia") {
+		return true
+	}
+
+	// deploy.resources.reservations.devices[*] (driver: nvidia or capabilities: [gpu]).
+	return deployReservesGPU(svc)
+}
+
+// deployReservesGPU walks deploy.resources.reservations.devices looking for a GPU
+// device entry. The navigation mirrors compose.StripGPUDevices so the two stay
+// in lock-step on what counts as a GPU reservation.
+func deployReservesGPU(svc map[string]any) bool {
+	deploy, ok := svc["deploy"].(map[string]any)
+	if !ok {
+		return false
+	}
+	resources, ok := deploy["resources"].(map[string]any)
+	if !ok {
+		return false
+	}
+	reservations, ok := resources["reservations"].(map[string]any)
+	if !ok {
+		return false
+	}
+	devices, ok := reservations["devices"].([]any)
+	if !ok {
+		return false
+	}
+	for _, d := range devices {
+		dev, ok := d.(map[string]any)
+		if !ok {
+			continue
+		}
+		if drv, ok := dev["driver"].(string); ok && strings.EqualFold(strings.TrimSpace(drv), "nvidia") {
+			return true
+		}
+		if caps, ok := dev["capabilities"].([]any); ok {
+			for _, c := range caps {
+				if s, ok := c.(string); ok && strings.EqualFold(strings.TrimSpace(s), "gpu") {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// decodeComposeServices decodes a compose document into a per-service generic
+// map keyed by service name, preserving each service body so callers can inspect
+// already-set keys (for inject-only-where-absent) and GPU signals. A document
+// with no services yields an empty map and a nil error; malformed YAML returns
+// the unmarshal error.
+func decodeComposeServices(composeYAML string) (map[string]map[string]any, error) {
+	var doc struct {
+		Services map[string]map[string]any `yaml:"services"`
+	}
+	if err := yaml.Unmarshal([]byte(composeYAML), &doc); err != nil {
+		return nil, err
+	}
+	if doc.Services == nil {
+		return map[string]map[string]any{}, nil
+	}
+	return doc.Services, nil
+}

--- a/internal/catalog/gpu_compose_test.go
+++ b/internal/catalog/gpu_compose_test.go
@@ -1,0 +1,129 @@
+package catalog
+
+import "testing"
+
+func TestServiceRequestsGPU(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want bool
+	}{
+		{
+			name: "no gpu signal",
+			yaml: "services:\n  svc:\n    image: nginx:latest\n",
+			want: false,
+		},
+		{
+			name: "gpus shorthand all",
+			yaml: "services:\n  svc:\n    image: x\n    gpus: all\n",
+			want: true,
+		},
+		{
+			name: "runtime nvidia",
+			yaml: "services:\n  svc:\n    image: x\n    runtime: nvidia\n",
+			want: true,
+		},
+		{
+			name: "runtime nvidia case-insensitive",
+			yaml: "services:\n  svc:\n    image: x\n    runtime: NVIDIA\n",
+			want: true,
+		},
+		{
+			name: "runtime non-nvidia is not gpu",
+			yaml: "services:\n  svc:\n    image: x\n    runtime: runc\n",
+			want: false,
+		},
+		{
+			name: "deploy reservation driver nvidia",
+			yaml: `services:
+  svc:
+    image: x
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+`,
+			want: true,
+		},
+		{
+			name: "deploy reservation gpu capability without driver",
+			yaml: `services:
+  svc:
+    image: x
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: [gpu]
+`,
+			want: true,
+		},
+		{
+			name: "deploy without gpu device is not gpu",
+			yaml: `services:
+  svc:
+    image: x
+    deploy:
+      replicas: 3
+      resources:
+        reservations:
+          cpus: "2"
+`,
+			want: false,
+		},
+		{
+			name: "deploy reservation non-gpu device is not gpu",
+			yaml: `services:
+  svc:
+    image: x
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: foo
+              capabilities: [tpu]
+`,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svcs, err := decodeComposeServices(tt.yaml)
+			if err != nil {
+				t.Fatalf("decode error: %v", err)
+			}
+			svc, ok := svcs["svc"]
+			if !ok {
+				t.Fatalf("test compose missing service 'svc'")
+			}
+			if got := serviceRequestsGPU(svc); got != tt.want {
+				t.Errorf("serviceRequestsGPU = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestServiceRequestsGPU_NilSafe(t *testing.T) {
+	if serviceRequestsGPU(nil) {
+		t.Error("nil service must not be reported as GPU")
+	}
+}
+
+func TestDecodeComposeServices(t *testing.T) {
+	// No services section -> empty map, no error.
+	svcs, err := decodeComposeServices("name: not-a-compose\n")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(svcs) != 0 {
+		t.Errorf("expected empty services, got %v", svcs)
+	}
+
+	// Malformed YAML -> error.
+	if _, err := decodeComposeServices("services:\n  - a\n  b"); err == nil {
+		t.Error("expected an error for malformed YAML")
+	}
+}

--- a/internal/catalog/install.go
+++ b/internal/catalog/install.go
@@ -70,7 +70,7 @@ func Install(name string, servicesDir string, configOverrides map[string]string)
 	// un-overridable failure). Pass allowPrivileged=true. They are trusted, so
 	// untrusted=false: no sandbox hardening is applied. The module-source path
 	// passes the real flag + trust values.
-	return InstallFromManifest(manifest, composeSrc, servicesDir, configOverrides, true, true, false)
+	return InstallFromManifest(manifest, composeSrc, servicesDir, configOverrides, true, true, false, false)
 }
 
 // InstallFromManifest installs a service from an already-loaded manifest and a
@@ -99,9 +99,16 @@ func Install(name string, servicesDir string, configOverrides map[string]string)
 //
 // Trusted (Tier 0/1) installs pass untrusted=false and are unaffected.
 //
+// skipHardening is the explicit --no-harden opt-out. When true, the hardening
+// override is NOT generated even for an untrusted install -- but bind-mount
+// confinement still applies. This keeps the two containment layers independent:
+// opting out of the override does not silently disable bind-mount confinement
+// (the operator must use --allow-privileged for that). skipHardening is ignored
+// for trusted installs (which never generate an override anyway).
+//
 // An empty composeSrcPath means the service is host-provisioned (no container)
 // and InstallFromManifest returns ErrNotInstallable.
-func InstallFromManifest(manifest *ServiceManifest, composeSrcPath, servicesDir string, configOverrides map[string]string, interactive, allowPrivileged, untrusted bool) (*InstallResult, error) {
+func InstallFromManifest(manifest *ServiceManifest, composeSrcPath, servicesDir string, configOverrides map[string]string, interactive, allowPrivileged, untrusted, skipHardening bool) (*InstallResult, error) {
 	name := manifest.Name
 
 	// 1. Reject host-provisioned services up front (no compose.yml).
@@ -217,12 +224,14 @@ func InstallFromManifest(manifest *ServiceManifest, composeSrcPath, servicesDir 
 		ComposeDestPath: composeDest,
 	}
 
-	// 6b. Least-privilege sandbox (untrusted/Tier-2 only). Generate a hardening
-	// override from the manifest's declared needs and write it next to the
-	// compose as <name>.sandbox.yml; the run path includes it automatically when
-	// present. Also create the per-module sandbox data dir so the one allowed
-	// bind-mount root exists. Trusted (Tier 0/1) installs skip all of this.
-	if untrusted {
+	// 6b. Least-privilege sandbox (untrusted/Tier-2 only, unless --no-harden).
+	// Generate a hardening override from the manifest's declared needs and write
+	// it next to the compose as <name>.sandbox.yml; the run path includes it
+	// automatically when present. Also create the per-module sandbox data dir so
+	// the one allowed bind-mount root exists. Trusted (Tier 0/1) installs skip all
+	// of this; skipHardening opts an untrusted install out of the override only
+	// (bind-mount confinement above still ran).
+	if untrusted && !skipHardening {
 		baseData, rerr := os.ReadFile(composeDest)
 		if rerr != nil {
 			return nil, fmt.Errorf("failed to read copied compose for sandbox hardening: %w", rerr)

--- a/internal/catalog/risk_test.go
+++ b/internal/catalog/risk_test.go
@@ -189,13 +189,13 @@ func TestInstallFromManifest_PrivilegedGate(t *testing.T) {
 	servicesDir := filepath.Join(dir, "services")
 
 	// allowPrivileged=false must REFUSE even though interactive=false.
-	if _, err := InstallFromManifest(manifest, composePath, servicesDir, nil, false, false, false); err == nil {
+	if _, err := InstallFromManifest(manifest, composePath, servicesDir, nil, false, false, false, false); err == nil {
 		t.Fatal("expected refusal for Critical compose without allowPrivileged")
 	}
 
 	// allowPrivileged=true proceeds past the gate (install succeeds: no ports,
 	// no required config, compose copied).
-	res, err := InstallFromManifest(manifest, composePath, servicesDir, nil, false, true, false)
+	res, err := InstallFromManifest(manifest, composePath, servicesDir, nil, false, true, false, false)
 	if err != nil {
 		t.Fatalf("expected install to proceed with allowPrivileged=true, got %v", err)
 	}
@@ -213,7 +213,7 @@ func TestInstallFromManifest_CleanComposeNoGate(t *testing.T) {
 	manifest := &ServiceManifest{Name: "clean"}
 	servicesDir := filepath.Join(dir, "services")
 	// A clean compose installs fine even with allowPrivileged=false.
-	if _, err := InstallFromManifest(manifest, composePath, servicesDir, nil, false, false, false); err != nil {
+	if _, err := InstallFromManifest(manifest, composePath, servicesDir, nil, false, false, false, false); err != nil {
 		t.Fatalf("clean compose should not be gated, got %v", err)
 	}
 }

--- a/internal/catalog/runtime.go
+++ b/internal/catalog/runtime.go
@@ -1,0 +1,131 @@
+package catalog
+
+import "os/exec"
+
+// ContainerRuntime describes the container runtime (and its compose front-end)
+// that Citadel should drive for module containers. Module containment (#348)
+// prefers podman rootless over docker where available: podman is largely
+// CLI-compatible with docker, but its compose front-end differs (the `podman
+// compose` subcommand vs the separate `podman-compose` binary vs docker's
+// `docker compose`). Callers therefore must not hardcode the binary or the
+// compose prefix; they resolve a ContainerRuntime once and build commands from
+// it.
+type ContainerRuntime struct {
+	// EngineBin is the engine CLI binary (always "docker" or "podman") used for
+	// plain engine sub-commands such as `inspect`, `rm`, `ps`. It is NEVER
+	// "podman-compose": that wrapper is a compose front-end, not an engine CLI,
+	// and does not accept `inspect`/`rm`. Use EngineBin for engine sub-commands
+	// and Bin (+ComposePrefix) for compose invocations.
+	EngineBin string
+	// Bin is the binary to exec for a COMPOSE invocation (e.g. "docker",
+	// "podman", or "podman-compose"). Combined with ComposePrefix it forms the
+	// compose command.
+	Bin string
+	// ComposePrefix is the argument prefix that selects the compose front-end for
+	// Bin. For docker / podman-with-subcommand it is ["compose"]; for the separate
+	// `podman-compose` binary it is empty (Bin is "podman-compose").
+	ComposePrefix []string
+	// Rootless reports whether this runtime runs rootless by default (podman).
+	// Informational: callers may surface it; it does not change argument
+	// construction.
+	Rootless bool
+}
+
+// Label returns a short human-readable description of the selected runtime for
+// operator-facing logging (e.g. "podman (rootless)" or "docker").
+func (rt ContainerRuntime) Label() string {
+	name := rt.EngineBin
+	if name == "" {
+		name = rt.Bin
+	}
+	if rt.Rootless {
+		return name + " (rootless)"
+	}
+	return name
+}
+
+// ComposeArgs returns the full argument list for a compose invocation on this
+// runtime: the compose prefix followed by the caller's compose args. The binary
+// to exec is rt.Bin.
+func (rt ContainerRuntime) ComposeArgs(args ...string) []string {
+	out := make([]string, 0, len(rt.ComposePrefix)+len(args))
+	out = append(out, rt.ComposePrefix...)
+	return append(out, args...)
+}
+
+// runtimeProbes are the host probes the runtime selector depends on. They are an
+// injectable seam so selectContainerRuntime is unit-testable without podman or
+// docker installed.
+type runtimeProbes struct {
+	// lookPath reports whether a binary is resolvable on PATH (mirrors
+	// exec.LookPath, returning only the boolean we need).
+	lookPath func(bin string) bool
+	// podmanComposeSubcmd reports whether `podman compose` (the built-in compose
+	// subcommand) is usable, distinct from the separate `podman-compose` binary.
+	podmanComposeSubcmd func() bool
+}
+
+// defaultRuntimeProbes wires the probes to the real host.
+func defaultRuntimeProbes() runtimeProbes {
+	return runtimeProbes{
+		lookPath: func(bin string) bool {
+			_, err := exec.LookPath(bin)
+			return err == nil
+		},
+		podmanComposeSubcmd: hostPodmanComposeSubcmd,
+	}
+}
+
+// hostPodmanComposeSubcmd reports whether `podman compose version` succeeds,
+// i.e. the built-in compose subcommand is wired up on this host. A failure (or
+// no podman) returns false so the caller falls back to the `podman-compose`
+// binary.
+func hostPodmanComposeSubcmd() bool {
+	if _, err := exec.LookPath("podman"); err != nil {
+		return false
+	}
+	// `podman compose version` is a cheap, side-effect-free probe of the compose
+	// provider. It exits non-zero when no provider is configured.
+	return exec.Command("podman", "compose", "version").Run() == nil
+}
+
+// SelectContainerRuntime resolves the container runtime to drive module
+// containers, preferring rootless podman over docker (#348). It uses the real
+// host probes.
+func SelectContainerRuntime() ContainerRuntime {
+	return selectContainerRuntime(defaultRuntimeProbes())
+}
+
+// selectContainerRuntime is the pure core (probes injected) so the selection
+// policy is table-testable without podman/docker installed.
+//
+// Policy, in order:
+//  1. podman present + `podman compose` subcommand usable -> podman with the
+//     "compose" prefix (rootless).
+//  2. podman present + `podman-compose` binary present     -> podman-compose
+//     (rootless), empty compose prefix.
+//  3. podman present, no compose front-end                 -> docker (podman
+//     alone cannot run a compose file; fall back rather than fail).
+//  4. podman absent                                        -> docker.
+//
+// When neither runtime is present we still return docker: the existing start
+// path already surfaces a clear docker-not-found error, and returning a concrete
+// runtime keeps callers simple. Selection never fails.
+func selectContainerRuntime(p runtimeProbes) ContainerRuntime {
+	docker := ContainerRuntime{EngineBin: "docker", Bin: "docker", ComposePrefix: []string{"compose"}}
+
+	if !p.lookPath("podman") {
+		return docker
+	}
+	if p.podmanComposeSubcmd() {
+		return ContainerRuntime{EngineBin: "podman", Bin: "podman", ComposePrefix: []string{"compose"}, Rootless: true}
+	}
+	if p.lookPath("podman-compose") {
+		// Compose runs via the podman-compose wrapper, but engine sub-commands
+		// (inspect/rm) must still go to the podman CLI itself.
+		return ContainerRuntime{EngineBin: "podman", Bin: "podman-compose", ComposePrefix: nil, Rootless: true}
+	}
+	// podman present but no compose front-end: docker can still drive the compose
+	// file, so prefer it over failing.
+	return docker
+}

--- a/internal/catalog/runtime_test.go
+++ b/internal/catalog/runtime_test.go
@@ -1,0 +1,114 @@
+package catalog
+
+import (
+	"reflect"
+	"testing"
+)
+
+// probeStub builds a runtimeProbes whose behavior is fully driven by the test,
+// so the selection policy is exercised without podman/docker installed.
+func probeStub(present map[string]bool, composeSubcmd bool) runtimeProbes {
+	return runtimeProbes{
+		lookPath:            func(bin string) bool { return present[bin] },
+		podmanComposeSubcmd: func() bool { return composeSubcmd },
+	}
+}
+
+func TestSelectContainerRuntime(t *testing.T) {
+	tests := []struct {
+		name          string
+		present       map[string]bool
+		composeSubcmd bool
+		wantEngineBin string
+		wantBin       string
+		wantPrefix    []string
+		wantRootless  bool
+	}{
+		{
+			name:          "podman with compose subcommand preferred",
+			present:       map[string]bool{"podman": true, "docker": true},
+			composeSubcmd: true,
+			wantEngineBin: "podman",
+			wantBin:       "podman",
+			wantPrefix:    []string{"compose"},
+			wantRootless:  true,
+		},
+		{
+			name:          "podman without subcommand falls back to podman-compose binary",
+			present:       map[string]bool{"podman": true, "podman-compose": true, "docker": true},
+			composeSubcmd: false,
+			// Engine sub-commands (inspect/rm) must target podman, NOT the
+			// podman-compose wrapper (which has no inspect/rm).
+			wantEngineBin: "podman",
+			wantBin:       "podman-compose",
+			wantPrefix:    nil,
+			wantRootless:  true,
+		},
+		{
+			name:          "podman present but no compose front-end falls back to docker",
+			present:       map[string]bool{"podman": true, "docker": true},
+			composeSubcmd: false,
+			wantEngineBin: "docker",
+			wantBin:       "docker",
+			wantPrefix:    []string{"compose"},
+			wantRootless:  false,
+		},
+		{
+			name:          "podman absent uses docker",
+			present:       map[string]bool{"docker": true},
+			composeSubcmd: false,
+			wantEngineBin: "docker",
+			wantBin:       "docker",
+			wantPrefix:    []string{"compose"},
+			wantRootless:  false,
+		},
+		{
+			name:          "neither present still returns docker (selection never fails)",
+			present:       map[string]bool{},
+			composeSubcmd: false,
+			wantEngineBin: "docker",
+			wantBin:       "docker",
+			wantPrefix:    []string{"compose"},
+			wantRootless:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt := selectContainerRuntime(probeStub(tt.present, tt.composeSubcmd))
+			if rt.EngineBin != tt.wantEngineBin {
+				t.Errorf("EngineBin = %q, want %q", rt.EngineBin, tt.wantEngineBin)
+			}
+			if rt.Bin != tt.wantBin {
+				t.Errorf("Bin = %q, want %q", rt.Bin, tt.wantBin)
+			}
+			if !reflect.DeepEqual(rt.ComposePrefix, tt.wantPrefix) {
+				t.Errorf("ComposePrefix = %v, want %v", rt.ComposePrefix, tt.wantPrefix)
+			}
+			if rt.Rootless != tt.wantRootless {
+				t.Errorf("Rootless = %v, want %v", rt.Rootless, tt.wantRootless)
+			}
+			// EngineBin is never the compose wrapper.
+			if rt.EngineBin == "podman-compose" {
+				t.Errorf("EngineBin must never be the podman-compose wrapper")
+			}
+		})
+	}
+}
+
+func TestContainerRuntime_ComposeArgs(t *testing.T) {
+	docker := ContainerRuntime{Bin: "docker", ComposePrefix: []string{"compose"}}
+	got := docker.ComposeArgs("-f", "x.yml", "up", "-d")
+	want := []string{"compose", "-f", "x.yml", "up", "-d"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("docker ComposeArgs = %v, want %v", got, want)
+	}
+
+	// podman-compose has no prefix: the args pass through unchanged.
+	pc := ContainerRuntime{Bin: "podman-compose", ComposePrefix: nil}
+	got = pc.ComposeArgs("-f", "x.yml", "up", "-d")
+	want = []string{"-f", "x.yml", "up", "-d"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("podman-compose ComposeArgs = %v, want %v", got, want)
+	}
+}

--- a/internal/catalog/sandbox.go
+++ b/internal/catalog/sandbox.go
@@ -20,30 +20,16 @@ const (
 	defaultSandboxPIDs   = 512
 )
 
-// minimalGPUCaps are the capabilities kept for a GPU module even when the
-// manifest declares none. cap_drop: ALL is generally safe for NVIDIA-runtime
-// containers (GPU access goes through the runtime, not Linux caps), so the
-// default GPU cap set is empty; the NVIDIA device reservation in the BASE
-// compose is what grants the GPU, and the override never touches it. This slice
-// is the documented hook for keeping a known-required cap should a GPU image
-// turn out to need one -- today it is empty by design.
-var minimalGPUCaps = []string{}
-
-// composeRoot is the minimal shape we parse from a base compose to enumerate its
-// service names. A compose may define several services (an app + a db sidecar);
-// the hardening override must target each by name.
-type composeRoot struct {
-	Services map[string]yaml.Node `yaml:"services"`
-}
-
-// GenerateHardeningOverride builds a docker-compose override (a second `-f`
-// file) that applies manifest-declared least-privilege to EVERY service defined
-// in the base compose. It is PURE (string in, string out) and table-tested.
+// GenerateHardeningOverride builds a docker/podman compose override (a second
+// `-f` file) that applies manifest-declared least-privilege to the services of
+// the base compose. It is PURE (string in, string out) and table-tested.
 //
-// Per compose service it sets:
+// Per NON-GPU compose service it sets ONLY the keys the base service does not
+// already declare (inject-only-where-absent, so a module's own explicit choice
+// such as `read_only: false` is preserved rather than clobbered by the `-f`
+// merge):
 //   - security_opt: ["no-new-privileges:true"]
 //   - cap_drop: ["ALL"] then cap_add: only the manifest-declared capabilities
-//     (plus a minimal set for GPU modules, currently empty by design)
 //   - read_only: true plus tmpfs: ["/tmp"] and a tmpfs entry per declared
 //     writable_path (so a read-only rootfs module can still write where it must)
 //   - pids_limit, mem_limit, cpus from sandbox.resources (or conservative
@@ -51,43 +37,54 @@ type composeRoot struct {
 //   - devices: only the manifest-declared host devices (omitted if none)
 //   - network_mode: "host" ONLY if sandbox.host_network is true (never otherwise)
 //
-// GPU safety: the override deliberately emits NO GPU/device-reservation block.
-// The base compose owns the NVIDIA `deploy.resources.reservations.devices`
-// reservation; the override only adds hardening keys, so a legit GPU module
-// (e.g. the TEI embedding service, #343) still starts. Note that docker-compose
-// list-merges sequences, so a base `cap_add` survives this override's
-// `cap_drop: ALL` -- the override mechanism cannot subtract a base directive.
-// That residual escalation is already covered by the #342 privilege gate
-// (cap_add ALL/SYS_ADMIN is Critical and refused without --allow-privileged).
+// GPU EXEMPTION (#348): a service that REQUESTS A GPU (an NVIDIA
+// deploy.resources.reservations.devices entry, a `gpus:` shorthand, or
+// `runtime: nvidia`) is omitted from the override ENTIRELY. The conservative
+// defaults -- a read-only rootfs, dropped capabilities, and especially the 2g
+// memory / 2cpu limits -- break inference/embedding services (vLLM, TEI); the
+// only safe containment for those is to leave them as the module authored them.
+// This per-service exemption is the reason runtime sandboxing of GPU modules was
+// deferred to #348. The base compose owns the GPU reservation regardless; the
+// override never emits a GPU/deploy block.
+//
+// Note that compose list-merges sequences, so a base `cap_add` survives this
+// override's `cap_drop: ALL` -- the override mechanism cannot subtract a base
+// directive. That residual escalation is already covered by the #342 privilege
+// gate (cap_add ALL/SYS_ADMIN is Critical and refused without --allow-privileged).
 func GenerateHardeningOverride(baseComposeYAML string, manifest *ServiceManifest) (string, error) {
-	var root composeRoot
-	if err := yaml.Unmarshal([]byte(baseComposeYAML), &root); err != nil {
+	services, err := decodeComposeServices(baseComposeYAML)
+	if err != nil {
 		return "", fmt.Errorf("failed to parse base compose to enumerate services: %w", err)
 	}
-	if len(root.Services) == 0 {
+	if len(services) == 0 {
 		return "", fmt.Errorf("base compose declares no services: cannot generate a hardening override")
 	}
 
 	spec := SandboxSpec{}
-	gpu := false
 	if manifest != nil {
 		spec = manifest.Sandbox
-		gpu = manifest.Requires.GPU
 	}
 
-	// Resolve the per-service hardening once (identical for every service).
-	svc := buildServiceHardening(spec, gpu)
-
 	// Stable, deterministic output: sort service names.
-	names := make([]string, 0, len(root.Services))
-	for name := range root.Services {
+	names := make([]string, 0, len(services))
+	for name := range services {
 		names = append(names, name)
 	}
 	sort.Strings(names)
 
 	out := map[string]map[string]any{}
 	for _, name := range names {
-		out[name] = svc
+		base := services[name]
+		// GPU/inference services are exempt: omit them from the override so the
+		// hardening defaults never break them. A POSITIVE GPU signal is required
+		// (fail-safe: an ambiguous service is hardened, not exempted).
+		if serviceRequestsGPU(base) {
+			continue
+		}
+		svc := buildServiceHardening(spec, base)
+		if len(svc) > 0 {
+			out[name] = svc
+		}
 	}
 
 	doc := map[string]any{"services": out}
@@ -98,30 +95,46 @@ func GenerateHardeningOverride(baseComposeYAML string, manifest *ServiceManifest
 
 	header := "# Citadel least-privilege sandbox override (auto-generated).\n" +
 		"# Applied to untrusted (Tier 2) modules on top of the base compose via\n" +
-		"#   docker compose -f <name>.yml -f <name>.sandbox.yml up\n" +
+		"#   <runtime> compose -f <name>.yml -f <name>.sandbox.yml up\n" +
 		"# Drops all Linux capabilities, forbids privilege escalation, makes the\n" +
-		"# root filesystem read-only, and caps resources. Edit the module manifest's\n" +
+		"# root filesystem read-only, and caps resources. GPU/inference services are\n" +
+		"# exempt (their defaults would break them). Edit the module manifest's\n" +
 		"# sandbox: block (then reinstall) to declare additional needs.\n"
 	return header + string(data), nil
 }
 
-// buildServiceHardening returns the per-service hardening map applied to every
-// compose service. Pure helper so GenerateHardeningOverride stays small.
-func buildServiceHardening(spec SandboxSpec, gpu bool) map[string]any {
+// buildServiceHardening returns the per-service hardening map for one NON-GPU
+// service. It injects each hardening key ONLY when the base service does not
+// already declare it (inject-only-where-absent), so an explicit base choice is
+// preserved. Pure helper so GenerateHardeningOverride stays small.
+func buildServiceHardening(spec SandboxSpec, base map[string]any) map[string]any {
+	full := buildFullServiceHardening(spec)
+	svc := map[string]any{}
+	for k, v := range full {
+		if _, set := base[k]; set {
+			continue // base already declares it -- preserve the module's choice
+		}
+		svc[k] = v
+	}
+	return svc
+}
+
+// buildFullServiceHardening returns the complete set of hardening keys for a
+// non-GPU service before the inject-only-where-absent filter. Splitting this out
+// keeps the "what hardening looks like" logic separate from the "what is already
+// set" filter.
+func buildFullServiceHardening(spec SandboxSpec) map[string]any {
 	svc := map[string]any{
 		"security_opt": []string{"no-new-privileges:true"},
 		"cap_drop":     []string{"ALL"},
 		"read_only":    true,
 	}
 
-	// Capabilities to keep: declared caps, plus the minimal GPU set for GPU
-	// modules. cap_add is only emitted when there is something to add (an empty
-	// cap_add list is meaningless and noisy).
-	caps := normalizeCaps(spec.Capabilities)
-	if gpu {
-		caps = append(caps, minimalGPUCaps...)
-	}
-	caps = dedupeStrings(caps)
+	// Capabilities to keep: only the manifest-declared caps (GPU services are
+	// exempt from hardening entirely, so no GPU cap set is needed here). cap_add
+	// is only emitted when there is something to add (an empty cap_add list is
+	// meaningless and noisy).
+	caps := dedupeStrings(normalizeCaps(spec.Capabilities))
 	if len(caps) > 0 {
 		svc["cap_add"] = caps
 	}

--- a/internal/catalog/sandbox_test.go
+++ b/internal/catalog/sandbox_test.go
@@ -211,11 +211,13 @@ func TestGenerateHardeningOverride_HostNetworkOptIn(t *testing.T) {
 	}
 }
 
-// TestGenerateHardeningOverride_GPU encodes the TEI (#343) shape: a GPU module
-// with a NVIDIA device reservation, a model-cache writable path, and a declared
-// device. The override must still be valid, must NOT emit any GPU/deploy block,
-// and must keep cap_drop ALL with an empty (or empty-by-design) cap set.
-func TestGenerateHardeningOverride_GPU(t *testing.T) {
+// TestGenerateHardeningOverride_GPUExempt encodes the TEI (#343) shape: a GPU
+// service with a NVIDIA device reservation. Under #348 a GPU/inference service
+// is EXEMPT from hardening -- the read-only rootfs, cap-drops, and (especially)
+// the 2g/2cpu resource limits break inference. So the override must omit the GPU
+// service entirely (no entry for it at all) and must never emit a GPU/deploy
+// block.
+func TestGenerateHardeningOverride_GPUExempt(t *testing.T) {
 	base := `services:
   tei:
     image: ghcr.io/huggingface/text-embeddings-inference:latest
@@ -242,17 +244,126 @@ func TestGenerateHardeningOverride_GPU(t *testing.T) {
 	if strings.Contains(out, "deploy:") || strings.Contains(out, "reservations") || strings.Contains(out, "nvidia") {
 		t.Errorf("override must not emit a GPU/deploy block:\n%s", out)
 	}
-	tei := parseOverride(t, out)["tei"]
-	if cd := strSlice(t, tei["cap_drop"]); !contains2(cd, "ALL") {
-		t.Errorf("GPU module should still cap_drop ALL: %v", cd)
+	// The GPU service must be exempt: no override entry for it.
+	if _, present := parseOverride(t, out)["tei"]; present {
+		t.Errorf("GPU service 'tei' must be exempt (omitted from override):\n%s", out)
 	}
-	// minimalGPUCaps is empty by design -> no cap_add for a GPU module with no
-	// declared caps.
-	if _, present := tei["cap_add"]; present {
-		t.Errorf("GPU module with no declared caps should have no cap_add: %v", tei["cap_add"])
+}
+
+// TestGenerateHardeningOverride_GPUSignals exercises each per-service GPU signal
+// in isolation: each must exempt its service from the override.
+func TestGenerateHardeningOverride_GPUSignals(t *testing.T) {
+	cases := map[string]string{
+		"gpus shorthand": `services:
+  svc:
+    image: x
+    gpus: all
+`,
+		"runtime nvidia": `services:
+  svc:
+    image: x
+    runtime: nvidia
+`,
+		"deploy reservation driver nvidia": `services:
+  svc:
+    image: x
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+`,
+		"deploy reservation gpu capability": `services:
+  svc:
+    image: x
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: [gpu]
+`,
 	}
-	if tm := strSlice(t, tei["tmpfs"]); !contains2(tm, "/data") {
-		t.Errorf("GPU module writable path /data missing from tmpfs: %v", tm)
+	for name, base := range cases {
+		t.Run(name, func(t *testing.T) {
+			out, err := GenerateHardeningOverride(base, &ServiceManifest{Name: "m"})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if _, present := parseOverride(t, out)["svc"]; present {
+				t.Errorf("GPU-signalled service must be exempt:\n%s", out)
+			}
+		})
+	}
+}
+
+// TestGenerateHardeningOverride_MixedGPUAndSidecar is the discriminating case:
+// an untrusted compose with a GPU inference service AND a non-GPU sidecar. The
+// sidecar must be hardened; the GPU service must be untouched (exempt).
+func TestGenerateHardeningOverride_MixedGPUAndSidecar(t *testing.T) {
+	base := `services:
+  inference:
+    image: vllm/vllm-openai:latest
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+  proxy:
+    image: nginx:latest
+`
+	out, err := GenerateHardeningOverride(base, &ServiceManifest{Name: "m"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	svcs := parseOverride(t, out)
+	if _, present := svcs["inference"]; present {
+		t.Errorf("GPU service 'inference' must be exempt (omitted):\n%s", out)
+	}
+	proxy, ok := svcs["proxy"]
+	if !ok {
+		t.Fatalf("non-GPU sidecar 'proxy' must be hardened (present in override):\n%s", out)
+	}
+	if cd := strSlice(t, proxy["cap_drop"]); !contains2(cd, "ALL") {
+		t.Errorf("sidecar should cap_drop ALL: %v", cd)
+	}
+	if ro, _ := proxy["read_only"].(bool); !ro {
+		t.Errorf("sidecar should have read_only true")
+	}
+}
+
+// TestGenerateHardeningOverride_PreservesBaseOverrides verifies the
+// inject-only-where-absent rule: a hardening key the base service already
+// declares is NOT clobbered by the override (so a module's explicit
+// read_only:false / security_opt survives the `-f` merge).
+func TestGenerateHardeningOverride_PreservesBaseOverrides(t *testing.T) {
+	base := `services:
+  app:
+    image: x
+    read_only: false
+    mem_limit: 6g
+    security_opt:
+      - label=disable
+`
+	out, err := GenerateHardeningOverride(base, &ServiceManifest{Name: "m"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	app := parseOverride(t, out)["app"]
+	// Keys the base set must be absent from the override (not re-injected).
+	if _, present := app["read_only"]; present {
+		t.Errorf("read_only declared in base must not be injected by the override: %v", app["read_only"])
+	}
+	if _, present := app["mem_limit"]; present {
+		t.Errorf("mem_limit declared in base must not be injected: %v", app["mem_limit"])
+	}
+	if _, present := app["security_opt"]; present {
+		t.Errorf("security_opt declared in base must not be injected: %v", app["security_opt"])
+	}
+	// Keys the base did NOT set are still injected.
+	if cd := strSlice(t, app["cap_drop"]); !contains2(cd, "ALL") {
+		t.Errorf("cap_drop (not in base) should still be injected: %v", cd)
 	}
 }
 
@@ -393,7 +504,7 @@ func TestInstallFromManifest_UntrustedWritesSandboxOverride(t *testing.T) {
 	manifest := &ServiceManifest{Name: "mod"}
 
 	// untrusted=true must generate the override and flag the result.
-	res, err := InstallFromManifest(manifest, composePath, servicesDir, nil, false, false, true)
+	res, err := InstallFromManifest(manifest, composePath, servicesDir, nil, false, false, true, false)
 	if err != nil {
 		t.Fatalf("install failed: %v", err)
 	}
@@ -423,7 +534,7 @@ func TestInstallFromManifest_TrustedNoSandboxOverride(t *testing.T) {
 	manifest := &ServiceManifest{Name: "mod"}
 
 	// untrusted=false (Tier 0/1): no override, not flagged.
-	res, err := InstallFromManifest(manifest, composePath, servicesDir, nil, false, true, false)
+	res, err := InstallFromManifest(manifest, composePath, servicesDir, nil, false, true, false, false)
 	if err != nil {
 		t.Fatalf("install failed: %v", err)
 	}
@@ -447,12 +558,12 @@ func TestInstallFromManifest_BindMountConfinement(t *testing.T) {
 	manifest := &ServiceManifest{Name: "mod"}
 
 	// untrusted + !allowPrivileged: must REFUSE.
-	if _, err := InstallFromManifest(manifest, composePath, servicesDir, nil, false, false, true); err == nil {
+	if _, err := InstallFromManifest(manifest, composePath, servicesDir, nil, false, false, true, false); err == nil {
 		t.Fatal("expected refusal for untrusted module bind-mounting outside sandbox dir")
 	}
 
 	// allowPrivileged overrides the confinement.
-	if _, err := InstallFromManifest(manifest, composePath, servicesDir, nil, false, true, true); err != nil {
+	if _, err := InstallFromManifest(manifest, composePath, servicesDir, nil, false, true, true, false); err != nil {
 		t.Fatalf("allow-privileged should bypass bind-mount confinement, got %v", err)
 	}
 
@@ -462,7 +573,7 @@ func TestInstallFromManifest_BindMountConfinement(t *testing.T) {
 	if err := writeFileTest(t, composePath2, body); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := InstallFromManifest(manifest, composePath2, filepath.Join(dir2, "services"), nil, false, true, false); err != nil {
+	if _, err := InstallFromManifest(manifest, composePath2, filepath.Join(dir2, "services"), nil, false, true, false, false); err != nil {
 		t.Fatalf("trusted install should not be bind-confined, got %v", err)
 	}
 }

--- a/internal/catalog/sources_test.go
+++ b/internal/catalog/sources_test.go
@@ -435,13 +435,13 @@ func TestCommunityPrivilegedInstallRefused(t *testing.T) {
 	servicesDir := filepath.Join(t.TempDir(), "services")
 
 	// Untrusted install with allowPrivileged=false must refuse.
-	_, err := InstallFromManifest(manifest, composeSrc, servicesDir, nil, false, false, true)
+	_, err := InstallFromManifest(manifest, composeSrc, servicesDir, nil, false, false, true, false)
 	if err == nil {
 		t.Fatal("expected refusal installing a privileged community compose, got nil")
 	}
 
 	// Same compose as a trusted (default) install is allowed (allowPrivileged=true).
-	if _, err := InstallFromManifest(manifest, composeSrc, servicesDir, nil, false, true, false); err != nil {
+	if _, err := InstallFromManifest(manifest, composeSrc, servicesDir, nil, false, true, false, false); err != nil {
 		t.Errorf("trusted install of privileged compose should succeed, got %v", err)
 	}
 }


### PR DESCRIPTION
## Context

#342 gave us the *detection + consent* layer for installing service modules from untrusted git sources: a risk scan, a privilege gate (`--allow-privileged`), bind-mount confinement, and a manifest-driven least-privilege override written at install time. #348 is the **containment** layer that sits on top: actually running those modules under a harder-by-default posture, without breaking the GPU/inference modules that were the reason this was deferred.

Two pieces, per the maintainer's decision (trust-tiered hardening, podman rootless preferred):

1. **Prefer rootless podman as the module container runtime** where available, fall back to docker.
2. **Trust-tiered hardening that is GPU-exempt** — untrusted non-GPU services get cap-drops / no-new-privileges / read-only rootfs / resource caps; GPU/inference services (vLLM, TEI) are left as authored, because those defaults break them (the 2g memory default alone OOMs an inference container).

Per-module egress policy is explicitly **out of scope** (follow-up).

## Summary

### Runtime selection (`internal/catalog/runtime.go`)
`SelectContainerRuntime()` prefers rootless podman over docker. It returns a `ContainerRuntime` descriptor rather than a bare binary string, because podman exposes compose two incompatible ways — the `podman compose` subcommand vs the separate `podman-compose` wrapper — and the wrapper is **not** an engine CLI (no `inspect`/`rm`). So the descriptor keeps `EngineBin` (always docker/podman, used for inspect/rm/ps) separate from `Bin`+`ComposePrefix` (the compose front-end). Selection is fail-safe: podman with no usable compose front-end, or no podman at all, falls back to docker; selection never fails. Probes are injected, so the policy is table-tested without podman/docker installed.

Wired into `startService` (the path `citadel run <name>` uses): inspect/rm go through `EngineBin`, compose-up through `Bin`+`ComposePrefix`, and the selected runtime is logged.

### GPU-exempt hardening transform (`internal/catalog/sandbox.go`, `gpu_compose.go`)
`GenerateHardeningOverride` is reworked from "build one hardening map, clone it onto every service" into the real #348 transform:

| Property | Behavior |
|----------|----------|
| **Per-service** | Each service evaluated independently. |
| **GPU-exempt** | A service requesting a GPU (NVIDIA `deploy.resources.reservations.devices`, `gpus:` shorthand, or `runtime: nvidia`) is **omitted from the override entirely**. The per-service GPU probe mirrors `compose.StripGPUDevices`' navigation so the two stay in lock-step. |
| **Fail-safe** | Only a **positive** GPU signal exempts. An ambiguous service is hardened, not exempted. |
| **Inject-only-where-absent** | A hardening key the base service already declares is preserved, not clobbered by the `-f` merge (so an author's explicit `read_only: false` survives). |

**Why GPU-exempt is the whole point:** a read-only rootfs, dropped caps, and the conservative 2g/2cpu resource defaults break inference/embedding services. There is no "harden a little" middle ground for them — the only safe containment is to leave the GPU service as the module authored it. The base compose owns the GPU reservation; the override never emits a GPU/deploy block.

### `--no-harden` opt-out (`cmd/module.go`, `install.go`)
An explicit escape hatch (consistent with `--allow-privileged` style) that skips the hardening override for an untrusted module **without** disabling bind-mount confinement. Threaded as its own `skipHardening` param so the two containment layers stay independent — opting out of the override does not silently weaken bind-mount confinement (that still requires `--allow-privileged`).

## Test plan

| Group | Coverage |
|-------|----------|
| Runtime selection | podman+subcmd → podman; podman+wrapper → podman-compose (EngineBin still podman); podman no-compose → docker; podman absent → docker; neither → docker. Asserts `EngineBin` never equals the compose wrapper. |
| `ComposeArgs` | docker prefix applied; podman-compose passthrough (empty prefix). |
| Hardening transform | trusted → unchanged (no override); untrusted non-GPU → hardened; untrusted GPU service → exempt (omitted); each GPU signal in isolation; **mixed GPU + non-GPU sidecar** (sidecar hardened, GPU untouched); existing base overrides preserved. |
| GPU detection | each signal positive; non-GPU `deploy`/non-nvidia driver/non-gpu capability negative; nil-safe. |
| Existing #342 suites | privilege gate, bind-mount confinement, install wiring — all still green with the new `skipHardening` param. |

`go build ./...`, `go vet ./...`, `gofmt -l` clean. Full `go test ./...` green.

## Known limitation / follow-ups

- **GPU exemption reads the untrusted author's own compose.** A module could stamp `gpus: all` / `runtime: nvidia` onto an arbitrary service to opt it out of hardening. This is inherent to compose-driven detection (the specified approach), and the install-time gates (privilege gate, bind-mount confinement) still apply, so it is not a full escape. Cheap future mitigation: only honor the exemption when the host actually has a GPU (`CheckGPU()` exists) — on a non-GPU host a fake signal both fails to exempt and fails to start. Tracked as a follow-up.
- **Per-module egress policy** — out of scope here, follow-up.
- **Pre-#348 installed modules** keep their old uniform (GPU-breaking) `.sandbox.yml` until reinstalled/updated. `module update` regenerates the override, so the new GPU-exempt logic applies on next update.
- **GPU + rootless podman** passthrough needs CDI and often fails; since GPU services are exempt from hardening anyway, a future refinement could prefer docker for GPU-containing modules. Kept out of the tested core to stay simple.

## Related
- Closes #348
- Builds on #342 (trust tiers / risk scan / sandbox override / bind-mount confinement)
- #343 (TEI) is the canonical GPU-exempt shape exercised in tests
