### PR TITLE
feat(tui/proxmox): show config path + in-app "forget Proxmox" (disconnect a stale saved connection)

### DIFF
--- a/cmd/proxmox.go
+++ b/cmd/proxmox.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
@@ -16,6 +18,7 @@ var (
 	proxmoxURL         string
 	proxmoxTokenID     string
 	proxmoxTokenSecret string
+	proxmoxForgetYes   bool
 )
 
 var proxmoxCmd = &cobra.Command{
@@ -58,13 +61,29 @@ var proxmoxStatusCmd = &cobra.Command{
 	RunE:  runProxmoxStatus,
 }
 
+var proxmoxForgetCmd = &cobra.Command{
+	Use:   "forget",
+	Short: "Forget the saved Proxmox connection",
+	Long: `Delete the saved Proxmox configuration file (proxmox.json).
+
+The Control Center shows a Proxmox tab whenever a saved config exists, even if
+this machine isn't a Proxmox host — the config may point at a remote server.
+Forgetting the connection removes that file so the tab no longer appears.
+
+The config file path is printed before deletion. Use --yes to skip the prompt.`,
+	RunE: runProxmoxForget,
+}
+
 func init() {
 	proxmoxSetupCmd.Flags().StringVar(&proxmoxURL, "url", "", "Proxmox VE URL (e.g., https://192.168.2.4:8006)")
 	proxmoxSetupCmd.Flags().StringVar(&proxmoxTokenID, "token-id", "", "API token ID (e.g., root@pam!citadel)")
 	proxmoxSetupCmd.Flags().StringVar(&proxmoxTokenSecret, "token-secret", "", "API token secret (UUID)")
 
+	proxmoxForgetCmd.Flags().BoolVar(&proxmoxForgetYes, "yes", false, "Skip the confirmation prompt.")
+
 	proxmoxCmd.AddCommand(proxmoxSetupCmd)
 	proxmoxCmd.AddCommand(proxmoxStatusCmd)
+	proxmoxCmd.AddCommand(proxmoxForgetCmd)
 	rootCmd.AddCommand(proxmoxCmd)
 }
 
@@ -172,6 +191,8 @@ func runProxmoxSetup(cmd *cobra.Command, args []string) error {
 func runProxmoxStatus(cmd *cobra.Command, args []string) error {
 	configDir := platform.ConfigDir()
 
+	fmt.Printf("Config: %s\n", pmx.ConfigPath(configDir))
+
 	client, err := pmx.ClientFromConfig(configDir)
 	if err != nil {
 		return fmt.Errorf("loading config: %w", err)
@@ -258,6 +279,47 @@ func runProxmoxStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func runProxmoxForget(cmd *cobra.Command, args []string) error {
+	configDir := platform.ConfigDir()
+	path := pmx.ConfigPath(configDir)
+
+	bold := color.New(color.Bold)
+	green := color.New(color.FgGreen)
+
+	cfg, _ := pmx.LoadConfig(configDir)
+	if cfg == nil || cfg.BaseURL == "" {
+		fmt.Printf("No saved Proxmox connection to forget (looked for %s).\n", path)
+		return nil
+	}
+
+	bold.Println("Forget saved Proxmox connection")
+	fmt.Printf("  Base URL: %s\n", cfg.BaseURL)
+	fmt.Printf("  Config:   %s\n", path)
+
+	if !proxmoxForgetYes && !proxmoxConfirm(fmt.Sprintf("\nDelete %s?", path)) {
+		fmt.Println("Aborted.")
+		return nil
+	}
+
+	if err := pmx.DeleteConfig(configDir); err != nil {
+		return fmt.Errorf("forgetting proxmox connection: %w", err)
+	}
+
+	green.Printf("Forgot Proxmox connection. Deleted %s\n", path)
+	fmt.Println("The Control Center Proxmox tab will no longer appear (unless this host is itself a Proxmox node).")
+	return nil
+}
+
+// proxmoxConfirm reads a single yes/no line from stdin and reports whether it
+// is affirmative. The default is no.
+func proxmoxConfirm(question string) bool {
+	fmt.Printf("%s (y/N) ", question)
+	reader := bufio.NewReader(os.Stdin)
+	resp, _ := reader.ReadString('\n')
+	resp = strings.TrimSpace(strings.ToLower(resp))
+	return resp == "y" || resp == "yes"
 }
 
 func pmxFormatDuration(seconds int64) string {

--- a/internal/proxmox/config.go
+++ b/internal/proxmox/config.go
@@ -17,14 +17,17 @@ type Config struct {
 	NodeName    string `json:"node_name,omitempty"`
 }
 
-func configPath(configDir string) string {
+// ConfigPath returns the absolute path of the Proxmox config file for the
+// given config directory. This is the file that drives the Proxmox tab in the
+// Control Center: when it exists (and has a base URL), the tab is shown.
+func ConfigPath(configDir string) string {
 	return filepath.Join(configDir, configFileName)
 }
 
 // LoadConfig reads the Proxmox config from the given config directory.
 // Returns nil, nil if the file does not exist.
 func LoadConfig(configDir string) (*Config, error) {
-	path := configPath(configDir)
+	path := ConfigPath(configDir)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -51,9 +54,24 @@ func SaveConfig(configDir string, cfg *Config) error {
 		return fmt.Errorf("marshalling proxmox config: %w", err)
 	}
 
-	path := configPath(configDir)
+	path := ConfigPath(configDir)
 	if err := os.WriteFile(path, data, 0600); err != nil {
 		return fmt.Errorf("writing proxmox config: %w", err)
+	}
+	return nil
+}
+
+// DeleteConfig removes the saved Proxmox config file from the given config
+// directory. A missing file is treated as success (the connection is already
+// forgotten). This is what powers the "forget Proxmox" affordance: it deletes
+// the file that drives the Proxmox tab so it no longer appears on restart.
+func DeleteConfig(configDir string) error {
+	path := ConfigPath(configDir)
+	if err := os.Remove(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("removing proxmox config: %w", err)
 	}
 	return nil
 }

--- a/internal/proxmox/config_test.go
+++ b/internal/proxmox/config_test.go
@@ -1,0 +1,52 @@
+package proxmox
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestConfigPath(t *testing.T) {
+	dir := "/home/user/.citadel-cli"
+	got := ConfigPath(dir)
+	want := filepath.Join(dir, "proxmox.json")
+	if got != want {
+		t.Fatalf("ConfigPath(%q) = %q, want %q", dir, got, want)
+	}
+}
+
+func TestDeleteConfig_RemovesExistingFile(t *testing.T) {
+	dir := t.TempDir()
+
+	cfg := &Config{BaseURL: "https://192.168.2.4:8006", NodeName: "pve"}
+	if err := SaveConfig(dir, cfg); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	path := ConfigPath(dir)
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected config file to exist before delete: %v", err)
+	}
+
+	if err := DeleteConfig(dir); err != nil {
+		t.Fatalf("DeleteConfig: %v", err)
+	}
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected config file to be removed, stat err = %v", err)
+	}
+}
+
+func TestDeleteConfig_NotExistIsSuccess(t *testing.T) {
+	dir := t.TempDir()
+
+	// No config file was ever written; deleting it should be a no-op success.
+	if err := DeleteConfig(dir); err != nil {
+		t.Fatalf("DeleteConfig on missing file should succeed, got: %v", err)
+	}
+
+	// Calling it twice remains a success.
+	if err := DeleteConfig(dir); err != nil {
+		t.Fatalf("second DeleteConfig should still succeed, got: %v", err)
+	}
+}

--- a/internal/tui/controlcenter/controlcenter.go
+++ b/internal/tui/controlcenter/controlcenter.go
@@ -415,9 +415,11 @@ func (pm *PageManager) Build() *tview.Flex {
 // F-keys are avoided because terminal emulators (Terminator, etc.) intercept them.
 func (pm *PageManager) HandleGlobalInput(event *tcell.EventKey) *tcell.EventKey {
 	if pm.isModalActive != nil && pm.isModalActive() {
-		if pm.activeIdx >= 0 && pm.activeIdx < len(pm.registered) {
-			return pm.registered[pm.activeIdx].page.HandleInput(event)
-		}
+		// A modal owns the screen: pass the event straight through to the focused
+		// modal primitive instead of the active page. Pages that trigger a modal
+		// (e.g. the Proxmox tab's [D]=forget confirm) must not keep eating keys, or
+		// the modal buttons never receive Enter/arrows. The dashboard page's own
+		// HandleInput already bails while inModal, so this is equivalent for it.
 		return event
 	}
 
@@ -827,7 +829,9 @@ func (cc *ControlCenter) Run() error {
 		cc.pmgr.Register(NewProxmoxPage(ProxmoxPageConfig{
 			Client:     pmxClient,
 			NodeName:   cc.proxmoxConfig.NodeName,
+			ConfigDir:  platform.ConfigDir(),
 			ActivityFn: cc.AddActivity,
+			ConfirmFn:  cc.showConfirm,
 		}), true)
 	}
 
@@ -1573,6 +1577,39 @@ func (cc *ControlCenter) restartSelectedService() {
 			}
 		}()
 	}
+}
+
+// showConfirm displays a modal yes/no confirmation dialog. It captures the
+// currently-focused primitive before taking over the root, and restores both
+// the root view and that focus when the user answers — so callers on a
+// PageManager page (e.g. the Proxmox tab) return to their page rather than the
+// dashboard. onConfirm runs only if the user picks the affirmative button.
+func (cc *ControlCenter) showConfirm(prompt, confirmLabel string, onConfirm func()) {
+	cc.inModal = true
+	prevFocus := cc.app.GetFocus()
+
+	restore := func() {
+		cc.inModal = false
+		cc.app.SetRoot(cc.rootView, true)
+		if prevFocus != nil {
+			cc.app.SetFocus(prevFocus)
+		} else {
+			cc.updatePaneFocus()
+		}
+	}
+
+	modal := tview.NewModal().
+		SetText(prompt).
+		AddButtons([]string{"Cancel", confirmLabel}).
+		SetDoneFunc(func(buttonIndex int, buttonLabel string) {
+			restore()
+			if buttonLabel == confirmLabel {
+				onConfirm()
+			}
+		})
+
+	cc.app.SetRoot(modal, true)
+	cc.app.SetFocus(modal)
 }
 
 // showServiceLogs shows recent logs for the selected service

--- a/internal/tui/controlcenter/proxmox_page.go
+++ b/internal/tui/controlcenter/proxmox_page.go
@@ -22,12 +22,18 @@ type ProxmoxPage struct {
 	app   *tview.Application
 
 	// Proxmox client
-	client   *proxmox.Client
-	nodeName string // Proxmox node to query
+	client    *proxmox.Client
+	nodeName  string // Proxmox node to query
+	configDir string // dir holding proxmox.json (drives this tab)
+
+	// confirmFn shows a modal yes/no dialog. Wired from the ControlCenter so the
+	// page can prompt for destructive actions (forget) without owning root/focus.
+	confirmFn func(prompt, confirmLabel string, onConfirm func())
 
 	// UI components
 	root       *tview.Flex
 	statusView *tview.TextView
+	configView *tview.TextView
 	guestTable *tview.Table
 	detailView *tview.TextView
 	helpBar    *tview.TextView
@@ -47,7 +53,11 @@ type ProxmoxPage struct {
 type ProxmoxPageConfig struct {
 	Client     *proxmox.Client
 	NodeName   string // Proxmox node name (auto-detected if empty)
+	ConfigDir  string // dir holding proxmox.json (for path display + forget)
 	ActivityFn func(level, msg string)
+	// ConfirmFn shows a modal yes/no dialog for destructive actions. Optional:
+	// when nil, the forget action logs guidance instead of prompting.
+	ConfirmFn func(prompt, confirmLabel string, onConfirm func())
 }
 
 // NewProxmoxPage creates a new Proxmox management page.
@@ -61,7 +71,9 @@ func NewProxmoxPage(cfg ProxmoxPageConfig) *ProxmoxPage {
 		title:      "Proxmox",
 		client:     cfg.Client,
 		nodeName:   cfg.NodeName,
+		configDir:  cfg.ConfigDir,
 		activityFn: activityFn,
+		confirmFn:  cfg.ConfirmFn,
 	}
 }
 
@@ -75,6 +87,14 @@ func (p *ProxmoxPage) Build(app *tview.Application) tview.Primitive {
 	p.statusView = tview.NewTextView().
 		SetDynamicColors(true).
 		SetTextAlign(tview.AlignLeft)
+
+	// Config-path line: makes it obvious which file drives this tab and where to
+	// manage it. This is the "how is it detecting the VMs?" answer — a saved
+	// proxmox.json pointing at a (possibly remote) host.
+	p.configView = tview.NewTextView().
+		SetDynamicColors(true).
+		SetTextAlign(tview.AlignLeft)
+	p.configView.SetText(proxmoxConfigLine(p.configDir, proxmox.IsConfigured(p.configDir)))
 
 	// Guest table (main content)
 	p.guestTable = tview.NewTable().
@@ -99,7 +119,7 @@ func (p *ProxmoxPage) Build(app *tview.Application) tview.Primitive {
 	p.helpBar = tview.NewTextView().
 		SetDynamicColors(true).
 		SetTextAlign(tview.AlignLeft)
-	p.helpBar.SetText(" [yellow]s[-]=start  [yellow]S[-]=shutdown  [yellow]k[-]=force stop  [yellow]r[-]=reboot  [yellow]c[-]=console  [yellow]Enter[-]=details  [yellow]R[-]=refresh")
+	p.helpBar.SetText(" [yellow]s[-]=start  [yellow]S[-]=shutdown  [yellow]k[-]=force stop  [yellow]r[-]=reboot  [yellow]c[-]=console  [yellow]Enter[-]=details  [yellow]R[-]=refresh  [yellow]D[-]=forget")
 
 	// Main layout: table on left, detail on right
 	contentFlex := tview.NewFlex().SetDirection(tview.FlexColumn).
@@ -108,6 +128,7 @@ func (p *ProxmoxPage) Build(app *tview.Application) tview.Primitive {
 
 	p.root = tview.NewFlex().SetDirection(tview.FlexRow).
 		AddItem(p.statusView, 1, 0, false).
+		AddItem(p.configView, 1, 0, false).
 		AddItem(contentFlex, 0, 1, true).
 		AddItem(p.helpBar, 1, 0, false)
 
@@ -156,6 +177,9 @@ func (p *ProxmoxPage) HandleInput(event *tcell.EventKey) *tcell.EventKey {
 			return nil
 		case 'R':
 			go p.refreshData()
+			return nil
+		case 'D':
+			p.forgetConnection()
 			return nil
 		}
 	}
@@ -570,6 +594,63 @@ func (p *ProxmoxPage) openConsole() {
 	if err := platform.OpenURL(consoleURL); err != nil {
 		p.activityFn("error", fmt.Sprintf("Failed to open browser: %v", err))
 	}
+}
+
+// forgetConnection prompts to delete the saved Proxmox config and, on confirm,
+// removes proxmox.json. The tab is built once at startup from the saved config,
+// so it stays until the next restart — we tell the user that explicitly rather
+// than faking a live hide.
+func (p *ProxmoxPage) forgetConnection() {
+	path := proxmox.ConfigPath(p.configDir)
+
+	// The tab can also appear because this host is a detected Proxmox node with
+	// no saved file. There is nothing to forget in that case — deleting a
+	// nonexistent file would not hide the tab (detection still applies).
+	if !proxmox.IsConfigured(p.configDir) {
+		p.activityFn("info", "This host is a detected Proxmox node — there is no saved connection file to forget.")
+		return
+	}
+
+	baseURL := ""
+	if p.client != nil {
+		baseURL = p.client.BaseURL()
+	}
+	target := baseURL
+	if target == "" {
+		target = "this Proxmox host"
+	}
+
+	doForget := func() {
+		if err := proxmox.DeleteConfig(p.configDir); err != nil {
+			p.activityFn("error", fmt.Sprintf("Failed to forget Proxmox connection: %v", err))
+			return
+		}
+		p.activityFn("success", fmt.Sprintf("Forgot Proxmox connection to %s — deleted %s. Restart Citadel to hide the tab.", target, path))
+	}
+
+	if p.confirmFn == nil {
+		// No modal host wired (e.g. tests): fall back to guidance instead of
+		// silently deleting without confirmation.
+		p.activityFn("info", fmt.Sprintf("To forget this Proxmox connection, run: citadel proxmox forget  (config: %s)", path))
+		return
+	}
+
+	prompt := fmt.Sprintf(
+		"Forget the saved Proxmox connection to %s?\n\nThis deletes %s.\nThe tab is hidden after restart.",
+		target, path)
+	p.confirmFn(prompt, "Forget", doForget)
+}
+
+// proxmoxConfigLine renders the config-path header shown on the Proxmox page.
+// The tab appears either because a saved proxmox.json exists (hasSavedConfig) or
+// because this host is itself a detected Proxmox node with no saved file. Only
+// the saved-config case has a file to forget, so the [D]=forget affordance is
+// shown only then; the detected case explains why there is nothing to remove.
+func proxmoxConfigLine(configDir string, hasSavedConfig bool) string {
+	if !hasSavedConfig {
+		return " [gray]Config: (auto-detected local Proxmox — no saved config file to forget)[-]"
+	}
+	return fmt.Sprintf(" [gray]Config: %s   ([yellow]D[-][gray]=forget)[-]", proxmox.ConfigPath(configDir))
 }
 
 // pmxColorizeStatus wraps a status string with tview color tags.

--- a/internal/tui/controlcenter/proxmox_page_test.go
+++ b/internal/tui/controlcenter/proxmox_page_test.go
@@ -1,0 +1,37 @@
+package controlcenter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/proxmox"
+)
+
+func TestProxmoxConfigLine_SavedConfigShowsPathAndForget(t *testing.T) {
+	dir := "/home/user/.citadel-cli"
+	line := proxmoxConfigLine(dir, true)
+
+	wantPath := proxmox.ConfigPath(dir)
+	if !strings.Contains(line, wantPath) {
+		t.Fatalf("config line %q should contain the config path %q", line, wantPath)
+	}
+	// The forget affordance should be discoverable from this line.
+	if !strings.Contains(line, "D") {
+		t.Fatalf("config line %q should mention the [D]=forget key", line)
+	}
+}
+
+func TestProxmoxConfigLine_DetectedHostNoSavedFile(t *testing.T) {
+	// A detected local Proxmox host has no saved file: don't print a misleading
+	// path or offer to forget a file that isn't there.
+	line := proxmoxConfigLine("/home/user/.citadel-cli", false)
+	if strings.TrimSpace(line) == "" {
+		t.Fatal("config line should not be blank when there is no saved config")
+	}
+	if !strings.Contains(strings.ToLower(line), "auto-detected") {
+		t.Fatalf("no-saved-config line %q should note the auto-detected case", line)
+	}
+	if strings.Contains(line, "proxmox.json") {
+		t.Fatalf("no-saved-config line %q should not print a config file path", line)
+	}
+}


### PR DESCRIPTION
## Context

The Control Center shows a **Proxmox** tab whenever a saved config exists at `<ConfigDir>/proxmox.json` (see `cmd/controlcenter.go` `buildProxmoxConfig` → `pmx.LoadConfig`). That file may point at a *remote* Proxmox host, so a user with a leftover `proxmox.json` sees the tab even though the local machine isn't a Proxmox node.

Jason's TUI feedback captured the confusion exactly — *"how is it detecting the VMs?"* The answer: a saved `proxmox.json` pointing at a remote host. Until now there was **no in-app way to see where that file lives, and no way to remove it.** This PR adds both affordances.

It deliberately does **not** touch the detection/gating logic (saved-config-OR-`DetectProxmox`), which is correct — most users have neither and see no tab. This is purely the missing "see where it is + remove it" surface.

## Summary

**TUI (`internal/tui/controlcenter/proxmox_page.go`)**
- **Config-path header line** on the Proxmox page shows the absolute path of the file driving the tab, e.g. `Config: /home/<user>/.citadel-cli/proxmox.json   (D=forget)`. This makes it obvious what's behind the tab and where to manage it.
- **`[D]`=forget** action pops a confirmation modal — *"Forget the saved Proxmox connection to `<base_url>`? This deletes `<config_path>`. The tab is hidden after restart."* — and deletes `proxmox.json` on confirm. `[D]=forget` is added to the help bar. `D` is free (existing keys: `s/S/k/r/c/Enter/R`). The tab is built once at `Run()`, so on success we tell the user to restart rather than fake a live hide.
- A *detected local Proxmox* host (no saved file) shows an explanatory line and the forget action reports there is nothing to remove — deleting a nonexistent file wouldn't hide the tab since detection still applies.

**Modal input fix (`controlcenter.go`)**
- While a Control Center modal was active, `PageManager.HandleGlobalInput` routed keys to the *active page's* `HandleInput`. The dashboard page guards this with `if cc.inModal { return event }`, but PageManager pages don't — so a page-triggered modal (this is the first one) would have its Enter/arrows swallowed and the buttons would never respond. Modals now receive input directly; equivalent for the dashboard page, correct for pages.

**CLI parity (`cmd/proxmox.go`)**
- `citadel proxmox forget` — prints the base URL + config path, deletes the file (confirm unless `--yes`), and confirms. Idempotent: reports "no saved connection" when there's nothing to forget.
- `citadel proxmox status` now prints the config file path so it's discoverable from the CLI too.

**Config helpers (`internal/proxmox/config.go`)**
- `configPath` → exported **`ConfigPath(configDir)`** (in-file callers updated).
- **`DeleteConfig(configDir) error`** — `os.Remove`, not-exist treated as success.

## Test plan

| Group | Coverage |
|-------|----------|
| `internal/proxmox/config_test.go` | `ConfigPath` join; `DeleteConfig` removes an existing file; not-exist (and double-delete) = success |
| `internal/tui/controlcenter/proxmox_page_test.go` | `proxmoxConfigLine` shows path + `[D]` when saved config exists; detected-host case shows the auto-detected note and no misleading path |
| CLI smoke (manual, isolated `$HOME`) | `status` prints path; `forget --yes` shows base URL + path, deletes file; second `forget` reports "no saved connection" |

`gofmt`, `go build ./...`, `go vet`, and `go test ./internal/... ./cmd/...` pass. The only failing package is the pre-existing environmental `internal/status` `:8080` bind flake, unrelated to this change.

**Interactive verification (draft):** In a running Control Center with a saved `proxmox.json`, confirm `[D]` opens the modal, Enter on **Forget** deletes the file and logs the success + restart hint, and **Cancel**/Esc returns focus to the Proxmox tab (not the dashboard).

## Related

- Builds on the keyboard-first + mouse Control Center navigation model (#388).
- Addresses Jason's TUI feedback on the stale Proxmox tab.
