### PR TITLE
fix(work): start managed services asynchronously so job subscription isn't blocked (#384)

### DIFF
--- a/cmd/work.go
+++ b/cmd/work.go
@@ -203,11 +203,14 @@ func runWork(cmd *cobra.Command, args []string) {
 			fmt.Fprintf(os.Stderr, "   - Warning: co-browse browser stop: %v\n", err)
 		}
 		// Cancel first so the async service-startup goroutine stops launching any
-		// further services, then tear down the ones we already started. Like
-		// co-browse, this stops the containers/processes we spawned but preserves
-		// their data (no `-v`), and only touches services this worker launched.
+		// further services.
 		cancel()
-		teardownStartedServices()
+		// Arm the watchdog BEFORE tearing down managed services. Service teardown
+		// shells out to `docker compose down` (potentially several times) and a
+		// wedged docker daemon could hang this handler; the watchdog (second
+		// signal + grace-period force-exit, issue #312) must already be running so
+		// a stuck teardown can never leave an orphaned node holding the VPN
+		// identity or the terminal-server port.
 		go func() {
 			select {
 			case <-sigs:
@@ -218,6 +221,10 @@ func runWork(cmd *cobra.Command, args []string) {
 				os.Exit(1)
 			}
 		}()
+		// Tear down the services we started. Like co-browse, this stops the
+		// containers/processes we spawned but preserves their data (no `-v`), and
+		// only touches services this worker launched.
+		teardownStartedServices()
 	}()
 
 	// Note: Update check is now handled by root.go's PersistentPreRun

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -76,7 +77,8 @@ var (
 	workTerminalDebug bool
 
 	// Service auto-start flags
-	workNoServices bool
+	workNoServices   bool
+	workWaitServices bool
 
 	// Update check flag
 	workNoUpdate bool
@@ -149,6 +151,31 @@ func runWork(cmd *cobra.Command, args []string) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	// Managed services this worker started (populated by the async startup
+	// goroutine below, read by the shutdown hook). Guarded by a mutex because
+	// the signal handler may fire while the startup goroutine is still filling
+	// it in — we only ever want to tear down services we actually launched.
+	var (
+		startedServicesMu sync.Mutex
+		startedServices   []startedService
+	)
+	recordStartedServices := func(svcs []startedService) {
+		startedServicesMu.Lock()
+		startedServices = append(startedServices, svcs...)
+		startedServicesMu.Unlock()
+	}
+	teardownStartedServices := func() {
+		startedServicesMu.Lock()
+		svcs := startedServices
+		startedServices = nil
+		startedServicesMu.Unlock()
+		stopManagedServices(svcs)
+	}
+	// Tear down managed services on any exit path (signal handler below also
+	// invokes this before the watchdog fires; the second call is a no-op because
+	// the slice is drained on first use).
+	defer teardownStartedServices()
+
 	// Apply --no-gateway / --no-terminal overrides (take precedence over defaults)
 	if workNoGateway {
 		workGateway = false
@@ -175,7 +202,12 @@ func runWork(cmd *cobra.Command, args []string) {
 		if err := platform.GetCobrowseManager().Stop(); err != nil {
 			fmt.Fprintf(os.Stderr, "   - Warning: co-browse browser stop: %v\n", err)
 		}
+		// Cancel first so the async service-startup goroutine stops launching any
+		// further services, then tear down the ones we already started. Like
+		// co-browse, this stops the containers/processes we spawned but preserves
+		// their data (no `-v`), and only touches services this worker launched.
 		cancel()
+		teardownStartedServices()
 		go func() {
 			select {
 			case <-sigs:
@@ -211,11 +243,26 @@ func runWork(cmd *cobra.Command, args []string) {
 	// so the OS inhibitor process is never orphaned past Citadel's lifetime.
 	defer keepAwakeMonitor.Stop()
 
-	// Auto-start services from manifest (unless --no-services is set)
-	if !workNoServices {
-		if err := autoStartServices(); err != nil {
-			fmt.Fprintf(os.Stderr, "   - Warning: Service auto-start: %v\n", err)
-		}
+	// Start managed services from the manifest (unless --no-services is set).
+	//
+	// Job serving is the node's core reason to exist and must never be gated on
+	// optional heavy services (e.g. vLLM pulling an image or loading a model onto
+	// the GPU). By default we launch services in a background goroutine and press
+	// on to VPN connect + job-stream subscription immediately, so the node comes
+	// online and serves jobs while services are still warming up (issue #384).
+	// Per-service status is surfaced by the status collector, which polls actual
+	// container state, so a slow or failed service simply reports as not-running
+	// rather than blocking startup. Use --wait-services to restore the old
+	// blocking behavior (subscribe only after every service is up).
+	switch {
+	case workNoServices:
+		// Skip service startup entirely.
+	case workWaitServices:
+		recordStartedServices(startManagedServices(ctx))
+	default:
+		go func() {
+			recordStartedServices(startManagedServices(ctx))
+		}()
 	}
 
 	// Resolve node capabilities early (used for queue routing and heartbeat)
@@ -1458,9 +1505,32 @@ func runWork(cmd *cobra.Command, args []string) {
 	}
 }
 
-// autoStartServices starts all services defined in the manifest.
-// This is called automatically by the work command unless --no-services is set.
-func autoStartServices() error {
+// startedService records a managed service that this worker actually started
+// (as opposed to one that was already running when the worker booted). It is
+// used to tear down only what we launched on graceful shutdown, mirroring how
+// the co-browse manager stops only the Chromium process it spawned.
+type startedService struct {
+	name string
+	// composePath is set for docker/compose services; empty for native services.
+	composePath string
+	native      bool
+}
+
+// startManagedServices starts all services defined in the manifest and returns
+// the subset it actually started (so callers can tear those down on shutdown).
+//
+// It honors ctx cancellation: if the worker is shutting down mid-startup (e.g.
+// vLLM is still pulling an image), it stops launching the remaining services
+// instead of orphaning a long-running goroutine. Per-service failures are
+// logged as warnings and never abort the sequence — a heavy service that fails
+// to come up must not block the rest, and the status collector reports actual
+// container state regardless of start ordering.
+//
+// This function may block for a long time (image pulls, model loads). Callers
+// that must not gate job-stream subscription on service readiness should invoke
+// it from a background goroutine (see runWork). The old blocking behavior is
+// still available via --wait-services.
+func startManagedServices(ctx context.Context) []startedService {
 	manifest, configDir, err := findAndReadManifest()
 	if err != nil {
 		// No manifest found - this is fine, just skip service startup
@@ -1473,7 +1543,15 @@ func autoStartServices() error {
 
 	fmt.Printf("--- Starting %d service(s) ---\n", len(manifest.Services))
 
+	var started []startedService
 	for _, service := range manifest.Services {
+		// Stop launching further services once shutdown has been requested so a
+		// slow startup goroutine unwinds promptly instead of racing teardown.
+		if ctx.Err() != nil {
+			fmt.Println("   - Service startup interrupted by shutdown")
+			break
+		}
+
 		serviceType := determineServiceType(service)
 
 		if serviceType == internalServices.ServiceTypeNative {
@@ -1482,6 +1560,7 @@ func autoStartServices() error {
 				fmt.Fprintf(os.Stderr, "     Warning: %s: %v\n", service.Name, err)
 				continue
 			}
+			started = append(started, startedService{name: service.Name, native: true})
 		} else {
 			// Validate that compose file path stays within config directory (prevent path traversal)
 			fullComposePath, err := platform.ValidatePathWithinDir(configDir, service.ComposeFile)
@@ -1494,12 +1573,38 @@ func autoStartServices() error {
 				fmt.Fprintf(os.Stderr, "     Warning: %s: %v\n", service.Name, err)
 				continue
 			}
+			started = append(started, startedService{name: service.Name, composePath: fullComposePath})
 		}
 		fmt.Printf("   - %s is running\n", service.Name)
 	}
 
 	fmt.Println("--- Services started ---")
-	return nil
+	return started
+}
+
+// stopManagedServices tears down services this worker started, mirroring the
+// co-browse manager teardown: it stops the containers/processes we launched but
+// preserves their data (docker compose down WITHOUT -v keeps model-cache
+// volumes; native stops leave any on-disk state). Services that were already
+// running when the worker booted are not in the list and are left untouched.
+func stopManagedServices(started []startedService) {
+	if len(started) == 0 {
+		return
+	}
+	fmt.Printf("   - Stopping %d managed service(s)...\n", len(started))
+	// Reverse order for graceful shutdown, matching `citadel stop`.
+	for i := len(started) - 1; i >= 0; i-- {
+		svc := started[i]
+		if svc.native {
+			if err := internalServices.StopNativeService(svc.name); err != nil {
+				fmt.Fprintf(os.Stderr, "   - Warning: stop %s: %v\n", svc.name, err)
+			}
+			continue
+		}
+		if err := stopServiceByCompose(svc.composePath, false); err != nil {
+			fmt.Fprintf(os.Stderr, "   - Warning: stop %s: %v\n", svc.name, err)
+		}
+	}
 }
 
 // shellQueueName returns the shared per-org shell command queue name.
@@ -1869,6 +1974,7 @@ func init() {
 
 	// Service auto-start flags
 	workCmd.Flags().BoolVar(&workNoServices, "no-services", false, "Skip auto-starting services from manifest")
+	workCmd.Flags().BoolVar(&workWaitServices, "wait-services", false, "Block until all manifest services are up before subscribing to job streams (default: start services asynchronously)")
 
 	// Update check flags (deprecated - update check now runs on all commands via root.go)
 	workCmd.Flags().BoolVar(&workNoUpdate, "no-update", false, "(Deprecated) No longer has any effect - use 'citadel update disable' instead")

--- a/cmd/work_services_test.go
+++ b/cmd/work_services_test.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// writeManifestWithServices creates an isolated HOME containing a global config
+// and a node manifest with the given services, so findAndReadManifest resolves
+// to the temp tree. It returns the node config dir.
+func writeManifestWithServices(t *testing.T, services []Service) string {
+	t.Helper()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	configDir := filepath.Join(home, ".citadel-cli")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	nodeDir := filepath.Join(home, "citadel-node")
+	if err := os.MkdirAll(filepath.Join(nodeDir, "services"), 0o755); err != nil {
+		t.Fatalf("mkdir node dir: %v", err)
+	}
+
+	globalConfig := map[string]string{"node_config_dir": nodeDir}
+	globalData, err := yaml.Marshal(globalConfig)
+	if err != nil {
+		t.Fatalf("marshal global config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), globalData, 0o600); err != nil {
+		t.Fatalf("write global config: %v", err)
+	}
+
+	manifest := &CitadelManifest{Services: services}
+	manifestData, err := yaml.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(nodeDir, "citadel.yaml"), manifestData, 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	return nodeDir
+}
+
+// TestStartManagedServicesNoManifest verifies that with no manifest present the
+// helper returns immediately with nothing started — service startup must never
+// block or fail the worker just because no manifest exists.
+func TestStartManagedServicesNoManifest(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // isolated HOME with no global config / manifest
+
+	started := startManagedServices(context.Background())
+	if started != nil {
+		t.Fatalf("expected no services started without a manifest, got %v", started)
+	}
+}
+
+// TestStartManagedServicesCanceledContextDoesNotStart is the core sequencing
+// contract for issue #384: job-stream subscription must not be gated on service
+// readiness. We model shutdown-during-startup with an already-canceled context;
+// the helper must observe cancellation and return without ever shelling out to
+// docker/podman to start the (slow) service. If cancellation were ignored the
+// call would attempt to start "vllm" and either block or error on the missing
+// compose file.
+func TestStartManagedServicesCanceledContextDoesNotStart(t *testing.T) {
+	writeManifestWithServices(t, []Service{
+		{Name: "vllm", Type: "docker", ComposeFile: filepath.Join("services", "vllm.yml")},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // shutdown already requested before startup begins
+
+	started := startManagedServices(ctx)
+	if len(started) != 0 {
+		t.Fatalf("expected no services started under a canceled context, got %v", started)
+	}
+}
+
+// TestStopManagedServicesEmptyIsNoop verifies teardown of an empty started-set
+// is a no-op (the double-call path: signal handler + deferred cleanup).
+func TestStopManagedServicesEmptyIsNoop(t *testing.T) {
+	// Must not panic or touch docker when nothing was started.
+	stopManagedServices(nil)
+	stopManagedServices([]startedService{})
+}
+
+// TestWaitServicesFlagDefaultsToAsync documents the default: services start
+// asynchronously (workWaitServices=false) so subscription is not gated on them.
+func TestWaitServicesFlagDefaultsToAsync(t *testing.T) {
+	if flag := workCmd.Flags().Lookup("wait-services"); flag == nil {
+		t.Fatal("expected --wait-services flag to be registered")
+	} else if flag.DefValue != "false" {
+		t.Errorf("--wait-services default = %q, want \"false\" (async startup is the default)", flag.DefValue)
+	}
+	if flag := workCmd.Flags().Lookup("no-services"); flag == nil {
+		t.Fatal("expected --no-services flag to remain registered")
+	}
+}


### PR DESCRIPTION
## Context

`citadel work` is the primary node command: it starts managed services from the manifest, connects to the VPN, and subscribes to its job streams so it can serve jobs (`terminal_exec`, `cobrowse_*`, code/file ops, etc.). Until now it did those **in order** — services first, subscription second — so a slow managed service blocked the whole worker startup.

Observed live on `ubuntu-gpu` (issue #384): a manifest with `vllm` sat at

```
--- Starting 4 service(s) ---
   - Starting vllm...
   Container runtime: docker
```

for the entire observation window while vLLM pulled its image / loaded the model onto the GPU. The node stayed **offline / unsubscribed** and served **no** jobs of any kind during that window. The workaround was to run the systemd unit with `--no-services` — which keeps the node reachable but never auto-starts vLLM. Job serving (the node's reason to exist) should not be gated on optional heavy services.

## Summary

Managed-service startup is now **asynchronous by default**. `runWork` kicks off service startup in a background goroutine and proceeds immediately to VPN connect + job-stream subscription, so the node comes online and serves jobs while services are still warming up.

**`cmd/work.go`**

- **Extracted** the old `autoStartServices()` loop into `startManagedServices(ctx) []startedService`:
  - Honors `ctx` cancellation — checks `ctx.Err()` between services so a slow startup goroutine stops launching the rest (and doesn't orphan) once shutdown is requested.
  - Returns the subset of services it **actually started** (skipping already-running containers), so shutdown only tears down what this worker launched — mirroring how the co-browse manager tracks only the Chromium process it spawned.
  - Per-service failures are logged as warnings and never abort the sequence; a heavy/failing service no longer blocks the others.
- **Async by default**: the startup call runs in a goroutine. `--wait-services` restores the old blocking behavior (subscribe only after every service is up). `--no-services` is unchanged.
- **Graceful shutdown preserved** — mirrors the existing co-browse teardown in the signal handler. Order matters: `cancel()` (so the startup goroutine stops launching more services) → **arm the #312 watchdog** (second-signal + grace-period force-exit) → `stopManagedServices(...)`. The watchdog is armed *before* teardown because teardown shells out to `docker compose down` (potentially ×N) and a wedged docker daemon must never hang the handler past the grace window and orphan the node's VPN identity. Like co-browse (kill the process, keep the persistent profile), services are stopped via `docker compose down` **without `-v`** (containers stop, model-cache volumes survive) or `StopNativeService`. A `defer` also runs teardown on normal exit; the second call is a no-op because the started-set is drained on first use. Access to the shared set is mutex-guarded since the signal handler can fire while the startup goroutine is still filling it in.
- **Grace window**: `shutdownGracePeriod` is 5s. A `docker compose down` across several services can exceed that (docker's default per-container stop timeout), in which case the (now-armed) watchdog force-exits mid-teardown — acceptable, since the containers are detached and the next start reconciles.

**Status reporting** is unaffected: the `internal/status` collector polls actual container state, so a slow or failed service simply reports as not-running regardless of start ordering — nothing is swallowed.

### Behavior change to confirm (called out for review)

Teardown-on-exit means a systemd restart now **stops** managed services (vLLM reloads its model into the GPU on the next start), whereas the old detached behavior let containers survive a restart. This is **not** an availability regression — the async fix keeps the node subscribed and serving jobs during that reload — but it is a deliberate semantic change (matches the "stop what we started" shutdown contract) and worth a reviewer sign-off. `--wait-services` is available for callers who want the old blocking sequence.

Known minor race (acceptable, containers are detached and the next start reconciles): if shutdown fires while a service is mid-`startService`, that single in-flight service may not be in the started-set yet and could be left running; the `ctx.Err()` check still prevents launching any *further* services.

## Test plan

| Test | Coverage |
| --- | --- |
| `TestStartManagedServicesNoManifest` | No manifest → returns immediately, nothing started (never blocks/fails the worker) |
| `TestStartManagedServicesCanceledContextDoesNotStart` | **Core #384 contract**: a canceled context (shutdown-during-startup) halts before shelling out to docker — subscription is not gated on service readiness |
| `TestStopManagedServicesEmptyIsNoop` | Empty teardown is a no-op (double-call path: signal handler + deferred cleanup) |
| `TestWaitServicesFlagDefaultsToAsync` | `--wait-services` registered, defaults to `false` (async is the default); `--no-services` still registered |

Verification run:

- `gofmt -l` — clean
- `go build ./...` — passes
- `go vet ./cmd/... ./internal/...` — passes
- `go test ./cmd/...` — passes
- `go test ./internal/...` — passes except `internal/status/TestServerStartAndShutdown`, which fails only because the **live** `citadel` worker on this host holds `:8080` (`listen tcp :8080: bind: address already in use`). Environmental, unrelated to this change (this PR does not touch `internal/status`).

**Live-node acceptance check (why this is a draft):** on a node with services enabled (drop the `--no-services` workaround from the systemd unit), start `citadel work` and confirm the node **subscribes to its job streams and serves jobs immediately** while vLLM is still loading the model — i.e. `citadel_node_info` / a `terminal_exec` succeeds during the vLLM warm-up window, instead of timing out until the model finishes loading. Also confirm SIGTERM stops the managed services cleanly.

## Related

- Closes #384
- Surfaced while making co-browse durable under systemd (#380 / #4373)
