### PR TITLE
feat(tui): smooth Tab/arrow navigation + unify modules (WhatsApp/Proxmox) + seed sources (#388 follow-up)

### DIFF
--- a/cmd/module.go
+++ b/cmd/module.go
@@ -613,12 +613,78 @@ func confirmYes() bool {
 	return resp == "y" || resp == "yes"
 }
 
+// fallbackModuleSources is the small curated set surfaced when the catalog has
+// not been cloned yet, so the TUI's module picker is never blank on a fresh node.
+// These are first-party catalog names (Tier 0, trusted) resolvable once the
+// catalog is fetched; the resolve step clones on demand.
+var fallbackModuleSources = []controlcenter.ModuleSource{
+	{Name: "vllm", Source: "vllm", Description: "vLLM GPU inference server", Trusted: true},
+	{Name: "ollama", Source: "ollama", Description: "Ollama local model runner", Trusted: true},
+	{Name: "comfyui", Source: "comfyui", Description: "ComfyUI image generation", Trusted: true},
+}
+
+// moduleSourcesFromCatalog maps the loaded catalog registry + curated module
+// index into the TUI's seeded picker rows. Pure over its inputs (no IO) so the
+// seeding logic is unit-testable. Catalog registry entries are first-party
+// (Tier 0) and marked trusted; index entries carry their source repo and are
+// left untrusted unless the index says otherwise (it currently doesn't, so they
+// render with the untrusted warning at resolve time). Duplicate names (registry
+// vs index) are de-duplicated, registry winning. When both inputs are empty the
+// caller substitutes the fallback set.
+func moduleSourcesFromCatalog(reg *catalog.Registry, idx *catalog.ModuleIndex) []controlcenter.ModuleSource {
+	var out []controlcenter.ModuleSource
+	seen := make(map[string]bool)
+	if reg != nil {
+		for _, e := range reg.Services {
+			if e.Name == "" || seen[e.Name] {
+				continue
+			}
+			seen[e.Name] = true
+			out = append(out, controlcenter.ModuleSource{
+				Name:        e.Name,
+				Source:      e.Name, // catalog name resolves via the central catalog
+				Description: e.Description,
+				Trusted:     true,
+			})
+		}
+	}
+	if idx != nil {
+		for _, e := range idx.Modules {
+			if e.Name == "" || seen[e.Name] {
+				continue
+			}
+			seen[e.Name] = true
+			out = append(out, controlcenter.ModuleSource{
+				Name:        e.Name,
+				Source:      e.Source, // owner/repo or git URL from the curated index
+				Description: e.Description,
+				Trusted:     false,
+			})
+		}
+	}
+	return out
+}
+
+// listModuleSources loads the catalog registry + curated index and maps them into
+// the TUI picker rows. Fail-soft: any load error (catalog not cloned, no index
+// published) falls back to the small curated set so the picker is never blank.
+func listModuleSources() []controlcenter.ModuleSource {
+	reg, _ := catalog.LoadRegistry()
+	idx, _ := catalog.LoadModuleIndex()
+	srcs := moduleSourcesFromCatalog(reg, idx)
+	if len(srcs) == 0 {
+		return fallbackModuleSources
+	}
+	return srcs
+}
+
 // buildModuleInstallCallbacks wires the control center's module-install page to
 // the same source-resolution + install logic the CLI uses. The TUI collects all
 // required config up front and passes it as overrides, so the non-interactive
 // installer path is used (no stdin reads). All hooks are best-effort.
 func buildModuleInstallCallbacks() controlcenter.ModuleInstallCallbacks {
 	return controlcenter.ModuleInstallCallbacks{
+		ListSources: listModuleSources,
 		Resolve: func(source string) (controlcenter.ModuleResolveResult, error) {
 			var out controlcenter.ModuleResolveResult
 			src, err := catalog.ParseSource(source)

--- a/cmd/module_seed_test.go
+++ b/cmd/module_seed_test.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/catalog"
+)
+
+// TestModuleSourcesFromCatalog covers the seeding mapper that turns the catalog
+// registry + curated index into the TUI's known-modules picker rows: registry
+// entries are trusted (Tier 0), index entries carry their source repo and are
+// untrusted, and duplicate names de-duplicate with the registry winning.
+func TestModuleSourcesFromCatalog(t *testing.T) {
+	reg := &catalog.Registry{
+		Version: 1,
+		Services: []catalog.RegistryEntry{
+			{Name: "vllm", Description: "vLLM GPU inference"},
+			{Name: "", Description: "skip empty name"},
+			{Name: "vllm", Description: "dupe within registry"},
+		},
+	}
+	idx := &catalog.ModuleIndex{
+		Version: 1,
+		Modules: []catalog.ModuleIndexEntry{
+			{Name: "cool-bot", Source: "owner/cool-bot", Description: "community bot"},
+			{Name: "vllm", Source: "owner/vllm-fork", Description: "collides with registry"},
+		},
+	}
+
+	got := moduleSourcesFromCatalog(reg, idx)
+
+	if len(got) != 2 {
+		t.Fatalf("moduleSourcesFromCatalog returned %d rows, want 2 (vllm + cool-bot): %+v", len(got), got)
+	}
+
+	// Registry entry: trusted, source == catalog name.
+	if got[0].Name != "vllm" || got[0].Source != "vllm" || !got[0].Trusted {
+		t.Errorf("row 0 = %+v, want {Name:vllm Source:vllm Trusted:true}", got[0])
+	}
+	if got[0].Description != "vLLM GPU inference" {
+		t.Errorf("registry-winning dedupe failed: description = %q", got[0].Description)
+	}
+
+	// Index entry: untrusted, source == owner/repo.
+	if got[1].Name != "cool-bot" || got[1].Source != "owner/cool-bot" || got[1].Trusted {
+		t.Errorf("row 1 = %+v, want {Name:cool-bot Source:owner/cool-bot Trusted:false}", got[1])
+	}
+}
+
+// TestModuleSourcesFromCatalogEmpty asserts the mapper returns no rows for nil
+// inputs, which is the signal listModuleSources uses to substitute the fallback
+// curated set (so the picker is never blank on a fresh, un-cloned node).
+func TestModuleSourcesFromCatalogEmpty(t *testing.T) {
+	if got := moduleSourcesFromCatalog(nil, nil); len(got) != 0 {
+		t.Errorf("moduleSourcesFromCatalog(nil, nil) = %+v, want empty", got)
+	}
+	if len(fallbackModuleSources) == 0 {
+		t.Error("fallbackModuleSources is empty; the picker would be blank on a fresh node")
+	}
+	for _, s := range fallbackModuleSources {
+		if s.Name == "" || s.Source == "" {
+			t.Errorf("fallback source has empty Name/Source: %+v", s)
+		}
+	}
+}

--- a/internal/tui/controlcenter/controlcenter.go
+++ b/internal/tui/controlcenter/controlcenter.go
@@ -229,6 +229,47 @@ func (pm *PageManager) visibleIndices() []int {
 	return out
 }
 
+// nextVisibleIndex returns the real index of the visible page after cur, wrapping
+// to the first visible page. It is a pure function over the (index, visible)
+// projection of the registered pages so tab-cycle order is unit-testable without
+// a running app. Returns cur when nothing is visible or cur is the lone visible
+// page. visibles must be sorted ascending (as visibleIndices produces).
+func nextVisibleIndex(visibles []int, cur int) int {
+	if len(visibles) == 0 {
+		return cur
+	}
+	for _, idx := range visibles {
+		if idx > cur {
+			return idx
+		}
+	}
+	return visibles[0]
+}
+
+// prevVisibleIndex returns the real index of the visible page before cur,
+// wrapping to the last visible page. Pure counterpart to nextVisibleIndex.
+func prevVisibleIndex(visibles []int, cur int) int {
+	if len(visibles) == 0 {
+		return cur
+	}
+	for i := len(visibles) - 1; i >= 0; i-- {
+		if visibles[i] < cur {
+			return visibles[i]
+		}
+	}
+	return visibles[len(visibles)-1]
+}
+
+// switchToNextVisible advances to the next visible tab (wrapping).
+func (pm *PageManager) switchToNextVisible() {
+	pm.SwitchTo(nextVisibleIndex(pm.visibleIndices(), pm.activeIdx))
+}
+
+// switchToPrevVisible advances to the previous visible tab (wrapping).
+func (pm *PageManager) switchToPrevVisible() {
+	pm.SwitchTo(prevVisibleIndex(pm.visibleIndices(), pm.activeIdx))
+}
+
 // Show makes a page visible by name.
 func (pm *PageManager) Show(name string) {
 	for i := range pm.registered {
@@ -354,7 +395,23 @@ func (pm *PageManager) Build() *tview.Flex {
 	return pm.rootFlex
 }
 
-// HandleGlobalInput captures Alt+1-N before delegating to the active page.
+// HandleGlobalInput is the app-level input router. Navigation model (the shared
+// convention every page relies on — see #388 follow-up):
+//
+//   - Tab / Shift+Tab is the PRIMARY way to move between tabs. It is delivered to
+//     the active page FIRST; a page consumes it for its own internal focus
+//     movement (dashboard pane cycling, module list<->form) and returns it
+//     UNCONSUMED at its navigation boundary. When the page returns an unconsumed
+//     Tab/Backtab, we switch to the next/previous visible tab. A page that does
+//     nothing with Tab (the default) therefore gets tab-switching for free —
+//     that is what makes the default correct for parallel-owned pages.
+//   - Arrow keys move within a pane (each page's own concern).
+//   - Alt+1..N remain as optional accelerators to jump straight to a tab. They
+//     are captured before delegation so a focused input field never eats them.
+//   - Escape is NOT captured here: the dashboard's Esc=quit-confirm keybinding is
+//     preserved, and "Escape defocuses an input back to nav" is a per-page rule
+//     (e.g. the module page) that only fires when an input is focused.
+//
 // F-keys are avoided because terminal emulators (Terminator, etc.) intercept them.
 func (pm *PageManager) HandleGlobalInput(event *tcell.EventKey) *tcell.EventKey {
 	if pm.isModalActive != nil && pm.isModalActive() {
@@ -364,7 +421,7 @@ func (pm *PageManager) HandleGlobalInput(event *tcell.EventKey) *tcell.EventKey 
 		return event
 	}
 
-	// Alt+1 through Alt+N to switch to Nth visible page
+	// Alt+1 through Alt+N to switch to Nth visible page (optional accelerator).
 	if event.Modifiers()&tcell.ModAlt != 0 && event.Key() == tcell.KeyRune {
 		digit := int(event.Rune() - '0')
 		if digit >= 1 && digit <= 9 {
@@ -376,10 +433,24 @@ func (pm *PageManager) HandleGlobalInput(event *tcell.EventKey) *tcell.EventKey 
 		}
 	}
 
+	// Delegate to the active page first, then bubble an unconsumed Tab/Backtab up
+	// to tab-switching. This lets a page keep Tab for its own intra-page focus and
+	// hand off only at its edges.
+	out := event
 	if pm.activeIdx >= 0 && pm.activeIdx < len(pm.registered) {
-		return pm.registered[pm.activeIdx].page.HandleInput(event)
+		out = pm.registered[pm.activeIdx].page.HandleInput(event)
 	}
-	return event
+	if out != nil {
+		switch out.Key() {
+		case tcell.KeyTab:
+			pm.switchToNextVisible()
+			return nil
+		case tcell.KeyBacktab:
+			pm.switchToPrevVisible()
+			return nil
+		}
+	}
+	return out
 }
 
 // PlaceholderPage is a stub page that shows a "Coming soon" message.
@@ -585,6 +656,15 @@ type ProxmoxConfig struct {
 	NodeName string // Proxmox node name (auto-detected if empty)
 }
 
+// proxmoxTabVisible reports whether the Proxmox tab should be registered/shown.
+// Proxmox is host infrastructure, not an installable module, so its tab is gated
+// on actual detection: the cmd layer sets Enabled only when saved Proxmox config
+// exists OR a local Proxmox install is detected (/etc/pve + pvesh). Named as a
+// pure seam so the gate is unit-testable without the filesystem-coupled builder.
+func proxmoxTabVisible(cfg ProxmoxConfig) bool {
+	return cfg.Enabled && cfg.BaseURL != ""
+}
+
 // New creates a new control center
 func New(cfg Config) *ControlCenter {
 	return &ControlCenter{
@@ -713,8 +793,10 @@ func (cc *ControlCenter) Run() error {
 	cc.pmgr.Register(NewPlaceholderPage("jobs", "Jobs"), false)
 	cc.pmgr.Register(NewPlaceholderPage("network", "Network"), false)
 
-	// Proxmox page: conditional on detection or configuration
-	if cc.proxmoxConfig.Enabled {
+	// Proxmox page: gated on real detection (saved config or a detected local
+	// Proxmox host). Proxmox is host infra, not a module, so it stays a top-level
+	// tab but only appears when relevant — never folded into the module list.
+	if proxmoxTabVisible(cc.proxmoxConfig) {
 		pmxClient := proxmox.NewClient(proxmox.ClientConfig{
 			BaseURL:     cc.proxmoxConfig.BaseURL,
 			TokenID:     cc.proxmoxConfig.TokenID,
@@ -728,15 +810,49 @@ func (cc *ControlCenter) Run() error {
 	}
 
 	// WhatsApp bridge page: deploy/start/stop the community module and show the
-	// pairing QR. Visible only when the host wired the lifecycle callbacks.
-	if cc.whatsappConfig.Status != nil {
-		cc.pmgr.Register(NewWhatsAppPage(cc.whatsappConfig), true)
+	// pairing QR. WhatsApp is a community MODULE, so it no longer gets its own
+	// top-level tab (#388 feedback): it is registered HIDDEN and reached from the
+	// unified Install-module list, which surfaces a "WhatsApp" row that switches
+	// here. All bridge functionality (deploy/stop/QR) is preserved unchanged.
+	//
+	// Guard against orphaning: the module list is the only entry point to the
+	// hidden WhatsApp page, so if the module page is NOT wired we fall back to
+	// registering WhatsApp as its own visible tab (old behavior) rather than
+	// hiding a page nothing can reach.
+	whatsappAvailable := cc.whatsappConfig.Status != nil
+	moduleListAvailable := cc.moduleInstallConfig.Resolve != nil
+	if whatsappAvailable {
+		cc.pmgr.Register(NewWhatsAppPage(cc.whatsappConfig), !moduleListAvailable)
 	}
 
 	// Install-module page: install a service module from any standardized repo
-	// (catalog name, owner/repo, or git URL). Visible only when the host wired
-	// the resolve/install callbacks.
+	// (catalog name, owner/repo, or git URL) AND the single home for community
+	// modules (WhatsApp folds in here). Visible only when the host wired the
+	// resolve/install callbacks.
 	if cc.moduleInstallConfig.Resolve != nil {
+		// SelectSpecial lets a module-list row switch to an in-app module page
+		// (e.g. the hidden WhatsApp tab) without the page holding a PageManager ref.
+		cc.moduleInstallConfig.SelectSpecial = func(name string) {
+			if cc.pmgr != nil {
+				cc.pmgr.SwitchToName(name)
+			}
+		}
+		// Fold WhatsApp into the module list as a special row when it is available.
+		if whatsappAvailable {
+			baseList := cc.moduleInstallConfig.ListSources
+			cc.moduleInstallConfig.ListSources = func() []ModuleSource {
+				var srcs []ModuleSource
+				if baseList != nil {
+					srcs = baseList()
+				}
+				return append(srcs, ModuleSource{
+					Name:        "WhatsApp",
+					Description: "community bridge — deploy, link a phone, manage",
+					Trusted:     true,
+					Special:     "whatsapp",
+				})
+			}
+		}
 		cc.pmgr.Register(NewModulePage(cc.moduleInstallConfig), true)
 	}
 
@@ -983,11 +1099,19 @@ func (cc *ControlCenter) handleInput(event *tcell.EventKey) *tcell.EventKey {
 		cc.showQuitConfirm()
 		return nil
 	case tcell.KeyTab:
-		// Switch to next pane
+		// Move to the next pane; at the last pane, bubble the Tab up so the
+		// PageManager advances to the next TAB (shared navigation convention).
+		if cc.focusedPane >= paneCount-1 {
+			return event
+		}
 		cc.focusNextPane()
 		return nil
 	case tcell.KeyBacktab:
-		// Switch to previous pane
+		// Move to the previous pane; at the first pane, bubble Shift+Tab up so the
+		// PageManager falls back to the previous tab.
+		if cc.focusedPane <= 0 {
+			return event
+		}
 		cc.focusPrevPane()
 		return nil
 	case tcell.KeyEnter:
@@ -1564,10 +1688,11 @@ func isWindows() bool {
 func (cc *ControlCenter) showHelpModal() {
 	helpText := `[yellow::b]Citadel Control Center[-:-:-]
 
-[yellow]Navigation:[-]
-  [white::b]Tab[-:-:-]           Switch between Services/Peers panes
-  [white::b]↑/↓[-:-:-] or [white::b]j/k[-:-:-]   Navigate within focused pane
-  [white::b]Enter[-:-:-]         Toggle service / Ping peer
+[yellow]Navigation (nothing to memorize):[-]
+  [white::b]Tab[-:-:-] / [white::b]Shift+Tab[-:-:-]  Move through panes, then on to the next/prev tab
+  [white::b]↑/↓[-:-:-] or [white::b]j/k[-:-:-]   Navigate within the focused pane
+  [white::b]Enter[-:-:-]         Details / toggle service / ping peer
+  [white::b]Alt+1..N[-:-:-]      Jump straight to a tab (optional shortcut)
 
 [yellow]Services Pane:[-]
   [white::b]s[-:-:-]             Start selected service
@@ -2093,11 +2218,11 @@ func (cc *ControlCenter) updateHelpBar() {
 
 	switch cc.focusedPane {
 	case paneNode:
-		set("[yellow::b]Enter[-:-:-] details  │  [yellow::b]Tab[-:-:-] switch pane  [yellow::b]c[-:-:-] copy  [yellow::b]?[-:-:-] help  [yellow::b]q[-:-:-] quit")
+		set("[yellow::b]Enter[-:-:-] details  │  [yellow::b]Tab[-:-:-] pane/tab  [yellow::b]c[-:-:-] copy  [yellow::b]?[-:-:-] help  [yellow::b]q[-:-:-] quit")
 	case paneSystem:
-		set("[yellow::b]Enter[-:-:-] details  │  [yellow::b]Tab[-:-:-] switch pane  [yellow::b]c[-:-:-] copy  [yellow::b]?[-:-:-] help  [yellow::b]q[-:-:-] quit")
+		set("[yellow::b]Enter[-:-:-] details  │  [yellow::b]Tab[-:-:-] pane/tab  [yellow::b]c[-:-:-] copy  [yellow::b]?[-:-:-] help  [yellow::b]q[-:-:-] quit")
 	case paneJobs:
-		set("[yellow::b]Enter[-:-:-] view details  │  [yellow::b]Tab[-:-:-] switch pane  [yellow::b]c[-:-:-] copy  [yellow::b]?[-:-:-] help  [yellow::b]q[-:-:-] quit")
+		set("[yellow::b]Enter[-:-:-] view details  │  [yellow::b]Tab[-:-:-] pane/tab  [yellow::b]c[-:-:-] copy  [yellow::b]?[-:-:-] help  [yellow::b]q[-:-:-] quit")
 	case paneServices:
 		svcName := cc.getSelectedServiceName()
 		svcStatus := cc.getSelectedServiceStatus()
@@ -2108,36 +2233,36 @@ func (cc *ControlCenter) updateHelpBar() {
 				statusIcon = "[green]●[-]"
 				action = "stop"
 			}
-			set(fmt.Sprintf("[white::b]%s[-:-:-] %s  │  [yellow::b]Enter[-:-:-] %s  [yellow::b]Tab[-:-:-] switch pane  [yellow::b]0-3[-:-:-] actions  [yellow::b]?[-:-:-] help",
+			set(fmt.Sprintf("[white::b]%s[-:-:-] %s  │  [yellow::b]Enter[-:-:-] %s  [yellow::b]Tab[-:-:-] pane/tab  [yellow::b]0-3[-:-:-] actions  [yellow::b]?[-:-:-] help",
 				svcName, statusIcon, action))
 		} else {
-			set("[yellow::b]↑/↓[-:-:-] select  │  [yellow::b]Tab[-:-:-] switch pane  [yellow::b]0-3[-:-:-] actions  [yellow::b]?[-:-:-] help  [yellow::b]q[-:-:-] quit")
+			set("[yellow::b]↑/↓[-:-:-] select  │  [yellow::b]Tab[-:-:-] pane/tab  [yellow::b]0-3[-:-:-] actions  [yellow::b]?[-:-:-] help  [yellow::b]q[-:-:-] quit")
 		}
 	case paneActions:
 		row, _ := cc.actionsView.GetSelection()
 		actions := cc.getActions()
 		if row >= 0 && row < len(actions) {
 			action := actions[row]
-			set(fmt.Sprintf("[yellow::b]%s[-:-:-] [white::b]%s[-:-:-]  │  [yellow::b]Enter[-:-:-] execute  [yellow::b]Tab[-:-:-] switch pane  [yellow::b]?[-:-:-] help  [yellow::b]q[-:-:-] quit",
+			set(fmt.Sprintf("[yellow::b]%s[-:-:-] [white::b]%s[-:-:-]  │  [yellow::b]Enter[-:-:-] execute  [yellow::b]Tab[-:-:-] pane/tab  [yellow::b]?[-:-:-] help  [yellow::b]q[-:-:-] quit",
 				action.key, action.name))
 		} else {
-			set("[yellow::b]↑/↓[-:-:-] select action  │  [yellow::b]Enter[-:-:-] execute  [yellow::b]Tab[-:-:-] switch pane  [yellow::b]?[-:-:-] help")
+			set("[yellow::b]↑/↓[-:-:-] select action  │  [yellow::b]Enter[-:-:-] execute  [yellow::b]Tab[-:-:-] pane/tab  [yellow::b]?[-:-:-] help")
 		}
 	case panePeers:
 		if len(cc.data.Peers) > 0 {
 			row, _ := cc.peersView.GetSelection()
 			if row > 0 && row <= len(cc.data.Peers) {
 				peer := cc.data.Peers[row-1]
-				set(fmt.Sprintf("[white::b]%s[-:-:-]  │  [yellow::b]Enter[-:-:-] view peers  [yellow::b]p[-:-:-] ping  [yellow::b]a[-:-:-] ping all  [yellow::b]Tab[-:-:-] switch  [yellow::b]?[-:-:-] help",
+				set(fmt.Sprintf("[white::b]%s[-:-:-]  │  [yellow::b]Enter[-:-:-] view peers  [yellow::b]p[-:-:-] ping  [yellow::b]a[-:-:-] ping all  [yellow::b]Tab[-:-:-] pane/tab  [yellow::b]?[-:-:-] help",
 					peer.Hostname))
 			} else {
-				set("[yellow::b]↑/↓[-:-:-] select peer  │  [yellow::b]Enter[-:-:-] view peers  [yellow::b]a[-:-:-] ping all  [yellow::b]Tab[-:-:-] switch pane  [yellow::b]?[-:-:-] help")
+				set("[yellow::b]↑/↓[-:-:-] select peer  │  [yellow::b]Enter[-:-:-] view peers  [yellow::b]a[-:-:-] ping all  [yellow::b]Tab[-:-:-] pane/tab  [yellow::b]?[-:-:-] help")
 			}
 		} else {
-			set("[yellow::b]Tab[-:-:-] switch pane  │  [yellow::b]0[-:-:-] connect  [yellow::b]?[-:-:-] help  [yellow::b]q[-:-:-] quit")
+			set("[yellow::b]Tab[-:-:-] pane/tab  │  [yellow::b]0[-:-:-] connect  [yellow::b]?[-:-:-] help  [yellow::b]q[-:-:-] quit")
 		}
 	case paneActivity:
-		set("[yellow::b]Enter[-:-:-] full screen  │  [yellow::b]l[-:-:-] copy logs  [yellow::b]↑/↓[-:-:-] scroll  [yellow::b]Tab[-:-:-] switch  [yellow::b]?[-:-:-] help")
+		set("[yellow::b]Enter[-:-:-] full screen  │  [yellow::b]l[-:-:-] copy logs  [yellow::b]↑/↓[-:-:-] scroll  [yellow::b]Tab[-:-:-] pane/tab  [yellow::b]?[-:-:-] help")
 	}
 
 	// When mouse is on, advertise it so the click affordances are discoverable

--- a/internal/tui/controlcenter/controlcenter_test.go
+++ b/internal/tui/controlcenter/controlcenter_test.go
@@ -659,3 +659,100 @@ func TestDenseAltMapping(t *testing.T) {
 		t.Errorf("Alt+3 maps to index %d, want 4", vis[2])
 	}
 }
+
+// TestNextVisibleIndex covers the Tab-forward tab-cycle order used by the shared
+// navigation convention: skip hidden pages, wrap at the end, and no-op when a
+// single or no page is visible.
+func TestNextVisibleIndex(t *testing.T) {
+	cases := []struct {
+		name     string
+		visibles []int
+		cur      int
+		want     int
+	}{
+		{"advance to next visible", []int{0, 2, 4}, 0, 2},
+		{"skip hidden between", []int{0, 2, 4}, 2, 4},
+		{"wrap to first", []int{0, 2, 4}, 4, 0},
+		{"cur not in set advances to next greater", []int{0, 2, 4}, 1, 2},
+		{"cur beyond last wraps", []int{0, 2, 4}, 5, 0},
+		{"single visible stays", []int{3}, 3, 3},
+		{"empty stays", nil, 2, 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := nextVisibleIndex(tc.visibles, tc.cur); got != tc.want {
+				t.Errorf("nextVisibleIndex(%v, %d) = %d, want %d", tc.visibles, tc.cur, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPrevVisibleIndex covers the Shift+Tab-backward tab-cycle order: skip hidden
+// pages, wrap at the start, and no-op for single/empty sets.
+func TestPrevVisibleIndex(t *testing.T) {
+	cases := []struct {
+		name     string
+		visibles []int
+		cur      int
+		want     int
+	}{
+		{"back to previous visible", []int{0, 2, 4}, 4, 2},
+		{"skip hidden between", []int{0, 2, 4}, 2, 0},
+		{"wrap to last", []int{0, 2, 4}, 0, 4},
+		{"cur not in set goes to next lower", []int{0, 2, 4}, 3, 2},
+		{"cur below first wraps to last", []int{0, 2, 4}, -1, 4},
+		{"single visible stays", []int{3}, 3, 3},
+		{"empty stays", nil, 2, 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := prevVisibleIndex(tc.visibles, tc.cur); got != tc.want {
+				t.Errorf("prevVisibleIndex(%v, %d) = %d, want %d", tc.visibles, tc.cur, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestVisibleCycleRoundTrip asserts nextVisibleIndex over all visible pages
+// returns to the start, i.e. Tab cycles through every visible tab exactly once.
+func TestVisibleCycleRoundTrip(t *testing.T) {
+	visibles := []int{0, 1, 3, 6}
+	cur := visibles[0]
+	seen := map[int]bool{cur: true}
+	for i := 0; i < len(visibles)-1; i++ {
+		cur = nextVisibleIndex(visibles, cur)
+		if seen[cur] {
+			t.Fatalf("cycle revisited index %d before covering all visibles", cur)
+		}
+		seen[cur] = true
+	}
+	// One more Tab wraps back to the first visible page.
+	if got := nextVisibleIndex(visibles, cur); got != visibles[0] {
+		t.Errorf("cycle did not wrap to first: got %d, want %d", got, visibles[0])
+	}
+	if len(seen) != len(visibles) {
+		t.Errorf("cycle covered %d of %d visible tabs", len(seen), len(visibles))
+	}
+}
+
+// TestProxmoxTabVisible asserts the Proxmox tab is gated on real detection: shown
+// only when Enabled AND a BaseURL is set (never folded into the module list).
+func TestProxmoxTabVisible(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  ProxmoxConfig
+		want bool
+	}{
+		{"disabled (no detection)", ProxmoxConfig{}, false},
+		{"detected with URL", ProxmoxConfig{Enabled: true, BaseURL: "https://localhost:8006"}, true},
+		{"enabled but no URL (defensive)", ProxmoxConfig{Enabled: true}, false},
+		{"URL but not enabled", ProxmoxConfig{BaseURL: "https://localhost:8006"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := proxmoxTabVisible(tc.cfg); got != tc.want {
+				t.Errorf("proxmoxTabVisible(%+v) = %v, want %v", tc.cfg, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/tui/controlcenter/module_page.go
+++ b/internal/tui/controlcenter/module_page.go
@@ -39,8 +39,32 @@ type ModuleResolveResult struct {
 	HasCriticalRisk bool
 }
 
+// ModuleSource is one selectable row in the known/approved sources list. It maps
+// a curated catalog/index entry (or a special in-app module like WhatsApp) into a
+// display row so the user picks from a seeded list instead of typing a source
+// blind. Mapped from catalog entries in the cmd layer so this page imports no
+// catalog internals.
+type ModuleSource struct {
+	// Name is the module's display/catalog name (e.g. "vllm").
+	Name string
+	// Source is the value fed to Resolve when the row is chosen (catalog name,
+	// owner/repo, or git URL). Empty for special rows.
+	Source string
+	// Description is a short human summary shown next to the name.
+	Description string
+	// Trusted marks a first-party/curated source (rendered with a check).
+	Trusted bool
+	// Special, when non-empty, names an in-app module page to switch to instead of
+	// running the install form (e.g. "whatsapp" folds the WhatsApp bridge tab in).
+	Special string
+}
+
 // ModuleInstallCallbacks holds the hooks for the "Install module" page. They are
 // wired from cmd so the page stays free of catalog/network/docker imports.
+//
+// ListSources returns the seeded known/approved sources to pre-populate the
+// picker (curated catalog/index entries + any special in-app modules). It is
+// fail-soft: an empty slice just yields a blank list, never an error.
 //
 // Resolve clones/updates the source repo (or loads a catalog name) and returns
 // the module name + required config + trust/risk info; it may block on the
@@ -50,8 +74,12 @@ type ModuleResolveResult struct {
 // install to proceed when the compose has a Critical risk; the page only sets it
 // when the user explicitly opts in.
 type ModuleInstallCallbacks struct {
-	Resolve func(source string) (ModuleResolveResult, error)
-	Install func(source string, overrides map[string]string, allowPrivileged bool) (installedName string, err error)
+	ListSources func() []ModuleSource
+	Resolve     func(source string) (ModuleResolveResult, error)
+	Install     func(source string, overrides map[string]string, allowPrivileged bool) (installedName string, err error)
+	// SelectSpecial switches the control center to the named in-app module page
+	// (e.g. "whatsapp"). Wired from Run() so the page needs no PageManager ref.
+	SelectSpecial func(name string)
 }
 
 // allowPrivilegedLabel is the form checkbox shown when a Critical risk is found.
@@ -74,9 +102,10 @@ type ModulePage struct {
 	cb  ModuleInstallCallbacks
 
 	// UI
-	root   *tview.Flex
-	form   *tview.Form
-	status *tview.TextView
+	root       *tview.Flex
+	sourceList *tview.List
+	form       *tview.Form
+	status     *tview.TextView
 
 	// State
 	mu       sync.Mutex
@@ -87,6 +116,7 @@ type ModulePage struct {
 	busyMsg  string
 	message  string // last success/info message
 	errMsg   string // last error message
+	sources  []ModuleSource
 }
 
 // NewModulePage creates an Install-module page wired to the given callbacks.
@@ -104,6 +134,13 @@ func (p *ModulePage) Title() string { return "Install Module" }
 func (p *ModulePage) Build(app *tview.Application) tview.Primitive {
 	p.app = app
 
+	// Known/approved sources list (left column). Pre-populated on activate so the
+	// user picks a module instead of typing a source into a blank input blind.
+	p.sourceList = tview.NewList().ShowSecondaryText(true)
+	p.sourceList.SetBorder(true)
+	p.sourceList.SetTitle(" Known modules ")
+	p.sourceList.SetTitleAlign(tview.AlignLeft)
+
 	p.form = tview.NewForm()
 	p.form.SetBorder(true)
 	p.form.SetTitle(" Install module ")
@@ -117,28 +154,173 @@ func (p *ModulePage) Build(app *tview.Application) tview.Primitive {
 	p.status.SetTitleAlign(tview.AlignLeft)
 
 	p.root = tview.NewFlex().SetDirection(tview.FlexColumn).
-		AddItem(p.form, 0, 1, true).
-		AddItem(p.status, 0, 1, false)
+		AddItem(p.sourceList, 0, 1, true).
+		AddItem(p.form, 0, 2, false).
+		AddItem(p.status, 0, 2, false)
 
 	p.buildSourceForm()
 	p.render()
 	return p.root
 }
 
-// OnActivate implements Page.
+// OnActivate implements Page. Seeds the sources list (fail-soft) and focuses it
+// so the user lands on the pre-populated picker, not a blank input.
 func (p *ModulePage) OnActivate() {
-	if p.app != nil && p.form != nil {
-		p.app.SetFocus(p.form)
+	p.loadSources()
+	if p.app != nil && p.sourceList != nil {
+		p.app.SetFocus(p.sourceList)
 	}
 }
 
 // OnDeactivate implements Page.
 func (p *ModulePage) OnDeactivate() {}
 
-// HandleInput implements Page. The page does not steal keys: the form's text
-// inputs and buttons (Resolve / Install / Reset / Back) handle everything, so the
-// user can type a source and config values freely.
+// loadSources fills the list from the ListSources hook. Each normal row, when
+// chosen, drops its source into the form input and focuses the form so the user
+// can Resolve/Install. A special row (e.g. WhatsApp) switches to that in-app
+// module page instead.
+func (p *ModulePage) loadSources() {
+	if p.sourceList == nil {
+		return
+	}
+	var srcs []ModuleSource
+	if p.cb.ListSources != nil {
+		srcs = p.cb.ListSources()
+	}
+	p.mu.Lock()
+	p.sources = srcs
+	p.mu.Unlock()
+
+	p.sourceList.Clear()
+	for _, s := range srcs {
+		primary := s.Name
+		if s.Trusted {
+			primary = "✓ " + primary
+		}
+		secondary := s.Description
+		sel := s // capture
+		p.sourceList.AddItem(primary, secondary, 0, func() { p.chooseSource(sel) })
+	}
+	if len(srcs) == 0 {
+		p.sourceList.AddItem("(no seeded modules)", "type a source in the form on the right", 0, nil)
+	}
+}
+
+// chooseSource applies a picked list row: a special row switches pages; a normal
+// row seeds the source input and moves focus to the form.
+func (p *ModulePage) chooseSource(s ModuleSource) {
+	if s.Special != "" {
+		if p.cb.SelectSpecial != nil {
+			p.cb.SelectSpecial(s.Special)
+		}
+		return
+	}
+	p.mu.Lock()
+	p.source = s.Source
+	p.mu.Unlock()
+	// Rebuild the source form so the seeded value shows in the input.
+	p.buildSourceForm()
+	if p.app != nil && p.form != nil {
+		p.app.SetFocus(p.form)
+	}
+	p.render()
+}
+
+// nextFormFocus computes the next focus index within a tview.Form's LINEAR focus
+// space (form items first, then buttons — matching Form.SetFocus). cur is the
+// current linear index, total is itemCount+buttonCount, and forward selects Tab
+// (true) vs Shift+Tab (false). It returns (nextIndex, atBoundary): atBoundary is
+// true when moving off the first (backward) or last (forward) element, which is
+// the signal to hand Tab off to the PageManager for tab-switching.
+//
+// Pure function so the actual reported bug — Tab wrongly leaving the form mid-way
+// vs correctly cycling fields — is unit-testable without a running app.
+func nextFormFocus(cur, total int, forward bool) (int, bool) {
+	if total <= 0 {
+		return cur, true
+	}
+	if forward {
+		if cur >= total-1 {
+			return cur, true
+		}
+		return cur + 1, false
+	}
+	if cur <= 0 {
+		return cur, true
+	}
+	return cur - 1, false
+}
+
+// currentFormFocus returns the current linear focus index of the form (items
+// first, then buttons), or 0 when nothing is focused yet.
+func (p *ModulePage) currentFormFocus() int {
+	if p.form == nil {
+		return 0
+	}
+	idx, btn := p.form.GetFocusedItemIndex()
+	if btn >= 0 {
+		return p.form.GetFormItemCount() + btn
+	}
+	if idx < 0 {
+		return 0
+	}
+	return idx
+}
+
+// formTotal returns the count of focusable form elements (fields + buttons).
+func (p *ModulePage) formTotal() int {
+	if p.form == nil {
+		return 0
+	}
+	return p.form.GetFormItemCount() + p.form.GetButtonCount()
+}
+
+// HandleInput implements Page. It OWNS intra-page Tab navigation (it must — a
+// SetInputCapture handler that returns the event to let the form cycle fields
+// natively would be intercepted by the PageManager's bubble check first, so the
+// page advances form focus itself and returns the event ONLY at the true
+// first/last boundary). Tab/Shift+Tab cycle sources list ↔ form fields ↔ tabs;
+// Escape defocuses the form back to the list so an input never traps the user.
 func (p *ModulePage) HandleInput(event *tcell.EventKey) *tcell.EventKey {
+	if p.app == nil {
+		return event
+	}
+	onList := p.app.GetFocus() == p.sourceList
+
+	switch event.Key() {
+	case tcell.KeyTab:
+		if onList {
+			// List → first form element.
+			p.app.SetFocus(p.form)
+			return nil
+		}
+		next, boundary := nextFormFocus(p.currentFormFocus(), p.formTotal(), true)
+		if boundary {
+			return event // hand off: PageManager switches to the next tab
+		}
+		p.form.SetFocus(next)
+		p.app.SetFocus(p.form)
+		return nil
+	case tcell.KeyBacktab:
+		if onList {
+			return event // hand off: PageManager switches to the previous tab
+		}
+		next, boundary := nextFormFocus(p.currentFormFocus(), p.formTotal(), false)
+		if boundary {
+			// Off the first form element → back to the sources list.
+			p.app.SetFocus(p.sourceList)
+			return nil
+		}
+		p.form.SetFocus(next)
+		p.app.SetFocus(p.form)
+		return nil
+	case tcell.KeyEsc:
+		if !onList {
+			p.app.SetFocus(p.sourceList)
+			return nil
+		}
+		return event
+	}
 	return event
 }
 
@@ -363,6 +545,8 @@ func (p *ModulePage) render() {
 
 	var sb strings.Builder
 	sb.WriteString("\n [yellow::b]Install a service module[-:-:-]\n\n")
+	sb.WriteString(" [gray]Pick a known module on the left (Enter), or type a[-]\n")
+	sb.WriteString(" [gray]source in the form. Tab moves list ↔ form ↔ tabs.[-]\n\n")
 	sb.WriteString(" Install a module from any standardized repo.\n")
 	sb.WriteString(" [gray]A module repo self-describes via citadel/service.yaml[-]\n")
 	sb.WriteString(" [gray]+ citadel/compose.yml. Sources:[-]\n")

--- a/internal/tui/controlcenter/module_page_test.go
+++ b/internal/tui/controlcenter/module_page_test.go
@@ -1,0 +1,114 @@
+package controlcenter
+
+import (
+	"testing"
+
+	"github.com/rivo/tview"
+)
+
+// TestModulePageLoadSourcesSeedsList asserts the module page pre-populates its
+// known-modules list from the ListSources hook, so the user picks from a seeded
+// list instead of typing a source into a blank input.
+func TestModulePageLoadSourcesSeedsList(t *testing.T) {
+	rows := []ModuleSource{
+		{Name: "vllm", Source: "vllm", Description: "GPU inference", Trusted: true},
+		{Name: "WhatsApp", Description: "community bridge", Trusted: true, Special: "whatsapp"},
+	}
+	p := NewModulePage(ModuleInstallCallbacks{
+		ListSources: func() []ModuleSource { return rows },
+	})
+	p.Build(tview.NewApplication())
+	p.loadSources()
+
+	if got := p.sourceList.GetItemCount(); got != 2 {
+		t.Fatalf("sourceList has %d items, want 2", got)
+	}
+	primary, _ := p.sourceList.GetItemText(0)
+	if primary != "✓ vllm" {
+		t.Errorf("row 0 primary = %q, want %q (trusted check prefix)", primary, "✓ vllm")
+	}
+}
+
+// TestModulePageLoadSourcesEmpty asserts a blank ListSources still renders a
+// non-empty, non-crashing placeholder row rather than an empty list.
+func TestModulePageLoadSourcesEmpty(t *testing.T) {
+	p := NewModulePage(ModuleInstallCallbacks{
+		ListSources: func() []ModuleSource { return nil },
+	})
+	p.Build(tview.NewApplication())
+	p.loadSources()
+
+	if got := p.sourceList.GetItemCount(); got != 1 {
+		t.Fatalf("empty sources rendered %d items, want 1 placeholder", got)
+	}
+}
+
+// TestModulePageChooseSpecialSwitchesPage asserts picking a special row (e.g.
+// WhatsApp) invokes SelectSpecial with the page name instead of running the
+// install form — this is how WhatsApp folds into the unified module list.
+func TestModulePageChooseSpecialSwitchesPage(t *testing.T) {
+	var switched string
+	p := NewModulePage(ModuleInstallCallbacks{
+		SelectSpecial: func(name string) { switched = name },
+	})
+	p.Build(tview.NewApplication())
+
+	p.chooseSource(ModuleSource{Name: "WhatsApp", Special: "whatsapp"})
+
+	if switched != "whatsapp" {
+		t.Errorf("SelectSpecial called with %q, want %q", switched, "whatsapp")
+	}
+}
+
+// TestModulePageChooseNormalSeedsInput asserts picking a normal row drops its
+// source into the page state (which the source form input then displays).
+func TestModulePageChooseNormalSeedsInput(t *testing.T) {
+	p := NewModulePage(ModuleInstallCallbacks{})
+	p.Build(tview.NewApplication())
+
+	p.chooseSource(ModuleSource{Name: "vllm", Source: "vllm"})
+
+	p.mu.Lock()
+	src := p.source
+	p.mu.Unlock()
+	if src != "vllm" {
+		t.Errorf("chooseSource seeded source = %q, want %q", src, "vllm")
+	}
+}
+
+// TestNextFormFocus covers the actual reported nav bug: Tab must cycle between
+// form fields/buttons and only hand off (atBoundary) at the true first/last
+// element, so a mid-form Tab never accidentally leaves the module tab.
+func TestNextFormFocus(t *testing.T) {
+	cases := []struct {
+		name         string
+		cur, total   int
+		forward      bool
+		wantNext     int
+		wantBoundary bool
+	}{
+		// A 3-element form (input + 2 buttons): Tab advances 0→1→2, boundary at 2.
+		{"forward field to button", 0, 3, true, 1, false},
+		{"forward button to button", 1, 3, true, 2, false},
+		{"forward at last is boundary", 2, 3, true, 2, true},
+		// Shift+Tab retreats 2→1→0, boundary at 0 (hand back to the list).
+		{"backward button to button", 2, 3, false, 1, false},
+		{"backward button to field", 1, 3, false, 0, false},
+		{"backward at first is boundary", 0, 3, false, 0, true},
+		// Degenerate: empty form is always a boundary in both directions.
+		{"empty forward", 0, 0, true, 0, true},
+		{"empty backward", 0, 0, false, 0, true},
+		// Single element: any Tab is a boundary.
+		{"single forward", 0, 1, true, 0, true},
+		{"single backward", 0, 1, false, 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			next, boundary := nextFormFocus(tc.cur, tc.total, tc.forward)
+			if next != tc.wantNext || boundary != tc.wantBoundary {
+				t.Errorf("nextFormFocus(%d, %d, %v) = (%d, %v), want (%d, %v)",
+					tc.cur, tc.total, tc.forward, next, boundary, tc.wantNext, tc.wantBoundary)
+			}
+		})
+	}
+}

--- a/internal/tui/controlcenter/whatsapp_page.go
+++ b/internal/tui/controlcenter/whatsapp_page.go
@@ -338,6 +338,8 @@ func (p *WhatsAppPage) render() {
 	sb.WriteString("\n [gray]──────────────────────────────[-]\n")
 	sb.WriteString("   [yellow::b]u[-:-:-] deploy/start    [yellow::b]d[-:-:-] stop\n")
 	sb.WriteString("   [yellow::b]q[-:-:-] refresh QR       [yellow::b]r[-:-:-] refresh\n")
+	sb.WriteString("   [gray]Community module — opened from the Install Module[-]\n")
+	sb.WriteString("   [gray]tab. Press Tab to return to the tab bar.[-]\n")
 
 	p.statusBox.SetText(sb.String())
 


### PR DESCRIPTION
## Context

Jason interactively tested the Control Center after #388/#390 and flagged four IA/navigation issues: navigation felt clunky (too many `alt+N` hotkeys to memorize), the Install-module page trapped focus and forced blind typing, WhatsApp had a redundant top-level tab, and Proxmox appeared as a top-level tab with no obvious reason. This PR makes the Control Center keyboard-first ("nothing to memorize" — the TORLINK feel from #388) and unifies module management.

Everything is reachable with **arrow keys + Tab**. `alt+N` stays as an optional accelerator; the mouse support from #390 is untouched.

## Summary

### 1. Smooth Tab/arrow navigation (primary), `alt+N` kept as accelerators

The load-bearing decision: **bubble-after-delegate**. `PageManager.HandleGlobalInput` delegates each key to the active page first, then bubbles an *unconsumed* `Tab`/`Shift+Tab` up to tab-switching. A page consumes Tab for its own intra-page focus movement (dashboard pane cycling, module list ↔ form) and returns it **unconsumed only at its navigation boundary** to hand off to the next/previous tab.

- **This makes the default correct**: a page that does nothing with Tab (e.g. `chat_page.go`, `settings_page.go`) gets tab-switching for free — which is exactly the "convention parallel agents rely on".
- **Dashboard** pane cycling now bubbles at the edges (Tab past the last pane advances to the next tab; Shift+Tab before the first pane falls back to the previous tab) instead of wrapping forever inside the dashboard.
- **`Escape` is not captured globally** — the dashboard's `Esc = quit-confirm` keybinding is preserved. "Escape defocuses an input back to nav" is a per-page rule (implemented in the module page).
- Help modal + help bar copy updated to teach Tab-first nav.

### 2. Install Module (`alt+6`): fix intra-page nav + seed approved sources

- **Seeded "Known modules" list**: a new `ListSources` callback pre-populates a selectable list from the catalog registry + curated module index (`moduleSourcesFromCatalog`), fail-soft to a small curated set (`vllm`, `ollama`, `comfyui`) when the catalog isn't cloned. The user picks a module instead of typing into a blank input blind.
- **Fixed the focus bug**: Tab now cycles **list → form fields → tabs**. The form *owns* Tab (a `SetInputCapture` handler that returned the event to let tview cycle fields natively would be intercepted by the bubble check first), advancing form focus itself via `nextFormFocus` and returning the event only at the true first/last boundary. `Escape` from the form returns focus to the list so an input never traps the user.

### 3. WhatsApp (`alt+5`) folded into the module list

WhatsApp is a community module, so its standalone tab is removed: the page is registered **hidden** and surfaced as a "WhatsApp (community module)" row in the module list that switches to it (via a `SelectSpecial` hook). All bridge functionality (deploy / stop / pairing QR) is preserved unchanged — only the entry point moved.

### 4. Proxmox (`alt+4`) — decision: **keep gate-on-detection, do NOT fold**

Investigation showed Proxmox is **already gated on real detection**: `buildProxmoxConfig()` returns `Enabled: true` only when saved Proxmox config exists **or** a local host is detected (`/etc/pve` + `pvesh` via `DetectProxmox()`), and `Run()` only registers the tab when enabled. So the "shows unconditionally" premise was false — it appeared for Jason because he has saved config or a detected host (that answers his "how is it detected?" question).

**Rationale for keeping the gate rather than folding:** Proxmox is host-infrastructure management, not an installable module. Folding it into the module list would misrepresent it. The gate is now expressed through a pure, testable `proxmoxTabVisible()` seam (also defends against an `Enabled`-but-empty-URL config).

## Test plan

| Test group | Coverage |
|---|---|
| `nextVisibleIndex` / `prevVisibleIndex` / round-trip | Tab-cycle order: skip hidden, wrap at ends, single/empty no-op |
| `nextFormFocus` | Form boundary: cycle fields/buttons, hand off only at first/last (the reported bug) |
| `moduleSourcesFromCatalog` | Seeding: registry trusted, index untrusted, dedupe (registry wins), empty → fallback |
| `proxmoxTabVisible` | Gate: shown only when detected (Enabled + BaseURL) |
| module-page (headless `tview.Application`) | List seeding, trusted-check prefix, empty placeholder, special-row switch, normal-row seed |

```
gofmt -l          → clean
go build ./...    → ok
go vet ./internal/tui/... ./cmd/...  → ok
go test ./internal/tui/... ./cmd/... → ok
```

`internal/status` `TestServerStartAndShutdown` fails with `bind: :8080 address already in use` — the known environmental flake (a live citadel node runs on the test host), unrelated to this change.

## Notes for parallel agents (shared convention)

Pages with **internal focusable elements** (multi-field forms) must own Tab and return the event only at their first/last boundary (see `ModulePage.HandleInput`). Pages whose controls are activated by single keys (`settings_page.go`, `whatsapp_page.go`) can ignore Tab and let it bubble — the default is correct for them. Tab registrations for `chat_page.go` / `settings_page.go` were left intact; only the tab list/order was adjusted (WhatsApp hidden).

**This is a draft** pending interactive verification of the live TUI (arrow/Tab feel, module picker, WhatsApp fold) on a real terminal.

## Related

- Follows #388 (mouse-clickable Control Center) and #390.
- Addresses Jason's post-#388 interactive feedback (all four IA/nav issues).
