### PR TITLE
fix(catalog): gate GPU hardening-exemption on real host GPU (#377)

### DIFF
--- a/internal/catalog/install.go
+++ b/internal/catalog/install.go
@@ -236,7 +236,16 @@ func InstallFromManifest(manifest *ServiceManifest, composeSrcPath, servicesDir 
 		if rerr != nil {
 			return nil, fmt.Errorf("failed to read copied compose for sandbox hardening: %w", rerr)
 		}
-		override, gerr := GenerateHardeningOverride(string(baseData), manifest)
+		// Detect real host GPU presence to gate the per-service GPU exemption
+		// (#377). This MUST be a fresh CheckGPU() here, not the step-3 result:
+		// step 3 only runs when manifest.Requires.GPU is set, but the exemption is
+		// driven by author-controlled compose GPU signals a module can declare with
+		// Requires.GPU=false. CheckGPU() reports hasGPU=false on any detection error
+		// (nvidia-smi missing/failing), which is the fail-safe direction (harden),
+		// so dropping the error here is intentional -- unlike step 3, this is not a
+		// hard requirement, just an exemption gate.
+		hostHasGPU, _, _ := CheckGPU()
+		override, gerr := GenerateHardeningOverride(string(baseData), manifest, hostHasGPU)
 		if gerr != nil {
 			return nil, fmt.Errorf("failed to generate sandbox override for '%s': %w", name, gerr)
 		}

--- a/internal/catalog/sandbox.go
+++ b/internal/catalog/sandbox.go
@@ -37,7 +37,7 @@ const (
 //   - devices: only the manifest-declared host devices (omitted if none)
 //   - network_mode: "host" ONLY if sandbox.host_network is true (never otherwise)
 //
-// GPU EXEMPTION (#348): a service that REQUESTS A GPU (an NVIDIA
+// GPU EXEMPTION (#348, gated by #377): a service that REQUESTS A GPU (an NVIDIA
 // deploy.resources.reservations.devices entry, a `gpus:` shorthand, or
 // `runtime: nvidia`) is omitted from the override ENTIRELY. The conservative
 // defaults -- a read-only rootfs, dropped capabilities, and especially the 2g
@@ -47,11 +47,19 @@ const (
 // deferred to #348. The base compose owns the GPU reservation regardless; the
 // override never emits a GPU/deploy block.
 //
+// The exemption additionally REQUIRES hostHasGPU (#377). The GPU signal is
+// author-controlled: an untrusted module can declare `gpus:`/`runtime: nvidia`/
+// deploy-devices in its compose to dodge hardening even on a node with NO GPU.
+// So the exemption only applies when the HOST actually has a GPU; on a GPU-less
+// node a "GPU" service is hardened like everything else (fail-safe). The caller
+// passes hostHasGPU from CheckGPU(), which reports false on any detection error
+// -- the safe direction (harden).
+//
 // Note that compose list-merges sequences, so a base `cap_add` survives this
 // override's `cap_drop: ALL` -- the override mechanism cannot subtract a base
 // directive. That residual escalation is already covered by the #342 privilege
 // gate (cap_add ALL/SYS_ADMIN is Critical and refused without --allow-privileged).
-func GenerateHardeningOverride(baseComposeYAML string, manifest *ServiceManifest) (string, error) {
+func GenerateHardeningOverride(baseComposeYAML string, manifest *ServiceManifest, hostHasGPU bool) (string, error) {
 	services, err := decodeComposeServices(baseComposeYAML)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse base compose to enumerate services: %w", err)
@@ -77,8 +85,11 @@ func GenerateHardeningOverride(baseComposeYAML string, manifest *ServiceManifest
 		base := services[name]
 		// GPU/inference services are exempt: omit them from the override so the
 		// hardening defaults never break them. A POSITIVE GPU signal is required
-		// (fail-safe: an ambiguous service is hardened, not exempted).
-		if serviceRequestsGPU(base) {
+		// AND the host must actually have a GPU (#377) -- the compose GPU signal is
+		// author-controlled, so it cannot be trusted to grant exemption on a
+		// GPU-less node. Fail-safe: an ambiguous service, or a "GPU" service on a
+		// GPU-less host, is hardened rather than exempted.
+		if serviceRequestsGPU(base) && hostHasGPU {
 			continue
 		}
 		svc := buildServiceHardening(spec, base)

--- a/internal/catalog/sandbox_test.go
+++ b/internal/catalog/sandbox_test.go
@@ -63,7 +63,7 @@ func TestGenerateHardeningOverride_Defaults(t *testing.T) {
   app:
     image: ghcr.io/x/y:latest
 `
-	out, err := GenerateHardeningOverride(base, &ServiceManifest{Name: "x"})
+	out, err := GenerateHardeningOverride(base, &ServiceManifest{Name: "x"}, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -120,7 +120,7 @@ func TestGenerateHardeningOverride_MultiService(t *testing.T) {
   db:
     image: postgres:16
 `
-	out, err := GenerateHardeningOverride(base, &ServiceManifest{Name: "x"})
+	out, err := GenerateHardeningOverride(base, &ServiceManifest{Name: "x"}, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -153,7 +153,7 @@ func TestGenerateHardeningOverride_DeclaredCapsAndWritablePaths(t *testing.T) {
 			Resources:     SandboxResources{CPU: "4.0", Memory: "8g", PIDs: 1024},
 		},
 	}
-	out, err := GenerateHardeningOverride(base, m)
+	out, err := GenerateHardeningOverride(base, m, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -198,14 +198,14 @@ func TestGenerateHardeningOverride_HostNetworkOptIn(t *testing.T) {
 	base := "services:\n  app:\n    image: x\n"
 
 	// Default: no host networking.
-	out, _ := GenerateHardeningOverride(base, &ServiceManifest{Name: "x"})
+	out, _ := GenerateHardeningOverride(base, &ServiceManifest{Name: "x"}, true)
 	if _, present := parseOverride(t, out)["app"]["network_mode"]; present {
 		t.Errorf("network_mode must be absent unless host_network declared")
 	}
 
 	// Opt-in.
 	m := &ServiceManifest{Name: "x", Sandbox: SandboxSpec{HostNetwork: true}}
-	out, _ = GenerateHardeningOverride(base, m)
+	out, _ = GenerateHardeningOverride(base, m, true)
 	if got := parseOverride(t, out)["app"]["network_mode"]; got != "host" {
 		t.Errorf("network_mode = %v, want host", got)
 	}
@@ -214,9 +214,9 @@ func TestGenerateHardeningOverride_HostNetworkOptIn(t *testing.T) {
 // TestGenerateHardeningOverride_GPUExempt encodes the TEI (#343) shape: a GPU
 // service with a NVIDIA device reservation. Under #348 a GPU/inference service
 // is EXEMPT from hardening -- the read-only rootfs, cap-drops, and (especially)
-// the 2g/2cpu resource limits break inference. So the override must omit the GPU
-// service entirely (no entry for it at all) and must never emit a GPU/deploy
-// block.
+// the 2g/2cpu resource limits break inference. So on a REAL GPU host the override
+// must omit the GPU service entirely (no entry for it at all) and must never emit
+// a GPU/deploy block.
 func TestGenerateHardeningOverride_GPUExempt(t *testing.T) {
 	base := `services:
   tei:
@@ -236,7 +236,7 @@ func TestGenerateHardeningOverride_GPUExempt(t *testing.T) {
 			WritablePaths: []string{"/data"},
 		},
 	}
-	out, err := GenerateHardeningOverride(base, m)
+	out, err := GenerateHardeningOverride(base, m, true /* hostHasGPU */)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -250,8 +250,52 @@ func TestGenerateHardeningOverride_GPUExempt(t *testing.T) {
 	}
 }
 
+// TestGenerateHardeningOverride_GPUExemptDeniedOnGPULessHost is the #377 gate:
+// the SAME GPU-signalling compose, but hostHasGPU=false (no GPU on this node).
+// The GPU signal is author-controlled, so on a GPU-less host it MUST NOT grant
+// the hardening exemption -- the service is hardened like everything else
+// (fail-safe). This is the discriminating proof that the host-GPU gate flips
+// behavior, not merely that a bool was threaded through.
+func TestGenerateHardeningOverride_GPUExemptDeniedOnGPULessHost(t *testing.T) {
+	base := `services:
+  tei:
+    image: ghcr.io/huggingface/text-embeddings-inference:latest
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+`
+	m := &ServiceManifest{Name: "tei", Sandbox: SandboxSpec{WritablePaths: []string{"/data"}}}
+	out, err := GenerateHardeningOverride(base, m, false /* hostHasGPU */)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The override never emits a GPU/deploy block regardless of the gate.
+	if strings.Contains(out, "deploy:") || strings.Contains(out, "reservations") || strings.Contains(out, "nvidia") {
+		t.Errorf("override must not emit a GPU/deploy block:\n%s", out)
+	}
+	// On a GPU-less host the "GPU" service must be HARDENED (present, cap-dropped,
+	// read-only) -- the author-declared GPU signal cannot dodge hardening here.
+	tei, ok := parseOverride(t, out)["tei"]
+	if !ok {
+		t.Fatalf("on a GPU-less host, 'tei' must be hardened (present in override):\n%s", out)
+	}
+	if cd := strSlice(t, tei["cap_drop"]); !contains2(cd, "ALL") {
+		t.Errorf("hardened 'tei' should cap_drop ALL: %v", cd)
+	}
+	if ro, _ := tei["read_only"].(bool); !ro {
+		t.Errorf("hardened 'tei' should have read_only true")
+	}
+}
+
 // TestGenerateHardeningOverride_GPUSignals exercises each per-service GPU signal
-// in isolation: each must exempt its service from the override.
+// in isolation against BOTH host states: on a real GPU host each signal exempts
+// its service; on a GPU-less host (#377) the exemption is denied and the service
+// is hardened (fail-safe) -- the author-controlled signal cannot dodge hardening
+// on a node with no GPU.
 func TestGenerateHardeningOverride_GPUSignals(t *testing.T) {
 	cases := map[string]string{
 		"gpus shorthand": `services:
@@ -284,13 +328,26 @@ func TestGenerateHardeningOverride_GPUSignals(t *testing.T) {
 `,
 	}
 	for name, base := range cases {
-		t.Run(name, func(t *testing.T) {
-			out, err := GenerateHardeningOverride(base, &ServiceManifest{Name: "m"})
+		t.Run(name+"/hostHasGPU=true exempt", func(t *testing.T) {
+			out, err := GenerateHardeningOverride(base, &ServiceManifest{Name: "m"}, true)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			if _, present := parseOverride(t, out)["svc"]; present {
-				t.Errorf("GPU-signalled service must be exempt:\n%s", out)
+				t.Errorf("GPU-signalled service must be exempt on a GPU host:\n%s", out)
+			}
+		})
+		t.Run(name+"/hostHasGPU=false hardened", func(t *testing.T) {
+			out, err := GenerateHardeningOverride(base, &ServiceManifest{Name: "m"}, false)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			svc, present := parseOverride(t, out)["svc"]
+			if !present {
+				t.Fatalf("GPU-signalled service must be HARDENED on a GPU-less host:\n%s", out)
+			}
+			if cd := strSlice(t, svc["cap_drop"]); !contains2(cd, "ALL") {
+				t.Errorf("hardened service should cap_drop ALL: %v", cd)
 			}
 		})
 	}
@@ -313,7 +370,7 @@ func TestGenerateHardeningOverride_MixedGPUAndSidecar(t *testing.T) {
   proxy:
     image: nginx:latest
 `
-	out, err := GenerateHardeningOverride(base, &ServiceManifest{Name: "m"})
+	out, err := GenerateHardeningOverride(base, &ServiceManifest{Name: "m"}, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -346,7 +403,7 @@ func TestGenerateHardeningOverride_PreservesBaseOverrides(t *testing.T) {
     security_opt:
       - label=disable
 `
-	out, err := GenerateHardeningOverride(base, &ServiceManifest{Name: "m"})
+	out, err := GenerateHardeningOverride(base, &ServiceManifest{Name: "m"}, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -368,18 +425,18 @@ func TestGenerateHardeningOverride_PreservesBaseOverrides(t *testing.T) {
 }
 
 func TestGenerateHardeningOverride_NoServicesError(t *testing.T) {
-	if _, err := GenerateHardeningOverride("name: not-a-compose\n", &ServiceManifest{Name: "x"}); err == nil {
+	if _, err := GenerateHardeningOverride("name: not-a-compose\n", &ServiceManifest{Name: "x"}, true); err == nil {
 		t.Error("expected an error for a compose with no services")
 	}
-	if _, err := GenerateHardeningOverride(":::not yaml:::", &ServiceManifest{Name: "x"}); err == nil {
+	if _, err := GenerateHardeningOverride(":::not yaml:::", &ServiceManifest{Name: "x"}, true); err == nil {
 		t.Error("expected an error for invalid YAML")
 	}
 }
 
 func TestGenerateHardeningOverride_Deterministic(t *testing.T) {
 	base := "services:\n  b:\n    image: x\n  a:\n    image: y\n"
-	a, _ := GenerateHardeningOverride(base, &ServiceManifest{Name: "x"})
-	b, _ := GenerateHardeningOverride(base, &ServiceManifest{Name: "x"})
+	a, _ := GenerateHardeningOverride(base, &ServiceManifest{Name: "x"}, true)
+	b, _ := GenerateHardeningOverride(base, &ServiceManifest{Name: "x"}, true)
 	if a != b {
 		t.Errorf("override generation should be deterministic:\n%s\n---\n%s", a, b)
 	}


### PR DESCRIPTION
## Context

Untrusted community modules get a docker hardening override (dropped caps, etc.) from `internal/catalog/sandbox.go`. Today a service is *exempted* from part of that hardening when it "requests GPU" (`serviceRequestsGPU`) — but that's author-controlled: a module can declare `gpus:`/`runtime: nvidia` to dodge hardening even on a node with **no GPU**. Follow-up to #348/#376.

## Summary

Gate the GPU exemption on real host GPU presence. `GenerateHardeningOverride` now takes a `hostHasGPU bool`, passed from a fresh `CheckGPU()` in `install.go` (which reports `false` on any detection error — fail-safe). The exemption becomes `serviceRequestsGPU(base) && hostHasGPU`:
- GPU-less node → a "GPU" service is hardened like everything else.
- Real GPU node → legit vLLM/TEI stay exempt.

## Test plan

`internal/catalog/sandbox_test.go` covers both host states: (GPU-requested + hostHasGPU=true → exempt) and (GPU-requested + hostHasGPU=false → hardened). `go build/vet`, `go test ./internal/catalog/...` green.

## Related

Closes #377. Follow-up to #348/#376.