### PR TITLE
fix(status): tests bind ephemeral port, not :8080 (unblocks releases)

### DIFF
--- a/internal/status/server_test.go
+++ b/internal/status/server_test.go
@@ -167,9 +167,24 @@ func TestServerServicesEndpoint(t *testing.T) {
 	}
 }
 
+// freeTCPPort returns a currently-free localhost TCP port. NewServer treats
+// Port==0 as "unset" and defaults it to 8080, so tests that actually Start() the
+// server must pass a real ephemeral port — otherwise they bind :8080 and flake
+// whenever anything else (e.g. the llamacpp container) holds it. See #405.
+func freeTCPPort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to reserve an ephemeral port: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+	return port
+}
+
 func TestServerStartAndShutdown(t *testing.T) {
 	collector := NewCollector(CollectorConfig{NodeName: "test"})
-	server := NewServer(ServerConfig{Port: 0}, collector) // Port 0 for random available port
+	server := NewServer(ServerConfig{Port: freeTCPPort(t)}, collector)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
@@ -313,7 +328,7 @@ func TestServerDualListen(t *testing.T) {
 	extraAddr := extraLn.Addr().(*net.TCPAddr)
 
 	server := NewServer(ServerConfig{
-		Port:    0,
+		Port:    freeTCPPort(t),
 		Version: "test-dual",
 	}, collector)
 	server.AddListener(extraLn)


### PR DESCRIPTION
## Context

Every citadel release has required `docker stop citadel-llamacpp` to run `go test ./...`. Root cause: a **test bug**, not a runtime issue. `internal/status` `TestServerStartAndShutdown` (and the dual-listener test) set `ServerConfig{Port: 0}` expecting a random port — but `NewServer` defaults `Port==0 → 8080`, so they bound `:8080` and failed with `listen tcp :8080: bind: address already in use` whenever the llamacpp container (always on `:8080` on a GPU node) held the port.

## Summary

Add a `freeTCPPort(t)` helper (`net.Listen("tcp", "127.0.0.1:0")` → port → close) and pass a real free port to the two tests that actually `Start()` the server. In-memory handler tests (`buildMux`) are untouched.

## Test plan

- `go test ./internal/status/...` now **passes with the llamacpp container still bound to `:8080`** (previously failed). Verified on node 1054.
- `go vet ./internal/status/...` clean.

## Related

Part of #405. The runtime host-port collisions (llamacpp vs gateway on 8080; vllm vs extraction on 8100) are the systemic half, tracked in #405, coming as a follow-up PR.