### PR TITLE
fix(tui): chat deadlock — nested QueueUpdateDraw freezes the whole TUI on connect

### DIFF
--- a/internal/tui/controlcenter/chat_page.go
+++ b/internal/tui/controlcenter/chat_page.go
@@ -566,7 +566,10 @@ func (p *ChatPage) connect() {
 
 		p.app.QueueUpdateDraw(func() {
 			p.renderStatusBar(connConnected, "")
-			p.setStatus("[green]Connected[white] to #general")
+			// Already on the main goroutine inside QueueUpdateDraw: use the
+			// direct writeStatus, NOT setStatus (which re-enters QueueUpdateDraw
+			// and deadlocks the event loop).
+			p.writeStatus("[green]Connected[white] to #general")
 			// Clear the "connecting..." placeholder in the peers sidebar.
 			p.updatePeersView()
 		})
@@ -595,7 +598,8 @@ func (p *ChatPage) connect() {
 		if !connected && ctx.Err() == nil {
 			p.app.QueueUpdateDraw(func() {
 				p.renderStatusBar(connError, "timed out")
-				p.setStatus("[red]Connection timed out[white] — chat is unavailable")
+				// Inside QueueUpdateDraw: use writeStatus, not setStatus.
+				p.writeStatus("[red]Connection timed out[white] — chat is unavailable")
 				p.peersBox.SetText(" [red]offline[white]")
 			})
 		}
@@ -617,7 +621,8 @@ func (p *ChatPage) connect() {
 			errMsg := err.Error()
 			p.app.QueueUpdateDraw(func() {
 				p.renderStatusBar(connError, errMsg)
-				p.setStatus(fmt.Sprintf("[red]Connection failed[white]: %s", errMsg))
+				// Inside QueueUpdateDraw: use writeStatus, not setStatus.
+				p.writeStatus(fmt.Sprintf("[red]Connection failed[white]: %s", errMsg))
 				p.peersBox.SetText(" [red]offline[white]")
 			})
 		}
@@ -739,12 +744,32 @@ func (p *ChatPage) renderStatusBar(state connState, detail string) {
 	p.statusBar.SetText(formatChatStatusBar(state, endpoint, detail))
 }
 
-// setStatus updates the message view with a status line.
+// writeStatus replaces the message view with a single status line. It touches
+// the tview primitive DIRECTLY (no QueueUpdateDraw) and therefore MUST only be
+// called from the main/event-loop goroutine — i.e. from inside an existing
+// QueueUpdateDraw callback. Background-goroutine callers must use setStatus.
+//
+// This split exists to prevent a nested-QueueUpdateDraw deadlock: setStatus
+// wraps the body in QueueUpdateDraw, so calling it from within another
+// QueueUpdateDraw callback (already on the main goroutine) re-enters
+// QueueUpdateDraw, whose synchronous channel receive waits for the very event
+// loop it is blocking — a permanent hang that freezes the entire Control Center.
+func (p *ChatPage) writeStatus(text string) {
+	if p.msgView == nil {
+		return
+	}
+	p.msgView.Clear()
+	fmt.Fprintf(p.msgView, " %s\n\n", text)
+	p.msgView.ScrollToEnd()
+}
+
+// setStatus updates the message view with a status line from a background
+// goroutine. It wraps writeStatus in QueueUpdateDraw to hop onto the main
+// goroutine, so it MUST NOT be called from within an existing QueueUpdateDraw
+// callback — use writeStatus directly in that case (see writeStatus).
 func (p *ChatPage) setStatus(text string) {
 	p.app.QueueUpdateDraw(func() {
-		p.msgView.Clear()
-		fmt.Fprintf(p.msgView, " %s\n\n", text)
-		p.msgView.ScrollToEnd()
+		p.writeStatus(text)
 	})
 }
 

--- a/internal/tui/controlcenter/chat_page_test.go
+++ b/internal/tui/controlcenter/chat_page_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
 )
 
 // TestClassifyChatKey_ReleasesNavigationKeys is the keyboard-trap regression: the
@@ -254,4 +255,32 @@ func TestChatPageResolveConfig_NoProviderNoSnapshot(t *testing.T) {
 	if base != "" || tok != "" || org != "" {
 		t.Errorf("expected empty config, got base=%q tok=%q org=%q", base, tok, org)
 	}
+}
+
+// TestWriteStatus_DoesNotTouchAppQueue is the deadlock regression. writeStatus
+// is the DIRECT status writer meant to run on the main goroutine (inside an
+// existing QueueUpdateDraw callback), so it must render straight into msgView
+// WITHOUT calling p.app.QueueUpdateDraw. We construct the page with a real
+// msgView but a nil p.app: if writeStatus ever re-introduces QueueUpdateDraw
+// (which is exactly the nested-QueueUpdateDraw bug that froze the whole Control
+// Center on connect), it will dereference the nil app and panic here. A passing
+// run therefore mechanically forbids the regression — it proves writeStatus
+// never touches the app queue.
+func TestWriteStatus_DoesNotTouchAppQueue(t *testing.T) {
+	p := &ChatPage{msgView: tview.NewTextView()}
+	// p.app is deliberately nil: any QueueUpdateDraw path would panic.
+
+	p.writeStatus("hello-status-marker")
+
+	if got := p.msgView.GetText(true); !strings.Contains(got, "hello-status-marker") {
+		t.Errorf("writeStatus did not render into msgView: got %q", got)
+	}
+}
+
+// TestWriteStatus_NilMsgViewIsSafe documents that writeStatus is a no-op when
+// the view has not been built yet, mirroring renderStatusBar's nil guard, so a
+// status write racing page teardown never panics.
+func TestWriteStatus_NilMsgViewIsSafe(t *testing.T) {
+	p := &ChatPage{}
+	p.writeStatus("anything") // must not panic
 }


### PR DESCRIPTION
## Context — CRITICAL, ship ASAP

The citadel-cli Control Center **freezes completely** the moment the Chat tab's realtime transport connects: no keyboard, no mouse, no Alt-tab — the entire TUI event loop is dead. This is a hard hang of the whole Control Center, not just the Chat tab, so it should ship as soon as it's reviewed.

The bug is **latent-but-now-firing**: it only triggers because the chat now actually reaches `OnConnect` (after the subscribe-allowlist fix landed). Before that, the chat never connected, so the deadly path was never taken.

## Root cause — nested `QueueUpdateDraw`

tview's `Application.QueueUpdateDraw(f)` sends `f` to the event-loop goroutine over a channel and then **synchronously blocks** on a receive until the loop has run it (`a.updates <- ...; <-ch`). That is safe from a background goroutine, but **calling it from inside another `QueueUpdateDraw` callback deadlocks**: you're already on the event-loop goroutine, so the send waits for a loop that is busy running the current callback and will never read the channel again.

`setStatus()` wrapped its body in `QueueUpdateDraw`. It was also invoked from **inside** `OnConnect`'s own `QueueUpdateDraw` callback:

```go
client.OnConnect(func() {
    ...
    p.app.QueueUpdateDraw(func() {        // runs on the main/event-loop goroutine
        p.renderStatusBar(connConnected, "")
        p.setStatus("[green]Connected...") // <- re-enters QueueUpdateDraw -> DEADLOCK
        p.updatePeersView()
    })
})
```

When the chat connected, that outer callback ran on the main goroutine, and the nested `setStatus` re-entered `QueueUpdateDraw` → permanent hang.

**Live delve evidence:** Goroutine 1 blocked in tview `application.go:879` (`QueueUpdateDraw` chan receive), reached via `chat_page.go:744` (`setStatus`) ← `chat_page.go:569` (the `OnConnect` handler body).

## The fix — direct vs. queued split

The invariant: **a function that calls `QueueUpdateDraw` must never be called from within another `QueueUpdateDraw` callback (i.e. from the main goroutine).**

- Split the status writer into:
  - `writeStatus(text)` — **direct**: does `Clear()/Fprintf/ScrollToEnd` with **no** `QueueUpdateDraw`; must run on the main goroutine (inside an existing `QueueUpdateDraw`).
  - `setStatus(text)` — **queued wrapper**: `QueueUpdateDraw(func(){ p.writeStatus(text) })`, for **background-goroutine** callers only.
- Routed every inside-`QueueUpdateDraw` call site to the direct `writeStatus`.

## Full audit — every `setStatus` call site

I grepped the **whole `internal/tui/controlcenter/` package** (not just the file) for every helper that queues (`setStatus`) and every helper called from inside a queued block (`renderStatusBar`, `updatePeersView`, `appendMessage`). Result: **three** nested pairs, all in `chat_page.go` — the task named one; the audit found two more.

| Call site | Goroutine at call | Before | After |
|---|---|---|---|
| `connect()` not-configured branch (~L500) | background (not inside QueueUpdateDraw) | `setStatus` | **`setStatus`** (unchanged — correct) |
| `OnConnect` handler (~L569) | main (inside `QueueUpdateDraw`) | `setStatus` ❌ deadlock | **`writeStatus`** ✅ |
| connect watchdog timeout (~L598) | main (inside `QueueUpdateDraw`) | `setStatus` ❌ deadlock | **`writeStatus`** ✅ |
| `Connect()` error branch (~L620) | main (inside `QueueUpdateDraw`) | `setStatus` ❌ deadlock | **`writeStatus`** ✅ |

Other helpers verified **safe** (they never call `QueueUpdateDraw`, so nesting them is fine): `renderStatusBar`, `appendMessage`, `updatePeersView`. The lone out-of-file hit — `ControlCenter.updatePeersView` (`controlcenter.go:1810`) — is an **unrelated method on a different type** (the node peers table), not `ChatPage`. Confirmed the chat client fires `OnConnect`/`OnMessage`/`OnPresence` on a **background** goroutine (`client.Connect` runs under `go p.connect()`), which is exactly why the outer `QueueUpdateDraw` wraps are correct and only the inner nested calls were wrong.

## Test plan

| Test | Coverage |
|---|---|
| `TestWriteStatus_DoesNotTouchAppQueue` | Constructs a `ChatPage` with a real `msgView` but **nil `app`**, calls `writeStatus`, asserts the text landed and it did not panic. If anyone reintroduces `QueueUpdateDraw` into `writeStatus`, the nil-`app` deref panics → test fails. **Non-tautological** — verified it fails on the reintroduced bug. |
| `TestWriteStatus_NilMsgViewIsSafe` | `writeStatus` is a no-op before the view is built (mirrors `renderStatusBar`'s nil guard), so a status write racing teardown never panics. |
| existing `TestFormatChatStatusBar`, `TestClassifyChatKey_*`, resolveConfig tests | unchanged, still green |

`gofmt` clean, `go build ./...`, `go vet ./internal/tui/...`, and `go test ./internal/tui/...` all pass.

## Related

- Depends on / triggered by the subscribe-allowlist fix that made the chat actually reach `OnConnect`.

---
*Generated by Claude*
