### PR TITLE
fix(tui): escape the Chat keyboard trap + surface real chat connection state (#388 follow-up)

### DIFF
--- a/internal/tui/controlcenter/chat_page.go
+++ b/internal/tui/controlcenter/chat_page.go
@@ -16,6 +16,14 @@ import (
 // presenceTimeout is how long since last heartbeat before a node is considered offline.
 const presenceTimeout = 90 * time.Second
 
+// connectTimeout bounds how long the Chat tab shows "connecting…" before the
+// watchdog flips it to a real timeout error. It is longer than the underlying
+// WebSocket HandshakeTimeout (10s) so a dial failure surfaces its own specific
+// error first; the watchdog only catches the cases the dial itself can't (e.g. a
+// server that accepts the socket then closes on a scope mismatch, or a silently
+// rejected subscribe that never yields an OnConnect).
+const connectTimeout = 15 * time.Second
+
 // connState describes the chat transport connection lifecycle.
 type connState int
 
@@ -304,22 +312,140 @@ func (p *ChatPage) OnActivate() {
 // OnDeactivate implements Page.
 func (p *ChatPage) OnDeactivate() {}
 
-// HandleInput implements Page. Routes input to the input field or message view.
-func (p *ChatPage) HandleInput(event *tcell.EventKey) *tcell.EventKey {
-	// Page Up / Page Down scroll the message view
+// chatKeyAction classifies how the Chat page should treat a key event. It is the
+// escape hatch for the keyboard trap: when the input field is focused, tview's
+// InputField would otherwise *consume* Tab/Shift+Tab/Escape internally (its
+// SetDoneFunc path swallows them), leaving the user unable to leave the Chat tab.
+//
+// The Control Center routes every key through the active page's HandleInput
+// *before* it reaches the focused InputField (see PageManager.HandleGlobalInput),
+// so HandleInput returning nil consumes the key before the InputField ever sees
+// it — that is how we reclaim the navigation keys the InputField would trap.
+type chatKeyAction int
+
+const (
+	// chatKeyPassthrough returns the event unhandled so the focused primitive
+	// (usually the InputField: printable text, Enter=send, autocomplete) handles it.
+	chatKeyPassthrough chatKeyAction = iota
+	// chatKeyScrollUp / chatKeyScrollDown scroll the message history.
+	chatKeyScrollUp
+	chatKeyScrollDown
+	// chatKeyDefocus moves focus off the input back to the message view (Escape),
+	// so the user is no longer trapped typing.
+	chatKeyDefocus
+	// chatKeyNextPane / chatKeyPrevPane cycle focus among the Chat page's own
+	// panes (input -> messages -> peers -> channels -> input).
+	chatKeyNextPane
+	chatKeyPrevPane
+)
+
+// classifyChatKey maps a key event to a chatKeyAction. Pure and table-testable
+// without a running tview app. The rule (per the keyboard-trap fix): the chat
+// input only consumes printable text + Enter (send) + history/scroll keys;
+// everything navigational is reclaimed here so the user can always leave.
+func classifyChatKey(event *tcell.EventKey) chatKeyAction {
+	// Alt+<rune> is a global tab accelerator handled upstream in
+	// HandleGlobalInput before it ever reaches here; never treat it as text.
+	if event.Modifiers()&tcell.ModAlt != 0 {
+		return chatKeyPassthrough
+	}
 	switch event.Key() {
 	case tcell.KeyPgUp:
+		return chatKeyScrollUp
+	case tcell.KeyPgDn:
+		return chatKeyScrollDown
+	case tcell.KeyEscape:
+		return chatKeyDefocus
+	case tcell.KeyTab:
+		return chatKeyNextPane
+	case tcell.KeyBacktab:
+		return chatKeyPrevPane
+	default:
+		return chatKeyPassthrough
+	}
+}
+
+// HandleInput implements Page. It runs before the focused InputField sees the
+// event, so it is where we free the navigation keys the InputField would trap.
+func (p *ChatPage) HandleInput(event *tcell.EventKey) *tcell.EventKey {
+	switch classifyChatKey(event) {
+	case chatKeyScrollUp:
 		row, col := p.msgView.GetScrollOffset()
 		p.msgView.ScrollTo(row-10, col)
 		return nil
-	case tcell.KeyPgDn:
+	case chatKeyScrollDown:
 		row, col := p.msgView.GetScrollOffset()
 		p.msgView.ScrollTo(row+10, col)
 		return nil
+	case chatKeyDefocus:
+		// Escape releases the keyboard trap: move focus off the input to the
+		// message view so the user can navigate (Tab/Alt+N) freely.
+		if p.app != nil && p.msgView != nil {
+			p.app.SetFocus(p.msgView)
+		}
+		return nil
+	case chatKeyNextPane:
+		p.focusNextPane()
+		return nil
+	case chatKeyPrevPane:
+		p.focusPrevPane()
+		return nil
+	default:
+		return event
 	}
-
-	return event
 }
+
+// chatPanes returns the Chat page's focusable panes in tab order. Kept as a
+// helper so pane cycling and its tests share a single source of truth.
+func (p *ChatPage) chatPanes() []tview.Primitive {
+	return []tview.Primitive{p.input, p.msgView, p.peersBox, p.channelBox}
+}
+
+// nextChatPaneIndex computes the index of the pane to focus next, cycling
+// forward (delta=+1) or backward (delta=-1) from the currently focused pane.
+// Pure and testable: `focused` is the index of the currently focused pane, or
+// -1 when focus is elsewhere (in which case we start at the input).
+func nextChatPaneIndex(focused, count, delta int) int {
+	if count == 0 {
+		return -1
+	}
+	if focused < 0 {
+		if delta >= 0 {
+			return 0
+		}
+		return count - 1
+	}
+	return ((focused+delta)%count + count) % count
+}
+
+// currentChatPaneIndex returns the index of the currently focused chat pane, or
+// -1 if focus is not on any of them.
+func (p *ChatPage) currentChatPaneIndex() int {
+	if p.app == nil {
+		return -1
+	}
+	focused := p.app.GetFocus()
+	for i, pane := range p.chatPanes() {
+		if pane == focused {
+			return i
+		}
+	}
+	return -1
+}
+
+func (p *ChatPage) cycleChatPane(delta int) {
+	panes := p.chatPanes()
+	idx := nextChatPaneIndex(p.currentChatPaneIndex(), len(panes), delta)
+	if idx < 0 {
+		return
+	}
+	if p.app != nil {
+		p.app.SetFocus(panes[idx])
+	}
+}
+
+func (p *ChatPage) focusNextPane() { p.cycleChatPane(1) }
+func (p *ChatPage) focusPrevPane() { p.cycleChatPane(-1) }
 
 // connect establishes the chat client connection.
 func (p *ChatPage) connect() {
@@ -337,7 +463,14 @@ func (p *ChatPage) connect() {
 
 	if apiBaseURL == "" || apiToken == "" || orgID == "" {
 		p.clientMu.Unlock()
+		// Surface the failure in BOTH the message view AND the status bar. The
+		// status bar was seeded to connConnecting in Build(); without this it
+		// stays pinned on the "connecting…" spinner forever even though we never
+		// dial. Flip it to a real error state instead.
 		p.setStatus("[red]Not configured[white] — device authorization required")
+		p.app.QueueUpdateDraw(func() {
+			p.renderStatusBar(connError, "device authorization required")
+		})
 		return
 	}
 
@@ -411,6 +544,32 @@ func (p *ChatPage) connect() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	p.cancel = cancel
+
+	// Watchdog: if OnConnect has not fired within connectTimeout of dialing, flip
+	// the status bar out of the "connecting…" spinner into a real timeout error.
+	// This guarantees the UI never spins forever, regardless of the failure mode
+	// (a hung dial, a server that closes on a scope mismatch, or a silently
+	// rejected subscribe). It races the successful-connect path, so it must
+	// re-check p.connected / ctx.Err() under the lock — mirroring the guard on the
+	// Connect() error branch below — and no-op if either indicates success or
+	// shutdown.
+	go func() {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(connectTimeout):
+		}
+		p.clientMu.Lock()
+		connected := p.connected
+		p.clientMu.Unlock()
+		if !connected && ctx.Err() == nil {
+			p.app.QueueUpdateDraw(func() {
+				p.renderStatusBar(connError, "timed out")
+				p.setStatus("[red]Connection timed out[white] — chat is unavailable")
+				p.peersBox.SetText(" [red]offline[white]")
+			})
+		}
+	}()
 
 	// Connect blocks until ctx is cancelled on success, or returns quickly with
 	// an error if the handshake/subscribe fails. Surface the real error instead
@@ -514,6 +673,28 @@ func (p *ChatPage) appendMessage(msg chat.Message) {
 	p.msgView.ScrollToEnd()
 }
 
+// formatChatStatusBar renders the one-line status text for a given connection
+// state, endpoint, and optional error detail. Pure (no tview app required) so
+// the connecting/connected/error transitions are unit-testable. The endpoint is
+// assumed already sanitized to scheme + host by the caller.
+func formatChatStatusBar(state connState, endpoint, detail string) string {
+	if endpoint == "" {
+		endpoint = "not configured"
+	}
+	switch state {
+	case connConnected:
+		return fmt.Sprintf(" [green]●[white] connected  [gray]%s[white]", tview.Escape(endpoint))
+	case connError:
+		msg := fmt.Sprintf(" [red]●[white] error  [gray]%s[white]", tview.Escape(endpoint))
+		if detail != "" {
+			msg += fmt.Sprintf("  [red]%s[white]", tview.Escape(detail))
+		}
+		return msg
+	default:
+		return fmt.Sprintf(" [yellow]●[white] connecting…  [gray]%s[white]", tview.Escape(endpoint))
+	}
+}
+
 // renderStatusBar updates the one-line connection status indicator beneath the
 // message view. It surfaces which WSS endpoint the chat is using and its health
 // (connecting / connected / error). The endpoint is sanitized to scheme + host
@@ -525,22 +706,7 @@ func (p *ChatPage) renderStatusBar(state connState, detail string) {
 
 	p.state = state
 	endpoint := chat.SanitizeEndpoint(p.currentAPIBaseURL())
-	if endpoint == "" {
-		endpoint = "not configured"
-	}
-
-	switch state {
-	case connConnected:
-		p.statusBar.SetText(fmt.Sprintf(" [green]●[white] connected  [gray]%s[white]", tview.Escape(endpoint)))
-	case connError:
-		msg := fmt.Sprintf(" [red]●[white] error  [gray]%s[white]", tview.Escape(endpoint))
-		if detail != "" {
-			msg += fmt.Sprintf("  [red]%s[white]", tview.Escape(detail))
-		}
-		p.statusBar.SetText(msg)
-	default:
-		p.statusBar.SetText(fmt.Sprintf(" [yellow]●[white] connecting…  [gray]%s[white]", tview.Escape(endpoint)))
-	}
+	p.statusBar.SetText(formatChatStatusBar(state, endpoint, detail))
 }
 
 // setStatus updates the message view with a status line.

--- a/internal/tui/controlcenter/chat_page_test.go
+++ b/internal/tui/controlcenter/chat_page_test.go
@@ -1,6 +1,128 @@
 package controlcenter
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+// TestClassifyChatKey_ReleasesNavigationKeys is the keyboard-trap regression: the
+// chat input must only consume printable text + Enter (send) + scroll keys, and
+// return everything navigational so the user can leave the Chat tab. Enter is
+// intentionally passthrough here because sending is wired via the InputField's
+// SetDoneFunc, not HandleInput.
+func TestClassifyChatKey_ReleasesNavigationKeys(t *testing.T) {
+	tests := []struct {
+		name  string
+		event *tcell.EventKey
+		want  chatKeyAction
+	}{
+		{"escape defocuses", tcell.NewEventKey(tcell.KeyEscape, 0, tcell.ModNone), chatKeyDefocus},
+		{"tab switches pane", tcell.NewEventKey(tcell.KeyTab, 0, tcell.ModNone), chatKeyNextPane},
+		{"shift+tab switches pane back", tcell.NewEventKey(tcell.KeyBacktab, 0, tcell.ModNone), chatKeyPrevPane},
+		{"pgup scrolls", tcell.NewEventKey(tcell.KeyPgUp, 0, tcell.ModNone), chatKeyScrollUp},
+		{"pgdn scrolls", tcell.NewEventKey(tcell.KeyPgDn, 0, tcell.ModNone), chatKeyScrollDown},
+		{"enter passes through to send", tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone), chatKeyPassthrough},
+		{"printable rune passes through", tcell.NewEventKey(tcell.KeyRune, 'a', tcell.ModNone), chatKeyPassthrough},
+		{"space passes through", tcell.NewEventKey(tcell.KeyRune, ' ', tcell.ModNone), chatKeyPassthrough},
+		// Alt+digit is a global tab accelerator handled upstream; it must never be
+		// swallowed as text by the chat input.
+		{"alt+3 passes through untouched", tcell.NewEventKey(tcell.KeyRune, '3', tcell.ModAlt), chatKeyPassthrough},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyChatKey(tt.event); got != tt.want {
+				t.Errorf("classifyChatKey(%s) = %d, want %d", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNextChatPaneIndex covers forward/backward cycling and the "focus not on a
+// chat pane yet" (-1) start case.
+func TestNextChatPaneIndex(t *testing.T) {
+	const count = 4
+	tests := []struct {
+		name           string
+		focused, delta int
+		want           int
+	}{
+		{"forward from input", 0, 1, 1},
+		{"forward wraps to input", count - 1, 1, 0},
+		{"backward from input wraps to last", 0, -1, count - 1},
+		{"backward from second", 1, -1, 0},
+		{"no focus forward starts at input", -1, 1, 0},
+		{"no focus backward starts at last", -1, -1, count - 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := nextChatPaneIndex(tt.focused, count, tt.delta); got != tt.want {
+				t.Errorf("nextChatPaneIndex(%d, %d, %d) = %d, want %d",
+					tt.focused, count, tt.delta, got, tt.want)
+			}
+		})
+	}
+	if got := nextChatPaneIndex(0, 0, 1); got != -1 {
+		t.Errorf("nextChatPaneIndex with zero panes = %d, want -1", got)
+	}
+}
+
+// TestFormatChatStatusBar verifies the connection-state transitions render the
+// right status text: connecting spinner, connected, and — the key regression —
+// a real error state (never a permanent spinner) with the failure detail.
+func TestFormatChatStatusBar(t *testing.T) {
+	tests := []struct {
+		name             string
+		state            connState
+		endpoint, detail string
+		wantContains     []string
+		wantMissing      []string
+	}{
+		{
+			name:         "connecting shows spinner",
+			state:        connConnecting,
+			endpoint:     "wss://aceteam.ai",
+			wantContains: []string{"connecting", "wss://aceteam.ai"},
+		},
+		{
+			name:         "connected shows connected",
+			state:        connConnected,
+			endpoint:     "wss://aceteam.ai",
+			wantContains: []string{"connected", "wss://aceteam.ai"},
+			wantMissing:  []string{"connecting"},
+		},
+		{
+			name:         "error surfaces detail, not a spinner",
+			state:        connError,
+			endpoint:     "wss://aceteam.ai",
+			detail:       "timed out",
+			wantContains: []string{"error", "timed out"},
+			wantMissing:  []string{"connecting"},
+		},
+		{
+			name:         "empty endpoint falls back to not configured",
+			state:        connConnecting,
+			endpoint:     "",
+			wantContains: []string{"not configured"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatChatStatusBar(tt.state, tt.endpoint, tt.detail)
+			for _, want := range tt.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("formatChatStatusBar = %q, want it to contain %q", got, want)
+				}
+			}
+			for _, missing := range tt.wantMissing {
+				if strings.Contains(got, missing) {
+					t.Errorf("formatChatStatusBar = %q, want it to NOT contain %q", got, missing)
+				}
+			}
+		})
+	}
+}
 
 // TestChatPageResolveConfig_UsesProviderWhenSnapshotIncomplete reproduces the
 // device-auth wiring bug: the ChatPage is constructed before the node completes


### PR DESCRIPTION
## Context

While interactively testing the Control Center after #388/#390 (mouse + TUI polish), Jason hit two Chat-tab bugs. The first is a hard blocker:

1. **Keyboard trap (critical):** Once on the Chat tab (`Alt+3`), the input textbox captured the keyboard — there was no way to `Tab`, `Alt+N`, or `Escape` out. The user was stuck on the Chat tab.
2. **Chat stuck "connecting…":** The status bar showed `connecting… wss://aceteam.ai` and never resolved.

Both are fixed entirely within `internal/tui/controlcenter/chat_page.go` (parallel agents own `controlcenter.go` / `settings_page.go`, which are untouched).

## Root cause

**Bug 1 — keyboard trap.** tview's `InputField` consumes `Tab`/`Backtab`/`Escape` internally via its done/finished path; on the Chat tab those keys never reached any navigation handler. The Control Center already routes every key through the active page's `HandleInput` *before* the focused primitive sees it (`PageManager.HandleGlobalInput` → `activePage.HandleInput(event)`), so returning `nil` there consumes the key before the InputField can trap it. The old `HandleInput` only handled `PgUp`/`PgDn` and passed everything else straight to the trap.

**Bug 2 — stuck spinner.** The status bar is seeded to `connConnecting` in `Build()`. The `connect()` "Not configured" early return (empty creds) updated only the *message view* via `setStatus`, leaving the status bar pinned on the connecting spinner forever. Even on a configured node, no path guaranteed the spinner would ever resolve if the transport silently stalled.

The **verified server-side reason chat cannot deliver end-to-end** (out of scope for this repo): `app/api/fabric/redis/ws/route.ts` only allows subscriptions matching `ALLOWED_SUBSCRIBE_PATTERNS` — `stream:v1:{uuid}` and `config:node:{hostname}`. The chat client subscribes to `chat:v1:org_{id}:general` and `chat:v1:org_{id}:presence`, which match neither, so the server replies `{type:"error", "Invalid subscribe channels: …"}` and never subscribes. Separately, `redisapi.WSClient.Subscribe()` only writes the subscribe frame and does not await the server's `subscribed` ack, so `chat.Client.Connect` fires `onConnect()` optimistically — a rejected subscribe would still render as "connected" with zero messages. Both live in shared `redisapi`/server code and are left for a follow-up (see below).

## Summary of changes (`chat_page.go` only)

**Keyboard trap**
- Extracted a pure `classifyChatKey(event) -> chatKeyAction` helper: only printable text + Enter (send, via the InputField's `SetDoneFunc`) + `PgUp`/`PgDn` (scroll) pass through; `Escape` defocuses to the message view, `Tab`/`Shift+Tab` cycle chat panes. `Alt+<rune>` is passed through untouched (the global `Alt+N` accelerator is handled upstream in `HandleGlobalInput`).
- Rewrote `HandleInput` to act on the classification, and added chat-local pane cycling (`chatPanes`, `nextChatPaneIndex`, `focusNextPane`/`focusPrevPane`) so `Tab` moves focus among input → messages → peers → channels.

**Connection state**
- The "Not configured" early return now also flips the status bar to a real `connError("device authorization required")` instead of leaving the spinner up.
- Added a 15s connect **watchdog**: if `OnConnect` hasn't fired, it flips the status bar to `connError("timed out")`. It re-checks `p.connected`/`ctx.Err()` under the lock (mirroring the existing `Connect()` error guard) so a late success or a clean `Close()` never races into a false error.
- Extracted a pure `formatChatStatusBar(state, endpoint, detail)` so the connecting/connected/error transitions are unit-testable without a running app.

## Test plan

`go test ./internal/tui/... ./internal/chat/...` — all pass. New tests:

| Test | Covers |
|------|--------|
| `TestClassifyChatKey_ReleasesNavigationKeys` | Escape/Tab/Shift+Tab/PgUp/PgDn/Enter/rune/space/Alt+3 → correct action (the keyboard-trap regression) |
| `TestNextChatPaneIndex` | forward/backward pane cycling, wrap-around, no-focus start, zero-pane guard |
| `TestFormatChatStatusBar` | connecting spinner, connected, error-with-detail (never a spinner), empty-endpoint fallback |

Also verified: `gofmt` clean, `go build ./...`, `go vet ./internal/tui/... ./internal/chat/...`. (An `internal/status` `:8080` bind flake from the live worker on this host is environmental and unrelated.)

## How to verify in a terminal

1. Run the Control Center TUI on a node and press `Alt+3` to open Chat, then click/type in the input.
2. **Escape hatch:** `Tab`/`Shift+Tab` move focus among the chat panes; `Escape` returns focus to the message history; `Alt+1`/`Alt+2` switch tabs — you can always leave the Chat tab.
3. **Typing/sending unaffected:** type text and press `Enter` — the message sends and the input clears.
4. **No infinite spinner:** on an unconfigured node the status bar reads `error … device authorization required` immediately; on a configured node that can't complete the handshake, it flips to `error … timed out` within ~15s instead of spinning forever.

## Follow-up (server-side, not in this PR)

Chat still cannot deliver messages end-to-end until:
1. `app/api/fabric/redis/ws/route.ts` `ALLOWED_SUBSCRIBE_PATTERNS`/`ALLOWED_PUBLISH_PATTERNS` allow a `chat:v1:org_*:…` channel pattern (org-scoped).
2. `redisapi.WSClient.Subscribe()` awaits the server's `subscribed` ack (or surfaces the `error` reply) so the UI reflects true subscription success rather than an optimistic "connected".

Filing these as a follow-up issue on the `aceteam` repo.

## Related
- Follows up #388 / #390 (mouse-clickable Control Center, Chat tab).
- Draft: interactive terminal verification on a live node is the acceptance step.
