### PR TITLE
fix(tui): apply the Fullscreen rendering pref at launch (#394)

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -277,9 +277,13 @@ func runControlCenter() {
 		},
 		// Resolve the initial mouse state: persisted preference with the
 		// --no-mouse flag applied as a session override.
-		MouseEnabled:  controlcenter.ResolveMouseEnabled(noMouse, config.LoadMouse(platform.ConfigDir()).Enabled),
-		WhatsApp:      buildWhatsAppCallbacks(),
-		ModuleInstall: buildModuleInstallCallbacks(),
+		MouseEnabled: controlcenter.ResolveMouseEnabled(noMouse, config.LoadMouse(platform.ConfigDir()).Enabled),
+		// Resolve the initial fullscreen-rendering state from the persisted
+		// preference (defaults on). Consumed once at launch in Run(); a
+		// mid-session toggle only applies on the next start.
+		FullscreenEnabled: config.LoadRendering(platform.ConfigDir()).Fullscreen,
+		WhatsApp:          buildWhatsAppCallbacks(),
+		ModuleInstall:     buildModuleInstallCallbacks(),
 	}
 
 	cc := controlcenter.New(cfg)

--- a/internal/tui/controlcenter/controlcenter.go
+++ b/internal/tui/controlcenter/controlcenter.go
@@ -571,6 +571,13 @@ type ControlCenter struct {
 	// can be flipped live from the Settings pane. Keyboard navigation is fully
 	// preserved regardless of this value — mouse is purely additive.
 	mouseEnabled bool
+
+	// Fullscreen rendering. fullscreenEnabled is the resolved initial state
+	// (persisted Rendering preference). Unlike mouse, tview/tcell cannot swap the
+	// terminal's alternate-screen mode on a live screen, so this is consumed once
+	// in Run() before the screen is created; toggling it from Settings persists
+	// the choice and takes effect on the next launch (restart to apply).
+	fullscreenEnabled bool
 }
 
 // Pane focus constants
@@ -645,6 +652,13 @@ type Config struct {
 	// terminal mouse reporting so tabs/rows/Send are clickable. Keyboard
 	// navigation works either way.
 	MouseEnabled bool
+
+	// FullscreenEnabled is the resolved initial fullscreen-rendering state (the
+	// persisted Rendering preference, defaulting to true). When true, the TUI
+	// uses the terminal's alternate screen buffer for flicker-free, app-like
+	// rendering; when false, output goes to normal scrollback. Applied once at
+	// launch in Run() because tcell cannot swap the mode on a live screen.
+	FullscreenEnabled bool
 }
 
 // ProxmoxConfig holds configuration for the Proxmox TUI page.
@@ -695,6 +709,7 @@ func New(cfg Config) *ControlCenter {
 		whatsappConfig:      cfg.WhatsApp,
 		moduleInstallConfig: cfg.ModuleInstall,
 		mouseEnabled:        cfg.MouseEnabled,
+		fullscreenEnabled:   cfg.FullscreenEnabled,
 	}
 }
 
@@ -765,6 +780,13 @@ func (cc *ControlCenter) HandleInput(event *tcell.EventKey) *tcell.EventKey {
 }
 
 func (cc *ControlCenter) Run() error {
+	// Apply the persisted fullscreen-rendering preference BEFORE creating the
+	// tview app: tcell reads TCELL_ALTSCREEN once, when Run() below inits the
+	// screen, so this is the launch-time consumer of the Rendering setting the
+	// Settings pane persists. tcell cannot swap alternate-screen mode on a live
+	// screen, so a mid-session toggle only takes effect on the next launch.
+	applyFullscreenRendering(cc.fullscreenEnabled)
+
 	cc.app = tview.NewApplication()
 
 	// Create page manager

--- a/internal/tui/controlcenter/rendering.go
+++ b/internal/tui/controlcenter/rendering.go
@@ -1,0 +1,41 @@
+package controlcenter
+
+import "os"
+
+// tcellAltScreenEnv is the tcell environment variable that gates use of the
+// terminal's alternate screen buffer. The vendored tcell reads it once, at
+// screen Init() time (inside tview's Application.Run), in the unix tScreen's
+// engage() path: when it equals "disable", tcell skips both entering
+// (EnterCA) and exiting (ExitCA) the alternate screen, so output goes to the
+// normal scrollback buffer instead of an app-like in-place repaint.
+//
+// This env var is the ONLY seam this tcell version exposes for the choice —
+// there is no public setter on the screen — so a launch-time consumer must set
+// it before Run() creates the screen. tview/tcell cannot swap the mode on a
+// live screen, which is why the Settings toggle persists the choice and the
+// apply happens at the next launch.
+const tcellAltScreenEnv = "TCELL_ALTSCREEN"
+
+// applyFullscreenRendering configures the process environment so the next tcell
+// screen honors the fullscreen preference, and returns the value it set
+// TCELL_ALTSCREEN to (empty string when unset) so callers can assert the effect
+// without a terminal.
+//
+// It is symmetric on purpose: when fullscreen is enabled it UNSETS the variable
+// (rather than merely skipping it) so a stale "disable" from an earlier context
+// cannot leak the scrollback mode into a fullscreen launch. When disabled it
+// sets "disable". This determinism is what makes the toggle round-trip
+// correctly and keeps the helper unit-testable.
+//
+// Pure with respect to its input (the bool): it reads no config and holds no
+// tview/tcell types, so the launch-time behavior can be exercised directly via
+// os.Getenv in tests. The screen-creation coupling lives entirely in tcell's
+// engage(); this helper only stages the flag it reads.
+func applyFullscreenRendering(fullscreen bool) string {
+	if fullscreen {
+		_ = os.Unsetenv(tcellAltScreenEnv)
+		return ""
+	}
+	_ = os.Setenv(tcellAltScreenEnv, "disable")
+	return "disable"
+}

--- a/internal/tui/controlcenter/rendering_test.go
+++ b/internal/tui/controlcenter/rendering_test.go
@@ -1,0 +1,108 @@
+package controlcenter
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/config"
+)
+
+// TestApplyFullscreenRendering asserts the launch-time consumer stages the
+// TCELL_ALTSCREEN flag that the vendored tcell reads at screen Init(): fullscreen
+// on clears it (alternate screen used), fullscreen off sets "disable" (output to
+// normal scrollback). This is the pure unit that "applies" the pref without a
+// terminal or a running app.
+func TestApplyFullscreenRendering(t *testing.T) {
+	cases := []struct {
+		name       string
+		seed       string // value of TCELL_ALTSCREEN before the call
+		fullscreen bool
+		wantEnv    string // "" means the var must be unset
+		wantReturn string
+	}{
+		{"fullscreen on unsets", "", true, "", ""},
+		{"fullscreen off sets disable", "", false, "disable", "disable"},
+		{"fullscreen on clears a stale disable", "disable", true, "", ""},
+		{"fullscreen off is idempotent", "disable", false, "disable", "disable"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// t.Setenv isolates and auto-restores the process env per subtest.
+			t.Setenv(tcellAltScreenEnv, tc.seed)
+			if tc.seed == "" {
+				// t.Setenv cannot set an empty-but-present value meaningfully for
+				// this test's "unset" seed, so clear it explicitly.
+				_ = os.Unsetenv(tcellAltScreenEnv)
+			}
+
+			got := applyFullscreenRendering(tc.fullscreen)
+			if got != tc.wantReturn {
+				t.Errorf("applyFullscreenRendering(%v) return = %q, want %q",
+					tc.fullscreen, got, tc.wantReturn)
+			}
+
+			env, present := os.LookupEnv(tcellAltScreenEnv)
+			if tc.wantEnv == "" {
+				if present {
+					t.Errorf("TCELL_ALTSCREEN present = %q, want unset", env)
+				}
+				return
+			}
+			if !present || env != tc.wantEnv {
+				t.Errorf("TCELL_ALTSCREEN = %q (present=%v), want %q",
+					env, present, tc.wantEnv)
+			}
+		})
+	}
+}
+
+// TestFullscreenPrefReadAndAppliedAtLaunch exercises the full launch path end to
+// end without a terminal: a persisted Rendering preference is read via
+// config.LoadRendering, resolved into Config.FullscreenEnabled (mirroring the cmd
+// wiring), carried onto the ControlCenter by New, and applied by the same helper
+// Run() invokes before creating the screen. It asserts both the ON and OFF
+// preferences reach the tcell flag correctly.
+func TestFullscreenPrefReadAndAppliedAtLaunch(t *testing.T) {
+	cases := []struct {
+		name       string
+		fullscreen bool
+		wantEnvSet bool // whether TCELL_ALTSCREEN=disable is expected after launch-apply
+	}{
+		{"saved fullscreen on -> alternate screen", true, false},
+		{"saved fullscreen off -> scrollback", false, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := config.SaveRendering(dir, &config.Rendering{Fullscreen: tc.fullscreen}); err != nil {
+				t.Fatalf("SaveRendering: %v", err)
+			}
+			// Sanity: the file exists so we are exercising the read path, not just
+			// the default.
+			if _, err := os.Stat(filepath.Join(dir, "rendering.yaml")); err != nil {
+				t.Fatalf("expected rendering.yaml written: %v", err)
+			}
+
+			// Resolve exactly as cmd/controlcenter.go does.
+			cc := New(Config{
+				FullscreenEnabled: config.LoadRendering(dir).Fullscreen,
+			})
+			if cc.fullscreenEnabled != tc.fullscreen {
+				t.Fatalf("cc.fullscreenEnabled = %v, want %v", cc.fullscreenEnabled, tc.fullscreen)
+			}
+
+			// Apply the same way Run() does, isolated from the real env.
+			t.Setenv(tcellAltScreenEnv, "")
+			_ = os.Unsetenv(tcellAltScreenEnv)
+			applyFullscreenRendering(cc.fullscreenEnabled)
+
+			env, present := os.LookupEnv(tcellAltScreenEnv)
+			gotDisabled := present && env == "disable"
+			if gotDisabled != tc.wantEnvSet {
+				t.Errorf("after launch-apply: TCELL_ALTSCREEN disabled = %v (%q, present=%v), want %v",
+					gotDisabled, env, present, tc.wantEnvSet)
+			}
+		})
+	}
+}

--- a/internal/tui/controlcenter/settings_page.go
+++ b/internal/tui/controlcenter/settings_page.go
@@ -254,10 +254,12 @@ func (p *SettingsPage) reloadRendering() {
 }
 
 // toggleFullscreen flips fullscreen rendering and persists it. tview cannot swap
-// the terminal's alternate-screen mode mid-run, so this only persists the choice
-// today — no live apply, and nothing consumes the pref at launch yet (the
-// screen-creation path is owned by controlcenter.go). SetFullscreenEnabled is the
-// nil-able seam a future launch-time consumer will fill; it is a no-op today.
+// the terminal's alternate-screen mode mid-run, so this persists the choice and
+// it takes effect on the next launch: the control center's Run() reads the saved
+// Rendering preference and stages TCELL_ALTSCREEN before creating the screen (see
+// applyFullscreenRendering). The inline hint tells the user to restart to apply.
+// SetFullscreenEnabled remains the nil-able live-apply seam; it is a no-op today
+// because a live screen cannot switch alternate-screen mode.
 func (p *SettingsPage) toggleFullscreen() {
 	if p.rendering == nil {
 		p.reloadRendering()
@@ -315,7 +317,7 @@ func (p *SettingsPage) renderWithError(errMsg string) {
 	fullscreenEnabled := p.rendering != nil && p.rendering.Fullscreen
 	sb.WriteString(fmt.Sprintf("   %s [white::b]Fullscreen rendering[-:-:-]     Flicker-free, app-like. Off = output goes to normal\n", checkbox(fullscreenEnabled)))
 	sb.WriteString("                                scrollback (easier to scroll + copy long history).\n")
-	sb.WriteString("   [gray]press[-] [yellow::b]f[-:-:-] [gray]to toggle (saved; full apply coming soon)[-]\n")
+	sb.WriteString("   [gray]press[-] [yellow::b]f[-:-:-] [gray]to toggle (saved; restart to apply)[-]\n")
 
 	enabled := p.telemetry != nil && p.telemetry.AnonTelemetryEnabled
 


### PR DESCRIPTION
## Context

Follow-up from #391 / #393 (Jason's TUI Mouse & Rendering feedback). The Control Center Settings pane shows a `[✓] Fullscreen rendering` toggle that persists a `Rendering{Fullscreen}` preference (`internal/config/rendering.go`, default ON), and #391 added a nil-able `SetFullscreenEnabled` seam. But **nothing consumed the pref** — toggling it changed the saved YAML and nothing else, so the in-TUI hint honestly read `(saved; full apply coming soon)`.

This PR wires the consumer so the preference actually changes how the TUI draws.

**Why it matters:** fullscreen ON uses the terminal's alternate screen buffer for a flicker-free, app-like screen (the default experience). OFF sends output to the normal scrollback buffer, which users who want to scroll and copy long history natively asked for. Until now that choice did nothing.

## Summary

**Launch-time consumer (the fix)**
- `Run()` now calls `applyFullscreenRendering(cc.fullscreenEnabled)` **before** creating the tview app. The vendored tcell reads `TCELL_ALTSCREEN` exactly once — at screen `Init()`, inside `Application.Run()` — in the unix `tScreen.engage()` path. When it equals `"disable"`, tcell skips both entering (`EnterCA`) and exiting (`ExitCA`) the alternate screen, so output goes to normal scrollback. This env var is the **only** seam this tcell version exposes for the choice (no public screen setter), so staging it before `Run()` is the correct and sufficient mechanism.
- The helper (`internal/tui/controlcenter/rendering.go`) is **symmetric and deterministic**: fullscreen ON `Unsetenv`s the flag (so a stale `"disable"` from any earlier context can't leak scrollback mode into a fullscreen launch); fullscreen OFF sets `"disable"`. This determinism is what makes the toggle round-trip correctly.

**Wiring (mirrors the `MouseEnabled` path)**
- New `Config.FullscreenEnabled bool`; `cmd/controlcenter.go` resolves it as `config.LoadRendering(platform.ConfigDir()).Fullscreen`. This keeps `controlcenter.go` free of `platform`/config-dir imports, matching the deliberate separation the `MouseEnabled` path already uses (`SettingsCallbacks` are "wired from cmd so the page never imports platform/config-dir logic").

**Live vs launch (honest, no faking)**
- tcell/tview **cannot** swap alternate-screen mode on a live screen, so a mid-session toggle **persists and applies on the next launch**. The Settings hint now reads `(saved; restart to apply)` instead of `(saved; full apply coming soon)`.
- `SetFullscreenEnabled` stays a nil-able seam — it is **not** wired to fake a live re-init. The stretch goal (true live re-init) is not feasible with this tcell version, so it is intentionally not attempted.

## Test plan

| Test | Coverage |
| --- | --- |
| `TestApplyFullscreenRendering` (4 cases) | ON unsets the flag; OFF sets `"disable"`; ON clears a stale `"disable"`; OFF is idempotent |
| `TestFullscreenPrefReadAndAppliedAtLaunch` (2 cases) | End-to-end launch path: `SaveRendering` -> `LoadRendering` -> `Config.FullscreenEnabled` -> `New` -> apply; asserts the pref reaches the tcell flag for both ON and OFF |
| `TestSettingsToggleFullscreen_*` (pre-existing) | Toggle still persists + preserves state on save error |

Verification (in an isolated worktree; the live node on this host was left untouched — no `login`/`init`/`work`):

- `gofmt -l` — clean
- `go build ./...` — pass
- `go vet ./internal/tui/... ./internal/config/... ./cmd/...` — pass
- `go test ./internal/tui/... ./internal/config/...` — pass
- Full `go test ./...` — only the known environmental `internal/status` `:8080` bind flake fails (a live node holds the port), unrelated to this change

## Related

- Follows #391 (Mouse & Rendering settings panel), #393 (TUI nav unify)
- Closes #394