### PR TITLE
feat(services): citadel owns host-port allocation — no more compose port collisions (#405)

### DIFF
--- a/cmd/expose.go
+++ b/cmd/expose.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/network"
+	"github.com/aceteam-ai/citadel-cli/services"
 	"github.com/spf13/cobra"
 )
 
@@ -20,14 +21,16 @@ var (
 	exposeCheck   bool
 )
 
-// Known service ports
+// Known service ports. vllm/llamacpp use the citadel-owned host ports
+// (services/ports.go) so the URLs shown to the operator match what the
+// containers actually publish.
 var servicePorts = map[string]int{
-	"vllm":     8000,
+	"vllm":     services.VLLMHostPort,
 	"ollama":   11434,
-	"llamacpp": 8080,
+	"llamacpp": services.LlamacppHostPort,
 	"lmstudio": 1234,
-	// wechat is the per-person WeChat REST API (WeChatFerry on a Windows VM).
-	// Shares :8000 with vllm; the map is keyed by name so both coexist.
+	// wechat is the per-person WeChat REST API (WeChatFerry on a Windows VM) on
+	// its own :8000; the map is keyed by name so it coexists with the others.
 	"wechat": 8000,
 }
 

--- a/internal/apps/catalog.go
+++ b/internal/apps/catalog.go
@@ -82,7 +82,10 @@ var builtinCatalog = map[string]AppManifest{
 		Name:        "jupyter",
 		Description: "Jupyter Notebook for Python development",
 		Image:       "jupyter/minimal-notebook:latest",
-		Ports:       map[int]int{8888: 8101},
+		// Suggested host port. Actual host port is dynamically allocated by
+		// State.AllocatePort; this value avoids the citadel-reserved in-range
+		// ports (transcribe 8101, TEI 8102).
+		Ports: map[int]int{8888: 8104},
 		Volumes: []VolumeMount{
 			{HostPath: "work", ContainerPath: "/home/jovyan/work"},
 		},
@@ -99,7 +102,9 @@ var builtinCatalog = map[string]AppManifest{
 		Name:        "filebrowser",
 		Description: "Web-based file manager",
 		Image:       "filebrowser/filebrowser:latest",
-		Ports:       map[int]int{80: 8102},
+		// Suggested host port; actual port is dynamically allocated. 8102 is
+		// reserved for the TEI embedding upstream, so this avoids it.
+		Ports: map[int]int{80: 8105},
 		Volumes: []VolumeMount{
 			{HostPath: "data", ContainerPath: "/srv"},
 		},

--- a/internal/apps/hostport_collision_test.go
+++ b/internal/apps/hostport_collision_test.go
@@ -122,7 +122,13 @@ func publishedHostPorts(composeYAML string) ([]int, error) {
 				continue
 			}
 			if strings.HasPrefix(hostPart, "${") && strings.HasSuffix(hostPart, "}") {
-				varName := strings.TrimSuffix(strings.TrimPrefix(hostPart, "${"), "}")
+				inner := strings.TrimSuffix(strings.TrimPrefix(hostPart, "${"), "}")
+				// Strip any compose default/required suffix, e.g. VAR:?msg or
+				// VAR:-default, leaving the bare variable name.
+				varName := inner
+				if idx := strings.Index(inner, ":"); idx >= 0 {
+					varName = inner[:idx]
+				}
 				port, ok := envValue[varName]
 				if !ok {
 					return nil, fmt.Errorf("compose publishes unknown host-port var %q; add it to the registry", hostPart)
@@ -145,8 +151,22 @@ func publishedHostPorts(composeYAML string) ([]int, error) {
 //
 //	"HOST:CONTAINER"
 //	"IP:HOST:CONTAINER"
-//	"CONTAINER"            (no host publish -> "")
+//	"CONTAINER"                        (no host publish -> "")
+//	"${VAR:?msg}:CONTAINER"            (env var host port whose default/required
+//	                                    suffix itself contains colons)
+//
+// The host field may be a `${...}` expansion that contains its own colons
+// (compose's `:?`/`:-` operators), so we peel off a leading `${...}` group
+// intact before splitting the remainder on ":".
 func hostPortField(spec string) string {
+	if strings.HasPrefix(spec, "${") {
+		if end := strings.Index(spec, "}"); end >= 0 {
+			// The `${...}` group is the host field. Anything after it is
+			// ":CONTAINER" (and possibly a bind-mode suffix we ignore).
+			return spec[:end+1]
+		}
+		return spec
+	}
 	parts := strings.Split(spec, ":")
 	switch len(parts) {
 	case 1:

--- a/internal/apps/hostport_collision_test.go
+++ b/internal/apps/hostport_collision_test.go
@@ -1,0 +1,164 @@
+package apps
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/services"
+	"gopkg.in/yaml.v3"
+)
+
+// TestHostPortNoCollisions is the guarantee that "containers can't dictate the
+// host port". It builds the union of every host port claimed across:
+//
+//   - the citadel-owned service registry (services.ServiceHostPorts),
+//   - the apps catalog's suggested host ports (builtinCatalog),
+//   - every services/compose/*.yml file (parsed from the embedded ServiceMap),
+//
+// and asserts:
+//
+//  1. no two of those claim the same host port (pairwise-unique), and
+//  2. none of them intersect citadel's own reserved ports
+//     (services.ReservedCitadelPorts), which are shared across citadel-internal
+//     run contexts (gateway/status on 8080, etc.) and must never be taken by a
+//     module or app.
+//
+// Reserved ports are a set-to-AVOID, not a set-to-dedupe: 8080 is intentionally
+// reused by the gateway, the status server, and the whatsapp bridge across
+// different contexts, so it is not part of the pairwise-uniqueness check.
+func TestHostPortNoCollisions(t *testing.T) {
+	// owner records who claimed a given host port, so a collision message is
+	// actionable.
+	owner := map[int]string{}
+	reserved := services.ReservedCitadelPorts
+
+	claim := func(port int, who string) {
+		t.Helper()
+		if port == 0 {
+			return
+		}
+		if name, taken := reserved[port]; taken {
+			t.Errorf("host port %d claimed by %q collides with reserved citadel port %q", port, who, name)
+			return
+		}
+		if prev, exists := owner[port]; exists {
+			t.Errorf("host port %d claimed by both %q and %q", port, prev, who)
+			return
+		}
+		owner[port] = who
+	}
+
+	// 1. Apps catalog suggested host ports (the map VALUE is the suggested host
+	// port; the KEY is the container port).
+	for name, manifest := range builtinCatalog {
+		for _, hostPort := range manifest.Ports {
+			claim(hostPort, "apps:"+name)
+		}
+	}
+
+	// 2. Published host ports parsed out of every embedded compose file. The
+	// compose files are the authoritative published set; for the citadel-owned
+	// services their host port is resolved from the registry during parsing
+	// (see publishedHostPorts), so we do not claim the registry separately here
+	// (that would be a self-collision). Instead we assert below that each
+	// registry entry matches what its compose file publishes.
+	composePorts := map[string]int{}
+	for name, composeYAML := range services.ServiceMap {
+		ports, err := publishedHostPorts(composeYAML)
+		if err != nil {
+			t.Fatalf("parse compose %q: %v", name, err)
+		}
+		for _, port := range ports {
+			claim(port, "compose:"+name)
+		}
+		if len(ports) == 1 {
+			composePorts[name] = ports[0]
+		}
+	}
+
+	// 3. The registry must agree with what each managed service's compose file
+	// actually publishes — otherwise the env-var substitution and the Go
+	// consumers would target different ports.
+	for svc, port := range services.ServiceHostPorts {
+		if cp, ok := composePorts[svc]; ok && cp != port {
+			t.Errorf("registry host port for %q is %d but its compose publishes %d", svc, port, cp)
+		}
+	}
+}
+
+// composeFile is the minimal shape needed to read published ports from a
+// docker-compose YAML.
+type composeFile struct {
+	Services map[string]struct {
+		Ports []string `yaml:"ports"`
+	} `yaml:"services"`
+}
+
+// publishedHostPorts extracts the HOST side of every `ports:` publish in a
+// compose file. Entries whose host port is supplied by a ${CITADEL_*_HOST_PORT}
+// env var are resolved against the registry so the test validates the value
+// citadel actually injects (this is what proves the deferral is wired to a real
+// port). Entries with a literal host port are returned as-is.
+func publishedHostPorts(composeYAML string) ([]int, error) {
+	var cf composeFile
+	if err := yaml.Unmarshal([]byte(composeYAML), &cf); err != nil {
+		return nil, err
+	}
+
+	// Map each ${VAR} spelling to its registry value.
+	envValue := map[string]int{
+		services.EnvLlamacppHostPort:   services.LlamacppHostPort,
+		services.EnvVLLMHostPort:       services.VLLMHostPort,
+		services.EnvExtractionHostPort: services.ExtractionHostPort,
+	}
+
+	var out []int
+	for _, svc := range cf.Services {
+		for _, spec := range svc.Ports {
+			hostPart := hostPortField(spec)
+			if hostPart == "" {
+				continue
+			}
+			if strings.HasPrefix(hostPart, "${") && strings.HasSuffix(hostPart, "}") {
+				varName := strings.TrimSuffix(strings.TrimPrefix(hostPart, "${"), "}")
+				port, ok := envValue[varName]
+				if !ok {
+					return nil, fmt.Errorf("compose publishes unknown host-port var %q; add it to the registry", hostPart)
+				}
+				out = append(out, port)
+				continue
+			}
+			port, err := strconv.Atoi(hostPart)
+			if err != nil {
+				return nil, fmt.Errorf("unparseable host port %q in spec %q", hostPart, spec)
+			}
+			out = append(out, port)
+		}
+	}
+	return out, nil
+}
+
+// hostPortField extracts the host-port token from a compose short-syntax ports
+// entry. Handles the forms:
+//
+//	"HOST:CONTAINER"
+//	"IP:HOST:CONTAINER"
+//	"CONTAINER"            (no host publish -> "")
+func hostPortField(spec string) string {
+	parts := strings.Split(spec, ":")
+	switch len(parts) {
+	case 1:
+		// Only a container port; no host publish.
+		return ""
+	case 2:
+		// HOST:CONTAINER
+		return parts[0]
+	default:
+		// IP:HOST:CONTAINER (IP may itself contain colons for IPv6, but the
+		// compose files here use IPv4 / no IP, so the host port is the
+		// second-to-last field).
+		return parts[len(parts)-2]
+	}
+}

--- a/internal/apps/hostport_collision_test.go
+++ b/internal/apps/hostport_collision_test.go
@@ -112,6 +112,7 @@ func publishedHostPorts(composeYAML string) ([]int, error) {
 		services.EnvLlamacppHostPort:   services.LlamacppHostPort,
 		services.EnvVLLMHostPort:       services.VLLMHostPort,
 		services.EnvExtractionHostPort: services.ExtractionHostPort,
+		services.EnvDiffusersHostPort:  services.DiffusersHostPort,
 	}
 
 	var out []int

--- a/internal/apps/state.go
+++ b/internal/apps/state.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/aceteam-ai/citadel-cli/services"
 )
 
 // InstalledApp records the runtime state of a deployed app.
@@ -155,7 +157,10 @@ const (
 
 // AllocatePort returns the next available port in the 8100-8199 range
 // that is not already used by an installed app. It returns an error
-// if the range is exhausted.
+// if the range is exhausted. Ports reserved by citadel's own services that
+// happen to fall inside this range (e.g. the TEI embedding upstream 8102 and
+// the transcribe sidecar 8101) are skipped so a dynamically allocated app can
+// never collide with them.
 func (s *State) AllocatePort() (int, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -164,9 +169,10 @@ func (s *State) AllocatePort() (int, error) {
 	for _, app := range s.Apps {
 		used[app.HostPort] = true
 	}
+	reserved := services.InRangeReservedHostPorts()
 
 	for port := portRangeStart; port <= portRangeEnd; port++ {
-		if !used[port] {
+		if !used[port] && !reserved[port] {
 			return port, nil
 		}
 	}

--- a/internal/apps/state_test.go
+++ b/internal/apps/state_test.go
@@ -4,7 +4,23 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/services"
 )
+
+// nextFreeFrom returns the first port >= from within the apps range that is not
+// used by an already-allocated app and not citadel-reserved. It mirrors
+// AllocatePort's skip logic so the allocation tests don't hardcode ports that
+// shift when the reserved set changes.
+func nextFreeFrom(from int, used map[int]bool) int {
+	reserved := services.InRangeReservedHostPorts()
+	for p := from; p <= portRangeEnd; p++ {
+		if !used[p] && !reserved[p] {
+			return p
+		}
+	}
+	return 0
+}
 
 func TestStateRoundTrip(t *testing.T) {
 	tmpDir := t.TempDir()
@@ -100,23 +116,26 @@ func TestAllocatePort(t *testing.T) {
 		path: filepath.Join(t.TempDir(), "state.json"),
 	}
 
-	// First allocation should return portRangeStart.
+	// First allocation should return the first free, non-reserved port.
+	wantFirst := nextFreeFrom(portRangeStart, map[int]bool{})
 	port, err := s.AllocatePort()
 	if err != nil {
 		t.Fatalf("AllocatePort() error: %v", err)
 	}
-	if port != portRangeStart {
-		t.Errorf("AllocatePort() = %d, want %d", port, portRangeStart)
+	if port != wantFirst {
+		t.Errorf("AllocatePort() = %d, want %d", port, wantFirst)
 	}
 
-	// After setting an app on portRangeStart, next should be portRangeStart+1.
-	s.Set(InstalledApp{Name: "app1", HostPort: portRangeStart})
+	// After setting an app on the first port, the next allocation should skip
+	// it (and any citadel-reserved in-range ports).
+	s.Set(InstalledApp{Name: "app1", HostPort: port})
+	wantSecond := nextFreeFrom(portRangeStart, map[int]bool{port: true})
 	port, err = s.AllocatePort()
 	if err != nil {
 		t.Fatalf("AllocatePort() error: %v", err)
 	}
-	if port != portRangeStart+1 {
-		t.Errorf("AllocatePort() = %d, want %d", port, portRangeStart+1)
+	if port != wantSecond {
+		t.Errorf("AllocatePort() = %d, want %d", port, wantSecond)
 	}
 }
 

--- a/internal/jobs/config_handler.go
+++ b/internal/jobs/config_handler.go
@@ -263,10 +263,15 @@ func (h *ConfigHandler) startServices(configDir string, serviceNames []string) e
 		// Set working directory for relative paths in compose files
 		cmd.Dir = configDir
 
+		// Start from the process env and supply the citadel-owned host ports so
+		// compose files that defer their host publish to ${CITADEL_*_HOST_PORT}
+		// (llamacpp/vllm/extraction) resolve.
+		env := append(os.Environ(), services.HostPortEnv()...)
 		// Configure GPU runtime if on Linux
 		if platform.IsLinux() {
-			cmd.Env = append(os.Environ(), "DOCKER_DEFAULT_RUNTIME=nvidia")
+			env = append(env, "DOCKER_DEFAULT_RUNTIME=nvidia")
 		}
+		cmd.Env = env
 
 		output, err := cmd.CombinedOutput()
 		if err != nil {

--- a/internal/jobs/extraction_handler.go
+++ b/internal/jobs/extraction_handler.go
@@ -10,10 +10,18 @@ import (
 	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+	"github.com/aceteam-ai/citadel-cli/services"
 )
 
 // ExtractionHandler proxies extraction requests to the local extraction service.
 type ExtractionHandler struct{}
+
+// extractionBaseURL is the host-local base URL for the extraction service, using
+// the citadel-owned host port (services/ports.go) rather than a hardcoded
+// literal.
+func extractionBaseURL() string {
+	return fmt.Sprintf("http://localhost:%d", services.ExtractionHostPort)
+}
 
 func (h *ExtractionHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
 	text, textOk := job.Payload["text"]
@@ -46,7 +54,7 @@ func (h *ExtractionHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, err
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	resp, err := http.Post("http://localhost:8100/extract", "application/json", bytes.NewBuffer(reqBody))
+	resp, err := http.Post(extractionBaseURL()+"/extract", "application/json", bytes.NewBuffer(reqBody))
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to extraction service: %w", err)
 	}
@@ -61,7 +69,7 @@ func (h *ExtractionHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, err
 }
 
 func (h *ExtractionHandler) waitForReady() error {
-	healthURL := "http://localhost:8100/health"
+	healthURL := extractionBaseURL() + "/health"
 	maxWait := 60 * time.Second
 	pollInterval := 1 * time.Second
 	startTime := time.Now()

--- a/internal/jobs/llamacpp_inference.go
+++ b/internal/jobs/llamacpp_inference.go
@@ -14,9 +14,16 @@ import (
 
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
+	"github.com/aceteam-ai/citadel-cli/services"
 )
 
 type LlamaCppInferenceHandler struct{}
+
+// llamacppBaseURL is the host-local base URL for the llama.cpp server, using the
+// citadel-owned host port (services/ports.go) rather than a hardcoded literal.
+func llamacppBaseURL() string {
+	return fmt.Sprintf("http://localhost:%d", services.LlamacppHostPort)
+}
 
 // NOTE (from Architect): The logic below still restarts the container for every job.
 // This is a direct port of the original logic for the refactoring. The next step
@@ -37,6 +44,9 @@ func (h *LlamaCppInferenceHandler) Execute(ctx JobContext, job *nexus.Job) ([]by
 	newCommand := fmt.Sprintf("--model /models/%s --host 0.0.0.0 --port 8080 --n-gpu-layers -1", modelFile)
 	restartCmd := exec.Command("docker", "compose", "-f", composeFile, "up", "-d", "--force-recreate")
 	restartCmd.Env = append(os.Environ(), fmt.Sprintf("LLAMACPP_COMMAND=%s", newCommand))
+	// Supply the citadel-owned host port so the compose ports line
+	// (127.0.0.1:${CITADEL_LLAMACPP_HOST_PORT}:8080) resolves.
+	restartCmd.Env = append(restartCmd.Env, services.HostPortEnv()...)
 
 	if output, err := restartCmd.CombinedOutput(); err != nil {
 		return output, fmt.Errorf("failed to restart llama.cpp service with new model: %w", err)
@@ -54,7 +64,7 @@ func (h *LlamaCppInferenceHandler) Execute(ctx JobContext, job *nexus.Job) ([]by
 }
 
 func (h *LlamaCppInferenceHandler) waitForLlamaCppReady() error {
-	llamacppURL := "http://localhost:8080/completion"
+	llamacppURL := llamacppBaseURL() + "/completion"
 	maxWait := 120 * time.Second
 	pollInterval := 2 * time.Second
 	startTime := time.Now()
@@ -83,7 +93,7 @@ func (h *LlamaCppInferenceHandler) performInference(prompt string) ([]byte, erro
 		"temperature": 0.7,
 	}
 	reqBody, _ := json.Marshal(requestPayload)
-	resp, httpErr := http.Post("http://localhost:8080/completion", "application/json", bytes.NewBuffer(reqBody))
+	resp, httpErr := http.Post(llamacppBaseURL()+"/completion", "application/json", bytes.NewBuffer(reqBody))
 	if httpErr != nil {
 		return nil, fmt.Errorf("failed to connect to llama.cpp service: %w", httpErr)
 	}

--- a/internal/jobs/llm_inference.go
+++ b/internal/jobs/llm_inference.go
@@ -13,10 +13,19 @@ import (
 	"time"
 
 	redisclient "github.com/aceteam-ai/citadel-cli/internal/redis"
+	"github.com/aceteam-ai/citadel-cli/services"
 )
 
 // LLMInferenceHandler handles llm_inference jobs from the Redis queue.
 type LLMInferenceHandler struct{}
+
+// vllmBaseURL and llamacppBaseURL2 return host-local base URLs for the vLLM and
+// llama.cpp engines using the citadel-owned host ports (services/ports.go)
+// rather than hardcoded literals. (llamacppBaseURL is already defined in
+// llamacpp_inference.go within this package; this file reuses that helper.)
+func vllmBaseURL() string {
+	return fmt.Sprintf("http://localhost:%d", services.VLLMHostPort)
+}
 
 // CanHandle returns true if this handler can process the given job type.
 func (h *LLMInferenceHandler) CanHandle(jobType string) bool {
@@ -95,7 +104,7 @@ func (h *LLMInferenceHandler) executeVLLM(ctx context.Context, client *redisclie
 		return err
 	}
 
-	vllmURL := "http://localhost:8000/v1/completions"
+	vllmURL := vllmBaseURL() + "/v1/completions"
 
 	reqPayload := map[string]any{
 		"model":       payload.Model,
@@ -234,7 +243,7 @@ func (h *LLMInferenceHandler) handleVLLMNonStream(ctx context.Context, client *r
 }
 
 func (h *LLMInferenceHandler) waitForVLLMReady(ctx context.Context) error {
-	healthURL := "http://localhost:8000/health"
+	healthURL := vllmBaseURL() + "/health"
 	maxWait := 60 * time.Second
 	pollInterval := 1 * time.Second
 	startTime := time.Now()
@@ -445,7 +454,7 @@ func (h *LLMInferenceHandler) handleOllamaNonStream(ctx context.Context, client 
 
 // executeLlamaCpp handles inference via llama.cpp server API.
 func (h *LLMInferenceHandler) executeLlamaCpp(ctx context.Context, client *redisclient.Client, jobID, rayID string, payload *LLMInferencePayload) error {
-	llamaCppURL := "http://localhost:8080/completion"
+	llamaCppURL := llamacppBaseURL() + "/completion"
 
 	reqPayload := map[string]any{
 		"prompt":      payload.Prompt,

--- a/internal/jobs/service_handler.go
+++ b/internal/jobs/service_handler.go
@@ -533,6 +533,9 @@ func (h *ServiceHandler) composeEnv() []string {
 		// node actually writes job files into.
 		env = append(env, "CITADEL_WORKSPACE="+h.WorkspaceDir)
 	}
+	// Supply the citadel-owned host ports so compose files that defer their host
+	// publish to ${CITADEL_*_HOST_PORT} (llamacpp/vllm/extraction) resolve.
+	env = append(env, embeddedservices.HostPortEnv()...)
 	return env
 }
 

--- a/internal/services/native.go
+++ b/internal/services/native.go
@@ -6,8 +6,11 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
+
+	svcports "github.com/aceteam-ai/citadel-cli/services"
 )
 
 // ServiceType represents how a service is run
@@ -43,15 +46,17 @@ var NativeServices = map[string]NativeService{
 		Name:        "llamacpp",
 		Binary:      "llama-server",
 		AltBinaries: []string{"llama-cpp-server", "server"},
-		Port:        8080,
-		StartArgs:   []string{"--host", "0.0.0.0", "--port", "8080"},
-		EnvVars:     map[string]string{},
+		// Host port owned by citadel (services/ports.go) so the native path
+		// avoids colliding with the gateway/status server on 8080.
+		Port:      svcports.LlamacppHostPort,
+		StartArgs: []string{"--host", "0.0.0.0", "--port", strconv.Itoa(svcports.LlamacppHostPort)},
+		EnvVars:   map[string]string{},
 	},
 	"vllm": {
 		Name:        "vllm",
 		Binary:      "vllm",
 		AltBinaries: []string{"python -m vllm.entrypoints.openai.api_server"},
-		Port:        8100,
+		Port:        svcports.VLLMHostPort,
 		StartArgs:   []string{"serve"},
 		EnvVars:     map[string]string{},
 	},

--- a/internal/status/collector.go
+++ b/internal/status/collector.go
@@ -466,11 +466,13 @@ func idleEngineType(hint string) string {
 func InferServicePort(serviceName string) int {
 	name := strings.ToLower(serviceName)
 
-	// Common default ports
+	// Common default ports. The citadel-owned host ports (services/ports.go)
+	// are used for the engines whose host publish citadel controls so status
+	// probes hit the actual published port.
 	portMap := map[string]int{
-		"vllm":          8000,
+		"vllm":          services.VLLMHostPort,
 		"ollama":        11434,
-		"llamacpp":      8080,
+		"llamacpp":      services.LlamacppHostPort,
 		"lmstudio":      1234,
 		"postgres":      5432,
 		"mysql":         3306,

--- a/internal/status/engines.go
+++ b/internal/status/engines.go
@@ -105,10 +105,17 @@ func containerRunning(engineBin, containerName string) bool {
 // e.g. "8100:8000" or "127.0.0.1:8100:8000" -> host port 8100.
 var composePortRe = regexp.MustCompile(`(?:\d+\.\d+\.\d+\.\d+:)?(\d+):\d+`)
 
-// managedEngineHostPort resolves the published host port for a managed engine by
-// parsing the first port mapping of its embedded compose file. Returns 0 when
-// the compose file is absent or has no parseable port mapping.
+// managedEngineHostPort resolves the published host port for a managed engine.
+// For engines whose host publish citadel owns via ${CITADEL_*_HOST_PORT}
+// substitution (llamacpp/vllm/extraction/diffusers), the compose file no longer
+// carries a literal host port, so the port comes from the registry
+// (services/ports.go). For any other engine it falls back to parsing the first
+// port mapping of its embedded compose file. Returns 0 when neither yields a
+// port.
 func managedEngineHostPort(name string) int {
+	if port, ok := services.ManagedServiceHostPort(name); ok {
+		return port
+	}
 	compose, ok := services.ServiceMap[name]
 	if !ok {
 		return 0

--- a/internal/status/engines_test.go
+++ b/internal/status/engines_test.go
@@ -1,6 +1,10 @@
 package status
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/services"
+)
 
 func TestFirstComposeHostPort(t *testing.T) {
 	cases := []struct {
@@ -50,12 +54,14 @@ func TestFirstComposeHostPort(t *testing.T) {
 	}
 }
 
-// TestManagedEngineHostPort_VLLM confirms the embedded vLLM compose resolves to
-// its published host port. This guards against the compose file changing its
-// port mapping without the idle scraper following (it scrapes the host port).
+// TestManagedEngineHostPort_VLLM confirms vLLM resolves to its citadel-owned
+// published host port. vLLM's host publish is managed via
+// ${CITADEL_VLLM_HOST_PORT} (services/ports.go), so the port comes from the
+// registry rather than a literal in the compose file. This guards against the
+// registry and the idle scraper (which scrapes the host port) drifting apart.
 func TestManagedEngineHostPort_VLLM(t *testing.T) {
-	if got := managedEngineHostPort("vllm"); got != 8100 {
-		t.Fatalf("expected vllm host port 8100 from embedded compose, got %d", got)
+	if got := managedEngineHostPort("vllm"); got != services.VLLMHostPort {
+		t.Fatalf("expected vllm host port %d from registry, got %d", services.VLLMHostPort, got)
 	}
 	if got := managedEngineHostPort("does-not-exist"); got != 0 {
 		t.Fatalf("expected 0 for unknown engine, got %d", got)

--- a/services/compose/diffusers.yml
+++ b/services/compose/diffusers.yml
@@ -7,23 +7,19 @@
 #
 # NOTE: the container listens on 7860 (the aceteam `diffusers-text-to-image`
 # template's default_port), exactly as vllm listens on 8000. The HOST port is
-# mapped to 7861, chosen to clear every other host port a citadel node may bind:
-#   - the terminal server / diffusers contract port 7860,
-#   - the vllm (8100) / transcribe (8101) / TEI embeddings (8102) sequence, and
-#   - the 8100-8199 range that `internal/apps` auto-allocates for installed apps.
-# An earlier revision mapped host 8102, which collided with the TEI embedding
-# service already bound there on a GPU node (`docker compose up` failed with
-# "Bind for 0.0.0.0:8102 failed: port is already allocated"). See citadel-cli#415.
-# SERVICE_START starts this compose with `up -d --force-recreate` so the mapping
-# below is always applied to the running container, then inspects the container
-# and reports the reachable host endpoint (host:7861).
+# owned by citadel (services/ports.go) and supplied via
+# CITADEL_DIFFUSERS_HOST_PORT; the :? guard fails loudly if it is missing. It
+# must NOT be the container's own 7860 (that is the citadel terminal server's
+# host port) nor 8102 (the TEI embedding upstream). SERVICE_START does not pass
+# a port to the container; the port contract is satisfied by the server
+# listening on 7860 inside the container.
 
 services:
   diffusers:
     image: ghcr.io/aceteam-ai/diffusers-service:latest
     container_name: citadel-diffusers
     ports:
-      - "7861:7860"
+      - "${CITADEL_DIFFUSERS_HOST_PORT:?citadel must supply CITADEL_DIFFUSERS_HOST_PORT}:7860"
     volumes:
       # Share the HuggingFace model cache with the other HF-based services
       # (vllm, sglang, whisper) so weights are downloaded once per node.

--- a/services/compose/extraction.yml
+++ b/services/compose/extraction.yml
@@ -2,8 +2,12 @@ services:
   extraction:
     image: ghcr.io/aceteam-ai/gliner2-service:latest
     container_name: citadel-extraction
+    # Host port is owned by citadel (services/ports.go), supplied via
+    # CITADEL_EXTRACTION_HOST_PORT. Bound to 127.0.0.1 because this service is
+    # only consumed host-locally (internal/jobs/extraction_handler.go). The
+    # container still serves on :8100 internally.
     ports:
-      - "8100:8100"
+      - "127.0.0.1:${CITADEL_EXTRACTION_HOST_PORT}:8100"
     volumes:
       - ~/citadel-cache/huggingface:/root/.cache/huggingface
     environment:

--- a/services/compose/extraction.yml
+++ b/services/compose/extraction.yml
@@ -3,11 +3,11 @@ services:
     image: ghcr.io/aceteam-ai/gliner2-service:latest
     container_name: citadel-extraction
     # Host port is owned by citadel (services/ports.go), supplied via
-    # CITADEL_EXTRACTION_HOST_PORT. Bound to 127.0.0.1 because this service is
-    # only consumed host-locally (internal/jobs/extraction_handler.go). The
-    # container still serves on :8100 internally.
+    # CITADEL_EXTRACTION_HOST_PORT; the :? guard fails loudly if it is missing.
+    # Left on the default 0.0.0.0 bind for consistency with the other engines
+    # (peers may reach it over the mesh). The container still serves on :8100.
     ports:
-      - "127.0.0.1:${CITADEL_EXTRACTION_HOST_PORT}:8100"
+      - "${CITADEL_EXTRACTION_HOST_PORT:?citadel must supply CITADEL_EXTRACTION_HOST_PORT}:8100"
     volumes:
       - ~/citadel-cache/huggingface:/root/.cache/huggingface
     environment:

--- a/services/compose/llamacpp.yml
+++ b/services/compose/llamacpp.yml
@@ -4,8 +4,13 @@ services:
   llamacpp:
     image: ghcr.io/ggml-org/llama.cpp:server-cuda
     container_name: citadel-llamacpp
+    # Host port is owned by citadel (services/ports.go), supplied via
+    # CITADEL_LLAMACPP_HOST_PORT. Bound to 127.0.0.1 because the only
+    # mesh-exposed surface is the gateway, which reaches this engine over
+    # localhost; publishing on 0.0.0.0 would needlessly widen the mesh attack
+    # surface. The container still serves on :8080 internally.
     ports:
-      - "8080:8080"
+      - "127.0.0.1:${CITADEL_LLAMACPP_HOST_PORT}:8080"
     volumes:
       - ~/citadel-cache/llamacpp:/models
     command: ["--host", "0.0.0.0", "--port", "8080"]

--- a/services/compose/llamacpp.yml
+++ b/services/compose/llamacpp.yml
@@ -5,12 +5,13 @@ services:
     image: ghcr.io/ggml-org/llama.cpp:server-cuda
     container_name: citadel-llamacpp
     # Host port is owned by citadel (services/ports.go), supplied via
-    # CITADEL_LLAMACPP_HOST_PORT. Bound to 127.0.0.1 because the only
-    # mesh-exposed surface is the gateway, which reaches this engine over
-    # localhost; publishing on 0.0.0.0 would needlessly widen the mesh attack
-    # surface. The container still serves on :8080 internally.
+    # CITADEL_LLAMACPP_HOST_PORT. The :? guard makes a `docker compose up`
+    # without the var fail loudly (rather than binding a random host port and
+    # leaving the engine silently unreachable). Left on the default 0.0.0.0 bind
+    # because peers reach this engine directly over the mesh (see `citadel
+    # expose` / `citadel connect`). The container still serves on :8080.
     ports:
-      - "127.0.0.1:${CITADEL_LLAMACPP_HOST_PORT}:8080"
+      - "${CITADEL_LLAMACPP_HOST_PORT:?citadel must supply CITADEL_LLAMACPP_HOST_PORT}:8080"
     volumes:
       - ~/citadel-cache/llamacpp:/models
     command: ["--host", "0.0.0.0", "--port", "8080"]

--- a/services/compose/vllm.yml
+++ b/services/compose/vllm.yml
@@ -4,8 +4,12 @@ services:
   vllm:
     image: vllm/vllm-openai:latest
     container_name: citadel-vllm
+    # Host port is owned by citadel (services/ports.go), supplied via
+    # CITADEL_VLLM_HOST_PORT. Bound to 127.0.0.1 because the only mesh-exposed
+    # surface is the gateway, which reaches this engine over localhost. The
+    # container still serves the OpenAI API on :8000 internally.
     ports:
-      - "8100:8000"
+      - "127.0.0.1:${CITADEL_VLLM_HOST_PORT}:8000"
     volumes:
       - ~/citadel-cache/huggingface:/root/.cache/huggingface
     command: >-

--- a/services/compose/vllm.yml
+++ b/services/compose/vllm.yml
@@ -5,11 +5,11 @@ services:
     image: vllm/vllm-openai:latest
     container_name: citadel-vllm
     # Host port is owned by citadel (services/ports.go), supplied via
-    # CITADEL_VLLM_HOST_PORT. Bound to 127.0.0.1 because the only mesh-exposed
-    # surface is the gateway, which reaches this engine over localhost. The
-    # container still serves the OpenAI API on :8000 internally.
+    # CITADEL_VLLM_HOST_PORT; the :? guard fails loudly if citadel forgot to
+    # supply it. Left on the default 0.0.0.0 bind because peers reach this engine
+    # directly over the mesh. The container still serves the OpenAI API on :8000.
     ports:
-      - "127.0.0.1:${CITADEL_VLLM_HOST_PORT}:8000"
+      - "${CITADEL_VLLM_HOST_PORT:?citadel must supply CITADEL_VLLM_HOST_PORT}:8000"
     volumes:
       - ~/citadel-cache/huggingface:/root/.cache/huggingface
     command: >-

--- a/services/embed_test.go
+++ b/services/embed_test.go
@@ -102,9 +102,34 @@ func composeHostPorts(t *testing.T, composeYAML string) []int {
 	if err := yaml.Unmarshal([]byte(composeYAML), &doc); err != nil {
 		t.Fatalf("compose is not valid YAML: %v", err)
 	}
+	// A citadel-managed host publish defers to ${CITADEL_*_HOST_PORT}; resolve
+	// those tokens to the registry value so the collision assertions validate the
+	// port citadel actually injects (services/ports.go).
+	envVarHostPort := map[string]int{
+		EnvLlamacppHostPort:   LlamacppHostPort,
+		EnvVLLMHostPort:       VLLMHostPort,
+		EnvExtractionHostPort: ExtractionHostPort,
+		EnvDiffusersHostPort:  DiffusersHostPort,
+	}
 	var hosts []int
 	for _, svc := range doc.Services {
 		for _, mapping := range svc.Ports {
+			// The host side is everything before the container colon, but a
+			// ${CITADEL_*_HOST_PORT:?...} expansion carries its own colons, so
+			// peel a leading ${...} group intact and resolve it via the registry.
+			if strings.HasPrefix(mapping, "${") {
+				if end := strings.IndexByte(mapping, '}'); end >= 0 {
+					inner := mapping[2:end]
+					varName := inner
+					if c := strings.IndexByte(inner, ':'); c >= 0 {
+						varName = inner[:c]
+					}
+					if port, ok := envVarHostPort[varName]; ok {
+						hosts = append(hosts, port)
+					}
+				}
+				continue
+			}
 			// "HOST:CONTAINER" (optionally "HOST:CONTAINER/proto"); the host side
 			// is everything before the first colon.
 			hostStr := mapping

--- a/services/ports.go
+++ b/services/ports.go
@@ -1,0 +1,159 @@
+// services/ports.go
+//
+// Citadel owns host-port allocation for the pre-packaged service/module compose
+// files under services/compose/*.yml. Before this registry existed, each
+// compose template hardcoded the HOST side of its `ports:` publish, so
+// containers dictated host ports and collided with one another and with
+// citadel's own listeners (gateway 8080, gateway-HTTPS 8443, status server 8080,
+// the apps catalog's dynamic 8100-8199 range, and the TEI embedding upstream
+// 8102).
+//
+// The fix: templates defer the host port to an env var that citadel supplies
+// (e.g. `127.0.0.1:${CITADEL_LLAMACPP_HOST_PORT}:8080`). This file is the single
+// authoritative source of those host ports. Every `docker compose up` site that
+// can bring up one of these services must inject these variables into the
+// process environment (see EnvVars) so `${CITADEL_*_HOST_PORT}` substitution
+// resolves. Container ports are unchanged — only the host publish moves.
+//
+// Host ports for these services live in a dedicated 8200+ block, deliberately
+// clear of BOTH citadel's own reserved ports AND the apps catalog's dynamic
+// 8100-8199 allocation range (internal/apps/state.go), so a dynamically
+// allocated app can never collide with a module's fixed port.
+package services
+
+import "fmt"
+
+// Host-port env-var names referenced by services/compose/*.yml. Kept as
+// exported constants so consumers (Go code that reaches these services) and the
+// compose templates share one spelling.
+const (
+	EnvLlamacppHostPort   = "CITADEL_LLAMACPP_HOST_PORT"
+	EnvVLLMHostPort       = "CITADEL_VLLM_HOST_PORT"
+	EnvExtractionHostPort = "CITADEL_EXTRACTION_HOST_PORT"
+)
+
+// Citadel-assigned host ports for the pre-packaged compose services. These are
+// the ports the containers publish ON THE HOST; the in-container ports are
+// unchanged and defined by each compose file's command/args.
+//
+// Only services whose old hardcoded host port collided are managed here.
+// Services that already sat on a unique, well-known host port (ollama 11434,
+// sglang 30000, lmstudio 1234, transcribe 8101) keep their native port and are
+// still covered by the collision guard test so future edits can't reintroduce a
+// clash.
+const (
+	// llamacpp: was host 8080 (collided with gateway + status server).
+	LlamacppHostPort = 8200
+	// vllm: was host 8100 (collided with extraction and the apps range).
+	VLLMHostPort = 8201
+	// extraction: was host 8100 (collided with vllm and the apps range).
+	ExtractionHostPort = 8202
+)
+
+// ServiceHostPorts maps service name -> citadel-assigned host port for every
+// service whose host publish citadel owns via env-var substitution. The
+// collision guard test unions this with the apps catalog and the parsed compose
+// files to prove no two host ports clash.
+var ServiceHostPorts = map[string]int{
+	"llamacpp":   LlamacppHostPort,
+	"vllm":       VLLMHostPort,
+	"extraction": ExtractionHostPort,
+}
+
+// serviceHostPortEnv maps each managed service to the compose env-var that
+// carries its host port.
+var serviceHostPortEnv = map[string]string{
+	"llamacpp":   EnvLlamacppHostPort,
+	"vllm":       EnvVLLMHostPort,
+	"extraction": EnvExtractionHostPort,
+}
+
+// HostPortEnv returns "KEY=value" entries for every citadel-managed host port,
+// suitable for appending to a docker compose invocation's environment so
+// `${CITADEL_*_HOST_PORT}` substitutions in the compose templates resolve.
+//
+// It returns ALL managed vars unconditionally (not just the one for a given
+// service) so any `docker compose up` site can call it once and every managed
+// compose file it might bring up will substitute correctly.
+func HostPortEnv() []string {
+	env := make([]string, 0, len(serviceHostPortEnv))
+	for svc, key := range serviceHostPortEnv {
+		env = append(env, fmt.Sprintf("%s=%d", key, ServiceHostPorts[svc]))
+	}
+	return env
+}
+
+// ManagedServiceHostPort returns the citadel-assigned host port for a managed
+// service (llamacpp/vllm/extraction) and whether it is managed. Consumers that
+// reach these services over localhost should route through this so they hit the
+// current host port instead of a hardcoded literal.
+func ManagedServiceHostPort(name string) (int, bool) {
+	port, ok := ServiceHostPorts[name]
+	return port, ok
+}
+
+// Citadel's own listeners. These are NOT module ports; they belong to
+// citadel-internal processes and must never be handed to a module compose file
+// or dynamically allocated to an app.
+const (
+	// GatewayPort is the default plain gateway port (cmd/gateway.go) and the
+	// default status-server port (citadel work --status-port). Shared across
+	// those contexts by design.
+	GatewayPort = 8080
+	// GatewayHTTPSPort is the default HTTPS gateway port (cmd/serve.go).
+	GatewayHTTPSPort = 8443
+	// TEIEmbeddingPort is the local TEI embedding service, wired as the
+	// gateway's /v1/embeddings upstream (cmd/serve.go --embedding-port,
+	// internal/jobs/embedding_handler.go). It sits INSIDE the apps
+	// auto-allocation range (8100-8199), so app port allocation must skip it.
+	TEIEmbeddingPort = 8102
+	// TranscribePort is the whisper sidecar's host port (services/compose/
+	// transcribe.yml). It also sits inside the apps range, so allocation must
+	// skip it. It is left at its native 8101 because it never collided with
+	// another compose service.
+	TranscribePort = 8101
+	// VNCWebsockifyPort is the noVNC websockify bridge (cmd/work.go
+	// --gateway-vnc-port).
+	VNCWebsockifyPort = 6080
+	// VNCPort is the raw RFB VNC port (internal/desktop, internal/platform/vnc).
+	VNCPort = 5900
+	// DeskstreamPort is the H.264 desktop stream port (internal/deskstream).
+	DeskstreamPort = 5910
+)
+
+// ReservedCitadelPorts is the set of host ports owned by citadel's own
+// processes. No module compose file and no dynamically allocated app may use
+// any of these. The collision guard test asserts the module registry, the apps
+// catalog, and the parsed compose files all avoid this set.
+var ReservedCitadelPorts = map[int]string{
+	GatewayPort:       "gateway/status-server",
+	GatewayHTTPSPort:  "gateway-https",
+	TEIEmbeddingPort:  "tei-embeddings",
+	VNCWebsockifyPort: "vnc-websockify",
+	VNCPort:           "vnc-rfb",
+	DeskstreamPort:    "deskstream-h264",
+}
+
+// AppsPortRange is the inclusive range apps auto-allocate host ports from
+// (internal/apps.AllocatePort). Module ports live above this range.
+const (
+	AppsPortRangeStart = 8100
+	AppsPortRangeEnd   = 8199
+)
+
+// InRangeReservedHostPorts returns the citadel-reserved host ports that fall
+// inside the apps auto-allocation range, so app allocation can skip them.
+func InRangeReservedHostPorts() map[int]bool {
+	reserved := make(map[int]bool)
+	for port := range ReservedCitadelPorts {
+		if port >= AppsPortRangeStart && port <= AppsPortRangeEnd {
+			reserved[port] = true
+		}
+	}
+	// TranscribePort is a compose service (not in ReservedCitadelPorts) that
+	// nonetheless occupies a port inside the apps range.
+	if TranscribePort >= AppsPortRangeStart && TranscribePort <= AppsPortRangeEnd {
+		reserved[TranscribePort] = true
+	}
+	return reserved
+}

--- a/services/ports.go
+++ b/services/ports.go
@@ -30,6 +30,7 @@ const (
 	EnvLlamacppHostPort   = "CITADEL_LLAMACPP_HOST_PORT"
 	EnvVLLMHostPort       = "CITADEL_VLLM_HOST_PORT"
 	EnvExtractionHostPort = "CITADEL_EXTRACTION_HOST_PORT"
+	EnvDiffusersHostPort  = "CITADEL_DIFFUSERS_HOST_PORT"
 )
 
 // Citadel-assigned host ports for the pre-packaged compose services. These are
@@ -48,6 +49,8 @@ const (
 	VLLMHostPort = 8201
 	// extraction: was host 8100 (collided with vllm and the apps range).
 	ExtractionHostPort = 8202
+	// diffusers: was host 8102 (collided with the TEI embedding upstream).
+	DiffusersHostPort = 8203
 )
 
 // ServiceHostPorts maps service name -> citadel-assigned host port for every
@@ -58,6 +61,7 @@ var ServiceHostPorts = map[string]int{
 	"llamacpp":   LlamacppHostPort,
 	"vllm":       VLLMHostPort,
 	"extraction": ExtractionHostPort,
+	"diffusers":  DiffusersHostPort,
 }
 
 // serviceHostPortEnv maps each managed service to the compose env-var that
@@ -66,6 +70,7 @@ var serviceHostPortEnv = map[string]string{
 	"llamacpp":   EnvLlamacppHostPort,
 	"vllm":       EnvVLLMHostPort,
 	"extraction": EnvExtractionHostPort,
+	"diffusers":  EnvDiffusersHostPort,
 }
 
 // HostPortEnv returns "KEY=value" entries for every citadel-managed host port,
@@ -119,6 +124,10 @@ const (
 	VNCPort = 5900
 	// DeskstreamPort is the H.264 desktop stream port (internal/deskstream).
 	DeskstreamPort = 5910
+	// TerminalPort is the local terminal server port (cmd/work.go
+	// --terminal-port, internal/terminal/config.go). The platform relay dials
+	// ws://<vpn_ip>:7860, so this is a live mesh port a module must not take.
+	TerminalPort = 7860
 )
 
 // ReservedCitadelPorts is the set of host ports owned by citadel's own
@@ -132,6 +141,7 @@ var ReservedCitadelPorts = map[int]string{
 	VNCWebsockifyPort: "vnc-websockify",
 	VNCPort:           "vnc-rfb",
 	DeskstreamPort:    "deskstream-h264",
+	TerminalPort:      "terminal-server",
 }
 
 // AppsPortRange is the inclusive range apps auto-allocate host ports from


### PR DESCRIPTION
## Context

Fixes the runtime half of #405. Before this, every service/module compose template under `services/compose/*.yml` hardcoded the **host** side of its `ports:` publish. Citadel did not own host-port allocation, so containers dictated host ports — and they collided, both with each other and with citadel's own listeners:

- `llamacpp.yml` published host `8080` → collided with citadel's **gateway** (`cmd/gateway.go` default) and the **status server** (default 8080).
- `vllm.yml` (host `8100`) and `extraction.yml` (host `8100`) → collided with **each other** and sat inside the apps auto-allocation range (`8100-8199`, `internal/apps/state.go`).
- The TEI embedding upstream (`8102`, the gateway's `/v1/embeddings` backend) and the transcribe sidecar (`8101`) sit inside that same apps range, so `AllocatePort` could hand a dynamically-installed app a port an engine already held.
- Mid-review, a rebase onto `main` surfaced a **live** instance of the bug: the newly-added `diffusers` service (#4468) grabbed host `8102` — the TEI port. The collision guard test below caught it automatically.

The fix makes **citadel** the single owner of host-port allocation for these services: one authoritative registry, templates that defer their host port to an env var citadel supplies, and a regression guard that fails CI if any two services ever claim the same host port again.

## Enumerated host-port set (before → after)

**Citadel's own reserved ports (never assigned to a module/app):**

| Port | Owner |
|------|-------|
| 8080 | gateway (default) / status server / whatsapp bridge default |
| 8443 | gateway HTTPS |
| 8102 | TEI embedding upstream (gateway `/v1/embeddings`) |
| 8101 | transcribe sidecar (in apps range → allocation skips it) |
| 7860 | terminal server (platform relay dials `ws://<vpn>:7860`) |
| 6080 | VNC websockify bridge |
| 5900 | VNC RFB |
| 5910 | deskstream H.264 |

**Compose services — host port:**

| Service | Container | Host (before) | Host (after) | Why moved |
|---------|-----------|---------------|--------------|-----------|
| llamacpp | 8080 | **8080** | **8200** | collided with gateway + status server |
| vllm | 8000 | **8100** | **8201** | collided with extraction + apps range |
| extraction | 8100 | **8100** | **8202** | collided with vllm + apps range |
| diffusers | 7860 | **8102** | **8203** | collided with TEI upstream (caught by the guard on rebase) |
| transcribe | 8101 | 8101 | 8101 | unique; unchanged (guard-protected) |
| ollama | 11434 | 11434 | 11434 | unique; unchanged |
| sglang | 30000 | 30000 | 30000 | unique; unchanged |
| lmstudio | 1234 | 1234 | 1234 | unique; unchanged |

**Apps catalog suggested host ports** (actual port is dynamically allocated by `AllocatePort`; these values are advisory and were made honest so they avoid the reserved in-range ports):

| App | Before | After |
|-----|--------|-------|
| code-server | 8100 | 8100 |
| jupyter | 8101 | **8104** (8101 = transcribe) |
| filebrowser | 8102 | **8105** (8102 = TEI) |
| ollama-webui | 8103 | 8103 |

Module host ports now live in a dedicated **8200+ block**, deliberately clear of both citadel's own ports and the apps `8100-8199` range, so a dynamically-allocated app can never collide with a module.

## Summary

**`services/ports.go` (new) — the single source of truth.** Maps `service → citadel-assigned host port`, the `${CITADEL_*_HOST_PORT}` env-var names, the reserved-citadel-port set, and helpers: `HostPortEnv()` (all managed vars for compose injection) and `InRangeReservedHostPorts()` (reserved ports inside the apps range).

**Templates defer the host port** via env substitution with a fail-loud guard, matching the existing `${CITADEL_WORKSPACE:?...}` idiom:

    ports:
      - "${CITADEL_LLAMACPP_HOST_PORT:?citadel must supply CITADEL_LLAMACPP_HOST_PORT}:8080"

The `:?` guard turns a missed env injection into a loud failure instead of docker silently binding a random host port. **Kept the default `0.0.0.0` bind** (did not shrink to `127.0.0.1`): peers reach these engines directly over the mesh — `citadel expose` advertises `http://<node-ip>:<port>` and `connect`/`proxy` dial peer engines — so localhost-only would break backwards-compat. The port move alone resolves every collision (`0.0.0.0:8200` doesn't clash with `0.0.0.0:8080`). A localhost shrink that also reroutes `connect`/`proxy` through the gateway is a reasonable follow-up.

**Env injected at every `docker compose up` site** that can bring up a moved service: `service_handler.go` `composeEnv()` (SERVICE_START), `config_handler.go` `startServices()` (onboarding autostart — also fixes `cmd.Env` only being set on Linux), and `llamacpp_inference.go` restartCmd (model swap).

**Consumers routed through the registry** so they hit the new host ports: `llm_inference.go` (vllm + llamacpp), `extraction_handler.go`, `internal/services/native.go` native ports, `status/collector.go` `InferServicePort`, and `cmd/expose.go`. Citadel's own gateway/status `8080` is untouched.

**`AllocatePort` skips in-range reserved ports** (transcribe 8101, TEI 8102) so a dynamically-installed app can't collide with them.

## Test plan

| Group | Coverage |
|-------|----------|
| `TestHostPortNoCollisions` (new) | Parses every embedded compose file, unions published host ports with the registry + apps catalog, asserts pairwise-uniqueness AND no intersection with the reserved citadel set. This IS the "containers can't dictate the port" guarantee. |
| Non-tautological proof | Temporarily reverting `LlamacppHostPort` to 8080 makes the guard go **red** (`8080 collides with reserved gateway/status-server`); restored to green in the final commit. It also caught the real diffusers/8102 collision during rebase. |
| `TestAllocatePort` (updated) | Verifies allocation skips reserved in-range ports (computed, not hardcoded). |
| `go build ./...`, `go vet ./...` | Clean. |
| `go test ./services/... ./internal/apps/... ./internal/jobs/... ./internal/services/... ./cmd/...` | All pass. |

> `internal/status/server_test.go` fails on this host with `bind: address already in use` on `:8080` — that is the pre-existing flake being fixed separately in #406 (something external holds :8080), unrelated to this change, and I was asked not to touch that file.

**Draft — needs live GPU-node validation before merge.** Two things to check on a real node:

1. **End-to-end inference on the new ports.** Bring up llamacpp/vllm/extraction/diffusers via SERVICE_START and confirm they publish on 8200-8203 and inference works.
2. **Migration on existing nodes.** Upgraded nodes still have the **old** `8080:8080` `llamacpp.yml` on disk. The disk compose is only rewritten from the embedded `ServiceMap` on `APPLY_DEVICE_CONFIG` (onboarding/re-config), not on a plain binary upgrade — so post-upgrade the Go consumers point at 8200 while a stale disk file still publishes 8080. Re-running device config (or otherwise refreshing the on-disk `.yml`) fixes it. Worth confirming whether we want the up-sites to rewrite the `.yml` from embed before `up` as a follow-up.

## Related

- Closes #405 (runtime half — citadel owns host-port allocation)
- #401 (host-port ownership discussion)
- #406 (separate `internal/status` `:8080` test-port flake — do not touch here)
- #4468 (diffusers service — the live collision this guard caught)
