### PR TITLE
feat(tui): per-managed-service resource footprint (CPU/RAM/VRAM) + heavy-and-idle warning (#421)

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -1208,6 +1208,13 @@ func gatherControlCenterData() (controlcenter.StatusData, error) {
 		}
 	}
 
+	// Enrich running services with their live resource footprint (CPU/RAM/VRAM/
+	// GPU) and a footprint-derived idle label, then roll up a one-line managed
+	// summary (citadel #421). This is what makes the services panel resource-
+	// aware: a heavy-and-idle container (the diffusers eviction candidate) is now
+	// visible and highlighted instead of a bare "running".
+	enrichServiceFootprints(&data)
+
 	// Detect system tailscale (dual connection)
 	running, ip, name, sameNetwork := controlcenter.DetectSystemTailscale(nexusURL)
 	data.SystemTailscaleRunning = running
@@ -1230,6 +1237,80 @@ func gatherControlCenterData() (controlcenter.StatusData, error) {
 	}
 
 	return data, nil
+}
+
+// ccFootprintIdleTracker is the long-lived footprint-derived idle tracker for
+// the Control Center refresh path (citadel #421). It MUST be a package-level
+// singleton: idle duration accumulates across refreshes from a container's
+// first-inactive timestamp, so a fresh tracker per refresh would never cross the
+// idle threshold and the heavy-and-idle warning would never fire.
+var ccFootprintIdleTracker = status.NewFootprintIdleTracker()
+
+// enrichServiceFootprints attaches a live resource footprint + idle label to
+// each running managed service in data, and computes the one-line managed
+// summary. It makes a single batched footprint collection for all running
+// services (one stats call + one nvidia-smi pair), then formats per-service.
+func enrichServiceFootprints(data *controlcenter.StatusData) {
+	// Collect candidate container names for running services only.
+	var names []string
+	nameToIdx := map[string]int{}
+	for i := range data.Services {
+		if data.Services[i].Status != "running" {
+			continue
+		}
+		for _, cn := range []string{"citadel-" + data.Services[i].Name, data.Services[i].Name} {
+			if _, dup := nameToIdx[cn]; dup {
+				continue
+			}
+			nameToIdx[cn] = i
+			names = append(names, cn)
+		}
+	}
+	if len(names) == 0 {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	footprints := status.CollectFootprints(ctx, names)
+
+	var totalRAM, totalVRAM uint64
+	var anyGPU bool
+	for cn, fp := range footprints {
+		idx, ok := nameToIdx[cn]
+		if !ok {
+			continue
+		}
+		// Skip a candidate name that resolved to no container (bare name when
+		// the "citadel-" variant is the real one).
+		if fp.CPUPercent < 0 && fp.RAMBytes == 0 && fp.VRAMBytes == 0 {
+			continue
+		}
+		fpCopy := fp
+		idle := ccFootprintIdleTracker.Observe(cn, &fpCopy)
+		data.Services[idx].Footprint = status.FormatFootprint(&fpCopy)
+		data.Services[idx].IdleLabel = status.FormatIdleLabel(&idle)
+		data.Services[idx].HeavyAndIdle = status.IsHeavyAndIdle(&fpCopy, &idle)
+
+		totalRAM += fpCopy.RAMBytes
+		totalVRAM += fpCopy.VRAMBytes
+		if fpCopy.HasGPU {
+			anyGPU = true
+		}
+	}
+
+	// One-line node roll-up: "managed: RAM 13G/62G · VRAM 21G/24G".
+	summary := "managed: RAM " + status.FormatBytesGB(totalRAM)
+	if data.MemoryTotal != "" {
+		summary += "/" + data.MemoryTotal
+	}
+	if anyGPU {
+		summary += " · VRAM " + status.FormatBytesGB(totalVRAM)
+		if data.GPUMemory != "" {
+			summary += "/" + data.GPUMemory
+		}
+	}
+	data.ManagedSummary = summary
 }
 
 // extractUptime tries to extract uptime from docker status string like "Up 2 hours"

--- a/internal/status/collector.go
+++ b/internal/status/collector.go
@@ -26,8 +26,9 @@ type Collector struct {
 	services       []ServiceConfig
 	startTime      time.Time
 	modelDiscovery *ModelDiscovery
-	capabilities   *NodeCapabilities // cached capabilities (set once at startup)
-	idleTracker    *IdleTracker      // per-service idle detection (aceteam#4472 / citadel #416)
+	capabilities   *NodeCapabilities     // cached capabilities (set once at startup)
+	idleTracker    *IdleTracker          // metrics-based per-service idle detection (aceteam#4472 / citadel #416)
+	fpIdleTracker  *FootprintIdleTracker // footprint-derived idle for engines #416 can't scrape (citadel #421)
 }
 
 // ServiceConfig holds the configuration for a service from the manifest.
@@ -56,6 +57,7 @@ func NewCollector(cfg CollectorConfig) *Collector {
 		modelDiscovery: NewModelDiscovery(),
 		capabilities:   cfg.Capabilities,
 		idleTracker:    NewIdleTracker(IdleThresholdSeconds()),
+		fpIdleTracker:  NewFootprintIdleTracker(),
 	}
 }
 
@@ -102,6 +104,13 @@ func (c *Collector) Collect() (*NodeStatus, error) {
 
 	// Collect installed app status
 	status.Apps = c.collectAppStatus()
+
+	// Attach live resource footprints (CPU/RAM/VRAM/GPU) to running managed
+	// services and apps in one batched pass (citadel #421). This is what makes
+	// the heartbeat and TUI resource-aware: a running-but-idle vLLM/diffusers
+	// holding GPU/RAM is now visible instead of a bare "running" with no
+	// footprint. One stats call + one nvidia-smi pair for the whole set.
+	c.attachFootprints(status)
 
 	// Include cached capabilities if available. Copy the cached struct rather
 	// than aliasing it, so populating the per-heartbeat capability flags below

--- a/internal/status/footprint.go
+++ b/internal/status/footprint.go
@@ -1,0 +1,655 @@
+package status
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/apps"
+	"github.com/aceteam-ai/citadel-cli/internal/catalog"
+)
+
+// footprintCollectTimeout bounds the batched stats/nvidia-smi execs so a hung
+// container runtime under overload can't stall the heartbeat.
+const footprintCollectTimeout = 5 * time.Second
+
+// ServiceFootprint captures the live resource footprint of a single
+// citadel-managed serving container (vllm, diffusers, ollama, ...). It rides
+// the heartbeat (embedded in ServiceInfo/AppInfo) so the platform can see idle
+// GPU hogs, and is rendered in the Control Center services panel.
+//
+// Motivation (citadel #421): a leftover diffusers container held ~7.4 GB RAM
+// while completely idle and drove the node to load average 585 before a human
+// noticed. The TUI showed it as "running" with no footprint and no idle signal.
+// This makes the managed-service view resource-aware so the heavy-and-idle
+// eviction candidate is obvious at a glance.
+type ServiceFootprint struct {
+	// CPUPercent is the container's CPU utilization as reported by
+	// `docker/podman stats` (can exceed 100 on multi-core). -1 means unknown.
+	CPUPercent float64 `json:"cpu_percent"`
+	// RAMBytes is the container's resident memory (RSS) in bytes. 0 when unknown.
+	RAMBytes uint64 `json:"ram_bytes"`
+	// VRAMBytes is GPU memory attributed to this container's process subtree,
+	// summed across GPUs, in bytes. 0 when the node has no GPU, nvidia-smi is
+	// absent, or no compute process maps to the container.
+	VRAMBytes uint64 `json:"vram_bytes"`
+	// GPUUtilPercent is the whole-GPU utilization (device-level, not
+	// per-process — nvidia-smi does not expose reliable per-process SM%).
+	// -1 means n/a (no GPU / nvidia-smi absent).
+	GPUUtilPercent float64 `json:"gpu_util_percent"`
+	// HasGPU reports whether GPU stats were available at all, so a "0.0G / 0%"
+	// footprint can be rendered as "n/a" instead of a misleading zero.
+	HasGPU bool `json:"has_gpu"`
+}
+
+// heavyRAMBytes is the RSS threshold above which an idle managed service is
+// flagged as an eviction candidate. ~4 GiB — large enough to exclude small
+// sidecars, low enough to catch a stuck diffusers/vLLM worker.
+const heavyRAMBytes uint64 = 4 * 1024 * 1024 * 1024
+
+// heavyVRAMBytes is the VRAM threshold above which an idle managed service is
+// flagged as an eviction candidate regardless of its RAM. Any multi-GB VRAM
+// reservation held while idle is worth surfacing on a contended GPU node.
+const heavyVRAMBytes uint64 = 2 * 1024 * 1024 * 1024
+
+// IsHeavyAndIdle reports whether a service is both idle and holding enough
+// RAM or VRAM to be worth evicting. This is the highlight predicate for the
+// TUI and the signal that would have caught the #421 incident: a diffusers
+// container idle for 38m while pinning 7.4 GB RAM.
+//
+// A nil footprint or nil idle state means "not enough signal to warn" (false).
+func IsHeavyAndIdle(fp *ServiceFootprint, idle *IdleState) bool {
+	if fp == nil || idle == nil || !idle.Idle {
+		return false
+	}
+	return fp.RAMBytes >= heavyRAMBytes || fp.VRAMBytes >= heavyVRAMBytes
+}
+
+// CollectFootprints returns a per-container resource footprint keyed by
+// container name, for the given set of container names. It makes exactly one
+// `stats` call and (at most) one pair of nvidia-smi calls per invocation,
+// joining the results in memory — never one exec per service. Callers pass the
+// managed container names they care about (e.g. "citadel-vllm",
+// "citadel-diffusers"); unknown containers in the stats output are ignored.
+//
+// It degrades gracefully: with no GPU / no nvidia-smi, VRAM/GPU fields are
+// zeroed and HasGPU is false; with no container runtime, an empty map is
+// returned. It never errors — a missing signal is reported as "unknown", not a
+// failure, so the TUI/heartbeat keep working on non-GPU and non-container hosts.
+func CollectFootprints(ctx context.Context, containerNames []string) map[string]ServiceFootprint {
+	if len(containerNames) == 0 {
+		return map[string]ServiceFootprint{}
+	}
+
+	engineBin := catalog.SelectContainerRuntime().EngineBin
+	if engineBin == "" {
+		engineBin = "docker"
+	}
+
+	// One batched stats read for CPU% + RAM across ALL running containers. We
+	// deliberately pass no container names: `docker stats <name>` hard-fails the
+	// whole batch (non-zero exit, empty stdout) if ANY named container is
+	// absent, and we probe both "citadel-<n>" and bare "<n>" candidates — the
+	// bare one usually doesn't exist. Listing all and filtering by name in
+	// memory is the robust batch, and still ignores unrelated containers.
+	stats := collectContainerStats(ctx, engineBin)
+
+	// One nvidia-smi compute-apps read (pid -> vram) + one gpu-util read.
+	pidVRAM, gpuUtil, hasGPU := collectGPUFootprint(ctx)
+
+	// Build the /proc parent->children map once (not per container): pidSubtree
+	// would otherwise re-walk all of /proc for every GPU container, which adds
+	// up under the exact overload this feature targets.
+	var procChildren map[int][]int
+	if hasGPU {
+		procChildren = readProcChildren()
+	}
+
+	out := make(map[string]ServiceFootprint, len(containerNames))
+	for _, name := range containerNames {
+		fp := ServiceFootprint{CPUPercent: -1, GPUUtilPercent: -1, HasGPU: hasGPU}
+		if s, ok := stats[name]; ok {
+			fp.CPUPercent = s.cpuPercent
+			fp.RAMBytes = s.ramBytes
+		}
+		if hasGPU {
+			fp.GPUUtilPercent = gpuUtil
+			if pid, ok := containerMainPID(ctx, engineBin, name); ok {
+				fp.VRAMBytes = attributeVRAM(pidVRAM, pidSubtree(pid, procChildren))
+			}
+		}
+		out[name] = fp
+	}
+	return out
+}
+
+// containerStats holds the CPU% and RAM parsed from one `stats` row.
+type containerStats struct {
+	cpuPercent float64
+	ramBytes   uint64
+}
+
+// statsFormat is the Go-template format string passed to `stats --format`. Tab
+// separated so a container name with a space can't break parsing.
+const statsFormat = "{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}"
+
+// collectContainerStats runs one `<engine> stats --no-stream` over ALL running
+// containers and returns a name -> {cpu%, ram} map. No container names are
+// passed: naming a missing container makes docker/podman fail the whole batch,
+// so callers filter the returned map by name instead. Any exec error yields an
+// empty map (unknown), never a panic.
+func collectContainerStats(ctx context.Context, engineBin string) map[string]containerStats {
+	cmd := exec.CommandContext(ctx, engineBin, "stats", "--no-stream", "--format", statsFormat)
+	out, err := cmd.Output()
+	if err != nil {
+		return map[string]containerStats{}
+	}
+	return parseStatsOutput(string(out))
+}
+
+// parseStatsOutput parses the tab-separated `stats --format` output into a
+// name -> {cpu%, ram} map. Lines that don't parse are skipped. Exported field
+// units follow docker/podman conventions: CPUPerc like "74.31%", MemUsage like
+// "6.1GiB / 62.0GiB" (we take the used side).
+func parseStatsOutput(out string) map[string]containerStats {
+	res := map[string]containerStats{}
+	sc := bufio.NewScanner(strings.NewReader(out))
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		fields := strings.Split(line, "\t")
+		if len(fields) < 3 {
+			continue
+		}
+		name := strings.TrimSpace(fields[0])
+		if name == "" || strings.EqualFold(name, "NAME") {
+			continue // skip a header row if one slips through
+		}
+		cs := containerStats{cpuPercent: parsePercent(fields[1])}
+		// MemUsage is "<used> / <limit>"; take the used side.
+		usedStr := fields[2]
+		if idx := strings.Index(usedStr, "/"); idx >= 0 {
+			usedStr = usedStr[:idx]
+		}
+		cs.ramBytes = parseMemBytes(usedStr)
+		res[name] = cs
+	}
+	return res
+}
+
+// parsePercent parses a value like "74.31%" or "74.31" into a float. Returns
+// -1 for unparseable input so an unknown reading is distinguishable from 0.
+func parsePercent(s string) float64 {
+	s = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(s), "%"))
+	if s == "" || s == "--" {
+		return -1
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return -1
+	}
+	return v
+}
+
+// parseMemBytes parses a docker/podman memory string like "6.1GiB", "512MiB",
+// "6.1GB", "1.5kB", or "0B" into bytes. Returns 0 on failure. Both binary
+// (GiB/MiB) and decimal (GB/MB) suffixes are accepted since podman and docker
+// differ; both are treated with their respective multipliers.
+func parseMemBytes(s string) uint64 {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0
+	}
+	// Split the trailing unit from the number.
+	i := 0
+	for i < len(s) && (s[i] == '.' || s[i] == '-' || (s[i] >= '0' && s[i] <= '9')) {
+		i++
+	}
+	numStr := strings.TrimSpace(s[:i])
+	unit := strings.ToLower(strings.TrimSpace(s[i:]))
+	val, err := strconv.ParseFloat(numStr, 64)
+	if err != nil || val < 0 {
+		return 0
+	}
+	var mult float64
+	switch unit {
+	case "b", "":
+		mult = 1
+	case "kb", "k":
+		mult = 1e3
+	case "kib":
+		mult = 1024
+	case "mb", "m":
+		mult = 1e6
+	case "mib":
+		mult = 1 << 20
+	case "gb", "g":
+		mult = 1e9
+	case "gib":
+		mult = 1 << 30
+	case "tb", "t":
+		mult = 1e12
+	case "tib":
+		mult = 1 << 40
+	default:
+		return 0
+	}
+	return uint64(val * mult)
+}
+
+// collectGPUFootprint runs one nvidia-smi compute-apps query (pid -> vram
+// bytes) and one gpu-utilization query. It returns hasGPU=false when nvidia-smi
+// is absent or errors, so callers render "n/a" rather than a misleading zero.
+func collectGPUFootprint(ctx context.Context) (pidVRAM map[int]uint64, gpuUtil float64, hasGPU bool) {
+	if _, err := exec.LookPath("nvidia-smi"); err != nil {
+		return nil, -1, false
+	}
+	appsOut, err := exec.CommandContext(ctx, "nvidia-smi",
+		"--query-compute-apps=pid,used_memory", "--format=csv,noheader,nounits").Output()
+	if err != nil {
+		return nil, -1, false
+	}
+	pidVRAM = parseComputeApps(string(appsOut))
+
+	utilOut, err := exec.CommandContext(ctx, "nvidia-smi",
+		"--query-gpu=utilization.gpu", "--format=csv,noheader,nounits").Output()
+	if err != nil {
+		// compute-apps worked, so a GPU is present; util is just unknown.
+		return pidVRAM, -1, true
+	}
+	return pidVRAM, parseGPUUtil(string(utilOut)), true
+}
+
+// parseComputeApps parses nvidia-smi `--query-compute-apps=pid,used_memory`
+// CSV output (units stripped, so used_memory is in MiB) into a pid -> vram
+// bytes map. When two rows share a pid (multi-GPU process), their VRAM is
+// summed. Unparseable rows are skipped.
+func parseComputeApps(out string) map[int]uint64 {
+	res := map[int]uint64{}
+	sc := bufio.NewScanner(strings.NewReader(out))
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		parts := strings.Split(line, ",")
+		if len(parts) < 2 {
+			continue
+		}
+		pid, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+		if err != nil {
+			continue
+		}
+		mib, err := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
+		if err != nil || mib < 0 {
+			continue
+		}
+		res[pid] += uint64(mib * (1 << 20))
+	}
+	return res
+}
+
+// parseGPUUtil parses nvidia-smi `--query-gpu=utilization.gpu` CSV (units
+// stripped) and returns the max utilization across GPUs, or -1 if none parse.
+// Max (not sum/avg) so a busy GPU isn't diluted by an idle second card.
+func parseGPUUtil(out string) float64 {
+	max := -1.0
+	sc := bufio.NewScanner(strings.NewReader(out))
+	for sc.Scan() {
+		v := parsePercent(sc.Text())
+		if v > max {
+			max = v
+		}
+	}
+	return max
+}
+
+// attributeVRAM sums the VRAM of every compute-app PID that falls inside the
+// container's process subtree. This is the crux of VRAM attribution: nvidia-smi
+// reports *host* PIDs, and the GPU process is typically a child of the
+// container's main PID (PID 1 inside the namespace), so a naive join on the
+// main PID alone misses the real VRAM holder. We match any compute PID in the
+// full descendant set.
+func attributeVRAM(pidVRAM map[int]uint64, subtree map[int]struct{}) uint64 {
+	var total uint64
+	for pid, vram := range pidVRAM {
+		if _, ok := subtree[pid]; ok {
+			total += vram
+		}
+	}
+	return total
+}
+
+// containerMainPID returns the host PID of a container's main process via
+// `<engine> inspect --format {{.State.Pid}}`. Returns (0,false) on any error or
+// a zero/absent PID (stopped container).
+func containerMainPID(ctx context.Context, engineBin, name string) (int, bool) {
+	out, err := exec.CommandContext(ctx, engineBin, "inspect", "--format", "{{.State.Pid}}", name).Output()
+	if err != nil {
+		return 0, false
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil || pid <= 0 {
+		return 0, false
+	}
+	return pid, true
+}
+
+// pidSubtree returns the set of host PIDs rooted at (and including) root, given
+// a prebuilt parent->children adjacency map (from readProcChildren). This
+// captures GPU worker children of a container's main PID that nvidia-smi
+// attributes by host PID. With an empty/nil map (e.g. non-Linux, no /proc) it
+// returns just {root} so the main-PID case still works.
+func pidSubtree(root int, children map[int][]int) map[int]struct{} {
+	subtree := map[int]struct{}{root: {}}
+	if len(children) == 0 {
+		return subtree
+	}
+	// BFS from root over the child adjacency list.
+	queue := []int{root}
+	for len(queue) > 0 {
+		p := queue[0]
+		queue = queue[1:]
+		for _, c := range children[p] {
+			if _, seen := subtree[c]; seen {
+				continue
+			}
+			subtree[c] = struct{}{}
+			queue = append(queue, c)
+		}
+	}
+	return subtree
+}
+
+// readProcChildren builds a parent -> children adjacency map by scanning
+// /proc/<pid>/stat for each process's PPID. Returns an empty map when /proc is
+// unavailable (e.g. macOS) so callers fall back to the single-PID match.
+func readProcChildren() map[int][]int {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil
+	}
+	children := map[int][]int{}
+	for _, e := range entries {
+		pid, err := strconv.Atoi(e.Name())
+		if err != nil {
+			continue // non-numeric entries (e.g. /proc/cpuinfo)
+		}
+		ppid, ok := readPPID(pid)
+		if !ok {
+			continue
+		}
+		children[ppid] = append(children[ppid], pid)
+	}
+	return children
+}
+
+// readPPID reads the parent PID of a process from /proc/<pid>/stat. The stat
+// file's comm field (field 2) can contain spaces and parentheses, so we key off
+// the last ')' and take PPID as the second whitespace field after it.
+func readPPID(pid int) (int, bool) {
+	data, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "stat"))
+	if err != nil {
+		return 0, false
+	}
+	s := string(data)
+	close := strings.LastIndex(s, ")")
+	if close < 0 || close+1 >= len(s) {
+		return 0, false
+	}
+	// After ") " the fields are: state ppid ...
+	rest := strings.Fields(s[close+1:])
+	if len(rest) < 2 {
+		return 0, false
+	}
+	ppid, err := strconv.Atoi(rest[1])
+	if err != nil {
+		return 0, false
+	}
+	return ppid, true
+}
+
+// FormatBytesGB renders a byte count as a compact "6.1G" string used in the TUI
+// footprint line. 0 renders as "0.0G".
+func FormatBytesGB(b uint64) string {
+	gb := float64(b) / (1 << 30)
+	return fmt.Sprintf("%.1fG", gb)
+}
+
+// idleCPUThresholdPercent is the container CPU% at or below which a managed
+// service is considered inactive by the footprint-derived idle heuristic. A
+// serving engine that is genuinely handling requests sits well above this; a
+// stuck/leftover container (the #421 diffusers case) idles near zero.
+const idleCPUThresholdPercent = 2.0
+
+// idleGPUThresholdPercent is the whole-GPU utilization at or below which a GPU
+// service is considered inactive. Combined with CPU: a service is inactive only
+// when both CPU and (if present) GPU are quiet.
+const idleGPUThresholdPercent = 5.0
+
+// footprintIdleThreshold is how long a container must stay inactive before the
+// footprint-derived heuristic marks it idle. Mirrors the intent of #420's
+// metrics-based threshold for engines that expose no request counters.
+const footprintIdleThreshold = 60 * time.Second
+
+// FootprintIdleTracker derives a per-container idle signal purely from resource
+// footprint (CPU + GPU utilization), for managed engines that #420's
+// metrics-based IdleTracker cannot scrape (diffusers, ollama, llama.cpp, ...).
+// It is complementary to — not a replacement for — the request-counter idle
+// signal: #420 owns engines with Prometheus counters (vLLM); this covers the
+// rest so the "heavy AND idle" eviction warning still fires for them. That is
+// the exact gap the #421 incident fell through (idle diffusers, no request
+// metrics, invisible).
+//
+// It is stateful and MUST be long-lived (one instance across refreshes): idle
+// duration accumulates from the first-inactive timestamp, so a fresh tracker
+// per refresh would never cross the threshold. Safe for concurrent use.
+type FootprintIdleTracker struct {
+	mu sync.Mutex
+	// inactiveSince maps container name -> the time it first went inactive.
+	// Absent when the container is currently active. threshold is the idle
+	// cutoff.
+	inactiveSince map[string]time.Time
+	threshold     time.Duration
+	now           func() time.Time // injectable for tests
+}
+
+// NewFootprintIdleTracker returns a tracker with the default idle threshold.
+func NewFootprintIdleTracker() *FootprintIdleTracker {
+	return &FootprintIdleTracker{
+		inactiveSince: map[string]time.Time{},
+		threshold:     footprintIdleThreshold,
+		now:           time.Now,
+	}
+}
+
+// footprintActive reports whether a footprint indicates the container is doing
+// work: CPU above the idle threshold, or (when a GPU is present) GPU utilization
+// above its threshold. Unknown CPU (-1) is treated as not-active-on-CPU so a
+// missing stats read alone doesn't mask idleness.
+func footprintActive(fp *ServiceFootprint) bool {
+	if fp == nil {
+		return false
+	}
+	if fp.CPUPercent > idleCPUThresholdPercent {
+		return true
+	}
+	if fp.HasGPU && fp.GPUUtilPercent > idleGPUThresholdPercent {
+		return true
+	}
+	return false
+}
+
+// Observe updates the tracker for a container's current footprint and returns
+// its derived idle state. Active containers reset the idle clock and report
+// idle=false with idle_seconds=0. Inactive containers accumulate idle_seconds
+// from when they first went quiet, flipping idle=true once past the threshold.
+func (t *FootprintIdleTracker) Observe(name string, fp *ServiceFootprint) IdleState {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	now := t.now()
+	if footprintActive(fp) {
+		delete(t.inactiveSince, name)
+		return IdleState{Idle: false, IdleSeconds: 0}
+	}
+
+	since, ok := t.inactiveSince[name]
+	if !ok {
+		t.inactiveSince[name] = now
+		return IdleState{Idle: false, IdleSeconds: 0}
+	}
+	idleFor := now.Sub(since)
+	return IdleState{
+		Idle:        idleFor >= t.threshold,
+		IdleSeconds: int64(idleFor.Seconds()),
+	}
+}
+
+// FormatIdleLabel renders a compact usage label for the TUI from an idle state:
+// "busy" when active, "idle <duration>" when idle. Empty when the state is nil.
+func FormatIdleLabel(idle *IdleState) string {
+	if idle == nil {
+		return ""
+	}
+	if !idle.Idle {
+		return "busy"
+	}
+	return "idle " + formatIdleDuration(idle.IdleSeconds)
+}
+
+// formatIdleDuration renders an idle duration compactly: "38m", "2h", "45s".
+func formatIdleDuration(seconds int64) string {
+	switch {
+	case seconds >= 3600:
+		return fmt.Sprintf("%dh", seconds/3600)
+	case seconds >= 60:
+		return fmt.Sprintf("%dm", seconds/60)
+	default:
+		return fmt.Sprintf("%ds", seconds)
+	}
+}
+
+// serviceContainerNames returns the candidate container names to probe for a
+// managed service by its logical name. Managed engines/services deploy as
+// "citadel-<name>" (compose path) but a manifest service may also run under its
+// bare name, so both are tried; the first one that appears in the stats output
+// wins.
+func serviceContainerNames(name string) []string {
+	return []string{"citadel-" + name, name}
+}
+
+// attachFootprints attaches a live resource footprint to every running managed
+// service and app in the status, using a single batched collection. It maps
+// each running service/app to its container name(s), collects footprints once,
+// and writes the result back. Stopped services/apps are skipped (no container
+// to stat).
+func (c *Collector) attachFootprints(status *NodeStatus) {
+	// Map candidate container name -> back-reference so we can attach the result.
+	type ref struct {
+		svcIdx int // index into status.Services, or -1
+		appIdx int // index into status.Apps, or -1
+	}
+	refs := map[string]ref{}
+	var names []string
+	addName := func(cn string, r ref) {
+		if _, exists := refs[cn]; exists {
+			return
+		}
+		refs[cn] = r
+		names = append(names, cn)
+	}
+
+	for i := range status.Services {
+		if status.Services[i].Status != ServiceStatusRunning {
+			continue
+		}
+		for _, cn := range serviceContainerNames(status.Services[i].Name) {
+			addName(cn, ref{svcIdx: i, appIdx: -1})
+		}
+	}
+	for i := range status.Apps {
+		if status.Apps[i].Status != "running" {
+			continue
+		}
+		addName(apps.ContainerName(status.Apps[i].Name), ref{svcIdx: -1, appIdx: i})
+	}
+
+	if len(names) == 0 {
+		return
+	}
+
+	// Bound the stats/nvidia-smi execs: under the exact overload this feature
+	// targets (the #421 incident hit load average 585), `docker stats` and
+	// `nvidia-smi` can hang for many seconds. Since this runs inside Collect()
+	// on the heartbeat path, an unbounded wait would stall the heartbeat during
+	// overload — precisely when it's most needed. Degrade to "unknown" instead.
+	ctx, cancel := context.WithTimeout(context.Background(), footprintCollectTimeout)
+	defer cancel()
+	footprints := CollectFootprints(ctx, names)
+	for cn, fp := range footprints {
+		r, ok := refs[cn]
+		if !ok {
+			continue
+		}
+		// Only attach a footprint that actually resolved to a container: a bare
+		// name that produced no stats row leaves CPU=-1/RAM=0, which we skip so
+		// the "citadel-<name>" variant (or nothing) wins.
+		if fp.CPUPercent < 0 && fp.RAMBytes == 0 && fp.VRAMBytes == 0 {
+			continue
+		}
+		fpCopy := fp
+		if r.svcIdx >= 0 {
+			status.Services[r.svcIdx].Footprint = &fpCopy
+			c.attachDerivedIdle(cn, &fpCopy, &status.Services[r.svcIdx].IdleState)
+		} else if r.appIdx >= 0 {
+			status.Apps[r.appIdx].Footprint = &fpCopy
+			c.attachDerivedIdle(cn, &fpCopy, &status.Apps[r.appIdx].IdleState)
+		}
+	}
+}
+
+// attachDerivedIdle fills in a footprint-derived idle signal when the
+// metrics-based path (#420) left one absent. This is what surfaces idleness for
+// engines with no scrapeable request counters (diffusers, ollama) — the exact
+// #421 blind spot. When #420 already attached an IdleState (e.g. for vLLM), it
+// is authoritative and left untouched. The tracker is always fed so its
+// per-container idle clock stays warm regardless of which signal wins.
+func (c *Collector) attachDerivedIdle(containerName string, fp *ServiceFootprint, dst **IdleState) {
+	if c.fpIdleTracker == nil {
+		return
+	}
+	derived := c.fpIdleTracker.Observe(containerName, fp)
+	if *dst != nil {
+		return // metrics-based idle signal is authoritative
+	}
+	d := derived
+	*dst = &d
+}
+
+// FormatFootprint renders a one-line footprint summary for the TUI, e.g.
+// "RAM 6.1G   VRAM 21.0G   GPU 74%". VRAM/GPU degrade to "n/a" when the node has
+// no GPU. RAM is always shown (from container stats).
+func FormatFootprint(fp *ServiceFootprint) string {
+	if fp == nil {
+		return ""
+	}
+	ram := FormatBytesGB(fp.RAMBytes)
+	if fp.HasGPU {
+		gpu := "n/a"
+		if fp.GPUUtilPercent >= 0 {
+			gpu = fmt.Sprintf("%.0f%%", fp.GPUUtilPercent)
+		}
+		return fmt.Sprintf("RAM %s  VRAM %s  GPU %s", ram, FormatBytesGB(fp.VRAMBytes), gpu)
+	}
+	return fmt.Sprintf("RAM %s  VRAM n/a  GPU n/a", ram)
+}

--- a/internal/status/footprint_test.go
+++ b/internal/status/footprint_test.go
@@ -1,0 +1,446 @@
+package status
+
+import (
+	"testing"
+	"time"
+)
+
+// gib is a non-constant GiB multiplier so fractional byte literals (e.g.
+// uint64(6.1*gib)) compile — a constant float with a fractional value cannot be
+// converted to uint64 in a constant expression.
+var gib = float64(1 << 30)
+
+func TestParseComputeApps(t *testing.T) {
+	// nvidia-smi --query-compute-apps=pid,used_memory --format=csv,noheader,nounits
+	// used_memory is in MiB.
+	out := `12345, 21504
+12346, 512
+67890, 0
+`
+	got := parseComputeApps(out)
+
+	if len(got) != 3 {
+		t.Fatalf("expected 3 pids, got %d: %v", len(got), got)
+	}
+	if want := uint64(21504) * (1 << 20); got[12345] != want {
+		t.Errorf("pid 12345 vram = %d, want %d", got[12345], want)
+	}
+	if want := uint64(512) * (1 << 20); got[12346] != want {
+		t.Errorf("pid 12346 vram = %d, want %d", got[12346], want)
+	}
+	if got[67890] != 0 {
+		t.Errorf("pid 67890 vram = %d, want 0", got[67890])
+	}
+}
+
+func TestParseComputeApps_MultiGPUSamePIDSums(t *testing.T) {
+	// A process spanning two GPUs appears on two rows; VRAM must sum.
+	out := "999, 1024\n999, 2048\n"
+	got := parseComputeApps(out)
+	want := uint64(1024+2048) * (1 << 20)
+	if got[999] != want {
+		t.Errorf("pid 999 vram = %d, want %d (summed across GPUs)", got[999], want)
+	}
+}
+
+func TestParseComputeApps_SkipsGarbage(t *testing.T) {
+	out := "notapid, 1024\n42, notanumber\n\n7, 8\n"
+	got := parseComputeApps(out)
+	if len(got) != 1 {
+		t.Fatalf("expected only the valid row, got %v", got)
+	}
+	if got[7] != uint64(8)*(1<<20) {
+		t.Errorf("pid 7 vram = %d, want %d", got[7], uint64(8)*(1<<20))
+	}
+}
+
+func TestParseGPUUtil(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want float64
+	}{
+		{"single", "74\n", 74},
+		{"max across gpus", "10\n74\n33\n", 74},
+		{"empty is unknown", "", -1},
+		{"garbage is unknown", "n/a\n--\n", -1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := parseGPUUtil(c.in); got != c.want {
+				t.Errorf("parseGPUUtil(%q) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestParseStatsOutput(t *testing.T) {
+	// "{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}"
+	out := "citadel-vllm\t74.31%\t6.1GiB / 62.0GiB\n" +
+		"citadel-diffusers\t0.02%\t7.4GiB / 62.0GiB\n"
+	got := parseStatsOutput(out)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 containers, got %d: %v", len(got), got)
+	}
+	vllm := got["citadel-vllm"]
+	if vllm.cpuPercent != 74.31 {
+		t.Errorf("vllm cpu = %v, want 74.31", vllm.cpuPercent)
+	}
+	// 6.1 GiB
+	if wantMin, wantMax := uint64(6.0*gib), uint64(6.2*gib); vllm.ramBytes < wantMin || vllm.ramBytes > wantMax {
+		t.Errorf("vllm ram = %d bytes, want ~6.1GiB", vllm.ramBytes)
+	}
+	diff := got["citadel-diffusers"]
+	if diff.cpuPercent != 0.02 {
+		t.Errorf("diffusers cpu = %v, want 0.02", diff.cpuPercent)
+	}
+}
+
+func TestParseStatsOutput_SkipsHeaderAndBlank(t *testing.T) {
+	out := "NAME\tCPU %\tMEM USAGE / LIMIT\n\ncitadel-vllm\t5.0%\t1.0GiB / 2.0GiB\n"
+	got := parseStatsOutput(out)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 real row, got %v", got)
+	}
+	if _, ok := got["citadel-vllm"]; !ok {
+		t.Errorf("missing citadel-vllm: %v", got)
+	}
+}
+
+func TestParseMemBytes(t *testing.T) {
+	cases := []struct {
+		in   string
+		want uint64
+	}{
+		{"0B", 0},
+		{"512MiB", 512 << 20},
+		{"6.1GiB", uint64(6.1 * gib)},
+		{"1.5GB", uint64(1.5 * 1e9)},
+		{"2kB", 2000},
+		{"1KiB", 1024},
+		{"", 0},
+		{"garbage", 0},
+	}
+	for _, c := range cases {
+		if got := parseMemBytes(c.in); got != c.want {
+			t.Errorf("parseMemBytes(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParsePercent(t *testing.T) {
+	cases := []struct {
+		in   string
+		want float64
+	}{
+		{"74.31%", 74.31},
+		{"0.00%", 0},
+		{"100", 100},
+		{"--", -1},
+		{"", -1},
+		{"n/a", -1},
+	}
+	for _, c := range cases {
+		if got := parsePercent(c.in); got != c.want {
+			t.Errorf("parsePercent(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestAttributeVRAM_MatchesSubtreeOnly(t *testing.T) {
+	// nvidia-smi reports host PIDs; the GPU worker is a child of the container
+	// main PID, so attribution must sum over the whole subtree, not just PID 1.
+	pidVRAM := map[int]uint64{
+		1000: 1 << 30,  // container main pid — no GPU work itself
+		1001: 20 << 30, // GPU worker child — the real VRAM holder
+		9999: 4 << 30,  // unrelated process on the host — must NOT be counted
+	}
+	subtree := map[int]struct{}{1000: {}, 1001: {}}
+
+	got := attributeVRAM(pidVRAM, subtree)
+	want := uint64(1<<30) + uint64(20<<30)
+	if got != want {
+		t.Errorf("attributeVRAM = %d, want %d (subtree only, unrelated pid excluded)", got, want)
+	}
+}
+
+func TestIsHeavyAndIdle(t *testing.T) {
+	idleState := &IdleState{Idle: true, IdleSeconds: 2280}
+	busyState := &IdleState{Idle: false}
+
+	cases := []struct {
+		name string
+		fp   *ServiceFootprint
+		idle *IdleState
+		want bool
+	}{
+		{
+			name: "heavy RAM and idle -> warn (the #421 diffusers case)",
+			fp:   &ServiceFootprint{RAMBytes: 7 << 30},
+			idle: idleState,
+			want: true,
+		},
+		{
+			name: "heavy VRAM and idle -> warn",
+			fp:   &ServiceFootprint{RAMBytes: 100 << 20, VRAMBytes: 21 << 30, HasGPU: true},
+			idle: idleState,
+			want: true,
+		},
+		{
+			name: "heavy but busy -> no warn",
+			fp:   &ServiceFootprint{RAMBytes: 7 << 30},
+			idle: busyState,
+			want: false,
+		},
+		{
+			name: "idle but light -> no warn",
+			fp:   &ServiceFootprint{RAMBytes: 100 << 20, VRAMBytes: 0},
+			idle: idleState,
+			want: false,
+		},
+		{
+			name: "nil idle -> no warn",
+			fp:   &ServiceFootprint{RAMBytes: 7 << 30},
+			idle: nil,
+			want: false,
+		},
+		{
+			name: "nil footprint -> no warn",
+			fp:   nil,
+			idle: idleState,
+			want: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := IsHeavyAndIdle(c.fp, c.idle); got != c.want {
+				t.Errorf("IsHeavyAndIdle = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestFormatBytesGB(t *testing.T) {
+	cases := []struct {
+		in   uint64
+		want string
+	}{
+		{0, "0.0G"},
+		{uint64(6.1 * gib), "6.1G"},
+		{21 * (1 << 30), "21.0G"},
+	}
+	for _, c := range cases {
+		if got := FormatBytesGB(c.in); got != c.want {
+			t.Errorf("FormatBytesGB(%d) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestFormatFootprint(t *testing.T) {
+	gpu := &ServiceFootprint{RAMBytes: uint64(6.1 * gib), VRAMBytes: 21 * (1 << 30), GPUUtilPercent: 74, HasGPU: true}
+	if got := FormatFootprint(gpu); got != "RAM 6.1G  VRAM 21.0G  GPU 74%" {
+		t.Errorf("gpu footprint = %q", got)
+	}
+
+	noGPU := &ServiceFootprint{RAMBytes: 2 * (1 << 30), HasGPU: false}
+	if got := FormatFootprint(noGPU); got != "RAM 2.0G  VRAM n/a  GPU n/a" {
+		t.Errorf("no-gpu footprint = %q", got)
+	}
+
+	unknownUtil := &ServiceFootprint{RAMBytes: 1 << 30, VRAMBytes: 0, GPUUtilPercent: -1, HasGPU: true}
+	if got := FormatFootprint(unknownUtil); got != "RAM 1.0G  VRAM 0.0G  GPU n/a" {
+		t.Errorf("unknown-util footprint = %q", got)
+	}
+
+	if got := FormatFootprint(nil); got != "" {
+		t.Errorf("nil footprint = %q, want empty", got)
+	}
+}
+
+func TestFootprintActive(t *testing.T) {
+	cases := []struct {
+		name string
+		fp   *ServiceFootprint
+		want bool
+	}{
+		{"busy cpu", &ServiceFootprint{CPUPercent: 50}, true},
+		{"quiet cpu no gpu", &ServiceFootprint{CPUPercent: 0.5, HasGPU: false}, false},
+		{"quiet cpu busy gpu", &ServiceFootprint{CPUPercent: 0.5, GPUUtilPercent: 80, HasGPU: true}, true},
+		{"quiet cpu idle gpu (diffusers)", &ServiceFootprint{CPUPercent: 0.02, GPUUtilPercent: 0, HasGPU: true}, false},
+		{"unknown cpu no gpu", &ServiceFootprint{CPUPercent: -1, HasGPU: false}, false},
+		{"nil", nil, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := footprintActive(c.fp); got != c.want {
+				t.Errorf("footprintActive = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestFootprintIdleTracker_AccumulatesAndFlips(t *testing.T) {
+	tr := NewFootprintIdleTracker()
+	now := time.Unix(1_700_000_000, 0)
+	tr.now = func() time.Time { return now }
+
+	idleFP := &ServiceFootprint{CPUPercent: 0.02, GPUUtilPercent: 0, HasGPU: true}
+
+	// First observation: goes inactive, but not yet idle (clock just started).
+	s := tr.Observe("citadel-diffusers", idleFP)
+	if s.Idle {
+		t.Fatalf("first inactive observe should not be idle yet: %+v", s)
+	}
+
+	// 30s later: still under the 60s threshold.
+	now = now.Add(30 * time.Second)
+	s = tr.Observe("citadel-diffusers", idleFP)
+	if s.Idle {
+		t.Fatalf("30s inactive should not be idle yet: %+v", s)
+	}
+
+	// 40s more (70s total): crosses the threshold.
+	now = now.Add(40 * time.Second)
+	s = tr.Observe("citadel-diffusers", idleFP)
+	if !s.Idle {
+		t.Fatalf("70s inactive should be idle: %+v", s)
+	}
+	if s.IdleSeconds < 70 {
+		t.Errorf("idle_seconds = %d, want >= 70", s.IdleSeconds)
+	}
+}
+
+func TestFootprintIdleTracker_ActivityResets(t *testing.T) {
+	tr := NewFootprintIdleTracker()
+	now := time.Unix(1_700_000_000, 0)
+	tr.now = func() time.Time { return now }
+
+	idleFP := &ServiceFootprint{CPUPercent: 0.02, HasGPU: false}
+	busyFP := &ServiceFootprint{CPUPercent: 90, HasGPU: false}
+
+	tr.Observe("svc", idleFP)
+	now = now.Add(120 * time.Second)
+	if s := tr.Observe("svc", idleFP); !s.Idle {
+		t.Fatalf("should be idle after 120s: %+v", s)
+	}
+
+	// A burst of activity resets the clock.
+	if s := tr.Observe("svc", busyFP); s.Idle || s.IdleSeconds != 0 {
+		t.Fatalf("activity should reset idle: %+v", s)
+	}
+
+	// Going quiet again starts a fresh clock, not idle immediately.
+	now = now.Add(10 * time.Second)
+	if s := tr.Observe("svc", idleFP); s.Idle {
+		t.Fatalf("fresh quiet period should not be immediately idle: %+v", s)
+	}
+}
+
+func TestFormatIdleLabel(t *testing.T) {
+	cases := []struct {
+		name string
+		in   *IdleState
+		want string
+	}{
+		{"busy", &IdleState{Idle: false}, "busy"},
+		{"idle minutes", &IdleState{Idle: true, IdleSeconds: 2280}, "idle 38m"},
+		{"idle hours", &IdleState{Idle: true, IdleSeconds: 7200}, "idle 2h"},
+		{"idle seconds", &IdleState{Idle: true, IdleSeconds: 45}, "idle 45s"},
+		{"nil", nil, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := FormatIdleLabel(c.in); got != c.want {
+				t.Errorf("FormatIdleLabel = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestReadPPID_ParsesCommWithSpacesAndParens(t *testing.T) {
+	// readPPID must key off the last ')' because comm can contain spaces/parens.
+	// We can't easily write /proc, so exercise the parsing indirectly by
+	// confirming the current process resolves to a plausible parent.
+	pid := 1 // init always exists on Linux
+	if ppid, ok := readPPID(pid); ok {
+		if ppid < 0 {
+			t.Errorf("ppid of pid 1 = %d, want >= 0", ppid)
+		}
+	}
+	// A definitely-absent pid returns not-ok, never panics.
+	if _, ok := readPPID(2_000_000_000); ok {
+		t.Errorf("absent pid should return ok=false")
+	}
+}
+
+func TestCollectFootprints_EmptyNames(t *testing.T) {
+	got := CollectFootprints(nil, nil)
+	if len(got) != 0 {
+		t.Errorf("expected empty map for no names, got %v", got)
+	}
+}
+
+// TestStatsFilterByCandidateName is the regression test for the batch-poisoning
+// bug: `docker stats` is run over ALL running containers (no name args), and
+// the caller filters by candidate name. A candidate that names a nonexistent
+// container (the bare "diffusers" when only "citadel-diffusers" runs) must NOT
+// prevent the real container's RAM from being found — which is exactly what
+// would happen if the missing name were passed to `docker stats`.
+func TestStatsFilterByCandidateName(t *testing.T) {
+	// stats output lists all running containers; the bare "diffusers" is absent.
+	out := "citadel-diffusers\t0.02%\t7.4GiB / 62.0GiB\n" +
+		"some-unrelated-db\t3.0%\t128MiB / 62.0GiB\n"
+	stats := parseStatsOutput(out)
+
+	// Candidate names for the diffusers service, mirroring serviceContainerNames.
+	candidates := []string{"citadel-diffusers", "diffusers"}
+	var found containerStats
+	var ok bool
+	for _, cn := range candidates {
+		if s, present := stats[cn]; present {
+			found, ok = s, true
+			break
+		}
+	}
+	if !ok {
+		t.Fatal("expected to resolve diffusers via citadel-diffusers despite bare name being absent")
+	}
+	// The 7.4 GiB RSS — the exact #421 incident value — must be recoverable so
+	// IsHeavyAndIdle can fire on the RAM path.
+	if found.ramBytes < uint64(7.0*gib) {
+		t.Errorf("diffusers ram = %d, want >= 7GiB", found.ramBytes)
+	}
+	fp := &ServiceFootprint{RAMBytes: found.ramBytes}
+	if !IsHeavyAndIdle(fp, &IdleState{Idle: true, IdleSeconds: 2280}) {
+		t.Error("7.4GiB idle diffusers should be flagged heavy-and-idle")
+	}
+}
+
+func TestPidSubtree_WalksChildren(t *testing.T) {
+	// Synthetic /proc adjacency: 1000 -> 1001 -> 1002, plus an unrelated 2000.
+	children := map[int][]int{
+		1000: {1001},
+		1001: {1002},
+		2000: {2001},
+	}
+	got := pidSubtree(1000, children)
+	for _, pid := range []int{1000, 1001, 1002} {
+		if _, ok := got[pid]; !ok {
+			t.Errorf("subtree missing pid %d: %v", pid, got)
+		}
+	}
+	if _, ok := got[2000]; ok {
+		t.Errorf("subtree should not include unrelated pid 2000: %v", got)
+	}
+}
+
+func TestPidSubtree_NoProcFallsBackToRoot(t *testing.T) {
+	got := pidSubtree(42, nil)
+	if len(got) != 1 {
+		t.Fatalf("expected just {root}, got %v", got)
+	}
+	if _, ok := got[42]; !ok {
+		t.Errorf("subtree should contain root pid 42: %v", got)
+	}
+}

--- a/internal/status/types.go
+++ b/internal/status/types.go
@@ -46,6 +46,12 @@ type AppInfo struct {
 	// GPU memory). Populated only for running inference apps whose metrics
 	// endpoint could be scraped; omitted otherwise. See IdleState.
 	*IdleState
+
+	// Footprint is the live resource footprint (CPU/RAM/VRAM/GPU) of the app's
+	// container, populated for running managed apps (citadel #421). Omitted for
+	// stopped apps or when stats could not be read. Rides the heartbeat so the
+	// platform can spot idle GPU hogs.
+	Footprint *ServiceFootprint `json:"footprint,omitempty"`
 }
 
 // NodeCapabilities describes the GPU and inference engine capabilities of a node.
@@ -161,6 +167,12 @@ type ServiceInfo struct {
 	// scraped; omitted otherwise. Promotes idle/idle_seconds/last_request_at
 	// to the top level of the JSON object. See IdleState.
 	*IdleState
+
+	// Footprint is the live resource footprint (CPU/RAM/VRAM/GPU) of the
+	// service's container, populated for running managed services (citadel
+	// #421). Omitted when stats could not be read. Rides the heartbeat so the
+	// platform can spot a heavy-and-idle eviction candidate.
+	Footprint *ServiceFootprint `json:"footprint,omitempty"`
 }
 
 // HealthResponse is the response for /health endpoint.

--- a/internal/tui/controlcenter/controlcenter.go
+++ b/internal/tui/controlcenter/controlcenter.go
@@ -96,6 +96,11 @@ type StatusData struct {
 	// Services
 	Services []ServiceInfo
 
+	// ManagedSummary is a one-line footprint roll-up for citadel-managed
+	// services, e.g. "managed: RAM 13G/62G · VRAM 21G/24G" (citadel #421).
+	// Empty when no managed service is running.
+	ManagedSummary string
+
 	// Peers
 	Peers []PeerInfo
 
@@ -124,6 +129,15 @@ type ServiceInfo struct {
 	Name   string
 	Status string // "running", "stopped", "error"
 	Uptime string
+
+	// Live resource footprint for a running managed service (citadel #421).
+	// Footprint is a compact pre-formatted string like "RAM 6.1G  VRAM 21.0G
+	// GPU 74%" (empty when unavailable). IdleLabel is a short usage label like
+	// "busy" or "idle 38m" (empty when no idle signal). HeavyAndIdle marks the
+	// eviction candidate (heavy + idle) so the row can be highlighted.
+	Footprint    string
+	IdleLabel    string
+	HeavyAndIdle bool
 }
 
 // ServiceDetailInfo holds detailed service information for the modal
@@ -2015,12 +2029,18 @@ func (cc *ControlCenter) updateServicesView() {
 	cc.servicesView.Clear()
 
 	// Header
-	headers := []string{"SERVICE", "STATUS", "UPTIME"}
+	headers := []string{"SERVICE", "STATUS", "FOOTPRINT", "USAGE", "UPTIME"}
 	for i, h := range headers {
 		cell := tview.NewTableCell("[yellow::b]" + h + "[-:-:-]").
 			SetSelectable(false).
 			SetAlign(tview.AlignLeft)
 		cc.servicesView.SetCell(0, i, cell)
+	}
+
+	// One-line managed footprint roll-up above the rows (citadel #421).
+	if cc.data.ManagedSummary != "" {
+		cc.servicesView.SetCell(0, len(headers), tview.NewTableCell(
+			"[gray]"+cc.data.ManagedSummary+"[-]").SetSelectable(false))
 	}
 
 	row := 1
@@ -2076,12 +2096,39 @@ func (cc *ControlCenter) updateServicesView() {
 
 		cc.servicesView.SetCell(row, 1, tview.NewTableCell(statusCell).SetSelectable(true))
 
+		// Footprint (RAM/VRAM/GPU) — highlight in red when heavy AND idle, the
+		// eviction candidate the #421 incident would have surfaced.
+		footprint := svc.Footprint
+		if footprint == "" {
+			footprint = "-"
+		}
+		footprintColor := "gray"
+		if svc.HeavyAndIdle {
+			footprintColor = "red::b"
+		}
+		cc.servicesView.SetCell(row, 2, tview.NewTableCell(
+			"["+footprintColor+"]"+footprint+"[-:-:-]").SetSelectable(true))
+
+		// Usage label (busy / idle 38m). Heavy-and-idle rows show it in red too.
+		usage := svc.IdleLabel
+		if usage == "" {
+			usage = "-"
+		}
+		usageColor := "gray"
+		if svc.HeavyAndIdle {
+			usageColor = "red::b"
+		} else if strings.HasPrefix(usage, "idle") {
+			usageColor = "yellow"
+		}
+		cc.servicesView.SetCell(row, 3, tview.NewTableCell(
+			"["+usageColor+"]"+usage+"[-:-:-]").SetSelectable(true))
+
 		// Uptime
 		uptime := svc.Uptime
 		if uptime == "" {
 			uptime = "-"
 		}
-		cc.servicesView.SetCell(row, 2, tview.NewTableCell("[gray]"+uptime+"[-]").SetSelectable(true))
+		cc.servicesView.SetCell(row, 4, tview.NewTableCell("[gray]"+uptime+"[-]").SetSelectable(true))
 		row++
 	}
 
@@ -2089,8 +2136,9 @@ func (cc *ControlCenter) updateServicesView() {
 	if len(cc.activeForwards) > 0 {
 		// Separator
 		cc.servicesView.SetCell(row, 0, tview.NewTableCell("[yellow::b]─── EXPOSED ───[-:-:-]").SetSelectable(false))
-		cc.servicesView.SetCell(row, 1, tview.NewTableCell("").SetSelectable(false))
-		cc.servicesView.SetCell(row, 2, tview.NewTableCell("").SetSelectable(false))
+		for col := 1; col <= 4; col++ {
+			cc.servicesView.SetCell(row, col, tview.NewTableCell("").SetSelectable(false))
+		}
 		row++
 
 		for _, fwd := range cc.activeForwards {
@@ -2100,7 +2148,9 @@ func (cc *ControlCenter) updateServicesView() {
 			}
 			cc.servicesView.SetCell(row, 0, tview.NewTableCell(fmt.Sprintf(" :%d", fwd.LocalPort)).SetSelectable(true))
 			cc.servicesView.SetCell(row, 1, tview.NewTableCell("[cyan]● exposed[-]").SetSelectable(true))
-			cc.servicesView.SetCell(row, 2, tview.NewTableCell("[gray]"+desc+"[-]").SetSelectable(true))
+			cc.servicesView.SetCell(row, 2, tview.NewTableCell("").SetSelectable(true))
+			cc.servicesView.SetCell(row, 3, tview.NewTableCell("").SetSelectable(true))
+			cc.servicesView.SetCell(row, 4, tview.NewTableCell("[gray]"+desc+"[-]").SetSelectable(true))
 			row++
 		}
 	}

--- a/internal/tui/controlcenter/controlcenter_test.go
+++ b/internal/tui/controlcenter/controlcenter_test.go
@@ -1,6 +1,7 @@
 package controlcenter
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -367,6 +368,70 @@ func TestServiceInfo(t *testing.T) {
 	}
 	if svc.Uptime != "2h30m" {
 		t.Errorf("ServiceInfo.Uptime = %s, want 2h30m", svc.Uptime)
+	}
+}
+
+// TestUpdateServicesViewRendersFootprint verifies the services panel renders
+// the per-service footprint + usage columns and highlights a heavy-and-idle
+// service (the #421 eviction candidate) in red.
+func TestUpdateServicesViewRendersFootprint(t *testing.T) {
+	cc := New(Config{Version: "1.0.0"})
+	// updateServicesView reads/writes cc.servicesView; the table is normally
+	// created during UI setup, which we don't run headless.
+	cc.servicesView = tview.NewTable().SetSelectable(true, false).SetFixed(1, 0)
+	cc.data = StatusData{
+		ManagedSummary: "managed: RAM 13G/62G · VRAM 21G/24G",
+		Services: []ServiceInfo{
+			{
+				Name:      "vllm",
+				Status:    "running",
+				Uptime:    "2h",
+				Footprint: "RAM 6.1G  VRAM 21.0G  GPU 74%",
+				IdleLabel: "busy",
+			},
+			{
+				Name:         "diffusers",
+				Status:       "running",
+				Uptime:       "1h",
+				Footprint:    "RAM 7.4G  VRAM 0.0G  GPU 0%",
+				IdleLabel:    "idle 38m",
+				HeavyAndIdle: true,
+			},
+		},
+	}
+
+	cc.updateServicesView()
+
+	// Header now has FOOTPRINT and USAGE columns.
+	if got := cc.servicesView.GetCell(0, 2).Text; !strings.Contains(got, "FOOTPRINT") {
+		t.Errorf("col 2 header = %q, want FOOTPRINT", got)
+	}
+	if got := cc.servicesView.GetCell(0, 3).Text; !strings.Contains(got, "USAGE") {
+		t.Errorf("col 3 header = %q, want USAGE", got)
+	}
+
+	// Row 1 = vllm: busy, gray footprint (no red highlight).
+	vllmFootprint := cc.servicesView.GetCell(1, 2).Text
+	if !strings.Contains(vllmFootprint, "VRAM 21.0G") {
+		t.Errorf("vllm footprint cell = %q", vllmFootprint)
+	}
+	if strings.Contains(vllmFootprint, "red") {
+		t.Errorf("busy vllm should not be red-highlighted: %q", vllmFootprint)
+	}
+
+	// Row 2 = diffusers: heavy AND idle -> red highlight on both footprint and usage.
+	diffFootprint := cc.servicesView.GetCell(2, 2).Text
+	if !strings.Contains(diffFootprint, "red") {
+		t.Errorf("heavy-and-idle diffusers footprint should be red: %q", diffFootprint)
+	}
+	diffUsage := cc.servicesView.GetCell(2, 3).Text
+	if !strings.Contains(diffUsage, "idle 38m") || !strings.Contains(diffUsage, "red") {
+		t.Errorf("heavy-and-idle diffusers usage cell = %q, want red 'idle 38m'", diffUsage)
+	}
+
+	// Uptime moved to column 4.
+	if got := cc.servicesView.GetCell(1, 4).Text; !strings.Contains(got, "2h") {
+		t.Errorf("vllm uptime cell (col 4) = %q, want 2h", got)
 	}
 }
 


### PR DESCRIPTION
## Context

A leftover **diffusers** container held ~**7.4 GB RAM** while completely idle and drove the node to **load average 585** before a human noticed. The Control Center showed it as a bare `● running` — no footprint, no idle signal — so nothing pointed at the obvious eviction candidate. This makes the managed-service view **resource-aware**: for every citadel-managed serving container we now collect its live CPU/RAM/VRAM/GPU footprint, combine it with the idle signal, and highlight the one that's **heavy AND idle**.

```
SERVICE     STATUS       FOOTPRINT                     USAGE      managed: RAM 13G/62G · VRAM 21G/24G
vllm        ● running    RAM 6.1G  VRAM 21.0G  GPU 74%  busy
diffusers   ● running    RAM 7.4G  VRAM 0.0G   GPU 0%   idle 38m   <- highlighted red
```

## Summary

**Node-side collection (`internal/status/footprint.go`)**
- `ServiceFootprint {CPUPercent, RAMBytes, VRAMBytes, GPUUtilPercent, HasGPU}` added to `status.ServiceInfo` and `status.AppInfo`, so it **rides the heartbeat** (mirrors how #420 added its idle fields) and the platform can spot idle GPU hogs.
- `CollectFootprints` is **batched**: one `<engine> stats --no-stream` (CPU% + RAM for all containers) + one `nvidia-smi --query-compute-apps` + one `--query-gpu=utilization.gpu` per refresh. Never one exec per service.
- **Runtime-agnostic**: uses `catalog.SelectContainerRuntime().EngineBin` (docker OR podman), inherited from the #348 start path — not hardcoded docker.
- **VRAM attribution**: `nvidia-smi` reports *host* PIDs and the GPU worker is typically a **child** of the container's main PID (not PID 1). We resolve the container main PID via `inspect {{.State.Pid}}`, walk its full `/proc` PPID subtree, and sum VRAM over any compute-app PID in that set. The `/proc` parent→children map is built **once** per refresh, not per container.
- **Graceful degradation**: VRAM/GPU render `n/a` with no GPU / `nvidia-smi` absent; a `5s` exec timeout bounds the stats/nvidia-smi calls so a hung runtime under overload (the exact #421 condition) can't stall the heartbeat.
- **`FootprintIdleTracker`** derives idle purely from CPU + GPU utilization for engines #420's metrics-based tracker can't scrape (diffusers, ollama, llama.cpp). This is **complementary** to #420 — vLLM's request-counter idle stays authoritative — and is what makes the heavy-and-idle warning fire for the diffusers case that motivated this. Long-lived so `idle_seconds` accumulates across refreshes.
- **`IsHeavyAndIdle`** predicate: idle AND (RAM ≥ 4 GiB OR VRAM ≥ 2 GiB).

**TUI (`internal/tui/controlcenter/`, `cmd/controlcenter.go`)**
- Adds **FOOTPRINT** and **USAGE** columns to the services panel; heavy-and-idle rows render footprint + usage in **red**.
- One-line managed roll-up above the rows: `managed: RAM 13G/62G · VRAM 21G/24G`.
- `gatherControlCenterData` enriches running services via one batched `CollectFootprints` call; a **package-level singleton** `FootprintIdleTracker` accumulates idle across the 30s refreshes (a per-refresh tracker would never cross the threshold).

## Test plan

| Group | Coverage |
|-------|----------|
| nvidia-smi compute-apps parse | pid→VRAM map, multi-GPU same-pid sums, garbage rows skipped |
| GPU util parse | max across GPUs, empty/garbage → unknown (-1) |
| docker/podman stats parse | tab-split, MemUsage used-side, header/blank skip |
| mem/percent parse | GiB/MiB/GB/kB units, `--`/empty → unknown |
| VRAM attribution | subtree-only sum, unrelated host PID excluded |
| PID subtree | child walk, unrelated branch excluded, no-`/proc` → {root} |
| heavy-and-idle predicate | heavy RAM/VRAM + idle → warn; busy/light/nil → no warn |
| **batch-poison regression** | stats over all containers + candidate-name filter recovers the 7.4 GiB diffusers RSS even when the bare-name candidate is absent |
| footprint-derived idle tracker | accumulates, flips past threshold, activity resets |
| formatting | bytes→G, footprint line, idle label (busy / idle 38m/2h/45s) |
| TUI render | FOOTPRINT/USAGE columns present, heavy-and-idle row red, uptime moved to col 4 |

`gofmt -w .`, `go build ./...`, `go vet ./...`, `go test ./internal/status/... ./internal/tui/...` all green.

**Live-verified on a real GPU node**: `CollectFootprints` against running `citadel-vllm` returned **RAM 3.6G / VRAM 20.8G** (the 21274 MiB compute-app PID correctly attributed via the subtree walk), and `citadel-llamacpp` correctly showed 0 VRAM. Confirmed the `docker stats` template and `nvidia-smi` CSV formats match the parsers exactly.

## Related

- **#420** (idle detection) — reused its `IdleState` + `collectManagedEngineStatus`; this rebased on top of #420 already landed in `main`.
- **#422** (footprint logging) — separate agent, owns historical CSV/DuckDB persistence. **No overlap**: this PR owns live collection (`CollectFootprints`) + TUI; #422 can persist the same `ServiceFootprint` values from the heartbeat.
- aceteam **#4472** — heartbeat idle telemetry consumer.

Closes #421
