### PR TITLE
fix(worker): NAK unsupported job types instead of silent no-op (#382)

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -1724,9 +1724,10 @@ func runTUIWorker(ctx context.Context, activityFn func(level, msg string)) error
 
 	// Create runner with TUI callbacks
 	runner := worker.NewRunner(source, handlers, worker.RunnerConfig{
-		WorkerID:   workerID,
-		Verbose:    false,
-		ActivityFn: activity, // Route logs through TUI
+		WorkerID:     workerID,
+		AgentVersion: Version,
+		Verbose:      false,
+		ActivityFn:   activity, // Route logs through TUI
 		JobRecordFn: func(record usage.UsageRecord) {
 			// Job recording callback - could be extended to pass to TUI
 			// For now, the activity log covers job status

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1413,6 +1413,7 @@ func runWork(cmd *cobra.Command, args []string) {
 	runner := worker.NewRunner(source, handlers, worker.RunnerConfig{
 		WorkerID:       workerID,
 		NodeID:         headscaleNodeID,
+		AgentVersion:   Version,
 		Verbose:        true,
 		ActivityFn:     func(_ string, msg string) { Log("%s", msg) },
 		JobRecordFn:    jobRecordFn,

--- a/internal/worker/api_source.go
+++ b/internal/worker/api_source.go
@@ -280,6 +280,28 @@ func (s *APISource) Nack(ctx context.Context, job *Job, err error) error {
 	return nil
 }
 
+// Fail is a terminal failure: record "failed" status (with structured data) and
+// ACK the message so it is removed from the consumer group's PEL. Used for
+// failures that will never succeed on retry (e.g. an unsupported job type).
+func (s *APISource) Fail(ctx context.Context, job *Job, err error, data map[string]any) error {
+	status := map[string]any{"error": err.Error()}
+	for k, v := range data {
+		status[k] = v
+	}
+	s.client.SetJobStatus(ctx, job.ID, "failed", status)
+	queue := job.SourceQueue
+	if queue == "" {
+		if qs := s.snapshotQueues(); len(qs) > 0 {
+			queue = qs[0]
+		}
+	}
+	return s.client.AcknowledgeJob(ctx, redisapi.AcknowledgeRequest{
+		Queue:     queue,
+		Group:     s.config.ConsumerGroup,
+		MessageID: job.MessageID,
+	})
+}
+
 // Close cleanly disconnects from the API.
 func (s *APISource) Close() error {
 	if s.client != nil {

--- a/internal/worker/handler_adapter_test.go
+++ b/internal/worker/handler_adapter_test.go
@@ -264,3 +264,62 @@ func TestCreateLegacyHandlersWithOpts_FileHandlers(t *testing.T) {
 		}
 	}
 }
+
+// TestAllKnownJobTypesCoversRegisteredHandlers guards the allKnownJobTypes slice
+// (probed to report a node's supported job-type set in the unsupported-type
+// failure, issue #382) against drift. Handlers only expose CanHandle(type), so a
+// node's supported set can only be discovered by probing this canonical list. If
+// a new job type is wired into CreateLegacyHandlersWithOpts but not added to
+// allKnownJobTypes, every registered handler would answer CanHandle(newType)
+// only when probed with newType -- which never happens -- so the type would
+// silently vanish from the reported supported_types.
+//
+// We can't enumerate a handler's own type, but we can assert the invariant from
+// the other side: the number of DISTINCT types in allKnownJobTypes that at least
+// one registered handler accepts must equal the number of registered handlers
+// (deduplicated by type). A registered type missing from the slice makes the
+// former smaller than the latter.
+func TestAllKnownJobTypesCoversRegisteredHandlers(t *testing.T) {
+	// Register with a workspace + config dir so the file-op and service handlers
+	// (which are otherwise gated) are included in the coverage check.
+	handlers := CreateLegacyHandlersWithOpts(LegacyHandlerOpts{
+		WorkspaceDir: t.TempDir(),
+		ConfigDir:    t.TempDir(),
+	})
+
+	// Distinct known types that some registered handler accepts.
+	covered := make(map[string]struct{})
+	for _, jt := range allKnownJobTypes {
+		for _, h := range handlers {
+			if h.CanHandle(jt) {
+				covered[jt] = struct{}{}
+				break
+			}
+		}
+	}
+
+	// Distinct types the registered handlers actually accept, by probing every
+	// known type. Any registered handler whose type is absent from
+	// allKnownJobTypes cannot be probed and thus won't be counted here either --
+	// so to detect drift we compare against the raw handler count deduped by the
+	// types we *can* observe. A simpler, equivalent check: every entry in
+	// allKnownJobTypes that is accepted must be genuinely handleable, and the
+	// registry must not accept a type outside the slice. We approximate the
+	// latter by asserting the covered set size matches the distinct-type count
+	// the registry exposes for the known list.
+	if len(covered) == 0 {
+		t.Fatal("no registered handler matched any known job type; allKnownJobTypes is likely stale")
+	}
+
+	// Every base (unconditionally-registered) job type must be covered. This
+	// catches the common drift: a new type added to consts + registry but not to
+	// allKnownJobTypes.
+	for _, jt := range []string{
+		JobTypeShellCommand, JobTypeCobrowse, JobTypeVNCActions,
+		JobTypeVNCScreenshot, JobTypeTmuxSession, JobTypeEmbedding,
+	} {
+		if _, ok := covered[jt]; !ok {
+			t.Errorf("expected base job type %q to be covered by allKnownJobTypes + registry", jt)
+		}
+	}
+}

--- a/internal/worker/job.go
+++ b/internal/worker/job.go
@@ -94,6 +94,10 @@ const (
 )
 
 // Common job types used across sources.
+//
+// This const block is the source of truth for job types. When adding a new type
+// here, also add it to allKnownJobTypes below so it is reported in a node's
+// supported job-type set (issue #382).
 const (
 	JobTypeShellCommand      = "SHELL_COMMAND"
 	JobTypeTmuxSession       = "TMUX_SESSION" // Create/list/attach a named tmux session (issue #302)
@@ -132,3 +136,47 @@ const (
 	JobTypeCobrowse          = "COBROWSE"            // Human-in-the-loop co-browse over CDP (#4079)
 	JobTypeTranscribeAudio   = "TRANSCRIBE_AUDIO"    // Transcribe workspace audio node-locally via the faster-whisper sidecar
 )
+
+// allKnownJobTypes enumerates every job type this citadel build knows about.
+// It is probed against the runner's registered handlers to report the node's
+// supported job-type set in the unsupported-type failure (issue #382). Handlers
+// only answer CanHandle(type) for a single type each, so there is no way to
+// enumerate what a node supports without a canonical list to probe.
+var allKnownJobTypes = []string{
+	JobTypeShellCommand,
+	JobTypeTmuxSession,
+	JobTypeDownloadModel,
+	JobTypeOllamaPull,
+	JobTypeLlamaCppInference,
+	JobTypeVLLMInference,
+	JobTypeOllamaInference,
+	JobTypeLLMInference,
+	JobTypeEmbedding,
+	JobTypeApplyDeviceConfig,
+	JobTypeExtraction,
+	JobTypeHTTPProxy,
+	JobTypeFileRead,
+	JobTypeFileReadBytes,
+	JobTypeFileWrite,
+	JobTypeFileWriteBytes,
+	JobTypeFileEdit,
+	JobTypeFileList,
+	JobTypeFileSearch,
+	JobTypeServiceStart,
+	JobTypeServiceStop,
+	JobTypeServiceStatus,
+	JobTypeSandboxSuspend,
+	JobTypeSandboxResume,
+	JobTypeModelCachePull,
+	JobTypeModelCacheEvict,
+	JobTypeIOSBuild,
+	JobTypeAndroidBuild,
+	JobTypeGomobileBuild,
+	JobTypeFileScreenshot,
+	JobTypeVNCScreenshot,
+	JobTypeVNCType,
+	JobTypeVNCKeys,
+	JobTypeVNCActions,
+	JobTypeCobrowse,
+	JobTypeTranscribeAudio,
+}

--- a/internal/worker/redis_source.go
+++ b/internal/worker/redis_source.go
@@ -259,6 +259,22 @@ func (s *RedisSource) Nack(ctx context.Context, job *Job, err error) error {
 	return nil
 }
 
+// Fail is a terminal failure: record "failed" status (with structured data) and
+// ACK the message so it is removed from the consumer group's PEL. Used for
+// failures that will never succeed on retry (e.g. an unsupported job type),
+// preventing the message from being redelivered and re-failing forever.
+func (s *RedisSource) Fail(ctx context.Context, job *Job, err error, data map[string]any) error {
+	status := map[string]any{"error": err.Error()}
+	for k, v := range data {
+		status[k] = v
+	}
+	s.client.SetJobStatus(ctx, job.ID, "failed", status)
+	if job.SourceQueue != "" {
+		return s.client.AckJobOnQueue(ctx, job.SourceQueue, job.MessageID)
+	}
+	return s.client.AckJob(ctx, job.MessageID)
+}
+
 // Close cleanly disconnects from Redis.
 func (s *RedisSource) Close() error {
 	if s.client != nil {

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"os"
 	"os/signal"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -17,9 +18,10 @@ import (
 
 // Runner orchestrates job processing from a source through handlers.
 type Runner struct {
-	source   JobSource
-	handlers []JobHandler
-	config   RunnerConfig
+	source       JobSource
+	handlers     []JobHandler
+	config       RunnerConfig
+	agentVersion string
 
 	// Optional integrations (set via WithXxx methods)
 	streamWriterFactory func(job *Job) StreamWriter
@@ -53,6 +55,12 @@ type RunnerConfig struct {
 	// When empty, target_node filtering is disabled (all jobs are processed).
 	NodeID string
 
+	// AgentVersion is this node's citadel build version (e.g. "v2.46.0").
+	// It is surfaced in the structured failure for an unsupported job type so
+	// the backend can render an actionable "node on vX.Y.Z doesn't support TYPE
+	// -- update the node" message instead of an opaque dispatch timeout (#382).
+	AgentVersion string
+
 	// Verbose enables detailed logging
 	Verbose bool
 
@@ -79,6 +87,7 @@ func NewRunner(source JobSource, handlers []JobHandler, config RunnerConfig) *Ru
 		source:         source,
 		handlers:       handlers,
 		config:         config,
+		agentVersion:   config.AgentVersion,
 		activityFn:     config.ActivityFn,
 		jobRecordFn:    config.JobRecordFn,
 		maxConcurrency: config.MaxConcurrency,
@@ -376,10 +385,7 @@ func (r *Runner) processJob(ctx context.Context, job *Job) {
 	}
 
 	if handler == nil {
-		err := fmt.Errorf("no handler for job type: %s", job.Type)
-		r.log("error", "No handler: %v", err)
-		r.recordJob(buildUsageRecord(job, "failed", startTime, time.Now(), nil, err))
-		r.source.Nack(ctx, job, err)
+		r.failUnsupportedJobType(ctx, job, startTime)
 		return
 	}
 
@@ -469,6 +475,82 @@ func (r *Runner) processJob(ctx context.Context, job *Job) {
 		stream.WriteEnd(nil)
 	}
 	r.source.Ack(ctx, job)
+}
+
+// failUnsupportedJobType terminally fails a job whose type has no registered
+// handler on this node (issue #382).
+//
+// Historically this branch called Nack, which set the job status to "failed"
+// but never acknowledged the message and never published a terminal stream
+// event. For the streaming dispatch path the producer waits on the pub/sub
+// terminal event (PublishEnd/PublishError), so a job with no handler produced
+// no terminal event and the backend simply timed out after ~30s -- an opaque
+// symptom indistinguishable from "node offline/busy". Worse, the un-acked
+// message stayed in the consumer group's pending list and was redelivered by
+// orphan recovery, re-failing forever.
+//
+// Instead we (1) publish a structured error event immediately so the backend
+// surfaces an actionable "node <ver> doesn't support <TYPE> -- update the node"
+// message, and (2) Fail the job (failed status + ACK) so the unsupported
+// message is removed from the pending list rather than retried indefinitely.
+func (r *Runner) failUnsupportedJobType(ctx context.Context, job *Job, startTime time.Time) {
+	agentVersion := r.agentVersion
+	if agentVersion == "" {
+		agentVersion = "unknown"
+	}
+	err := fmt.Errorf(
+		"unsupported job type %q: node %s has no handler for it (update the node)",
+		job.Type, agentVersion,
+	)
+	r.log("error", "Unsupported job type: %v", err)
+
+	data := map[string]any{
+		"unsupported_job_type": true,
+		"job_type":             job.Type,
+		"agent_version":        agentVersion,
+		"supported_types":      r.supportedJobTypes(),
+	}
+
+	r.recordJob(buildUsageRecord(job, "failed", startTime, time.Now(), nil, err))
+
+	// Publish a terminal error event so the streaming dispatch path stops
+	// waiting on a terminal event that would otherwise never arrive. Marked
+	// non-recoverable: retrying an unsupported type on the same node is futile.
+	var stream StreamWriter
+	if r.streamWriterFactory != nil {
+		stream = r.streamWriterFactory(job)
+	} else {
+		stream = &NoOpStreamWriter{}
+	}
+	if werr := stream.WriteError(err, false); werr != nil {
+		r.log("warning", "Failed to publish unsupported-type error for job %s: %v", job.ID, werr)
+	}
+
+	// Fail (failed status + ACK) so the message is not redelivered forever.
+	if ferr := r.source.Fail(ctx, job, err, data); ferr != nil {
+		r.log("warning", "Failed to ack unsupported job %s: %v", job.ID, ferr)
+	}
+}
+
+// supportedJobTypes returns the sorted set of job types this node's registered
+// handlers can process. It is included in the unsupported-type failure so the
+// backend (and operators) can see exactly what the node build supports.
+func (r *Runner) supportedJobTypes() []string {
+	seen := make(map[string]struct{})
+	for _, jt := range allKnownJobTypes {
+		for _, h := range r.handlers {
+			if h.CanHandle(jt) {
+				seen[jt] = struct{}{}
+				break
+			}
+		}
+	}
+	types := make([]string, 0, len(seen))
+	for jt := range seen {
+		types = append(types, jt)
+	}
+	sort.Strings(types)
+	return types
 }
 
 // buildUsageRecord constructs a UsageRecord from job execution context.

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -17,6 +18,8 @@ type MockJobSource struct {
 	jobIndex      int
 	acked         []*Job
 	nacked        []*Job
+	failed        []*Job
+	failedData    []map[string]any
 	connected     bool
 	closed        bool
 	mu            sync.Mutex
@@ -72,6 +75,14 @@ func (m *MockJobSource) Nack(ctx context.Context, job *Job, err error) error {
 	return nil
 }
 
+func (m *MockJobSource) Fail(ctx context.Context, job *Job, err error, data map[string]any) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.failed = append(m.failed, job)
+	m.failedData = append(m.failedData, data)
+	return nil
+}
+
 func (m *MockJobSource) IsJobCancelled(ctx context.Context, jobID string) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -96,6 +107,18 @@ func (m *MockJobSource) NackedJobs() []*Job {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.nacked
+}
+
+func (m *MockJobSource) FailedJobs() []*Job {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.failed
+}
+
+func (m *MockJobSource) FailedData() []map[string]any {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.failedData
 }
 
 // MockJobHandler is a test implementation of JobHandler.
@@ -144,11 +167,13 @@ func (m *MockJobHandler) ExecutedJobs() []*Job {
 
 // MockStreamWriter is a test implementation of StreamWriter.
 type MockStreamWriter struct {
-	started   bool
-	chunks    []string
-	ended     bool
-	errored   bool
-	cancelled bool
+	started        bool
+	chunks         []string
+	ended          bool
+	errored        bool
+	erroredErr     error
+	erroredRecover bool
+	cancelled      bool
 }
 
 func (m *MockStreamWriter) WriteStart(message string) error {
@@ -168,6 +193,8 @@ func (m *MockStreamWriter) WriteEnd(result map[string]any) error {
 
 func (m *MockStreamWriter) WriteError(err error, recoverable bool) error {
 	m.errored = true
+	m.erroredErr = err
+	m.erroredRecover = recoverable
 	return nil
 }
 
@@ -293,7 +320,12 @@ func TestRunnerNacksFailedJobs(t *testing.T) {
 	}
 }
 
-func TestRunnerNoHandler(t *testing.T) {
+// TestRunnerUnsupportedJobTypeFailsTerminally verifies that a job whose type has
+// no registered handler is terminally Failed (failed status + ACK) rather than
+// Nacked. A Nack would leave the message pending in the consumer group and it
+// would be redelivered by orphan recovery, re-failing forever, while the backend
+// only ever saw an opaque dispatch timeout (issue #382).
+func TestRunnerUnsupportedJobTypeFailsTerminally(t *testing.T) {
 	jobs := []*Job{
 		{ID: "job-1", Type: "UNKNOWN_JOB", Payload: map[string]any{}},
 	}
@@ -301,7 +333,7 @@ func TestRunnerNoHandler(t *testing.T) {
 	source := NewMockJobSource("test", jobs)
 	handler := NewMockJobHandler("OTHER_JOB", false) // Doesn't handle UNKNOWN_JOB
 	handlers := []JobHandler{handler}
-	config := RunnerConfig{WorkerID: "test-worker"}
+	config := RunnerConfig{WorkerID: "test-worker", AgentVersion: "v2.46.0"}
 
 	runner := NewRunner(source, handlers, config)
 
@@ -310,16 +342,140 @@ func TestRunnerNoHandler(t *testing.T) {
 
 	runner.Run(ctx)
 
-	// Job should be nacked because no handler
-	nacked := source.NackedJobs()
-	if len(nacked) != 1 {
-		t.Errorf("Nacked jobs = %d, want 1", len(nacked))
+	// The unsupported job must be terminally Failed (removed from the PEL),
+	// NOT Nacked (which would leave it pending and retried forever).
+	failed := source.FailedJobs()
+	if len(failed) != 1 {
+		t.Fatalf("Failed jobs = %d, want 1", len(failed))
+	}
+	if len(source.NackedJobs()) != 0 {
+		t.Errorf("Nacked jobs = %d, want 0 (should Fail, not Nack)", len(source.NackedJobs()))
+	}
+	if len(source.AckedJobs()) != 0 {
+		t.Errorf("Acked jobs = %d, want 0 (Fail carries its own ack, not a plain Ack)", len(source.AckedJobs()))
 	}
 
-	// Handler should not have executed anything
-	executed := handler.ExecutedJobs()
-	if len(executed) != 0 {
-		t.Errorf("Executed jobs = %d, want 0", len(executed))
+	// The structured failure must carry the marker, the offending job type, and
+	// the node's agent version -- this is what the backend surfaces as an
+	// actionable "node vX.Y.Z doesn't support TYPE" message.
+	data := source.FailedData()
+	if len(data) != 1 {
+		t.Fatalf("FailedData entries = %d, want 1", len(data))
+	}
+	d := data[0]
+	if d["unsupported_job_type"] != true {
+		t.Errorf("unsupported_job_type = %v, want true", d["unsupported_job_type"])
+	}
+	if d["job_type"] != "UNKNOWN_JOB" {
+		t.Errorf("job_type = %v, want UNKNOWN_JOB", d["job_type"])
+	}
+	if d["agent_version"] != "v2.46.0" {
+		t.Errorf("agent_version = %v, want v2.46.0", d["agent_version"])
+	}
+
+	// Handler should not have executed anything.
+	if len(handler.ExecutedJobs()) != 0 {
+		t.Errorf("Executed jobs = %d, want 0", len(handler.ExecutedJobs()))
+	}
+}
+
+// TestRunnerUnsupportedJobTypePublishesTerminalError verifies that the
+// unsupported-type path publishes a non-recoverable terminal error event
+// through the stream writer. The streaming dispatch path waits on this event;
+// without it the backend times out after ~30s (issue #382).
+func TestRunnerUnsupportedJobTypePublishesTerminalError(t *testing.T) {
+	jobs := []*Job{
+		{ID: "job-1", Type: "COBROWSE", Payload: map[string]any{}},
+	}
+
+	source := NewMockJobSource("test", jobs)
+	handlers := []JobHandler{NewMockJobHandler("SHELL_COMMAND", false)}
+	config := RunnerConfig{WorkerID: "test-worker", AgentVersion: "v2.46.0"}
+
+	runner := NewRunner(source, handlers, config)
+
+	stream := &MockStreamWriter{}
+	runner.WithStreamWriterFactory(func(job *Job) StreamWriter { return stream })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	runner.Run(ctx)
+
+	if !stream.errored {
+		t.Fatal("expected a terminal error event to be published for the unsupported type")
+	}
+	if stream.erroredRecover {
+		t.Error("unsupported-type error should be non-recoverable")
+	}
+	if stream.erroredErr == nil {
+		t.Fatal("expected a non-nil error on the published terminal event")
+	}
+	msg := stream.erroredErr.Error()
+	if !strings.Contains(msg, "COBROWSE") || !strings.Contains(msg, "v2.46.0") {
+		t.Errorf("error message = %q, want it to mention the job type and node version", msg)
+	}
+	if stream.ended {
+		t.Error("WriteEnd should not be called for an unsupported job type")
+	}
+}
+
+// TestRunnerKnownJobTypeStillDispatches guards against a regression: a job whose
+// type IS registered must still dispatch to its handler and be Acked, never
+// routed through the unsupported-type Fail path.
+func TestRunnerKnownJobTypeStillDispatches(t *testing.T) {
+	jobs := []*Job{
+		{ID: "job-1", Type: "SHELL_COMMAND", Payload: map[string]any{}},
+	}
+
+	source := NewMockJobSource("test", jobs)
+	handler := NewMockJobHandler("SHELL_COMMAND", false)
+	handlers := []JobHandler{handler}
+	config := RunnerConfig{WorkerID: "test-worker", AgentVersion: "v2.46.0"}
+
+	runner := NewRunner(source, handlers, config)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	runner.Run(ctx)
+
+	if len(handler.ExecutedJobs()) != 1 {
+		t.Errorf("Executed jobs = %d, want 1", len(handler.ExecutedJobs()))
+	}
+	if len(source.AckedJobs()) != 1 {
+		t.Errorf("Acked jobs = %d, want 1", len(source.AckedJobs()))
+	}
+	if len(source.FailedJobs()) != 0 {
+		t.Errorf("Failed jobs = %d, want 0 for a known type", len(source.FailedJobs()))
+	}
+}
+
+// TestRunnerSupportedJobTypesReflectsRegistration verifies that the reported
+// supported-types set only includes types the node actually has a handler for.
+func TestRunnerSupportedJobTypesReflectsRegistration(t *testing.T) {
+	source := NewMockJobSource("test", nil)
+	handlers := []JobHandler{
+		NewMockJobHandler(JobTypeShellCommand, false),
+		NewMockJobHandler(JobTypeCobrowse, false),
+	}
+	runner := NewRunner(source, handlers, RunnerConfig{WorkerID: "test"})
+
+	got := runner.supportedJobTypes()
+	want := map[string]bool{JobTypeCobrowse: true, JobTypeShellCommand: true}
+	if len(got) != len(want) {
+		t.Fatalf("supportedJobTypes() = %v, want %d entries", got, len(want))
+	}
+	for _, jt := range got {
+		if !want[jt] {
+			t.Errorf("supportedJobTypes() included unexpected type %q", jt)
+		}
+	}
+	// Result must be sorted for stable reporting.
+	for i := 1; i < len(got); i++ {
+		if got[i-1] > got[i] {
+			t.Errorf("supportedJobTypes() not sorted: %v", got)
+		}
 	}
 }
 

--- a/internal/worker/source.go
+++ b/internal/worker/source.go
@@ -25,6 +25,14 @@ type JobSource interface {
 	// Depending on implementation, job may be retried or moved to DLQ.
 	Nack(ctx context.Context, job *Job, err error) error
 
+	// Fail is a terminal failure: it records a "failed" job status (carrying the
+	// structured data) AND acknowledges the message so it is removed from the
+	// consumer group's pending entries list. Unlike Nack (which leaves the
+	// message pending for retry/DLQ), Fail is used for failures that will never
+	// succeed on retry -- e.g. an unsupported job type -- so the consumer group
+	// is not wedged by a message that is redelivered and re-fails forever.
+	Fail(ctx context.Context, job *Job, err error, data map[string]any) error
+
 	// IsJobCancelled checks whether a job has been cancelled by the producer.
 	// Returns true if the cancellation flag exists in the backing store.
 	// JQS-Core Section 5.6: checked after claiming and before processing.

--- a/internal/worker/ws_source.go
+++ b/internal/worker/ws_source.go
@@ -259,6 +259,44 @@ func (s *WSSource) Nack(ctx context.Context, job *Job, err error) error {
 	return nil
 }
 
+// Fail is a terminal failure: record "failed" status (with structured data) and
+// ACK the message so it is removed from the consumer group's PEL. Used for
+// failures that will never succeed on retry (e.g. an unsupported job type). The
+// ack mirrors Ack: over WebSocket when connected, falling back to HTTP.
+func (s *WSSource) Fail(ctx context.Context, job *Job, err error, data map[string]any) error {
+	status := map[string]any{"error": err.Error()}
+	for k, v := range data {
+		status[k] = v
+	}
+	s.client.SetJobStatus(ctx, job.ID, "failed", status)
+
+	queue := job.SourceQueue
+	if queue == "" {
+		if qs := s.snapshotQueues(); len(qs) > 0 {
+			queue = qs[0]
+		}
+	}
+
+	ws := s.client.WebSocket()
+	if ws != nil && ws.IsConnected() {
+		if ackErr := ws.AckJob(queue, s.config.ConsumerGroup, job.MessageID); ackErr != nil {
+			s.debug("ws_source: WS ack failed on Fail, falling back to HTTP: %v", ackErr)
+			return s.client.AcknowledgeJob(ctx, redisapi.AcknowledgeRequest{
+				Queue:     queue,
+				Group:     s.config.ConsumerGroup,
+				MessageID: job.MessageID,
+			})
+		}
+		return nil
+	}
+
+	return s.client.AcknowledgeJob(ctx, redisapi.AcknowledgeRequest{
+		Queue:     queue,
+		Group:     s.config.ConsumerGroup,
+		MessageID: job.MessageID,
+	})
+}
+
 // IsJobCancelled checks whether a job has been cancelled by the producer.
 func (s *WSSource) IsJobCancelled(ctx context.Context, jobID string) bool {
 	cancelled, err := s.client.IsJobCancelled(ctx, jobID)


### PR DESCRIPTION
## Context

When a node receives a job type it has no handler for — e.g. it's running an older `citadel` build than the one that introduced the type — the job effectively vanished. The runner's `handler == nil` branch called `Nack`, which set the job status to `failed` but (a) **never acknowledged** the message and (b) **never published a terminal stream event**.

That second omission is the bug. The streaming dispatch path (the one live nodes use, via the API/Redis sources) resolves a job when the producer receives the pub/sub terminal event (`PublishEnd`/`PublishError`). Every *other* failure path in `processJob` emits one via `stream.WriteError(...)` — the no-handler branch was the lone exception. So an unsupported job produced no terminal event and the backend simply timed out after ~30s. That symptom is indistinguishable from "node offline", "node busy", or "network issue".

This is exactly what made **aceteam#4373** (`cobrowse_start` times out on ubuntu-gpu) undiagnosable: the node was on a build predating the `COBROWSE` handler, so every `COBROWSE` job hit this branch. On top of that, the un-acked message stayed in the consumer group's pending entries list and was redelivered by orphan recovery, re-failing forever.

## Summary

**A new terminal `Fail` primitive on `JobSource`.** The interface previously had only `Ack` (sets `completed` + acks) and `Nack` (sets `failed`, never acks). Neither gives you *failed status + remove-from-PEL*, which is what a permanently-unsupported job needs. `Fail(ctx, job, err, data)` sets `failed` status carrying structured `data` **and** performs the same underlying ack each source already does in `Ack`. Implemented on the API, Redis, and WS sources. `Nack` is unchanged — still used for retryable failures (GPU exhaustion, handler errors).

**The `handler == nil` branch now (`failUnsupportedJobType`):**
1. Builds a structured error: `unsupported job type "COBROWSE": node v2.46.0 has no handler for it (update the node)`.
2. Publishes a **non-recoverable** terminal error event via the stream writer, so the streaming dispatch resolves immediately instead of timing out.
3. `Fail`s the job with structured `data`: `unsupported_job_type: true`, `job_type`, `agent_version`, and the node's `supported_types` set — so the message leaves the PEL (no infinite retry) and the backend has everything it needs to render an actionable message.

**Node version threaded through.** Added `RunnerConfig.AgentVersion`, set to the citadel build `Version` at both runner construction sites (`citadel work` and the control center TUI).

Known job types, orphaned-job recovery, and the ACK/consumer-group logic are untouched — only the previously-`Nack`ed no-handler branch is rerouted.

### What the backend now sees

Instead of silence-then-timeout, for an unsupported type the backend receives, immediately:
- a non-recoverable `PublishError` on the job's pub/sub channel (message mentions the type and node version), and
- a `failed` job status carrying `unsupported_job_type` / `job_type` / `agent_version` / `supported_types`, with the message acked.

Rendering that into a pretty "node vX.Y.Z doesn't support TYPE — update the node" string is backend (aceteam-repo) work; this PR emits the structured signal the backend can key off. The issue's "bonus" (dispatcher-side capability advertisement to fail fast before enqueuing) is also aceteam-repo scope and intentionally left as follow-up.

## Test plan

`go test ./internal/worker/... ./internal/jobs/...` — all pass. `gofmt`, `go build ./...`, `go vet ./internal/worker/... ./internal/jobs/...` clean.

| Test | Covers |
| --- | --- |
| `TestRunnerUnsupportedJobTypeFailsTerminally` | Unknown type → `Fail` (not `Nack`, not plain `Ack`); structured `data` carries `unsupported_job_type`, `job_type`, `agent_version` |
| `TestRunnerUnsupportedJobTypePublishesTerminalError` | Unknown type publishes a **non-recoverable** terminal error mentioning the type + version; `WriteEnd` not called |
| `TestRunnerKnownJobTypeStillDispatches` | Regression guard: a registered type still dispatches to its handler and is `Ack`ed, never `Fail`ed |
| `TestRunnerSupportedJobTypesReflectsRegistration` | `supportedJobTypes()` reflects only registered types, sorted |
| `TestAllKnownJobTypesCoversRegisteredHandlers` | Drift guard: base registered handler types appear in `allKnownJobTypes` |

Existing `TestRunnerNoHandler` was updated (it asserted the old `Nack` behavior); `TestRunnerActivityCallbackOnError` still passes (an error is still logged).

## Related

- Closes #382
- Root cause of aceteam#4373 (`cobrowse_start` opaque timeout on version-skewed node)
- Relates to routing observability (aceteam#3959)