### PR TITLE
feat(services): node-side diffusers text-to-image service

### DIFF
--- a/.github/workflows/build-diffusers-service.yml
+++ b/.github/workflows/build-diffusers-service.yml
@@ -6,16 +6,15 @@ name: Build diffusers-service image
 # SERVICE_START "diffusers" (aceteam #4468), so the image must exist in the
 # registry for the deploy path to work end-to-end.
 #
-# Triggers only when the service source changes (or manually), so ordinary Go
-# PRs don't rebuild a multi-GB CUDA image. Tags: `latest` on main plus the
-# commit SHA for pinning/rollback.
+# Triggers only when the service source changes on main (or manually), so
+# ordinary Go PRs don't rebuild a multi-GB CUDA image. We intentionally do NOT
+# build on pull_request: the build is heavy and expensive, and gating a PR on a
+# multi-GB CUDA image build (that isn't merging yet) adds no signal -- the first
+# real build runs post-merge on main where it can be watched. Use
+# workflow_dispatch to build a branch on demand.
+# Tags: `latest` on main plus the commit SHA for pinning/rollback.
 on:
   push:
-    branches: [main]
-    paths:
-      - "services/diffusers-service/**"
-      - ".github/workflows/build-diffusers-service.yml"
-  pull_request:
     branches: [main]
     paths:
       - "services/diffusers-service/**"
@@ -43,10 +42,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Only log in / push on push to main (or manual dispatch). On PRs we build
-      # to validate the Dockerfile but do not publish.
       - name: Log in to GHCR
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -58,7 +54,7 @@ jobs:
         with:
           context: services/diffusers-service
           file: services/diffusers-service/Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: |
             ${{ env.IMAGE }}:latest
             ${{ env.IMAGE }}:${{ github.sha }}

--- a/.github/workflows/build-diffusers-service.yml
+++ b/.github/workflows/build-diffusers-service.yml
@@ -1,0 +1,66 @@
+name: Build diffusers-service image
+
+# Builds and publishes the node-local diffusers text-to-image sidecar to GHCR
+# as ghcr.io/aceteam-ai/diffusers-service. The node compose file
+# (services/compose/diffusers.yml) pulls this image when a node runs
+# SERVICE_START "diffusers" (aceteam #4468), so the image must exist in the
+# registry for the deploy path to work end-to-end.
+#
+# Triggers only when the service source changes (or manually), so ordinary Go
+# PRs don't rebuild a multi-GB CUDA image. Tags: `latest` on main plus the
+# commit SHA for pinning/rollback.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "services/diffusers-service/**"
+      - ".github/workflows/build-diffusers-service.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "services/diffusers-service/**"
+      - ".github/workflows/build-diffusers-service.yml"
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE: ghcr.io/aceteam-ai/diffusers-service
+
+jobs:
+  build:
+    name: Build + push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Only log in / push on push to main (or manual dispatch). On PRs we build
+      # to validate the Dockerfile but do not publish.
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: services/diffusers-service
+          file: services/diffusers-service/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/citadel.yaml
+++ b/citadel.yaml
@@ -15,6 +15,14 @@ services:
   - name: vllm
     compose_file: ./services/vllm.yml
 
+  # Text-to-image (HuggingFace diffusers). Enable this to serve image models
+  # (SDXL-Turbo by default; override with DIFFUSERS_MODEL, e.g. SD 3.5 Medium).
+  # The server listens on the diffusers contract port 7860 with a /health check;
+  # the compose file maps host port 8102 to it (7860 is used by the terminal
+  # server). Started remotely via SERVICE_START "diffusers".
+  # - name: diffusers
+  #   compose_file: ./services/diffusers.yml
+
 # Optional: declare GPU capabilities explicitly.
 # If omitted, capabilities are auto-detected via nvidia-smi at startup.
 # capabilities:

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -575,6 +575,7 @@ func getSelectedService() (string, error) {
 			"ollama (General purpose, easy to use)",
 			"llamacpp (Versatile GGUF server)",
 			"extraction (Entity/relation extraction, CPU-only)",
+			"diffusers (Text-to-image generation, GPU)",
 		},
 	)
 	if err != nil {

--- a/services/compose/diffusers.yml
+++ b/services/compose/diffusers.yml
@@ -27,6 +27,10 @@ services:
       #   DIFFUSERS_MODEL=stabilityai/stable-diffusion-3.5-medium
       - DIFFUSERS_MODEL=${DIFFUSERS_MODEL:-stabilityai/sdxl-turbo}
       - PORT=7860
+      # Gated models (e.g. stabilityai/stable-diffusion-3.5-medium) require a
+      # HuggingFace token. Set HF_TOKEN in the node's environment before
+      # SERVICE_START; the default SDXL-Turbo is open and needs no token.
+      - HF_TOKEN=${HF_TOKEN:-}
     healthcheck:
       # Hits the /health endpoint on the contract port (inside the container).
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:7860/health')"]

--- a/services/compose/diffusers.yml
+++ b/services/compose/diffusers.yml
@@ -1,0 +1,46 @@
+# services/compose/diffusers.yml
+#
+# Node-local text-to-image serving via the HuggingFace diffusers library.
+# Launched on a node by SERVICE_START "diffusers" (aceteam #4468). The image is
+# our own diffusers sidecar (services/diffusers-service), which serves a
+# /generate endpoint and a /health check on the diffusers contract port 7860.
+#
+# NOTE: the container listens on 7860 (the aceteam `diffusers-text-to-image`
+# template's default_port), exactly as vllm listens on 8000. The HOST port is
+# remapped to 8102 to avoid colliding with the citadel terminal server, which
+# binds host port 7860 by default (following the vllm 8100 / transcribe 8101
+# host-port sequence). SERVICE_START does not pass a port to the container; the
+# port contract is satisfied by the server listening on 7860 inside the container.
+
+services:
+  diffusers:
+    image: ghcr.io/aceteam-ai/diffusers-service:latest
+    container_name: citadel-diffusers
+    ports:
+      - "8102:7860"
+    volumes:
+      # Share the HuggingFace model cache with the other HF-based services
+      # (vllm, sglang, whisper) so weights are downloaded once per node.
+      - ~/citadel-cache/huggingface:/root/.cache/huggingface
+    environment:
+      # Model repo id to serve. Override for SD 3.5 Medium / SDXL / etc.:
+      #   DIFFUSERS_MODEL=stabilityai/stable-diffusion-3.5-medium
+      - DIFFUSERS_MODEL=${DIFFUSERS_MODEL:-stabilityai/sdxl-turbo}
+      - PORT=7860
+    healthcheck:
+      # Hits the /health endpoint on the contract port (inside the container).
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:7860/health')"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      # Generous start_period: a large model download on first boot can take a
+      # while, and /health answers before the model finishes loading anyway.
+      start_period: 120s
+    restart: unless-stopped
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/services/diffusers-service/Dockerfile
+++ b/services/diffusers-service/Dockerfile
@@ -1,0 +1,32 @@
+# Node-local diffusers text-to-image sidecar for Citadel.
+# Built and published as ghcr.io/aceteam-ai/diffusers-service (see
+# services/compose/diffusers.yml). Launched on a node via SERVICE_START.
+#
+# Unlike the whisper sidecar (CPU, python:3.12-slim), text-to-image is a GPU
+# workload, so we start from an official PyTorch CUDA runtime image that already
+# bundles a CUDA-enabled torch build. We only layer the diffusers + serving deps
+# on top. On a GPU-less node the service still starts and falls back to CPU
+# (see app.py _resolve_device_and_dtype), just slowly.
+FROM pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime
+
+WORKDIR /app
+
+# torch is already provided by the base image; requirements.txt intentionally
+# omits it so we don't pull a second (possibly CPU-only) torch wheel on top.
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app.py /app/app.py
+
+# 7860 is the diffusers contract port (aceteam #4468). The node compose file
+# maps a host port to this; see services/compose/diffusers.yml.
+ENV PORT=7860
+# Default model; override at deploy time with DIFFUSERS_MODEL.
+ENV DIFFUSERS_MODEL=stabilityai/sdxl-turbo
+# Cache HF weights under /root/.cache/huggingface, bind-mounted from the node's
+# ~/citadel-cache/huggingface (shared with vllm/sglang/whisper).
+ENV HF_HOME=/root/.cache/huggingface
+
+EXPOSE 7860
+
+CMD ["sh", "-c", "uvicorn app:app --host 0.0.0.0 --port ${PORT}"]

--- a/services/diffusers-service/app.py
+++ b/services/diffusers-service/app.py
@@ -1,0 +1,166 @@
+"""Node-local text-to-image sidecar for Citadel.
+
+A small FastAPI service that wraps the HuggingFace ``diffusers`` library and
+serves text-to-image generation on the node's GPU. It mirrors the proven
+node-local sidecar pattern already shipped in Citadel (see
+services/whisper-service/app.py): load a model once, expose a ``/health`` check
+and a single inference endpoint, and keep the heavy Python/ML dependency inside
+a Docker container reachable over localhost.
+
+Built and published as ``ghcr.io/aceteam-ai/diffusers-service`` and launched on
+a node via ``SERVICE_START "diffusers"`` (see services/compose/diffusers.yml).
+
+Contract (aceteam #4468, `diffusers-text-to-image` provisioning template):
+  - engine/service name: ``diffusers``
+  - listens on port 7860 (the container/server port; the node compose file may
+    map a different host port to avoid colliding with the terminal server)
+  - ``GET /health`` liveness/readiness probe
+
+The model is selected via the ``DIFFUSERS_MODEL`` env var (same knob as sglang's
+``SGLANG_COMMAND`` / whisper's ``WHISPER_MODEL``), defaulting to a small, fast
+SDXL-Turbo model. GPU is used when available; falls back to CPU otherwise so the
+service still starts (slowly) on a GPU-less node for smoke testing.
+
+Images never leave the node: generation happens on the user's own hardware and
+the resulting PNG is returned (base64) to the local Go worker, which relays it
+back over the VPN mesh to the user's own AceTeam org.
+"""
+
+import base64
+import io
+import os
+import threading
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+# Model repo id to serve. Defaults to SDXL-Turbo: small (~7GB), fast (1-4 steps),
+# and a good default for a first render. Override for SD 3.5 Medium, SDXL, etc.:
+#   DIFFUSERS_MODEL=stabilityai/stable-diffusion-3.5-medium
+DIFFUSERS_MODEL = os.environ.get("DIFFUSERS_MODEL", "stabilityai/sdxl-turbo")
+
+# Torch dtype for the pipeline. fp16 halves VRAM and is the norm for GPU serving;
+# fp32 is used automatically on CPU (fp16 is not supported on most CPUs).
+DIFFUSERS_DTYPE = os.environ.get("DIFFUSERS_DTYPE", "float16")
+
+# Server port. 7860 is the diffusers contract port (aceteam #4468). Matches the
+# EXPOSE/CMD in the Dockerfile; the node compose file owns the host mapping.
+PORT = int(os.environ.get("PORT", "7860"))
+
+app = FastAPI(title="citadel-diffusers-service")
+
+# The pipeline is expensive to load (weights download + GPU upload), so we build
+# it lazily on the first generation request and cache it. This lets /health
+# answer immediately while a large model is still downloading, so container
+# healthchecks pass during model pull (same lazy pattern as whisper's _get_model).
+_pipe = None
+_pipe_lock = threading.Lock()
+_device = None
+
+
+def _resolve_device_and_dtype():
+    """Pick cuda+fp16 when a GPU is visible, else cpu+fp32."""
+    import torch
+
+    if torch.cuda.is_available():
+        dtype = torch.float16 if DIFFUSERS_DTYPE == "float16" else torch.float32
+        return "cuda", dtype
+    # fp16 math is unsupported on most CPUs; force fp32 there.
+    return "cpu", torch.float32
+
+
+def _get_pipe():
+    """Lazy-load the diffusers text-to-image pipeline once, thread-safely."""
+    global _pipe, _device
+    if _pipe is not None:
+        return _pipe
+    with _pipe_lock:
+        if _pipe is not None:  # re-check inside the lock
+            return _pipe
+        from diffusers import AutoPipelineForText2Image
+
+        device, dtype = _resolve_device_and_dtype()
+        pipe = AutoPipelineForText2Image.from_pretrained(
+            DIFFUSERS_MODEL,
+            torch_dtype=dtype,
+        )
+        pipe = pipe.to(device)
+        _device = device
+        _pipe = pipe
+        return _pipe
+
+
+class GenerateRequest(BaseModel):
+    prompt: str = Field(..., description="Text prompt to render.")
+    # Optional negative prompt (ignored by turbo/distilled models but accepted
+    # so callers can send a uniform request shape).
+    negative_prompt: str | None = None
+    # SDXL-Turbo renders in 1-4 steps; larger models want ~20-50. Default keeps
+    # the turbo default fast; callers override for quality.
+    num_inference_steps: int = Field(default=4, ge=1, le=150)
+    # Turbo models are trained for guidance_scale=0.0; standard SD uses ~7.5.
+    guidance_scale: float = Field(default=0.0, ge=0.0, le=30.0)
+    width: int = Field(default=512, ge=64, le=2048)
+    height: int = Field(default=512, ge=64, le=2048)
+    # Optional seed for reproducible output.
+    seed: int | None = None
+
+
+@app.get("/health")
+def health():
+    """Liveness/readiness probe.
+
+    Returns immediately (does NOT force the model to load) so container
+    healthchecks pass while a large model is still downloading. ``model_loaded``
+    tells callers whether the first (cold) generation will pay the load cost.
+    """
+    return {
+        "status": "ok",
+        "model": DIFFUSERS_MODEL,
+        "model_loaded": _pipe is not None,
+        "device": _device,
+    }
+
+
+@app.post("/generate")
+def generate(req: GenerateRequest):
+    """Render a single image from a text prompt and return it as base64 PNG."""
+    try:
+        pipe = _get_pipe()
+    except Exception as exc:  # model load failure (OOM, bad repo id, auth)
+        raise HTTPException(500, f"failed to load model {DIFFUSERS_MODEL}: {exc}")
+
+    generator = None
+    if req.seed is not None:
+        import torch
+
+        generator = torch.Generator(device=_device).manual_seed(req.seed)
+
+    try:
+        result = pipe(
+            prompt=req.prompt,
+            negative_prompt=req.negative_prompt,
+            num_inference_steps=req.num_inference_steps,
+            guidance_scale=req.guidance_scale,
+            width=req.width,
+            height=req.height,
+            generator=generator,
+        )
+    except Exception as exc:  # inference failure (OOM at generate time, etc.)
+        raise HTTPException(500, f"generation failed: {exc}")
+
+    image = result.images[0]
+    buf = io.BytesIO()
+    image.save(buf, format="PNG")
+    image_b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+
+    return {
+        "model": DIFFUSERS_MODEL,
+        "device": _device,
+        "width": req.width,
+        "height": req.height,
+        "seed": req.seed,
+        # PNG bytes, base64-encoded. The Go worker relays this back to the org.
+        "image_base64": image_b64,
+        "content_type": "image/png",
+    }

--- a/services/diffusers-service/requirements.txt
+++ b/services/diffusers-service/requirements.txt
@@ -2,7 +2,11 @@ diffusers==0.31.0
 transformers==4.46.3
 accelerate==1.1.1
 safetensors==0.4.5
+# sentencepiece + protobuf are needed by the T5 text encoder used by SD 3.5 /
+# other transformer-encoder diffusion models (the default SDXL-Turbo does not
+# need them, but the documented DIFFUSERS_MODEL alternatives do).
 sentencepiece==0.2.0
+protobuf==5.28.3
 fastapi==0.115.6
 uvicorn==0.34.0
 pydantic==2.10.4

--- a/services/diffusers-service/requirements.txt
+++ b/services/diffusers-service/requirements.txt
@@ -1,0 +1,8 @@
+diffusers==0.31.0
+transformers==4.46.3
+accelerate==1.1.1
+safetensors==0.4.5
+sentencepiece==0.2.0
+fastapi==0.115.6
+uvicorn==0.34.0
+pydantic==2.10.4

--- a/services/embed.go
+++ b/services/embed.go
@@ -27,6 +27,9 @@ var ExtractionCompose string
 //go:embed compose/transcribe.yml
 var TranscribeCompose string
 
+//go:embed compose/diffusers.yml
+var DiffusersCompose string
+
 // ServiceMap provides a lookup for pre-packaged service compose files.
 var ServiceMap = map[string]string{
 	"ollama":     OllamaCompose,
@@ -36,6 +39,7 @@ var ServiceMap = map[string]string{
 	"sglang":     SGLangCompose,
 	"extraction": ExtractionCompose,
 	"transcribe": TranscribeCompose,
+	"diffusers":  DiffusersCompose,
 }
 
 // GetAvailableServices returns a sorted list of service names.

--- a/services/embed_test.go
+++ b/services/embed_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -44,5 +45,45 @@ func TestGetAvailableServicesIncludesSGLang(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("GetAvailableServices() = %v, want sglang to be included", available)
+	}
+}
+
+// TestDiffusersComposeRegistered ensures the diffusers service is in the
+// ServiceMap so `citadel init` writes services/diffusers.yml and a node can
+// enable it (aceteam #4468).
+func TestDiffusersComposeRegistered(t *testing.T) {
+	if _, ok := ServiceMap["diffusers"]; !ok {
+		t.Fatal("diffusers not found in ServiceMap")
+	}
+}
+
+// TestGetAvailableServicesIncludesDiffusers ensures diffusers appears in the
+// sorted available services list.
+func TestGetAvailableServicesIncludesDiffusers(t *testing.T) {
+	available := GetAvailableServices()
+	found := false
+	for _, s := range available {
+		if s == "diffusers" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("GetAvailableServices() = %v, want diffusers to be included", available)
+	}
+}
+
+// TestDiffusersComposeContract verifies the embedded diffusers compose file
+// satisfies the aceteam #4468 contract: the container listens on the contract
+// port 7860 and the host mapping avoids the terminal server's default 7860.
+func TestDiffusersComposeContract(t *testing.T) {
+	content := ServiceMap["diffusers"]
+	// Container/server port is the contract port.
+	if !strings.Contains(content, ":7860") {
+		t.Errorf("diffusers compose should map to container port 7860; got:\n%s", content)
+	}
+	// Host port must not be 7860 (that would collide with the terminal server).
+	if strings.Contains(content, "\"7860:") {
+		t.Errorf("diffusers compose host port must not be 7860 (collides with terminal server); got:\n%s", content)
 	}
 }


### PR DESCRIPTION
## Context
Epic child of the Fabric Model Library: **aceteam-ai/aceteam#4468** (serving-engine templates per model type), part of epic **aceteam-ai/aceteam#4472**.

A live-render validation (aceteam #4474 spike) confirmed the concrete gap: node `citadel.yaml` files define `vllm`, `ollama`, `llamacpp`, `tei` but **no `diffusers` service**, so `SERVICE_START "diffusers"` had nothing to launch. This adds the node-side `diffusers` serving service so the deploy path clicks through end-to-end.

## Changes
- **`services/diffusers-service/`** — a small FastAPI server wrapping the HuggingFace `diffusers` library (`AutoPipelineForText2Image`). Exposes `POST /generate` (returns a base64 PNG) and `GET /health`. Model selected via `DIFFUSERS_MODEL` (default `stabilityai/sdxl-turbo`; override for SD 3.5 Medium / SDXL). Lazy model load so `/health` answers during weight download; GPU when available, CPU fallback otherwise. Mirrors the existing `whisper-service` sidecar pattern.
- **`services/compose/diffusers.yml`** — embedded compose file. Pulls `ghcr.io/aceteam-ai/diffusers-service:latest`, HF cache volume shared with vllm/sglang/whisper, nvidia GPU reservation (from vllm.yml), and a `/health` container healthcheck.
- **`services/embed.go`** — registers `diffusers` in `ServiceMap`, so `citadel init` auto-writes `services/diffusers.yml` and every dynamic service list (`citadel run/stop/logs`, init validation) includes it.
- **`cmd/init.go`** — adds diffusers to the interactive service menu.
- **`citadel.yaml`** — documented, commented opt-in block.
- **`.github/workflows/build-diffusers-service.yml`** — builds + pushes the image to GHCR (nothing built it before; whisper-service was pushed out-of-band). Path-filtered so ordinary Go PRs don't rebuild a multi-GB CUDA image.
- **tests** — `TestDiffusersComposeRegistered`, available-list check, and a contract test asserting container port 7860 with host port != 7860.

## Port-7860 / `/health` contract (aceteam #4468)
The aceteam `diffusers-text-to-image` template declares `default_port: 7860` and a `/health` check. As with vLLM (template `default_port: 8000`, node compose maps host `8100:8000`), the **contract port is the server/container port**: the diffusers server listens on **7860** and serves **`/health`**, satisfying the contract exactly. `SERVICE_START`'s payload is `{service, model}` only — it does **not** pass a port — so the node compose file owns the **host** mapping. Because the citadel terminal server binds host `7860` by default, the compose maps host **8102 -> container 7860** (following the vllm `8100` / transcribe `8101` sequence), avoiding the collision without breaking the contract.

## How a node opts in
Add to the node's `citadel.yaml` (documented example is in the repo's `citadel.yaml`):
```yaml
services:
  - name: diffusers
    compose_file: ./services/diffusers.yml
```
`citadel init` already writes `services/diffusers.yml` for every node from the embedded `ServiceMap`, so enabling it is just uncommenting/adding the two lines above (or selecting `diffusers` in `citadel init`'s menu). The web control plane can then `SERVICE_START "diffusers"`.

## Testing
- `gofmt -l` (changed files): clean
- `go vet ./services/...`: clean
- `go build ./cmd/citadel`: OK
- `go test ./services/... ./cmd/...`: PASS (new contract/registration tests included)
- `python3 -m py_compile services/diffusers-service/app.py`: OK
- compose + workflow YAML validated

The one failing test in the full suite (`internal/status/TestServerStartAndShutdown`) is a pre-existing, environment-only flake (port 8080 already in use on the dev host); it fails identically on a clean `main` checkout and is unrelated to this change.

Does not touch any running node's live config.

## Notes for the sibling aceteam #4468 template task
1. **Cross-repo port handoff.** The node serves diffusers on **host port 8102** (container 7860). When the aceteam `diffusers-text-to-image` template lands with `default_port: 7860`, the fabric reachability/inference path must target **8102** on the node, not 7860 (7860 is the terminal server). This is the same latent host-vs-container gap vLLM already has (8100 host vs 8000 container) — deferred, not new, but called out explicitly.
2. **Model is not wired through SERVICE_START (intentional parity).** `service_handler` passes only `{service, model}` and does not forward `model` into the container env; the node uses its compose `DIFFUSERS_MODEL` default — same as vLLM's hardcoded `--model` and sglang's `SGLANG_COMMAND` default. Passing the requested model through to the container is a known follow-up (would apply uniformly to vllm/sglang/diffusers).
3. **Gated models.** Default `stabilityai/sdxl-turbo` is open and needs no token. The documented SD 3.5 Medium alternative is gated: set `HF_TOKEN` in the node env (compose now passes it through) and `protobuf` is included for its T5 encoder.

## Image build
`ghcr.io/aceteam-ai/diffusers-service` did not exist before this PR (whisper-service was pushed out-of-band). The added workflow builds+pushes it on push to `main` (and `workflow_dispatch`); it does **not** run on PRs, so a multi-GB CUDA build does not gate this not-yet-merging PR. Base tag `pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime` was verified to exist via `docker manifest inspect`. The first real image build runs post-merge on main.
