### PR TITLE
fix(services): reconcile embedded services into manifest on demand (#413)

### DIFF
--- a/internal/jobs/service_handler.go
+++ b/internal/jobs/service_handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
 	"github.com/aceteam-ai/citadel-cli/internal/services"
+	embeddedservices "github.com/aceteam-ai/citadel-cli/services"
 	"gopkg.in/yaml.v3"
 )
 
@@ -79,8 +80,26 @@ func (h *ServiceHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error)
 
 	svc, ok := h.findService(manifest, svcName)
 	if !ok {
-		return nil, fmt.Errorf("service %q not found in manifest (known: %s)",
-			svcName, h.knownServiceNames(manifest))
+		// The manifest may predate a newly-embedded service (e.g. a node
+		// initialized before "diffusers" existed, then binary-upgraded). The
+		// heartbeat advertises every embedded ServiceMap key as available, so a
+		// deploy can legitimately target a service the runtime manifest never
+		// listed. Reconcile lazily: if the requested service is present in the
+		// embedded ServiceMap, materialize its compose file and additively
+		// register it in citadel.yaml, then proceed. This keeps
+		// advertised == runnable without auto-starting every embedded service at
+		// boot (which additively pre-populating the manifest would cause).
+		// See citadel-cli#413.
+		if _, embedded := embeddedservices.ServiceMap[svcName]; !embedded {
+			return nil, fmt.Errorf("service %q not found in manifest (known: %s)",
+				svcName, h.knownServiceNames(manifest))
+		}
+		var mErr error
+		svc, mErr = h.materializeEmbeddedService(svcName)
+		if mErr != nil {
+			return nil, fmt.Errorf("failed to reconcile embedded service %q: %w", svcName, mErr)
+		}
+		ctx.Log("info", "     - [Job %s] Reconciled embedded service %s into manifest", job.ID, svcName)
 	}
 
 	switch job.Type {
@@ -238,6 +257,127 @@ func (h *ServiceHandler) loadManifest() (*serviceManifest, error) {
 		return nil, err
 	}
 	return &m, nil
+}
+
+// materializeEmbeddedService makes a newly-embedded service (present in the
+// binary's ServiceMap but absent from citadel.yaml) startable on this node. It
+// writes the embedded compose file into ConfigDir/services/<name>.yml (if not
+// already present) and additively registers a service block in citadel.yaml.
+// It returns the resulting manifestService so the caller can proceed with the
+// requested operation. The persist is additive and idempotent: it never removes
+// or overwrites existing services, and preserves the rest of the manifest
+// (node:, capabilities:, comments) untouched.
+func (h *ServiceHandler) materializeEmbeddedService(name string) (manifestService, error) {
+	svc := manifestService{
+		Name:        name,
+		ComposeFile: "services/" + name + ".yml",
+	}
+
+	if err := h.ensureEmbeddedComposeFile(name); err != nil {
+		return manifestService{}, err
+	}
+	if err := h.addServiceToManifestFile(svc); err != nil {
+		return manifestService{}, err
+	}
+	return svc, nil
+}
+
+// ensureEmbeddedComposeFile writes the embedded compose file for name into
+// ConfigDir/services/<name>.yml if it does not already exist. Mirrors
+// cmd.ensureComposeFile (kept here to avoid a jobs -> cmd import).
+func (h *ServiceHandler) ensureEmbeddedComposeFile(name string) error {
+	content, ok := embeddedservices.ServiceMap[name]
+	if !ok {
+		return fmt.Errorf("unknown embedded service: %s", name)
+	}
+	servicesDir := filepath.Join(h.ConfigDir, "services")
+	destPath := filepath.Join(servicesDir, name+".yml")
+	if _, err := os.Stat(destPath); err == nil {
+		return nil // already materialized
+	}
+	if err := os.MkdirAll(servicesDir, 0755); err != nil {
+		return fmt.Errorf("failed to create services directory: %w", err)
+	}
+	// 0600 to protect any sensitive env vars, matching cmd.ensureComposeFile.
+	if err := os.WriteFile(destPath, []byte(content), 0600); err != nil {
+		return fmt.Errorf("failed to write compose file: %w", err)
+	}
+	return nil
+}
+
+// addServiceToManifestFile appends a single service block to the citadel.yaml
+// services list without disturbing the rest of the document. It operates on the
+// raw yaml.Node tree (not the minimal serviceManifest struct) so that node:,
+// capabilities:, and any operator-defined services survive the rewrite -- a
+// struct round-trip would silently drop every field the minimal struct does not
+// model. The operation is idempotent: if a service with the same name already
+// exists, the file is left unchanged.
+func (h *ServiceHandler) addServiceToManifestFile(svc manifestService) error {
+	path := filepath.Join(h.ConfigDir, "citadel.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return err
+	}
+	// A well-formed citadel.yaml is a document node wrapping a mapping node.
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
+		return fmt.Errorf("unexpected manifest structure in %s", path)
+	}
+	root := doc.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return fmt.Errorf("manifest root is not a mapping in %s", path)
+	}
+
+	// Locate (or create) the top-level "services" sequence.
+	var servicesSeq *yaml.Node
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		if root.Content[i].Value == "services" {
+			servicesSeq = root.Content[i+1]
+			break
+		}
+	}
+	if servicesSeq == nil {
+		keyNode := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "services"}
+		servicesSeq = &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
+		root.Content = append(root.Content, keyNode, servicesSeq)
+	} else if servicesSeq.Kind != yaml.SequenceNode {
+		// services: present but empty/null -- normalize to an empty sequence.
+		servicesSeq.Kind = yaml.SequenceNode
+		servicesSeq.Tag = "!!seq"
+		servicesSeq.Value = ""
+		servicesSeq.Content = nil
+	}
+
+	// Idempotency: bail if a service with this name is already registered.
+	for _, item := range servicesSeq.Content {
+		if item.Kind != yaml.MappingNode {
+			continue
+		}
+		for j := 0; j+1 < len(item.Content); j += 2 {
+			if item.Content[j].Value == "name" && item.Content[j+1].Value == svc.Name {
+				return nil
+			}
+		}
+	}
+
+	entry := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	entry.Content = append(entry.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "name"},
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: svc.Name},
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "compose_file"},
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: svc.ComposeFile},
+	)
+	servicesSeq.Content = append(servicesSeq.Content, entry)
+
+	out, err := yaml.Marshal(&doc)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, out, 0600)
 }
 
 func (h *ServiceHandler) findService(m *serviceManifest, name string) (manifestService, bool) {

--- a/internal/jobs/service_handler.go
+++ b/internal/jobs/service_handler.go
@@ -2,6 +2,7 @@
 package jobs
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -373,11 +374,18 @@ func (h *ServiceHandler) addServiceToManifestFile(svc manifestService) error {
 	)
 	servicesSeq.Content = append(servicesSeq.Content, entry)
 
-	out, err := yaml.Marshal(&doc)
-	if err != nil {
+	// Encode with 2-space indent to match the citadel.yaml written by
+	// `citadel init` (yaml.v3's default is 4), keeping the reconciled diff minimal.
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(&doc); err != nil {
 		return err
 	}
-	return os.WriteFile(path, out, 0600)
+	if err := enc.Close(); err != nil {
+		return err
+	}
+	return os.WriteFile(path, buf.Bytes(), 0600)
 }
 
 func (h *ServiceHandler) findService(m *serviceManifest, name string) (manifestService, bool) {

--- a/internal/jobs/service_handler_test.go
+++ b/internal/jobs/service_handler_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
 	embeddedservices "github.com/aceteam-ai/citadel-cli/services"
 )
 
@@ -151,12 +152,68 @@ func TestReconcileEmbeddedServiceIsIdempotent(t *testing.T) {
 	}
 }
 
-// TestReconcileUnknownServiceStillErrors verifies that a service absent from
-// both the manifest AND the embedded ServiceMap (e.g. a typo) is not
-// materialized -- Execute keeps returning the "not found in manifest" error.
-func TestReconcileUnknownServiceStillErrors(t *testing.T) {
-	if _, ok := embeddedservices.ServiceMap["definitely-not-a-service"]; ok {
-		t.Skip("unexpected: test sentinel is a real embedded service")
+// TestExecuteReconcilesEmbeddedService drives the actual Execute() gate: a
+// SERVICE_STATUS job (the repro command) for diffusers on a pre-diffusers
+// manifest must succeed after reconciliation instead of erroring. This proves
+// the fallback wiring, not just the materialize helper.
+func TestExecuteReconcilesEmbeddedService(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "citadel.yaml"), []byte(preDiffusersManifest), 0600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	h := NewServiceHandler(dir)
+
+	out, err := h.Execute(JobContext{}, &nexus.Job{
+		ID:      "job-1",
+		Type:    "SERVICE_STATUS",
+		Payload: map[string]string{"service": "diffusers"},
+	})
+	if err != nil {
+		t.Fatalf("Execute SERVICE_STATUS diffusers: unexpected error: %v", err)
+	}
+	if !strings.Contains(string(out), "diffusers") {
+		t.Errorf("status result did not mention diffusers: %s", out)
+	}
+
+	// The service is now persisted and startable.
+	m, err := h.loadManifest()
+	if err != nil {
+		t.Fatalf("loadManifest: %v", err)
+	}
+	if _, ok := h.findService(m, "diffusers"); !ok {
+		t.Fatal("diffusers not registered in manifest after Execute")
+	}
+}
+
+// TestExecuteUnknownServiceStillErrors verifies that a service absent from both
+// the manifest AND the embedded ServiceMap (e.g. a typo) is not materialized:
+// Execute keeps returning the "not found in manifest" error.
+func TestExecuteUnknownServiceStillErrors(t *testing.T) {
+	const bogus = "definitely-not-a-service"
+	if _, ok := embeddedservices.ServiceMap[bogus]; ok {
+		t.Skipf("unexpected: %q is a real embedded service", bogus)
+	}
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "citadel.yaml"), []byte(preDiffusersManifest), 0600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	h := NewServiceHandler(dir)
+
+	_, err := h.Execute(JobContext{}, &nexus.Job{
+		ID:      "job-2",
+		Type:    "SERVICE_START",
+		Payload: map[string]string{"service": bogus},
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown service, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found in manifest") {
+		t.Errorf("error = %q, want it to contain 'not found in manifest'", err)
+	}
+	// It must not have been materialized.
+	if _, statErr := os.Stat(filepath.Join(dir, "services", bogus+".yml")); statErr == nil {
+		t.Errorf("unknown service was materialized to disk")
 	}
 }
 

--- a/internal/jobs/service_handler_test.go
+++ b/internal/jobs/service_handler_test.go
@@ -2,9 +2,163 @@
 package jobs
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	embeddedservices "github.com/aceteam-ai/citadel-cli/services"
 )
+
+// preDiffusersManifest mirrors a citadel.yaml written before the diffusers
+// service was embedded: it lists only vllm/ollama/llamacpp/tei and carries a
+// node: block and a capabilities: block that must survive reconciliation.
+const preDiffusersManifest = `# citadel.yaml
+node:
+  name: ubuntu-gpu
+  tags: [rtx-3090, gpu]
+  org_id: org_test
+services:
+  - name: vllm
+    compose_file: ./services/vllm.yml
+  - name: ollama
+    compose_file: ./services/ollama.yml
+  - name: llamacpp
+    compose_file: ./services/llamacpp.yml
+  - name: tei
+    compose_file: ./services/tei.yml
+capabilities:
+  engines:
+    - vllm
+`
+
+// TestReconcileEmbeddedServiceOnMissingManifest verifies that a node whose
+// manifest predates the diffusers service (issue #413) can resolve diffusers
+// after the fix: the handler materializes the embedded compose file and
+// additively registers the service in citadel.yaml, WITHOUT clobbering the
+// existing node:/capabilities:/services entries.
+func TestReconcileEmbeddedServiceOnMissingManifest(t *testing.T) {
+	if _, ok := embeddedservices.ServiceMap["diffusers"]; !ok {
+		t.Fatal("precondition: diffusers must be present in embedded ServiceMap")
+	}
+
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "citadel.yaml")
+	if err := os.WriteFile(manifestPath, []byte(preDiffusersManifest), 0600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	h := NewServiceHandler(dir)
+
+	// diffusers must not resolve from the original manifest.
+	m, err := h.loadManifest()
+	if err != nil {
+		t.Fatalf("loadManifest: %v", err)
+	}
+	if _, ok := h.findService(m, "diffusers"); ok {
+		t.Fatal("precondition: diffusers unexpectedly present in pre-diffusers manifest")
+	}
+
+	// Reconcile: this is what Execute() now does when findService misses but the
+	// service is embedded.
+	svc, err := h.materializeEmbeddedService("diffusers")
+	if err != nil {
+		t.Fatalf("materializeEmbeddedService: %v", err)
+	}
+	if svc.Name != "diffusers" || svc.ComposeFile != "services/diffusers.yml" {
+		t.Errorf("materialized service = %+v, want diffusers/services/diffusers.yml", svc)
+	}
+
+	// The embedded compose file must be written to disk so resolveComposePath
+	// (and docker compose) can find it.
+	composePath := filepath.Join(dir, "services", "diffusers.yml")
+	if _, err := os.Stat(composePath); err != nil {
+		t.Errorf("compose file not materialized at %s: %v", composePath, err)
+	}
+
+	// After reconcile, diffusers must resolve from the manifest.
+	m2, err := h.loadManifest()
+	if err != nil {
+		t.Fatalf("loadManifest after reconcile: %v", err)
+	}
+	if _, ok := h.findService(m2, "diffusers"); !ok {
+		t.Fatal("diffusers not startable after reconcile")
+	}
+
+	// Anti-clobber: the pre-existing services and the node:/capabilities: blocks
+	// must all survive the additive rewrite.
+	raw, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read reconciled manifest: %v", err)
+	}
+	got := string(raw)
+	for _, want := range []string{"vllm", "ollama", "llamacpp", "tei", "ubuntu-gpu", "org_test", "capabilities", "engines"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("reconciled manifest dropped %q:\n%s", want, got)
+		}
+	}
+	names := map[string]int{}
+	for _, s := range m2.Services {
+		names[s.Name]++
+	}
+	for _, want := range []string{"vllm", "ollama", "llamacpp", "tei", "diffusers"} {
+		if names[want] != 1 {
+			t.Errorf("service %q appears %d times, want exactly 1", want, names[want])
+		}
+	}
+}
+
+// TestReconcileEmbeddedServiceIsIdempotent verifies a second materialize is a
+// no-op (no duplicate service block, manifest unchanged).
+func TestReconcileEmbeddedServiceIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "citadel.yaml")
+	if err := os.WriteFile(manifestPath, []byte(preDiffusersManifest), 0600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	h := NewServiceHandler(dir)
+
+	if _, err := h.materializeEmbeddedService("diffusers"); err != nil {
+		t.Fatalf("first materialize: %v", err)
+	}
+	first, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read after first: %v", err)
+	}
+	if _, err := h.materializeEmbeddedService("diffusers"); err != nil {
+		t.Fatalf("second materialize: %v", err)
+	}
+	second, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read after second: %v", err)
+	}
+	if string(first) != string(second) {
+		t.Errorf("second materialize changed the manifest:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+
+	m, err := h.loadManifest()
+	if err != nil {
+		t.Fatalf("loadManifest: %v", err)
+	}
+	count := 0
+	for _, s := range m.Services {
+		if s.Name == "diffusers" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("diffusers appears %d times after two materializes, want 1", count)
+	}
+}
+
+// TestReconcileUnknownServiceStillErrors verifies that a service absent from
+// both the manifest AND the embedded ServiceMap (e.g. a typo) is not
+// materialized -- Execute keeps returning the "not found in manifest" error.
+func TestReconcileUnknownServiceStillErrors(t *testing.T) {
+	if _, ok := embeddedservices.ServiceMap["definitely-not-a-service"]; ok {
+		t.Skip("unexpected: test sentinel is a real embedded service")
+	}
+}
 
 // TestComposeEnv_InjectsWorkspace verifies that SERVICE_START exports an
 // absolute CITADEL_WORKSPACE to docker compose. The transcribe sidecar compose


### PR DESCRIPTION
## Context

Closes #413.

Discovered during a live prod test of the Fabric Model Library deploy loop (aceteam-ai/aceteam#4472). Node `1054` (RTX 3090) on v2.55.0 embeds `diffusers` in the `ServiceMap` and advertises it via `GetAvailableServices()`, so the platform resolved `sd-3.5-medium` -> engine `diffusers` and dispatched a deploy. It failed at the node:

```
service "diffusers" not found in manifest (known: vllm, ollama, llamacpp, tei)
```

## Root Cause

Capability advertisement and runtime runnability are decoupled:

- The heartbeat advertises every embedded `ServiceMap` key as `available_services` (`internal/status/collector.go` `populateServices`).
- The runtime manifest `~/citadel-node/citadel.yaml` is written at `citadel init` time. A node initialized before `diffusers` existed lists only `vllm/ollama/llamacpp/tei`.
- A binary upgrade (`citadel update`) never reconciles `citadel.yaml` with the newly-embedded `ServiceMap`, so `SERVICE_START`/`SERVICE_STATUS diffusers` is rejected at the manifest gate (`internal/jobs/service_handler.go`).

Net: the node advertises a capability it cannot start.

## Solution — approach (b), lazy materialization at the handler

The issue listed approach (a) — additively pre-populate `citadel.yaml` on upgrade/startup — as preferred, but that is a regression here: `startManagedServices` (`cmd/work.go`) iterates `manifest.Services` and starts **every** entry on each boot. Adding all embedded services to the manifest would make every GPU node pull the diffusers image and load a model at boot just because the binary embeds it. So I chose **(b)**: reconcile lazily at the single enforcement gate.

When `findService` misses in `ServiceHandler.Execute`:
- If the requested service is **not** in the embedded `ServiceMap` (a typo), keep the existing `"not found in manifest (known: ...)"` error.
- If it **is** embedded, `materializeEmbeddedService`:
  1. writes the embedded compose to `ConfigDir/services/<name>.yml` (0600, mkdir -p) if absent — mirrors `cmd.ensureComposeFile`, so `resolveComposePath` and `docker compose` find it;
  2. additively registers a `{name, compose_file}` block in `citadel.yaml`;
  3. returns the resolved `manifestService` so START/STATUS/STOP proceed.

This keeps advertised == runnable and covers **both** `SERVICE_START` and `SERVICE_STATUS` (the repro uses `service_status`). Nothing auto-starts: a service only lands in the manifest when something explicitly targets it, after which it is managed like any `citadel run` / module service (auto-starts on subsequent reboots — correct and consistent).

### Anti-clobber persist

The persist rewrites the raw `yaml.Node` tree and appends one entry to the `services` sequence — it does **not** marshal the handler's minimal `serviceManifest` struct (which models only `Services` and would silently drop `node:` and `capabilities:`). It cannot reuse `cmd.writeManifest` (jobs -> cmd is the wrong import direction; that is why the minimal struct exists). The operation is additive and idempotent: a service already present by name is a no-op.

## Changes

- `internal/jobs/service_handler.go`: fall back to the embedded `ServiceMap` when a service is missing from the manifest; `materializeEmbeddedService`, `ensureEmbeddedComposeFile`, and `addServiceToManifestFile` (yaml.Node additive persist). Aliased the top-level `services` package as `embeddedservices`.
- `internal/jobs/service_handler_test.go`: tests.

## Test plan

- `go test ./...` — pass.
- `./build.sh` — pass.
- New tests:
  - `TestReconcileEmbeddedServiceOnMissingManifest`: a pre-diffusers manifest (vllm/ollama/llamacpp/tei + `node:` + `capabilities:`) does not resolve `diffusers`, then does after reconcile; compose file materialized; `node:`/`capabilities:`/existing services all survive; no duplicates.
  - `TestReconcileEmbeddedServiceIsIdempotent`: second materialize is a byte-for-byte no-op.
  - `TestExecuteReconcilesEmbeddedService`: drives `Execute()` with a `SERVICE_STATUS diffusers` job (the repro command) on a pre-diffusers manifest — succeeds and registers the service.
  - `TestExecuteUnknownServiceStillErrors`: `Execute()` with a `SERVICE_START` for a service in neither the manifest nor the ServiceMap returns "not found in manifest" and materializes nothing.

Note: the reconciled manifest is re-emitted with a 2-space-indent encoder to match `citadel init`'s output (yaml.v3 defaults to 4); comments are preserved by the `yaml.Node` round-trip.

**Not covered here (needs a live GPU node, verified separately):** the full `provision_model("sd-3.5-medium")` -> dispatch -> `docker compose up` -> container path. Kept as draft for that reason.

## Related

- aceteam-ai/aceteam#4472 (Fabric Model Library epic), #404 (diffusers service), #408 (self-declare `available_services`).
- Companion platform-side: deploy should verify runnability + pre-pull image before SERVICE_START.

---
*Generated by Claude Opus 4.8*
