### PR TITLE
fix(security): scrub inherited secrets from SHELL_COMMAND env + --no-shell node flag (#381)

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -1743,9 +1743,11 @@ func runTUIWorker(ctx context.Context, activityFn func(level, msg string)) error
 
 	// Create handlers with activity callback to route job output through TUI.
 	wsDir := resolveWorkspaceDir()
+	ccPerms := config.LoadPermissions(platform.ConfigDir())
 	handlers := worker.CreateLegacyHandlersWithOpts(worker.LegacyHandlerOpts{
-		LogFn:        activity,
-		WorkspaceDir: wsDir,
+		LogFn:         activity,
+		WorkspaceDir:  wsDir,
+		ShellDisabled: !ccPerms.Shell,
 	})
 
 	// Create runner with TUI callbacks

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1425,10 +1425,12 @@ func runWork(cmd *cobra.Command, args []string) {
 	}
 
 	// Create handlers with optional workspace for file-operation jobs.
+	workPerms := config.LoadPermissions(platform.ConfigDir())
 	handlers := worker.CreateLegacyHandlersWithOpts(worker.LegacyHandlerOpts{
 		WorkspaceDir:              wsDir,
 		ConfigDir:                 workConfigDir,
 		AllowReadOutsideWorkspace: resolveAllowReadOutsideWorkspace(),
+		ShellDisabled:             !workPerms.Shell,
 	})
 	handlers = append(handlers, workflow.NewHandler(wfExec))
 
@@ -1944,6 +1946,7 @@ func permissionsToHeartbeat(p *config.Permissions) *heartbeat.PermissionState {
 		Files:    p.Files,
 		Services: p.Services,
 		SSH:      p.SSH,
+		Shell:    p.Shell,
 	}
 }
 

--- a/internal/config/permissions.go
+++ b/internal/config/permissions.go
@@ -18,6 +18,7 @@ type Permissions struct {
 	Services  bool `yaml:"services" json:"services"`   // Service list/management
 	SSH       bool `yaml:"ssh" json:"ssh"`             // SSH authorized_keys sync
 	Provision bool `yaml:"provision" json:"provision"` // Container provisioning API
+	Shell     bool `yaml:"shell" json:"shell"`         // SHELL_COMMAND job execution
 }
 
 const permissionsFile = "permissions.yaml"
@@ -31,6 +32,7 @@ func DefaultPermissions() *Permissions {
 		Services:  true,
 		SSH:       true,
 		Provision: true,
+		Shell:     true,
 	}
 }
 

--- a/internal/config/permissions_test.go
+++ b/internal/config/permissions_test.go
@@ -8,8 +8,32 @@ import (
 
 func TestDefaultPermissions(t *testing.T) {
 	p := DefaultPermissions()
-	if !p.Console || !p.Desktop || !p.Files || !p.Services || !p.SSH {
+	if !p.Console || !p.Desktop || !p.Files || !p.Services || !p.SSH || !p.Shell {
 		t.Errorf("DefaultPermissions should have all fields true, got %+v", p)
+	}
+}
+
+func TestLoadPermissions_ShellDefaultsEnabled(t *testing.T) {
+	// A pre-existing permissions file that predates the shell field must still
+	// leave shell enabled (backward compatible: absent key keeps the default).
+	dir := t.TempDir()
+	data := []byte("console: true\nssh: false\n")
+	if err := os.WriteFile(filepath.Join(dir, "permissions.yaml"), data, 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	p := LoadPermissions(dir)
+	if !p.Shell {
+		t.Error("shell should default to enabled when absent from an older config file")
+	}
+
+	// Explicit opt-out must round-trip.
+	data = []byte("shell: false\n")
+	if err := os.WriteFile(filepath.Join(dir, "permissions.yaml"), data, 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	p = LoadPermissions(dir)
+	if p.Shell {
+		t.Error("shell should be false when explicitly disabled in config")
 	}
 }
 

--- a/internal/heartbeat/redis.go
+++ b/internal/heartbeat/redis.go
@@ -50,6 +50,7 @@ type PermissionState struct {
 	Files    bool `json:"files"`
 	Services bool `json:"services"`
 	SSH      bool `json:"ssh"`
+	Shell    bool `json:"shell"`
 }
 
 // RedisPublisher publishes node status to Redis for real-time updates and reliable processing.

--- a/internal/jobs/shell_command.go
+++ b/internal/jobs/shell_command.go
@@ -2,6 +2,7 @@
 package jobs
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -10,6 +11,12 @@ import (
 
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
 )
+
+// ShellDisabledError is the exact message returned when SHELL_COMMAND execution
+// has been disabled on this node via the persisted `shell: false` permission
+// (the `--no-shell`-style opt-out). The wording is part of the handler's
+// contract and is asserted in tests, so keep it stable.
+const ShellDisabledError = "shell command execution is disabled on this node"
 
 // standardPATHDirs are directories ensured on PATH when the inherited process
 // environment is restricted (e.g. citadel running via systemd or nohup with a
@@ -24,18 +31,128 @@ var standardPATHDirs = []string{
 	"/bin",
 }
 
-// augmentedEnv returns os.Environ() with the PATH entry extended to include any
-// standardPATHDirs not already present (no duplicates). If no PATH entry exists,
-// one is added. This preserves the restricted-environment fallback from #154
-// now that commands run through /bin/sh rather than a direct exec lookup.
-func augmentedEnv() []string {
-	env := os.Environ()
-	sep := string(os.PathListSeparator)
-	for i, kv := range env {
-		if !strings.HasPrefix(kv, "PATH=") {
+// envAllowExact is the allowlist of environment variable names that are safe to
+// forward from citadel's own process environment into a SHELL_COMMAND child.
+// Anything not on this list (or the envAllowPrefixes below) is dropped, so
+// inherited secrets never leak into dispatched shell jobs.
+var envAllowExact = map[string]struct{}{
+	"PATH":  {},
+	"HOME":  {},
+	"LANG":  {},
+	"TERM":  {},
+	"TZ":    {},
+	"USER":  {},
+	"SHELL": {},
+}
+
+// envAllowPrefixes are name prefixes that are also forwarded (locale settings
+// such as LC_ALL, LC_CTYPE, ...). A denylist match still wins over these.
+var envAllowPrefixes = []string{
+	"LC_",
+}
+
+// envDenySubstrings deny any variable whose name contains one of these tokens,
+// even if it would otherwise be allowed. This constrains the LC_* prefix (e.g.
+// a contrived LC_SECRET_KEY) and guards against a careless future allowlist
+// addition. Matching is case-insensitive.
+var envDenySubstrings = []string{
+	"TOKEN",
+	"SECRET",
+	"KEY",
+	"PASSWORD",
+}
+
+// envDenyPrefixes deny any variable whose name starts with one of these
+// prefixes. Covers cloud/CI credential families and citadel's own config/token
+// vars. Matching is case-insensitive.
+var envDenyPrefixes = []string{
+	"AWS_",
+	"DOCKER_",
+	"GITHUB_",
+	"CITADEL_",
+}
+
+// envDenyExact deny these specific variable names outright.
+var envDenyExact = map[string]struct{}{
+	"SSH_AUTH_SOCK": {},
+}
+
+// isDeniedEnvName reports whether an environment variable name matches any
+// denylist rule. Deny always wins over the allowlist.
+func isDeniedEnvName(name string) bool {
+	upper := strings.ToUpper(name)
+	if _, ok := envDenyExact[upper]; ok {
+		return true
+	}
+	for _, p := range envDenyPrefixes {
+		if strings.HasPrefix(upper, p) {
+			return true
+		}
+	}
+	for _, s := range envDenySubstrings {
+		if strings.Contains(upper, s) {
+			return true
+		}
+	}
+	return false
+}
+
+// isAllowedInheritedEnvName reports whether an inherited variable name is on the
+// allowlist. The denylist is applied separately (and wins).
+func isAllowedInheritedEnvName(name string) bool {
+	if _, ok := envAllowExact[name]; ok {
+		return true
+	}
+	for _, p := range envAllowPrefixes {
+		if strings.HasPrefix(name, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// scrubEnv builds the environment for a SHELL_COMMAND child from a base
+// environment (typically os.Environ()) plus any job-provided vars.
+//
+// Inherited vars are kept only when they match the allowlist AND do not match
+// the denylist (deny wins). Job-provided vars are trusted and bypass the lists —
+// the dispatcher is authenticated, and the threat model here is inherited
+// ambient secrets, not vars the caller deliberately set. PATH is always
+// augmented with standardPATHDirs so /bin/sh can resolve common executables even
+// under a restricted inherited PATH (#154).
+func scrubEnv(base []string, jobEnv map[string]string) []string {
+	kept := make(map[string]string)
+	var order []string
+	add := func(name, value string) {
+		if _, seen := kept[name]; !seen {
+			order = append(order, name)
+		}
+		kept[name] = value
+	}
+
+	for _, kv := range base {
+		eq := strings.IndexByte(kv, '=')
+		if eq < 0 {
 			continue
 		}
-		current := strings.TrimPrefix(kv, "PATH=")
+		name := kv[:eq]
+		if !isAllowedInheritedEnvName(name) || isDeniedEnvName(name) {
+			continue
+		}
+		add(name, kv[eq+1:])
+	}
+
+	// Job-provided vars are explicit and override inherited values.
+	for name, value := range jobEnv {
+		if name == "" {
+			continue
+		}
+		add(name, value)
+	}
+
+	// Ensure PATH includes the standard directories (restricted-env fallback).
+	sep := string(os.PathListSeparator)
+	if current, ok := kept["PATH"]; ok {
 		existing := make(map[string]struct{})
 		for _, d := range filepath.SplitList(current) {
 			existing[d] = struct{}{}
@@ -47,11 +164,33 @@ func augmentedEnv() []string {
 			}
 		}
 		if len(additions) > 0 {
-			env[i] = "PATH=" + current + sep + strings.Join(additions, sep)
+			kept["PATH"] = current + sep + strings.Join(additions, sep)
 		}
-		return env
+	} else {
+		add("PATH", strings.Join(standardPATHDirs, sep))
 	}
-	return append(env, "PATH="+strings.Join(standardPATHDirs, sep))
+
+	env := make([]string, 0, len(order))
+	for _, name := range order {
+		env = append(env, name+"="+kept[name])
+	}
+	return env
+}
+
+// parseJobEnv extracts explicit environment overrides from the job payload's
+// optional "env" field (a JSON object of string->string). Absent or malformed
+// values yield no overrides rather than an error, so a bad env map never blocks
+// an otherwise-valid command.
+func parseJobEnv(job *nexus.Job) map[string]string {
+	raw, ok := job.Payload["env"]
+	if !ok || strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	var m map[string]string
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		return nil
+	}
+	return m
 }
 
 // ShellCommandHandler executes a command string through /bin/sh -c, so pipes,
@@ -60,6 +199,10 @@ type ShellCommandHandler struct {
 	// WorkspaceDir, when non-empty, is set as the command's working directory so
 	// relative paths resolve consistently with the file-operation handlers.
 	WorkspaceDir string
+	// Disabled, when true, makes Execute refuse every command with
+	// ShellDisabledError instead of running it. Wired from the persisted
+	// `shell` node permission (default: enabled).
+	Disabled bool
 }
 
 // NewShellCommandHandler constructs a handler bound to a workspace directory.
@@ -69,6 +212,11 @@ func NewShellCommandHandler(workspace string) *ShellCommandHandler {
 }
 
 func (h *ShellCommandHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	if h.Disabled {
+		ctx.Log("warn", "     - [Job %s] Refusing shell command: %s", job.ID, ShellDisabledError)
+		return nil, fmt.Errorf("%s", ShellDisabledError)
+	}
+
 	cmdString, ok := job.Payload["command"]
 	if !ok {
 		return nil, fmt.Errorf("job payload missing 'command' field")
@@ -79,7 +227,7 @@ func (h *ShellCommandHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, e
 	ctx.Log("info", "     - [Job %s] Running shell command: '%s'", job.ID, cmdString)
 
 	cmd := exec.Command("/bin/sh", "-c", cmdString)
-	cmd.Env = augmentedEnv()
+	cmd.Env = scrubEnv(os.Environ(), parseJobEnv(job))
 	if h.WorkspaceDir != "" {
 		cmd.Dir = h.WorkspaceDir
 	}

--- a/internal/jobs/shell_command_test.go
+++ b/internal/jobs/shell_command_test.go
@@ -188,7 +188,7 @@ func TestScrubEnv_JobProvidedVarsBypassLists(t *testing.T) {
 	// would otherwise trip the denylist, and they override inherited values.
 	base := []string{"PATH=/usr/bin", "HOME=/home/citadel"}
 	jobEnv := map[string]string{
-		"MY_TOKEN": "explicit",   // denylisted name, but explicitly provided
+		"MY_TOKEN": "explicit",    // denylisted name, but explicitly provided
 		"HOME":     "/tmp/custom", // override inherited HOME
 	}
 

--- a/internal/jobs/shell_command_test.go
+++ b/internal/jobs/shell_command_test.go
@@ -3,6 +3,7 @@ package jobs
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
@@ -116,6 +117,144 @@ func TestShellCommand_WorkspaceCwd(t *testing.T) {
 	}
 	if string(out) != "bar" {
 		t.Errorf("output = %q, want %q", string(out), "bar")
+	}
+}
+
+func TestScrubEnv_DropsInheritedSecretsKeepsSafe(t *testing.T) {
+	// A synthetic base environment mixing safe vars, inherited secrets, and a
+	// contrived locale var that must be denied despite the LC_ prefix.
+	base := []string{
+		"PATH=/usr/bin",
+		"HOME=/home/citadel",
+		"LANG=en_US.UTF-8",
+		"LC_ALL=en_US.UTF-8",
+		"TERM=xterm",
+		"USER=citadel",
+		"FOO_TOKEN=super-secret",
+		"AWS_SECRET_ACCESS_KEY=aws-secret",
+		"AWS_ACCESS_KEY_ID=aws-id",
+		"GITHUB_TOKEN=ghp_deadbeef",
+		"DOCKER_HOST=tcp://evil",
+		"CITADEL_DEVICE_TOKEN=dev-token",
+		"MY_PASSWORD=hunter2",
+		"SSH_AUTH_SOCK=/tmp/agent.sock",
+		"LC_SECRET_KEY=nope",
+		"RANDOM_UNLISTED=whatever",
+	}
+
+	got := scrubEnv(base, nil)
+	set := make(map[string]string)
+	for _, kv := range got {
+		if eq := strings.IndexByte(kv, '='); eq >= 0 {
+			set[kv[:eq]] = kv[eq+1:]
+		}
+	}
+
+	// Must be kept.
+	wantKept := []string{"PATH", "HOME", "LANG", "LC_ALL", "TERM", "USER"}
+	for _, name := range wantKept {
+		if _, ok := set[name]; !ok {
+			t.Errorf("expected %s to be kept in scrubbed env, but it was dropped", name)
+		}
+	}
+
+	// Must be dropped: inherited secrets and unlisted vars.
+	wantDropped := []string{
+		"FOO_TOKEN",
+		"AWS_SECRET_ACCESS_KEY",
+		"AWS_ACCESS_KEY_ID",
+		"GITHUB_TOKEN",
+		"DOCKER_HOST",
+		"CITADEL_DEVICE_TOKEN",
+		"MY_PASSWORD",
+		"SSH_AUTH_SOCK",
+		"LC_SECRET_KEY", // deny (contains KEY) wins over LC_ allow prefix
+		"RANDOM_UNLISTED",
+	}
+	for _, name := range wantDropped {
+		if v, ok := set[name]; ok {
+			t.Errorf("expected %s to be scrubbed, but it leaked with value %q", name, v)
+		}
+	}
+
+	// PATH must be augmented with the standard fallback dirs.
+	if !strings.Contains(set["PATH"], "/usr/bin") || !strings.Contains(set["PATH"], "/bin") {
+		t.Errorf("PATH not augmented with standard dirs: %q", set["PATH"])
+	}
+}
+
+func TestScrubEnv_JobProvidedVarsBypassLists(t *testing.T) {
+	// Explicit job-provided vars are trusted and forwarded even if their names
+	// would otherwise trip the denylist, and they override inherited values.
+	base := []string{"PATH=/usr/bin", "HOME=/home/citadel"}
+	jobEnv := map[string]string{
+		"MY_TOKEN": "explicit",   // denylisted name, but explicitly provided
+		"HOME":     "/tmp/custom", // override inherited HOME
+	}
+
+	got := scrubEnv(base, jobEnv)
+	set := make(map[string]string)
+	for _, kv := range got {
+		if eq := strings.IndexByte(kv, '='); eq >= 0 {
+			set[kv[:eq]] = kv[eq+1:]
+		}
+	}
+
+	if set["MY_TOKEN"] != "explicit" {
+		t.Errorf("job-provided MY_TOKEN should be forwarded, got %q", set["MY_TOKEN"])
+	}
+	if set["HOME"] != "/tmp/custom" {
+		t.Errorf("job-provided HOME should override inherited value, got %q", set["HOME"])
+	}
+}
+
+func TestShellCommand_DisabledRefusesAndDoesNotExec(t *testing.T) {
+	dir := t.TempDir()
+	sentinel := filepath.Join(dir, "executed.marker")
+
+	h := &ShellCommandHandler{Disabled: true}
+	out, err := runShell(t, h, "touch "+sentinel)
+
+	if err == nil {
+		t.Fatal("expected refusal error when shell is disabled, got nil")
+	}
+	if err.Error() != ShellDisabledError {
+		t.Errorf("error = %q, want %q", err.Error(), ShellDisabledError)
+	}
+	if len(out) != 0 {
+		t.Errorf("expected no output when disabled, got %q", string(out))
+	}
+	// Proves the command never ran: the sentinel file must not exist.
+	if _, statErr := os.Stat(sentinel); statErr == nil {
+		t.Error("command executed despite shell being disabled (sentinel file was created)")
+	}
+}
+
+func TestShellCommand_EnabledByDefault(t *testing.T) {
+	// A zero-value handler (Disabled=false) must still execute normally.
+	h := &ShellCommandHandler{}
+	out, err := runShell(t, h, "echo ok")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(out) != "ok\n" {
+		t.Errorf("output = %q, want %q", string(out), "ok\n")
+	}
+}
+
+func TestShellCommand_ScrubsSecretsFromChildEnv(t *testing.T) {
+	// End-to-end: a planted secret in the real process env must not be visible
+	// to the executed command.
+	t.Setenv("FOO_TOKEN", "leak-me")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "leak-me-too")
+
+	h := &ShellCommandHandler{}
+	out, err := runShell(t, h, "echo \"[$FOO_TOKEN][$AWS_SECRET_ACCESS_KEY]\"")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.TrimSpace(string(out)) != "[][]" {
+		t.Errorf("secrets leaked into child env: output = %q", string(out))
 	}
 }
 

--- a/internal/tui/controlcenter/actions.go
+++ b/internal/tui/controlcenter/actions.go
@@ -1939,6 +1939,12 @@ func (cc *ControlCenter) showBuiltinServicesModal() {
 			detail:  fmt.Sprintf("Syncs SSH authorized keys from the AceTeam platform.\nLocal SSH server: %s\nGateway route: /ssh", sshStatus),
 			enabled: &perms.SSH,
 		},
+		{
+			name:    "Shell",
+			desc:    "Remote shell command execution",
+			detail:  "Allows dispatched SHELL_COMMAND jobs to run through /bin/sh on this node.\nDisable to make the node refuse all remote shell execution.\nInherited secrets are always scrubbed from the command environment.",
+			enabled: &perms.Shell,
+		},
 	}
 
 	// Left: service list table

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -107,6 +107,11 @@ type LegacyHandlerOpts struct {
 	// (FILE_READ, FILE_READ_BYTES, FILE_LIST, FILE_SEARCH) access paths
 	// outside the workspace sandbox. Write handlers are unaffected.
 	AllowReadOutsideWorkspace bool
+	// ShellDisabled, when true, registers the SHELL_COMMAND handler in a
+	// refusing state: it is still dispatchable (so the node returns the
+	// "disabled" error rather than "unsupported job type"), but every command
+	// is rejected. Wired from the persisted `shell` node permission.
+	ShellDisabled bool
 }
 
 // CreateLegacyHandlers creates JobHandler adapters for all existing Nexus job handlers.
@@ -123,8 +128,11 @@ func CreateLegacyHandlers(logFn ...func(level, msg string)) []JobHandler {
 // structured options value for richer configuration (e.g. workspace directory
 // for file-operation handlers).
 func CreateLegacyHandlersWithOpts(opts LegacyHandlerOpts) []JobHandler {
+	shellHandler := jobs.NewShellCommandHandler(opts.WorkspaceDir)
+	shellHandler.Disabled = opts.ShellDisabled
+
 	handlers := []*LegacyHandlerAdapter{
-		NewLegacyHandlerAdapter(JobTypeShellCommand, jobs.NewShellCommandHandler(opts.WorkspaceDir)),
+		NewLegacyHandlerAdapter(JobTypeShellCommand, shellHandler),
 		NewLegacyHandlerAdapter(JobTypeTmuxSession, jobs.NewTmuxSessionHandler("")),
 		NewLegacyHandlerAdapter(JobTypeDownloadModel, &jobs.DownloadModelHandler{}),
 		NewLegacyHandlerAdapter(JobTypeOllamaPull, &jobs.OllamaPullHandler{}),

--- a/internal/worker/handler_adapter_test.go
+++ b/internal/worker/handler_adapter_test.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/aceteam-ai/citadel-cli/internal/jobs"
@@ -176,6 +177,72 @@ func TestCreateLegacyHandlers(t *testing.T) {
 
 func TestLegacyHandlerAdapterImplementsJobHandler(t *testing.T) {
 	var _ JobHandler = (*LegacyHandlerAdapter)(nil)
+}
+
+// TestCreateLegacyHandlers_ShellDisabled verifies that ShellDisabled still
+// registers a SHELL_COMMAND handler (so the node returns the "disabled" refusal
+// rather than "unsupported job type"), but that handler refuses execution.
+func TestCreateLegacyHandlers_ShellDisabled(t *testing.T) {
+	handlers := CreateLegacyHandlersWithOpts(LegacyHandlerOpts{ShellDisabled: true})
+
+	var shell JobHandler
+	for _, h := range handlers {
+		if h.CanHandle(JobTypeShellCommand) {
+			shell = h
+			break
+		}
+	}
+	if shell == nil {
+		t.Fatal("SHELL_COMMAND handler must remain registered even when disabled")
+	}
+
+	job := &Job{
+		ID:      "job-shell-disabled",
+		Type:    JobTypeShellCommand,
+		Payload: map[string]any{"command": "echo should-not-run"},
+	}
+	result, err := shell.Execute(context.Background(), job, &NoOpStreamWriter{})
+	if err == nil {
+		t.Fatal("disabled SHELL_COMMAND handler should return an error")
+	}
+	if !strings.Contains(err.Error(), jobs.ShellDisabledError) {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), jobs.ShellDisabledError)
+	}
+	// The adapter surfaces failures via the returned error; result should not
+	// report success.
+	if result != nil && result.Status == JobStatusSuccess {
+		t.Error("disabled shell handler must not report success")
+	}
+}
+
+// TestCreateLegacyHandlers_ShellEnabledByDefault confirms the default opt
+// (ShellDisabled=false) leaves shell execution working.
+func TestCreateLegacyHandlers_ShellEnabledByDefault(t *testing.T) {
+	handlers := CreateLegacyHandlersWithOpts(LegacyHandlerOpts{})
+
+	var shell JobHandler
+	for _, h := range handlers {
+		if h.CanHandle(JobTypeShellCommand) {
+			shell = h
+			break
+		}
+	}
+	if shell == nil {
+		t.Fatal("SHELL_COMMAND handler must be registered by default")
+	}
+
+	job := &Job{
+		ID:      "job-shell-enabled",
+		Type:    JobTypeShellCommand,
+		Payload: map[string]any{"command": "echo ok"},
+	}
+	result, err := shell.Execute(context.Background(), job, &NoOpStreamWriter{})
+	if err != nil {
+		t.Fatalf("enabled shell handler should run: %v", err)
+	}
+	if result.Status != JobStatusSuccess {
+		t.Errorf("result.Status = %v, want success", result.Status)
+	}
 }
 
 func TestLegacyHandlerAdapterPayloadCoercion(t *testing.T) {


### PR DESCRIPTION
## Context

`SHELL_COMMAND` (the node side of `terminal_exec` and the `code_*`/file dispatch) is the highest-blast-radius handler on a Citadel node: a single leaked org API key means arbitrary RCE on every node in the org. #381 tracks the full fix — signed-capability gating (aceteam#4313), an opt-in execution sandbox (bubblewrap/landlock/container), cgroup/ulimit resource caps, and a scrubbed environment.

This PR lands the **PKI-independent slice** of that epic: the two hardening steps that need no new infrastructure and are safe to ship today — env scrubbing and a per-node shell kill-switch. The sandbox, capability gate, and resource limits remain tracked in #381 / aceteam#4313.

Before this change, `cmd.Env = augmentedEnv()` handed every dispatched command the **entire** `os.Environ()` — cloud creds, API tokens, the SSH agent socket, and citadel's own config vars. That's a secret-exfiltration primitive available to any authenticated dispatcher.

## Summary

**1. Env allowlist scrub (`internal/jobs/shell_command.go`)**

`augmentedEnv()` → a centralized, pure `scrubEnv(base, jobEnv)`:

- **Allowed (inherited):** `PATH`, `HOME`, `LANG`, `LC_*`, `TERM`, `TZ`, `USER`, `SHELL`
- **Dropped:** everything else, and explicitly anything matching the denylist — name contains `TOKEN` / `SECRET` / `KEY` / `PASSWORD`, name is `SSH_AUTH_SOCK`, or name starts with `AWS_` / `DOCKER_` / `GITHUB_` / `CITADEL_`
- **Deny wins over allow** (case-insensitive), so a contrived `LC_SECRET_KEY` is dropped despite the `LC_` allow-prefix
- **Job-provided env** (optional `env` JSON object in the job payload) is trusted and bypasses the lists — the threat model is *inherited ambient* secrets, not vars the authenticated caller deliberately set. This is the escape hatch for jobs that genuinely need e.g. `LD_LIBRARY_PATH` / `CUDA_*` / proxy vars. Note: nothing upstream emits an `env` payload for `SHELL_COMMAND` today — it's a new forward-looking field, not wired end-to-end from the dispatcher yet.
- **PATH is still augmented** with the standard fallback dirs (`/usr/bin`, `/bin`, ...) so `/bin/sh` resolves executables under a restricted inherited PATH (preserves the #154 fallback).

**2. `shell` node permission (the `--no-shell` opt-out)**

A persisted `shell` field added to `config.Permissions` (`permissions.yaml`), **default enabled** (opt-out model, backward compatible — an older config file with no `shell:` key keeps shell on). When disabled, the `SHELL_COMMAND` handler stays **registered** but refuses every command with `shell command execution is disabled on this node`, so the node returns a clear refusal rather than `unsupported job type`.

Wired the same way the existing SSH/Desktop/Console/Files/Services flags flow — there is no cobra `--no-shell` flag because those precedent flags aren't cobra flags either; they're persisted permissions toggled via `permissions.yaml` + the TUI. This satisfies "persisted node option that survives restart" more directly than a process flag would. Specifically:
- `LegacyHandlerOpts.ShellDisabled` threaded through both live worker callers (`cmd/work.go`, `cmd/controlcenter.go`), sourced from `!perms.Shell`
- Surfaced as a toggle in the TUI **Built-in Services** panel
- Mirrored into `heartbeat.PermissionState` + `permissionsToHeartbeat` so node status reflects it

## Scope & caveat

**This is env/flag hardening, NOT the RCE fix.** The command still runs as the full citadel user through `/bin/sh -c`, with no chroot/namespace/seccomp/landlock and no resource limits. Critically, the device API token lives **on disk** in `~/.citadel-cli/config.yaml`, not in the environment — scrubbing `cmd.Env` does **not** stop a command from reading that file. The real containment (filesystem sandbox + signed-capability gate that default-denies on shared/marketplace nodes) remains tracked in #381 and the Fabric PKI epic **aceteam#4313**. Do not read this PR as closing the RCE.

## Test plan

| Test | Coverage |
| --- | --- |
| `TestScrubEnv_DropsInheritedSecretsKeepsSafe` | Synthetic base env with planted `FOO_TOKEN`, `AWS_SECRET_ACCESS_KEY`, `GITHUB_TOKEN`, `DOCKER_HOST`, `CITADEL_DEVICE_TOKEN`, `SSH_AUTH_SOCK`, `LC_SECRET_KEY` → all dropped; `PATH`/`HOME`/`LANG`/`LC_ALL`/`TERM`/`USER` kept; PATH augmented |
| `TestScrubEnv_JobProvidedVarsBypassLists` | Job-provided `MY_TOKEN` forwarded despite denylist; job `HOME` overrides inherited |
| `TestShellCommand_ScrubsSecretsFromChildEnv` | E2E: real `t.Setenv` secrets are invisible to the executed command (`[][]`) |
| `TestShellCommand_DisabledRefusesAndDoesNotExec` | Disabled handler returns exact refusal string, no output, and the `touch` sentinel file is **not** created (proves non-execution) |
| `TestShellCommand_EnabledByDefault` | Zero-value handler still executes |
| `TestCreateLegacyHandlers_ShellDisabled` | `ShellDisabled` opt keeps SHELL_COMMAND registered but refusing (not "unsupported job type") |
| `TestCreateLegacyHandlers_ShellEnabledByDefault` | Default opt runs shell normally |
| `TestDefaultPermissions` / `TestLoadPermissions_ShellDefaultsEnabled` | `shell` defaults true; absent key in an older config keeps it enabled; explicit `shell: false` round-trips |
| Existing shell tests (pipe/&&/quoting/restricted-PATH/workspace-cwd) | Still green |

`go build ./...`, `go vet ./...`, and `go test ./internal/jobs/... ./internal/worker/... ./internal/config/... ./internal/heartbeat/... ./cmd/... ./internal/tui/...` all pass.

## Related

- Part of #381 (leaving it open for the sandbox / capability-gate / resource-limit work)
- Fabric PKI + signed-capabilities epic: aceteam#4313 (first consumer = shell/exec grant)
