### PR TITLE
fix(worker): AGENT_UPDATE job handler for remote node updates (aceteam#4427)

### DIFF
--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1427,6 +1427,22 @@ func runWork(cmd *cobra.Command, args []string) {
 		runner.WithStreamWriterFactory(streamFactory)
 	}
 
+	// Register the AGENT_UPDATE job handler (issue aceteam#4427), which lets the
+	// control plane update this node's agent remotely — the fix for silent
+	// version skew (aceteam#4373). It is registered after the runner exists so it
+	// can borrow the runner's Drain/ActiveJobs for the "publish result, THEN
+	// restart" ordering, mirroring how the AutoUpdater is wired below. The handler
+	// self-restarts only when running as a managed service (CITADEL_SERVICE=true);
+	// in a foreground run it reports "restart required" instead.
+	runner.RegisterHandler(worker.NewAgentUpdateHandler(worker.AgentUpdateConfig{
+		Version:    Version,
+		Drain:      func() { runner.Drain() },
+		ActiveJobs: runner.ActiveJobs,
+		Log: func(format string, args ...any) {
+			Log(format, args...)
+		},
+	}))
+
 	// Start the periodic auto-updater. The goroutine always runs; whether it
 	// actually checks/installs on a given tick is decided per-tick by
 	// resolveAutoUpdateEnabled() so the switch can be flipped on a *running*

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -104,6 +104,49 @@ func (c *Client) GetLatestRelease() (*Release, error) {
 	return c.fetchLatestRelease()
 }
 
+// GetReleaseByTag fetches a specific release by its tag name (e.g. "v2.47.0").
+// Used by the AGENT_UPDATE job handler to install a pinned target version
+// rather than only the latest release. The leading "v" is optional and is
+// normalized to match the release tag convention.
+func (c *Client) GetReleaseByTag(tag string) (*Release, error) {
+	tag = strings.TrimSpace(tag)
+	if tag == "" {
+		return nil, fmt.Errorf("release tag must not be empty")
+	}
+	if !strings.HasPrefix(tag, "v") {
+		tag = "v" + tag
+	}
+
+	url := fmt.Sprintf("%s/repos/%s/releases/tags/%s", GitHubAPIBase, GitHubRepo, tag)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("User-Agent", "citadel-cli")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("release %s not found", tag)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub API returned status: %s", resp.Status)
+	}
+
+	var release Release
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, err
+	}
+
+	return &release, nil
+}
+
 // Download downloads the binary for the current OS/ARCH
 func (c *Client) Download(release *Release, destPath string) error {
 	downloadURL := c.getDownloadURL(release)

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -230,6 +230,19 @@ func TestCalculateSHA256FileNotFound(t *testing.T) {
 	}
 }
 
+// TestGetReleaseByTagEmpty asserts the empty-tag guard fires before any network
+// call, so an AGENT_UPDATE job with a blank target_version fails fast and
+// structurally rather than hitting GitHub with a malformed URL.
+func TestGetReleaseByTagEmpty(t *testing.T) {
+	client := NewClient("v1.0.0")
+	if _, err := client.GetReleaseByTag(""); err == nil {
+		t.Error("GetReleaseByTag(\"\") should return an error")
+	}
+	if _, err := client.GetReleaseByTag("   "); err == nil {
+		t.Error("GetReleaseByTag(whitespace) should return an error")
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
 }

--- a/internal/worker/agent_update.go
+++ b/internal/worker/agent_update.go
@@ -1,0 +1,364 @@
+// internal/worker/agent_update.go
+//
+// AGENT_UPDATE job handler (issue aceteam#4427). Lets the control plane update
+// a node's Citadel agent remotely, closing the "silent version skew" gap that
+// made aceteam#4373 undiagnosable (a node stuck on an old release, invisible
+// from the dashboard, with no remote way to fix it short of SSH).
+//
+// The handler reuses the exact same update machinery as `citadel update
+// install` (internal/update): check GitHub Releases, download + checksum-verify
+// the platform asset, atomically swap the running binary, and keep the previous
+// binary for rollback. It supports an optional pinned `target_version` in the
+// payload and defaults to the latest release.
+//
+// # The self-restart crux
+//
+// This handler runs *inside* the worker process it must restart. If it restarted
+// synchronously, the job result would never be published — the dispatcher would
+// see a timeout (exactly the failure mode we're trying to eliminate). So the
+// ordering guarantee is:
+//
+//  1. Execute() installs the new binary and returns a SUCCESS result
+//     ({new_version, old_version}) through the normal result path.
+//  2. The runner publishes that result (stream.WriteEnd) and ACKs the job.
+//  3. Only THEN does a restart fire.
+//
+// The post-ack signal we lean on is the runner's activeJobs counter: it is
+// decremented in a `defer` that runs *after* WriteEnd + Ack (see
+// runner.processJob). So observing ActiveJobs()==0 from the arming goroutine
+// proves this job's own result was already published and acked. We Drain first
+// (stop fetching new jobs) to close the pickup race, wait for idle, then
+// restart — the same discipline the AutoUpdater already uses.
+//
+// Restart re-execs the current process onto the freshly-installed binary via
+// update.RestartProcess (syscall.Exec) — the same mechanism the production
+// AutoUpdater already uses. This is deliberately NOT a SIGTERM-and-exit: the
+// systemd unit ships Restart=on-failure (internal/service/systemd.go), which
+// does not relaunch on a clean exit, so a graceful exit would leave the node
+// permanently down — strictly worse than the version-skew bug this fixes.
+// syscall.Exec preserves the PID and replaces the image in place, so it does
+// not depend on the supervisor's restart policy at all. Crucially, it does NOT
+// orphan the VPN identity: the tsnet node key is persisted to the node's state
+// directory (internal/network), so the new image re-inits the mesh from the
+// same identity. We only self-restart when running as a managed service
+// (CITADEL_SERVICE=true); in a foreground/interactive run we report "updated,
+// restart required" and leave the operator's session alone.
+//
+// Privilege gating: AGENT_UPDATE is only honored when the job arrives on the
+// per-node stream (jobs:v1:shell:org_<id>:node:<nodeid>), never the shared org
+// pool — updating a node is a privileged, node-targeted operation. Server-side
+// this should additionally require a scope / signed capability (#4313); that is
+// aceteam-side and tracked separately.
+package worker
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/update"
+)
+
+// AgentUpdateConfig configures an AgentUpdateHandler. Every side-effecting
+// dependency is injectable so the handler can be unit-tested without touching
+// the network, the filesystem, or the running process.
+type AgentUpdateConfig struct {
+	// Version is the currently-running agent version (e.g. "v2.46.0"). Reported
+	// back as old_version and used to decide "already latest".
+	Version string
+
+	// GetRelease returns the release to install. `target` is the requested
+	// version tag (empty means "latest"). It returns (nil, nil) when already on
+	// the requested/latest version. Defaults to a GitHub-backed lookup.
+	GetRelease func(target string) (*update.Release, error)
+
+	// Download downloads + checksum-verifies the release asset to destPath.
+	// Defaults to update.NewClient(...).DownloadAndVerify.
+	Download func(release *update.Release, destPath string) error
+
+	// Apply atomically swaps the running binary with the verified pending
+	// binary (keeping the previous copy for rollback). Defaults to
+	// update.ApplyUpdate.
+	Apply func(pendingPath string) error
+
+	// PendingPath is where the downloaded binary is staged.
+	// Defaults to update.GetPendingBinaryPath().
+	PendingPath string
+
+	// IsService reports whether we are running under a managed service
+	// supervisor (systemd/launchd/Windows SCM) that will relaunch us on a clean
+	// exit. Defaults to a CITADEL_SERVICE=true env-var check. Only when true do
+	// we self-restart; otherwise we report "restart required".
+	IsService func() bool
+
+	// Drain stops the runner from fetching new jobs so no work is picked up
+	// between our ack and the restart. Wired to runner.Drain.
+	Drain func()
+
+	// ActiveJobs reports the number of in-flight jobs. Reaching 0 proves our own
+	// result was published + acked (the counter is decremented after ack), so we
+	// only restart once it hits 0. Wired to runner.ActiveJobs.
+	ActiveJobs func() int
+
+	// Restart re-execs the process onto the freshly-installed binary. Defaults to
+	// update.RestartProcess (syscall.Exec, in-place image swap, PID-preserving —
+	// the same mechanism the AutoUpdater uses). Overridable so tests can assert
+	// restart ordering without actually exec'ing.
+	Restart func() error
+
+	// IdlePollInterval is how often to re-check ActiveJobs while waiting to
+	// restart. Zero uses a sensible default (500ms).
+	IdlePollInterval time.Duration
+
+	// IdleTimeout bounds how long the arming goroutine waits for the node to go
+	// idle before restarting anyway. Zero uses a sensible default (2m). Our own
+	// job acking should make the node idle almost immediately.
+	IdleTimeout time.Duration
+
+	// Log reports progress. If nil a no-op logger is used.
+	Log func(format string, args ...any)
+
+	// RecordState persists the update to disk (previous/current version) so the
+	// new process and `citadel update status` reflect it. Defaults to writing
+	// update state; overridable/no-op in tests.
+	RecordState func(oldVersion, newVersion string)
+}
+
+// AgentUpdateHandler processes AGENT_UPDATE jobs.
+type AgentUpdateHandler struct {
+	cfg AgentUpdateConfig
+}
+
+// NewAgentUpdateHandler constructs an AGENT_UPDATE handler, applying defaults
+// that wire it to the real update package and the running process. Runner-bound
+// dependencies (Drain, ActiveJobs) must be set by the caller after the runner
+// exists — see cmd/work.go.
+func NewAgentUpdateHandler(cfg AgentUpdateConfig) *AgentUpdateHandler {
+	if cfg.GetRelease == nil {
+		cfg.GetRelease = func(target string) (*update.Release, error) {
+			client := update.NewClientWithTimeout(cfg.Version, 60*time.Second)
+			if target == "" {
+				// Latest, with the same "nil means already up to date" contract.
+				return client.CheckForUpdate()
+			}
+			rel, err := client.GetReleaseByTag(target)
+			if err != nil {
+				return nil, err
+			}
+			// Honor the "already on requested version" case symmetrically with
+			// the latest path so the caller gets (nil, nil) → "already-latest".
+			newer, err := update.IsNewerVersion(cfg.Version, rel.TagName)
+			if err != nil {
+				return nil, err
+			}
+			if !newer {
+				return nil, nil
+			}
+			return rel, nil
+		}
+	}
+	if cfg.Download == nil {
+		cfg.Download = func(release *update.Release, destPath string) error {
+			return update.NewClientWithTimeout(cfg.Version, 5*time.Minute).DownloadAndVerify(release, destPath)
+		}
+	}
+	if cfg.Apply == nil {
+		cfg.Apply = update.ApplyUpdate
+	}
+	if cfg.PendingPath == "" {
+		cfg.PendingPath = update.GetPendingBinaryPath()
+	}
+	if cfg.IsService == nil {
+		cfg.IsService = defaultIsService
+	}
+	if cfg.Restart == nil {
+		cfg.Restart = update.RestartProcess
+	}
+	if cfg.IdlePollInterval <= 0 {
+		cfg.IdlePollInterval = 500 * time.Millisecond
+	}
+	if cfg.IdleTimeout <= 0 {
+		cfg.IdleTimeout = 2 * time.Minute
+	}
+	if cfg.Log == nil {
+		cfg.Log = func(string, ...any) {}
+	}
+	if cfg.RecordState == nil {
+		cfg.RecordState = func(oldVersion, newVersion string) {
+			state, err := update.LoadState()
+			if err != nil {
+				return
+			}
+			update.RecordUpdate(state, oldVersion, newVersion)
+			state.AvailableUpdate = ""
+			update.UpdateLastCheck(state)
+			_ = update.SaveState(state)
+		}
+	}
+	return &AgentUpdateHandler{cfg: cfg}
+}
+
+// CanHandle reports whether this handler processes the given job type.
+func (h *AgentUpdateHandler) CanHandle(jobType string) bool {
+	return jobType == JobTypeAgentUpdate
+}
+
+// Execute installs the requested (or latest) agent release and, when running as
+// a managed service, arms a graceful self-restart that fires only after this
+// job's result is published and acked. See the package doc for the ordering
+// guarantee.
+func (h *AgentUpdateHandler) Execute(ctx context.Context, job *Job, stream StreamWriter) (*JobResult, error) {
+	// Privilege gate: AGENT_UPDATE must arrive on the per-node stream, not the
+	// shared org pool. isPerNodeStream reports a structural reason on failure so
+	// the dispatcher surfaces "why" rather than hanging.
+	if !isPerNodeStream(job.SourceQueue) {
+		return h.failure(fmt.Errorf(
+			"AGENT_UPDATE refused: must be dispatched to the per-node stream, got source queue %q", job.SourceQueue)), nil
+	}
+
+	target := payloadString(job.Payload, "target_version")
+	h.cfg.Log("AGENT_UPDATE: checking for release (target=%q, current=%s)", target, h.cfg.Version)
+
+	release, err := h.cfg.GetRelease(target)
+	if err != nil {
+		return h.failure(fmt.Errorf("update check failed: %w", err)), nil
+	}
+	if release == nil {
+		// Already on the requested/latest version — a structured, non-error
+		// terminal state rather than a hang or a failure.
+		h.cfg.Log("AGENT_UPDATE: already on %s; nothing to do", h.cfg.Version)
+		return h.success(map[string]any{
+			"updated":     false,
+			"reason":      "already-latest",
+			"old_version": h.cfg.Version,
+			"new_version": h.cfg.Version,
+		}), nil
+	}
+
+	h.cfg.Log("AGENT_UPDATE: downloading %s", release.TagName)
+	if err := h.cfg.Download(release, h.cfg.PendingPath); err != nil {
+		return h.failure(fmt.Errorf("download/verify failed for %s: %w", release.TagName, err)), nil
+	}
+
+	h.cfg.Log("AGENT_UPDATE: installing %s", release.TagName)
+	if err := h.cfg.Apply(h.cfg.PendingPath); err != nil {
+		// Apply validates the new binary and rolls back internally on failure, so
+		// the current version keeps running.
+		return h.failure(fmt.Errorf("install failed for %s (kept %s): %w", release.TagName, h.cfg.Version, err)), nil
+	}
+
+	h.cfg.RecordState(h.cfg.Version, release.TagName)
+
+	isService := h.cfg.IsService()
+	h.cfg.Log("AGENT_UPDATE: installed %s (was %s); service=%v", release.TagName, h.cfg.Version, isService)
+
+	result := map[string]any{
+		"updated":     true,
+		"old_version": h.cfg.Version,
+		"new_version": release.TagName,
+		"restarting":  isService,
+	}
+	if !isService {
+		// Foreground / interactive run: don't kill the operator's session. Report
+		// that a manual restart is needed to load the new binary.
+		result["reason"] = "updated, restart required (not running as a managed service)"
+		return h.success(result), nil
+	}
+
+	// Managed service: arm the restart BEFORE returning. This job is still
+	// counted active (its defers have not run yet), so the goroutine cannot fire
+	// until ActiveJobs()==0 — which is only reached after the runner publishes
+	// this result and acks the job. Draining first closes the pickup race.
+	h.armRestart(ctx, release.TagName)
+	return h.success(result), nil
+}
+
+// armRestart launches the background goroutine that waits for the node to go
+// idle (proving this job's result was published + acked) and then triggers a
+// graceful restart. It returns immediately so Execute can return its result.
+func (h *AgentUpdateHandler) armRestart(ctx context.Context, newVersion string) {
+	if h.cfg.Drain != nil {
+		h.cfg.Drain()
+	}
+	go func() {
+		if err := h.waitForIdle(ctx); err != nil {
+			h.cfg.Log("AGENT_UPDATE: %v; restarting anyway to load %s", err, newVersion)
+		}
+		h.cfg.Log("AGENT_UPDATE: restarting to load %s", newVersion)
+		if err := h.cfg.Restart(); err != nil {
+			// The new binary is already in place; the supervisor will pick it up
+			// on the next natural restart. Log and keep running on the old image.
+			h.cfg.Log("AGENT_UPDATE: restart failed: %v (new binary loads on next restart)", err)
+		}
+	}()
+}
+
+// waitForIdle blocks until ActiveJobs reports 0, ctx is cancelled, or the idle
+// timeout elapses. A nil ActiveJobs is treated as immediately idle.
+func (h *AgentUpdateHandler) waitForIdle(ctx context.Context) error {
+	if h.cfg.ActiveJobs == nil {
+		return nil
+	}
+	deadline := time.Now().Add(h.cfg.IdleTimeout)
+	ticker := time.NewTicker(h.cfg.IdlePollInterval)
+	defer ticker.Stop()
+	for {
+		if h.cfg.ActiveJobs() == 0 {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out after %s waiting for %d in-flight job(s)", h.cfg.IdleTimeout, h.cfg.ActiveJobs())
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context cancelled while waiting for idle")
+		case <-ticker.C:
+		}
+	}
+}
+
+func (h *AgentUpdateHandler) success(output map[string]any) *JobResult {
+	return &JobResult{Status: JobStatusSuccess, Output: output}
+}
+
+func (h *AgentUpdateHandler) failure(err error) *JobResult {
+	return &JobResult{
+		Status: JobStatusFailure,
+		Error:  err,
+		Output: map[string]any{"error": err.Error()},
+	}
+}
+
+// isPerNodeStream reports whether a source queue name is a per-node shell
+// stream (jobs:v1:shell:org_<id>:node:<nodeid>) rather than the shared org
+// pool. The per-node marker is the ":node:" segment appended by the platform
+// when routing a job at a specific node (see internal/worker AddQueue and the
+// aceteam dispatcher).
+func isPerNodeStream(sourceQueue string) bool {
+	return strings.Contains(sourceQueue, ":node:")
+}
+
+// payloadString reads a string value from a job payload, coercing common
+// JSON-decoded types (numbers arrive as float64). Missing/empty yields "".
+func payloadString(payload map[string]any, key string) string {
+	v, ok := payload[key]
+	if !ok || v == nil {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return fmt.Sprint(v)
+}
+
+// defaultIsService reports whether we are running under a managed service
+// supervisor. The service unit/plist/SCM all set CITADEL_SERVICE=true (see
+// internal/service).
+func defaultIsService() bool {
+	return os.Getenv("CITADEL_SERVICE") == "true"
+}
+
+// Ensure AgentUpdateHandler implements JobHandler.
+var _ JobHandler = (*AgentUpdateHandler)(nil)

--- a/internal/worker/agent_update_test.go
+++ b/internal/worker/agent_update_test.go
@@ -1,0 +1,404 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/update"
+)
+
+// perNodeQueue is a representative per-node shell stream name. The ":node:"
+// segment is what the privilege gate keys on.
+const perNodeQueue = "jobs:v1:shell:org_test:node:1008"
+
+// newTestHandler builds an AgentUpdateHandler with every side effect stubbed so
+// no test touches the network, filesystem, or the running process. Callers
+// override individual fields via the mutator.
+func newTestHandler(t *testing.T, mutate func(*AgentUpdateConfig)) *AgentUpdateHandler {
+	t.Helper()
+	cfg := AgentUpdateConfig{
+		Version: "v2.46.0",
+		GetRelease: func(target string) (*update.Release, error) {
+			return &update.Release{TagName: "v2.47.0"}, nil
+		},
+		Download:    func(*update.Release, string) error { return nil },
+		Apply:       func(string) error { return nil },
+		PendingPath: "/tmp/does-not-matter",
+		IsService:   func() bool { return true },
+		Restart:     func() error { return nil },
+		RecordState: func(string, string) {},
+		// Fast idle polling so the ordering test doesn't wait on the 500ms default.
+		IdlePollInterval: time.Millisecond,
+		IdleTimeout:      2 * time.Second,
+	}
+	if mutate != nil {
+		mutate(&cfg)
+	}
+	return NewAgentUpdateHandler(cfg)
+}
+
+func agentUpdateJob(sourceQueue string, payload map[string]any) *Job {
+	if payload == nil {
+		payload = map[string]any{}
+	}
+	return &Job{ID: "job-1", Type: JobTypeAgentUpdate, SourceQueue: sourceQueue, Payload: payload}
+}
+
+// TestAgentUpdateAlreadyLatest: when GetRelease reports (nil, nil), the handler
+// returns a structured success with reason "already-latest" and never touches
+// Apply or Restart.
+func TestAgentUpdateAlreadyLatest(t *testing.T) {
+	var applied, restarted bool
+	h := newTestHandler(t, func(c *AgentUpdateConfig) {
+		c.GetRelease = func(string) (*update.Release, error) { return nil, nil }
+		c.Apply = func(string) error { applied = true; return nil }
+		c.Restart = func() error { restarted = true; return nil }
+	})
+
+	res, err := h.Execute(context.Background(), agentUpdateJob(perNodeQueue, nil), &NoOpStreamWriter{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Status != JobStatusSuccess {
+		t.Fatalf("status = %v, want success", res.Status)
+	}
+	if res.Output["reason"] != "already-latest" {
+		t.Errorf("reason = %v, want already-latest", res.Output["reason"])
+	}
+	if res.Output["updated"] != false {
+		t.Errorf("updated = %v, want false", res.Output["updated"])
+	}
+	if applied {
+		t.Error("Apply was called on the already-latest path")
+	}
+	// Give any (erroneously) armed goroutine a chance to fire.
+	time.Sleep(20 * time.Millisecond)
+	if restarted {
+		t.Error("Restart was called on the already-latest path")
+	}
+}
+
+// TestAgentUpdateTargetVersionPassthrough: an explicit target_version payload is
+// parsed and forwarded verbatim to GetRelease.
+func TestAgentUpdateTargetVersionPassthrough(t *testing.T) {
+	var gotTarget string
+	h := newTestHandler(t, func(c *AgentUpdateConfig) {
+		c.GetRelease = func(target string) (*update.Release, error) {
+			gotTarget = target
+			return &update.Release{TagName: "v2.99.0"}, nil
+		}
+		// Don't actually restart in this test.
+		c.IsService = func() bool { return false }
+	})
+
+	_, err := h.Execute(context.Background(), agentUpdateJob(perNodeQueue, map[string]any{"target_version": "v2.99.0"}), &NoOpStreamWriter{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotTarget != "v2.99.0" {
+		t.Errorf("target forwarded to GetRelease = %q, want v2.99.0", gotTarget)
+	}
+}
+
+// TestAgentUpdateEmptyTargetDefaultsLatest: no target_version yields an empty
+// string target ("latest") to GetRelease.
+func TestAgentUpdateEmptyTargetDefaultsLatest(t *testing.T) {
+	var gotTarget = "sentinel"
+	h := newTestHandler(t, func(c *AgentUpdateConfig) {
+		c.GetRelease = func(target string) (*update.Release, error) {
+			gotTarget = target
+			return nil, nil
+		}
+	})
+	_, err := h.Execute(context.Background(), agentUpdateJob(perNodeQueue, nil), &NoOpStreamWriter{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotTarget != "" {
+		t.Errorf("target = %q, want empty (latest)", gotTarget)
+	}
+}
+
+// TestAgentUpdatePerNodeGate: a job that did NOT arrive on the per-node stream
+// is refused with a structured failure, and no install/restart happens.
+func TestAgentUpdatePerNodeGate(t *testing.T) {
+	cases := []struct {
+		name        string
+		sourceQueue string
+		wantRefused bool
+	}{
+		{"shared org pool", "jobs:v1:shell:org_test", true},
+		{"generic queue", "jobs:v1:cpu-general", true},
+		{"empty source", "", true},
+		{"per-node stream", perNodeQueue, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var applied bool
+			h := newTestHandler(t, func(c *AgentUpdateConfig) {
+				c.Apply = func(string) error { applied = true; return nil }
+				c.IsService = func() bool { return false } // avoid restart in the accepted case
+			})
+			res, err := h.Execute(context.Background(), agentUpdateJob(tc.sourceQueue, nil), &NoOpStreamWriter{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantRefused {
+				if res.Status != JobStatusFailure {
+					t.Fatalf("status = %v, want failure (refused)", res.Status)
+				}
+				if applied {
+					t.Error("Apply ran despite the per-node gate refusing the job")
+				}
+			} else {
+				if res.Status != JobStatusSuccess {
+					t.Fatalf("status = %v, want success (accepted)", res.Status)
+				}
+				if !applied {
+					t.Error("Apply did not run for an accepted per-node job")
+				}
+			}
+		})
+	}
+}
+
+// TestAgentUpdateServiceContextGating: in a foreground (non-service) run the
+// handler installs but does NOT restart, returning "restart required".
+func TestAgentUpdateServiceContextGating(t *testing.T) {
+	var restarted, drained bool
+	h := newTestHandler(t, func(c *AgentUpdateConfig) {
+		c.IsService = func() bool { return false }
+		c.Restart = func() error { restarted = true; return nil }
+		c.Drain = func() { drained = true }
+	})
+
+	res, err := h.Execute(context.Background(), agentUpdateJob(perNodeQueue, nil), &NoOpStreamWriter{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Status != JobStatusSuccess {
+		t.Fatalf("status = %v, want success", res.Status)
+	}
+	if res.Output["updated"] != true {
+		t.Errorf("updated = %v, want true", res.Output["updated"])
+	}
+	if res.Output["restarting"] != false {
+		t.Errorf("restarting = %v, want false in foreground", res.Output["restarting"])
+	}
+	time.Sleep(20 * time.Millisecond)
+	if restarted {
+		t.Error("Restart was called in a foreground (non-service) run")
+	}
+	if drained {
+		t.Error("Drain was called in a foreground run (would wedge the worker)")
+	}
+}
+
+// TestAgentUpdateReportBeforeRestartOrdering is the crux test. It proves the
+// handler returns its SUCCESS result BEFORE Restart is invoked, and that Restart
+// only fires once the node is idle (ActiveJobs()==0) — the post-ack signal.
+//
+// We simulate the runner's lifecycle: this job is "active" (ActiveJobs()==1)
+// while Execute runs and its result is being published/acked. The test asserts:
+//  1. Execute returns a success result while a restart has NOT yet happened.
+//  2. Drain() was called (closes the new-job pickup race).
+//  3. Restart fires only after we drop ActiveJobs to 0 (mirroring the runner's
+//     post-ack activeJobs decrement), never before.
+func TestAgentUpdateReportBeforeRestartOrdering(t *testing.T) {
+	var active int64 = 1 // this job is in flight until we say otherwise
+
+	var mu sync.Mutex
+	var events []string
+	record := func(e string) {
+		mu.Lock()
+		events = append(events, e)
+		mu.Unlock()
+	}
+
+	restartCh := make(chan struct{})
+	h := newTestHandler(t, func(c *AgentUpdateConfig) {
+		c.ActiveJobs = func() int { return int(atomic.LoadInt64(&active)) }
+		c.Drain = func() { record("drain") }
+		c.Restart = func() error {
+			record("restart")
+			close(restartCh)
+			return nil
+		}
+	})
+
+	res, err := h.Execute(context.Background(), agentUpdateJob(perNodeQueue, nil), &NoOpStreamWriter{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Status != JobStatusSuccess || res.Output["updated"] != true {
+		t.Fatalf("unexpected result: %+v", res.Output)
+	}
+	record("result-returned")
+
+	// The restart must NOT have fired yet: the node is still "active" (this job's
+	// own ack has not been simulated). Assert restart is still pending.
+	select {
+	case <-restartCh:
+		t.Fatal("Restart fired before the job result was acked (ActiveJobs still 1)")
+	case <-time.After(30 * time.Millisecond):
+		// good: still waiting for idle
+	}
+
+	// Drain must already have been called (before Execute returned), so the
+	// runner stops fetching new jobs while the restart is pending.
+	mu.Lock()
+	if len(events) == 0 || events[0] != "drain" {
+		mu.Unlock()
+		t.Fatalf("Drain was not called before Execute returned; events=%v", events)
+	}
+	mu.Unlock()
+
+	// Now simulate the runner publishing + acking this job: activeJobs -> 0.
+	atomic.StoreInt64(&active, 0)
+
+	select {
+	case <-restartCh:
+		// good
+	case <-time.After(2 * time.Second):
+		t.Fatal("Restart never fired after the node went idle")
+	}
+
+	// Final ordering assertion: result-returned precedes restart.
+	mu.Lock()
+	defer mu.Unlock()
+	var resultIdx, restartIdx = -1, -1
+	for i, e := range events {
+		switch e {
+		case "result-returned":
+			resultIdx = i
+		case "restart":
+			restartIdx = i
+		}
+	}
+	if resultIdx == -1 || restartIdx == -1 {
+		t.Fatalf("missing events: %v", events)
+	}
+	if restartIdx < resultIdx {
+		t.Fatalf("restart happened before result was returned: %v", events)
+	}
+}
+
+// TestAgentUpdateCheckFailure: an update-check error is reported as a structured
+// failure rather than hanging or panicking.
+func TestAgentUpdateCheckFailure(t *testing.T) {
+	h := newTestHandler(t, func(c *AgentUpdateConfig) {
+		c.GetRelease = func(string) (*update.Release, error) { return nil, errors.New("github unreachable") }
+	})
+	res, err := h.Execute(context.Background(), agentUpdateJob(perNodeQueue, nil), &NoOpStreamWriter{})
+	if err != nil {
+		t.Fatalf("Execute should return the failure in the result, not as err: %v", err)
+	}
+	if res.Status != JobStatusFailure {
+		t.Fatalf("status = %v, want failure", res.Status)
+	}
+	if res.Output["error"] == nil {
+		t.Error("failure result missing structured error field")
+	}
+}
+
+// TestAgentUpdateInstallFailure: an Apply error keeps the current version and is
+// reported structurally; no restart is armed.
+func TestAgentUpdateInstallFailure(t *testing.T) {
+	var restarted bool
+	h := newTestHandler(t, func(c *AgentUpdateConfig) {
+		c.Apply = func(string) error { return errors.New("checksum mismatch on swap") }
+		c.Restart = func() error { restarted = true; return nil }
+	})
+	res, err := h.Execute(context.Background(), agentUpdateJob(perNodeQueue, nil), &NoOpStreamWriter{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Status != JobStatusFailure {
+		t.Fatalf("status = %v, want failure", res.Status)
+	}
+	time.Sleep(20 * time.Millisecond)
+	if restarted {
+		t.Error("Restart was armed despite the install failing")
+	}
+}
+
+// TestAgentUpdateRestartAfterAckEndToEnd drives the handler through a *real*
+// Runner (not injected ActiveJobs/Drain) to prove the actual guarantee this PR
+// exists for: the job's result is published + acked BEFORE the restart fires.
+// The handler borrows runner.ActiveJobs/runner.Drain exactly as cmd/work.go
+// wires it, and the injected Restart records how many jobs the source had acked
+// at the moment it was called — which must be >= 1 (this job).
+func TestAgentUpdateRestartAfterAckEndToEnd(t *testing.T) {
+	source := NewMockJobSource("test", []*Job{
+		agentUpdateJob(perNodeQueue, nil),
+	})
+
+	runner := NewRunner(source, nil, RunnerConfig{
+		WorkerID:       "w",
+		MaxConcurrency: 1,
+		ActivityFn:     func(string, string) {},
+	})
+
+	restarted := make(chan int, 1)
+	runner.RegisterHandler(NewAgentUpdateHandler(AgentUpdateConfig{
+		Version:          "v2.46.0",
+		GetRelease:       func(string) (*update.Release, error) { return &update.Release{TagName: "v2.47.0"}, nil },
+		Download:         func(*update.Release, string) error { return nil },
+		Apply:            func(string) error { return nil },
+		RecordState:      func(string, string) {},
+		IsService:        func() bool { return true },
+		Drain:            func() { runner.Drain() },
+		ActiveJobs:       runner.ActiveJobs,
+		IdlePollInterval: time.Millisecond,
+		IdleTimeout:      2 * time.Second,
+		Restart: func() error {
+			// At restart time, this job must already be acked.
+			restarted <- len(source.AckedJobs())
+			return nil
+		},
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() { _ = runner.Run(ctx); close(done) }()
+
+	select {
+	case ackedAtRestart := <-restarted:
+		if ackedAtRestart < 1 {
+			t.Fatalf("restart fired with %d acked jobs; the result was not acked first", ackedAtRestart)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("restart never fired end-to-end")
+	}
+
+	// The job must be in the acked set (success), not nacked (failure).
+	if got := len(source.AckedJobs()); got != 1 {
+		t.Errorf("acked jobs = %d, want 1", got)
+	}
+	if got := len(source.NackedJobs()); got != 0 {
+		t.Errorf("nacked jobs = %d, want 0 (job should have succeeded)", got)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runner did not shut down")
+	}
+}
+
+// TestAgentUpdateCanHandle guards the dispatch key.
+func TestAgentUpdateCanHandle(t *testing.T) {
+	h := NewAgentUpdateHandler(AgentUpdateConfig{Version: "v1"})
+	if !h.CanHandle(JobTypeAgentUpdate) {
+		t.Error("handler should claim AGENT_UPDATE")
+	}
+	if h.CanHandle("SHELL_COMMAND") {
+		t.Error("handler must not claim other job types")
+	}
+}

--- a/internal/worker/job.go
+++ b/internal/worker/job.go
@@ -135,6 +135,7 @@ const (
 	JobTypeVNCActions        = "VNC_ACTIONS"         // Execute pointer/keyboard actions (click, move, drag) on the node's display (issue #4180)
 	JobTypeCobrowse          = "COBROWSE"            // Human-in-the-loop co-browse over CDP (#4079)
 	JobTypeTranscribeAudio   = "TRANSCRIBE_AUDIO"    // Transcribe workspace audio node-locally via the faster-whisper sidecar
+	JobTypeAgentUpdate       = "AGENT_UPDATE"        // Remotely update + restart this node's own citadel agent (aceteam#4427)
 )
 
 // allKnownJobTypes enumerates every job type this citadel build knows about.
@@ -179,4 +180,5 @@ var allKnownJobTypes = []string{
 	JobTypeVNCActions,
 	JobTypeCobrowse,
 	JobTypeTranscribeAudio,
+	JobTypeAgentUpdate,
 }


### PR DESCRIPTION
## Context

There is no way to update or restart a Citadel node's agent **from the control plane**. `citadel update install` is a local command and auto-update is a local, default-off timer. To fix a node stuck on an old citadel today you need SSH — and `terminal_exec`, the other option, may itself be broken by the very version skew you're trying to fix.

Version skew is silent and costly: aceteam#4373 (`cobrowse_start` times out) was ultimately "node 702 was on v2.46.0, the handler shipped in v2.47.0" — invisible from the dashboard, undiagnosable without SSH.

This PR is the **citadel-cli half** of aceteam#4427: a dispatchable `AGENT_UPDATE` job that a node runs against itself. The paired aceteam-side work (a dispatch tool + an "outdated citadel" fleet view) is a separate follow-up.

## Summary

| Component | What & why |
| --- | --- |
| `internal/worker/agent_update.go` (new) | The `AgentUpdateHandler`. Reuses the exact `internal/update` code path as `citadel update install` (check → download → checksum-verify → atomic swap keeping the rollback copy). Optional `target_version` payload; defaults to latest. Every side effect is config-injectable (GetRelease/Download/Apply/IsService/Drain/ActiveJobs/Restart/RecordState) so it is fully unit-testable without network, disk, or exiting the process. |
| `internal/update/update.go` | New `GetReleaseByTag(tag)` — the package only had `/releases/latest`; installing a pinned target needs `/releases/tags/{tag}`. Normalizes the leading `v`, rejects empty, maps 404 to a clear "not found". |
| `internal/worker/job.go` | Adds the `JobTypeAgentUpdate` constant **and** the entry in `allKnownJobTypes`, so a node correctly advertises AGENT_UPDATE as supported (feeds the #382 "NAK unsupported job type" diagnosability). |
| `cmd/work.go` | Registers the handler on the runner via `runner.RegisterHandler(...)` after the runner exists, borrowing `runner.Drain`/`runner.ActiveJobs` — mirroring how the AutoUpdater is wired. |

### The self-restart crux — result published *before* restart

The handler runs **inside** the worker it must restart. A synchronous restart would kill the process before the result was published, and the dispatcher would see a timeout (exactly aceteam#4373's failure mode). The ordering guarantee:

1. `Execute()` installs the new binary and returns a **SUCCESS** result `{updated, old_version, new_version, restarting}` through the normal result path.
2. The runner publishes it (`stream.WriteEnd`) and **Ack**s the job.
3. Only *then* does the restart fire.

The post-ack signal is the runner's `activeJobs` counter: it is decremented in a `defer` that runs **after** `WriteEnd` + `Ack` (see `runner.processJob`). So observing `ActiveJobs()==0` from the arming goroutine proves this job's own result was published and acked — the same discipline the AutoUpdater already uses. The handler arms the goroutine *before* returning (this job is still counted active, so it cannot fire prematurely) and calls `Drain()` first to stop new-job pickup.

### Why exec, not SIGTERM

Restart uses `update.RestartProcess` (`syscall.Exec`, in-place, PID-preserving) — **not** a graceful SIGTERM-and-exit. The systemd unit ships `Restart=on-failure` (`internal/service/systemd.go`), which does **not** relaunch on a clean exit, so a SIGTERM approach would leave the node permanently down — strictly worse than the bug. `syscall.Exec` sidesteps the supervisor's restart policy entirely and does **not** orphan the VPN identity: the tsnet node key is persisted to the node state dir (`internal/network`), so the re-exec'd image re-inits the mesh from the same identity. This is the same mechanism the production AutoUpdater already uses.

### Service-context gating

Self-restart only fires when running as a managed service (`CITADEL_SERVICE=true`, set by the systemd unit / launchd plist / Windows SCM). In a foreground/interactive run the handler installs and returns `"updated, restart required"` rather than killing the operator's session.

### Privilege gating (and the aceteam-side contract)

The handler refuses AGENT_UPDATE unless the job arrived on the **per-node stream** (`jobs:v1:shell:org_<id>:node:<nodeid>` — keyed on the `:node:` segment of `SourceQueue`), never the shared org pool. **Cross-repo contract:** the aceteam dispatcher must send AGENT_UPDATE **on the per-node stream**, not via a `target_node` payload on the shared pool — the gate rejects the latter. Server-side, this should additionally require a scope / signed capability (#4313); that is aceteam-side.

### Notes for review

- **Downgrade:** with an explicit `target_version` older than the running version, `GetRelease` returns `(nil,nil)` → the handler reports `already-latest` and does nothing (it only rolls *forward*). Rollback stays the local `citadel update rollback` path. Called out so it isn't mistaken for a bug.
- Failures (update-check failed / checksum mismatch / install failed / already-latest) are reported **structurally** as a FAILURE result or a `reason` field, never a hang.
- **Idle-timeout behavior:** if in-flight jobs don't drain within the 2m idle timeout, the arming goroutine restarts **anyway** (the binary is already swapped). This differs from the AutoUpdater, which defers to its next cycle — an AutoUpdater always has a next tick, whereas this one-shot job does not. It can interrupt an unrelated long-running job in that rare window; called out so it isn't read as an oversight.

## Test plan

| Test | Coverage |
| --- | --- |
| `TestAgentUpdateAlreadyLatest` | `(nil,nil)` release → structured success `reason=already-latest`; Apply/Restart never called |
| `TestAgentUpdateTargetVersionPassthrough` | explicit `target_version` forwarded verbatim to GetRelease |
| `TestAgentUpdateEmptyTargetDefaultsLatest` | no payload → empty target ("latest") |
| `TestAgentUpdatePerNodeGate` | shared-pool / generic / empty source refused; per-node accepted |
| `TestAgentUpdateServiceContextGating` | foreground run installs but does **not** restart or drain |
| `TestAgentUpdateReportBeforeRestartOrdering` | **the crux (unit)**: result returns first; Drain called before return; Restart fires only after ActiveJobs 1→0, never before |
| `TestAgentUpdateRestartAfterAckEndToEnd` | **the crux (end-to-end)**: drives a real `Runner`+`MockJobSource`; asserts the job is **acked** before the injected Restart fires |
| `TestAgentUpdateCheckFailure` / `TestAgentUpdateInstallFailure` | structured failure, no restart armed; install failure keeps current version |
| `TestAgentUpdateCanHandle` | dispatch key |
| `TestGetReleaseByTagEmpty` | empty/whitespace tag fails fast before any network call |

`gofmt`, `go build ./...`, `go vet`, and `go test ./internal/update/ ./internal/worker/ ./cmd/` all pass. (The only failing package in the full suite is `internal/status`, an environmental `:8080` bind conflict from the live worker on the dev host — unrelated to this change; no files under `internal/status` were touched.)

## What a reviewer should verify on a live node

1. **End-to-end on a systemd node:** dispatch AGENT_UPDATE on the node's per-node stream. Confirm the dispatcher receives the SUCCESS result `{old_version, new_version}` **before** the process restarts (no timeout), then `citadel version` shows the new version and the node re-appears on the VPN with the same identity (node key preserved).
2. **`Restart=on-failure` interaction:** confirm the `syscall.Exec` re-exec relaunches on the new binary (it should — exec replaces the image in place, independent of the supervisor's restart policy).
3. **Foreground run:** dispatch to a `citadel work` started manually (no `CITADEL_SERVICE`); confirm it reports `"updated, restart required"` and does **not** exit.
4. **Gate:** confirm a shared-pool dispatch is refused with the structural reason.

Marked **draft** until the live-node self-restart is verified.

## Related

- aceteam#4427 (this issue) — paired aceteam-side dispatch tool + fleet view is a separate follow-up
- aceteam#4373 (silent version skew that motivated this)
- #382 (NAK unsupported job types — AGENT_UPDATE added to `allKnownJobTypes`)
- #4313 (signed capabilities — the server-side authorization this defers to)

---
*Generated by Claude*
