### PR TITLE
feat(tui): Mouse & Rendering settings panel (#388 follow-up)

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -263,6 +263,17 @@ func runControlCenter() {
 			},
 			// SetMouseEnabled is injected by the control center itself in Run(),
 			// where the running tview app exists to receive EnableMouse.
+			LoadRendering: func() *config.Rendering {
+				return config.LoadRendering(platform.ConfigDir())
+			},
+			SaveRendering: func(r *config.Rendering) error {
+				return config.SaveRendering(platform.ConfigDir(), r)
+			},
+			// SetFullscreenEnabled is intentionally left nil: tview cannot swap the
+			// terminal's alternate-screen mode on a running app. Today the toggle only
+			// persists the preference; wiring a launch-time consumer that reads it at
+			// screen creation lives in the control center's Run() path and is a
+			// follow-up.
 		},
 		// Resolve the initial mouse state: persisted preference with the
 		// --no-mouse flag applied as a session override.

--- a/internal/config/rendering.go
+++ b/internal/config/rendering.go
@@ -1,0 +1,76 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Rendering controls how the control-center TUI draws to the terminal. Like
+// Mouse (opt-out, default-on), fullscreen rendering is the experience the user
+// is expected to want — a flicker-free, app-like screen — so it defaults ON. It
+// is a per-user preference persisted alongside the other config files.
+//
+// When Fullscreen is true the TUI uses the terminal's alternate screen buffer
+// (the whole viewport is repainted in place, no flicker, and the screen is
+// restored on exit). When false, output goes to the normal scrollback buffer,
+// which is easier to scroll and copy long history from but does not get the
+// app-like repaint.
+//
+// Consuming this preference at screen-creation time lives in the control
+// center's Run() path; the Settings pane only persists the choice. See the
+// SetFullscreenEnabled seam in SettingsCallbacks for the live/launch-time apply.
+type Rendering struct {
+	// Fullscreen gates use of the terminal's alternate screen buffer. When true
+	// (the default), the TUI renders flicker-free, app-like, and restores the
+	// prior screen on exit. When false, output goes to normal scrollback so long
+	// history is easier to scroll and copy.
+	Fullscreen bool `yaml:"fullscreen" json:"fullscreen"`
+}
+
+const renderingFile = "rendering.yaml"
+
+// DefaultRendering returns a Rendering struct with fullscreen enabled.
+// Default-on is intentional: the flicker-free, app-like screen is the expected
+// experience, and scrollback mode is an explicit opt-out for users who prefer to
+// scroll/copy long history from their terminal's native buffer.
+func DefaultRendering() *Rendering {
+	return &Rendering{
+		Fullscreen: true,
+	}
+}
+
+// LoadRendering reads rendering settings from the config directory. If the file
+// doesn't exist, returns defaults (fullscreen). Partial files preserve defaults
+// for absent keys (unmarshal into a pre-initialized struct), mirroring
+// LoadMouse.
+func LoadRendering(configDir string) *Rendering {
+	r := DefaultRendering()
+
+	data, err := os.ReadFile(filepath.Join(configDir, renderingFile))
+	if err != nil {
+		return r
+	}
+
+	// yaml.Unmarshal only overwrites keys present in the file, so an absent key
+	// keeps its default (true) value.
+	_ = yaml.Unmarshal(data, r)
+	return r
+}
+
+// SaveRendering writes rendering settings to the config directory. The Settings
+// pane calls this when the operator toggles fullscreen rendering.
+func SaveRendering(configDir string, r *Rendering) error {
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+
+	data, err := yaml.Marshal(r)
+	if err != nil {
+		return fmt.Errorf("marshal rendering: %w", err)
+	}
+
+	return os.WriteFile(filepath.Join(configDir, renderingFile), data, 0644)
+}

--- a/internal/config/rendering_test.go
+++ b/internal/config/rendering_test.go
@@ -1,0 +1,88 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultRendering(t *testing.T) {
+	r := DefaultRendering()
+	if !r.Fullscreen {
+		t.Errorf("DefaultRendering should be fullscreen (flicker-free is the expected experience), got %+v", r)
+	}
+}
+
+func TestLoadRendering_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	r := LoadRendering(dir)
+	if !r.Fullscreen {
+		t.Errorf("LoadRendering with no file should default to fullscreen, got %+v", r)
+	}
+}
+
+func TestRenderingSaveAndLoadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	original := &Rendering{Fullscreen: false}
+
+	if err := SaveRendering(dir, original); err != nil {
+		t.Fatalf("SaveRendering: %v", err)
+	}
+
+	loaded := LoadRendering(dir)
+	if loaded.Fullscreen != original.Fullscreen {
+		t.Errorf("round trip mismatch: saved %+v, loaded %+v", original, loaded)
+	}
+}
+
+func TestLoadRendering_DisabledFromFile(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte("fullscreen: false\n")
+	if err := os.WriteFile(filepath.Join(dir, "rendering.yaml"), data, 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	r := LoadRendering(dir)
+	if r.Fullscreen {
+		t.Error("fullscreen should be false from file")
+	}
+}
+
+// Precedence: a partial file (an unrelated key present, fullscreen absent) must
+// keep the default (true), because Unmarshal only overwrites keys present in the
+// file. This mirrors LoadMouse's partial-file behavior.
+func TestLoadRendering_PartialFileKeepsDefault(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte("unrelated: true\n")
+	if err := os.WriteFile(filepath.Join(dir, "rendering.yaml"), data, 0644); err != nil {
+		t.Fatalf("write partial config: %v", err)
+	}
+
+	r := LoadRendering(dir)
+	if !r.Fullscreen {
+		t.Errorf("partial file (fullscreen absent) should keep default true, got %+v", r)
+	}
+}
+
+func TestLoadRendering_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte("not: [valid: yaml: {{{")
+	if err := os.WriteFile(filepath.Join(dir, "rendering.yaml"), data, 0644); err != nil {
+		t.Fatalf("write invalid yaml: %v", err)
+	}
+
+	r := LoadRendering(dir)
+	if !r.Fullscreen {
+		t.Errorf("invalid YAML should return defaults (fullscreen), got %+v", r)
+	}
+}
+
+func TestSaveRendering_CreatesDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "dir")
+	if err := SaveRendering(dir, DefaultRendering()); err != nil {
+		t.Fatalf("SaveRendering should create nested dirs: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "rendering.yaml")); err != nil {
+		t.Errorf("rendering file should exist after save: %v", err)
+	}
+}

--- a/internal/tui/controlcenter/settings_page.go
+++ b/internal/tui/controlcenter/settings_page.go
@@ -35,6 +35,17 @@ type SettingsCallbacks struct {
 	// SetMouseEnabled applies mouse capture live on the running app (no restart),
 	// mirroring tview's app.EnableMouse. May be nil in contexts without an app.
 	SetMouseEnabled func(bool)
+
+	// LoadRendering returns the current persisted fullscreen-rendering setting.
+	LoadRendering func() *config.Rendering
+	// SaveRendering persists an updated fullscreen-rendering setting.
+	SaveRendering func(*config.Rendering) error
+	// SetFullscreenEnabled is the injection seam for applying the fullscreen
+	// preference on the running app. Unlike mouse capture, tview cannot swap the
+	// terminal's alternate-screen mode mid-run, so today this is a no-op seam that
+	// a launch-time consumer in the control center's Run() path will fill (the
+	// screen path is owned by controlcenter.go). May be nil.
+	SetFullscreenEnabled func(bool)
 }
 
 // connStatusProvider exposes the user-facing connection status. The ChatPage
@@ -58,6 +69,7 @@ type SettingsPage struct {
 	telemetry *config.Telemetry
 	keepAwake *config.KeepAwake
 	mouse     *config.Mouse
+	rendering *config.Rendering
 
 	// UI
 	root *tview.Flex
@@ -102,6 +114,7 @@ func (p *SettingsPage) OnActivate() {
 	p.reloadTelemetry()
 	p.reloadKeepAwake()
 	p.reloadMouse()
+	p.reloadRendering()
 	p.render()
 	if p.app != nil && p.view != nil {
 		p.app.SetFocus(p.view)
@@ -111,12 +124,16 @@ func (p *SettingsPage) OnActivate() {
 // OnDeactivate implements Page.
 func (p *SettingsPage) OnDeactivate() {}
 
-// HandleInput implements Page. Space/Enter/'t' toggles the telemetry opt-out;
-// 'k' toggles the keep-awake-on-AC opt-in; 'm' toggles mouse control.
+// HandleInput implements Page. 'm' toggles mouse control; 'f' toggles fullscreen
+// rendering (the two Mouse & Rendering checkboxes); 'k' toggles keep-awake-on-AC;
+// Space/Enter/'t' toggles the telemetry opt-out.
 func (p *SettingsPage) HandleInput(event *tcell.EventKey) *tcell.EventKey {
 	switch {
 	case event.Key() == tcell.KeyRune && (event.Rune() == 'm' || event.Rune() == 'M'):
 		p.toggleMouse()
+		return nil
+	case event.Key() == tcell.KeyRune && (event.Rune() == 'f' || event.Rune() == 'F'):
+		p.toggleFullscreen()
 		return nil
 	case event.Key() == tcell.KeyRune && (event.Rune() == 'k' || event.Rune() == 'K'):
 		p.toggleKeepAwake()
@@ -226,6 +243,43 @@ func (p *SettingsPage) toggleMouse() {
 	p.render()
 }
 
+// reloadRendering refreshes the in-memory fullscreen-rendering setting from disk.
+func (p *SettingsPage) reloadRendering() {
+	if p.cb.LoadRendering != nil {
+		p.rendering = p.cb.LoadRendering()
+	}
+	if p.rendering == nil {
+		p.rendering = config.DefaultRendering()
+	}
+}
+
+// toggleFullscreen flips fullscreen rendering and persists it. tview cannot swap
+// the terminal's alternate-screen mode mid-run, so this only persists the choice
+// today — no live apply, and nothing consumes the pref at launch yet (the
+// screen-creation path is owned by controlcenter.go). SetFullscreenEnabled is the
+// nil-able seam a future launch-time consumer will fill; it is a no-op today.
+func (p *SettingsPage) toggleFullscreen() {
+	if p.rendering == nil {
+		p.reloadRendering()
+	}
+
+	next := &config.Rendering{Fullscreen: !p.rendering.Fullscreen}
+
+	if p.cb.SetFullscreenEnabled != nil {
+		p.cb.SetFullscreenEnabled(next.Fullscreen)
+	}
+
+	if p.cb.SaveRendering != nil {
+		if err := p.cb.SaveRendering(next); err != nil {
+			p.rendering = next
+			p.renderWithError(fmt.Sprintf("Failed to save: %v", err))
+			return
+		}
+	}
+	p.rendering = next
+	p.render()
+}
+
 // render redraws the settings view from current state.
 func (p *SettingsPage) render() {
 	p.renderWithError("")
@@ -236,9 +290,34 @@ func (p *SettingsPage) renderWithError(errMsg string) {
 		return
 	}
 
-	enabled := p.telemetry != nil && p.telemetry.AnonTelemetryEnabled
-
 	var sb strings.Builder
+
+	// -- Mouse & Rendering (headline section) --
+	// Two checkboxes, each carrying its own tradeoff copy. The value here is the
+	// copy, not just the switch: mouse control trades native drag-to-copy for
+	// GUI-feel, and fullscreen rendering trades scrollback for a flicker-free app
+	// screen. A bare toggle would just relocate the confusion, so name the
+	// tradeoff and the bypass/consequence inline.
+	sb.WriteString("\n [yellow::b]Mouse & Rendering[-:-:-]\n")
+	sb.WriteString(" [gray]─────────────────[-]\n\n")
+
+	// Checkbox 1: Mouse control.
+	mouseEnabled := p.mouse != nil && p.mouse.Enabled
+	sb.WriteString(fmt.Sprintf("   %s [white::b]Mouse control[-:-:-]            Click tabs, peers, and Send instead of memorizing keys.\n", checkbox(mouseEnabled)))
+	sb.WriteString("                                Tradeoff: your terminal's drag-to-copy stops working while\n")
+	sb.WriteString("                                this is on. To copy anyway, hold:\n")
+	sb.WriteString("                                  [white]• Shift[-]        (most terminals)\n")
+	sb.WriteString("                                  [white]• Fn[-]           (macOS Terminal.app)\n")
+	sb.WriteString("                                  [white]• Option[-]        (iTerm2)\n")
+	sb.WriteString("   [gray]press[-] [yellow::b]m[-:-:-] [gray]to toggle (applies immediately)[-]\n\n")
+
+	// Checkbox 2: Fullscreen rendering.
+	fullscreenEnabled := p.rendering != nil && p.rendering.Fullscreen
+	sb.WriteString(fmt.Sprintf("   %s [white::b]Fullscreen rendering[-:-:-]     Flicker-free, app-like. Off = output goes to normal\n", checkbox(fullscreenEnabled)))
+	sb.WriteString("                                scrollback (easier to scroll + copy long history).\n")
+	sb.WriteString("   [gray]press[-] [yellow::b]f[-:-:-] [gray]to toggle (saved; full apply coming soon)[-]\n")
+
+	enabled := p.telemetry != nil && p.telemetry.AnonTelemetryEnabled
 
 	// -- Anonymous data collection --
 	sb.WriteString("\n [yellow::b]Anonymous Data Collection[-:-:-]\n\n")
@@ -272,26 +351,6 @@ func (p *SettingsPage) renderWithError(errMsg string) {
 	sb.WriteString("   mesh. Released on battery and on exit. Display may still sleep.\n\n")
 	sb.WriteString("   [yellow::b]k[-:-:-] toggle keep-awake\n")
 
-	// -- Mouse control --
-	// The value here is the copy, not just the switch: the real tradeoff is
-	// "GUI-feel vs. native terminal drag-to-copy", and a bare toggle just
-	// relocates the confusion. Name the tradeoff and the bypass keys inline.
-	mouseEnabled := p.mouse != nil && p.mouse.Enabled
-	sb.WriteString("\n [yellow::b]Mouse Control[-:-:-]\n\n")
-	if mouseEnabled {
-		sb.WriteString("   Status:  [green::b]ON[-:-:-]  [gray](click to drive)[-]\n")
-	} else {
-		sb.WriteString("   Status:  [red::b]OFF[-:-:-]  [gray](keyboard only)[-]\n")
-	}
-	sb.WriteString("\n   [white]What it does:[-] click tabs, peers, and Send instead of\n")
-	sb.WriteString("   memorizing keys. Keyboard shortcuts keep working either way.\n\n")
-	sb.WriteString("   [white]Tradeoff:[-] your terminal's drag-to-copy stops working while\n")
-	sb.WriteString("   this is on. To copy anyway, hold:\n")
-	sb.WriteString("     [white]• Shift[-]    (most terminals)\n")
-	sb.WriteString("     [white]• Fn[-]       (macOS Terminal.app)\n")
-	sb.WriteString("     [white]• Option[-]   (iTerm2)\n\n")
-	sb.WriteString("   [yellow::b]m[-:-:-] toggle mouse control [gray](applies immediately)[-]\n")
-
 	// -- Connection status (read-only) --
 	sb.WriteString("\n [yellow::b]Connection[-:-:-]\n\n")
 	endpoint, state := p.connectionStatus()
@@ -315,6 +374,15 @@ func (p *SettingsPage) connectionStatus() (string, ConnState) {
 		return "", ConnDisconnected
 	}
 	return p.connStatus.ConnectionStatus()
+}
+
+// checkbox renders a colored checkbox glyph for a boolean setting: a green
+// checkmark when on, a dim empty box when off.
+func checkbox(on bool) string {
+	if on {
+		return "[green::b][✓][-:-:-]"
+	}
+	return "[gray][ ][-]"
 }
 
 // connStateLabel renders a colored health label for a connection state.

--- a/internal/tui/controlcenter/settings_page_test.go
+++ b/internal/tui/controlcenter/settings_page_test.go
@@ -200,6 +200,132 @@ func TestSettingsToggleMouse_SaveErrorStillAppliesLive(t *testing.T) {
 	}
 }
 
+func TestSettingsToggleFullscreen_Persists(t *testing.T) {
+	store := config.DefaultRendering() // Fullscreen: true by default
+	var seam []bool
+	cb := SettingsCallbacks{
+		LoadRendering: func() *config.Rendering {
+			cp := *store
+			return &cp
+		},
+		SaveRendering: func(r *config.Rendering) error {
+			store.Fullscreen = r.Fullscreen
+			return nil
+		},
+		SetFullscreenEnabled: func(enabled bool) {
+			seam = append(seam, enabled)
+		},
+	}
+	p := NewSettingsPage(cb, nil)
+	p.reloadRendering()
+
+	if !p.rendering.Fullscreen {
+		t.Fatalf("expected default fullscreen enabled, got %+v", p.rendering)
+	}
+
+	// Toggle off: persists false. The seam is invoked for any future live-apply
+	// consumer, but the real apply is deferred to next launch.
+	p.toggleFullscreen()
+	if p.rendering.Fullscreen {
+		t.Error("in-memory state should be disabled after toggle")
+	}
+	if store.Fullscreen {
+		t.Error("persisted store should be disabled after toggle")
+	}
+	if len(seam) != 1 || seam[0] != false {
+		t.Errorf("SetFullscreenEnabled seam should have been called once with false, got %v", seam)
+	}
+
+	// Toggle back on.
+	p.toggleFullscreen()
+	if !p.rendering.Fullscreen {
+		t.Error("in-memory state should be enabled after second toggle")
+	}
+	if !store.Fullscreen {
+		t.Error("persisted store should be enabled after second toggle")
+	}
+	if len(seam) != 2 || seam[1] != true {
+		t.Errorf("SetFullscreenEnabled seam should have been called with true, got %v", seam)
+	}
+}
+
+func TestSettingsToggleFullscreen_SaveErrorKeepsState(t *testing.T) {
+	cb := SettingsCallbacks{
+		LoadRendering: config.DefaultRendering,
+		SaveRendering: func(*config.Rendering) error {
+			return errTestSave
+		},
+	}
+	p := NewSettingsPage(cb, nil)
+	p.Build(nil)
+	p.reloadRendering()
+
+	p.toggleFullscreen()
+	// Even on save error, in-memory state reflects the attempted change so the UI
+	// stays consistent with what the user pressed.
+	if p.rendering.Fullscreen {
+		t.Error("in-memory state should reflect attempted toggle even on save error")
+	}
+}
+
+// The Mouse & Rendering headline section must render both checkboxes with the
+// mock's exact copy so the panel matches the approved design.
+func TestSettingsRender_MouseAndRenderingCopy(t *testing.T) {
+	cb := SettingsCallbacks{
+		LoadTelemetry: config.DefaultTelemetry,
+		LoadKeepAwake: config.DefaultKeepAwake,
+		LoadMouse:     config.DefaultMouse,
+		LoadRendering: config.DefaultRendering,
+	}
+	p := NewSettingsPage(cb, fakeConnStatus{endpoint: "wss://aceteam.ai", state: ConnConnected})
+	p.Build(nil)
+	p.OnActivate()
+
+	got := p.view.GetText(true) // stripped of color tags
+
+	wantFragments := []string{
+		"Mouse & Rendering",
+		"Mouse control",
+		"Click tabs, peers, and Send instead of memorizing keys.",
+		"Tradeoff: your terminal's drag-to-copy stops working while",
+		"this is on. To copy anyway, hold:",
+		"• Shift        (most terminals)",
+		"• Fn           (macOS Terminal.app)",
+		"• Option        (iTerm2)",
+		"Fullscreen rendering",
+		"Flicker-free, app-like. Off = output goes to normal",
+		"scrollback (easier to scroll + copy long history).",
+	}
+	for _, frag := range wantFragments {
+		if !strings.Contains(got, frag) {
+			t.Errorf("rendered settings missing expected copy fragment:\n  %q\nfull render:\n%s", frag, got)
+		}
+	}
+}
+
+// Checkbox glyphs must reflect each setting's on/off state so the panel tells
+// the truth about what is enabled.
+func TestSettingsRender_CheckboxReflectsState(t *testing.T) {
+	cb := SettingsCallbacks{
+		LoadTelemetry: config.DefaultTelemetry,
+		LoadKeepAwake: config.DefaultKeepAwake,
+		LoadMouse:     func() *config.Mouse { return &config.Mouse{Enabled: true} },
+		LoadRendering: func() *config.Rendering { return &config.Rendering{Fullscreen: false} },
+	}
+	p := NewSettingsPage(cb, nil)
+	p.Build(nil)
+	p.OnActivate()
+
+	got := p.view.GetText(true)
+	// Mouse on -> checked; Fullscreen off -> unchecked. Both rows must be present.
+	if !strings.Contains(got, "[✓] Mouse control") {
+		t.Errorf("expected checked Mouse control row, got:\n%s", got)
+	}
+	if !strings.Contains(got, "[ ] Fullscreen rendering") {
+		t.Errorf("expected unchecked Fullscreen rendering row, got:\n%s", got)
+	}
+}
+
 func TestWSSEndpoint_HidesRedisTransport(t *testing.T) {
 	cases := map[string]string{
 		"https://aceteam.ai":          "wss://aceteam.ai",


### PR DESCRIPTION
## Context

PR #390 (Closes #388) made the Control Center mouse-clickable and added a persisted mouse preference with a live no-restart toggle in Settings. In Jason's interactive test of that work, the Settings tab (`alt+7`) still read as **generic keyboard toggles** — it didn't surface the two decisions that actually shape how the TUI feels: whether you drive it with the mouse, and whether it renders full-screen (flicker-free, app-like) or into normal scrollback.

This follow-up restructures the Settings panel so its headline is a **"Mouse & Rendering"** section with exactly two checkboxes, each carrying the tradeoff copy inline (a bare toggle just relocates the confusion). The approved copy this PR implements:

```
Mouse & Rendering
─────────────────
[✓] Mouse control            Click tabs, peers, and Send instead of memorizing keys.
                             Tradeoff: your terminal's drag-to-copy stops working while
                             this is on. To copy anyway, hold:
                               • Shift        (most terminals)
                               • Fn           (macOS Terminal.app)
                               • Option        (iTerm2)
[✓] Fullscreen rendering     Flicker-free, app-like. Off = output goes to normal
                             scrollback (easier to scroll + copy long history).
```

## Summary

**`internal/config/rendering.go` (new)** — Persisted `Rendering{Fullscreen bool}` preference (`rendering.yaml`), default **ON**, mirroring the `Mouse` pref from #390: `DefaultRendering` / `LoadRendering` / `SaveRendering`, with partial-file-keeps-default unmarshal semantics. Default-on is intentional — flicker-free app-screen is the expected experience; scrollback mode is an explicit opt-out for scrolling/copying long history.

**`internal/tui/controlcenter/settings_page.go`** — The panel now leads with the **Mouse & Rendering** headline (underlined) and two `[✓]`/`[ ]` checkbox rows rendered with a `checkbox()` helper. Each row shows the exact mock copy. Telemetry, Keep-awake, and Connection are kept as genuinely-useful secondary sections below.
- **Mouse control** (`m`): toggles **live, no restart** via the existing `SetMouseEnabled` hook (`app.EnableMouse`) added in #390.
- **Fullscreen rendering** (`f`): the pref **persists immediately**, but is **not applied yet** — not live (tview can't swap the terminal's alternate-screen mode on a running app) and not at launch either (nothing consumes the pref at screen creation yet). A nil-able `SetFullscreenEnabled` field is added to `SettingsCallbacks` as the clean injection seam a future launch-time consumer will fill. The in-TUI hint honestly reads `(saved; full apply coming soon)` so it never implies an apply that doesn't happen.

**`cmd/controlcenter.go`** — Wires `LoadRendering` / `SaveRendering` alongside the existing mouse hooks so the toggle actually persists (the Settings pane never reaches `platform.ConfigDir()` directly). `SetFullscreenEnabled` is left nil with a comment explaining the deferral.

### Fullscreen: apply status (honest)

| Setting | Persists | Applies |
|---|---|---|
| Mouse control | immediately | **live, no restart** (`app.EnableMouse`) |
| Fullscreen rendering | immediately | **not yet (follow-up)** — no live apply (tview can't swap alt-screen mid-run) and no launch-time consumer; the screen-creation path lives in `controlcenter.go` (owned elsewhere) |

## Test plan

| Test group | Coverage |
|---|---|
| `rendering_test.go` | default-ON, no-file default, save/load round-trip, disabled-from-file, **partial-file-keeps-default (precedence)**, invalid-YAML defaults, nested-dir creation — mirrors `mouse_test.go` |
| `settings_page_test.go` (fullscreen) | toggle persists both directions + seam invoked; save-error keeps attempted in-memory state |
| `settings_page_test.go` (render) | headline section renders the **exact** Mouse & Rendering copy (all bullet lines incl. alignment); checkbox glyph reflects on/off state per setting |

Local results (worktree, isolated):

- `gofmt -l` — clean
- `go build ./...` — pass
- `go vet ./...` — pass
- `go test ./internal/tui/... ./internal/config/...` — pass (the `internal/status` `:8080` bind is an environmental flake, not run here)

**Draft:** interactive verification of the live mouse toggle on a real terminal is still pending.

## Related

- Follows #390 (Closes #388) — mouse-clickable Control Center + persisted mouse pref + live Settings toggle
- Jason's interactive feedback: Settings tab read as generic keyboard toggles; should be a Mouse & Rendering panel
- **Follow-up needed:** consume `config.LoadRendering()` at screen-creation time in the control center `Run()` path (owned by `controlcenter.go`) so fullscreen actually applies at launch.
