### PR TITLE
feat(footprint): sample per-service resource footprints to rotated, DuckDB-queryable CSV + citadel footprints query (#422)

### DIFF
--- a/cmd/footprints.go
+++ b/cmd/footprints.go
@@ -1,0 +1,149 @@
+// cmd/footprints.go
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/tabwriter"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/footprint"
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
+	"github.com/spf13/cobra"
+)
+
+var (
+	footprintsService  string
+	footprintsSince    string
+	footprintsIdleOnly bool
+)
+
+var footprintsCmd = &cobra.Command{
+	Use:   "footprints",
+	Short: "Summarize logged per-service resource footprints",
+	Long: `Summarize the per-service resource footprint history recorded by the
+background sampler (` + "`citadel work`" + ` writes one sample per minute).
+
+For each managed service it reports average/peak RAM, average/peak VRAM,
+average/peak CPU, the fraction of samples that were idle, the longest idle
+stretch, and the sample count + time window.
+
+The raw rows live in rotated daily CSVs under ~/citadel-node/footprints/
+(footprints-YYYY-MM-DD.csv) and are directly DuckDB/pandas-queryable for
+ad-hoc analysis, e.g.:
+
+  duckdb -c "SELECT service, avg(rss_mb), max(rss_mb) \
+    FROM '~/citadel-node/footprints/*.csv' GROUP BY 1 ORDER BY 2 DESC"
+
+The node-level row is recorded under the service name "_node" and carries
+host CPU/RAM plus total GPU utilisation and VRAM used.`,
+	Example: `  # Summarize all services over the last hour
+  citadel footprints --since 1h
+
+  # One service only
+  citadel footprints --service vllm --since 6h
+
+  # Only samples where the node was idle
+  citadel footprints --idle-only --since 24h`,
+	Run: runFootprints,
+}
+
+func init() {
+	footprintsCmd.Flags().StringVar(&footprintsService, "service", "", "Restrict to a single service name")
+	footprintsCmd.Flags().StringVar(&footprintsSince, "since", "", "Only include samples newer than this duration (e.g. 30m, 1h, 6h)")
+	footprintsCmd.Flags().BoolVar(&footprintsIdleOnly, "idle-only", false, "Only include samples where the node was idle")
+	rootCmd.AddCommand(footprintsCmd)
+}
+
+func runFootprints(cmd *cobra.Command, args []string) {
+	nodeDir, err := platform.DefaultNodeDir("")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: could not resolve node dir: %v\n", err)
+		os.Exit(1)
+	}
+	dir := footprint.DefaultDir(nodeDir)
+
+	opts := footprint.QueryOptions{
+		Service:  footprintsService,
+		IdleOnly: footprintsIdleOnly,
+	}
+	if footprintsSince != "" {
+		since, err := time.ParseDuration(footprintsSince)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: invalid --since %q (use e.g. 30m, 1h, 6h): %v\n", footprintsSince, err)
+			os.Exit(1)
+		}
+		opts.Since = since
+	}
+
+	interval, _ := footprint.IntervalFromEnv()
+	summaries, err := footprint.Summarize(dir, opts, interval)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: could not read footprints: %v\n", err)
+		os.Exit(1)
+	}
+
+	if len(summaries) == 0 {
+		fmt.Printf("No footprint samples found in %s\n", dir)
+		fmt.Println("The sampler runs under `citadel work`; wait for it to record data,")
+		fmt.Println("or check CITADEL_FOOTPRINT_INTERVAL is not set to a non-positive value.")
+		return
+	}
+
+	printFootprintSummaries(summaries, dir)
+}
+
+func printFootprintSummaries(summaries []footprint.ServiceSummary, dir string) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "SERVICE\tSAMPLES\tAVG RAM\tPEAK RAM\tAVG VRAM\tPEAK VRAM\tAVG CPU\tPEAK CPU\tIDLE %\tLONGEST IDLE\tWINDOW")
+	for _, s := range summaries {
+		fmt.Fprintf(w, "%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%.0f%%\t%s\t%s\n",
+			s.Service,
+			s.Samples,
+			mb(s.AvgRSSMB),
+			mb(s.PeakRSSMB),
+			mb(s.AvgVRAMMB),
+			mb(s.PeakVRAMMB),
+			pct(s.AvgCPUPercent),
+			pct(s.PeakCPUPercent),
+			s.IdlePercent,
+			idleDur(s.LongestIdle),
+			window(s.FirstSeen, s.LastSeen),
+		)
+	}
+	w.Flush()
+	fmt.Printf("\nRaw CSVs: %s%s*.csv (DuckDB/pandas-queryable)\n", dir, string(filepath.Separator))
+}
+
+// mb formats a megabyte value, blanking a zero so "no data" reads as "-".
+func mb(v float64) string {
+	if v <= 0 {
+		return "-"
+	}
+	if v >= 1024 {
+		return fmt.Sprintf("%.1f GB", v/1024)
+	}
+	return fmt.Sprintf("%.0f MB", v)
+}
+
+func pct(v float64) string {
+	if v <= 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%.1f%%", v)
+}
+
+func idleDur(d time.Duration) string {
+	if d <= 0 {
+		return "-"
+	}
+	return d.Round(time.Second).String()
+}
+
+func window(first, last time.Time) string {
+	if first.IsZero() || last.IsZero() {
+		return "-"
+	}
+	return fmt.Sprintf("%s → %s", first.Local().Format("15:04"), last.Local().Format("15:04"))
+}

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -19,7 +19,9 @@ import (
 	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/capabilities"
+	"github.com/aceteam-ai/citadel-cli/internal/catalog"
 	"github.com/aceteam-ai/citadel-cli/internal/config"
+	"github.com/aceteam-ai/citadel-cli/internal/footprint"
 	"github.com/aceteam-ai/citadel-cli/internal/gateway"
 	"github.com/aceteam-ai/citadel-cli/internal/heartbeat"
 	"github.com/aceteam-ai/citadel-cli/internal/network"
@@ -83,6 +85,9 @@ var (
 
 	// Update check flag
 	workNoUpdate bool
+
+	// Footprint sampler flag
+	workNoFootprint bool
 
 	// Auto-update (periodic self-update) flags
 	workAutoUpdate         bool
@@ -710,6 +715,14 @@ func runWork(cmd *cobra.Command, args []string) {
 	// Log the final registration outcome for post-mortem diagnosis (issue #246).
 	Log("registered: online=%v node_name=%s headscale_id=%s state_dir=%s",
 		connected, nodeName, headscaleNodeID, network.GetStateDir())
+
+	// Start the background resource-footprint sampler (issue #422). It appends a
+	// lightweight per-service + node-level time-series to rotated, DuckDB-queryable
+	// CSVs under ~/citadel-node/footprints/, so an idle service hoarding RSS/VRAM
+	// leaves a queryable trail (queryable via `citadel footprints`). Cheap by
+	// design: one container-stats exec + one GPU read per tick (default 60s), never
+	// per-service. Disabled by --no-footprint or CITADEL_FOOTPRINT_INTERVAL<=0.
+	startFootprintSampler(ctx, nodeName, workManifest)
 
 	// Default consumer group to node identity when --group is not explicitly set.
 	workGroup = resolveConsumerGroup(workGroup, headscaleNodeID, nodeName)
@@ -1626,6 +1639,49 @@ func startManagedServices(ctx context.Context) []startedService {
 	return started
 }
 
+// startFootprintSampler launches the background footprint sampler goroutine
+// (issue #422) unless it is disabled via --no-footprint or a non-positive
+// CITADEL_FOOTPRINT_INTERVAL. The service list is taken from the manifest (the
+// status collector is constructed with a nil service list, so it is not a usable
+// source here), and the container engine is the selected runtime's engine binary
+// so podman nodes sample podman, not a hardcoded docker.
+func startFootprintSampler(ctx context.Context, nodeName string, manifest *CitadelManifest) {
+	if workNoFootprint {
+		Debug("footprint sampler disabled (--no-footprint)")
+		return
+	}
+	interval, enabled := footprint.IntervalFromEnv()
+	if !enabled {
+		Debug("footprint sampler disabled (CITADEL_FOOTPRINT_INTERVAL<=0)")
+		return
+	}
+
+	nodeDir, err := platform.DefaultNodeDir("")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "   - Warning: footprint sampler disabled (no node dir): %v\n", err)
+		return
+	}
+
+	var serviceNames []string
+	if manifest != nil {
+		for _, svc := range manifest.Services {
+			serviceNames = append(serviceNames, svc.Name)
+		}
+	}
+
+	cfg := footprint.Config{
+		NodeID:        nodeName,
+		Services:      serviceNames,
+		EngineBin:     catalog.SelectContainerRuntime().EngineBin,
+		Dir:           footprint.DefaultDir(nodeDir),
+		Interval:      interval,
+		RetentionDays: footprint.RetentionFromEnv(),
+		Logf:          func(format string, args ...any) { Log(format, args...) },
+	}
+	go footprint.Run(ctx, cfg)
+	fmt.Printf("   - Footprint sampler: every %s → %s\n", interval, cfg.Dir)
+}
+
 // stopManagedServices tears down services this worker started, mirroring the
 // co-browse manager teardown: it stops the containers/processes we launched but
 // preserves their data (docker compose down WITHOUT -v keeps model-cache
@@ -2023,6 +2079,7 @@ func init() {
 
 	// Update check flags (deprecated - update check now runs on all commands via root.go)
 	workCmd.Flags().BoolVar(&workNoUpdate, "no-update", false, "(Deprecated) No longer has any effect - use 'citadel update disable' instead")
+	workCmd.Flags().BoolVar(&workNoFootprint, "no-footprint", false, "Disable the background resource-footprint sampler")
 	workCmd.Flags().MarkDeprecated("no-update", "use 'citadel update disable' to disable auto-update checks")
 
 	// Auto-update (periodic self-update) flags

--- a/internal/footprint/footprint.go
+++ b/internal/footprint/footprint.go
@@ -1,0 +1,52 @@
+// Package footprint samples per-service and node-level resource footprints over
+// time and appends them to a rotated, DuckDB/pandas-queryable CSV store under
+// ~/citadel-node/footprints/. It is the historical/persistence half of the
+// footprint-logging feature (citadel-cli#422); the live TUI view is #421.
+//
+// Motivation: when a serving engine idled holding VRAM and drove the node to a
+// runaway load average, there was NO history to query after the fact. This
+// package writes a lightweight time-series so operators can answer "what was
+// service X's RSS/VRAM over the last hour?" long after the incident.
+//
+// The package is intentionally self-contained: it reads the same read-only OS /
+// nvidia-smi sources the status collector reads (via internal/platform) but owns
+// all of its own code so it never collides with the #421 live-view collector.
+package footprint
+
+import "time"
+
+// Sample is one row of the footprint time-series. Per-service rows carry the
+// service name and its docker/podman-stats-derived CPU% and RSS; the node-level
+// row (Service == NodeService) additionally carries node GPU utilisation and
+// total VRAM used. Fields that are not applicable to a given row are left empty
+// (represented as an unset *float64 / *int) so the CSV distinguishes "zero" from
+// "not measured".
+type Sample struct {
+	// Timestamp is when the sample was taken (written RFC3339, UTC).
+	Timestamp time.Time
+	// NodeID is the node identity (Headscale hostname) shared by every row in a
+	// tick, so a multi-node footprints/*.csv glob can be grouped by node.
+	NodeID string
+	// Service is the managed-service name, or NodeService for the node-level row.
+	Service string
+	// Running reports whether a container for this service was present in the
+	// stats snapshot. Always true for the node-level row.
+	Running bool
+
+	// CPUPercent is the container's (or host's, for the node row) CPU percentage.
+	CPUPercent *float64
+	// RSSMB is resident memory in MB.
+	RSSMB *float64
+	// VRAMMB is total GPU memory used in MB. Only set on the node-level row.
+	VRAMMB *int
+	// GPUUtilPercent is aggregate GPU utilisation. Only set on the node-level row.
+	GPUUtilPercent *float64
+	// IdleSeconds is how long the node has been idle, when a readily-available
+	// idle signal is wired in (#420). Left empty otherwise — this package does
+	// NOT reimplement idle detection.
+	IdleSeconds *int
+}
+
+// NodeService is the reserved Service value for the synthetic node-level row that
+// carries host CPU/RSS + GPU util/VRAM. It is not a real managed service name.
+const NodeService = "_node"

--- a/internal/footprint/host.go
+++ b/internal/footprint/host.go
@@ -1,0 +1,29 @@
+package footprint
+
+import (
+	"time"
+
+	"github.com/shirou/gopsutil/v3/cpu"
+	"github.com/shirou/gopsutil/v3/mem"
+)
+
+// hostCPUPercent returns the host-wide CPU utilisation percentage. The 100ms
+// sample is cheap and matches the status collector's cadence. Returns (0, false)
+// on read error.
+func hostCPUPercent() (float64, bool) {
+	pcts, err := cpu.Percent(100*time.Millisecond, false)
+	if err != nil || len(pcts) == 0 {
+		return 0, false
+	}
+	return pcts[0], true
+}
+
+// hostRSSMB returns the host used-memory in MB. Returns (0, false) on read
+// error.
+func hostRSSMB() (float64, bool) {
+	v, err := mem.VirtualMemory()
+	if err != nil {
+		return 0, false
+	}
+	return float64(v.Used) / (1024 * 1024), true
+}

--- a/internal/footprint/query.go
+++ b/internal/footprint/query.go
@@ -1,0 +1,268 @@
+package footprint
+
+import (
+	"encoding/csv"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ServiceSummary aggregates one service's footprint over a query window.
+type ServiceSummary struct {
+	Service        string
+	Samples        int
+	AvgRSSMB       float64
+	PeakRSSMB      float64
+	AvgVRAMMB      float64
+	PeakVRAMMB     float64
+	AvgCPUPercent  float64
+	PeakCPUPercent float64
+	// IdlePercent is the fraction (0-100) of samples that were idle. Zero when no
+	// sample carried an idle_seconds value.
+	IdlePercent float64
+	// LongestIdle is the longest contiguous idle stretch observed, derived from
+	// consecutive idle samples spaced by the sampling interval. Zero when idle
+	// data is absent.
+	LongestIdle time.Duration
+	// FirstSeen / LastSeen bound the window actually covered by this service's
+	// rows (useful when the CSVs span more than the requested --since).
+	FirstSeen time.Time
+	LastSeen  time.Time
+}
+
+// QueryOptions filters the aggregation.
+type QueryOptions struct {
+	// Service, when non-empty, restricts the summary to that single service.
+	Service string
+	// Since, when non-zero, drops samples older than Since before now.
+	Since time.Duration
+	// IdleOnly restricts the aggregation to samples marked idle (idle_seconds>0).
+	IdleOnly bool
+	// Now overrides the reference time for Since filtering (testing seam).
+	Now time.Time
+}
+
+// row is a parsed CSV record used only during aggregation.
+type row struct {
+	ts       time.Time
+	service  string
+	cpu      *float64
+	rss      *float64
+	vram     *int
+	idleSecs *int
+}
+
+// isIdle reports whether the row counts as idle: an idle_seconds value that
+// parsed and is strictly positive. A missing idle_seconds is NOT idle (the
+// signal is simply unavailable in this branch).
+func (r row) isIdle() bool {
+	return r.idleSecs != nil && *r.idleSecs > 0
+}
+
+// Summarize reads every footprints CSV under dir, applies opts, and returns one
+// ServiceSummary per service (sorted by service name). interval is the sampling
+// cadence, used to bound the longest-idle-stretch computation. A missing dir
+// yields an empty result, not an error.
+func Summarize(dir string, opts QueryOptions, interval time.Duration) ([]ServiceSummary, error) {
+	rows, err := readRows(dir)
+	if err != nil {
+		return nil, err
+	}
+	return summarizeRows(rows, opts, interval), nil
+}
+
+// readRows loads and parses all footprints-*.csv rows under dir.
+func readRows(dir string) ([]row, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var out []row
+	for _, e := range entries {
+		if e.IsDir() || !dailyFilePattern.MatchString(e.Name()) {
+			continue
+		}
+		rows, err := readFileRows(filepath.Join(dir, e.Name()))
+		if err != nil {
+			continue // Skip a corrupt/partial file rather than failing the query.
+		}
+		out = append(out, rows...)
+	}
+	return out, nil
+}
+
+// readFileRows parses one CSV file into rows, keyed by the header order.
+func readFileRows(path string) ([]row, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	r := csv.NewReader(f)
+	r.FieldsPerRecord = -1 // tolerate short/long lines from a partial write
+
+	var rows []row
+	first := true
+	for {
+		rec, err := r.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			break // Stop at the first malformed record; keep what we parsed.
+		}
+		if first {
+			first = false
+			if len(rec) > 0 && rec[0] == "ts" {
+				continue // header
+			}
+		}
+		if len(rec) < len(csvHeader) {
+			continue
+		}
+		parsed, ok := parseRecord(rec)
+		if ok {
+			rows = append(rows, parsed)
+		}
+	}
+	return rows, nil
+}
+
+// parseRecord maps a CSV record (csvHeader order) into a row.
+func parseRecord(rec []string) (row, bool) {
+	ts, err := time.Parse(time.RFC3339, rec[0])
+	if err != nil {
+		return row{}, false
+	}
+	r := row{ts: ts, service: rec[2]}
+	if v, err := strconv.ParseFloat(strings.TrimSpace(rec[4]), 64); err == nil && rec[4] != "" {
+		r.cpu = &v
+	}
+	if v, err := strconv.ParseFloat(strings.TrimSpace(rec[5]), 64); err == nil && rec[5] != "" {
+		r.rss = &v
+	}
+	if v, err := strconv.Atoi(strings.TrimSpace(rec[6])); err == nil && rec[6] != "" {
+		r.vram = &v
+	}
+	if v, err := strconv.Atoi(strings.TrimSpace(rec[8])); err == nil && rec[8] != "" {
+		r.idleSecs = &v
+	}
+	return r, true
+}
+
+// summarizeRows is the pure aggregation core (testable with synthetic rows).
+func summarizeRows(rows []row, opts QueryOptions, interval time.Duration) []ServiceSummary {
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	if interval <= 0 {
+		interval = DefaultInterval
+	}
+
+	// Group filtered rows by service.
+	grouped := map[string][]row{}
+	for _, r := range rows {
+		if opts.Service != "" && r.service != opts.Service {
+			continue
+		}
+		if opts.Since > 0 && r.ts.Before(now.Add(-opts.Since)) {
+			continue
+		}
+		if opts.IdleOnly && !r.isIdle() {
+			continue
+		}
+		grouped[r.service] = append(grouped[r.service], r)
+	}
+
+	summaries := make([]ServiceSummary, 0, len(grouped))
+	for svc, srows := range grouped {
+		summaries = append(summaries, aggregateService(svc, srows, interval))
+	}
+	sort.Slice(summaries, func(i, j int) bool {
+		return summaries[i].Service < summaries[j].Service
+	})
+	return summaries
+}
+
+// aggregateService computes one service's summary from its rows.
+func aggregateService(service string, rows []row, interval time.Duration) ServiceSummary {
+	sort.Slice(rows, func(i, j int) bool { return rows[i].ts.Before(rows[j].ts) })
+
+	s := ServiceSummary{Service: service, Samples: len(rows)}
+	if len(rows) == 0 {
+		return s
+	}
+	s.FirstSeen = rows[0].ts
+	s.LastSeen = rows[len(rows)-1].ts
+
+	var rssSum, cpuSum, vramSum float64
+	var rssN, cpuN, vramN int
+	idleCount := 0
+
+	// Longest idle stretch: count consecutive idle samples and multiply the
+	// longest run of k idle samples by the sampling interval, so k idle samples
+	// report k*interval of idle time. We cannot see between samples, so each idle
+	// sample is credited one full interval; a lone idle sample is thus one
+	// interval of observed idle time.
+	var curRun int
+	var longest int
+	for _, r := range rows {
+		if r.rss != nil {
+			rssSum += *r.rss
+			rssN++
+			if *r.rss > s.PeakRSSMB {
+				s.PeakRSSMB = *r.rss
+			}
+		}
+		if r.cpu != nil {
+			cpuSum += *r.cpu
+			cpuN++
+			if *r.cpu > s.PeakCPUPercent {
+				s.PeakCPUPercent = *r.cpu
+			}
+		}
+		if r.vram != nil {
+			vf := float64(*r.vram)
+			vramSum += vf
+			vramN++
+			if vf > s.PeakVRAMMB {
+				s.PeakVRAMMB = vf
+			}
+		}
+		if r.isIdle() {
+			idleCount++
+			curRun++
+			if curRun > longest {
+				longest = curRun
+			}
+		} else {
+			curRun = 0
+		}
+	}
+
+	if rssN > 0 {
+		s.AvgRSSMB = rssSum / float64(rssN)
+	}
+	if cpuN > 0 {
+		s.AvgCPUPercent = cpuSum / float64(cpuN)
+	}
+	if vramN > 0 {
+		s.AvgVRAMMB = vramSum / float64(vramN)
+	}
+	if len(rows) > 0 {
+		s.IdlePercent = float64(idleCount) / float64(len(rows)) * 100
+	}
+	if longest > 0 {
+		s.LongestIdle = time.Duration(longest) * interval
+	}
+	return s
+}

--- a/internal/footprint/query_test.go
+++ b/internal/footprint/query_test.go
@@ -1,0 +1,166 @@
+package footprint
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// writeSyntheticCSV appends samples to a store so the query path reads real
+// CSVs (exercising header-skipping + parsing), not in-memory structs.
+func writeSyntheticCSV(t *testing.T, dir string, samples []Sample) {
+	t.Helper()
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	// Group by day so Append (which files by the first sample's day) rotates
+	// correctly for multi-day inputs.
+	byDay := map[string][]Sample{}
+	for _, s := range samples {
+		key := s.Timestamp.UTC().Format("2006-01-02")
+		byDay[key] = append(byDay[key], s)
+	}
+	for _, batch := range byDay {
+		if err := store.Append(batch); err != nil {
+			t.Fatalf("Append: %v", err)
+		}
+	}
+}
+
+func TestSummarizeAvgPeakAndIdle(t *testing.T) {
+	dir := t.TempDir()
+	base := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	interval := time.Minute
+
+	// vllm: RSS 1000, 2000, 3000 -> avg 2000 peak 3000; CPU 10,20,30 -> avg 20 peak 30.
+	// idle_seconds present on samples 2 and 3 (idle), sample 1 active.
+	samples := []Sample{
+		{Timestamp: base, NodeID: "n", Service: "vllm", Running: true, RSSMB: f64(1000), CPUPercent: f64(10)},
+		{Timestamp: base.Add(interval), NodeID: "n", Service: "vllm", Running: true, RSSMB: f64(2000), CPUPercent: f64(20), IdleSeconds: ip(60)},
+		{Timestamp: base.Add(2 * interval), NodeID: "n", Service: "vllm", Running: true, RSSMB: f64(3000), CPUPercent: f64(30), IdleSeconds: ip(120)},
+		// node-level row with VRAM.
+		{Timestamp: base, NodeID: "n", Service: NodeService, Running: true, VRAMMB: ip(8000), GPUUtilPercent: f64(50)},
+	}
+	writeSyntheticCSV(t, dir, samples)
+
+	got, err := Summarize(dir, QueryOptions{Now: base.Add(3 * interval)}, interval)
+	if err != nil {
+		t.Fatalf("Summarize: %v", err)
+	}
+	// Sorted: NodeService "_node" sorts before "vllm".
+	if len(got) != 2 {
+		t.Fatalf("expected 2 service summaries, got %d: %+v", len(got), got)
+	}
+
+	var vllm *ServiceSummary
+	for i := range got {
+		if got[i].Service == "vllm" {
+			vllm = &got[i]
+		}
+	}
+	if vllm == nil {
+		t.Fatal("missing vllm summary")
+	}
+	if vllm.Samples != 3 {
+		t.Errorf("vllm samples = %d, want 3", vllm.Samples)
+	}
+	if math.Abs(vllm.AvgRSSMB-2000) > 1e-6 || vllm.PeakRSSMB != 3000 {
+		t.Errorf("vllm RSS avg/peak = %.1f/%.1f, want 2000/3000", vllm.AvgRSSMB, vllm.PeakRSSMB)
+	}
+	if math.Abs(vllm.AvgCPUPercent-20) > 1e-6 || vllm.PeakCPUPercent != 30 {
+		t.Errorf("vllm CPU avg/peak = %.1f/%.1f, want 20/30", vllm.AvgCPUPercent, vllm.PeakCPUPercent)
+	}
+	// 2 of 3 samples idle -> 66.67%.
+	if math.Abs(vllm.IdlePercent-(2.0/3.0*100)) > 0.1 {
+		t.Errorf("vllm idle%% = %.2f, want ~66.67", vllm.IdlePercent)
+	}
+	// Longest idle stretch: samples 2 and 3 are consecutive idle -> run length 2 -> 2*interval.
+	if vllm.LongestIdle != 2*interval {
+		t.Errorf("vllm longest idle = %s, want %s", vllm.LongestIdle, 2*interval)
+	}
+}
+
+func TestSummarizeLongestIdleStretchResetsOnActive(t *testing.T) {
+	dir := t.TempDir()
+	base := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	interval := time.Minute
+	// idle pattern: I I A I I I A -> longest run is 3.
+	idle := []bool{true, true, false, true, true, true, false}
+	var samples []Sample
+	for i, isIdle := range idle {
+		s := Sample{Timestamp: base.Add(time.Duration(i) * interval), NodeID: "n", Service: "svc", Running: true, RSSMB: f64(100)}
+		if isIdle {
+			s.IdleSeconds = ip(30)
+		} else {
+			s.IdleSeconds = ip(0)
+		}
+		samples = append(samples, s)
+	}
+	writeSyntheticCSV(t, dir, samples)
+
+	got, err := Summarize(dir, QueryOptions{Now: base.Add(10 * interval)}, interval)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 summary, got %d", len(got))
+	}
+	if got[0].LongestIdle != 3*interval {
+		t.Errorf("longest idle = %s, want %s", got[0].LongestIdle, 3*interval)
+	}
+}
+
+func TestSummarizeSinceFilter(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 7, 2, 12, 0, 0, 0, time.UTC)
+	interval := time.Minute
+	samples := []Sample{
+		{Timestamp: now.AddDate(0, 0, -1), NodeID: "n", Service: "svc", Running: true, RSSMB: f64(999)}, // old
+		{Timestamp: now.Add(-30 * time.Minute), NodeID: "n", Service: "svc", Running: true, RSSMB: f64(100)},
+	}
+	writeSyntheticCSV(t, dir, samples)
+
+	got, err := Summarize(dir, QueryOptions{Since: time.Hour, Now: now}, interval)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Samples != 1 {
+		t.Fatalf("since filter should keep 1 recent sample, got %+v", got)
+	}
+	if got[0].PeakRSSMB != 100 {
+		t.Errorf("expected only recent sample (100), got peak %.0f", got[0].PeakRSSMB)
+	}
+}
+
+func TestSummarizeServiceAndIdleOnlyFilters(t *testing.T) {
+	dir := t.TempDir()
+	base := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	samples := []Sample{
+		{Timestamp: base, NodeID: "n", Service: "a", Running: true, RSSMB: f64(1), IdleSeconds: ip(0)},
+		{Timestamp: base, NodeID: "n", Service: "a", Running: true, RSSMB: f64(2), IdleSeconds: ip(10)},
+		{Timestamp: base, NodeID: "n", Service: "b", Running: true, RSSMB: f64(3), IdleSeconds: ip(10)},
+	}
+	writeSyntheticCSV(t, dir, samples)
+
+	// Service filter.
+	got, _ := Summarize(dir, QueryOptions{Service: "a"}, time.Minute)
+	if len(got) != 1 || got[0].Service != "a" || got[0].Samples != 2 {
+		t.Fatalf("service filter failed: %+v", got)
+	}
+	// Idle-only filter on service a -> only the idle sample remains.
+	got, _ = Summarize(dir, QueryOptions{Service: "a", IdleOnly: true}, time.Minute)
+	if len(got) != 1 || got[0].Samples != 1 {
+		t.Fatalf("idle-only filter failed: %+v", got)
+	}
+}
+
+func TestSummarizeMissingDirIsEmpty(t *testing.T) {
+	got, err := Summarize("/nonexistent/footprints/dir", QueryOptions{}, time.Minute)
+	if err != nil {
+		t.Fatalf("missing dir should not error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty result, got %+v", got)
+	}
+}

--- a/internal/footprint/runner.go
+++ b/internal/footprint/runner.go
@@ -1,0 +1,141 @@
+package footprint
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+)
+
+const (
+	// DefaultInterval is the sampling cadence when CITADEL_FOOTPRINT_INTERVAL is
+	// unset. 60s keeps the sampler negligibly cheap (one stats exec + one GPU
+	// read per minute) while still catching multi-minute idle-hoarding stretches.
+	DefaultInterval = 60 * time.Second
+	// DefaultRetentionDays bounds on-disk history so the log never becomes a disk
+	// hog. One week of per-minute rows is a few MB.
+	DefaultRetentionDays = 7
+)
+
+// Config configures the background footprint sampler. It deliberately takes
+// primitives (not cmd types) so internal/footprint never imports cmd.
+type Config struct {
+	// NodeID is the node identity stamped on every row (Headscale hostname).
+	NodeID string
+	// Services is the list of managed service names to attribute stats to
+	// (typically the manifest's service names).
+	Services []string
+	// EngineBin is the container engine CLI ("docker" or "podman") for the stats
+	// exec, resolved by the caller from catalog.SelectContainerRuntime().
+	EngineBin string
+	// Dir is the footprints directory (~/citadel-node/footprints).
+	Dir string
+	// Interval is the sampling cadence. Zero uses DefaultInterval.
+	Interval time.Duration
+	// RetentionDays prunes files older than this many days. Zero uses
+	// DefaultRetentionDays; negative disables pruning.
+	RetentionDays int
+	// Logf is an optional structured log sink (e.g. cmd.Log). May be nil.
+	Logf func(format string, args ...any)
+}
+
+// IntervalFromEnv resolves the sampling interval, honoring
+// CITADEL_FOOTPRINT_INTERVAL (seconds). A value <= 0 disables the sampler
+// entirely (returns ok=false). An unset/invalid env var falls back to
+// DefaultInterval.
+func IntervalFromEnv() (interval time.Duration, enabled bool) {
+	raw := os.Getenv("CITADEL_FOOTPRINT_INTERVAL")
+	if raw == "" {
+		return DefaultInterval, true
+	}
+	secs, err := strconv.Atoi(raw)
+	if err != nil {
+		return DefaultInterval, true
+	}
+	if secs <= 0 {
+		return 0, false
+	}
+	return time.Duration(secs) * time.Second, true
+}
+
+// RetentionFromEnv resolves the retention window, honoring
+// CITADEL_FOOTPRINT_RETENTION_DAYS. Unset/invalid falls back to
+// DefaultRetentionDays.
+func RetentionFromEnv() int {
+	raw := os.Getenv("CITADEL_FOOTPRINT_RETENTION_DAYS")
+	if raw == "" {
+		return DefaultRetentionDays
+	}
+	days, err := strconv.Atoi(raw)
+	if err != nil {
+		return DefaultRetentionDays
+	}
+	return days
+}
+
+// Run samples footprints on cfg.Interval until ctx is cancelled. It prunes stale
+// files once at startup and opportunistically after each tick, so the log stays
+// bounded even for a long-lived node. Errors are logged (via cfg.Logf when set)
+// and never abort the loop — a transient stats failure must not kill the sampler.
+func Run(ctx context.Context, cfg Config) {
+	interval := cfg.Interval
+	if interval <= 0 {
+		interval = DefaultInterval
+	}
+	retentionDays := cfg.RetentionDays
+	if retentionDays == 0 {
+		retentionDays = DefaultRetentionDays
+	}
+
+	logf := cfg.Logf
+	if logf == nil {
+		logf = func(string, ...any) {}
+	}
+
+	store, err := NewStore(cfg.Dir)
+	if err != nil {
+		logf("footprint: sampler disabled: %v", err)
+		return
+	}
+
+	sampler := NewSampler(cfg.NodeID, cfg.Services, cfg.EngineBin)
+
+	// Prune once at startup so a node that was offline past the retention window
+	// cleans up immediately rather than after the first tick.
+	if _, err := store.Prune(time.Now(), retentionDays); err != nil {
+		logf("footprint: startup prune: %v", err)
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	tick := func() {
+		now := time.Now()
+		samples := sampler.Sample(ctx, now)
+		if err := store.Append(samples); err != nil {
+			logf("footprint: append: %v", err)
+		}
+		if _, err := store.Prune(now, retentionDays); err != nil {
+			logf("footprint: prune: %v", err)
+		}
+	}
+
+	// Emit one sample immediately so `citadel footprints` has data without waiting
+	// a full interval.
+	tick()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tick()
+		}
+	}
+}
+
+// DefaultDir returns the footprints directory under the given node dir.
+func DefaultDir(nodeDir string) string {
+	return filepath.Join(nodeDir, "footprints")
+}

--- a/internal/footprint/runner_test.go
+++ b/internal/footprint/runner_test.go
@@ -1,0 +1,51 @@
+package footprint
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIntervalFromEnv(t *testing.T) {
+	cases := map[string]struct {
+		want    time.Duration
+		enabled bool
+	}{
+		"":     {DefaultInterval, true},
+		"30":   {30 * time.Second, true},
+		"0":    {0, false},
+		"-5":   {0, false},
+		"junk": {DefaultInterval, true},
+	}
+	for raw, exp := range cases {
+		t.Setenv("CITADEL_FOOTPRINT_INTERVAL", raw)
+		if raw == "" {
+			// t.Setenv can't unset; emulate unset by clearing.
+			t.Setenv("CITADEL_FOOTPRINT_INTERVAL", "")
+		}
+		got, enabled := IntervalFromEnv()
+		if enabled != exp.enabled || (enabled && got != exp.want) {
+			t.Errorf("IntervalFromEnv(%q) = (%s, %v), want (%s, %v)", raw, got, enabled, exp.want, exp.enabled)
+		}
+	}
+}
+
+func TestRetentionFromEnv(t *testing.T) {
+	t.Setenv("CITADEL_FOOTPRINT_RETENTION_DAYS", "")
+	if got := RetentionFromEnv(); got != DefaultRetentionDays {
+		t.Errorf("unset retention = %d, want %d", got, DefaultRetentionDays)
+	}
+	t.Setenv("CITADEL_FOOTPRINT_RETENTION_DAYS", "14")
+	if got := RetentionFromEnv(); got != 14 {
+		t.Errorf("retention = %d, want 14", got)
+	}
+	t.Setenv("CITADEL_FOOTPRINT_RETENTION_DAYS", "junk")
+	if got := RetentionFromEnv(); got != DefaultRetentionDays {
+		t.Errorf("junk retention = %d, want default %d", got, DefaultRetentionDays)
+	}
+}
+
+func TestDefaultDir(t *testing.T) {
+	if got := DefaultDir("/home/x/citadel-node"); got != "/home/x/citadel-node/footprints" {
+		t.Errorf("DefaultDir = %q", got)
+	}
+}

--- a/internal/footprint/sampler.go
+++ b/internal/footprint/sampler.go
@@ -1,0 +1,193 @@
+package footprint
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
+)
+
+// GPUSnapshot is the node-level GPU reading captured once per tick: total VRAM
+// used across all GPUs and their aggregate (max) utilisation.
+type GPUSnapshot struct {
+	VRAMUsedMB     int
+	GPUUtilPercent float64
+	// HasGPU is false on nodes without an NVIDIA/Metal GPU, in which case the
+	// node-level row leaves vram_mb / gpu_util_pct empty.
+	HasGPU bool
+}
+
+// statsFunc runs the single container-stats exec for a tick. Injected so the
+// sampler is testable without a container daemon.
+type statsFunc func(ctx context.Context, engineBin string) ([]containerStat, error)
+
+// gpuFunc reads the node-level GPU snapshot for a tick. Injected so the sampler
+// is testable without a GPU.
+type gpuFunc func() GPUSnapshot
+
+// idleFunc returns the node's current idle-seconds signal and whether it is
+// available. Injected; the default returns (0, false) because #420's idle signal
+// is not wired into this branch and this package must NOT reimplement idle
+// detection.
+type idleFunc func() (int, bool)
+
+// Sampler builds one batch of footprint samples per tick: one row per managed
+// service (from stats) plus one node-level row (host CPU/RSS + GPU).
+type Sampler struct {
+	nodeID    string
+	services  []string
+	engineBin string
+
+	stats statsFunc
+	gpu   gpuFunc
+	idle  idleFunc
+}
+
+// NewSampler wires a Sampler to the real host probes.
+func NewSampler(nodeID string, services []string, engineBin string) *Sampler {
+	return &Sampler{
+		nodeID:    nodeID,
+		services:  services,
+		engineBin: engineBin,
+		stats:     sampleContainerStats,
+		gpu:       sampleGPU,
+		idle:      func() (int, bool) { return 0, false },
+	}
+}
+
+// SetIdleFunc lets callers supply a readily-available idle signal (#420). When
+// unset, idle_seconds is left empty in the CSV.
+func (s *Sampler) SetIdleFunc(f idleFunc) {
+	if f != nil {
+		s.idle = f
+	}
+}
+
+// Sample builds the footprint rows for a single tick at time ts. It performs at
+// most ONE container-stats exec and ONE GPU read — never per-service execs.
+func (s *Sampler) Sample(ctx context.Context, ts time.Time) []Sample {
+	var idlePtr *int
+	if secs, ok := s.idle(); ok {
+		idlePtr = &secs
+	}
+
+	// One stats exec for the whole tick. On error (daemon down, engine missing)
+	// treat as "no containers": services report running=false, and we still emit
+	// the node-level row so host/GPU history is never lost.
+	stats, _ := s.stats(ctx, s.engineBin)
+
+	rows := make([]Sample, 0, len(s.services)+1)
+	for _, svc := range s.services {
+		row := Sample{
+			Timestamp:   ts,
+			NodeID:      s.nodeID,
+			Service:     svc,
+			IdleSeconds: idlePtr,
+		}
+		if cs, ok := matchContainer(stats, svc); ok {
+			row.Running = true
+			if cpu, ok := parseCPUPercent(cs.CPUPerc); ok {
+				row.CPUPercent = &cpu
+			}
+			if rss, ok := parseMemUsageMB(cs.MemUsage); ok {
+				row.RSSMB = &rss
+			}
+		}
+		rows = append(rows, row)
+	}
+
+	// Node-level row: host CPU/RSS from gopsutil + GPU util/VRAM. This is where
+	// VRAM lives — per-service VRAM is intentionally NOT attributed (nvidia-smi is
+	// not container-aware; PID->container mapping would be a per-service exec
+	// storm). The GPU-hoarding half of the incident is covered node-level here.
+	node := Sample{
+		Timestamp:   ts,
+		NodeID:      s.nodeID,
+		Service:     NodeService,
+		Running:     true,
+		IdleSeconds: idlePtr,
+	}
+	if cpu, ok := hostCPUPercent(); ok {
+		node.CPUPercent = &cpu
+	}
+	if rss, ok := hostRSSMB(); ok {
+		node.RSSMB = &rss
+	}
+	if snap := s.gpu(); snap.HasGPU {
+		vram := snap.VRAMUsedMB
+		util := snap.GPUUtilPercent
+		node.VRAMMB = &vram
+		node.GPUUtilPercent = &util
+	}
+	rows = append(rows, node)
+	return rows
+}
+
+// matchContainer returns the first stats row whose container name contains the
+// service name (case-insensitive). Compose containers are named like
+// "<project>-<service>-1", so a substring match reliably attributes them to the
+// manifest service without an extra `compose ps` exec.
+func matchContainer(stats []containerStat, service string) (containerStat, bool) {
+	needle := strings.ToLower(service)
+	for _, cs := range stats {
+		if strings.Contains(strings.ToLower(cs.Name), needle) {
+			return cs, true
+		}
+	}
+	return containerStat{}, false
+}
+
+// sampleGPU reads the node-level GPU snapshot via the read-only platform GPU
+// detector (the same source #421 reads). Returns HasGPU=false when no GPU is
+// present or the read fails.
+func sampleGPU() GPUSnapshot {
+	detector, err := platform.GetGPUDetector()
+	if err != nil || !detector.HasGPU() {
+		return GPUSnapshot{}
+	}
+	infos, err := detector.GetGPUInfo()
+	if err != nil || len(infos) == 0 {
+		return GPUSnapshot{}
+	}
+	snap := GPUSnapshot{HasGPU: true}
+	for _, gpu := range infos {
+		if mb, ok := parseMBField(gpu.MemoryUsed); ok {
+			snap.VRAMUsedMB += mb
+		}
+		if util, ok := parsePercentField(gpu.Utilization); ok && util > snap.GPUUtilPercent {
+			snap.GPUUtilPercent = util
+		}
+	}
+	return snap
+}
+
+// parseMBField parses a platform GPUInfo memory string like "8192 MB" into MB.
+func parseMBField(s string) (int, bool) {
+	s = strings.TrimSpace(s)
+	s = strings.TrimSuffix(s, "MB")
+	s = strings.TrimSuffix(s, " MB")
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, false
+	}
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}
+
+// parsePercentField parses a platform GPUInfo utilisation string like "85%".
+func parsePercentField(s string) (float64, bool) {
+	s = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(s), "%"))
+	if s == "" {
+		return 0, false
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}

--- a/internal/footprint/sampler_test.go
+++ b/internal/footprint/sampler_test.go
@@ -1,0 +1,116 @@
+package footprint
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+)
+
+func TestSamplerBuildsServiceAndNodeRows(t *testing.T) {
+	s := &Sampler{
+		nodeID:    "node-x",
+		services:  []string{"vllm", "diffusers"},
+		engineBin: "docker",
+		stats: func(ctx context.Context, engineBin string) ([]containerStat, error) {
+			if engineBin != "docker" {
+				t.Errorf("expected engineBin docker, got %q", engineBin)
+			}
+			// Only vllm is running; diffusers absent.
+			return []containerStat{
+				{Name: "proj-vllm-1", CPUPerc: "42.0%", MemUsage: "7.4GiB / 62GiB"},
+			}, nil
+		},
+		gpu: func() GPUSnapshot {
+			return GPUSnapshot{HasGPU: true, VRAMUsedMB: 7400, GPUUtilPercent: 3}
+		},
+		idle: func() (int, bool) { return 0, false },
+	}
+
+	ts := time.Date(2026, 7, 1, 9, 0, 0, 0, time.UTC)
+	rows := s.Sample(context.Background(), ts)
+	if len(rows) != 3 { // 2 services + node
+		t.Fatalf("expected 3 rows, got %d", len(rows))
+	}
+
+	byService := map[string]Sample{}
+	for _, r := range rows {
+		byService[r.Service] = r
+	}
+
+	vllm := byService["vllm"]
+	if !vllm.Running {
+		t.Error("vllm should be running")
+	}
+	if vllm.RSSMB == nil || math.Abs(*vllm.RSSMB-7.4*1024) > 1 {
+		t.Errorf("vllm RSS = %v, want ~7577 MB", vllm.RSSMB)
+	}
+	if vllm.CPUPercent == nil || *vllm.CPUPercent != 42 {
+		t.Errorf("vllm CPU = %v, want 42", vllm.CPUPercent)
+	}
+	// Per-service VRAM is intentionally not attributed.
+	if vllm.VRAMMB != nil {
+		t.Errorf("per-service VRAM must be nil, got %v", vllm.VRAMMB)
+	}
+
+	diff := byService["diffusers"]
+	if diff.Running {
+		t.Error("diffusers should not be running (no matching container)")
+	}
+	if diff.RSSMB != nil {
+		t.Errorf("absent service should have nil RSS, got %v", diff.RSSMB)
+	}
+
+	node := byService[NodeService]
+	if !node.Running {
+		t.Error("node row should be marked running")
+	}
+	if node.VRAMMB == nil || *node.VRAMMB != 7400 {
+		t.Errorf("node VRAM = %v, want 7400", node.VRAMMB)
+	}
+	if node.GPUUtilPercent == nil || *node.GPUUtilPercent != 3 {
+		t.Errorf("node GPU util = %v, want 3", node.GPUUtilPercent)
+	}
+}
+
+func TestSamplerStatsErrorStillEmitsNodeRow(t *testing.T) {
+	s := &Sampler{
+		nodeID:    "n",
+		services:  []string{"vllm"},
+		engineBin: "docker",
+		stats: func(ctx context.Context, engineBin string) ([]containerStat, error) {
+			return nil, context.DeadlineExceeded
+		},
+		gpu:  func() GPUSnapshot { return GPUSnapshot{} }, // no GPU
+		idle: func() (int, bool) { return 0, false },
+	}
+	rows := s.Sample(context.Background(), time.Now())
+	if len(rows) != 2 {
+		t.Fatalf("expected service + node rows even on stats error, got %d", len(rows))
+	}
+	for _, r := range rows {
+		if r.Service == "vllm" && r.Running {
+			t.Error("vllm should report not running when stats fails")
+		}
+		if r.Service == NodeService && r.VRAMMB != nil {
+			t.Error("node row should have nil VRAM when no GPU")
+		}
+	}
+}
+
+func TestSamplerIdleSignalWiredThrough(t *testing.T) {
+	s := &Sampler{
+		nodeID:    "n",
+		services:  []string{"svc"},
+		engineBin: "docker",
+		stats:     func(ctx context.Context, _ string) ([]containerStat, error) { return nil, nil },
+		gpu:       func() GPUSnapshot { return GPUSnapshot{} },
+		idle:      func() (int, bool) { return 300, true },
+	}
+	rows := s.Sample(context.Background(), time.Now())
+	for _, r := range rows {
+		if r.IdleSeconds == nil || *r.IdleSeconds != 300 {
+			t.Errorf("row %s: idle = %v, want 300", r.Service, r.IdleSeconds)
+		}
+	}
+}

--- a/internal/footprint/stats.go
+++ b/internal/footprint/stats.go
@@ -1,0 +1,142 @@
+package footprint
+
+import (
+	"context"
+	"encoding/json"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// containerStat is one container's line from `<engine> stats --no-stream
+// --format json`. Docker emits one JSON object per line; podman emits either
+// per-line objects or a single JSON array — parseStatsJSON handles both.
+//
+// Field names follow docker's stats formatting keys (Name, CPUPerc, MemUsage).
+// Podman's `--format json` uses the same capitalised keys, so a single struct
+// covers both engines.
+type containerStat struct {
+	Name     string `json:"Name"`
+	CPUPerc  string `json:"CPUPerc"`
+	MemUsage string `json:"MemUsage"`
+}
+
+// sampleContainerStats runs ONE `<engineBin> stats --no-stream --format json`
+// and returns the parsed per-container rows. This is the single stats exec per
+// tick — never one exec per service. A non-nil error means the stats command
+// itself failed (engine not installed / daemon down); callers treat that as "no
+// containers running" rather than aborting the tick.
+func sampleContainerStats(ctx context.Context, engineBin string) ([]containerStat, error) {
+	if engineBin == "" {
+		engineBin = "docker"
+	}
+	cmd := exec.CommandContext(ctx, engineBin, "stats", "--no-stream", "--format", "json")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return parseStatsJSON(out), nil
+}
+
+// parseStatsJSON parses the output of `<engine> stats --format json`, tolerating
+// both docker's newline-delimited objects and podman's single JSON array.
+func parseStatsJSON(out []byte) []containerStat {
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" {
+		return nil
+	}
+	// Podman: a single JSON array.
+	if strings.HasPrefix(trimmed, "[") {
+		var arr []containerStat
+		if err := json.Unmarshal([]byte(trimmed), &arr); err == nil {
+			return arr
+		}
+		return nil
+	}
+	// Docker: one JSON object per line.
+	var stats []containerStat
+	for _, line := range strings.Split(trimmed, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var cs containerStat
+		if err := json.Unmarshal([]byte(line), &cs); err == nil {
+			stats = append(stats, cs)
+		}
+	}
+	return stats
+}
+
+// parseCPUPercent parses a docker/podman CPUPerc string such as "12.34%" into a
+// float. Returns (0, false) when the field is empty or unparseable.
+func parseCPUPercent(s string) (float64, bool) {
+	s = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(s), "%"))
+	if s == "" {
+		return 0, false
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}
+
+// parseMemUsageMB parses the left-hand (used) side of a docker/podman MemUsage
+// string such as "7.4GiB / 62.5GiB" or "512MiB / 16GiB" and returns the used
+// value in MB. Returns (0, false) when the field is empty or unparseable.
+//
+// This is the load-bearing parse for the incident that motivated #422 (a service
+// idling at 7.4 GB RSS), so unit handling (GiB/MiB/KiB/GB/MB/B) is explicit.
+func parseMemUsageMB(s string) (float64, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, false
+	}
+	// Take the used side before the "/".
+	if idx := strings.Index(s, "/"); idx >= 0 {
+		s = s[:idx]
+	}
+	return parseByteSizeMB(strings.TrimSpace(s))
+}
+
+// parseByteSizeMB converts a size token like "7.4GiB" or "512MiB" into MB
+// (megabytes, 1 MB = 1024*1024 bytes to match binary IEC units). It accepts both
+// IEC (GiB/MiB/KiB) and the SI-style suffixes docker sometimes emits (GB/MB/kB).
+func parseByteSizeMB(tok string) (float64, bool) {
+	tok = strings.TrimSpace(tok)
+	if tok == "" {
+		return 0, false
+	}
+	lower := strings.ToLower(tok)
+
+	// Ordered longest-suffix-first so "gib" is matched before "b".
+	type unit struct {
+		suffix   string
+		bytesPer float64
+	}
+	units := []unit{
+		{"gib", 1024 * 1024 * 1024},
+		{"mib", 1024 * 1024},
+		{"kib", 1024},
+		{"gb", 1000 * 1000 * 1000},
+		{"mb", 1000 * 1000},
+		{"kb", 1000},
+		{"b", 1},
+	}
+	for _, u := range units {
+		if strings.HasSuffix(lower, u.suffix) {
+			num := strings.TrimSpace(lower[:len(lower)-len(u.suffix)])
+			v, err := strconv.ParseFloat(num, 64)
+			if err != nil {
+				return 0, false
+			}
+			return v * u.bytesPer / (1024 * 1024), true
+		}
+	}
+	// No recognised suffix: treat as raw bytes.
+	if v, err := strconv.ParseFloat(lower, 64); err == nil {
+		return v / (1024 * 1024), true
+	}
+	return 0, false
+}

--- a/internal/footprint/stats_test.go
+++ b/internal/footprint/stats_test.go
@@ -1,0 +1,126 @@
+package footprint
+
+import (
+	"math"
+	"testing"
+)
+
+func TestParseStatsJSONDockerLines(t *testing.T) {
+	// Docker emits one JSON object per line.
+	out := []byte(`{"Name":"vllm-vllm-1","CPUPerc":"12.34%","MemUsage":"7.4GiB / 62.5GiB"}
+{"Name":"redis-redis-1","CPUPerc":"0.50%","MemUsage":"12MiB / 62.5GiB"}`)
+	stats := parseStatsJSON(out)
+	if len(stats) != 2 {
+		t.Fatalf("expected 2 stats, got %d", len(stats))
+	}
+	if stats[0].Name != "vllm-vllm-1" || stats[0].CPUPerc != "12.34%" {
+		t.Fatalf("unexpected first stat: %+v", stats[0])
+	}
+}
+
+func TestParseStatsJSONPodmanArray(t *testing.T) {
+	// Podman may emit a single JSON array.
+	out := []byte(`[{"Name":"vllm","CPUPerc":"5.0%","MemUsage":"1.0GiB / 8GiB"}]`)
+	stats := parseStatsJSON(out)
+	if len(stats) != 1 || stats[0].Name != "vllm" {
+		t.Fatalf("podman array parse failed: %+v", stats)
+	}
+}
+
+func TestParseStatsJSONEmpty(t *testing.T) {
+	if s := parseStatsJSON([]byte("  \n ")); s != nil {
+		t.Fatalf("expected nil for empty output, got %v", s)
+	}
+}
+
+func TestParseCPUPercent(t *testing.T) {
+	cases := map[string]struct {
+		want float64
+		ok   bool
+	}{
+		"12.34%": {12.34, true},
+		"0.00%":  {0, true},
+		"":       {0, false},
+		"n/a":    {0, false},
+	}
+	for in, exp := range cases {
+		got, ok := parseCPUPercent(in)
+		if ok != exp.ok || (ok && math.Abs(got-exp.want) > 1e-9) {
+			t.Errorf("parseCPUPercent(%q) = (%v, %v), want (%v, %v)", in, got, ok, exp.want, exp.ok)
+		}
+	}
+}
+
+func TestParseMemUsageMB(t *testing.T) {
+	cases := map[string]struct {
+		want float64 // MB
+		ok   bool
+	}{
+		"7.4GiB / 62.5GiB": {7.4 * 1024, true},                           // 7577.6 MB
+		"512MiB / 16GiB":   {512, true},                                  // exact
+		"1GB / 8GB":        {1000 * 1000 * 1000.0 / (1024 * 1024), true}, // SI GB
+		"0B / 8GiB":        {0, true},
+		"":                 {0, false},
+		"garbage":          {0, false},
+	}
+	for in, exp := range cases {
+		got, ok := parseMemUsageMB(in)
+		if ok != exp.ok {
+			t.Errorf("parseMemUsageMB(%q) ok = %v, want %v", in, ok, exp.ok)
+			continue
+		}
+		if ok && math.Abs(got-exp.want) > 0.5 {
+			t.Errorf("parseMemUsageMB(%q) = %.3f MB, want %.3f MB", in, got, exp.want)
+		}
+	}
+}
+
+func TestParseMBField(t *testing.T) {
+	cases := map[string]struct {
+		want int
+		ok   bool
+	}{
+		"8192 MB": {8192, true},
+		"8192MB":  {8192, true},
+		"0 MB":    {0, true},
+		"":        {0, false},
+		"n/a":     {0, false},
+	}
+	for in, exp := range cases {
+		got, ok := parseMBField(in)
+		if ok != exp.ok || (ok && got != exp.want) {
+			t.Errorf("parseMBField(%q) = (%d, %v), want (%d, %v)", in, got, ok, exp.want, exp.ok)
+		}
+	}
+}
+
+func TestParsePercentField(t *testing.T) {
+	cases := map[string]struct {
+		want float64
+		ok   bool
+	}{
+		"85%": {85, true},
+		"0%":  {0, true},
+		"":    {0, false},
+		"n/a": {0, false},
+	}
+	for in, exp := range cases {
+		got, ok := parsePercentField(in)
+		if ok != exp.ok || (ok && got != exp.want) {
+			t.Errorf("parsePercentField(%q) = (%v, %v), want (%v, %v)", in, got, ok, exp.want, exp.ok)
+		}
+	}
+}
+
+func TestMatchContainer(t *testing.T) {
+	stats := []containerStat{
+		{Name: "diffusers-diffusers-1"},
+		{Name: "vllm-server-1"},
+	}
+	if cs, ok := matchContainer(stats, "vllm"); !ok || cs.Name != "vllm-server-1" {
+		t.Fatalf("expected to match vllm, got %+v ok=%v", cs, ok)
+	}
+	if _, ok := matchContainer(stats, "ollama"); ok {
+		t.Fatalf("did not expect to match ollama")
+	}
+}

--- a/internal/footprint/store.go
+++ b/internal/footprint/store.go
@@ -1,0 +1,175 @@
+package footprint
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+// csvHeader is the fixed column order for footprint CSVs. It is written once as
+// the first line of each daily file. DuckDB / pandas read these headers directly
+// (e.g. `duckdb -c "SELECT service, avg(rss_mb) FROM 'footprints/*.csv' GROUP BY 1"`).
+var csvHeader = []string{
+	"ts", "node_id", "service", "running",
+	"cpu_pct", "rss_mb", "vram_mb", "gpu_util_pct", "idle_seconds",
+}
+
+// dailyFilePattern matches footprints-YYYY-MM-DD.csv so retention pruning only
+// ever touches this package's own rotated files.
+var dailyFilePattern = regexp.MustCompile(`^footprints-\d{4}-\d{2}-\d{2}\.csv$`)
+
+// Store appends footprint samples to a per-day CSV under dir. It is safe for a
+// single sampler goroutine; it does not guard against concurrent writers (there
+// is only ever one sampler per node).
+type Store struct {
+	dir string
+}
+
+// NewStore returns a Store writing to dir, creating the directory if needed.
+func NewStore(dir string) (*Store, error) {
+	if dir == "" {
+		return nil, fmt.Errorf("footprint: empty store dir")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("footprint: create store dir: %w", err)
+	}
+	return &Store{dir: dir}, nil
+}
+
+// Dir returns the store's directory (the footprints/ path).
+func (s *Store) Dir() string { return s.dir }
+
+// dailyFileName returns the file name for the given day.
+func dailyFileName(day time.Time) string {
+	return fmt.Sprintf("footprints-%s.csv", day.UTC().Format("2006-01-02"))
+}
+
+// filePathFor returns the absolute path of the daily file for ts.
+func (s *Store) filePathFor(ts time.Time) string {
+	return filepath.Join(s.dir, dailyFileName(ts))
+}
+
+// Append writes a batch of samples to the daily file for the first sample's
+// timestamp. It writes the CSV header exactly once per file (on creation), so
+// files rotate cleanly at UTC-day boundaries: a new day means a new file with a
+// fresh header. An empty batch is a no-op.
+func (s *Store) Append(samples []Sample) error {
+	if len(samples) == 0 {
+		return nil
+	}
+	path := s.filePathFor(samples[0].Timestamp)
+
+	// A file needs a header iff it does not yet exist (or is empty). Stat before
+	// opening in append mode so we can decide whether to emit the header row.
+	needHeader := false
+	if info, err := os.Stat(path); os.IsNotExist(err) || (err == nil && info.Size() == 0) {
+		needHeader = true
+	} else if err != nil {
+		return fmt.Errorf("footprint: stat %s: %w", path, err)
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("footprint: open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	w := csv.NewWriter(f)
+	if needHeader {
+		if err := w.Write(csvHeader); err != nil {
+			return fmt.Errorf("footprint: write header: %w", err)
+		}
+	}
+	for _, sm := range samples {
+		if err := w.Write(sm.toRecord()); err != nil {
+			return fmt.Errorf("footprint: write row: %w", err)
+		}
+	}
+	w.Flush()
+	if err := w.Error(); err != nil {
+		return fmt.Errorf("footprint: flush %s: %w", path, err)
+	}
+	return nil
+}
+
+// toRecord renders a sample as a CSV record in csvHeader column order. Unset
+// optional metrics render as the empty string, so DuckDB reads them as NULL and
+// a human greps them as blank — distinct from a measured zero.
+func (sm Sample) toRecord() []string {
+	return []string{
+		sm.Timestamp.UTC().Format(time.RFC3339),
+		sm.NodeID,
+		sm.Service,
+		strconv.FormatBool(sm.Running),
+		floatField(sm.CPUPercent),
+		floatField(sm.RSSMB),
+		intField(sm.VRAMMB),
+		floatField(sm.GPUUtilPercent),
+		intField(sm.IdleSeconds),
+	}
+}
+
+func floatField(v *float64) string {
+	if v == nil {
+		return ""
+	}
+	return strconv.FormatFloat(*v, 'f', 2, 64)
+}
+
+func intField(v *int) string {
+	if v == nil {
+		return ""
+	}
+	return strconv.Itoa(*v)
+}
+
+// Prune deletes daily footprint files whose day is older than retentionDays
+// relative to now, so the log never becomes an unbounded disk hog. Only files
+// matching the footprints-YYYY-MM-DD.csv pattern are ever considered — unrelated
+// files in the directory are left untouched. A retentionDays <= 0 is treated as
+// "keep everything" (pruning disabled). Returns the names of pruned files.
+func (s *Store) Prune(now time.Time, retentionDays int) ([]string, error) {
+	if retentionDays <= 0 {
+		return nil, nil
+	}
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("footprint: read store dir: %w", err)
+	}
+	// Cutoff is the oldest UTC day we keep. Files dated strictly before this are
+	// pruned. now-retentionDays: with retentionDays=7, today plus the previous 6
+	// days are kept (7 days of data).
+	cutoff := now.UTC().AddDate(0, 0, -(retentionDays - 1)).Truncate(24 * time.Hour)
+
+	var pruned []string
+	for _, e := range entries {
+		if e.IsDir() || !dailyFilePattern.MatchString(e.Name()) {
+			continue
+		}
+		day, err := dayFromFileName(e.Name())
+		if err != nil {
+			continue // Malformed date despite pattern match: leave it alone.
+		}
+		if day.Before(cutoff) {
+			if err := os.Remove(filepath.Join(s.dir, e.Name())); err != nil {
+				return pruned, fmt.Errorf("footprint: remove %s: %w", e.Name(), err)
+			}
+			pruned = append(pruned, e.Name())
+		}
+	}
+	return pruned, nil
+}
+
+// dayFromFileName parses the YYYY-MM-DD date out of a footprints-*.csv name.
+func dayFromFileName(name string) (time.Time, error) {
+	// footprints-2006-01-02.csv -> 2006-01-02
+	base := name[len("footprints-") : len(name)-len(".csv")]
+	return time.Parse("2006-01-02", base)
+}

--- a/internal/footprint/store_test.go
+++ b/internal/footprint/store_test.go
@@ -1,0 +1,152 @@
+package footprint
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func f64(v float64) *float64 { return &v }
+func ip(v int) *int          { return &v }
+
+func TestAppendWritesHeaderOnce(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	day := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	batch := []Sample{
+		{Timestamp: day, NodeID: "node-a", Service: "vllm", Running: true, CPUPercent: f64(12.5), RSSMB: f64(7580)},
+		{Timestamp: day, NodeID: "node-a", Service: NodeService, Running: true, VRAMMB: ip(7400), GPUUtilPercent: f64(0)},
+	}
+	if err := store.Append(batch); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	// Append a second batch to the same day: header must NOT be repeated.
+	if err := store.Append([]Sample{{Timestamp: day.Add(time.Minute), NodeID: "node-a", Service: "vllm", Running: true, RSSMB: f64(7600)}}); err != nil {
+		t.Fatalf("Append 2: %v", err)
+	}
+
+	path := filepath.Join(dir, "footprints-2026-07-01.csv")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 4 { // header + 3 data rows
+		t.Fatalf("expected 4 lines (1 header + 3 rows), got %d: %q", len(lines), lines)
+	}
+	if !strings.HasPrefix(lines[0], "ts,node_id,service,running,cpu_pct,rss_mb,vram_mb,gpu_util_pct,idle_seconds") {
+		t.Fatalf("unexpected header: %q", lines[0])
+	}
+	if strings.Contains(strings.Join(lines[1:], "\n"), "ts,node_id") {
+		t.Fatalf("header repeated in data rows")
+	}
+	// Unset optional metrics must render as blank, not "0".
+	if !strings.Contains(lines[1], "12.50,7580.00,,,") {
+		t.Fatalf("expected blank vram/gpu/idle for vllm row, got %q", lines[1])
+	}
+}
+
+func TestAppendRotatesByDay(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := NewStore(dir)
+
+	d1 := time.Date(2026, 7, 1, 23, 59, 0, 0, time.UTC)
+	d2 := time.Date(2026, 7, 2, 0, 1, 0, 0, time.UTC)
+	if err := store.Append([]Sample{{Timestamp: d1, NodeID: "n", Service: "svc"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Append([]Sample{{Timestamp: d2, NodeID: "n", Service: "svc"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range []string{"footprints-2026-07-01.csv", "footprints-2026-07-02.csv"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Fatalf("expected daily file %s: %v", name, err)
+		}
+	}
+}
+
+func TestAppendEmptyIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := NewStore(dir)
+	if err := store.Append(nil); err != nil {
+		t.Fatalf("Append(nil): %v", err)
+	}
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 0 {
+		t.Fatalf("expected no files, got %d", len(entries))
+	}
+}
+
+func TestPruneRemovesOldKeepsRecent(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := NewStore(dir)
+
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	// Create files spanning old and recent days plus an unrelated file.
+	days := []time.Time{
+		now.AddDate(0, 0, -10), // old -> pruned (retention 7)
+		now.AddDate(0, 0, -7),  // exactly at boundary -> pruned (keeps 7 incl today)
+		now.AddDate(0, 0, -6),  // kept
+		now,                    // kept
+	}
+	for _, d := range days {
+		if err := store.Append([]Sample{{Timestamp: d, NodeID: "n", Service: "svc"}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	unrelated := filepath.Join(dir, "notes.txt")
+	if err := os.WriteFile(unrelated, []byte("keep me"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pruned, err := store.Prune(now, 7)
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if len(pruned) != 2 {
+		t.Fatalf("expected 2 pruned files, got %d: %v", len(pruned), pruned)
+	}
+
+	// Recent files + the unrelated file survive.
+	for _, keep := range []string{
+		dailyFileName(now.AddDate(0, 0, -6)),
+		dailyFileName(now),
+		"notes.txt",
+	} {
+		if _, err := os.Stat(filepath.Join(dir, keep)); err != nil {
+			t.Fatalf("expected %s to survive prune: %v", keep, err)
+		}
+	}
+	// Old files are gone.
+	for _, gone := range []string{
+		dailyFileName(now.AddDate(0, 0, -10)),
+		dailyFileName(now.AddDate(0, 0, -7)),
+	} {
+		if _, err := os.Stat(filepath.Join(dir, gone)); !os.IsNotExist(err) {
+			t.Fatalf("expected %s to be pruned", gone)
+		}
+	}
+}
+
+func TestPruneDisabledWhenRetentionNonPositive(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := NewStore(dir)
+	now := time.Now()
+	if err := store.Append([]Sample{{Timestamp: now.AddDate(0, 0, -100), NodeID: "n", Service: "svc"}}); err != nil {
+		t.Fatal(err)
+	}
+	pruned, err := store.Prune(now, 0)
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if len(pruned) != 0 {
+		t.Fatalf("retention<=0 should prune nothing, got %v", pruned)
+	}
+}


### PR DESCRIPTION
## Context

When a diffusers container idled holding **7.4 GB** of VRAM and drove the node to a runaway **load average of 585**, there was **no history to query after the fact** — we could see the node was wedged, but not which service had been hoarding resources or for how long. This PR gives operators a lightweight, local, queryable time-series of resource footprints so that incident leaves a trail.

This is the **historical/persistence** half of the footprint-logging feature. The **live TUI view** (#421) is a separate agent's work; the two are deliberately kept in separate packages (`internal/footprint` here, `internal/status` there) so they never collide. This code reuses the same read-only OS / nvidia-smi sources but owns all of its own logic and does **not** edit the #421 status collector.

## Summary

**Background sampler (`internal/footprint`)** — a goroutine started under `citadel work` alongside the other background loops. Every tick (default 60s, `CITADEL_FOOTPRINT_INTERVAL`) it:
- Enumerates managed services from the **manifest** (the status collector is constructed with a nil service list, so it's not a usable source here).
- Runs **one** `<engine> stats --no-stream --format json` (docker **or** podman — the engine comes from `catalog.SelectContainerRuntime()`, never hardcoded) and **one** GPU read per tick — never a per-service exec storm.
- Emits one row per service (`running`, `cpu_pct`, `rss_mb`) plus one **node-level** row (`_node`) carrying host CPU/RSS + total `vram_mb` + `gpu_util_pct`.

**Storage — zero-daemon, DuckDB/pandas-queryable.** Rows append to **rotated daily CSVs** under `~/citadel-node/footprints/` (`footprints-YYYY-MM-DD.csv`, header written once per file). CSV is human-greppable and DuckDB reads it directly:
```
duckdb -c "SELECT service, avg(rss_mb), max(rss_mb) FROM 'footprints/*.csv' GROUP BY 1 ORDER BY 2 DESC"
```
**Bounded retention** (`CITADEL_FOOTPRINT_RETENTION_DAYS`, default 7) prunes old files at startup and per tick, so the log never becomes a disk hog. Only `footprints-*.csv` files are ever considered for pruning.

**Query command — `citadel footprints [--service NAME] [--since 1h] [--idle-only]`.** Reads the CSVs in **pure Go** (no duckdb binary at runtime) and prints a per-service summary: avg/peak RAM, avg/peak VRAM, avg/peak CPU, % of samples idle, longest idle stretch, sample count + window. `--help` notes the raw CSVs are DuckDB/pandas-queryable for ad-hoc analysis.

### Design notes / documented choices
- **No per-service VRAM.** nvidia-smi is not container-aware; PID→container mapping would be exactly the per-service exec storm we're avoiding. VRAM/GPU util live on the node-level row, which covers the GPU-hoarding half of the incident; per-service RSS+CPU covers the rest.
- **`idle_seconds` left empty for now.** #420's idle signal isn't in this branch and we do not reimplement idle detection. The column, the idle aggregation (%-idle, longest stretch, `--idle-only`), and a `SetIdleFunc` seam are all in place and unit-tested against synthetic rows, ready to light up when #420 lands.
- **Native (non-container) manifest services** always log `running=false` with empty RSS/CPU — they don't appear in `docker/podman stats`. This is an accepted consequence of the one-stats-call constraint.
- **Longest idle stretch:** k consecutive idle samples report k·interval; since we can't see between samples, each idle sample is credited one full interval.

## Test plan

| Group | Coverage |
|-------|----------|
| CSV store | header written exactly once, blank vs zero for unset metrics, daily rotation at UTC boundary, empty-batch no-op |
| Retention | old files pruned, recent + unrelated files kept, boundary day, disabled when retention ≤ 0 |
| stats parsing | docker per-line + podman array JSON, CPU% parse, `MemUsage` GiB/MiB/SI-GB/bytes unit parser, container-name substring match |
| nvidia-smi parsing (own) | `parseMBField` ("8192 MB"), `parsePercentField` ("85%") incl. empty/bad input |
| sampler | service + node rows from injected stats/GPU, per-service VRAM asserted nil, node row emitted even on stats error, idle signal wired through |
| aggregation | avg/peak RAM/CPU/VRAM, idle-% math, longest-idle-stretch (incl. reset-on-active), `--since`/`--service`/`--idle-only` filters, missing dir |
| env config | `CITADEL_FOOTPRINT_INTERVAL` disable/default, retention default/override |

`gofmt -w .`, `go build ./...`, `go vet ./...`, `go test ./...` all green. Confirmed `internal/status` is untouched.

## Related
- #421 — live TUI footprint view (separate agent; separate package)
- #416 / #420 — node idle detection (`idle_seconds` column reserved for #420)

Closes #422
