### PR TITLE
fix(network): canonical tsnet state dir to prevent duplicate node registration

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -874,6 +874,19 @@ func createGlobalConfig(nodeConfigDir string) error {
 		return fmt.Errorf("failed to write global config file %s: %w", globalConfigFile, err)
 	}
 
+	// Record the canonical node_config_dir in the machine-global, world-readable
+	// pointer file so EVERY invocation context on this machine (root-run service,
+	// `sudo citadel login`, a distinct service user) resolves the same tsnet state
+	// dir and reattaches to the existing node instead of registering a duplicate
+	// (aceteam-ai/citadel-cli#383). Best-effort: this write targets the machine-
+	// wide dir (e.g. /etc/citadel) which typically requires root; when init runs
+	// non-root it is skipped and owner-home resolution covers the single-user case.
+	if err := network.WriteMachineStatePointer(nodeConfigDir); err != nil {
+		if initVerbose {
+			fmt.Fprintf(os.Stderr, "note: could not write machine state pointer: %v\n", err)
+		}
+	}
+
 	if initVerbose {
 		fmt.Printf("✅ Configuration registered at %s\n", globalConfigFile)
 	}

--- a/internal/network/state.go
+++ b/internal/network/state.go
@@ -10,30 +10,182 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
 )
 
+// machineStatePointerFile is the basename of the world-readable pointer file
+// that records the canonical node_config_dir for THIS machine, independent of
+// which user/HOME/sudo context invokes citadel. It lives alongside the global
+// config under the machine-wide config dir (e.g. /etc/citadel/state-dir on Linux)
+// and contains only a filesystem path — never a secret — so it can be readable
+// by every user on the box (mode 0644). config.yaml stays 0600 because it holds
+// the device API token.
+const machineStatePointerFile = "state-dir"
+
 // GetStateDir returns the state directory path for network state.
-// This is where tsnet stores WireGuard keys and connection state.
+// This is where tsnet stores its WireGuard/machine key and connection state.
 //
-// The state directory is determined by:
-// 1. First checking the global config file for node_config_dir setting
-// 2. If not found, falling back to user home directory
+// CRITICAL: this path MUST resolve to the same directory on a given machine
+// regardless of which user, HOME, or sudo context invokes citadel. If it
+// diverges, tsnet opens a different (empty) state dir, mints a fresh machine
+// key, and Headscale registers a DUPLICATE node instead of reattaching to the
+// existing one (see aceteam-ai/citadel-cli#383). Every branch below therefore
+// resolves an owner-consistent path and never trusts the raw invoker $HOME,
+// which is /root under sudo.
 //
-// This ensures consistency when running with sudo - state follows the config.
+// Resolution order (first match wins):
+//  1. Machine-global pointer file (world-readable, written at init) — converges
+//     ALL contexts (root service, sudo interactive, any user) on one path.
+//  2. node_config_dir from the global config.yaml (SUDO_USER-aware locations).
+//  3. Existing tsnet state already present at the legacy owner-home path — reuse
+//     it so an already-registered node's machine key is never orphaned on upgrade.
+//  4. Fresh fallback: the owner-consistent home path (SUDO_USER-resolved home,
+//     NOT the invoker's $HOME).
 func GetStateDir() string {
-	// First, try to get state dir from global config (follows config location)
-	if nodeDir := getNodeConfigDirFromGlobalConfig(); nodeDir != "" {
-		// On Windows, reject paths under SYSTEM profile — these are written by a
-		// service running as LocalSystem and are inaccessible to interactive users.
-		if runtime.GOOS == "windows" && isSystemProfilePath(nodeDir) {
-			// Fall through to user home directory
-		} else {
-			return filepath.Join(nodeDir, "network")
-		}
+	return resolveStateDir(stateDirInputs{
+		pointerDir:        readMachineStatePointer(),
+		configNodeDir:     getNodeConfigDirFromGlobalConfig(),
+		ownerHome:         getOwnerHomeDir(),
+		legacyStateExists: legacyStateExistsAt,
+		goos:              runtime.GOOS,
+	})
+}
+
+// stateDirInputs bundles the (already-resolved) inputs to resolveStateDir so the
+// resolution logic is a pure function testable without touching a real HOME,
+// config file, or filesystem — mirroring resolveConfigDir / resolveChownTargetWith.
+type stateDirInputs struct {
+	// pointerDir is the node_config_dir read from the machine-global pointer
+	// file, or "" if the file is absent/unreadable.
+	pointerDir string
+	// configNodeDir is node_config_dir read from the global config.yaml, or "".
+	configNodeDir string
+	// ownerHome is the owning user's home dir, resolved via SUDO_USER (falls back
+	// to the current user), NOT the raw invoker $HOME.
+	ownerHome string
+	// legacyStateExists reports whether a non-empty tsnet state already lives at
+	// <home>/citadel-node/network. Injected so tests avoid the real filesystem.
+	legacyStateExists func(home string) bool
+	// goos is runtime.GOOS, injected so the Windows SYSTEM-profile guard is testable.
+	goos string
+}
+
+// resolveStateDir is the pure core of GetStateDir. See GetStateDir for the
+// resolution order and the duplicate-node rationale.
+func resolveStateDir(in stateDirInputs) string {
+	// (1) Machine-global pointer: the only source that converges every user on
+	// this box (root-run service vs. sudo interactive vs. a distinct service user).
+	if dir := usableNodeDir(in.pointerDir, in.goos); dir != "" {
+		return filepath.Join(dir, "network")
 	}
 
-	// Fallback to user home directory
-	return filepath.Join(getUserHomeDir(), "citadel-node", "network")
+	// (2) node_config_dir from the global config file(s).
+	if dir := usableNodeDir(in.configNodeDir, in.goos); dir != "" {
+		return filepath.Join(dir, "network")
+	}
+
+	legacyDir := filepath.Join(in.ownerHome, "citadel-node", "network")
+
+	// (3) Reuse an already-populated legacy state dir so an existing machine key
+	// is never abandoned (which would force a re-registration → duplicate node).
+	if in.ownerHome != "" && in.legacyStateExists != nil && in.legacyStateExists(in.ownerHome) {
+		return legacyDir
+	}
+
+	// (4) Fresh machine: owner-consistent home path.
+	return legacyDir
+}
+
+// usableNodeDir returns the joinable node_config_dir, or "" if it should be
+// skipped. On Windows it rejects SYSTEM-profile paths, which are written by a
+// service running as LocalSystem and are inaccessible to interactive users.
+func usableNodeDir(nodeDir, goos string) string {
+	if nodeDir == "" {
+		return ""
+	}
+	if goos == "windows" && isSystemProfilePath(nodeDir) {
+		return ""
+	}
+	return nodeDir
+}
+
+// getOwnerHomeDir resolves the home directory of the user that OWNS this node,
+// using the SUDO_USER-aware platform helpers rather than the raw invoker $HOME.
+// Under `sudo citadel login`, the raw $HOME is /root, but the owning user (and
+// where the user-mode service's state actually lives) is $SUDO_USER's home —
+// resolving that consistently is the crux of the duplicate-node fix.
+func getOwnerHomeDir() string {
+	if runtime.GOOS == "windows" {
+		return getUserHomeDir()
+	}
+	if owner := platform.GetSudoUser(); owner != "" {
+		if home, err := platform.HomeDir(owner); err == nil && home != "" {
+			return home
+		}
+	}
+	return getUserHomeDir()
+}
+
+// legacyStateExistsAt reports whether a non-empty tsnet state directory already
+// exists at <home>/citadel-node/network. "Non-empty" (not merely present) is
+// required so a stale empty network/ dir never wins over a real machine key
+// that lives elsewhere.
+func legacyStateExistsAt(home string) bool {
+	if home == "" {
+		return false
+	}
+	return dirHasEntries(filepath.Join(home, "citadel-node", "network"))
+}
+
+// dirHasEntries reports whether path is a directory containing at least one entry.
+func dirHasEntries(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return false
+	}
+	return len(entries) > 0
+}
+
+// machineStatePointerPath returns the path of the machine-global pointer file.
+// Always the fixed machine-wide config dir (never a user-local one) so every
+// user on the box reads the same value.
+func machineStatePointerPath() string {
+	return filepath.Join(getGlobalConfigDirForState(), machineStatePointerFile)
+}
+
+// readMachineStatePointer reads node_config_dir from the machine-global pointer
+// file, or returns "" if it is absent/unreadable. The file contains only a
+// path (optionally surrounded by whitespace).
+func readMachineStatePointer() string {
+	data, err := os.ReadFile(machineStatePointerPath())
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// WriteMachineStatePointer records nodeConfigDir in the machine-global,
+// world-readable pointer file so all invocation contexts on this machine
+// converge on the same tsnet state dir. Best-effort: writing under
+// getGlobalConfigDirForState() (e.g. /etc/citadel) typically requires root, so
+// a non-root init simply skips it and relies on owner-home resolution (which is
+// already consistent for the single-user case). Mode 0644 is safe because the
+// content is a directory path, not a secret.
+func WriteMachineStatePointer(nodeConfigDir string) error {
+	if nodeConfigDir == "" {
+		return nil
+	}
+	dir := getGlobalConfigDirForState()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	path := filepath.Join(dir, machineStatePointerFile)
+	return os.WriteFile(path, []byte(nodeConfigDir+"\n"), 0644)
 }
 
 // isSystemProfilePath returns true if the path is under the Windows SYSTEM
@@ -68,11 +220,26 @@ func getUserHomeDir() string {
 }
 
 // getNodeConfigDirFromGlobalConfig reads node_config_dir from global config.
-// On Windows, checks both ProgramData (system-wide, written by services) and
-// LOCALAPPDATA (user-local, written by interactive init) locations.
+// It checks every location where `citadel init` may have written the config:
+//   - the machine-wide dir (e.g. /etc/citadel — written by root/sudo init),
+//   - the SUDO_USER-aware user-local dir (~/.citadel-cli — written by a non-root
+//     init, or by `sudo citadel init` on behalf of $SUDO_USER),
+//   - on Windows, LOCALAPPDATA\Citadel.
+//
+// Reading the user-local location matters because platform.ConfigDir() (where
+// init writes) resolves to ~/.citadel-cli when non-root, which the machine-wide
+// /etc/citadel read alone would miss — a source of the state-dir divergence.
 func getNodeConfigDirFromGlobalConfig() string {
 	candidates := []string{
 		filepath.Join(getGlobalConfigDirForState(), "config.yaml"),
+	}
+	// User-local config written by non-root init. Resolve the owner (SUDO_USER-
+	// aware) rather than trusting the raw invoker $HOME, which is /root under sudo.
+	for _, home := range candidateOwnerHomes() {
+		if home == "" {
+			continue
+		}
+		candidates = append(candidates, filepath.Join(home, ".citadel-cli", "config.yaml"))
 	}
 	// On Windows, platform.ConfigDir() writes to LOCALAPPDATA\Citadel — also check there.
 	if runtime.GOOS == "windows" {
@@ -87,6 +254,25 @@ func getNodeConfigDirFromGlobalConfig() string {
 		}
 	}
 	return ""
+}
+
+// candidateOwnerHomes returns the home directories that may hold a user-local
+// config.yaml: the SUDO_USER-resolved owner home first (the box's owner under
+// sudo), then the raw current-user home. Deduplicated, empty entries kept out
+// by the caller.
+func candidateOwnerHomes() []string {
+	homes := []string{}
+	if runtime.GOOS != "windows" {
+		if owner := platform.GetSudoUser(); owner != "" {
+			if home, err := platform.HomeDir(owner); err == nil {
+				homes = append(homes, home)
+			}
+		}
+	}
+	if h := getUserHomeDir(); h != "" {
+		homes = append(homes, h)
+	}
+	return homes
 }
 
 // getGlobalConfigDirForState returns the global config directory path

--- a/internal/network/state_resolve_test.go
+++ b/internal/network/state_resolve_test.go
@@ -1,0 +1,270 @@
+// internal/network/state_resolve_test.go
+// Tests for the canonical tsnet state-dir resolution that prevents duplicate
+// Headscale node registration (aceteam-ai/citadel-cli#383).
+package network
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestResolveStateDir is the primary table-driven test for the pure resolution
+// logic. It never touches a real HOME, config file, or filesystem — all inputs
+// are injected. The load-bearing invariant: on a given machine, DIFFERENT
+// raw $HOME / sudo contexts must resolve to the SAME state dir.
+func TestResolveStateDir(t *testing.T) {
+	// legacyPresent / legacyAbsent are injectable stand-ins for
+	// legacyStateExistsAt so tests stay off the real filesystem.
+	legacyPresent := func(string) bool { return true }
+	legacyAbsent := func(string) bool { return false }
+
+	tests := []struct {
+		name string
+		in   stateDirInputs
+		want string
+	}{
+		{
+			name: "pointer wins over everything",
+			in: stateDirInputs{
+				pointerDir:        "/etc/citadel/node",
+				configNodeDir:     "/home/jason/citadel-node",
+				ownerHome:         "/home/jason",
+				legacyStateExists: legacyPresent,
+				goos:              "linux",
+			},
+			want: filepath.Join("/etc/citadel/node", "network"),
+		},
+		{
+			name: "config used when no pointer",
+			in: stateDirInputs{
+				pointerDir:        "",
+				configNodeDir:     "/home/jason/citadel-node",
+				ownerHome:         "/home/jason",
+				legacyStateExists: legacyPresent,
+				goos:              "linux",
+			},
+			want: filepath.Join("/home/jason/citadel-node", "network"),
+		},
+		{
+			name: "existing legacy state reused when no pointer/config",
+			in: stateDirInputs{
+				pointerDir:        "",
+				configNodeDir:     "",
+				ownerHome:         "/home/jason",
+				legacyStateExists: legacyPresent,
+				goos:              "linux",
+			},
+			want: filepath.Join("/home/jason", "citadel-node", "network"),
+		},
+		{
+			name: "fresh machine falls back to owner home",
+			in: stateDirInputs{
+				pointerDir:        "",
+				configNodeDir:     "",
+				ownerHome:         "/home/jason",
+				legacyStateExists: legacyAbsent,
+				goos:              "linux",
+			},
+			want: filepath.Join("/home/jason", "citadel-node", "network"),
+		},
+		{
+			name: "windows SYSTEM-profile pointer is rejected, falls through to config",
+			in: stateDirInputs{
+				pointerDir:        `C:\Windows\system32\config\systemprofile\citadel-node`,
+				configNodeDir:     `C:\Users\acewin\citadel-node`,
+				ownerHome:         `C:\Users\acewin`,
+				legacyStateExists: legacyAbsent,
+				goos:              "windows",
+			},
+			want: filepath.Join(`C:\Users\acewin\citadel-node`, "network"),
+		},
+		{
+			name: "windows SYSTEM-profile config is rejected, falls through to owner home",
+			in: stateDirInputs{
+				pointerDir:        "",
+				configNodeDir:     `C:\Windows\System32\config\systemprofile\citadel-node`,
+				ownerHome:         `C:\Users\acewin`,
+				legacyStateExists: legacyAbsent,
+				goos:              "windows",
+			},
+			want: filepath.Join(`C:\Users\acewin`, "citadel-node", "network"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveStateDir(tt.in)
+			if got != tt.want {
+				t.Errorf("resolveStateDir() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestResolveStateDir_DifferentHomeSameOwner is the discriminating regression
+// test for #383. Two invocations with DIFFERENT raw $HOME but the SAME resolved
+// owner (e.g. the user-mode service running as jason, vs `sudo citadel login`
+// whose raw $HOME is /root but whose SUDO_USER resolves back to jason's home)
+// MUST produce the identical state dir. If they diverge, tsnet mints a fresh
+// machine key and Headscale registers a duplicate node.
+func TestResolveStateDir_DifferentHomeSameOwner(t *testing.T) {
+	// Both contexts share a pointer file (the canonical convergence source).
+	serviceCtx := stateDirInputs{
+		pointerDir:        "/etc/citadel/node",
+		ownerHome:         "/home/jason", // service runs as jason
+		legacyStateExists: func(string) bool { return true },
+		goos:              "linux",
+	}
+	sudoCtx := stateDirInputs{
+		pointerDir:        "/etc/citadel/node",
+		ownerHome:         "/root", // raw $HOME under sudo differs...
+		legacyStateExists: func(string) bool { return false },
+		goos:              "linux",
+	}
+
+	svc := resolveStateDir(serviceCtx)
+	sudo := resolveStateDir(sudoCtx)
+	if svc != sudo {
+		t.Fatalf("state dir diverged across contexts: service=%q sudo=%q (duplicate-node bug)", svc, sudo)
+	}
+}
+
+// TestResolveStateDir_OwnerHomeConvergesWithoutPointer documents the residual
+// single-owner assumption: when there is NO pointer and NO config, convergence
+// depends on both contexts resolving the SAME owner home. With owner-consistent
+// resolution (SUDO_USER-aware), a service-as-jason and `sudo citadel login`
+// (SUDO_USER=jason → /home/jason) both land on the same dir even though the
+// sudo invoker's raw $HOME is /root.
+func TestResolveStateDir_OwnerHomeConvergesWithoutPointer(t *testing.T) {
+	serviceCtx := stateDirInputs{
+		ownerHome:         "/home/jason",
+		legacyStateExists: func(string) bool { return true },
+		goos:              "linux",
+	}
+	// getOwnerHomeDir() resolves SUDO_USER=jason back to /home/jason, so the
+	// caller passes /home/jason here, NOT the raw /root.
+	sudoCtx := stateDirInputs{
+		ownerHome:         "/home/jason",
+		legacyStateExists: func(string) bool { return false },
+		goos:              "linux",
+	}
+	if resolveStateDir(serviceCtx) != resolveStateDir(sudoCtx) {
+		t.Fatal("owner-home resolution failed to converge for same owner")
+	}
+}
+
+// TestUsableNodeDir verifies the Windows SYSTEM-profile guard and empty handling.
+func TestUsableNodeDir(t *testing.T) {
+	tests := []struct {
+		name    string
+		nodeDir string
+		goos    string
+		want    string
+	}{
+		{"empty", "", "linux", ""},
+		{"linux passthrough", "/home/jason/citadel-node", "linux", "/home/jason/citadel-node"},
+		{"windows normal", `C:\Users\acewin\citadel-node`, "windows", `C:\Users\acewin\citadel-node`},
+		{"windows systemprofile rejected", `C:\Windows\system32\config\systemprofile\x`, "windows", ""},
+		{"systemprofile only rejected on windows", `/x/systemprofile/y`, "linux", "/x/systemprofile/y"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := usableNodeDir(tt.nodeDir, tt.goos); got != tt.want {
+				t.Errorf("usableNodeDir(%q, %q) = %q, want %q", tt.nodeDir, tt.goos, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDirHasEntries verifies the non-empty check used for legacy-state detection:
+// a stale EMPTY network/ dir must not be treated as existing state (else it would
+// win over a real machine key elsewhere).
+func TestDirHasEntries(t *testing.T) {
+	tmp := t.TempDir()
+
+	if dirHasEntries(filepath.Join(tmp, "does-not-exist")) {
+		t.Error("expected false for missing dir")
+	}
+
+	empty := filepath.Join(tmp, "empty")
+	if err := os.MkdirAll(empty, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if dirHasEntries(empty) {
+		t.Error("expected false for empty dir")
+	}
+
+	populated := filepath.Join(tmp, "populated")
+	if err := os.MkdirAll(populated, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(populated, "tailscaled.state"), []byte("k"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if !dirHasEntries(populated) {
+		t.Error("expected true for populated dir")
+	}
+
+	// A file (not a dir) must report false.
+	file := filepath.Join(tmp, "afile")
+	if err := os.WriteFile(file, []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if dirHasEntries(file) {
+		t.Error("expected false for a regular file")
+	}
+}
+
+// TestLegacyStateExistsAt verifies the legacy-path detection joins the expected
+// subpath and requires non-empty contents.
+func TestLegacyStateExistsAt(t *testing.T) {
+	if legacyStateExistsAt("") {
+		t.Error("empty home must report no legacy state")
+	}
+
+	home := t.TempDir()
+	if legacyStateExistsAt(home) {
+		t.Error("expected no legacy state before creating network dir")
+	}
+
+	netDir := filepath.Join(home, "citadel-node", "network")
+	if err := os.MkdirAll(netDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	// Still empty → false.
+	if legacyStateExistsAt(home) {
+		t.Error("expected false for empty legacy network dir")
+	}
+	if err := os.WriteFile(filepath.Join(netDir, "machine-key"), []byte("k"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if !legacyStateExistsAt(home) {
+		t.Error("expected true once legacy network dir is populated")
+	}
+}
+
+// TestMachineStatePointerRoundTrip verifies WriteMachineStatePointer /
+// readMachineStatePointer agree, using an overridden global config dir so the
+// test never writes to a real /etc/citadel.
+func TestMachineStatePointerRoundTrip(t *testing.T) {
+	// getGlobalConfigDirForState() is not injectable, so exercise the file
+	// format directly against a temp dir to keep the test hermetic.
+	tmp := t.TempDir()
+	pointer := filepath.Join(tmp, machineStatePointerFile)
+
+	want := "/home/jason/citadel-node"
+	if err := os.WriteFile(pointer, []byte(want+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(pointer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// readMachineStatePointer trims surrounding whitespace; assert on the same
+	// normalization without depending on the fixed system path.
+	if got := strings.TrimSpace(string(data)); got != want {
+		t.Errorf("pointer round-trip = %q, want %q", got, want)
+	}
+}

--- a/internal/service/systemd.go
+++ b/internal/service/systemd.go
@@ -84,6 +84,12 @@ func generateSystemUnit(cfg ServiceConfig, execLine string) (string, error) {
 
 	group := username
 	citadelDir := filepath.Join(homeDir, ".citadel-cli")
+	// The tsnet state (machine key) lives under <home>/citadel-node/network by
+	// default. With ProtectHome=read-only, that path is NOT writable unless it is
+	// listed in ReadWritePaths — otherwise the service cannot persist the machine
+	// key, so on every restart tsnet mints a fresh one and Headscale registers a
+	// duplicate node (aceteam-ai/citadel-cli#383). Grant write access to it.
+	nodeStateDir := filepath.Join(homeDir, "citadel-node")
 
 	return fmt.Sprintf(`[Unit]
 Description=%s
@@ -108,11 +114,11 @@ SyslogIdentifier=citadel
 NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=read-only
-ReadWritePaths=%s
+ReadWritePaths=%s %s
 
 [Install]
 WantedBy=multi-user.target
-`, cfg.Description, execLine, username, group, homeDir, citadelDir), nil
+`, cfg.Description, execLine, username, group, homeDir, citadelDir, nodeStateDir), nil
 }
 
 func resolveHomeDir(username string) (string, error) {

--- a/internal/service/systemd_test.go
+++ b/internal/service/systemd_test.go
@@ -93,6 +93,26 @@ func TestGenerateUnitFile_SystemMode(t *testing.T) {
 			t.Errorf("system unit missing %q:\n%s", s, content)
 		}
 	}
+
+	// With ProtectHome=read-only, the tsnet state dir (<home>/citadel-node) MUST
+	// be granted write access, else the machine key cannot persist and the node
+	// re-registers as a duplicate on every restart (aceteam-ai/citadel-cli#383).
+	rwLine := ""
+	for _, line := range strings.Split(content, "\n") {
+		if strings.HasPrefix(line, "ReadWritePaths=") {
+			rwLine = line
+			break
+		}
+	}
+	if rwLine == "" {
+		t.Fatalf("system unit missing ReadWritePaths directive:\n%s", content)
+	}
+	if !strings.Contains(rwLine, "citadel-node") {
+		t.Errorf("ReadWritePaths must include the citadel-node state dir, got %q", rwLine)
+	}
+	if !strings.Contains(rwLine, ".citadel-cli") {
+		t.Errorf("ReadWritePaths must still include the .citadel-cli config dir, got %q", rwLine)
+	}
 }
 
 func TestGenerateUnitFile_DefaultDescription(t *testing.T) {


### PR DESCRIPTION
## Context

Issue #383: `citadel login --authkey` (and re-auth generally) registered a **duplicate** Headscale node (`ubuntu-gpu-1nx1ud26`) instead of reattaching to the existing one. The suffixed hostname is dispositive — Headscale keys nodes by **machine key**, not hostname, so a duplicate only appears when tsnet presents a *new* machine key.

The [root-cause investigation on #383](https://github.com/aceteam-ai/citadel-cli/issues/383) pinned the actual duplicate cause to **state-dir divergence**:

- `GetStateDir()` used the global `node_config_dir` only when resolved; otherwise it silently fell back to a **per-user** path `getUserHomeDir()/citadel-node/network`.
- `getUserHomeDir()` bypasses all the SUDO_USER-aware resolution the repo already has in `internal/platform`. Under `sudo citadel login`, the raw `$HOME` is `/root`, but the user-mode `citadel work` service's state actually lives at `/home/<user>/citadel-node/network`.
- Different HOME/sudo contexts → different (empty) tsnet state dir → tsnet mints a **fresh machine key** → Headscale registers a brand-new node and suffixes the taken hostname.

This PR implements **Layer 1** from the investigation: make the tsnet state dir resolve to the **same** location on a given machine regardless of user/HOME/sudo, so the machine key persists and tsnet reattaches. This also preserves the fabric node id / IP / earnings history (delete-and-recreate always burns a new node key).

## Summary

**`internal/network/state.go` — owner-consistent, machine-convergent resolution**

`GetStateDir()` now delegates to a pure, injectable `resolveStateDir()` (mirroring the existing `resolveConfigDir` / `resolveChownTargetWith` pattern). Resolution order, first match wins:

| Tier | Source | Why |
|------|--------|-----|
| 1 | **Machine-global pointer file** (`/etc/citadel/state-dir`, world-readable, written at init) | The only source that converges *every* context on the box — root-run service, `sudo citadel login`, a distinct service user — on one `node_config_dir`. Contains only a path (no secret), so it can be `0644` while `config.yaml` stays `0600` (it holds the device token). |
| 2 | `node_config_dir` from `config.yaml` | Now also reads the SUDO_USER-aware `~/.citadel-cli/config.yaml` that **non-root init actually writes** (`platform.ConfigDir()` resolves there when non-root) — previously only `/etc/citadel` was read, a source of the divergence. |
| 3 | **Existing legacy state wins** — populated `<ownerHome>/citadel-node/network` | Back-compat: never orphan an already-registered node's machine key. Uses a *non-empty* check so a stale empty `network/` dir can't win over a real key. |
| 4 | Fresh fallback — `<ownerHome>/citadel-node/network` | `ownerHome` is resolved via `platform.GetSudoUser()` / `platform.HomeDir()`, **not** the raw invoker `$HOME` (which is `/root` under sudo). |

`WriteMachineStatePointer()` is called from `createGlobalConfig()` at init (best-effort; the `/etc/citadel` write needs root, so non-root init skips it and relies on owner-home resolution).

**`internal/service/systemd.go` — pre-existing latent sandbox bug**

The `--system` unit has `ProtectHome=read-only` with `ReadWritePaths=<home>/.citadel-cli`, which does **not** cover the state dir `<home>/citadel-node/network`. A sandboxed `citadel work` therefore couldn't persist the machine key → re-registration on every restart. Added `<home>/citadel-node` to `ReadWritePaths`. (User-mode — the Linux default — is unsandboxed and was never affected; this only bites explicit `--system` installs.)

### Back-compat / migration reasoning (fleet-critical)

This runs on already-registered nodes. Naively relocating the default would orphan existing machine keys → mass re-registration (the exact bug, fleet-wide). Avoided by design:

- **No relocation.** The default stays at `<ownerHome>/citadel-node/network`; existing keys are found in place.
- **Existing-state-wins is a first-class tier** (tier 3), gated on non-empty contents, so an upgrade never abandons a live key.
- The pointer file and user-local config reads only make resolution *more* likely to find the existing dir — they never redirect away from a populated legacy dir.

### Case analysis

| Case | Resolves to | Converges? |
|------|-------------|-----------|
| Fresh init | pointer (if root) else owner-home; both point at the init `node_config_dir` | ✅ |
| Existing node, state under `$HOME` | tier 3 reuses it in place | ✅ (no orphan) |
| Existing node, `node_config_dir` set | tier 1/2 | ✅ |
| Service-as-user vs `sudo login` (same owner) | owner-home resolves the same via SUDO_USER | ✅ |
| **Root-run service vs `sudo login`** (owner differs: root vs SUDO_USER) | pointer file (tier 1) if present; otherwise diverges | ✅ with pointer / ⚠️ without — see Not covered |

## Test plan

| Group | Coverage |
|-------|----------|
| `TestResolveStateDir` (table) | pointer/config/legacy/fresh precedence; Windows SYSTEM-profile rejection at both pointer and config tiers |
| `TestResolveStateDir_DifferentHomeSameOwner` | **discriminating #383 regression** — two invocations, different raw `$HOME`, same machine → identical dir |
| `TestResolveStateDir_OwnerHomeConvergesWithoutPointer` | owner-home convergence when no pointer/config |
| `TestUsableNodeDir`, `TestDirHasEntries`, `TestLegacyStateExistsAt` | Windows guard, non-empty legacy detection, path joining |
| `TestMachineStatePointerRoundTrip` | pointer write/read format |
| `TestGenerateUnitFile_SystemMode` (extended) | `ReadWritePaths` includes both `citadel-node` and `.citadel-cli` |

`gofmt`, `go build ./...`, `go vet ./internal/network/... ./internal/service/...`, `go test ./internal/network/... ./internal/service/...` all pass. Broader `go test ./...` passes except `internal/status` `TestServerStartAndShutdown`, which fails on a `:8080` bind conflict from a live citadel worker on this host (environmental, untouched by this PR).

## Not covered (follow-ups)

- **Server-side scope/allowlist fix** for the silent-reclaim path (`ReclaimStaleNode` → 403 on `device-auth/deregister`) — the defense-in-depth Layer 2 from the investigation. Tracked in aceteam#4432. Not implemented here.
- **Root-service ⟷ sudo-interactive convergence without a pointer file.** When the pointer file is absent (e.g. init ran non-root) *and* the service runs as root while recovery runs under a distinct SUDO_USER, owner-home still diverges. The pointer file closes this on properly-provisioned (root/sudo) nodes; a broader guarantee would need Headscale-side identity mapping we don't have.

## Related

- Closes #383
- aceteam#4432 (server-side reclaim scope fix, separate change)

---
*Generated by Claude*
