### PR TITLE
fix(services): reconcile manifest with embedded services on upgrade + publish SERVICE_START host ports (#413, #415)

### DIFF
--- a/cmd/manifest.go
+++ b/cmd/manifest.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -268,6 +269,79 @@ func addServiceToManifestWithTags(configDir, serviceName string, nodeTags []stri
 
 	// Write back
 	return writeManifest(manifestPath, manifest)
+}
+
+// reconcileManifestServices makes the on-disk manifest consistent with the
+// services this binary can deploy. For every service embedded in the binary
+// (services.ServiceMap) that is missing from the manifest's services list, it
+// adds an additive service block and materializes the embedded compose file
+// into <configDir>/services/<name>.yml.
+//
+// This closes the "advertised-but-unstartable" gap (citadel-cli#413): when a
+// newer binary embeds a service (e.g. diffusers in v2.55.0) and advertises it in
+// the heartbeat, but the node's citadel.yaml was written at init time before that
+// service existed, a SERVICE_START would be rejected with "service not found in
+// manifest". A binary upgrade does not otherwise touch the manifest, so the node
+// keeps advertising a capability it cannot start until reconciled here.
+//
+// Guarantees:
+//   - Additive-only: never removes or overwrites operator-defined entries. An
+//     existing service (matched by name) is left untouched, including
+//     operator-authored compose files (ensureComposeFile is a no-op when the file
+//     already exists).
+//   - Preserves unknown entries: services in the manifest that are not embedded
+//     (e.g. a hand-added "tei") are retained as-is.
+//   - Idempotent: a second call is a no-op.
+//
+// It returns the names of services newly added (for logging). It never returns an
+// error that should abort startup; failures for a single service are collected
+// and surfaced, but the manifest write only includes services that materialized
+// cleanly.
+//
+// IMPORTANT ordering note for callers: this must run AFTER startManagedServices
+// so newly-reconciled embedded services are not auto-started on this boot. The
+// manifest lists only operator intent for the purposes of auto-start (#384: never
+// gate boot on heavy GPU services); reconciled entries exist so an on-demand
+// SERVICE_START can find them, not so they launch unbidden.
+func reconcileManifestServices(configDir string) (added []string, err error) {
+	manifestPath := filepath.Join(configDir, "citadel.yaml")
+
+	manifest, _, mErr := findAndReadManifest()
+	if mErr != nil {
+		return nil, fmt.Errorf("failed to read manifest for reconcile: %w", mErr)
+	}
+
+	// Iterate embedded services in a stable order so logs and writes are
+	// deterministic.
+	changed := false
+	for _, svcName := range services.GetAvailableServices() {
+		if hasService(manifest, svcName) {
+			continue // operator/prior-reconcile entry -- leave untouched
+		}
+
+		// Materialize the embedded compose file (no-op if it already exists).
+		if cErr := ensureComposeFile(configDir, svcName); cErr != nil {
+			err = errors.Join(err, fmt.Errorf("reconcile %s: %w", svcName, cErr))
+			continue
+		}
+
+		manifest.Services = append(manifest.Services, Service{
+			Name:        svcName,
+			ComposeFile: filepath.Join("./services", svcName+".yml"),
+		})
+		added = append(added, svcName)
+		changed = true
+	}
+
+	if !changed {
+		return added, err
+	}
+
+	if wErr := writeManifest(manifestPath, manifest); wErr != nil {
+		return added, errors.Join(err, fmt.Errorf("failed to write reconciled manifest: %w", wErr))
+	}
+
+	return added, err
 }
 
 // containsTag checks if a tag is already in the tags slice.

--- a/cmd/manifest_reconcile_test.go
+++ b/cmd/manifest_reconcile_test.go
@@ -1,0 +1,189 @@
+// cmd/manifest_reconcile_test.go
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
+	"github.com/aceteam-ai/citadel-cli/services"
+	"gopkg.in/yaml.v3"
+)
+
+// setupReconcileHome wires a fake HOME so platform.ConfigDir() resolves to a
+// temp .citadel-cli, writes the global config pointing at a node dir, and seeds
+// that node dir with the given manifest YAML. It returns the node config dir.
+//
+// This mirrors the real on-disk layout the reconcile reads through
+// findAndReadManifest (global config -> node_config_dir -> citadel.yaml).
+func setupReconcileHome(t *testing.T, manifestYAML string) string {
+	t.Helper()
+	if platform.IsRoot() {
+		t.Skip("reconcile test relies on non-root HOME-based ConfigDir")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	configDir := platform.ConfigDir() // <home>/.citadel-cli
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+
+	nodeDir := filepath.Join(home, "citadel-node")
+	if err := os.MkdirAll(filepath.Join(nodeDir, "services"), 0o755); err != nil {
+		t.Fatalf("mkdir node dir: %v", err)
+	}
+
+	globalConfig := []byte("node_config_dir: " + nodeDir + "\n")
+	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), globalConfig, 0o600); err != nil {
+		t.Fatalf("write global config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(nodeDir, "citadel.yaml"), []byte(manifestYAML), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	return nodeDir
+}
+
+// preDiffusersManifestYAML lists the legacy serving services plus a hand-added,
+// non-embedded "tei" entry (to prove reconcile is additive).
+const preDiffusersManifestYAML = `node:
+  name: test-node
+  tags:
+    - gpu
+  org_id: org-abc
+services:
+  - name: vllm
+    compose_file: ./services/vllm.yml
+  - name: ollama
+    compose_file: ./services/ollama.yml
+  - name: llamacpp
+    compose_file: ./services/llamacpp.yml
+  - name: tei
+    compose_file: ./services/tei.yml
+`
+
+// TestReconcileManifestServices_AddsEmbeddedDiffusers verifies bug A
+// (citadel-cli#413): a pre-diffusers manifest reconciles to include every
+// embedded service (including diffusers), additively, and materializes each
+// compose file.
+func TestReconcileManifestServices_AddsEmbeddedDiffusers(t *testing.T) {
+	nodeDir := setupReconcileHome(t, preDiffusersManifestYAML)
+
+	added, err := reconcileManifestServices(nodeDir)
+	if err != nil {
+		t.Fatalf("reconcileManifestServices: %v", err)
+	}
+
+	// diffusers must be among the newly-added services.
+	foundDiffusers := false
+	for _, name := range added {
+		if name == "diffusers" {
+			foundDiffusers = true
+		}
+	}
+	if !foundDiffusers {
+		t.Errorf("reconcile did not add diffusers; added = %v", added)
+	}
+
+	manifest, _, err := findAndReadManifest()
+	if err != nil {
+		t.Fatalf("re-read manifest: %v", err)
+	}
+
+	// Every embedded service is now present -> a SERVICE_START "known service"
+	// check will pass for all of them.
+	for _, name := range services.GetAvailableServices() {
+		if !hasService(manifest, name) {
+			t.Errorf("embedded service %q missing from manifest after reconcile", name)
+		}
+	}
+
+	// Additive: legacy + non-embedded operator entries survive.
+	for _, name := range []string{"vllm", "ollama", "llamacpp", "tei"} {
+		if !hasService(manifest, name) {
+			t.Errorf("reconcile dropped pre-existing service %q", name)
+		}
+	}
+
+	// Node identity preserved.
+	if manifest.Node.OrgID != "org-abc" {
+		t.Errorf("node.org_id = %q, want org-abc (reconcile clobbered node block)", manifest.Node.OrgID)
+	}
+
+	// The embedded compose file was materialized on disk.
+	if _, err := os.Stat(filepath.Join(nodeDir, "services", "diffusers.yml")); err != nil {
+		t.Errorf("diffusers compose not materialized: %v", err)
+	}
+}
+
+// TestReconcileManifestServices_Idempotent verifies a second reconcile adds
+// nothing and does not duplicate entries.
+func TestReconcileManifestServices_Idempotent(t *testing.T) {
+	nodeDir := setupReconcileHome(t, preDiffusersManifestYAML)
+
+	if _, err := reconcileManifestServices(nodeDir); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+	added, err := reconcileManifestServices(nodeDir)
+	if err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+	if len(added) != 0 {
+		t.Errorf("second reconcile added %v, want none (not idempotent)", added)
+	}
+
+	// No duplicate diffusers entries.
+	raw, _ := os.ReadFile(filepath.Join(nodeDir, "citadel.yaml"))
+	var doc struct {
+		Services []struct {
+			Name string `yaml:"name"`
+		} `yaml:"services"`
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse manifest: %v", err)
+	}
+	count := 0
+	for _, s := range doc.Services {
+		if s.Name == "diffusers" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("diffusers appears %d times after two reconciles, want 1", count)
+	}
+}
+
+// TestReconcileManifestServices_PreservesOperatorComposeFile verifies reconcile
+// never overwrites an operator-authored compose file for a service it also
+// embeds.
+func TestReconcileManifestServices_PreservesOperatorComposeFile(t *testing.T) {
+	// Manifest omits vllm from services so reconcile will re-add it; but the
+	// operator already placed a custom vllm.yml on disk.
+	const yaml = `node:
+  name: test-node
+services:
+  - name: ollama
+    compose_file: ./services/ollama.yml
+`
+	nodeDir := setupReconcileHome(t, yaml)
+
+	customCompose := "# operator custom vllm\nservices:\n  vllm:\n    image: custom\n"
+	vllmPath := filepath.Join(nodeDir, "services", "vllm.yml")
+	if err := os.WriteFile(vllmPath, []byte(customCompose), 0o600); err != nil {
+		t.Fatalf("write custom compose: %v", err)
+	}
+
+	if _, err := reconcileManifestServices(nodeDir); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	got, err := os.ReadFile(vllmPath)
+	if err != nil {
+		t.Fatalf("read vllm compose: %v", err)
+	}
+	if string(got) != customCompose {
+		t.Error("reconcile overwrote an operator-authored compose file")
+	}
+}

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -273,6 +273,20 @@ func runWork(cmd *cobra.Command, args []string) {
 		}()
 	}
 
+	// Reconcile the on-disk manifest with the services this binary can deploy
+	// (citadel-cli#413). This runs AFTER startManagedServices on purpose: newly
+	// added embedded services (e.g. diffusers on a node whose citadel.yaml predates
+	// it) must NOT be auto-started here -- the manifest drives boot auto-start and
+	// we never gate startup on heavy GPU services (#384). The reconcile only makes
+	// an on-demand SERVICE_START able to find + materialize the service.
+	if _, reconcileConfigDir, mErr := findAndReadManifest(); mErr == nil && reconcileConfigDir != "" {
+		if added, rErr := reconcileManifestServices(reconcileConfigDir); rErr != nil {
+			fmt.Fprintf(os.Stderr, "   - Warning: manifest service reconcile: %v\n", rErr)
+		} else if len(added) > 0 {
+			fmt.Printf("   - Reconciled manifest with newly-embedded service(s): %s\n", strings.Join(added, ", "))
+		}
+	}
+
 	// Resolve node capabilities early (used for queue routing and heartbeat)
 	var nodeCaps *capabilities.NodeCapabilities
 	workManifest, workConfigDir, _ := findAndReadManifest()

--- a/internal/compose/hostports_test.go
+++ b/internal/compose/hostports_test.go
@@ -1,0 +1,104 @@
+package compose
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// TestHostPorts_ShortAndLongForm verifies the parser extracts published host
+// ports across the compose short and long forms, and skips bare/ephemeral
+// publishes. This underpins the citadel-cli#415 assertion that a SERVICE_START
+// container publishes the host port its compose declares.
+func TestHostPorts_ShortAndLongForm(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []int
+	}{
+		{
+			name: "short form host:container",
+			input: `services:
+  diffusers:
+    image: x
+    ports:
+      - "8102:7860"`,
+			want: []int{8102},
+		},
+		{
+			name: "short form with protocol suffix",
+			input: `services:
+  svc:
+    ports:
+      - "5000:5000/tcp"`,
+			want: []int{5000},
+		},
+		{
+			name: "ip:host:container",
+			input: `services:
+  svc:
+    ports:
+      - "127.0.0.1:9000:9000"`,
+			want: []int{9000},
+		},
+		{
+			name: "long form published/target",
+			input: `services:
+  svc:
+    ports:
+      - target: 80
+        published: 8080
+        protocol: tcp`,
+			want: []int{8080},
+		},
+		{
+			name: "bare container port is ephemeral -> skipped",
+			input: `services:
+  svc:
+    ports:
+      - "7860"`,
+			want: nil,
+		},
+		{
+			name: "no ports section",
+			input: `services:
+  svc:
+    image: x`,
+			want: nil,
+		},
+		{
+			name: "multiple services and ports deduped",
+			input: `services:
+  a:
+    ports:
+      - "8000:8000"
+  b:
+    ports:
+      - "8000:8000"
+      - "9000:9000"`,
+			want: []int{8000, 9000},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := HostPorts([]byte(tt.input))
+			sort.Ints(got)
+			want := append([]int(nil), tt.want...)
+			sort.Ints(want)
+			if len(got) == 0 && len(want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("HostPorts() = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+// TestHostPorts_InvalidYAML returns nil rather than panicking on malformed input.
+func TestHostPorts_InvalidYAML(t *testing.T) {
+	if got := HostPorts([]byte("::not yaml::")); got != nil {
+		t.Errorf("HostPorts(invalid) = %v, want nil", got)
+	}
+}

--- a/internal/compose/modifier.go
+++ b/internal/compose/modifier.go
@@ -2,8 +2,111 @@
 package compose
 
 import (
+	"strconv"
+	"strings"
+
 	"gopkg.in/yaml.v3"
 )
+
+// HostPorts extracts the published HOST ports declared in a Docker Compose file's
+// services. It parses the short-form `ports` entries ("HOST:CONTAINER",
+// "HOST:CONTAINER/proto", "IP:HOST:CONTAINER", or a bare "CONTAINER" which
+// publishes an ephemeral host port and is skipped) as well as the long-form
+// mapping ({published: HOST, target: CONTAINER}).
+//
+// It underpins the citadel-cli#415 assertion that a SERVICE_START container comes
+// up with its compose-declared host port actually published: given the embedded
+// diffusers compose (`ports: ["8102:7860"]`) it returns [8102]. It is pure and
+// daemon-free, so callers can verify the intended publish without a live docker.
+func HostPorts(content []byte) []int {
+	var doc map[string]any
+	if err := yaml.Unmarshal(content, &doc); err != nil {
+		return nil
+	}
+
+	servicesRaw, ok := doc["services"].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	var ports []int
+	seen := make(map[int]bool)
+	add := func(p int) {
+		if p > 0 && !seen[p] {
+			seen[p] = true
+			ports = append(ports, p)
+		}
+	}
+
+	for _, svcRaw := range servicesRaw {
+		svc, ok := svcRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+		portsRaw, ok := svc["ports"].([]any)
+		if !ok {
+			continue
+		}
+		for _, entry := range portsRaw {
+			switch e := entry.(type) {
+			case string:
+				if p, ok := hostPortFromShortForm(e); ok {
+					add(p)
+				}
+			case int:
+				// Bare container port (e.g. `- 8080`) -> ephemeral host port; skip.
+			case map[string]any:
+				if pub, ok := e["published"]; ok {
+					if p, ok := toInt(pub); ok {
+						add(p)
+					}
+				}
+			}
+		}
+	}
+
+	return ports
+}
+
+// hostPortFromShortForm parses a short-form compose port mapping and returns the
+// host port. Forms: "HOST:CONTAINER", "HOST:CONTAINER/proto", "IP:HOST:CONTAINER".
+// A bare "CONTAINER" (no colon) publishes an ephemeral host port and yields ok=false.
+func hostPortFromShortForm(spec string) (int, bool) {
+	spec = strings.TrimSpace(spec)
+	// Drop any /protocol suffix (e.g. "8102:7860/tcp").
+	if i := strings.Index(spec, "/"); i >= 0 {
+		spec = spec[:i]
+	}
+	parts := strings.Split(spec, ":")
+	switch len(parts) {
+	case 1:
+		// Bare container port: ephemeral host publish, not a fixed host port.
+		return 0, false
+	case 2:
+		// HOST:CONTAINER
+		return toInt(parts[0])
+	case 3:
+		// IP:HOST:CONTAINER
+		return toInt(parts[1])
+	default:
+		return 0, false
+	}
+}
+
+func toInt(v any) (int, bool) {
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case string:
+		i, err := strconv.Atoi(strings.TrimSpace(n))
+		if err != nil {
+			return 0, false
+		}
+		return i, true
+	default:
+		return 0, false
+	}
+}
 
 // StripGPUDevices removes GPU device reservations from a Docker Compose file.
 // This is used on non-Linux platforms where NVIDIA Container Toolkit is not available.

--- a/internal/jobs/service_handler.go
+++ b/internal/jobs/service_handler.go
@@ -10,9 +10,11 @@ import (
 	"strings"
 
 	"github.com/aceteam-ai/citadel-cli/internal/catalog"
+	"github.com/aceteam-ai/citadel-cli/internal/compose"
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
 	"github.com/aceteam-ai/citadel-cli/internal/services"
+	embedded "github.com/aceteam-ai/citadel-cli/services"
 	"gopkg.in/yaml.v3"
 )
 
@@ -61,6 +63,10 @@ type serviceResult struct {
 	Error   string `json:"error,omitempty"`
 	Action  string `json:"action,omitempty"`  // "start", "stop", "status"
 	Message string `json:"message,omitempty"` // human-readable summary
+	// HostPorts are the published host ports declared by the started service's
+	// compose file. Populated on a successful docker SERVICE_START so the caller
+	// knows where the service is reachable on the node (citadel-cli#415).
+	HostPorts []int `json:"host_ports,omitempty"`
 }
 
 func (h *ServiceHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
@@ -79,8 +85,26 @@ func (h *ServiceHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error)
 
 	svc, ok := h.findService(manifest, svcName)
 	if !ok {
-		return nil, fmt.Errorf("service %q not found in manifest (known: %s)",
-			svcName, h.knownServiceNames(manifest))
+		// The service is not in the manifest. This is the common failure after a
+		// binary upgrade adds a new embedded service (e.g. diffusers in v2.55.0):
+		// the node advertises the capability in its heartbeat but its citadel.yaml,
+		// written at init time, predates the service (citadel-cli#413). If the
+		// requested service is one this binary embeds, materialize its compose from
+		// the embedded template, persist an additive manifest block, and proceed --
+		// so an on-demand SERVICE_START self-heals instead of being rejected. This
+		// is the belt-and-suspenders companion to the startup manifest reconcile.
+		reconciled, rErr := h.materializeEmbeddedService(svcName)
+		if rErr != nil {
+			return nil, fmt.Errorf("service %q not found in manifest (known: %s); "+
+				"failed to materialize embedded service: %w",
+				svcName, h.knownServiceNames(manifest), rErr)
+		}
+		if reconciled == nil {
+			return nil, fmt.Errorf("service %q not found in manifest (known: %s)",
+				svcName, h.knownServiceNames(manifest))
+		}
+		svc = *reconciled
+		ctx.Log("info", "     - [Job %s] Materialized embedded service %s into manifest", job.ID, svcName)
 	}
 
 	switch job.Type {
@@ -153,7 +177,14 @@ func (h *ServiceHandler) serviceStart(ctx JobContext, svc manifestService) ([]by
 			strings.TrimSuffix(filepath.Base(composePath), filepath.Ext(filepath.Base(composePath)))); override != "" {
 			composeArgs = append(composeArgs, "-f", override)
 		}
-		composeArgs = append(composeArgs, "up", "-d")
+		// --force-recreate guarantees the container is (re)created from THIS compose
+		// definition. Without it, a stale citadel-<svc> container left from a prior
+		// run with a different (or no) port mapping is reused, and the container
+		// comes up with NetworkSettings.Ports == {} -- a healthy server on its
+		// internal contract port is then unreachable on the host (citadel-cli#415).
+		// We only reach here when the service is not already running (checked
+		// above), so recreating is safe.
+		composeArgs = append(composeArgs, "up", "-d", "--force-recreate")
 		cmd := exec.Command("docker", composeArgs...)
 		cmd.Env = h.composeEnv()
 		out, cmdErr := cmd.CombinedOutput()
@@ -170,10 +201,32 @@ func (h *ServiceHandler) serviceStart(ctx JobContext, svc manifestService) ([]by
 		})
 	}
 
-	return json.Marshal(serviceResult{
+	result := serviceResult{
 		Name: svc.Name, Running: true, Kind: kind,
 		Action: "start", Message: fmt.Sprintf("%s started successfully", svc.Name),
-	})
+	}
+	// Surface the compose-declared host ports so the caller knows where the
+	// service is reachable on the node (citadel-cli#415). Docker-kind only; native
+	// services manage their own listen port.
+	if kind == "docker" {
+		result.HostPorts = h.composeHostPorts(svc)
+	}
+	return json.Marshal(result)
+}
+
+// composeHostPorts returns the published host ports declared in a service's
+// compose file, or nil if the file cannot be read/parsed. Used to report the
+// reachable endpoint after a successful SERVICE_START (citadel-cli#415).
+func (h *ServiceHandler) composeHostPorts(svc manifestService) []int {
+	composePath, err := h.resolveComposePath(svc)
+	if err != nil {
+		return nil
+	}
+	content, err := os.ReadFile(composePath)
+	if err != nil {
+		return nil
+	}
+	return compose.HostPorts(content)
 }
 
 func (h *ServiceHandler) serviceStop(ctx JobContext, svc manifestService) ([]byte, error) {
@@ -238,6 +291,108 @@ func (h *ServiceHandler) loadManifest() (*serviceManifest, error) {
 		return nil, err
 	}
 	return &m, nil
+}
+
+// serviceNameOK guards against path traversal via the service name before it is
+// used to build a compose file path. It mirrors the config handler's allowlist:
+// lowercase alphanumerics and hyphens only.
+func serviceNameOK(name string) bool {
+	if name == "" || len(name) > 32 {
+		return false
+	}
+	for _, r := range name {
+		if (r < 'a' || r > 'z') && (r < '0' || r > '9') && r != '-' {
+			return false
+		}
+	}
+	return true
+}
+
+// materializeEmbeddedService self-heals a manifest that predates an embedded
+// service (citadel-cli#413). If svcName is one this binary embeds
+// (embedded.ServiceMap), it writes the embedded compose to
+// <ConfigDir>/services/<name>.yml (without overwriting an existing file),
+// persists an additive service block into citadel.yaml (preserving all other
+// manifest content), and returns the resolved manifestService. If svcName is not
+// an embedded service it returns (nil, nil) so the caller emits the normal
+// "not found in manifest" error.
+func (h *ServiceHandler) materializeEmbeddedService(svcName string) (*manifestService, error) {
+	if !serviceNameOK(svcName) {
+		return nil, nil
+	}
+	content, ok := embedded.ServiceMap[svcName]
+	if !ok {
+		return nil, nil // not an embedded service -- caller emits normal error
+	}
+
+	// Write the embedded compose file if it is not already present. An existing
+	// (operator-authored) file is left untouched.
+	servicesDir := filepath.Join(h.ConfigDir, "services")
+	composeFile := filepath.Join(servicesDir, svcName+".yml")
+	if _, err := os.Stat(composeFile); os.IsNotExist(err) {
+		if err := os.MkdirAll(servicesDir, 0o755); err != nil {
+			return nil, fmt.Errorf("create services dir: %w", err)
+		}
+		// 0600 to protect any sensitive env vars, matching the config handler.
+		if err := os.WriteFile(composeFile, []byte(content), 0o600); err != nil {
+			return nil, fmt.Errorf("write compose file: %w", err)
+		}
+	}
+
+	relCompose := filepath.Join("./services", svcName+".yml")
+	svc := manifestService{Name: svcName, ComposeFile: relCompose}
+
+	// Persist the additive manifest block, preserving every other field.
+	if err := h.appendManifestService(svc); err != nil {
+		return nil, fmt.Errorf("persist manifest block: %w", err)
+	}
+	return &svc, nil
+}
+
+// appendManifestService adds a service block to citadel.yaml without disturbing
+// any other content (node, capabilities, config, other services). It performs a
+// generic YAML read-modify-write so unknown top-level keys survive. It is a no-op
+// when the service is already present.
+func (h *ServiceHandler) appendManifestService(svc manifestService) error {
+	path := filepath.Join(h.ConfigDir, "citadel.yaml")
+
+	var doc map[string]any
+	if data, err := os.ReadFile(path); err == nil {
+		if err := yaml.Unmarshal(data, &doc); err != nil {
+			return fmt.Errorf("parse manifest: %w", err)
+		}
+	}
+	if doc == nil {
+		doc = make(map[string]any)
+	}
+
+	var svcList []any
+	if existing, ok := doc["services"].([]any); ok {
+		svcList = existing
+	}
+	// Idempotency: bail if a service with this name already exists.
+	for _, entry := range svcList {
+		if m, ok := entry.(map[string]any); ok {
+			if name, _ := m["name"].(string); name == svc.Name {
+				return nil
+			}
+		}
+	}
+
+	svcList = append(svcList, map[string]any{
+		"name":         svc.Name,
+		"compose_file": svc.ComposeFile,
+	})
+	doc["services"] = svcList
+
+	out, err := yaml.Marshal(doc)
+	if err != nil {
+		return fmt.Errorf("marshal manifest: %w", err)
+	}
+	if err := os.WriteFile(path, out, 0o600); err != nil {
+		return fmt.Errorf("write manifest: %w", err)
+	}
+	return nil
 }
 
 func (h *ServiceHandler) findService(m *serviceManifest, name string) (manifestService, bool) {

--- a/internal/jobs/service_reconcile_test.go
+++ b/internal/jobs/service_reconcile_test.go
@@ -1,0 +1,255 @@
+// internal/jobs/service_reconcile_test.go
+package jobs
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	embedded "github.com/aceteam-ai/citadel-cli/services"
+	"gopkg.in/yaml.v3"
+)
+
+// preDiffusersManifest is a manifest written before the diffusers service
+// existed (v2.55.0). It lists the four legacy serving services plus a
+// hand-added, non-embedded "tei" entry (to prove reconcile is additive and
+// preserves unknown operator entries).
+const preDiffusersManifest = `node:
+  name: test-node
+  tags:
+    - gpu
+  org_id: org-123
+services:
+  - name: vllm
+    compose_file: ./services/vllm.yml
+  - name: ollama
+    compose_file: ./services/ollama.yml
+  - name: llamacpp
+    compose_file: ./services/llamacpp.yml
+  - name: tei
+    compose_file: ./services/tei.yml
+capabilities:
+  engines:
+    - vllm
+    - ollama
+`
+
+func writePreDiffusersManifest(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "citadel.yaml"), []byte(preDiffusersManifest), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	return dir
+}
+
+// TestMaterializeEmbeddedService_AddsDiffusers verifies bug A (citadel-cli#413):
+// a node whose manifest predates diffusers can, on an on-demand SERVICE_START,
+// self-heal by materializing the embedded compose + manifest block so the
+// "known service" check passes.
+func TestMaterializeEmbeddedService_AddsDiffusers(t *testing.T) {
+	dir := writePreDiffusersManifest(t)
+	h := NewServiceHandler(dir)
+
+	// Sanity: diffusers is NOT in the manifest to begin with.
+	m0, err := h.loadManifest()
+	if err != nil {
+		t.Fatalf("loadManifest: %v", err)
+	}
+	if _, ok := h.findService(m0, "diffusers"); ok {
+		t.Fatal("precondition failed: diffusers should be absent from the pre-diffusers manifest")
+	}
+
+	svc, err := h.materializeEmbeddedService("diffusers")
+	if err != nil {
+		t.Fatalf("materializeEmbeddedService: %v", err)
+	}
+	if svc == nil {
+		t.Fatal("materializeEmbeddedService returned nil for an embedded service")
+	}
+	if svc.Name != "diffusers" {
+		t.Errorf("materialized service name = %q, want diffusers", svc.Name)
+	}
+
+	// The embedded compose file was written to disk.
+	composePath := filepath.Join(dir, "services", "diffusers.yml")
+	data, err := os.ReadFile(composePath)
+	if err != nil {
+		t.Fatalf("expected materialized compose file: %v", err)
+	}
+	if string(data) != embedded.ServiceMap["diffusers"] {
+		t.Error("materialized compose content does not match the embedded template")
+	}
+
+	// Reloading the manifest now finds diffusers -> the "known service" check passes.
+	m1, err := h.loadManifest()
+	if err != nil {
+		t.Fatalf("reload manifest: %v", err)
+	}
+	if _, ok := h.findService(m1, "diffusers"); !ok {
+		t.Fatalf("diffusers not found after materialize (known: %s)", h.knownServiceNames(m1))
+	}
+
+	// Additive: the pre-existing, non-embedded "tei" entry survives.
+	if _, ok := h.findService(m1, "tei"); !ok {
+		t.Error("reconcile dropped the non-embedded operator entry 'tei'")
+	}
+	for _, name := range []string{"vllm", "ollama", "llamacpp"} {
+		if _, ok := h.findService(m1, name); !ok {
+			t.Errorf("reconcile dropped legacy service %q", name)
+		}
+	}
+
+	// Non-service manifest content (node, capabilities) is preserved.
+	raw, _ := os.ReadFile(filepath.Join(dir, "citadel.yaml"))
+	var doc map[string]any
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse rewritten manifest: %v", err)
+	}
+	node, _ := doc["node"].(map[string]any)
+	if node == nil || node["org_id"] != "org-123" {
+		t.Errorf("node.org_id not preserved after reconcile: %v", doc["node"])
+	}
+	if _, ok := doc["capabilities"]; !ok {
+		t.Error("capabilities section dropped after reconcile")
+	}
+}
+
+// TestMaterializeEmbeddedService_Idempotent verifies a second materialize is a
+// no-op (no duplicate manifest entries, compose content unchanged).
+func TestMaterializeEmbeddedService_Idempotent(t *testing.T) {
+	dir := writePreDiffusersManifest(t)
+	h := NewServiceHandler(dir)
+
+	if _, err := h.materializeEmbeddedService("diffusers"); err != nil {
+		t.Fatalf("first materialize: %v", err)
+	}
+	if _, err := h.materializeEmbeddedService("diffusers"); err != nil {
+		t.Fatalf("second materialize: %v", err)
+	}
+
+	m, err := h.loadManifest()
+	if err != nil {
+		t.Fatalf("loadManifest: %v", err)
+	}
+	count := 0
+	for _, s := range m.Services {
+		if s.Name == "diffusers" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("diffusers appears %d times in manifest, want 1", count)
+	}
+}
+
+// TestMaterializeEmbeddedService_UnknownService returns (nil, nil) so the caller
+// emits the normal "not found in manifest" error rather than fabricating an entry.
+func TestMaterializeEmbeddedService_UnknownService(t *testing.T) {
+	dir := writePreDiffusersManifest(t)
+	h := NewServiceHandler(dir)
+
+	svc, err := h.materializeEmbeddedService("definitely-not-a-real-service")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if svc != nil {
+		t.Errorf("expected nil for unknown service, got %+v", svc)
+	}
+}
+
+// TestMaterializeEmbeddedService_RejectsPathTraversal ensures a crafted service
+// name cannot escape the services directory.
+func TestMaterializeEmbeddedService_RejectsPathTraversal(t *testing.T) {
+	dir := writePreDiffusersManifest(t)
+	h := NewServiceHandler(dir)
+
+	svc, err := h.materializeEmbeddedService("../../etc/passwd")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if svc != nil {
+		t.Error("path-traversal service name should be rejected (nil result)")
+	}
+}
+
+// TestComposeHostPorts_DiffusersPublishesHostPort verifies bug B
+// (citadel-cli#415): after the diffusers compose is materialized, the
+// SERVICE_START result reports the compose-declared host port so the service is
+// reachable on the node. This asserts the intended host-port publish without a
+// live docker daemon.
+func TestComposeHostPorts_DiffusersPublishesHostPort(t *testing.T) {
+	dir := writePreDiffusersManifest(t)
+	h := NewServiceHandler(dir)
+
+	svc, err := h.materializeEmbeddedService("diffusers")
+	if err != nil {
+		t.Fatalf("materializeEmbeddedService: %v", err)
+	}
+
+	ports := h.composeHostPorts(*svc)
+	if len(ports) == 0 {
+		t.Fatal("composeHostPorts returned no host ports for diffusers; " +
+			"a started container would come up with no published ports (citadel-cli#415)")
+	}
+
+	// Do not hard-depend on a specific number (that is #410's territory); assert
+	// the host port matches whatever the embedded compose currently declares.
+	wantPort := hostPortFromEmbeddedDiffusers(t)
+	found := false
+	for _, p := range ports {
+		if p == wantPort {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("composeHostPorts = %v, want it to include the compose-declared host port %d", ports, wantPort)
+	}
+}
+
+// TestServiceStart_ForceRecreateFlag guards the fix that prevents a stale,
+// port-less container from being reused: the docker SERVICE_START path must pass
+// --force-recreate so the container is (re)created from the current compose
+// definition (citadel-cli#415).
+func TestServiceStart_ForceRecreateFlag(t *testing.T) {
+	src, err := os.ReadFile("service_handler.go")
+	if err != nil {
+		t.Fatalf("read handler source: %v", err)
+	}
+	if !strings.Contains(string(src), "--force-recreate") {
+		t.Error("SERVICE_START docker path must pass --force-recreate to avoid reusing a port-less stale container")
+	}
+}
+
+// hostPortFromEmbeddedDiffusers parses the host port out of the embedded
+// diffusers compose so the test tracks the compose's current value rather than a
+// hardcoded number.
+func hostPortFromEmbeddedDiffusers(t *testing.T) int {
+	t.Helper()
+	var doc struct {
+		Services map[string]struct {
+			Ports []string `yaml:"ports"`
+		} `yaml:"services"`
+	}
+	if err := yaml.Unmarshal([]byte(embedded.ServiceMap["diffusers"]), &doc); err != nil {
+		t.Fatalf("parse embedded diffusers compose: %v", err)
+	}
+	svc, ok := doc.Services["diffusers"]
+	if !ok || len(svc.Ports) == 0 {
+		t.Fatal("embedded diffusers compose declares no ports")
+	}
+	// "HOST:CONTAINER"
+	parts := strings.Split(svc.Ports[0], ":")
+	if len(parts) < 2 {
+		t.Fatalf("unexpected diffusers port spec: %q", svc.Ports[0])
+	}
+	var p int
+	for _, r := range parts[0] {
+		if r < '0' || r > '9' {
+			t.Fatalf("non-numeric host port in %q", svc.Ports[0])
+		}
+		p = p*10 + int(r-'0')
+	}
+	return p
+}


### PR DESCRIPTION
## Context

The diffusers deploy loop was dead in two coupled places, and a node could advertise a serving capability it was physically unable to start.

When citadel embeds a **new** service (diffusers landed in `services.ServiceMap` in v2.55.0) it immediately advertises it in the heartbeat via `services.GetAvailableServices()` / `internal/status/collector.go`'s `populateServices`. But the node's on-disk runtime manifest (`~/citadel-node/citadel.yaml`) was written at `init` time, *before* that service existed — and a plain `citadel update` never touches the manifest. So the fabric schedules a `SERVICE_START diffusers` to a node that reports it can run it, and the node rejects it:

```
service "diffusers" not found in manifest (known: vllm, ollama, llamacpp, tei)
```

Separately, even once a service *was* startable, the container it produced came up with `NetworkSettings.Ports == {}` (verified via `docker inspect`) — the compose's `ports:` mapping was silently not applied, so a perfectly healthy server on its internal contract port was unreachable on the host.

Net effect: advertise → schedule → reject, and when it didn't reject, → unreachable. This PR closes both halves so a fresh binary self-heals its manifest and actually publishes the port its compose declares.

## Summary

### Bug A — manifest reconcile (`Closes #413`)

- **Startup reconcile (primary, Option 1).** New `reconcileManifestServices()` in `cmd/manifest.go`: for every embedded `ServiceMap` entry missing from the manifest, it adds an additive service block and materializes the embedded compose into `services/<name>.yml`. It is **additive-only** (never removes/overwrites operator-defined entries), **idempotent**, preserves unknown operator entries (e.g. a hand-added `tei`) and all non-service manifest content (`node`, `capabilities`).
- **Ordering matters.** Wired into `runWork` **after** `startManagedServices`, on purpose. `startManagedServices` boots *every* manifest entry, and #384's design is "never gate startup on heavy GPU services." If reconcile ran before it, a node whose manifest just gained diffusers/sglang/lmstudio would kick off unrequested multi-GB image pulls + model downloads at every boot. Running reconcile after means the reconciled entries only exist so an **on-demand** `SERVICE_START` can find them — they never launch unbidden.
- **On-demand self-heal (Option 2, belt-and-suspenders).** In the `SERVICE_START` handler, if a requested service is absent from the manifest but present in the embedded `ServiceMap`, it materializes the compose + persists an additive manifest block and proceeds. This also covers the TUI-launched worker path (`ccStartWorker`/`runTUIWorker`), which doesn't run the startup reconcile — so a `SERVICE_START` to a TUI worker self-heals too. Guarded by a path-traversal-safe service-name check.

> **Deviation note:** the task named the startup reconcile as the primary fix. I kept it as primary, but the on-demand materialize in the handler is what makes both worker boot paths robust without the boot-time auto-start regression. Both ship.

### Bug B — publish `SERVICE_START` host ports (`addresses the SERVICE_START-no-published-ports half of #415`; the 8102↔TEI collision half is fixed in #410)

- **Force recreation.** The docker `SERVICE_START` path now passes `--force-recreate` to `docker compose up -d`. The `Ports == {}` symptom happens when a stale `citadel-<svc>` container from a prior run (with a different or absent port mapping) is reused instead of recreated from the current compose. `cmd/service.go`'s startup path already `rm -f`'d stale containers; the handler path did not. `--force-recreate` guarantees the container is built from *this* compose definition. We only reach this branch when the service isn't already running, so recreating is safe.
- **Report the endpoint.** `serviceResult` gains `host_ports`, populated on a successful docker start, so the caller knows where the service is reachable on the node.
- **`compose.HostPorts()`** — a new pure, daemon-free parser (`internal/compose/modifier.go`) for the published host ports in a compose file (short form `HOST:CONTAINER`, `IP:HOST:CONTAINER`, `/proto` suffixes, and long-form `published/target`; bare/ephemeral publishes skipped). Lets us report the endpoint and assert the intended publish in tests without a live docker.

**No host-port numbers touched.** This PR does not modify port *numbers* or `services/ports.go`/`services/compose/*.yml` host ports — that's #410's territory (see Related).

## Test plan

| Group | Coverage |
|-------|----------|
| `cmd` manifest reconcile | pre-diffusers manifest reconciles to include diffusers + all embedded services; additive (legacy + non-embedded `tei` survive); node identity preserved; compose materialized; idempotent (2nd run adds nothing, no dupes); operator-authored compose file never overwritten |
| `internal/jobs` materialize | on-demand materialize adds diffusers to a pre-diffusers manifest and passes the "known service" check; preserves `node`/`capabilities`; idempotent; unknown service → normal "not found" error; path-traversal name rejected |
| `internal/jobs` port publish | materialized diffusers compose reports its declared host port (asserts the intended publish without docker); `--force-recreate` present in the docker start path |
| `internal/compose` HostPorts | short/long form, `IP:HOST:CONTAINER`, `/proto` suffix, bare/ephemeral skipped, multi-service dedupe, invalid YAML → nil |

`gofmt -w .`, `go build ./...`, `go vet ./...`, and `go test ./internal/jobs/... ./internal/status/... ./internal/compose/... ./services/... ./cmd/...` all green.

## Related

- Closes #413 (manifest not reconciled with embedded services on upgrade)
- Addresses the "SERVICE_START comes up with no published ports" half of #415. The diffusers host-port **collision** (8102 vs TEI) is fixed separately in #410 (a citadel-owned host-port registry). No overlap: this PR changes *whether* the declared port is published, not *which* port it is.
