### PR TITLE
feat(capabilities): node declares runnable services in heartbeat

### DIFF
--- a/internal/status/capabilities_flags_test.go
+++ b/internal/status/capabilities_flags_test.go
@@ -72,6 +72,55 @@ func TestCapabilityFlagsJSONContract(t *testing.T) {
 	}
 }
 
+// TestPopulateServicesAdvertisesRunnableSet verifies that AvailableServices is
+// populated with the serving services this build can deploy (embedded
+// ServiceMap keys) so the fabric can schedule engine-specific deploys to
+// capable nodes (aceteam#4483). Asserts concrete known keys rather than
+// comparing to GetAvailableServices() (which would be circular).
+func TestPopulateServicesAdvertisesRunnableSet(t *testing.T) {
+	caps := &NodeCapabilities{}
+	populateServices(caps)
+
+	if len(caps.AvailableServices) == 0 {
+		t.Fatal("AvailableServices should be populated, got empty")
+	}
+
+	set := make(map[string]bool, len(caps.AvailableServices))
+	for _, s := range caps.AvailableServices {
+		set[s] = true
+	}
+	for _, want := range []string{"vllm", "ollama", "diffusers"} {
+		if !set[want] {
+			t.Errorf("AvailableServices missing %q; got %v", want, caps.AvailableServices)
+		}
+	}
+
+	// Sorted output keeps heartbeats deterministic.
+	for i := 1; i < len(caps.AvailableServices); i++ {
+		if caps.AvailableServices[i-1] > caps.AvailableServices[i] {
+			t.Errorf("AvailableServices not sorted: %v", caps.AvailableServices)
+			break
+		}
+	}
+}
+
+// TestAvailableServicesJSONContract verifies the wire format: an
+// "available_services" array nested inside the capabilities object, distinct
+// from the top-level NodeStatus.Services (aceteam#4483).
+func TestAvailableServicesJSONContract(t *testing.T) {
+	caps := &NodeCapabilities{
+		AvailableServices: []string{"diffusers", "ollama", "vllm"},
+	}
+	b, err := json.Marshal(caps)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	got := string(b)
+	if !strings.Contains(got, `"available_services":["diffusers","ollama","vllm"]`) {
+		t.Errorf("capabilities JSON missing available_services array; got %s", got)
+	}
+}
+
 // TestNodeStatusCapabilitiesKeyPresent verifies the capabilities block is
 // emitted under the "capabilities" key on NodeStatus (the heartbeat payload),
 // matching CitadelStatus.capabilities on the backend.

--- a/internal/status/collector.go
+++ b/internal/status/collector.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/desktop"
 	"github.com/aceteam-ai/citadel-cli/internal/network"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
+	"github.com/aceteam-ai/citadel-cli/services"
 	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/shirou/gopsutil/v3/disk"
 	"github.com/shirou/gopsutil/v3/host"
@@ -122,7 +123,20 @@ func (c *Collector) Collect() (*NodeStatus, error) {
 	}
 	populateCapabilityFlags(status.Capabilities, status.VNCPort)
 
+	// Advertise the serving services this build can deploy (embedded ServiceMap
+	// keys) so the fabric can schedule engine-specific deploys only to capable
+	// nodes (aceteam#4483).
+	populateServices(status.Capabilities)
+
 	return status, nil
+}
+
+// populateServices sets AvailableServices to the sorted list of serving
+// services this build knows how to deploy (the embedded services.ServiceMap
+// keys). It advertises what the binary CAN run, not what is currently
+// configured/running, matching the backend's tolerant matching (aceteam#4483).
+func populateServices(caps *NodeCapabilities) {
+	caps.AvailableServices = services.GetAvailableServices()
 }
 
 // CollectCompact returns a minimal status suitable for heartbeats.

--- a/internal/status/types.go
+++ b/internal/status/types.go
@@ -62,6 +62,23 @@ type NodeCapabilities struct {
 	Tags       []string        `json:"tags,omitempty"`
 	Hypervisor *HypervisorInfo `json:"hypervisor,omitempty"`
 
+	// AvailableServices lists the serving services/engines this build knows how
+	// to deploy: the keys of the embedded services.ServiceMap (vllm, ollama,
+	// whisper, diffusers, ...). The fabric scheduler uses it to route
+	// engine-specific deploys only to capable nodes (aceteam#4483).
+	//
+	// This is distinct from Engines above:
+	//   - AvailableServices = what this binary version CAN run (static per build,
+	//     from the embedded compose registry). Sorted for deterministic output.
+	//   - Engines = engines currently detected/running on the node.
+	// Both can overlap in value (e.g. "vllm"); they answer different questions.
+	// Emitted under the "available_services" key so it never collides with the
+	// top-level NodeStatus.Services (running service instances). The backend does
+	// tolerant matching against these keys (aceteam#4483), so advertising the full
+	// runnable set (rather than only configured/enabled ones) is the correct first
+	// cut. Omitted on legacy builds, which the backend treats as "unknown".
+	AvailableServices []string `json:"available_services,omitempty"`
+
 	// Real node capability flags (citadel-cli#324). Console = shell/SSH
 	// available, Desktop = VNC reachable, Files = node-files filesystem access,
 	// GPU = GPU present / inference-capable.


### PR DESCRIPTION
## Context

Backend companion to aceteam-ai/aceteam#4483 (engine-aware scheduling). The control plane reads each node's `node:capabilities:{id}` to decide where to place a deploy, but a node never advertised *which serving engines it can actually run*. So a diffusers deploy could be scheduled onto a node with no diffusers service. This makes the node declare itself.

Supersedes #407 (that PR was auto-closed when its stacked base `feat/diffusers-service` merged as #404; this is the same commit rebased cleanly onto main).

## Summary

- **`types.go`** — add `AvailableServices []string` (JSON `available_services`, `omitempty`) to `NodeCapabilities`. Documented as the static set of services this build can run (ServiceMap keys), distinct from `Engines` (currently-detected runtimes).
- **`collector.go`** — `populateServices()` (mirrors `populateCapabilityFlags`), called in `Collect()`, sourced from `services.GetAvailableServices()` (already sorted, so heartbeats stay deterministic).
- **`capabilities_flags_test.go`** — known-key/sorted assertion + JSON wire-contract test.

Field name is `available_services` (not `services`) to avoid colliding with the existing `NodeStatus.Services` (running instances). Additive and backward-compatible: `omitempty` means legacy binaries omit it and the backend treats absence as "unknown / eligible".

The diffusers entry is present in `ServiceMap` as of #404 (now on main), so a node that opts into diffusers advertises it automatically.

## Test plan

- `go build ./...`, `gofmt`, `go test ./internal/status/` all pass locally.
- CI (Build + Test, cross-compile matrix) runs on this PR since it targets main.

## Related

- aceteam-ai/aceteam#4483 (backend matching half)
- #404 (diffusers service, merged)
- Fabric Model Library epic aceteam-ai/aceteam#4472

---
*Generated by Claude Opus 4.8*