### PR TITLE
fix(tui): Chat Tab bubbles at pane edge so the user can leave (fixes the #392/#393 trap)

### DIFF
--- a/internal/tui/controlcenter/chat_page.go
+++ b/internal/tui/controlcenter/chat_page.go
@@ -385,11 +385,20 @@ func (p *ChatPage) HandleInput(event *tcell.EventKey) *tcell.EventKey {
 		}
 		return nil
 	case chatKeyNextPane:
-		p.focusNextPane()
-		return nil
+		// Cycle forward among chat panes; at the LAST pane focus doesn't move,
+		// so return the (unconsumed) event and let HandleGlobalInput switch to
+		// the next tab — that is how the user leaves the Chat tab by keyboard.
+		if p.focusNextPane() {
+			return nil
+		}
+		return event
 	case chatKeyPrevPane:
-		p.focusPrevPane()
-		return nil
+		// Cycle backward; at the FIRST pane bubble the event so HandleGlobalInput
+		// falls back to the previous tab.
+		if p.focusPrevPane() {
+			return nil
+		}
+		return event
 	default:
 		return event
 	}
@@ -403,8 +412,20 @@ func (p *ChatPage) chatPanes() []tview.Primitive {
 
 // nextChatPaneIndex computes the index of the pane to focus next, cycling
 // forward (delta=+1) or backward (delta=-1) from the currently focused pane.
+//
+// Unlike a wrapping cycle, this bubbles at the pane edge so the user can leave
+// the Chat tab with the same Tab/Shift+Tab that navigates within it (the shared
+// navigation convention in HandleGlobalInput): moving forward past the LAST pane
+// returns an out-of-range index (== count) and moving backward before the FIRST
+// pane returns -1. The caller treats any out-of-range result as "past the edge"
+// and returns the key event UNCONSUMED so HandleGlobalInput switches tabs. This
+// is what un-traps the Chat tab — the previous wrapping cycle (input->messages->
+// peers->channels->input forever) always consumed Tab and never bubbled.
+//
 // Pure and testable: `focused` is the index of the currently focused pane, or
-// -1 when focus is elsewhere (in which case we start at the input).
+// -1 when focus is elsewhere. When focus is elsewhere we do NOT bubble — we
+// enter the pane list at the input (forward) or the last pane (backward), so a
+// Tab from the off-list sendButton lands on a pane rather than leaving the tab.
 func nextChatPaneIndex(focused, count, delta int) int {
 	if count == 0 {
 		return -1
@@ -415,7 +436,9 @@ func nextChatPaneIndex(focused, count, delta int) int {
 		}
 		return count - 1
 	}
-	return ((focused+delta)%count + count) % count
+	// Deliberately no modulo wrap: forward-from-last yields count and
+	// backward-from-first yields -1, both out of range, signalling "bubble".
+	return focused + delta
 }
 
 // currentChatPaneIndex returns the index of the currently focused chat pane, or
@@ -433,19 +456,26 @@ func (p *ChatPage) currentChatPaneIndex() int {
 	return -1
 }
 
-func (p *ChatPage) cycleChatPane(delta int) {
+// cycleChatPane moves focus to the next/previous chat pane. It reports whether
+// focus actually moved: false means the target index is past the pane edge (or
+// there are no panes), i.e. the caller should bubble the key up for tab
+// switching rather than consuming it. Guarding BOTH ends is load-bearing — the
+// forward bubble sentinel is `len(panes)` (a positive, in-range-looking value),
+// so a lone `idx < 0` check would index panes[len(panes)] and panic.
+func (p *ChatPage) cycleChatPane(delta int) bool {
 	panes := p.chatPanes()
 	idx := nextChatPaneIndex(p.currentChatPaneIndex(), len(panes), delta)
-	if idx < 0 {
-		return
+	if idx < 0 || idx >= len(panes) {
+		return false
 	}
 	if p.app != nil {
 		p.app.SetFocus(panes[idx])
 	}
+	return true
 }
 
-func (p *ChatPage) focusNextPane() { p.cycleChatPane(1) }
-func (p *ChatPage) focusPrevPane() { p.cycleChatPane(-1) }
+func (p *ChatPage) focusNextPane() bool { return p.cycleChatPane(1) }
+func (p *ChatPage) focusPrevPane() bool { return p.cycleChatPane(-1) }
 
 // connect establishes the chat client connection.
 func (p *ChatPage) connect() {

--- a/internal/tui/controlcenter/chat_page_test.go
+++ b/internal/tui/controlcenter/chat_page_test.go
@@ -39,19 +39,29 @@ func TestClassifyChatKey_ReleasesNavigationKeys(t *testing.T) {
 	}
 }
 
-// TestNextChatPaneIndex covers forward/backward cycling and the "focus not on a
-// chat pane yet" (-1) start case.
+// TestNextChatPaneIndex covers the edge-bubble navigation: Tab cycles panes in
+// the MIDDLE of the list but, instead of wrapping, returns an out-of-range index
+// at the edges (count forward-past-last, -1 backward-before-first) so the caller
+// bubbles the key up and the user leaves the Chat tab. It also covers the
+// "focus not on a chat pane yet" start case (which enters the list, never
+// bubbles) and the empty-panes guard.
 func TestNextChatPaneIndex(t *testing.T) {
-	const count = 4
+	const count = 4 // panes: input, messages, peers, channels
 	tests := []struct {
 		name           string
 		focused, delta int
 		want           int
 	}{
-		{"forward from input", 0, 1, 1},
-		{"forward wraps to input", count - 1, 1, 0},
-		{"backward from input wraps to last", 0, -1, count - 1},
-		{"backward from second", 1, -1, 0},
+		// Middle-of-list cycling (focus moves, stays in range).
+		{"forward from input to messages", 0, 1, 1},
+		{"forward from messages to peers", 1, 1, 2},
+		{"forward from peers to channels", 2, 1, 3},
+		{"backward from channels to peers", 3, -1, 2},
+		{"backward from messages to input", 1, -1, 0},
+		// Edge bubbles: out-of-range signals "leave the tab".
+		{"forward at last pane bubbles (== count)", count - 1, 1, count},
+		{"backward at first pane bubbles (== -1)", 0, -1, -1},
+		// Focus not yet on a chat pane: enter the list, do NOT bubble.
 		{"no focus forward starts at input", -1, 1, 0},
 		{"no focus backward starts at last", -1, -1, count - 1},
 	}
@@ -65,6 +75,20 @@ func TestNextChatPaneIndex(t *testing.T) {
 	}
 	if got := nextChatPaneIndex(0, 0, 1); got != -1 {
 		t.Errorf("nextChatPaneIndex with zero panes = %d, want -1", got)
+	}
+}
+
+// TestNextChatPaneIndex_EdgeResultsAreBubbles asserts the contract the caller
+// relies on: at a pane edge the returned index is out of [0, count), which
+// cycleChatPane treats as "past the edge -> bubble" (and, critically, guards so
+// the positive forward sentinel `count` never indexes panes[count] and panics).
+func TestNextChatPaneIndex_EdgeResultsAreBubbles(t *testing.T) {
+	const count = 4
+	if idx := nextChatPaneIndex(count-1, count, 1); idx >= 0 && idx < count {
+		t.Errorf("forward-at-last idx = %d, want out of [0,%d) to bubble", idx, count)
+	}
+	if idx := nextChatPaneIndex(0, count, -1); idx >= 0 && idx < count {
+		t.Errorf("backward-at-first idx = %d, want out of [0,%d) to bubble", idx, count)
 	}
 }
 


### PR DESCRIPTION
## Context

The Control Center **Chat** tab (#388 introduced it; #392 tried to fix the keyboard trap; #393 defined the shared Tab-to-switch-tabs navigation model) *still* trapped the keyboard. A user on the Chat tab could not leave by keyboard: Tab just cycled the chat's own panes forever, Escape only defocused the input to the message view (still on the tab), and `alt+2` was a no-op because 2 **is** the Chat tab. The only escape was the mouse.

### Root cause: wrap vs. bubble

`internal/tui/controlcenter/chat_page.go` classified `Tab -> chatKeyNextPane` / `Shift+Tab -> chatKeyPrevPane`, and the pane cycler used `nextChatPaneIndex`, which **wrapped**:

```go
return ((focused+delta)%count + count) % count
```

So Tab cycled the four chat panes `input -> messages -> peers -> channels -> input` **forever**, and `HandleInput` **always returned `nil` (consumed)**. The event therefore never bubbled up to `PageManager.HandleGlobalInput`, whose navigation model (#393) is:

> keys go to the active page's `HandleInput` first; an **unconsumed** `Tab`/`Shift+Tab` returned from the page bubbles up and switches to the next/prev **tab**.

A wrapping cycle that always consumes Tab can never hand off at its edge, so the user is pinned to the Chat tab.

## Summary

Make Chat Tab/Shift+Tab **bubble at the pane edge** instead of wrapping, composing cleanly with `HandleGlobalInput`:

| Change | What & why |
| --- | --- |
| `nextChatPaneIndex` | Drops the modulo wrap. Forward-past-last returns `count`, backward-before-first returns `-1` — both **out of range**, signalling "past the edge". The `focused < 0` (focus elsewhere, e.g. the off-list Send button) branch is unchanged: it enters the pane list rather than bubbling. Stays pure + table-testable. |
| `cycleChatPane` | Now returns `bool` (true = focus moved, false = bubble) and guards **both** ends (`idx < 0 || idx >= len(panes)`). The forward sentinel `count` is a positive, in-range-*looking* value, so a lone `idx < 0` check would index `panes[count]` and **panic** the TUI. |
| `HandleInput` | On `chatKeyNextPane`/`chatKeyPrevPane`, returns `nil` when focus moved, else returns the **unconsumed** original `event` so `HandleGlobalInput`'s `switch out.Key()` sees `Tab`/`Backtab` and switches tabs. |

Result: `Tab` cycles `input -> messages -> peers -> channels`; at **channels** (last) it bubbles to the next tab. `Shift+Tab` cycles backward; at **input** (first) it bubbles to the previous tab.

**Unchanged (verified):** `Escape` = defocus input -> message view; `PgUp`/`PgDn` = scroll history; `Enter` = send; printable text passthrough; `Alt+<rune>` passthrough. Mouse focus-on-click (#390) is untouched.

**Alt accelerators need no change.** `HandleGlobalInput` catches `Alt+digit` **before** delegating to the page (returns `nil` immediately), so chat's `HandleInput` never sees it — `alt+N` to a *different* tab already leaves Chat. The `classifyChatKey` Alt-passthrough is belt-and-suspenders for `Alt+<non-digit>`. The user's `alt+2` failed only because **2 is the Chat tab's own accelerator** (a no-op).

## Test plan

`go test ./internal/tui/...` passes. (`internal/status` `:8080` bind flake is environmental and not run here.)

Extended `TestNextChatPaneIndex` for the new edge-bubble contract:

| Case | Expect |
| --- | --- |
| forward middle (input->messages, messages->peers, peers->channels) | in-range next index (cycle) |
| backward middle (channels->peers, messages->input) | in-range prev index (cycle) |
| forward at last pane | `count` (out of range -> bubble) |
| backward at first pane | `-1` (out of range -> bubble) |
| no focus forward / backward | enter list at input / last (never bubble) |
| zero panes | `-1` (guard) |

Added `TestNextChatPaneIndex_EdgeResultsAreBubbles` asserting edge results fall outside `[0, count)` (the caller's bubble/no-panic contract). Existing `TestClassifyChatKey_ReleasesNavigationKeys` still passes (Tab/Shift+Tab/Escape/PgUp/PgDn/Alt classification unchanged).

## Test plan (manual — acceptance)

- [ ] On the Chat tab with the input focused, press `Tab` repeatedly: focus walks input -> messages -> peers -> channels, then the **next tab** activates.
- [ ] Press `Shift+Tab` from the input: the **previous tab** activates.
- [ ] `Escape` defocuses to the message view; `Enter` sends; typing works; `PgUp`/`PgDn` scroll history.
- [ ] `alt+<other tab number>` jumps straight out of Chat.

## Related

- #388 — Chat tab introduced
- #392 — prior (incomplete) keyboard-trap fix
- #393 — shared Tab/Shift+Tab tab-switch navigation model this composes with
- #390 — mouse focus-on-click (kept intact)
