### PR TITLE
feat(tui): mouse-clickable Control Center, Chat tab first (#388)

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -255,7 +255,18 @@ func runControlCenter() {
 			SaveKeepAwake: func(k *config.KeepAwake) error {
 				return config.SaveKeepAwake(platform.ConfigDir(), k)
 			},
+			LoadMouse: func() *config.Mouse {
+				return config.LoadMouse(platform.ConfigDir())
+			},
+			SaveMouse: func(m *config.Mouse) error {
+				return config.SaveMouse(platform.ConfigDir(), m)
+			},
+			// SetMouseEnabled is injected by the control center itself in Run(),
+			// where the running tview app exists to receive EnableMouse.
 		},
+		// Resolve the initial mouse state: persisted preference with the
+		// --no-mouse flag applied as a session override.
+		MouseEnabled:  controlcenter.ResolveMouseEnabled(noMouse, config.LoadMouse(platform.ConfigDir()).Enabled),
 		WhatsApp:      buildWhatsAppCallbacks(),
 		ModuleInstall: buildModuleInstallCallbacks(),
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,6 +33,11 @@ var debugMode bool
 var daemonMode bool
 var noColorGlobal bool
 
+// noMouse, when set, disables terminal mouse reporting in the control center for
+// the current session, overriding the persisted preference. Users set it to keep
+// their terminal's native drag-to-copy working.
+var noMouse bool
+
 // debugToStderr forces debug console output to stderr instead of stdout.
 // Set by commands that use stdout as a transport (e.g., MCP).
 var debugToStderr bool
@@ -214,6 +219,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&debugMode, "debug", false, "Enable debug output")
 	rootCmd.PersistentFlags().BoolVar(&noColorGlobal, "no-color", false, "Disable colorized output")
 	rootCmd.Flags().BoolVar(&daemonMode, "daemon", false, "Run in background daemon mode (no TUI)")
+	rootCmd.Flags().BoolVar(&noMouse, "no-mouse", false, "Disable control-center mouse control (keeps terminal drag-to-copy)")
 
 	// Hide persistent flags that are only for dev/scripting
 	rootCmd.PersistentFlags().MarkHidden("config")

--- a/internal/config/mouse.go
+++ b/internal/config/mouse.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Mouse controls whether the control-center TUI opts into terminal mouse
+// reporting. Unlike KeepAwake (opt-in, default-off), mouse control is the
+// feature the user is expected to want — clicking tabs, peers, and Send instead
+// of memorizing keybindings — so it defaults ON. It is a per-user preference
+// persisted alongside the other config files.
+//
+// The tradeoff mouse reporting imposes is that the terminal's native
+// drag-to-copy stops working while it is on (the user must hold Shift / Fn /
+// Option to bypass, depending on the terminal). Users who prefer native
+// selection can disable it from the Settings pane or with the --no-mouse flag.
+type Mouse struct {
+	// Enabled gates terminal mouse reporting in the control center. When true
+	// (the default), clicks/scroll drive the TUI. When false, the app never
+	// enables mouse capture, preserving native terminal drag-to-copy.
+	Enabled bool `yaml:"enabled" json:"enabled"`
+}
+
+const mouseFile = "mouse.yaml"
+
+// DefaultMouse returns a Mouse struct with mouse control enabled. Default-on is
+// intentional: the click-to-drive UX is the feature, and keyboard navigation is
+// fully preserved either way.
+func DefaultMouse() *Mouse {
+	return &Mouse{
+		Enabled: true,
+	}
+}
+
+// LoadMouse reads mouse settings from the config directory. If the file doesn't
+// exist, returns defaults (enabled). Partial files preserve defaults for absent
+// keys (unmarshal into a pre-initialized struct), mirroring LoadKeepAwake.
+func LoadMouse(configDir string) *Mouse {
+	m := DefaultMouse()
+
+	data, err := os.ReadFile(filepath.Join(configDir, mouseFile))
+	if err != nil {
+		return m
+	}
+
+	// yaml.Unmarshal only overwrites keys present in the file, so an absent key
+	// keeps its default (true) value.
+	_ = yaml.Unmarshal(data, m)
+	return m
+}
+
+// SaveMouse writes mouse settings to the config directory. The Settings pane
+// calls this when the operator toggles mouse control.
+func SaveMouse(configDir string, m *Mouse) error {
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+
+	data, err := yaml.Marshal(m)
+	if err != nil {
+		return fmt.Errorf("marshal mouse: %w", err)
+	}
+
+	return os.WriteFile(filepath.Join(configDir, mouseFile), data, 0644)
+}

--- a/internal/config/mouse_test.go
+++ b/internal/config/mouse_test.go
@@ -1,0 +1,72 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultMouse(t *testing.T) {
+	m := DefaultMouse()
+	if !m.Enabled {
+		t.Errorf("DefaultMouse should be enabled (mouse is the feature), got %+v", m)
+	}
+}
+
+func TestLoadMouse_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	m := LoadMouse(dir)
+	if !m.Enabled {
+		t.Errorf("LoadMouse with no file should default to enabled, got %+v", m)
+	}
+}
+
+func TestMouseSaveAndLoadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	original := &Mouse{Enabled: false}
+
+	if err := SaveMouse(dir, original); err != nil {
+		t.Fatalf("SaveMouse: %v", err)
+	}
+
+	loaded := LoadMouse(dir)
+	if loaded.Enabled != original.Enabled {
+		t.Errorf("round trip mismatch: saved %+v, loaded %+v", original, loaded)
+	}
+}
+
+func TestLoadMouse_DisabledFromFile(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte("enabled: false\n")
+	if err := os.WriteFile(filepath.Join(dir, "mouse.yaml"), data, 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	m := LoadMouse(dir)
+	if m.Enabled {
+		t.Error("enabled should be false from file")
+	}
+}
+
+func TestLoadMouse_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte("not: [valid: yaml: {{{")
+	if err := os.WriteFile(filepath.Join(dir, "mouse.yaml"), data, 0644); err != nil {
+		t.Fatalf("write invalid yaml: %v", err)
+	}
+
+	m := LoadMouse(dir)
+	if !m.Enabled {
+		t.Errorf("invalid YAML should return defaults (enabled), got %+v", m)
+	}
+}
+
+func TestSaveMouse_CreatesDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "dir")
+	if err := SaveMouse(dir, DefaultMouse()); err != nil {
+		t.Fatalf("SaveMouse should create nested dirs: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "mouse.yaml")); err != nil {
+		t.Errorf("mouse file should exist after save: %v", err)
+	}
+}

--- a/internal/tui/controlcenter/chat_page.go
+++ b/internal/tui/controlcenter/chat_page.go
@@ -61,6 +61,7 @@ type ChatPage struct {
 	msgView    *tview.TextView
 	statusBar  *tview.TextView
 	input      *tview.InputField
+	sendButton *tview.Button
 
 	// Chat client
 	client   *chat.Client
@@ -213,7 +214,7 @@ func (p *ChatPage) Build(app *tview.Application) tview.Primitive {
 	p.input.SetLabel("> ")
 	p.input.SetFieldBackgroundColor(tcell.ColorDarkSlateGray)
 	p.input.SetLabelColor(tcell.ColorGreen)
-	p.input.SetPlaceholder("Type a message and press Enter")
+	p.input.SetPlaceholder("Type a message and press Enter (or click Send)")
 	p.input.SetPlaceholderTextColor(tcell.ColorDimGray)
 	p.input.SetDoneFunc(func(key tcell.Key) {
 		if key == tcell.KeyEnter {
@@ -221,10 +222,28 @@ func (p *ChatPage) Build(app *tview.Application) tview.Primitive {
 		}
 	})
 
+	// Visible, clickable Send affordance so mouse users aren't forced to know
+	// that Enter submits. Button.SetSelectedFunc fires on both keyboard Enter
+	// (when focused) and MouseLeftClick, so it works either way. After sending,
+	// focus returns to the input so the user can keep typing.
+	p.sendButton = tview.NewButton("Send")
+	p.sendButton.SetSelectedFunc(func() {
+		p.sendMessage()
+		if p.app != nil && p.input != nil {
+			p.app.SetFocus(p.input)
+		}
+	})
+
+	// Input row: the text field expands, the Send button is a fixed-width click
+	// target on the right.
+	inputRow := tview.NewFlex().
+		AddItem(p.input, 0, 1, true).
+		AddItem(p.sendButton, 8, 0, false)
+
 	rightPanel := tview.NewFlex().SetDirection(tview.FlexRow).
 		AddItem(p.msgView, 0, 1, false).
 		AddItem(p.statusBar, 1, 0, false).
-		AddItem(p.input, 1, 0, true)
+		AddItem(inputRow, 1, 0, true)
 
 	// Render the initial "connecting" status line.
 	p.renderStatusBar(connConnecting, "")
@@ -234,6 +253,31 @@ func (p *ChatPage) Build(app *tview.Application) tview.Primitive {
 	p.root = tview.NewFlex().
 		AddItem(p.sidebar, 24, 0, false).
 		AddItem(rightPanel, 0, 1, true)
+
+	// Mouse: clicking the message history, a channel, or a peer focuses the input
+	// so a mouse user can immediately start typing (rather than the clicked pane
+	// stealing focus). The scroll wheel still scrolls the message history because
+	// scroll actions are passed through unchanged; only left-clicks redirect
+	// focus. Keyboard navigation is unaffected — this is a mouse-only hook.
+	focusInputOnClick := func(action tview.MouseAction, event *tcell.EventMouse) (tview.MouseAction, *tcell.EventMouse) {
+		switch action {
+		case tview.MouseLeftClick, tview.MouseLeftDown:
+			if p.app != nil && p.input != nil {
+				p.app.SetFocus(p.input)
+			}
+			// Consume the click so the clicked TextView does not immediately grab
+			// focus back on MouseLeftDown. Returning a nil event with the
+			// MouseConsumed action skips the primitive's default handler.
+			return tview.MouseConsumed, nil
+		default:
+			// Pass scroll (and everything else) through so wheel-scrolling the
+			// message history keeps working.
+			return action, event
+		}
+	}
+	p.msgView.SetMouseCapture(focusInputOnClick)
+	p.channelBox.SetMouseCapture(focusInputOnClick)
+	p.peersBox.SetMouseCapture(focusInputOnClick)
 
 	return p.root
 }

--- a/internal/tui/controlcenter/controlcenter.go
+++ b/internal/tui/controlcenter/controlcenter.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -257,6 +258,21 @@ func (pm *PageManager) Hide(name string) {
 	}
 }
 
+// activeName returns the name of the currently active page, or "" if none.
+func (pm *PageManager) activeName() string {
+	if pm.activeIdx >= 0 && pm.activeIdx < len(pm.registered) {
+		return pm.registered[pm.activeIdx].page.Name()
+	}
+	return ""
+}
+
+// isDashboardActive reports whether the Dashboard (control center) page is the
+// active one. The dashboard has its own focus/highlight model that the mouse
+// capture must keep in sync; other pages handle clicks natively.
+func (pm *PageManager) isDashboardActive() bool {
+	return pm.activeName() == "dashboard"
+}
+
 // SwitchToName switches to a page by name (for programmatic switching).
 func (pm *PageManager) SwitchToName(name string) {
 	for i, rp := range pm.registered {
@@ -276,18 +292,62 @@ func (pm *PageManager) updateTabBar() {
 		}
 		displayNum++
 		key := fmt.Sprintf("Alt+%d", displayNum)
+		// Wrap each tab in a TextView region keyed by its real registered index.
+		// Regions make the tab a native click target: tview resolves a click to
+		// the region under the cursor (correctly, even with center alignment), so
+		// clicking a tab switches to it. The keyboard path (Alt+N) is unchanged.
+		fmt.Fprintf(&sb, `["tab_%d"]`, i)
 		if i == pm.activeIdx {
 			sb.WriteString(fmt.Sprintf("[yellow::b][%s %s][-:-:-]", key, rp.page.Title()))
 		} else {
 			sb.WriteString(fmt.Sprintf("[gray] %s %s [-]", key, rp.page.Title()))
 		}
+		sb.WriteString(`[""]`)
 		sb.WriteString(" ")
 	}
 	pm.tabBar.SetText(sb.String())
 }
 
+// tabIndexFromRegion parses a tab region ID ("tab_<realIdx>") back to the real
+// registered index it encodes, returning (idx, true) on success. Extracted so
+// the region-ID parsing is unit-testable without a running app.
+func tabIndexFromRegion(regionID string) (int, bool) {
+	const prefix = "tab_"
+	if !strings.HasPrefix(regionID, prefix) {
+		return 0, false
+	}
+	idx, err := strconv.Atoi(strings.TrimPrefix(regionID, prefix))
+	if err != nil {
+		return 0, false
+	}
+	return idx, true
+}
+
+// enableTabClicks wires click-to-switch on the tab bar. A click highlights the
+// tab's region; the highlight handler maps that region back to a page index and
+// switches to it, then clears the highlight so no tab stays visually "stuck"
+// (the active-tab styling is driven by updateTabBar, not by region highlight).
+func (pm *PageManager) enableTabClicks() {
+	pm.tabBar.SetRegions(true)
+	pm.tabBar.SetHighlightedFunc(func(added, removed, remaining []string) {
+		if len(added) == 0 {
+			return
+		}
+		idx, ok := tabIndexFromRegion(added[0])
+		if !ok || idx < 0 || idx >= len(pm.registered) || !pm.registered[idx].visible {
+			pm.tabBar.Highlight()
+			return
+		}
+		// Clear the transient highlight first; SwitchTo re-renders the tab bar and
+		// drives the active-tab styling itself.
+		pm.tabBar.Highlight()
+		pm.SwitchTo(idx)
+	})
+}
+
 // Build returns the root layout: pages container + tab bar.
 func (pm *PageManager) Build() *tview.Flex {
+	pm.enableTabClicks()
 	pm.rootFlex = tview.NewFlex().SetDirection(tview.FlexRow).
 		AddItem(pm.pages, 0, 1, true).
 		AddItem(pm.tabBar, 1, 0, false)
@@ -434,6 +494,12 @@ type ControlCenter struct {
 
 	// Module install (install a service module from any standardized repo)
 	moduleInstallConfig ModuleInstallCallbacks
+
+	// Mouse control. mouseEnabled is the resolved initial state (persisted config
+	// overridden by the --no-mouse flag); it is applied to the app in Run() and
+	// can be flipped live from the Settings pane. Keyboard navigation is fully
+	// preserved regardless of this value — mouse is purely additive.
+	mouseEnabled bool
 }
 
 // Pane focus constants
@@ -502,6 +568,12 @@ type Config struct {
 	Settings           SettingsCallbacks                        // Settings page hooks (telemetry load/save)
 	WhatsApp           WhatsAppCallbacks                        // WhatsApp bridge page hooks (deploy/stop/status/QR)
 	ModuleInstall      ModuleInstallCallbacks                   // Install-module page hooks (resolve source + install)
+
+	// MouseEnabled is the resolved initial mouse state (persisted preference with
+	// the --no-mouse flag applied). When true, the control center opts into
+	// terminal mouse reporting so tabs/rows/Send are clickable. Keyboard
+	// navigation works either way.
+	MouseEnabled bool
 }
 
 // ProxmoxConfig holds configuration for the Proxmox TUI page.
@@ -542,6 +614,7 @@ func New(cfg Config) *ControlCenter {
 		settingsConfig:      cfg.Settings,
 		whatsappConfig:      cfg.WhatsApp,
 		moduleInstallConfig: cfg.ModuleInstall,
+		mouseEnabled:        cfg.MouseEnabled,
 	}
 }
 
@@ -668,6 +741,10 @@ func (cc *ControlCenter) Run() error {
 	}
 
 	// Settings page (Alt+5): telemetry opt-out + read-only connection status.
+	// Inject the live mouse-toggle hook here (not in cmd) because it needs a
+	// reference to the running app, which only exists once Run() has created it.
+	// The persistence hooks (LoadMouse/SaveMouse) are wired from cmd.
+	cc.settingsConfig.SetMouseEnabled = cc.SetMouseEnabled
 	cc.pmgr.Register(NewSettingsPage(cc.settingsConfig, cc.chatPage), true)
 
 	cc.rootView = cc.pmgr.Build()
@@ -679,6 +756,15 @@ func (cc *ControlCenter) Run() error {
 	cc.app.SetInputCapture(cc.pmgr.HandleGlobalInput)
 
 	cc.app.SetRoot(cc.rootView, true)
+
+	// Opt into terminal mouse reporting so tabs, list rows, and the chat Send
+	// button are clickable. This is purely additive: SetMouseCapture below syncs
+	// the control-center's own focus/highlight model with tview's native
+	// focus-on-click, and all keybindings remain wired through SetInputCapture.
+	// Gated by the resolved preference (persisted config with --no-mouse applied)
+	// so a user who wants native terminal drag-to-copy can turn it off.
+	cc.app.EnableMouse(cc.mouseEnabled)
+	cc.app.SetMouseCapture(cc.handleMouse)
 
 	// Start background tasks after a brief delay to ensure event loop is running
 	go func() {
@@ -852,6 +938,28 @@ func (cc *ControlCenter) buildUI() {
 		AddItem(bottomRow, 0, 1, false).
 		AddItem(cc.helpBar, 1, 0, false).
 		AddItem(cc.statusBar, 1, 0, false)
+
+	// Keep the help bar accurate when the selection changes by mouse click within
+	// an already-focused pane (a click that doesn't change the focused pane skips
+	// updatePaneFocus, which is what normally refreshes the help bar). The
+	// keyboard arrow path already calls updateHelpBar, so this only adds coverage
+	// for mouse row-selection; it never double-fires meaningfully because SetText
+	// is idempotent.
+	cc.servicesView.SetSelectionChangedFunc(func(row, column int) {
+		if cc.focusedPane == paneServices {
+			cc.updateHelpBar()
+		}
+	})
+	cc.peersView.SetSelectionChangedFunc(func(row, column int) {
+		if cc.focusedPane == panePeers {
+			cc.updateHelpBar()
+		}
+	})
+	cc.actionsView.SetSelectionChangedFunc(func(row, column int) {
+		if cc.focusedPane == paneActions {
+			cc.updateHelpBar()
+		}
+	})
 
 	cc.focusedPane = paneServices
 }
@@ -1482,6 +1590,13 @@ func (cc *ControlCenter) showHelpModal() {
   [white::b]?[-:-:-] or [white::b]h[-:-:-]       Show this help
   [white::b]q[-:-:-] / [white::b]Esc[-:-:-]      Quit (with confirmation)
 
+[yellow]Mouse:[-]
+  Click a pane to focus it, double-click for details, click an
+  Action to run it. In Chat, click Send or a message to type.
+  [gray]Mouse reporting disables terminal drag-to-copy — hold Shift
+  (Fn on macOS Terminal, Option in iTerm2) to select text, or
+  turn mouse off in Settings (Alt tab) / launch with --no-mouse.[-]
+
 [gray]Press any key to close[-]`
 
 	cc.inModal = true
@@ -1552,9 +1667,21 @@ func (cc *ControlCenter) updateActionsPanel() {
 
 	actions := cc.getActions()
 	for i, action := range actions {
-		cc.actionsView.SetCell(i, 0, tview.NewTableCell("[yellow::b]"+action.key+"[-:-:-]").SetSelectable(true))
-		cc.actionsView.SetCell(i, 1, tview.NewTableCell(action.name).SetSelectable(true).SetExpansion(1))
-		cc.actionsView.SetCell(i, 2, tview.NewTableCell(action.desc).SetSelectable(true))
+		// Single-click on any cell of an action row runs it — the same behavior as
+		// the 0-3 hotkeys. SetClickedFunc fires on MouseLeftClick; returning false
+		// lets the row also become selected so the highlight tracks the click.
+		// (tview's Table only invokes SetSelectedFunc on keyboard Enter, never on
+		// click, so this is the click path and cannot double-fire with Enter.)
+		fn := action.fn
+		run := func() bool {
+			if fn != nil {
+				fn()
+			}
+			return false
+		}
+		cc.actionsView.SetCell(i, 0, tview.NewTableCell("[yellow::b]"+action.key+"[-:-:-]").SetSelectable(true).SetClickedFunc(run))
+		cc.actionsView.SetCell(i, 1, tview.NewTableCell(action.name).SetSelectable(true).SetExpansion(1).SetClickedFunc(run))
+		cc.actionsView.SetCell(i, 2, tview.NewTableCell(action.desc).SetSelectable(true).SetClickedFunc(run))
 	}
 
 	cc.actionsView.Select(0, 0)
@@ -1961,13 +2088,16 @@ func (cc *ControlCenter) updateActivityView() {
 }
 
 func (cc *ControlCenter) updateHelpBar() {
+	var text string
+	set := func(s string) { text = s }
+
 	switch cc.focusedPane {
 	case paneNode:
-		cc.helpBar.SetText("[yellow::b]Enter[-:-:-] details  │  [yellow::b]Tab[-:-:-] switch pane  [yellow::b]c[-:-:-] copy  [yellow::b]?[-:-:-] help  [yellow::b]q[-:-:-] quit")
+		set("[yellow::b]Enter[-:-:-] details  │  [yellow::b]Tab[-:-:-] switch pane  [yellow::b]c[-:-:-] copy  [yellow::b]?[-:-:-] help  [yellow::b]q[-:-:-] quit")
 	case paneSystem:
-		cc.helpBar.SetText("[yellow::b]Enter[-:-:-] details  │  [yellow::b]Tab[-:-:-] switch pane  [yellow::b]c[-:-:-] copy  [yellow::b]?[-:-:-] help  [yellow::b]q[-:-:-] quit")
+		set("[yellow::b]Enter[-:-:-] details  │  [yellow::b]Tab[-:-:-] switch pane  [yellow::b]c[-:-:-] copy  [yellow::b]?[-:-:-] help  [yellow::b]q[-:-:-] quit")
 	case paneJobs:
-		cc.helpBar.SetText("[yellow::b]Enter[-:-:-] view details  │  [yellow::b]Tab[-:-:-] switch pane  [yellow::b]c[-:-:-] copy  [yellow::b]?[-:-:-] help  [yellow::b]q[-:-:-] quit")
+		set("[yellow::b]Enter[-:-:-] view details  │  [yellow::b]Tab[-:-:-] switch pane  [yellow::b]c[-:-:-] copy  [yellow::b]?[-:-:-] help  [yellow::b]q[-:-:-] quit")
 	case paneServices:
 		svcName := cc.getSelectedServiceName()
 		svcStatus := cc.getSelectedServiceStatus()
@@ -1978,37 +2108,48 @@ func (cc *ControlCenter) updateHelpBar() {
 				statusIcon = "[green]●[-]"
 				action = "stop"
 			}
-			cc.helpBar.SetText(fmt.Sprintf("[white::b]%s[-:-:-] %s  │  [yellow::b]Enter[-:-:-] %s  [yellow::b]Tab[-:-:-] switch pane  [yellow::b]0-3[-:-:-] actions  [yellow::b]?[-:-:-] help",
+			set(fmt.Sprintf("[white::b]%s[-:-:-] %s  │  [yellow::b]Enter[-:-:-] %s  [yellow::b]Tab[-:-:-] switch pane  [yellow::b]0-3[-:-:-] actions  [yellow::b]?[-:-:-] help",
 				svcName, statusIcon, action))
 		} else {
-			cc.helpBar.SetText("[yellow::b]↑/↓[-:-:-] select  │  [yellow::b]Tab[-:-:-] switch pane  [yellow::b]0-3[-:-:-] actions  [yellow::b]?[-:-:-] help  [yellow::b]q[-:-:-] quit")
+			set("[yellow::b]↑/↓[-:-:-] select  │  [yellow::b]Tab[-:-:-] switch pane  [yellow::b]0-3[-:-:-] actions  [yellow::b]?[-:-:-] help  [yellow::b]q[-:-:-] quit")
 		}
 	case paneActions:
 		row, _ := cc.actionsView.GetSelection()
 		actions := cc.getActions()
 		if row >= 0 && row < len(actions) {
 			action := actions[row]
-			cc.helpBar.SetText(fmt.Sprintf("[yellow::b]%s[-:-:-] [white::b]%s[-:-:-]  │  [yellow::b]Enter[-:-:-] execute  [yellow::b]Tab[-:-:-] switch pane  [yellow::b]?[-:-:-] help  [yellow::b]q[-:-:-] quit",
+			set(fmt.Sprintf("[yellow::b]%s[-:-:-] [white::b]%s[-:-:-]  │  [yellow::b]Enter[-:-:-] execute  [yellow::b]Tab[-:-:-] switch pane  [yellow::b]?[-:-:-] help  [yellow::b]q[-:-:-] quit",
 				action.key, action.name))
 		} else {
-			cc.helpBar.SetText("[yellow::b]↑/↓[-:-:-] select action  │  [yellow::b]Enter[-:-:-] execute  [yellow::b]Tab[-:-:-] switch pane  [yellow::b]?[-:-:-] help")
+			set("[yellow::b]↑/↓[-:-:-] select action  │  [yellow::b]Enter[-:-:-] execute  [yellow::b]Tab[-:-:-] switch pane  [yellow::b]?[-:-:-] help")
 		}
 	case panePeers:
 		if len(cc.data.Peers) > 0 {
 			row, _ := cc.peersView.GetSelection()
 			if row > 0 && row <= len(cc.data.Peers) {
 				peer := cc.data.Peers[row-1]
-				cc.helpBar.SetText(fmt.Sprintf("[white::b]%s[-:-:-]  │  [yellow::b]Enter[-:-:-] view peers  [yellow::b]p[-:-:-] ping  [yellow::b]a[-:-:-] ping all  [yellow::b]Tab[-:-:-] switch  [yellow::b]?[-:-:-] help",
+				set(fmt.Sprintf("[white::b]%s[-:-:-]  │  [yellow::b]Enter[-:-:-] view peers  [yellow::b]p[-:-:-] ping  [yellow::b]a[-:-:-] ping all  [yellow::b]Tab[-:-:-] switch  [yellow::b]?[-:-:-] help",
 					peer.Hostname))
 			} else {
-				cc.helpBar.SetText("[yellow::b]↑/↓[-:-:-] select peer  │  [yellow::b]Enter[-:-:-] view peers  [yellow::b]a[-:-:-] ping all  [yellow::b]Tab[-:-:-] switch pane  [yellow::b]?[-:-:-] help")
+				set("[yellow::b]↑/↓[-:-:-] select peer  │  [yellow::b]Enter[-:-:-] view peers  [yellow::b]a[-:-:-] ping all  [yellow::b]Tab[-:-:-] switch pane  [yellow::b]?[-:-:-] help")
 			}
 		} else {
-			cc.helpBar.SetText("[yellow::b]Tab[-:-:-] switch pane  │  [yellow::b]0[-:-:-] connect  [yellow::b]?[-:-:-] help  [yellow::b]q[-:-:-] quit")
+			set("[yellow::b]Tab[-:-:-] switch pane  │  [yellow::b]0[-:-:-] connect  [yellow::b]?[-:-:-] help  [yellow::b]q[-:-:-] quit")
 		}
 	case paneActivity:
-		cc.helpBar.SetText("[yellow::b]Enter[-:-:-] full screen  │  [yellow::b]l[-:-:-] copy logs  [yellow::b]↑/↓[-:-:-] scroll  [yellow::b]Tab[-:-:-] switch  [yellow::b]?[-:-:-] help")
+		set("[yellow::b]Enter[-:-:-] full screen  │  [yellow::b]l[-:-:-] copy logs  [yellow::b]↑/↓[-:-:-] scroll  [yellow::b]Tab[-:-:-] switch  [yellow::b]?[-:-:-] help")
 	}
+
+	// When mouse is on, advertise it so the click affordances are discoverable
+	// (and, by extension, so the drag-to-copy tradeoff is findable in help). The
+	// hint points at Settings, which is the actual off-switch — the mock's [S]
+	// key would collide with the existing 's' = start-service binding, so we do
+	// not bind a key here.
+	if cc.mouseEnabled {
+		text += "  [gray]│  mouse on[-]"
+	}
+
+	cc.helpBar.SetText(text)
 }
 
 func (cc *ControlCenter) updateStatusBar() {

--- a/internal/tui/controlcenter/mouse.go
+++ b/internal/tui/controlcenter/mouse.go
@@ -1,0 +1,132 @@
+package controlcenter
+
+import (
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+// ResolveMouseEnabled computes the effective initial mouse state from the
+// persisted preference and the --no-mouse flag. The flag is a session override:
+// when set it forces mouse off regardless of the saved preference, but it does
+// not mutate the persisted value. When the flag is unset, the persisted
+// preference wins (defaulting to enabled when no config exists).
+//
+// Extracted as a pure function so the precedence is unit-testable without a
+// terminal or a running app, and callable from cmd where the flag lives.
+func ResolveMouseEnabled(flagNoMouse bool, savedEnabled bool) bool {
+	if flagNoMouse {
+		return false
+	}
+	return savedEnabled
+}
+
+// rect is a minimal, dependency-free rectangle used by the pane hit-test so the
+// geometry logic is testable without constructing tview primitives.
+type rect struct {
+	x, y, w, h int
+}
+
+// contains reports whether the point (px, py) lies within the rectangle.
+func (r rect) contains(px, py int) bool {
+	return px >= r.x && px < r.x+r.w && py >= r.y && py < r.y+r.h
+}
+
+// paneAtPoint returns the pane constant whose rectangle contains the point, or
+// -1 when the click landed outside every dashboard pane (e.g. the header, help
+// bar, or a gap between panels). rects is indexed by the pane* constants.
+//
+// Pure function: the caller passes the current on-screen rectangles (from each
+// primitive's GetRect) and the click coordinates, keeping tview out of the
+// hit-test so it can be exercised directly in tests.
+func paneAtPoint(rects [paneCount]rect, px, py int) int {
+	for i := 0; i < paneCount; i++ {
+		if rects[i].contains(px, py) {
+			return i
+		}
+	}
+	return -1
+}
+
+// paneRects snapshots the current on-screen rectangle of each dashboard pane.
+// Only valid to call after the layout has been drawn at least once; GetRect
+// returns zero-sized rects before the first draw, in which case paneAtPoint
+// simply reports no hit (contains is false for zero width/height).
+func (cc *ControlCenter) paneRects() [paneCount]rect {
+	var rects [paneCount]rect
+	set := func(pane int, p tview.Primitive) {
+		if p == nil {
+			return
+		}
+		x, y, w, h := p.GetRect()
+		rects[pane] = rect{x: x, y: y, w: w, h: h}
+	}
+	set(paneNode, cc.nodePanel)
+	set(paneSystem, cc.vitalsPanel)
+	set(paneJobs, cc.jobsPanel)
+	set(paneServices, cc.servicesView)
+	set(paneActions, cc.actionsView)
+	set(panePeers, cc.peersView)
+	set(paneActivity, cc.activityView)
+	return rects
+}
+
+// handleMouse is the Application-level mouse capture. It runs only for the
+// dashboard page (the active page owns focus; other pages' primitives handle
+// their own clicks natively). Its job is to keep the control center's OWN focus
+// model (cc.focusedPane + the yellow border/title highlight) in sync with
+// tview's native focus-on-click, and to map a double-click to the same "details"
+// action that Enter triggers.
+//
+// It deliberately returns the event unchanged so tview still forwards it to the
+// target primitive's MouseHandler — that is what gives us native row selection,
+// input focus, and wheel scrolling for free. Keyboard handling is untouched
+// (that path is SetInputCapture, a separate hook).
+func (cc *ControlCenter) handleMouse(event *tcell.EventMouse, action tview.MouseAction) (*tcell.EventMouse, tview.MouseAction) {
+	if event == nil {
+		return event, action
+	}
+
+	// Only manage focus sync while the dashboard page is active and we are not in
+	// a modal overlay. On other pages, or in a modal, pass the event straight
+	// through to native handling.
+	if cc.inModal || cc.pmgr == nil || !cc.pmgr.isDashboardActive() {
+		return event, action
+	}
+
+	switch action {
+	case tview.MouseLeftClick, tview.MouseLeftDown:
+		x, y := event.Position()
+		if pane := paneAtPoint(cc.paneRects(), x, y); pane >= 0 && pane != cc.focusedPane {
+			cc.focusedPane = pane
+			cc.updatePaneFocus()
+		}
+	case tview.MouseLeftDoubleClick:
+		x, y := event.Position()
+		if pane := paneAtPoint(cc.paneRects(), x, y); pane >= 0 {
+			cc.focusedPane = pane
+			cc.updatePaneFocus()
+			// paneActions already runs its action on a single click (via each
+			// cell's SetClickedFunc), so a double-click there must NOT re-trigger
+			// it. For the other panes, a double-click maps to the same "details"
+			// action that Enter triggers.
+			if pane != paneActions {
+				cc.handleEnter()
+			}
+		}
+	}
+
+	return event, action
+}
+
+// SetMouseEnabled toggles terminal mouse reporting on the running app with no
+// restart. Persisting the choice is the caller's responsibility (the Settings
+// pane). Safe to call before Run() sets up the app — it is a no-op until then.
+func (cc *ControlCenter) SetMouseEnabled(enabled bool) {
+	cc.mouseEnabled = enabled
+	if cc.app != nil {
+		cc.app.EnableMouse(enabled)
+	}
+}
+
+// IsMouseEnabled reports the current resolved mouse state.
+func (cc *ControlCenter) IsMouseEnabled() bool { return cc.mouseEnabled }

--- a/internal/tui/controlcenter/mouse_test.go
+++ b/internal/tui/controlcenter/mouse_test.go
@@ -1,0 +1,116 @@
+package controlcenter
+
+import "testing"
+
+func TestTabIndexFromRegion(t *testing.T) {
+	cases := []struct {
+		in      string
+		wantIdx int
+		wantOK  bool
+	}{
+		{"tab_0", 0, true},
+		{"tab_5", 5, true},
+		{"tab_12", 12, true},
+		{"tab_", 0, false},
+		{"tab_x", 0, false},
+		{"nope", 0, false},
+		{"", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			idx, ok := tabIndexFromRegion(tc.in)
+			if ok != tc.wantOK || (ok && idx != tc.wantIdx) {
+				t.Errorf("tabIndexFromRegion(%q) = (%d, %v), want (%d, %v)",
+					tc.in, idx, ok, tc.wantIdx, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestResolveMouseEnabled(t *testing.T) {
+	cases := []struct {
+		name        string
+		flagNoMouse bool
+		saved       bool
+		want        bool
+	}{
+		{"flag off, saved on -> on", false, true, true},
+		{"flag off, saved off -> off", false, false, false},
+		{"flag on overrides saved on -> off", true, true, false},
+		{"flag on, saved off -> off", true, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ResolveMouseEnabled(tc.flagNoMouse, tc.saved); got != tc.want {
+				t.Errorf("ResolveMouseEnabled(%v, %v) = %v, want %v",
+					tc.flagNoMouse, tc.saved, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRectContains(t *testing.T) {
+	r := rect{x: 10, y: 5, w: 20, h: 8} // covers x in [10,30), y in [5,13)
+
+	cases := []struct {
+		name   string
+		px, py int
+		want   bool
+	}{
+		{"top-left corner inside", 10, 5, true},
+		{"interior", 20, 9, true},
+		{"just left of edge", 9, 9, false},
+		{"just right of edge (exclusive)", 30, 9, false},
+		{"just above", 20, 4, false},
+		{"just below (exclusive)", 20, 13, false},
+		{"bottom-right inclusive corner", 29, 12, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := r.contains(tc.px, tc.py); got != tc.want {
+				t.Errorf("contains(%d,%d) = %v, want %v", tc.px, tc.py, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPaneAtPoint(t *testing.T) {
+	// Lay out non-overlapping rects for a few panes; leave others zero-sized
+	// (zero-width/height rects never match, simulating the pre-first-draw state).
+	var rects [paneCount]rect
+	rects[paneServices] = rect{x: 0, y: 0, w: 40, h: 10}
+	rects[paneActions] = rect{x: 40, y: 0, w: 40, h: 10}
+	rects[panePeers] = rect{x: 0, y: 10, w: 80, h: 10}
+
+	cases := []struct {
+		name   string
+		px, py int
+		want   int
+	}{
+		{"click in services", 5, 5, paneServices},
+		{"click in actions", 45, 5, paneActions},
+		{"click in peers", 20, 15, panePeers},
+		{"click in a gap / unset pane", 60, 30, -1},
+		{"click on a zero-sized pane's origin does not match", 0, 0, paneServices},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := paneAtPoint(rects, tc.px, tc.py); got != tc.want {
+				t.Errorf("paneAtPoint(%d,%d) = %d, want %d", tc.px, tc.py, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPaneAtPoint_ZeroRectsNoMatch verifies the pre-first-draw case: with every
+// rect zero-sized (as GetRect returns before the layout is drawn), no click maps
+// to a pane, so the mouse handler is a safe no-op instead of mis-focusing.
+func TestPaneAtPoint_ZeroRectsNoMatch(t *testing.T) {
+	var rects [paneCount]rect
+	if got := paneAtPoint(rects, 0, 0); got != -1 {
+		t.Errorf("paneAtPoint on all-zero rects = %d, want -1", got)
+	}
+	if got := paneAtPoint(rects, 100, 100); got != -1 {
+		t.Errorf("paneAtPoint on all-zero rects = %d, want -1", got)
+	}
+}

--- a/internal/tui/controlcenter/settings_page.go
+++ b/internal/tui/controlcenter/settings_page.go
@@ -27,6 +27,14 @@ type SettingsCallbacks struct {
 	// May be nil if the monitor is not running. The string is a short,
 	// already-formatted label like "on (AC)" or "off (battery)".
 	KeepAwakeState func() string
+
+	// LoadMouse returns the current persisted mouse-control setting.
+	LoadMouse func() *config.Mouse
+	// SaveMouse persists an updated mouse-control setting.
+	SaveMouse func(*config.Mouse) error
+	// SetMouseEnabled applies mouse capture live on the running app (no restart),
+	// mirroring tview's app.EnableMouse. May be nil in contexts without an app.
+	SetMouseEnabled func(bool)
 }
 
 // connStatusProvider exposes the user-facing connection status. The ChatPage
@@ -49,6 +57,7 @@ type SettingsPage struct {
 	// State
 	telemetry *config.Telemetry
 	keepAwake *config.KeepAwake
+	mouse     *config.Mouse
 
 	// UI
 	root *tview.Flex
@@ -92,6 +101,7 @@ func (p *SettingsPage) Build(app *tview.Application) tview.Primitive {
 func (p *SettingsPage) OnActivate() {
 	p.reloadTelemetry()
 	p.reloadKeepAwake()
+	p.reloadMouse()
 	p.render()
 	if p.app != nil && p.view != nil {
 		p.app.SetFocus(p.view)
@@ -102,9 +112,12 @@ func (p *SettingsPage) OnActivate() {
 func (p *SettingsPage) OnDeactivate() {}
 
 // HandleInput implements Page. Space/Enter/'t' toggles the telemetry opt-out;
-// 'k' toggles the keep-awake-on-AC opt-in.
+// 'k' toggles the keep-awake-on-AC opt-in; 'm' toggles mouse control.
 func (p *SettingsPage) HandleInput(event *tcell.EventKey) *tcell.EventKey {
 	switch {
+	case event.Key() == tcell.KeyRune && (event.Rune() == 'm' || event.Rune() == 'M'):
+		p.toggleMouse()
+		return nil
 	case event.Key() == tcell.KeyRune && (event.Rune() == 'k' || event.Rune() == 'K'):
 		p.toggleKeepAwake()
 		return nil
@@ -176,6 +189,43 @@ func (p *SettingsPage) toggleKeepAwake() {
 	p.render()
 }
 
+// reloadMouse refreshes the in-memory mouse setting from disk.
+func (p *SettingsPage) reloadMouse() {
+	if p.cb.LoadMouse != nil {
+		p.mouse = p.cb.LoadMouse()
+	}
+	if p.mouse == nil {
+		p.mouse = config.DefaultMouse()
+	}
+}
+
+// toggleMouse flips mouse control, applies it live on the running app, and
+// persists it. The live apply (SetMouseEnabled) takes effect immediately with no
+// restart — strictly better than a setting that only applies next launch.
+func (p *SettingsPage) toggleMouse() {
+	if p.mouse == nil {
+		p.reloadMouse()
+	}
+
+	next := &config.Mouse{Enabled: !p.mouse.Enabled}
+
+	// Apply live first so the change is visible immediately even if persistence
+	// fails; the error line still surfaces a save failure.
+	if p.cb.SetMouseEnabled != nil {
+		p.cb.SetMouseEnabled(next.Enabled)
+	}
+
+	if p.cb.SaveMouse != nil {
+		if err := p.cb.SaveMouse(next); err != nil {
+			p.mouse = next
+			p.renderWithError(fmt.Sprintf("Failed to save: %v", err))
+			return
+		}
+	}
+	p.mouse = next
+	p.render()
+}
+
 // render redraws the settings view from current state.
 func (p *SettingsPage) render() {
 	p.renderWithError("")
@@ -221,6 +271,26 @@ func (p *SettingsPage) renderWithError(errMsg string) {
 	sb.WriteString("   this node is plugged in, so the laptop stays reachable on the\n")
 	sb.WriteString("   mesh. Released on battery and on exit. Display may still sleep.\n\n")
 	sb.WriteString("   [yellow::b]k[-:-:-] toggle keep-awake\n")
+
+	// -- Mouse control --
+	// The value here is the copy, not just the switch: the real tradeoff is
+	// "GUI-feel vs. native terminal drag-to-copy", and a bare toggle just
+	// relocates the confusion. Name the tradeoff and the bypass keys inline.
+	mouseEnabled := p.mouse != nil && p.mouse.Enabled
+	sb.WriteString("\n [yellow::b]Mouse Control[-:-:-]\n\n")
+	if mouseEnabled {
+		sb.WriteString("   Status:  [green::b]ON[-:-:-]  [gray](click to drive)[-]\n")
+	} else {
+		sb.WriteString("   Status:  [red::b]OFF[-:-:-]  [gray](keyboard only)[-]\n")
+	}
+	sb.WriteString("\n   [white]What it does:[-] click tabs, peers, and Send instead of\n")
+	sb.WriteString("   memorizing keys. Keyboard shortcuts keep working either way.\n\n")
+	sb.WriteString("   [white]Tradeoff:[-] your terminal's drag-to-copy stops working while\n")
+	sb.WriteString("   this is on. To copy anyway, hold:\n")
+	sb.WriteString("     [white]• Shift[-]    (most terminals)\n")
+	sb.WriteString("     [white]• Fn[-]       (macOS Terminal.app)\n")
+	sb.WriteString("     [white]• Option[-]   (iTerm2)\n\n")
+	sb.WriteString("   [yellow::b]m[-:-:-] toggle mouse control [gray](applies immediately)[-]\n")
 
 	// -- Connection status (read-only) --
 	sb.WriteString("\n [yellow::b]Connection[-:-:-]\n\n")

--- a/internal/tui/controlcenter/settings_page_test.go
+++ b/internal/tui/controlcenter/settings_page_test.go
@@ -127,6 +127,79 @@ func TestSettingsToggleKeepAwake_PersistsOptIn(t *testing.T) {
 	}
 }
 
+func TestSettingsToggleMouse_PersistsAndAppliesLive(t *testing.T) {
+	store := config.DefaultMouse() // Enabled: true by default
+	var liveState []bool
+	cb := SettingsCallbacks{
+		LoadMouse: func() *config.Mouse {
+			cp := *store
+			return &cp
+		},
+		SaveMouse: func(m *config.Mouse) error {
+			store.Enabled = m.Enabled
+			return nil
+		},
+		SetMouseEnabled: func(enabled bool) {
+			liveState = append(liveState, enabled)
+		},
+	}
+	p := NewSettingsPage(cb, nil)
+	p.reloadMouse()
+
+	if !p.mouse.Enabled {
+		t.Fatalf("expected default enabled, got %+v", p.mouse)
+	}
+
+	// Toggle off: persists false and applies live immediately.
+	p.toggleMouse()
+	if p.mouse.Enabled {
+		t.Error("in-memory state should be disabled after toggle")
+	}
+	if store.Enabled {
+		t.Error("persisted store should be disabled after toggle")
+	}
+	if len(liveState) != 1 || liveState[0] != false {
+		t.Errorf("SetMouseEnabled should have been called once with false, got %v", liveState)
+	}
+
+	// Toggle back on.
+	p.toggleMouse()
+	if !p.mouse.Enabled {
+		t.Error("in-memory state should be enabled after second toggle")
+	}
+	if !store.Enabled {
+		t.Error("persisted store should be enabled after second toggle")
+	}
+	if len(liveState) != 2 || liveState[1] != true {
+		t.Errorf("SetMouseEnabled should have been called with true, got %v", liveState)
+	}
+}
+
+func TestSettingsToggleMouse_SaveErrorStillAppliesLive(t *testing.T) {
+	var liveState []bool
+	cb := SettingsCallbacks{
+		LoadMouse: config.DefaultMouse,
+		SaveMouse: func(*config.Mouse) error {
+			return errTestSave
+		},
+		SetMouseEnabled: func(enabled bool) {
+			liveState = append(liveState, enabled)
+		},
+	}
+	p := NewSettingsPage(cb, nil)
+	p.Build(nil)
+	p.reloadMouse()
+
+	p.toggleMouse()
+	// Live apply must happen even when persistence fails, so the UX is not stuck.
+	if len(liveState) != 1 || liveState[0] != false {
+		t.Errorf("SetMouseEnabled should apply live even on save error, got %v", liveState)
+	}
+	if p.mouse.Enabled {
+		t.Error("in-memory state should reflect attempted toggle even on save error")
+	}
+}
+
 func TestWSSEndpoint_HidesRedisTransport(t *testing.T) {
 	cases := map[string]string{
 		"https://aceteam.ai":          "wss://aceteam.ai",

--- a/internal/tui/dashboard/status.go
+++ b/internal/tui/dashboard/status.go
@@ -487,7 +487,9 @@ func visibleLength(s string) int {
 // RunDashboard runs the interactive status dashboard
 func RunDashboard(data StatusData, refreshFn func() (StatusData, error)) error {
 	model := NewStatusModel(data, refreshFn)
-	p := tea.NewProgram(model, tea.WithAltScreen())
+	// WithMouseCellMotion enables scroll/click in the status dashboard, matching
+	// the control center's mouse-on default. Keyboard bindings are unaffected.
+	p := tea.NewProgram(model, tea.WithAltScreen(), tea.WithMouseCellMotion())
 	_, err := p.Run()
 	return err
 }

--- a/internal/tui/dashboard/tview.go
+++ b/internal/tui/dashboard/tview.go
@@ -40,6 +40,10 @@ func NewTviewDashboard(data StatusData, refreshFn func() (StatusData, error)) *T
 // Run starts the tview dashboard
 func (d *TviewDashboard) Run() error {
 	d.app = tview.NewApplication()
+	// Opt into mouse reporting so tables/rows are clickable and scrollable. tview
+	// primitives handle clicks/scroll natively once enabled; keyboard bindings
+	// (below) are untouched.
+	d.app.EnableMouse(true)
 	d.buildUI()
 	d.updateUI()
 

--- a/internal/tui/repl/repl.go
+++ b/internal/tui/repl/repl.go
@@ -370,7 +370,9 @@ func (m *Model) runExternalCommand(name string, args ...string) (string, error) 
 }
 
 func Run(cfg Config) error {
-	p := tea.NewProgram(New(cfg))
+	// Enable mouse cell motion so scroll/click work in the REPL, matching the
+	// control center's mouse-on-by-default behavior. Keyboard input is unaffected.
+	p := tea.NewProgram(New(cfg), tea.WithMouseCellMotion())
 	_, err := p.Run()
 	return err
 }


### PR DESCRIPTION
## Context

The Control Center TUI is powerful but keyboard-only: Tab to switch panes, `0-3` for actions, Enter for details, arrows to move. A new user has to learn the keymap before they can do anything. Issue #388 asks us to make it **mouse-clickable so it feels like a GUI** — click a tab, click a peer, click Send — the "nothing to memorize" feel of a desktop app. Fullscreen TUIs already turn on terminal mouse reporting; the events were right there, the app just never listened.

This PR turns mouse on and wires clicks to the **existing** handlers, starting with the Chat tab. **Keyboard-first is 100% preserved** — mouse is purely additive; power users lose nothing. It also ships the escape hatch the issue calls for, because mouse reporting costs native terminal drag-to-copy.

## Summary

**Turn it on (both tview apps)**
- `EnableMouse` on the Control Center app and the standalone dashboard.
- An Application-level `SetMouseCapture` (`internal/tui/controlcenter/mouse.go`) is the single chokepoint that keeps the control center's **own** focus model (`focusedPane` + the yellow border/title highlight) in sync with tview's native focus-on-click. It hit-tests the click against each pane's rect and returns the event unchanged, so native row-selection, input focus, and wheel-scroll all come for free.

**Clickable tab bar** — the headline "GUI feel" interaction
- `updateTabBar` wraps each visible tab in a `TextView` region (`["tab_<idx>"]…[""]`); a highlight handler maps the clicked region back to a page and calls `SwitchTo`. Regions route clicks correctly even under center alignment, so no fragile x→column math.

**Wire clicks to existing actions (no logic duplicated)**
- Click a pane → focus it (same as Tab landing there); double-click → the pane's `Enter` "details" action (`handleEnter`).
- Actions list: single-click runs the item via `SetClickedFunc` (same as the `0-3` hotkeys); double-click is excluded there so it can't double-fire.
- Services/Peers: double-click opens details. Help bar refreshes on mouse row-select (`SetSelectionChangedFunc`) so hints never go stale.
- tview's `Table.SetSelectedFunc` only fires on keyboard Enter, never on click — so the mouse wiring is cleanly additive and cannot double-fire with the keyboard.

**Chat tab** (`chat_page.go`)
- Visible, clickable **Send** button next to the input (a `Button`, which fires on both click and Enter) so mouse users aren't forced to know Enter submits.
- Clicking the message history / channels / peers focuses the input so you can immediately type (the click is consumed so the pane doesn't steal focus back); scroll wheel still scrolls history.

**bubbletea sub-views**
- REPL and status dashboard get `tea.WithMouseCellMotion()` for consistent scroll/click.

**Escape hatch + discoverability**
- Persisted per-user preference `internal/config/mouse.go` (**default ON** — mouse is the feature; keyboard works either way), mirroring the keep-awake toggle pattern.
- `--no-mouse` flag: a session override that forces mouse off without mutating the saved preference.
- Settings pane gains a **Mouse Control** section that names the tradeoff and the workaround inline (drag-to-copy stops; hold **Shift** / **Fn** on macOS Terminal / **Option** in iTerm2). Its toggle applies **live with no restart** (`app.EnableMouse`) and persists.
- Help view + help bar mention mouse and the drag-to-copy caveat; the help bar shows `mouse on` when active. (No `[S]` key hint — it would collide with the existing `s` = start-service binding; Settings is its own Alt tab.)

## Test plan

| Group | Coverage |
| --- | --- |
| `internal/config` mouse config | default-ON, no-file default, save/load round trip, disabled-from-file, invalid-YAML fallback, dir creation (6 tests) |
| `ResolveMouseEnabled` | flag/preference precedence matrix — `--no-mouse` overrides saved-on (4 cases) |
| pane hit-test | `rect.contains` edge/exclusive bounds; `paneAtPoint` hit/gap/zero-rect (pre-first-draw no-op) |
| `tabIndexFromRegion` | region-ID parse: valid / empty / non-numeric / missing prefix (7 cases) |
| Settings mouse toggle | persists + applies live; save-error still applies live (2 tests) |

Automated: `gofmt` clean, `go build ./...`, `go vet ./...`, and `go test ./internal/tui/... ./cmd/... ./internal/config/...` all pass. (The `internal/status` `:8080` bind failure is environmental — the live worker on the build host holds that port.)

**Manual (acceptance check → draft):** interactive click verification in a real terminal — click a tab to switch, click a pane (highlight follows), double-click for details, click an Action, and in Chat click Send / a message / wheel-scroll. Then flip the Settings toggle and confirm mouse turns off live and drag-to-copy returns, and that `--no-mouse` starts with mouse off.

**Scoped for follow-up (intentional):** Chat channel/peer *switching* is focus-input-only — there is a single hardcoded `#general` room, so per the issue's "wire to existing actions, don't duplicate logic" guard there is no channel/DM switch to wire to yet. The first-time drag-select hint and clickable Settings toggles are also deferred. The "Fullscreen rendering" toggle from the settings mock is deliberately omitted — it belongs to the separate fullscreen renderer and would be a switch wired to nothing.

## Related

- Closes #388
