### PR TITLE
feat(tui): numbered-key nav + fix WhatsApp deploy deadlock

### DIFF
--- a/internal/tui/controlcenter/module_page.go
+++ b/internal/tui/controlcenter/module_page.go
@@ -128,7 +128,7 @@ func NewModulePage(cb ModuleInstallCallbacks) *ModulePage {
 func (p *ModulePage) Name() string { return "module" }
 
 // Title implements Page.
-func (p *ModulePage) Title() string { return "Install Module" }
+func (p *ModulePage) Title() string { return "Modules" }
 
 // Build implements Page.
 func (p *ModulePage) Build(app *tview.Application) tview.Primitive {
@@ -555,7 +555,9 @@ func (p *ModulePage) render() {
 	sb.WriteString("   [aqua]owner/repo@v1.2.0[-]     [gray]pinned ref[-]\n")
 	sb.WriteString("   [aqua]https://git…/repo.git[-] [gray]full git URL[-]\n\n")
 	sb.WriteString(" [gray]Private repos need this node to have git[-]\n")
-	sb.WriteString(" [gray]credentials (GITHUB_TOKEN / SSH key / helper).[-]\n")
+	sb.WriteString(" [gray]credentials (GITHUB_TOKEN / SSH key / helper).[-]\n\n")
+	sb.WriteString(" [gray]Modules will also be manageable remotely from the[-]\n")
+	sb.WriteString(" [gray]AceTeam web dashboard [white](coming soon)[-][gray].[-]\n")
 
 	if phase == phaseConfig && res.Name != "" {
 		sb.WriteString("\n [white::b]Resolved[-:-:-]\n")

--- a/internal/tui/controlcenter/proxmox_page.go
+++ b/internal/tui/controlcenter/proxmox_page.go
@@ -119,7 +119,7 @@ func (p *ProxmoxPage) Build(app *tview.Application) tview.Primitive {
 	p.helpBar = tview.NewTextView().
 		SetDynamicColors(true).
 		SetTextAlign(tview.AlignLeft)
-	p.helpBar.SetText(" [yellow]s[-]=start  [yellow]S[-]=shutdown  [yellow]k[-]=force stop  [yellow]r[-]=reboot  [yellow]c[-]=console  [yellow]Enter[-]=details  [yellow]R[-]=refresh  [yellow]D[-]=forget")
+	p.helpBar.SetText(" [yellow]1[-]=start  [yellow]2[-]=shutdown  [yellow]3[-]=force stop  [yellow]4[-]=reboot  [yellow]5[-]=console  [yellow]Enter[-]=details  [yellow]6[-]=refresh  [yellow]7[-]=forget")
 
 	// Main layout: table on left, detail on right
 	contentFlex := tview.NewFlex().SetDirection(tview.FlexColumn).
@@ -158,27 +158,29 @@ func (p *ProxmoxPage) OnDeactivate() {
 }
 
 func (p *ProxmoxPage) HandleInput(event *tcell.EventKey) *tcell.EventKey {
+	// Numbered actions (numbers + arrows convention, no letter shortcuts). Arrow
+	// keys / Enter select a guest; these act on the selected one.
 	if event.Key() == tcell.KeyRune {
 		switch event.Rune() {
-		case 's':
+		case '1':
 			p.actionOnSelected("start")
 			return nil
-		case 'S':
+		case '2':
 			p.actionOnSelected("shutdown")
 			return nil
-		case 'k':
+		case '3':
 			p.actionOnSelected("stop")
 			return nil
-		case 'r':
+		case '4':
 			p.actionOnSelected("reboot")
 			return nil
-		case 'c':
+		case '5':
 			p.openConsole()
 			return nil
-		case 'R':
+		case '6':
 			go p.refreshData()
 			return nil
-		case 'D':
+		case '7':
 			p.forgetConnection()
 			return nil
 		}
@@ -650,7 +652,7 @@ func proxmoxConfigLine(configDir string, hasSavedConfig bool) string {
 	if !hasSavedConfig {
 		return " [gray]Config: (auto-detected local Proxmox — no saved config file to forget)[-]"
 	}
-	return fmt.Sprintf(" [gray]Config: %s   ([yellow]D[-][gray]=forget)[-]", proxmox.ConfigPath(configDir))
+	return fmt.Sprintf(" [gray]Config: %s   ([yellow]7[-][gray]=forget)[-]", proxmox.ConfigPath(configDir))
 }
 
 // pmxColorizeStatus wraps a status string with tview color tags.

--- a/internal/tui/controlcenter/proxmox_page_test.go
+++ b/internal/tui/controlcenter/proxmox_page_test.go
@@ -16,8 +16,8 @@ func TestProxmoxConfigLine_SavedConfigShowsPathAndForget(t *testing.T) {
 		t.Fatalf("config line %q should contain the config path %q", line, wantPath)
 	}
 	// The forget affordance should be discoverable from this line.
-	if !strings.Contains(line, "D") {
-		t.Fatalf("config line %q should mention the [D]=forget key", line)
+	if !strings.Contains(line, "forget") {
+		t.Fatalf("config line %q should mention the forget affordance", line)
 	}
 }
 

--- a/internal/tui/controlcenter/settings_page.go
+++ b/internal/tui/controlcenter/settings_page.go
@@ -124,21 +124,24 @@ func (p *SettingsPage) OnActivate() {
 // OnDeactivate implements Page.
 func (p *SettingsPage) OnDeactivate() {}
 
-// HandleInput implements Page. 'm' toggles mouse control; 'f' toggles fullscreen
-// rendering (the two Mouse & Rendering checkboxes); 'k' toggles keep-awake-on-AC;
-// Space/Enter/'t' toggles the telemetry opt-out.
+// HandleInput implements Page. Numbered toggles (numbers + arrows convention, no
+// letter shortcuts): 1=mouse control, 2=fullscreen rendering, 3=anonymous
+// telemetry opt-out, 4=keep-awake-on-AC. Space/Enter also toggle telemetry.
 func (p *SettingsPage) HandleInput(event *tcell.EventKey) *tcell.EventKey {
 	switch {
-	case event.Key() == tcell.KeyRune && (event.Rune() == 'm' || event.Rune() == 'M'):
+	case event.Key() == tcell.KeyRune && event.Rune() == '1':
 		p.toggleMouse()
 		return nil
-	case event.Key() == tcell.KeyRune && (event.Rune() == 'f' || event.Rune() == 'F'):
+	case event.Key() == tcell.KeyRune && event.Rune() == '2':
 		p.toggleFullscreen()
 		return nil
-	case event.Key() == tcell.KeyRune && (event.Rune() == 'k' || event.Rune() == 'K'):
+	case event.Key() == tcell.KeyRune && event.Rune() == '3':
+		p.toggleTelemetry()
+		return nil
+	case event.Key() == tcell.KeyRune && event.Rune() == '4':
 		p.toggleKeepAwake()
 		return nil
-	case event.Key() == tcell.KeyRune && (event.Rune() == ' ' || event.Rune() == 't' || event.Rune() == 'T'):
+	case event.Key() == tcell.KeyRune && event.Rune() == ' ':
 		p.toggleTelemetry()
 		return nil
 	case event.Key() == tcell.KeyEnter:
@@ -311,13 +314,13 @@ func (p *SettingsPage) renderWithError(errMsg string) {
 	sb.WriteString("                                  [white]• Shift[-]        (most terminals)\n")
 	sb.WriteString("                                  [white]• Fn[-]           (macOS Terminal.app)\n")
 	sb.WriteString("                                  [white]• Option[-]        (iTerm2)\n")
-	sb.WriteString("   [gray]press[-] [yellow::b]m[-:-:-] [gray]to toggle (applies immediately)[-]\n\n")
+	sb.WriteString("   [gray]press[-] [yellow::b]1[-:-:-] [gray]to toggle (applies immediately)[-]\n\n")
 
 	// Checkbox 2: Fullscreen rendering.
 	fullscreenEnabled := p.rendering != nil && p.rendering.Fullscreen
 	sb.WriteString(fmt.Sprintf("   %s [white::b]Fullscreen rendering[-:-:-]     Flicker-free, app-like. Off = output goes to normal\n", checkbox(fullscreenEnabled)))
 	sb.WriteString("                                scrollback (easier to scroll + copy long history).\n")
-	sb.WriteString("   [gray]press[-] [yellow::b]f[-:-:-] [gray]to toggle (saved; restart to apply)[-]\n")
+	sb.WriteString("   [gray]press[-] [yellow::b]2[-:-:-] [gray]to toggle (saved; restart to apply)[-]\n")
 
 	enabled := p.telemetry != nil && p.telemetry.AnonTelemetryEnabled
 
@@ -333,7 +336,7 @@ func (p *SettingsPage) renderWithError(errMsg string) {
 	sb.WriteString("   no personal data.\n\n")
 	sb.WriteString("   [white]Why:[-] it helps us debug problems remotely and improve\n")
 	sb.WriteString("   Citadel. Opting out stops [white::b]all[-:-:-] anonymous collection.\n\n")
-	sb.WriteString("   [yellow::b]Space[-:-:-]/[yellow::b]Enter[-:-:-] toggle collection\n")
+	sb.WriteString("   [yellow::b]3[-:-:-] [gray](or[-] [yellow::b]Space[-:-:-]/[yellow::b]Enter[-:-:-][gray])[-] toggle collection\n")
 
 	// -- Keep-awake on AC --
 	keepEnabled := p.keepAwake != nil && p.keepAwake.KeepAwakeOnAC
@@ -351,7 +354,7 @@ func (p *SettingsPage) renderWithError(errMsg string) {
 	sb.WriteString("\n   [white]What it does:[-] holds a system idle-sleep assertion while\n")
 	sb.WriteString("   this node is plugged in, so the laptop stays reachable on the\n")
 	sb.WriteString("   mesh. Released on battery and on exit. Display may still sleep.\n\n")
-	sb.WriteString("   [yellow::b]k[-:-:-] toggle keep-awake\n")
+	sb.WriteString("   [yellow::b]4[-:-:-] toggle keep-awake\n")
 
 	// -- Connection status (read-only) --
 	sb.WriteString("\n [yellow::b]Connection[-:-:-]\n\n")

--- a/internal/tui/controlcenter/whatsapp_page.go
+++ b/internal/tui/controlcenter/whatsapp_page.go
@@ -131,22 +131,27 @@ func (p *WhatsAppPage) OnDeactivate() {
 	p.mu.Unlock()
 }
 
-// HandleInput implements Page. u=deploy/start, d=stop, q=refresh QR, r=refresh.
+// HandleInput implements Page. Numbered actions: 1=deploy/start, 2=stop,
+// 3=refresh QR, 4=refresh. Every action runs off the tview event-loop goroutine
+// (via `go p.doX()`): each helper calls queueRender -> app.QueueUpdateDraw, and
+// calling QueueUpdateDraw from the event-loop goroutine deadlocks the whole TUI
+// (same class as the chat deadlock in #402). Dispatching to a goroutine keeps
+// this handler render-free and safe-by-construction.
 func (p *WhatsAppPage) HandleInput(event *tcell.EventKey) *tcell.EventKey {
 	if event.Key() != tcell.KeyRune {
 		return event
 	}
 	switch event.Rune() {
-	case 'u', 'U':
-		p.doDeploy()
+	case '1':
+		go p.doDeploy()
 		return nil
-	case 'd', 'D':
-		p.doStop()
+	case '2':
+		go p.doStop()
 		return nil
-	case 'q', 'Q':
+	case '3':
 		go p.refreshQR()
 		return nil
-	case 'r', 'R':
+	case '4':
 		go p.refresh()
 		return nil
 	}
@@ -334,11 +339,12 @@ func (p *WhatsAppPage) render() {
 		sb.WriteString(fmt.Sprintf("\n   [red]%s[-]\n", tview.Escape(st.Err)))
 	}
 
-	// Controls.
+	// Controls. Numbered actions only (numbers + arrows convention) so there is
+	// nothing obscure to hunt for and every module page reads the same way.
 	sb.WriteString("\n [gray]──────────────────────────────[-]\n")
-	sb.WriteString("   [yellow::b]u[-:-:-] deploy/start    [yellow::b]d[-:-:-] stop\n")
-	sb.WriteString("   [yellow::b]q[-:-:-] refresh QR       [yellow::b]r[-:-:-] refresh\n")
-	sb.WriteString("   [gray]Community module — opened from the Install Module[-]\n")
+	sb.WriteString("   [yellow::b][1][-:-:-] deploy/start    [yellow::b][2][-:-:-] stop\n")
+	sb.WriteString("   [yellow::b][3][-:-:-] refresh QR       [yellow::b][4][-:-:-] refresh\n")
+	sb.WriteString("   [gray]Community module — opened from the Modules[-]\n")
 	sb.WriteString("   [gray]tab. Press Tab to return to the tab bar.[-]\n")
 
 	p.statusBox.SetText(sb.String())
@@ -349,8 +355,8 @@ func (p *WhatsAppPage) render() {
 	} else if st.LoggedIn {
 		p.qrBox.SetText("\n  [linked] No QR needed -- this number is connected.")
 	} else if st.Deployed && st.Reachable {
-		p.qrBox.SetText("\n  Generating QR... press q to refresh.")
+		p.qrBox.SetText("\n  Generating QR... press [3] to refresh.")
 	} else {
-		p.qrBox.SetText("\n  Deploy the bridge (press u) to generate a pairing QR.")
+		p.qrBox.SetText("\n  Deploy the bridge (press [1]) to generate a pairing QR.")
 	}
 }

--- a/internal/tui/controlcenter/whatsapp_page_test.go
+++ b/internal/tui/controlcenter/whatsapp_page_test.go
@@ -1,0 +1,131 @@
+package controlcenter
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+// TestWhatsAppHandleInputNeverBlocks is the deadlock guard for the class of bug
+// fixed in #402 (chat) and re-audited here: an action branch in HandleInput must
+// NEVER touch a QueueUpdateDraw/render path synchronously on the tview event-loop
+// goroutine. The old code called p.doDeploy()/p.doStop() directly, and both call
+// queueRender -> app.QueueUpdateDraw, whose synchronous channel receive can only
+// be drained by the very event loop the call is running on -> permanent hang that
+// freezes the whole Control Center.
+//
+// To make the hang reproducible without a running tview event loop, we give the
+// page a real *tview.Application (so queueRender is NOT a nil-app no-op) and start
+// no goroutine to drain QueueUpdateDraw. On the OLD code the synchronous
+// doDeploy/doStop would block forever inside QueueUpdateDraw; on the NEW code
+// HandleInput dispatches `go p.doX()` and returns promptly, so the handler call
+// completes well within the timeout.
+func TestWhatsAppHandleInputNeverBlocks(t *testing.T) {
+	// Deploy/Stop block briefly to model a real action, so if HandleInput ran them
+	// synchronously the handler would not return promptly even ignoring the
+	// QueueUpdateDraw hang.
+	deployStarted := make(chan struct{}, 1)
+	cb := WhatsAppCallbacks{
+		Status: func() WhatsAppStatus { return WhatsAppStatus{} },
+		Deploy: func() (string, string, error) {
+			select {
+			case deployStarted <- struct{}{}:
+			default:
+			}
+			time.Sleep(200 * time.Millisecond)
+			return "", "", nil
+		},
+		Stop:     func() error { time.Sleep(200 * time.Millisecond); return nil },
+		QRBlocks: func() (string, error) { return "", nil },
+	}
+	p := NewWhatsAppPage(cb)
+	// Build with a real application so queueRender exercises QueueUpdateDraw rather
+	// than no-oping on a nil app. We never call app.Run(), so nothing drains the
+	// QueueUpdateDraw queue — a synchronous QueueUpdateDraw from this goroutine
+	// would block forever, exactly reproducing the old deadlock.
+	p.Build(tview.NewApplication())
+
+	actionKeys := []rune{'1', '2', '3', '4'}
+	for _, key := range actionKeys {
+		key := key
+		done := make(chan struct{})
+		go func() {
+			p.HandleInput(tcell.NewEventKey(tcell.KeyRune, key, tcell.ModNone))
+			close(done)
+		}()
+		select {
+		case <-done:
+			// HandleInput returned promptly — good.
+		case <-time.After(2 * time.Second):
+			t.Fatalf("HandleInput('%c') did not return within 2s — likely a synchronous QueueUpdateDraw deadlock (the #402 class)", key)
+		}
+	}
+}
+
+// TestWhatsAppDoDeployRunsWorkOffGoroutine asserts doDeploy performs its blocking
+// work off the calling goroutine. Combined with HandleInput dispatching `go
+// p.doDeploy()`, this proves the action key both returns immediately AND actually
+// kicks off the deploy — so the guard is not passing merely because the action is
+// a no-op.
+func TestWhatsAppDoDeployRunsWorkOffGoroutine(t *testing.T) {
+	var mu sync.Mutex
+	deployCalled := false
+	release := make(chan struct{})
+	cb := WhatsAppCallbacks{
+		Status: func() WhatsAppStatus { return WhatsAppStatus{} },
+		Deploy: func() (string, string, error) {
+			mu.Lock()
+			deployCalled = true
+			mu.Unlock()
+			<-release // hold the deploy open so the test can observe it mid-flight
+			return "", "", nil
+		},
+		QRBlocks: func() (string, error) { return "", nil },
+	}
+	p := NewWhatsAppPage(cb)
+	app := tview.NewApplication()
+	// A simulation screen lets the tview event loop run headless so QueueUpdateDraw
+	// callbacks (from queueRender) drain and doDeploy can reach its inner deploy
+	// goroutine. Stopped at test end.
+	app.SetScreen(tcell.NewSimulationScreen(""))
+	p.Build(app)
+	app.SetRoot(p.root, true)
+
+	appDone := make(chan struct{})
+	go func() { _ = app.Run(); close(appDone) }()
+	defer func() { app.Stop(); <-appDone }()
+
+	done := make(chan struct{})
+	go func() {
+		p.HandleInput(tcell.NewEventKey(tcell.KeyRune, '1', tcell.ModNone))
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		close(release)
+		t.Fatal("HandleInput('1') blocked — deploy must run off the event-loop goroutine")
+	}
+
+	// The deploy should be running in the background even though HandleInput has
+	// already returned.
+	deadline := time.After(2 * time.Second)
+	for {
+		mu.Lock()
+		called := deployCalled
+		mu.Unlock()
+		if called {
+			break
+		}
+		select {
+		case <-deadline:
+			close(release)
+			t.Fatal("deploy work never started off-goroutine")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	close(release)
+}


### PR DESCRIPTION
## Context

Jason interactive-tested the Control Center on v2.54.0 and hit a hard **hang**: on the Modules tab (`alt+5`), opening the WhatsApp bridge and pressing `u` to deploy froze the entire TUI — no `q`, `r`, or `alt` escape. Same root cause as the chat deadlock (#402), which its audit missed on this page. He also asked to stop using obscure single-letter shortcuts entirely: *"these characters are hard to find… I'd like to use 1 2 3 4 like Claude Code — and be consistent for all module selections and interfaces, do not use the short character shortcut, just numbers and arrow keys allowed."* Plus rename the "Install Module" tab to "Modules" and note that modules can be managed from the web.

## Summary

**1. Fix the WhatsApp deploy/stop deadlock (the reported hang).** `whatsapp_page.HandleInput` called `p.doDeploy()`/`p.doStop()` **synchronously on the tview event-loop goroutine**; both call `queueRender → app.QueueUpdateDraw`, whose synchronous channel receive can only be drained by the very event loop making the call → permanent freeze (no keyboard/mouse/Alt). Fix is **safe-by-construction**: action branches now `go p.doDeploy()` / `go p.doStop()`, so `HandleInput` never touches a render path synchronously. Audited the whole package — this was the only remaining instance of the #402 class.

**2. Numbered-key navigation everywhere (no letter shortcuts).** Arrow keys / Tab / Enter continue to select; per-page **action** shortcuts are now numbers:
| Page | Before | After |
|------|--------|-------|
| WhatsApp | `u`/`d`/`q`/`r` | `1` deploy · `2` stop · `3` refresh QR · `4` refresh |
| Settings | `m`/`f`/`k`/`t` | `1` mouse · `2` fullscreen · `3` telemetry · `4` keep-awake (Space/Enter still toggle telemetry) |
| Proxmox | `s`/`S`/`k`/`r`/`c`/`R`/`D` | `1`–`7` start/shutdown/force-stop/reboot/console/refresh/forget |

`module_page` already used a list+form (arrows/Tab/Enter, no letter shortcuts), so it needed no remap.

**3. Rename + web-management note.** `Install Module` tab → **Modules**. Added a gray line on the Modules page: *"Modules will also be manageable remotely from the AceTeam web dashboard (coming soon)."* Worded as a **future** capability on purpose — the backend control-plane surface is a separate in-flight increment (aceteam#4478), so the TUI doesn't claim a feature that isn't shipped.

## Test plan

| Test | Coverage |
|------|----------|
| `TestWhatsAppHandleInputNeverBlocks` | Fires each action key through `HandleInput` with a **real** `tview.Application` and no queue drain — the old synchronous code hangs; new code returns < 2s. This is the deadlock guard. |
| `TestWhatsAppDoDeployRunsWorkOffGoroutine` | Non-tautological: proves the key both returns immediately **and** actually kicks off the deploy off-goroutine. |
| `proxmox_page_test` | Updated forget-affordance assertion (word, not `[D]`). |
| `go build ./...`, `go vet ./...`, `go test ./internal/tui/...` | All green. |

## Related

- Same deadlock class as #402 (chat).
- Backend control plane for remote module management: aceteam#4478 (draft), web UI follow-up aceteam#4477.