### PR TITLE
feat(cobrowse): dedicated Xvfb virtual display (headless support + privacy isolation)

### DIFF
--- a/internal/jobs/cobrowse.go
+++ b/internal/jobs/cobrowse.go
@@ -102,6 +102,7 @@ func statusResult(st platform.CobrowseStatus, err error) ([]byte, error) {
 		"url":        st.URL,
 		"debug_port": st.DebugPort,
 		"profile":    st.Profile,
+		"display":    st.Display,
 		"started_at": st.StartedAt,
 	})
 	if mErr != nil {

--- a/internal/platform/cobrowse.go
+++ b/internal/platform/cobrowse.go
@@ -429,6 +429,12 @@ func (m *CobrowseManager) Start(profileDir, startURL string, debugPort int) (Cob
 		return CobrowseStatus{}, err
 	}
 
+	// Clear any Xvfb left over from a prior launch that started the virtual
+	// display but then failed (e.g. CDP never came up) and whose browser has
+	// since died. We are not running (checked above), so any lingering managed
+	// Xvfb is stale and must be reaped before starting a fresh one, or it leaks.
+	m.teardownXvfbLocked()
+
 	// Resolve the X display the browser renders on. Default: a dedicated Xvfb
 	// virtual display, which (a) works on headless nodes with no :0 and (b)
 	// isolates the session from the operator's real desktop. Opt into a shared

--- a/internal/platform/cobrowse.go
+++ b/internal/platform/cobrowse.go
@@ -60,6 +60,29 @@ const EnvCobrowseStealth = "CITADEL_COBROWSE_STEALTH"
 // this when you deliberately want to spoof a specific UA.
 const EnvCobrowseUserAgent = "CITADEL_COBROWSE_USER_AGENT"
 
+// EnvCobrowseDisplay, when set, pins the X display the co-browse browser renders
+// on (e.g. ":0" to share the node's real desktop for a watch-along, or ":99" for
+// a pre-existing virtual display). When UNSET (the default), the manager starts
+// its OWN dedicated Xvfb virtual display. The dedicated display is the better
+// default on two axes:
+//   - Headless nodes (GPU/compute boxes with no monitor and no :0) can run
+//     co-browse at all -- a hardcoded :0 fails there.
+//   - Privacy/isolation: the live VNC view shows ONLY the co-browse browser, not
+//     whatever else is open on the operator's real desktop. Co-browse is meant to
+//     be a throwaway screen the agent drives, not a window onto the user's machine.
+//
+// Set this to ":0" (or the operator's real DISPLAY) to opt back into the legacy
+// shared-desktop behavior.
+const EnvCobrowseDisplay = "CITADEL_COBROWSE_DISPLAY"
+
+// EnvCobrowseResolution overrides the managed Xvfb virtual-display geometry as
+// WIDTHxHEIGHTxDEPTH. Defaults to defaultXvfbResolution.
+const EnvCobrowseResolution = "CITADEL_COBROWSE_RESOLUTION"
+
+// defaultXvfbResolution is the managed virtual-display geometry when
+// EnvCobrowseResolution is unset.
+const defaultXvfbResolution = "1920x1080x24"
+
 // cobrowseLaunchOptions is the full input to buildChromeArgs. Keeping it a plain
 // struct (rather than an interface/registry) is deliberate: a future full
 // CloakBrowser launcher swaps in by constructing different options or by calling
@@ -76,6 +99,11 @@ type cobrowseLaunchOptions struct {
 	// userAgent, when non-empty, overrides the browser User-Agent. Empty means
 	// "use real Chrome's own UA" (recommended -- see EnvCobrowseUserAgent).
 	userAgent string
+	// softwareGL forces software rendering (--disable-gpu). Set when the browser
+	// runs on a dedicated Xvfb virtual display, which has no GPU/GLX -- without it
+	// headed Chromium spawns a GPU process that fails to initialize on Xvfb and
+	// logs churn. Left false when sharing a real display that may have a GPU.
+	softwareGL bool
 }
 
 // stealthEnabled resolves whether stealth launch flags should be applied,
@@ -150,6 +178,13 @@ func buildChromeArgs(opts cobrowseLaunchOptions) []string {
 	// Emit the merged disable-features exactly once (see note above).
 	args = append(args, "--disable-features="+strings.Join(disableFeatures, ","))
 
+	if opts.softwareGL {
+		// Dedicated Xvfb has no GPU/GLX; force the software path so the GPU
+		// process does not fail to initialize. Page.captureScreenshot still works
+		// via the software compositor.
+		args = append(args, "--disable-gpu")
+	}
+
 	if opts.startURL != "" {
 		args = append(args, opts.startURL)
 	}
@@ -182,6 +217,7 @@ type CobrowseStatus struct {
 	URL       string         `json:"url"`
 	DebugPort int            `json:"debug_port"`
 	Profile   string         `json:"profile"`
+	Display   string         `json:"display,omitempty"`
 	StartedAt string         `json:"started_at,omitempty"`
 }
 
@@ -206,6 +242,14 @@ type CobrowseManager struct {
 	// terminates (whether killed by Stop or crashed on its own). isRunningLocked
 	// consults it so a dead browser is not reported as running.
 	exited chan struct{}
+	// display is the X display the browser renders on (e.g. ":99" for the managed
+	// virtual display, or an operator-pinned ":0"). Reported in status.
+	display string
+	// xvfb is the dedicated Xvfb virtual-display process when one is managed (nil
+	// when an operator-pinned display is used). Owned by this manager: started in
+	// Start(), reaped by xvfbExited, and killed by Stop() AFTER the browser.
+	xvfb       *exec.Cmd
+	xvfbExited chan struct{}
 }
 
 var (
@@ -235,6 +279,101 @@ func findChromium() (string, error) {
 		}
 	}
 	return "", fmt.Errorf("no Chromium/Chrome binary found (install google-chrome or chromium)")
+}
+
+// displayMode is how the co-browse browser obtains an X display.
+type displayMode int
+
+const (
+	// displayManaged starts a dedicated Xvfb virtual display (the default).
+	// Headless-safe and isolates the session from the node's real desktop.
+	displayManaged displayMode = iota
+	// displayExplicit uses an operator-pinned DISPLAY verbatim (EnvCobrowseDisplay).
+	displayExplicit
+)
+
+// resolveCobrowseDisplay decides how the browser gets a display from the
+// environment alone. Pure (no I/O) so the precedence is unit-testable without
+// launching an X server: an explicit EnvCobrowseDisplay wins, otherwise a
+// dedicated Xvfb is managed.
+func resolveCobrowseDisplay() (displayMode, string) {
+	if d := strings.TrimSpace(os.Getenv(EnvCobrowseDisplay)); d != "" {
+		return displayExplicit, d
+	}
+	return displayManaged, ""
+}
+
+// xvfbResolution returns the managed virtual-display geometry, honoring
+// EnvCobrowseResolution and falling back to defaultXvfbResolution.
+func xvfbResolution() string {
+	if r := strings.TrimSpace(os.Getenv(EnvCobrowseResolution)); r != "" {
+		return r
+	}
+	return defaultXvfbResolution
+}
+
+// fileExists reports whether a path exists (used to detect live X sockets/locks).
+func fileExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}
+
+// findFreeDisplay returns the first display number >= 99 with no X socket or
+// lock file, so the managed Xvfb never collides with an existing server -- the
+// operator's real :0/:1, another node tool, or a prior co-browse Xvfb.
+func findFreeDisplay() int {
+	for n := 99; n < 99+128; n++ {
+		if !fileExists(fmt.Sprintf("/tmp/.X11-unix/X%d", n)) &&
+			!fileExists(fmt.Sprintf("/tmp/.X%d-lock", n)) {
+			return n
+		}
+	}
+	return 99
+}
+
+// startManagedXvfb launches a dedicated Xvfb virtual display and waits for its
+// socket so the browser launch does not race startup. Returns the running
+// command and the ":N" display string; the caller owns reaping (mirroring the
+// Chromium reaper). A missing Xvfb binary yields an actionable error rather than
+// a confusing downstream "CDP not ready" timeout.
+func startManagedXvfb(resolution string) (*exec.Cmd, string, error) {
+	if !isCommandAvailable("Xvfb") {
+		return nil, "", fmt.Errorf(
+			"Xvfb not found: install it (e.g. 'apt-get install xvfb') to run headless co-browse, "+
+				"or set %s to an existing X display (e.g. :0)", EnvCobrowseDisplay)
+	}
+	n := findFreeDisplay()
+	display := fmt.Sprintf(":%d", n)
+	cmd := exec.Command("Xvfb", display, "-screen", "0", resolution, "-nolisten", "tcp")
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	if err := cmd.Start(); err != nil {
+		return nil, "", fmt.Errorf("launch Xvfb on %s: %w", display, err)
+	}
+	sock := fmt.Sprintf("/tmp/.X11-unix/X%d", n)
+	deadline := time.Now().Add(8 * time.Second)
+	for time.Now().Before(deadline) {
+		if fileExists(sock) {
+			return cmd, display, nil
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+	_ = cmd.Process.Kill()
+	return nil, "", fmt.Errorf("Xvfb on %s did not become ready within 8s", display)
+}
+
+// withDisplay returns env with DISPLAY set to the chosen value and any inherited
+// DISPLAY / WAYLAND_DISPLAY removed, so the headed browser targets exactly the
+// intended X display (and never silently falls onto a Wayland socket).
+func withDisplay(env []string, display string) []string {
+	out := make([]string, 0, len(env)+1)
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "DISPLAY=") || strings.HasPrefix(kv, "WAYLAND_DISPLAY=") {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return append(out, "DISPLAY="+display)
 }
 
 // IsRunning reports whether the managed browser process is alive.
@@ -290,6 +429,23 @@ func (m *CobrowseManager) Start(profileDir, startURL string, debugPort int) (Cob
 		return CobrowseStatus{}, err
 	}
 
+	// Resolve the X display the browser renders on. Default: a dedicated Xvfb
+	// virtual display, which (a) works on headless nodes with no :0 and (b)
+	// isolates the session from the operator's real desktop. Opt into a shared
+	// real display by setting EnvCobrowseDisplay (e.g. ":0"). A managed Xvfb runs
+	// without a GPU, so force software rendering for that case.
+	mode, explicitDisplay := resolveCobrowseDisplay()
+	var xvfb *exec.Cmd
+	display := explicitDisplay
+	softwareGL := false
+	if mode == displayManaged {
+		x, d, derr := startManagedXvfb(xvfbResolution())
+		if derr != nil {
+			return CobrowseStatus{}, derr
+		}
+		xvfb, display, softwareGL = x, d, true
+	}
+
 	// Stealth (anti-bot-detection) is ON by default for co-browse; this is the
 	// first citadel-side step toward the full CloakBrowser launch replacing this
 	// plain Chromium launch. Disable via EnvCobrowseStealth for plain behavior.
@@ -299,24 +455,24 @@ func (m *CobrowseManager) Start(profileDir, startURL string, debugPort int) (Cob
 		startURL:   startURL,
 		stealth:    stealthEnabled(),
 		userAgent:  os.Getenv(EnvCobrowseUserAgent),
+		softwareGL: softwareGL,
 	})
 
 	cmd := exec.Command(chrome, args...)
-	// The browser must render on the SAME X display the node's VNC server
-	// (x11vnc) exposes, so the existing /vnc/... stream shows it to the cockpit.
-	// citadel may run under systemd with no DISPLAY in its env; default to :0
-	// (the conventional x11vnc target) so headed Chromium lands on the streamed
-	// display rather than failing to find one. detectLinuxDisplay() reads the
-	// same DISPLAY var, so this keeps the browser and the VNC view in sync.
-	env := os.Environ()
-	if os.Getenv("DISPLAY") == "" && os.Getenv("WAYLAND_DISPLAY") == "" {
-		env = append(env, "DISPLAY=:0")
-	}
-	cmd.Env = env
+	// Pin the browser to the resolved display (managed Xvfb or operator-set), so
+	// the live VNC/desktop view in the cockpit shows exactly this browser. The
+	// managed virtual display means that view is the co-browse browser ALONE,
+	// never the operator's other windows.
+	cmd.Env = withDisplay(os.Environ(), display)
 	// Detach stdio; the browser is long-lived and headed on the node display.
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	if err := cmd.Start(); err != nil {
+		// Tear down the just-started Xvfb so a failed browser launch does not leak
+		// a virtual display.
+		if xvfb != nil && xvfb.Process != nil {
+			_ = xvfb.Process.Kill()
+		}
 		return CobrowseStatus{}, fmt.Errorf("launch chromium: %w", err)
 	}
 
@@ -326,6 +482,19 @@ func (m *CobrowseManager) Start(profileDir, startURL string, debugPort int) (Cob
 	m.profile = profileDir
 	m.chromePath = chrome
 	m.startedAt = time.Now()
+	m.display = display
+
+	// Own the managed Xvfb lifecycle alongside the browser: reap it so a crash is
+	// observable and Stop() can tear it down without double-Wait.
+	m.xvfb = xvfb
+	if xvfb != nil {
+		xvfbExited := make(chan struct{})
+		m.xvfbExited = xvfbExited
+		go func() {
+			_ = xvfb.Wait()
+			close(xvfbExited)
+		}()
+	}
 
 	// Reaper: own the single Wait() for this process. When Chromium exits (killed
 	// by Stop or crashed on its own), close exited so isRunningLocked stops
@@ -357,6 +526,7 @@ func (m *CobrowseManager) Stop() error {
 		m.cmd = nil
 		m.exited = nil
 		m.driver = DriverAI
+		m.teardownXvfbLocked()
 		return nil
 	}
 	err := m.cmd.Process.Kill()
@@ -371,7 +541,28 @@ func (m *CobrowseManager) Stop() error {
 	m.cmd = nil
 	m.exited = nil
 	m.driver = DriverAI
+	// Tear down the virtual display AFTER the browser so the browser is never
+	// left without a display mid-shutdown.
+	m.teardownXvfbLocked()
 	return err
+}
+
+// teardownXvfbLocked kills the managed Xvfb (if any) and waits, bounded, for the
+// reaper to confirm it exited so no zombie or orphaned virtual display is left.
+// No-op when an operator-pinned display was used (m.xvfb == nil). Caller holds m.mu.
+func (m *CobrowseManager) teardownXvfbLocked() {
+	if m.xvfb != nil && m.xvfb.Process != nil {
+		_ = m.xvfb.Process.Kill()
+		if m.xvfbExited != nil {
+			select {
+			case <-m.xvfbExited:
+			case <-time.After(5 * time.Second):
+			}
+		}
+	}
+	m.xvfb = nil
+	m.xvfbExited = nil
+	m.display = ""
 }
 
 // Handoff transfers control to the human. Idempotent.
@@ -409,6 +600,7 @@ func (m *CobrowseManager) statusLocked() CobrowseStatus {
 		Driver:    m.driver,
 		DebugPort: m.debugPort,
 		Profile:   m.profile,
+		Display:   m.display,
 	}
 	if !m.startedAt.IsZero() {
 		st.StartedAt = m.startedAt.UTC().Format(time.RFC3339)

--- a/internal/platform/cobrowse_test.go
+++ b/internal/platform/cobrowse_test.go
@@ -161,6 +161,65 @@ func TestStealthEnabled(t *testing.T) {
 	}
 }
 
+// TestBuildChromeArgs_SoftwareGL checks --disable-gpu is emitted only when the
+// browser runs on a managed (GPU-less) Xvfb virtual display.
+func TestBuildChromeArgs_SoftwareGL(t *testing.T) {
+	on := buildChromeArgs(cobrowseLaunchOptions{debugPort: 9222, profileDir: "/p", stealth: true, softwareGL: true})
+	if !containsArg(on, "--disable-gpu") {
+		t.Errorf("softwareGL on: missing --disable-gpu in %v", on)
+	}
+	off := buildChromeArgs(cobrowseLaunchOptions{debugPort: 9222, profileDir: "/p", stealth: true})
+	if containsArg(off, "--disable-gpu") {
+		t.Errorf("softwareGL off: --disable-gpu must be absent in %v", off)
+	}
+}
+
+// TestResolveCobrowseDisplay checks the display-mode precedence: a dedicated
+// managed Xvfb by default, an operator-pinned display when EnvCobrowseDisplay is
+// set (trimmed).
+func TestResolveCobrowseDisplay(t *testing.T) {
+	t.Setenv(EnvCobrowseDisplay, "")
+	if mode, d := resolveCobrowseDisplay(); mode != displayManaged || d != "" {
+		t.Errorf("unset: want (managed, \"\"), got (%v, %q)", mode, d)
+	}
+	t.Setenv(EnvCobrowseDisplay, "  :0 ")
+	if mode, d := resolveCobrowseDisplay(); mode != displayExplicit || d != ":0" {
+		t.Errorf("set :0: want (explicit, \":0\"), got (%v, %q)", mode, d)
+	}
+}
+
+// TestXvfbResolution checks the geometry override falls back to the default.
+func TestXvfbResolution(t *testing.T) {
+	t.Setenv(EnvCobrowseResolution, "")
+	if got := xvfbResolution(); got != defaultXvfbResolution {
+		t.Errorf("unset: want %q, got %q", defaultXvfbResolution, got)
+	}
+	t.Setenv(EnvCobrowseResolution, "1280x720x24")
+	if got := xvfbResolution(); got != "1280x720x24" {
+		t.Errorf("set: want 1280x720x24, got %q", got)
+	}
+}
+
+// TestWithDisplay checks DISPLAY is pinned and any inherited DISPLAY /
+// WAYLAND_DISPLAY entries are stripped so the browser targets exactly one X
+// display.
+func TestWithDisplay(t *testing.T) {
+	in := []string{"PATH=/bin", "DISPLAY=:0", "WAYLAND_DISPLAY=wayland-0", "HOME=/home/x"}
+	out := withDisplay(in, ":99")
+	if countPrefixArg(out, "DISPLAY=") != 1 {
+		t.Errorf("want exactly one DISPLAY= entry, got %v", out)
+	}
+	if !containsArg(out, "DISPLAY=:99") {
+		t.Errorf("want DISPLAY=:99, got %v", out)
+	}
+	if hasPrefixArg(out, "WAYLAND_DISPLAY=") {
+		t.Errorf("WAYLAND_DISPLAY must be stripped, got %v", out)
+	}
+	if !containsArg(out, "PATH=/bin") || !containsArg(out, "HOME=/home/x") {
+		t.Errorf("non-display env must be preserved, got %v", out)
+	}
+}
+
 // TestCobrowse_StopWhenNotRunning verifies Stop is a safe no-op with no session
 // and that calling it twice does not panic. The shutdown hook in cmd/work.go
 // relies on this being safe to call unconditionally on every worker exit.


### PR DESCRIPTION
## Context

Co-browsing (#4079) runs a headed Chromium on a Citadel node, driven over CDP. The launcher hard-defaulted the browser to `DISPLAY=:0`. That has two problems, both hit in practice:

1. **Headless nodes can't run it.** GPU/compute boxes (e.g. ubuntu-gpu) have no monitor and no `:0`. The browser launches, immediately dies with no display, and CDP never comes up — the `cobrowse_start` call fails with `browser launched but CDP not ready` (and, before the node even has the handler, the opaque 30s dispatch timeout reported in aceteam#4373).
2. **When a real desktop _is_ present, it streams the operator's actual screen.** The live VNC view should show the co-browse browser *alone*. Re-using `:0` means the agent (and anyone watching the cockpit) sees whatever else the user has open — a privacy leak.

Both are fixed by the same move: give co-browse its **own dedicated virtual display**.

## Summary

`CobrowseManager` now starts a dedicated **Xvfb** virtual display by default and launches the browser there:

- **Headless-safe** — Xvfb fabricates the display, so co-browse runs on nodes with no monitor/`:0`.
- **Isolated** — the cockpit view is the co-browse browser only, never the operator's other windows. Co-browse is meant to be a throwaway screen the agent drives, not a window onto the user's machine.
- **Software GL** (`--disable-gpu`) when on the managed display, since Xvfb has no GPU/GLX.
- **Collision-safe display pick** — chooses a free display `>= :99`, skipping stale X sockets/locks.
- **Owned lifecycle** — Xvfb is reaped like the browser and torn down in `Stop()` *after* the browser.
- **Fail-fast** — a missing `Xvfb` binary yields an actionable error (`install xvfb, or set CITADEL_COBROWSE_DISPLAY`) instead of a confusing downstream "CDP not ready" timeout.
- **Opt-out** — `CITADEL_COBROWSE_DISPLAY=:0` restores the legacy shared-desktop behavior (e.g. a deliberate watch-along on the real desktop); `CITADEL_COBROWSE_RESOLUTION` overrides the geometry (default `1920x1080x24`). `cobrowse_status` now reports the active display.

This keeps the PR scoped to *making co-browse work and stay private on any node*. Streaming the dedicated display into the cockpit (an `x11vnc` on `:N` wired to the existing websockify bridge) is a deliberate follow-up.

## Test plan

| Group | Coverage |
|-------|----------|
| `buildChromeArgs` software-GL | `--disable-gpu` emitted only when on a managed Xvfb |
| `resolveCobrowseDisplay` | default = managed; `CITADEL_COBROWSE_DISPLAY` = explicit (trimmed) |
| `xvfbResolution` | env override + default fallback |
| `withDisplay` | pins one `DISPLAY=`, strips inherited `DISPLAY`/`WAYLAND_DISPLAY`, preserves the rest |
| existing lifecycle tests | Stop/reaper still green |

`go build ./...`, `go vet`, and `go test ./internal/platform ./internal/jobs` all pass.

**Live-verified on a headless node** (no `:0`, real desktop on `:1`): a locally-built binary running `citadel work` → `cobrowse_start` started a managed `Xvfb :100` (`:99` was a stale lock — correctly skipped) + Chromium + CDP → navigated to example.com → `cobrowse_screenshot` returned the isolated browser viewport (the page, **not** the desktop).

## Related

- aceteam#4373 — `cobrowse_start` times out on ubuntu-gpu (the bug this resolves for headless nodes; the node also needed updating to ≥ v2.47.0 for the COBROWSE handler).
- #4079 — co-browse feature this extends.
- Follow-up: stream the dedicated display to the cockpit (`x11vnc :N` → existing `internal/websockify`).
