### PR TITLE
feat(services): per-service idle detection (last-request + idle_seconds in heartbeat) (#416)

### DIFF
--- a/internal/status/collector.go
+++ b/internal/status/collector.go
@@ -27,6 +27,7 @@ type Collector struct {
 	startTime      time.Time
 	modelDiscovery *ModelDiscovery
 	capabilities   *NodeCapabilities // cached capabilities (set once at startup)
+	idleTracker    *IdleTracker      // per-service idle detection (aceteam#4472 / citadel #416)
 }
 
 // ServiceConfig holds the configuration for a service from the manifest.
@@ -54,6 +55,7 @@ func NewCollector(cfg CollectorConfig) *Collector {
 		startTime:      time.Now(),
 		modelDiscovery: NewModelDiscovery(),
 		capabilities:   cfg.Capabilities,
+		idleTracker:    NewIdleTracker(IdleThresholdSeconds()),
 	}
 }
 
@@ -80,6 +82,23 @@ func (c *Collector) Collect() (*NodeStatus, error) {
 
 	// Collect service status
 	status.Services = c.collectServiceStatus()
+
+	// Collect status for managed serving engines that are running but not
+	// present in the manifest-driven services list (the common case: c.services
+	// is nil in the heartbeat path). This is what surfaces the per-service idle
+	// signal for a running vLLM in the heartbeat (citadel #416). Skip any engine
+	// already reported by the manifest-driven path above to avoid a duplicate
+	// entry when both paths are active.
+	reported := make(map[string]struct{}, len(status.Services))
+	for _, svc := range status.Services {
+		reported[svc.Name] = struct{}{}
+	}
+	for _, eng := range c.collectManagedEngineStatus() {
+		if _, dup := reported[eng.Name]; dup {
+			continue
+		}
+		status.Services = append(status.Services, eng)
+	}
 
 	// Collect installed app status
 	status.Apps = c.collectAppStatus()
@@ -290,6 +309,10 @@ func (c *Collector) collectServiceStatus() []ServiceInfo {
 					info.Health = health
 				}
 			}
+			// Attach the per-service idle signal for engines we can scrape.
+			if idle := c.observeIdle(ctx, svc.Name, svc.Name, svc.Port); idle != nil {
+				info.IdleState = idle
+			}
 		}
 
 		services = append(services, info)
@@ -387,14 +410,56 @@ func (c *Collector) collectAppStatus() []AppInfo {
 
 	for _, installed := range state.Apps {
 		dockerStatus := apps.ContainerStatus(ctx, runner, installed.Name)
-		result = append(result, AppInfo{
+		info := AppInfo{
 			Name:   installed.Name,
 			Status: dockerStatus,
 			Port:   installed.HostPort,
-		})
+		}
+		// Attach the per-service idle signal for running inference apps (e.g. a
+		// vLLM catalog app holding GPU memory). This is the live heartbeat path:
+		// catalog apps are always collected, so the idle signal reaches every
+		// heartbeat without any manifest wiring. The engine is discriminated on
+		// both the app name and its image (e.g. "vllm/vllm-openai"), since a
+		// catalog slug like "llm-server" would not match on name alone.
+		if dockerStatus == "running" && installed.HostPort > 0 {
+			if idle := c.observeIdle(ctx, installed.Name, installed.Name+" "+installed.Image, installed.HostPort); idle != nil {
+				info.IdleState = idle
+			}
+		}
+		result = append(result, info)
 	}
 
 	return result
+}
+
+// observeIdle scrapes the idle signal for a serving engine on the given port.
+// key is the stable per-service identity used to accumulate idle_seconds across
+// calls; hint is a free-text discriminator (name and/or image) used to select
+// the metrics dialect. Returns nil when the hint does not map to a scrapeable
+// engine or the metrics endpoint could not be read, so callers omit the idle
+// fields rather than report a misleading value.
+func (c *Collector) observeIdle(ctx context.Context, key, hint string, port int) *IdleState {
+	engine := idleEngineType(hint)
+	if engine == "" || c.idleTracker == nil {
+		return nil
+	}
+	state, ok := c.idleTracker.Observe(ctx, key, engine, port)
+	if !ok {
+		return nil
+	}
+	return &state
+}
+
+// idleEngineType maps a service/app name-or-image hint to the metrics dialect
+// used for idle detection, or "" when the engine has no scrapeable request
+// signal. Only vLLM exposes the Prometheus request counters + running/waiting
+// gauges this feature relies on; other engines (ollama, llama.cpp) are skipped
+// for now.
+func idleEngineType(hint string) string {
+	if strings.Contains(strings.ToLower(hint), "vllm") {
+		return "vllm"
+	}
+	return ""
 }
 
 // InferServicePort attempts to determine port from service name.

--- a/internal/status/engines.go
+++ b/internal/status/engines.go
@@ -1,0 +1,140 @@
+package status
+
+import (
+	"context"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/aceteam-ai/citadel-cli/internal/catalog"
+	nativesvc "github.com/aceteam-ai/citadel-cli/internal/services"
+	"github.com/aceteam-ai/citadel-cli/services"
+	"gopkg.in/yaml.v3"
+)
+
+// idleCapableEngines lists the serving engines for which idle detection has a
+// reliable request signal. Currently only vLLM exposes the Prometheus request
+// counters + running/waiting gauges the IdleTracker scrapes. Extend this as
+// other engines (sglang, llama.cpp) grow comparable metrics.
+var idleCapableEngines = []string{"vllm"}
+
+// collectManagedEngineStatus reports running managed serving engines (from the
+// embedded services.ServiceMap) that carry an idle signal, so the per-service
+// idle telemetry reaches the heartbeat even when no manifest-driven service
+// config was passed to the collector (the common heartbeat case, where
+// c.services is nil).
+//
+// It only emits an entry for an engine that is actually running AND whose
+// metrics endpoint could be scraped. A running-but-unscrapeable engine (e.g.
+// still loading its model, /metrics not yet up) is skipped rather than reported
+// with a misleading "idle since startup" — the existing manifest-driven
+// collectServiceStatus still reports its up/down state when configured.
+func (c *Collector) collectManagedEngineStatus() []ServiceInfo {
+	if c.idleTracker == nil {
+		return nil
+	}
+	ctx := context.Background()
+	var out []ServiceInfo
+
+	// Resolve the container runtime once and use its engine binary for the
+	// running-check, mirroring the start path (cmd/service.go). GPU/inference
+	// containers are the ones most likely to run under the hardened podman
+	// runtime (#348); a docker-only inspect would miss them entirely and the
+	// idle signal would never fire on exactly the nodes this feature targets.
+	engineBin := catalog.SelectContainerRuntime().EngineBin
+
+	for _, name := range idleCapableEngines {
+		port, running := managedEnginePortIfRunning(engineBin, name)
+		if !running || port <= 0 {
+			continue
+		}
+		state, ok := c.idleTracker.Observe(ctx, name, name, port)
+		if !ok {
+			continue
+		}
+		idle := state
+		out = append(out, ServiceInfo{
+			Name:      name,
+			Type:      ServiceTypeLLM,
+			Status:    ServiceStatusRunning,
+			Port:      port,
+			Health:    HealthStatusOK,
+			IdleState: &idle,
+		})
+	}
+	return out
+}
+
+// managedEnginePortIfRunning reports whether a managed engine is running and,
+// if so, its host port. It checks the container "citadel-<name>" first (the
+// compose deploy path) using the given engine binary (docker or podman), and
+// falls back to the native process check. The host port is resolved from the
+// embedded compose file's port mapping, falling back to the known native
+// default.
+func managedEnginePortIfRunning(engineBin, name string) (port int, running bool) {
+	if containerRunning(engineBin, "citadel-"+name) {
+		return managedEngineHostPort(name), true
+	}
+	if nativesvc.IsNativeServiceRunning(name) {
+		if p, ok := nativesvc.GetServicePort(name); ok {
+			return p, true
+		}
+		return managedEngineHostPort(name), true
+	}
+	return 0, false
+}
+
+// containerRunning reports whether a container with the given name is in the
+// "running" state, using the provided engine binary (docker or podman). Any
+// error (runtime not installed, container absent) yields false so callers treat
+// the engine as not-managed-here.
+func containerRunning(engineBin, containerName string) bool {
+	if engineBin == "" {
+		engineBin = "docker"
+	}
+	cmd := exec.Command(engineBin, "inspect", "--format", "{{.State.Status}}", containerName)
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) == "running"
+}
+
+// composePortRe matches the host side of a compose short-form port mapping,
+// e.g. "8100:8000" or "127.0.0.1:8100:8000" -> host port 8100.
+var composePortRe = regexp.MustCompile(`(?:\d+\.\d+\.\d+\.\d+:)?(\d+):\d+`)
+
+// managedEngineHostPort resolves the published host port for a managed engine by
+// parsing the first port mapping of its embedded compose file. Returns 0 when
+// the compose file is absent or has no parseable port mapping.
+func managedEngineHostPort(name string) int {
+	compose, ok := services.ServiceMap[name]
+	if !ok {
+		return 0
+	}
+	return firstComposeHostPort(compose)
+}
+
+// firstComposeHostPort parses a compose document and returns the host port of
+// the first service's first port mapping, or 0 if none is found.
+func firstComposeHostPort(composeYAML string) int {
+	var doc struct {
+		Services map[string]struct {
+			Ports []string `yaml:"ports"`
+		} `yaml:"services"`
+	}
+	if err := yaml.Unmarshal([]byte(composeYAML), &doc); err != nil {
+		return 0
+	}
+	for _, svc := range doc.Services {
+		for _, p := range svc.Ports {
+			if m := composePortRe.FindStringSubmatch(p); m != nil {
+				if hp, err := strconv.Atoi(m[1]); err == nil {
+					return hp
+				}
+			}
+		}
+	}
+	return 0
+}

--- a/internal/status/engines_test.go
+++ b/internal/status/engines_test.go
@@ -1,0 +1,73 @@
+package status
+
+import "testing"
+
+func TestFirstComposeHostPort(t *testing.T) {
+	cases := []struct {
+		name    string
+		compose string
+		want    int
+	}{
+		{
+			name: "simple mapping",
+			compose: `services:
+  vllm:
+    image: vllm/vllm-openai:latest
+    ports:
+      - "8100:8000"
+`,
+			want: 8100,
+		},
+		{
+			name: "ip-qualified mapping",
+			compose: `services:
+  svc:
+    ports:
+      - "127.0.0.1:9000:8000"
+`,
+			want: 9000,
+		},
+		{
+			name: "no ports",
+			compose: `services:
+  svc:
+    image: foo
+`,
+			want: 0,
+		},
+		{
+			name:    "malformed yaml",
+			compose: "::: not yaml",
+			want:    0,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := firstComposeHostPort(c.compose); got != c.want {
+				t.Fatalf("got %d, want %d", got, c.want)
+			}
+		})
+	}
+}
+
+// TestManagedEngineHostPort_VLLM confirms the embedded vLLM compose resolves to
+// its published host port. This guards against the compose file changing its
+// port mapping without the idle scraper following (it scrapes the host port).
+func TestManagedEngineHostPort_VLLM(t *testing.T) {
+	if got := managedEngineHostPort("vllm"); got != 8100 {
+		t.Fatalf("expected vllm host port 8100 from embedded compose, got %d", got)
+	}
+	if got := managedEngineHostPort("does-not-exist"); got != 0 {
+		t.Fatalf("expected 0 for unknown engine, got %d", got)
+	}
+}
+
+func TestIdleEngineType_MatchesImage(t *testing.T) {
+	// A catalog slug that doesn't contain "vllm" in the name but whose image does.
+	if got := idleEngineType("llm-server vllm/vllm-openai:latest"); got != "vllm" {
+		t.Fatalf("expected vllm engine from image hint, got %q", got)
+	}
+	if got := idleEngineType("postgres postgres:16"); got != "" {
+		t.Fatalf("expected empty engine for non-inference hint, got %q", got)
+	}
+}

--- a/internal/status/idle.go
+++ b/internal/status/idle.go
@@ -1,0 +1,297 @@
+package status
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// DefaultIdleThresholdSeconds is the number of seconds a managed service may go
+// without serving a request before it is reported as idle. Overridable via the
+// SERVICE_IDLE_THRESHOLD_SECONDS environment variable.
+const DefaultIdleThresholdSeconds = 300
+
+// IdleThresholdSeconds returns the configured idle threshold. It reads
+// SERVICE_IDLE_THRESHOLD_SECONDS and falls back to DefaultIdleThresholdSeconds
+// when unset, empty, non-numeric, or non-positive.
+func IdleThresholdSeconds() int {
+	if v := os.Getenv("SERVICE_IDLE_THRESHOLD_SECONDS"); v != "" {
+		if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil && n > 0 {
+			return n
+		}
+	}
+	return DefaultIdleThresholdSeconds
+}
+
+// IdleState is the per-service idle signal surfaced in the heartbeat. It answers
+// the "busy but idle" question the platform scheduler needs to reclaim VRAM: a
+// service can be up and holding GPU memory while having served no requests for
+// a long time.
+//
+// LastRequestAt is the wall-clock time of the most recent observed request, or
+// nil when no request has ever been seen since tracking began. IdleSeconds is
+// the number of seconds since LastRequestAt (or since tracking began, if no
+// request was ever seen). Idle is true when IdleSeconds meets or exceeds the
+// configured threshold.
+type IdleState struct {
+	Idle          bool       `json:"idle"`
+	IdleSeconds   int64      `json:"idle_seconds"`
+	LastRequestAt *time.Time `json:"last_request_at,omitempty"`
+}
+
+// engineMetrics holds the request signals scraped from an engine's Prometheus
+// /metrics endpoint. total is a monotonic count of completed requests; active
+// is the number of requests running or queued right now.
+type engineMetrics struct {
+	total    float64
+	active   float64
+	hasTotal bool
+}
+
+// idleEntry is the tracked state for a single (engine, port) endpoint.
+type idleEntry struct {
+	startedAt     time.Time
+	lastTotal     float64
+	haveLastTotal bool
+	lastRequestAt time.Time
+	haveRequest   bool
+}
+
+// IdleTracker scrapes managed-engine metrics endpoints and derives a per-service
+// idle signal. It is safe for concurrent use.
+//
+// Signal source and limitation: the tracker prefers the engine's own Prometheus
+// /metrics endpoint (vLLM exposes request counters and running/waiting gauges).
+// The citadel gateway is NOT in the general inference path — only /v1/embeddings
+// is proxied through it — so gateway-counted requests are not a reliable signal
+// for chat/completions services; scraping the engine directly is the cheapest
+// reliable signal. Because tracking state lives in-process, idle_seconds is
+// measured since citadel began tracking a service: a freshly restarted citadel
+// cannot prove a service was idle before startup, and the first scrape has no
+// prior counter baseline (it seeds last_request_at to the tracking start time).
+type IdleTracker struct {
+	client    *http.Client
+	threshold time.Duration
+	now       func() time.Time
+
+	mu      sync.Mutex
+	entries map[string]*idleEntry
+}
+
+// NewIdleTracker creates an IdleTracker with the given idle threshold (in
+// seconds). A threshold <= 0 falls back to the configured default.
+func NewIdleTracker(thresholdSeconds int) *IdleTracker {
+	if thresholdSeconds <= 0 {
+		thresholdSeconds = IdleThresholdSeconds()
+	}
+	return &IdleTracker{
+		client:    &http.Client{Timeout: 3 * time.Second},
+		threshold: time.Duration(thresholdSeconds) * time.Second,
+		now:       time.Now,
+		entries:   make(map[string]*idleEntry),
+	}
+}
+
+// Observe scrapes the engine's metrics endpoint on the given port and returns
+// the updated idle state. engineType selects the metrics dialect ("vllm").
+// key uniquely identifies the service instance (typically its name) so state
+// persists across calls even if the port is reused. Returns ok=false when no
+// usable signal is available (unknown engine or the metrics endpoint could not
+// be scraped) — callers should then omit the idle fields rather than report a
+// misleading "idle since startup".
+func (t *IdleTracker) Observe(ctx context.Context, key, engineType string, port int) (IdleState, bool) {
+	metrics, err := t.scrape(ctx, engineType, port)
+	if err != nil || !metrics.hasTotal {
+		return IdleState{}, false
+	}
+	return t.record(key, metrics), true
+}
+
+// record folds a fresh metrics sample into the tracked state for key and
+// computes the resulting idle state. Exposed logic is unit-tested directly via
+// RecordSample so no live engine is needed.
+func (t *IdleTracker) record(key string, m engineMetrics) IdleState {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	now := t.now()
+	e, ok := t.entries[key]
+	if !ok {
+		// First observation of this service: seed the baseline. We cannot know
+		// when the last request happened before we started tracking, so treat
+		// "tracking start" as the reference point for idle_seconds.
+		e = &idleEntry{startedAt: now, lastRequestAt: now}
+		t.entries[key] = e
+	}
+
+	// A request is "active right now" if the engine reports running or queued
+	// work; a completed request shows up as an increase in the monotonic total.
+	activeNow := m.active > 0
+	advanced := e.haveLastTotal && m.total > e.lastTotal
+	// Guard against a counter reset (engine restart): total dropping below the
+	// last seen value is not a real request, so do not refresh on it.
+	if activeNow || advanced {
+		e.lastRequestAt = now
+		e.haveRequest = e.haveRequest || advanced || activeNow
+	}
+
+	e.lastTotal = m.total
+	e.haveLastTotal = true
+
+	return t.stateLocked(e, now)
+}
+
+// RecordSample is a test-friendly wrapper around record that folds a raw
+// (total, active) sample for key and returns the resulting idle state.
+func (t *IdleTracker) RecordSample(key string, total, active float64, hasTotal bool) IdleState {
+	return t.record(key, engineMetrics{total: total, active: active, hasTotal: hasTotal})
+}
+
+// stateLocked computes the IdleState for an entry. Caller must hold t.mu.
+func (t *IdleTracker) stateLocked(e *idleEntry, now time.Time) IdleState {
+	idleFor := now.Sub(e.lastRequestAt)
+	if idleFor < 0 {
+		idleFor = 0
+	}
+	st := IdleState{
+		Idle:        idleFor >= t.threshold,
+		IdleSeconds: int64(idleFor.Seconds()),
+	}
+	if e.haveRequest {
+		last := e.lastRequestAt
+		st.LastRequestAt = &last
+	}
+	return st
+}
+
+// scrape fetches and parses the engine's metrics endpoint.
+func (t *IdleTracker) scrape(ctx context.Context, engineType string, port int) (engineMetrics, error) {
+	dialect, ok := metricsDialects[strings.ToLower(engineType)]
+	if !ok {
+		return engineMetrics{}, fmt.Errorf("no idle metrics dialect for engine %q", engineType)
+	}
+	url := fmt.Sprintf("http://127.0.0.1:%d%s", port, dialect.path)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return engineMetrics{}, err
+	}
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return engineMetrics{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return engineMetrics{}, fmt.Errorf("metrics endpoint returned %d", resp.StatusCode)
+	}
+	return parsePrometheusMetrics(resp.Body, dialect), nil
+}
+
+// metricsDialect names the Prometheus series that carry the request signals for
+// a given engine. totalMetrics are monotonic completed-request counters (any one
+// present is used); activeMetrics are running/queued gauges summed together.
+type metricsDialect struct {
+	path          string
+	totalMetrics  []string
+	activeMetrics []string
+}
+
+// metricsDialects maps an engine type to its /metrics series names.
+//
+// vLLM (OpenAI server) exposes Prometheus metrics at /metrics. Metric names have
+// drifted across versions; we accept several known spellings and use whichever
+// is present:
+//   - completed-request counters: vllm:request_success_total (newer) and the
+//     labelled request-latency count series vllm:e2e_request_latency_seconds_count.
+//   - live-work gauges: vllm:num_requests_running and vllm:num_requests_waiting.
+var metricsDialects = map[string]metricsDialect{
+	"vllm": {
+		path: "/metrics",
+		totalMetrics: []string{
+			"vllm:request_success_total",
+			"vllm:e2e_request_latency_seconds_count",
+		},
+		activeMetrics: []string{
+			"vllm:num_requests_running",
+			"vllm:num_requests_waiting",
+		},
+	},
+}
+
+// parsePrometheusMetrics reads a Prometheus text-format exposition and extracts
+// the total and active signals named by the dialect. Series are matched on the
+// bare metric name (label sets are ignored); values for the same metric name are
+// summed, which is correct both for per-label counter fan-out and for the two
+// distinct active gauges.
+func parsePrometheusMetrics(r io.Reader, d metricsDialect) engineMetrics {
+	totalSet := make(map[string]struct{}, len(d.totalMetrics))
+	for _, m := range d.totalMetrics {
+		totalSet[m] = struct{}{}
+	}
+	activeSet := make(map[string]struct{}, len(d.activeMetrics))
+	for _, m := range d.activeMetrics {
+		activeSet[m] = struct{}{}
+	}
+
+	var out engineMetrics
+	// Track which total metric names we actually saw so a labelled counter with
+	// multiple series is summed but the presence flag stays accurate.
+	seenTotal := false
+
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		name, value, ok := parseMetricLine(line)
+		if !ok {
+			continue
+		}
+		if _, ok := totalSet[name]; ok {
+			out.total += value
+			seenTotal = true
+			continue
+		}
+		if _, ok := activeSet[name]; ok {
+			out.active += value
+		}
+	}
+	out.hasTotal = seenTotal
+	return out
+}
+
+// parseMetricLine splits one Prometheus exposition line into the bare metric
+// name (label set stripped) and its float value.
+func parseMetricLine(line string) (name string, value float64, ok bool) {
+	// A sample line is: metric_name{labels} value [timestamp]
+	// Split off the value: it is the last whitespace-delimited field before an
+	// optional timestamp. Prometheus text format uses a single space between the
+	// series and the value, so splitting on the last space of the "series value"
+	// portion is robust enough here.
+	fields := strings.Fields(line)
+	if len(fields) < 2 {
+		return "", 0, false
+	}
+	// The metric series is everything up to the value; the value is the field
+	// immediately after the series token. Because label sets never contain
+	// unescaped spaces in practice for these engines, fields[0] is the series
+	// and fields[1] is the value.
+	series := fields[0]
+	v, err := strconv.ParseFloat(fields[1], 64)
+	if err != nil {
+		return "", 0, false
+	}
+	name = series
+	if i := strings.IndexByte(series, '{'); i >= 0 {
+		name = series[:i]
+	}
+	return name, v, true
+}

--- a/internal/status/idle_test.go
+++ b/internal/status/idle_test.go
@@ -1,0 +1,360 @@
+package status
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newTestTracker returns an IdleTracker with a controllable clock so idle_seconds
+// is deterministic without sleeping.
+func newTestTracker(thresholdSeconds int, clock *time.Time) *IdleTracker {
+	t := NewIdleTracker(thresholdSeconds)
+	t.now = func() time.Time { return *clock }
+	return t
+}
+
+func TestIdleThresholdSeconds_Default(t *testing.T) {
+	t.Setenv("SERVICE_IDLE_THRESHOLD_SECONDS", "")
+	if got := IdleThresholdSeconds(); got != DefaultIdleThresholdSeconds {
+		t.Fatalf("expected default %d, got %d", DefaultIdleThresholdSeconds, got)
+	}
+}
+
+func TestIdleThresholdSeconds_EnvOverride(t *testing.T) {
+	t.Setenv("SERVICE_IDLE_THRESHOLD_SECONDS", "42")
+	if got := IdleThresholdSeconds(); got != 42 {
+		t.Fatalf("expected 42, got %d", got)
+	}
+}
+
+func TestIdleThresholdSeconds_InvalidFallsBack(t *testing.T) {
+	for _, v := range []string{"0", "-5", "abc", "  "} {
+		t.Setenv("SERVICE_IDLE_THRESHOLD_SECONDS", v)
+		if got := IdleThresholdSeconds(); got != DefaultIdleThresholdSeconds {
+			t.Fatalf("value %q: expected default %d, got %d", v, DefaultIdleThresholdSeconds, got)
+		}
+	}
+}
+
+func TestIdleTracker_FirstSampleSeedsBaseline(t *testing.T) {
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	tr := newTestTracker(300, &now)
+
+	// First observation: no prior counter baseline. We just started tracking,
+	// so idle_seconds is 0 and last_request_at is unknown (no request proven).
+	st := tr.RecordSample("vllm", 5, 0, true)
+	if st.Idle {
+		t.Fatalf("expected not idle on first sample")
+	}
+	if st.IdleSeconds != 0 {
+		t.Fatalf("expected idle_seconds 0 on first sample, got %d", st.IdleSeconds)
+	}
+	if st.LastRequestAt != nil {
+		t.Fatalf("expected no last_request_at before any request is proven, got %v", st.LastRequestAt)
+	}
+}
+
+func TestIdleTracker_CounterAdvanceRefreshesLastRequest(t *testing.T) {
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	tr := newTestTracker(300, &now)
+
+	tr.RecordSample("vllm", 10, 0, true) // baseline
+
+	// 60s later, the completed-request counter advanced -> a request happened.
+	now = now.Add(60 * time.Second)
+	st := tr.RecordSample("vllm", 11, 0, true)
+	if st.LastRequestAt == nil {
+		t.Fatalf("expected last_request_at to be set after counter advanced")
+	}
+	if !st.LastRequestAt.Equal(now) {
+		t.Fatalf("expected last_request_at %v, got %v", now, *st.LastRequestAt)
+	}
+	if st.IdleSeconds != 0 {
+		t.Fatalf("expected idle_seconds 0 right after a request, got %d", st.IdleSeconds)
+	}
+	if st.Idle {
+		t.Fatalf("expected not idle right after a request")
+	}
+}
+
+func TestIdleTracker_GoesIdleAfterThreshold(t *testing.T) {
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	tr := newTestTracker(300, &now)
+
+	tr.RecordSample("vllm", 10, 0, true) // baseline
+	now = now.Add(30 * time.Second)
+	tr.RecordSample("vllm", 11, 0, true) // a request at t=30s
+
+	// 299s after the last request: still under the 300s threshold.
+	now = now.Add(299 * time.Second)
+	st := tr.RecordSample("vllm", 11, 0, true)
+	if st.Idle {
+		t.Fatalf("expected not idle at 299s (< threshold)")
+	}
+	if st.IdleSeconds != 299 {
+		t.Fatalf("expected idle_seconds 299, got %d", st.IdleSeconds)
+	}
+
+	// 1 more second: exactly at the threshold -> idle.
+	now = now.Add(1 * time.Second)
+	st = tr.RecordSample("vllm", 11, 0, true)
+	if !st.Idle {
+		t.Fatalf("expected idle at 300s (>= threshold), idle_seconds=%d", st.IdleSeconds)
+	}
+	if st.IdleSeconds != 300 {
+		t.Fatalf("expected idle_seconds 300, got %d", st.IdleSeconds)
+	}
+}
+
+func TestIdleTracker_ActiveGaugeKeepsBusy(t *testing.T) {
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	tr := newTestTracker(300, &now)
+
+	tr.RecordSample("vllm", 10, 0, true) // baseline, idle
+	now = now.Add(1000 * time.Second)
+
+	// Counter did NOT advance, but a request is running right now (active gauge
+	// > 0). This must be treated as busy, not idle.
+	st := tr.RecordSample("vllm", 10, 2, true)
+	if st.Idle {
+		t.Fatalf("expected not idle while a request is actively running")
+	}
+	if st.IdleSeconds != 0 {
+		t.Fatalf("expected idle_seconds 0 while active, got %d", st.IdleSeconds)
+	}
+	if st.LastRequestAt == nil || !st.LastRequestAt.Equal(now) {
+		t.Fatalf("expected last_request_at %v, got %v", now, st.LastRequestAt)
+	}
+}
+
+func TestIdleTracker_CounterResetDoesNotFalsePositive(t *testing.T) {
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	tr := newTestTracker(300, &now)
+
+	tr.RecordSample("vllm", 100, 0, true) // baseline high
+	now = now.Add(10 * time.Second)
+
+	// Engine restarted: counter reset to a lower value. That is NOT a request;
+	// last_request_at must not refresh, and no phantom request is recorded.
+	st := tr.RecordSample("vllm", 3, 0, true)
+	if st.LastRequestAt != nil {
+		t.Fatalf("expected no last_request_at after a counter reset with no prior request, got %v", st.LastRequestAt)
+	}
+	if st.IdleSeconds != 10 {
+		t.Fatalf("expected idle_seconds measured from tracking start (10), got %d", st.IdleSeconds)
+	}
+}
+
+func TestIdleTracker_SeparateKeysTrackedIndependently(t *testing.T) {
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	tr := newTestTracker(300, &now)
+
+	tr.RecordSample("a", 10, 0, true)
+	tr.RecordSample("b", 10, 0, true)
+
+	now = now.Add(60 * time.Second)
+	tr.RecordSample("a", 11, 0, true) // a served a request
+	stB := tr.RecordSample("b", 10, 0, true)
+
+	if stB.IdleSeconds != 60 {
+		t.Fatalf("expected b idle_seconds 60 (independent of a), got %d", stB.IdleSeconds)
+	}
+
+	now = now.Add(60 * time.Second)
+	stA := tr.RecordSample("a", 11, 0, true)
+	if stA.IdleSeconds != 60 {
+		t.Fatalf("expected a idle_seconds 60 since its last request, got %d", stA.IdleSeconds)
+	}
+}
+
+func TestParsePrometheusMetrics_VLLM(t *testing.T) {
+	body := strings.Join([]string{
+		"# HELP vllm:request_success_total Count of successful requests.",
+		"# TYPE vllm:request_success_total counter",
+		`vllm:request_success_total{model_name="llama"} 42.0`,
+		`vllm:num_requests_running{model_name="llama"} 3.0`,
+		`vllm:num_requests_waiting{model_name="llama"} 1.0`,
+		"vllm:gpu_cache_usage_perc 0.5", // unrelated series, ignored
+		"",
+	}, "\n")
+
+	m := parsePrometheusMetrics(strings.NewReader(body), metricsDialects["vllm"])
+	if !m.hasTotal {
+		t.Fatalf("expected hasTotal true")
+	}
+	if m.total != 42.0 {
+		t.Fatalf("expected total 42, got %v", m.total)
+	}
+	// active = running(3) + waiting(1)
+	if m.active != 4.0 {
+		t.Fatalf("expected active 4, got %v", m.active)
+	}
+}
+
+func TestParsePrometheusMetrics_SumsLabelledCounters(t *testing.T) {
+	body := strings.Join([]string{
+		`vllm:request_success_total{model_name="a"} 10`,
+		`vllm:request_success_total{model_name="b"} 5`,
+		"",
+	}, "\n")
+	m := parsePrometheusMetrics(strings.NewReader(body), metricsDialects["vllm"])
+	if m.total != 15.0 {
+		t.Fatalf("expected summed total 15, got %v", m.total)
+	}
+}
+
+func TestParsePrometheusMetrics_NoTotal(t *testing.T) {
+	body := "some_other_metric 1\n# a comment\n"
+	m := parsePrometheusMetrics(strings.NewReader(body), metricsDialects["vllm"])
+	if m.hasTotal {
+		t.Fatalf("expected hasTotal false when no known counter present")
+	}
+}
+
+func TestParseMetricLine(t *testing.T) {
+	cases := []struct {
+		line     string
+		wantName string
+		wantVal  float64
+		wantOK   bool
+	}{
+		{`vllm:request_success_total{m="x"} 42.5`, "vllm:request_success_total", 42.5, true},
+		{`plain_metric 7`, "plain_metric", 7, true},
+		{`with_ts{a="b"} 3 1699999999000`, "with_ts", 3, true},
+		{`# comment style`, "", 0, false},
+		{`malformed`, "", 0, false},
+		{`bad_value{a="b"} notanumber`, "", 0, false},
+	}
+	for _, c := range cases {
+		name, val, ok := parseMetricLine(c.line)
+		if ok != c.wantOK {
+			t.Fatalf("line %q: ok=%v want %v", c.line, ok, c.wantOK)
+		}
+		if !ok {
+			continue
+		}
+		if name != c.wantName || val != c.wantVal {
+			t.Fatalf("line %q: got (%q,%v) want (%q,%v)", c.line, name, val, c.wantName, c.wantVal)
+		}
+	}
+}
+
+func TestIdleTracker_Observe_ScrapesLiveEndpoint(t *testing.T) {
+	// Serve a vLLM-style /metrics response and confirm Observe wires the scrape
+	// into the idle computation end to end.
+	var total float64 = 5
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/metrics" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Write([]byte("vllm:request_success_total " + strconv.FormatFloat(total, 'f', -1, 64) + "\n" +
+			"vllm:num_requests_running 0\nvllm:num_requests_waiting 0\n"))
+	}))
+	defer server.Close()
+
+	port := portFromURL(t, server.URL)
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	tr := newTestTracker(300, &now)
+
+	st, ok := tr.Observe(context.Background(), "vllm", "vllm", port)
+	if !ok {
+		t.Fatalf("expected Observe to succeed against live metrics endpoint")
+	}
+	if st.LastRequestAt != nil {
+		t.Fatalf("expected no last_request_at on first scrape")
+	}
+
+	// A request completes; counter advances; time passes under threshold.
+	total = 6
+	now = now.Add(120 * time.Second)
+	st, ok = tr.Observe(context.Background(), "vllm", "vllm", port)
+	if !ok {
+		t.Fatalf("expected second Observe to succeed")
+	}
+	if st.LastRequestAt == nil || !st.LastRequestAt.Equal(now) {
+		t.Fatalf("expected last_request_at %v, got %v", now, st.LastRequestAt)
+	}
+	if st.Idle {
+		t.Fatalf("expected not idle 0s after a request")
+	}
+}
+
+func TestIdleTracker_Observe_UnknownEngine(t *testing.T) {
+	now := time.Now()
+	tr := newTestTracker(300, &now)
+	if _, ok := tr.Observe(context.Background(), "ollama", "ollama", 11434); ok {
+		t.Fatalf("expected Observe to fail for an engine with no metrics dialect")
+	}
+}
+
+func TestIdleState_JSONPromotion(t *testing.T) {
+	last := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	info := AppInfo{
+		Name:   "vllm",
+		Status: "running",
+		Port:   8100,
+		IdleState: &IdleState{
+			Idle:          true,
+			IdleSeconds:   600,
+			LastRequestAt: &last,
+		},
+	}
+	b, err := json.Marshal(info)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// Fields must be promoted to the top level, not nested under a struct.
+	if got["idle"] != true {
+		t.Fatalf("expected promoted idle=true, got %v (json=%s)", got["idle"], b)
+	}
+	if got["idle_seconds"].(float64) != 600 {
+		t.Fatalf("expected idle_seconds 600, got %v", got["idle_seconds"])
+	}
+	if _, ok := got["last_request_at"]; !ok {
+		t.Fatalf("expected last_request_at present, json=%s", b)
+	}
+}
+
+func TestIdleState_OmittedWhenNil(t *testing.T) {
+	info := AppInfo{Name: "postgres", Status: "running", Port: 5432}
+	b, err := json.Marshal(info)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "idle") {
+		t.Fatalf("expected no idle fields when IdleState is nil, got %s", b)
+	}
+}
+
+func TestIdleEngineType(t *testing.T) {
+	if idleEngineType("my-vllm-app") != "vllm" {
+		t.Fatalf("expected vllm engine for name containing vllm")
+	}
+	if idleEngineType("postgres") != "" {
+		t.Fatalf("expected empty engine for non-inference name")
+	}
+}
+
+func portFromURL(t *testing.T, url string) int {
+	t.Helper()
+	i := strings.LastIndex(url, ":")
+	if i < 0 {
+		t.Fatalf("no port in url %q", url)
+	}
+	p, err := strconv.Atoi(url[i+1:])
+	if err != nil {
+		t.Fatalf("bad port in url %q: %v", url, err)
+	}
+	return p
+}

--- a/internal/status/types.go
+++ b/internal/status/types.go
@@ -41,6 +41,11 @@ type AppInfo struct {
 	Name   string `json:"name"`
 	Status string `json:"status"` // "running", "stopped", "not_found"
 	Port   int    `json:"port,omitempty"`
+
+	// Idle usage signal for LLM-serving apps (e.g. a vLLM catalog app holding
+	// GPU memory). Populated only for running inference apps whose metrics
+	// endpoint could be scraped; omitted otherwise. See IdleState.
+	*IdleState
 }
 
 // NodeCapabilities describes the GPU and inference engine capabilities of a node.
@@ -150,6 +155,12 @@ type ServiceInfo struct {
 	Port   int      `json:"port,omitempty"`
 	Health string   `json:"health,omitempty"` // "healthy", "unhealthy", "unknown"
 	Models []string `json:"models,omitempty"` // For LLM services
+
+	// Idle usage signal for running LLM services. Populated only when the
+	// service is a running inference engine whose metrics endpoint could be
+	// scraped; omitted otherwise. Promotes idle/idle_seconds/last_request_at
+	// to the top level of the JSON object. See IdleState.
+	*IdleState
 }
 
 // HealthResponse is the response for /health endpoint.


### PR DESCRIPTION
## Context

A node can run vLLM holding ~21GB of a 24GB GPU while having served **zero** requests for 30+ minutes — GPU util 0%, no inference in flight. Today the node reports the service as "running/healthy" and nothing else, so a node operator or the platform scheduler can't tell "busy" from "busy but idle" and can't safely reclaim VRAM. This is the missing input for VRAM-headroom scheduling (aceteam #4472).

This PR adds a per-service **idle detection** signal and surfaces it in the heartbeat. It is detection + reporting only.

## Summary

### Idle signal (`internal/status/idle.go`)
- `IdleTracker` scrapes a serving engine's own Prometheus `/metrics` endpoint and derives, per service, a `last_request_at`, `idle_seconds`, and an `idle` bool against a configurable threshold.
- Two signals combined: the **active gauge** (`vllm:num_requests_running` + `vllm:num_requests_waiting`) means busy *right now*; a monotonic **completed-request counter** (`vllm:request_success_total`, falling back to `vllm:e2e_request_latency_seconds_count`) increasing between scrapes means a request just finished → refresh `last_request_at`.
- Counter-reset guard: a counter dropping (engine restart) is not treated as a request.
- `IdleState` is embedded into `ServiceInfo`/`AppInfo` so `idle`/`idle_seconds`/`last_request_at` are **promoted to the top level** of the per-service heartbeat object, and omitted entirely when no signal is available (legacy-safe).

### Which signal, and why
The citadel gateway is **not** in the general inference path — only `/v1/embeddings` is proxied through it — so gateway-counted requests are not a reliable signal for chat/completions services. The cheapest reliable signal is scraping the engine's own `/metrics`, which fits the existing engine-probe pattern in `internal/status` (model discovery + health checks already hit the engine over HTTP). (For the embeddings service specifically, the gateway metering middleware *does* already accumulate request counts + timestamps — a future enhancement can feed that in as the gateway-counted signal for TEI.)

### Making it live in the heartbeat (`internal/status/engines.go`)
The heartbeat path constructs the collector with `Services: nil`, so the manifest-driven service list is empty in production — wiring idle only there would emit nothing. `collectManagedEngineStatus()` enumerates running serving engines from the embedded `services.ServiceMap` (currently vLLM), resolves the container/native host port, scrapes idle, and emits a `ServiceInfo` carrying the signal.
- Running-check uses the **selected container runtime's** engine binary (docker *or* podman), mirroring the start path (`cmd/service.go`), so GPU/inference containers on the hardened podman runtime (#348) aren't silently missed.
- Catalog apps (`collectAppStatus`) and manifest services also carry the signal; the engine is discriminated on both **name and image** (`vllm/vllm-openai`).
- Dedup guard avoids a double entry when both paths report the same engine.

### Config
`SERVICE_IDLE_THRESHOLD_SECONDS` (default 300).

### Limitation (documented)
Tracking state is in-process, so `idle_seconds` is measured **since citadel began tracking** a service: a freshly restarted citadel can't prove a service was idle before startup, and the first scrape has no counter baseline (`last_request_at` stays unset until a request is proven). vLLM metric names have drifted across versions — we accept several known spellings and degrade gracefully (no signal emitted) when none is present, rather than reporting a misleading "idle since startup".

### Out of scope
Auto-stop / eviction **policy** is intentionally not implemented here — the platform scheduler consumes this signal and decides reclamation. TUI services view is not touched (it has its own decoupled `ServiceInfo` struct; adding an "idle" tag there is a low-value follow-up).

## Heartbeat fields added
Promoted onto each running LLM `ServiceInfo` / `AppInfo` entry:

| Field | Type | Meaning |
|-------|------|---------|
| `idle` | bool | `idle_seconds >= threshold` |
| `idle_seconds` | int | seconds since last observed request (or since tracking began) |
| `last_request_at` | RFC3339 (nullable) | time of most recent observed request; omitted until one is proven |

## Test plan

| Area | Coverage |
|------|----------|
| Threshold config | default, env override, invalid/zero/negative fallback |
| Idle computation | first-sample baseline, counter advance refreshes last-request, crosses threshold at exactly 300s, active gauge keeps busy despite flat counter, counter-reset no false positive, independent keys |
| Metrics parsing | vLLM total + running/waiting gauges, summed labelled counters, no-total case, per-line name/value/label-strip parsing |
| End-to-end scrape | `Observe` against a live httptest `/metrics` server; unknown-engine returns no signal |
| JSON promotion | `idle*` fields promoted to top level; fully omitted when nil |
| Engine port resolution | `firstComposeHostPort` (simple / ip-qualified / none / malformed), embedded vLLM compose → 8100, name+image discrimination |

`gofmt -w .`, `go build ./...`, `go vet`, and `go test ./internal/status/... ./internal/gateway/... ./internal/heartbeat/...` all green.

## Related
- Closes #416
- aceteam #4472 (VRAM-headroom scheduling — consumes this signal)
