### PR TITLE
feat(capabilities): node declares runnable services in heartbeat

### DIFF
--- a/internal/status/capabilities_flags_test.go
+++ b/internal/status/capabilities_flags_test.go
@@ -72,6 +72,55 @@ func TestCapabilityFlagsJSONContract(t *testing.T) {
 	}
 }
 
+// TestPopulateServicesAdvertisesRunnableSet verifies that AvailableServices is
+// populated with the serving services this build can deploy (embedded
+// ServiceMap keys) so the fabric can schedule engine-specific deploys to
+// capable nodes (aceteam#4483). Asserts concrete known keys rather than
+// comparing to GetAvailableServices() (which would be circular).
+func TestPopulateServicesAdvertisesRunnableSet(t *testing.T) {
+	caps := &NodeCapabilities{}
+	populateServices(caps)
+
+	if len(caps.AvailableServices) == 0 {
+		t.Fatal("AvailableServices should be populated, got empty")
+	}
+
+	set := make(map[string]bool, len(caps.AvailableServices))
+	for _, s := range caps.AvailableServices {
+		set[s] = true
+	}
+	for _, want := range []string{"vllm", "ollama", "diffusers"} {
+		if !set[want] {
+			t.Errorf("AvailableServices missing %q; got %v", want, caps.AvailableServices)
+		}
+	}
+
+	// Sorted output keeps heartbeats deterministic.
+	for i := 1; i < len(caps.AvailableServices); i++ {
+		if caps.AvailableServices[i-1] > caps.AvailableServices[i] {
+			t.Errorf("AvailableServices not sorted: %v", caps.AvailableServices)
+			break
+		}
+	}
+}
+
+// TestAvailableServicesJSONContract verifies the wire format: an
+// "available_services" array nested inside the capabilities object, distinct
+// from the top-level NodeStatus.Services (aceteam#4483).
+func TestAvailableServicesJSONContract(t *testing.T) {
+	caps := &NodeCapabilities{
+		AvailableServices: []string{"diffusers", "ollama", "vllm"},
+	}
+	b, err := json.Marshal(caps)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	got := string(b)
+	if !strings.Contains(got, `"available_services":["diffusers","ollama","vllm"]`) {
+		t.Errorf("capabilities JSON missing available_services array; got %s", got)
+	}
+}
+
 // TestNodeStatusCapabilitiesKeyPresent verifies the capabilities block is
 // emitted under the "capabilities" key on NodeStatus (the heartbeat payload),
 // matching CitadelStatus.capabilities on the backend.

--- a/internal/status/collector.go
+++ b/internal/status/collector.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/desktop"
 	"github.com/aceteam-ai/citadel-cli/internal/network"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
+	"github.com/aceteam-ai/citadel-cli/services"
 	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/shirou/gopsutil/v3/disk"
 	"github.com/shirou/gopsutil/v3/host"
@@ -122,7 +123,20 @@ func (c *Collector) Collect() (*NodeStatus, error) {
 	}
 	populateCapabilityFlags(status.Capabilities, status.VNCPort)
 
+	// Advertise the serving services this build can deploy (embedded ServiceMap
+	// keys) so the fabric can schedule engine-specific deploys only to capable
+	// nodes (aceteam#4483).
+	populateServices(status.Capabilities)
+
 	return status, nil
+}
+
+// populateServices sets AvailableServices to the sorted list of serving
+// services this build knows how to deploy (the embedded services.ServiceMap
+// keys). It advertises what the binary CAN run, not what is currently
+// configured/running, matching the backend's tolerant matching (aceteam#4483).
+func populateServices(caps *NodeCapabilities) {
+	caps.AvailableServices = services.GetAvailableServices()
 }
 
 // CollectCompact returns a minimal status suitable for heartbeats.

--- a/internal/status/types.go
+++ b/internal/status/types.go
@@ -62,6 +62,23 @@ type NodeCapabilities struct {
 	Tags       []string        `json:"tags,omitempty"`
 	Hypervisor *HypervisorInfo `json:"hypervisor,omitempty"`
 
+	// AvailableServices lists the serving services/engines this build knows how
+	// to deploy: the keys of the embedded services.ServiceMap (vllm, ollama,
+	// whisper, diffusers, ...). The fabric scheduler uses it to route
+	// engine-specific deploys only to capable nodes (aceteam#4483).
+	//
+	// This is distinct from Engines above:
+	//   - AvailableServices = what this binary version CAN run (static per build,
+	//     from the embedded compose registry). Sorted for deterministic output.
+	//   - Engines = engines currently detected/running on the node.
+	// Both can overlap in value (e.g. "vllm"); they answer different questions.
+	// Emitted under the "available_services" key so it never collides with the
+	// top-level NodeStatus.Services (running service instances). The backend does
+	// tolerant matching against these keys (aceteam#4483), so advertising the full
+	// runnable set (rather than only configured/enabled ones) is the correct first
+	// cut. Omitted on legacy builds, which the backend treats as "unknown".
+	AvailableServices []string `json:"available_services,omitempty"`
+
 	// Real node capability flags (citadel-cli#324). Console = shell/SSH
 	// available, Desktop = VNC reachable, Files = node-files filesystem access,
 	// GPU = GPU present / inference-capable.


### PR DESCRIPTION
## Context

Implements the **citadel-cli half** of aceteam-ai/aceteam#4483: a node should declare which serving services/engines it can run in its capability heartbeat, so the fabric scheduler can route engine-specific deploys (vllm, ollama, whisper, diffusers, ...) only to capable nodes.

The aceteam backend derives each node's capabilities from the status heartbeat (the `capabilities` block, ingested into `node:capabilities:{id}`). Today citadel publishes GPU/engine info but not the set of services the binary knows how to deploy.

> **Stacks on #404** (`feat/diffusers-service`). This PR is branched off and targets `feat/diffusers-service` so its `diffusers` entry is present in the embedded `ServiceMap`. Rebase/retarget to `main` once #404 merges.

## Changes

- **`internal/status/types.go`** — add `AvailableServices []string` (JSON `available_services`, `omitempty`) to `NodeCapabilities`, with a doc comment spelling out the `available_services` vs `engines` distinction (static runnable set per build vs currently-detected engines) and the #4483 tolerant-matching rationale.
- **`internal/status/collector.go`** — add `populateServices()` helper (mirrors the existing `populateCapabilityFlags` pattern), called in `Collect()` right after the capability flags. Populates from `services.GetAvailableServices()` (already sorted, so heartbeats are deterministic).
- **`internal/status/capabilities_flags_test.go`** — add two tests: one asserting concrete known keys (vllm/ollama/diffusers) are advertised and the list is sorted; one asserting the JSON wire contract (`"available_services":[...]` nested inside the capabilities object).

## Design notes

- **Advertises what the binary CAN run** (embedded `ServiceMap` keys), not only configured/enabled services — matching the backend's tolerant matching in #4483. First cut; per-node enable/disable can refine later.
- **`available_services` name** chosen deliberately to avoid confusion with the existing top-level `NodeStatus.Services` (running service instances). No JSON collision (different nesting), but the distinct name keeps the payload readable.
- **No changes to `redis.go` / `api.go`** — the field lives in the shared `NodeCapabilities` embedded in `NodeStatus`, so it flows through both the Redis stream and the HTTP heartbeat automatically.
- **Additive / backward-compatible** — `omitempty` means legacy binaries omit the field; the backend treats absence as "unknown".

## Testing

```bash
gofmt -l internal/status/...        # clean
go build ./...                      # ok
go vet ./internal/status/           # ok
go test ./internal/status/ -run 'TestPopulateServices|TestAvailableServices'   # PASS
```

The only failing test in the package is the pre-existing `TestServerStartAndShutdown` (hardcoded `:8080` bind, unrelated; fixed on `main` by #406, not yet in this stacked branch).

---
*Generated by Claude Opus 4.8*