### PR TITLE
fix(services): re-materialize citadel-owned composes on version change (#426)

### DIFF
--- a/cmd/compose_refresh.go
+++ b/cmd/compose_refresh.go
@@ -10,18 +10,25 @@
 // that were provisioned by an older binary and would otherwise keep stale,
 // hardcoded-port composes forever.
 //
-// Recreate-on-boot policy (see PR for rationale): the default is conservative --
-// refresh the FILE only and log a hint telling the operator to restart affected
-// services. Force-recreating a live container on boot interrupts inference
-// (e.g. a vLLM model reload), so auto-recreate is opt-in via
-// CITADEL_COMPOSE_RECREATE_ON_UPGRADE=1|true|yes. When enabled, a port-managed
-// service is recreated only if its running published host port actually moved.
+// Recreate-on-boot policy (see PR for rationale): the primary upgrade path is a
+// hands-off auto-update that re-execs the binary in place (syscall.Exec) WITHOUT
+// tearing down service containers, so the prior container keeps running on its
+// old host port and startManagedServices no-ops on it (it's already running).
+// Refreshing only the FILE would therefore never self-heal an auto-updated node
+// -- exactly the population #426 targets. So auto force-recreate on a *port
+// change* is the DEFAULT: it fires only when a managed service is running AND
+// its published host port actually differs from the new template (i.e. the
+// broken/colliding state, not healthy inference). Operators who prefer to move
+// live containers by hand can opt out with
+// CITADEL_COMPOSE_NO_RECREATE_ON_UPGRADE=1|true|yes, which downgrades to
+// file-refresh + a remediation hint.
 package cmd
 
 import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -38,20 +45,21 @@ func refreshManagedComposeFiles(configDir string) {
 	if configDir == "" {
 		return
 	}
-	servicesDir := configDir + "/services"
+	servicesDir := filepath.Join(configDir, "services")
 
 	var recreator composerefresh.PortRecreator
 	if recreateOnUpgradeEnabled() {
-		recreator = dockerPortRecreator
+		recreator = enginePortRecreator
 	}
 
 	res, err := composerefresh.Sweep(composerefresh.Options{
-		ServicesDir: servicesDir,
-		Version:     Version,
-		Embedded:    services.ServiceMap,
-		PortManaged: services.ServiceHostPorts,
-		Recreator:   recreator,
-		Log:         func(format string, args ...any) { Log(format, args...) },
+		ServicesDir:           servicesDir,
+		Version:               Version,
+		Embedded:              services.ServiceMap,
+		PortManaged:           services.ServiceHostPorts,
+		KnownHistoricalHashes: services.KnownComposeHashes,
+		Recreator:             recreator,
+		Log:                   func(format string, args ...any) { Log(format, args...) },
 	})
 	if err != nil {
 		Log("compose-refresh: sweep error: %v", err)
@@ -72,23 +80,26 @@ func refreshManagedComposeFiles(configDir string) {
 	}
 }
 
-// recreateOnUpgradeEnabled reports whether the operator opted into auto
-// force-recreate of a port-moved service on boot. Default is off.
+// recreateOnUpgradeEnabled reports whether boot-time auto force-recreate of a
+// port-moved service is active. It is ON by default because the primary upgrade
+// path (auto-update re-exec) leaves prior containers running on their old host
+// port, so file-refresh alone would never self-heal the collision #426 targets.
+// Operators can opt out with CITADEL_COMPOSE_NO_RECREATE_ON_UPGRADE.
 func recreateOnUpgradeEnabled() bool {
-	switch strings.ToLower(strings.TrimSpace(os.Getenv("CITADEL_COMPOSE_RECREATE_ON_UPGRADE"))) {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("CITADEL_COMPOSE_NO_RECREATE_ON_UPGRADE"))) {
 	case "1", "true", "yes", "on":
-		return true
-	default:
 		return false
+	default:
+		return true
 	}
 }
 
-// dockerPortRecreator inspects the running container's published host port and,
+// enginePortRecreator inspects the running container's published host port and,
 // if it differs from wantHostPort, force-recreates the service from composePath
 // with the citadel host-port env injected. Returns (recreated, err). When the
 // container is not running or already publishes the wanted port, it is left
 // untouched (recreated=false).
-func dockerPortRecreator(service, composePath string, wantHostPort int) (bool, error) {
+func enginePortRecreator(service, composePath string, wantHostPort int) (bool, error) {
 	rt := catalog.SelectContainerRuntime()
 	containerName := "citadel-" + service
 
@@ -107,7 +118,7 @@ func dockerPortRecreator(service, composePath string, wantHostPort int) (bool, e
 	composeArgs = append(composeArgs, "up", "-d", "--force-recreate")
 	args := rt.ComposeArgs(composeArgs...)
 	cmd := exec.Command(rt.Bin, args...)
-	cmd.Env = append(os.Environ(), services.HostPortEnv()...)
+	cmd.Env = composeEnv()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return false, fmt.Errorf("%s", strings.TrimSpace(string(out)))
 	}

--- a/cmd/compose_refresh.go
+++ b/cmd/compose_refresh.go
@@ -1,0 +1,138 @@
+// cmd/compose_refresh.go
+//
+// Boot-time re-materialization of citadel-owned embedded compose files (#426).
+//
+// On `citadel work` startup, BEFORE managed services are started, we run a
+// version-gated sweep that rewrites the on-disk copies of the embedded service
+// composes (services.ServiceMap) when the running binary differs from the one
+// that last materialized them. This is what carries template changes -- the
+// #405/#410 host-port fix, image tags, healthchecks, GPU stanzas -- to nodes
+// that were provisioned by an older binary and would otherwise keep stale,
+// hardcoded-port composes forever.
+//
+// Recreate-on-boot policy (see PR for rationale): the default is conservative --
+// refresh the FILE only and log a hint telling the operator to restart affected
+// services. Force-recreating a live container on boot interrupts inference
+// (e.g. a vLLM model reload), so auto-recreate is opt-in via
+// CITADEL_COMPOSE_RECREATE_ON_UPGRADE=1|true|yes. When enabled, a port-managed
+// service is recreated only if its running published host port actually moved.
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/aceteam-ai/citadel-cli/internal/catalog"
+	"github.com/aceteam-ai/citadel-cli/internal/composerefresh"
+	"github.com/aceteam-ai/citadel-cli/services"
+)
+
+// refreshManagedComposeFiles runs the version-gated compose refresh sweep for
+// the given node config directory. It is safe to call on every boot: when the
+// binary version is unchanged it is a cheap no-op. Failures are logged and never
+// abort startup -- a refresh problem must not stop the node from serving jobs.
+func refreshManagedComposeFiles(configDir string) {
+	if configDir == "" {
+		return
+	}
+	servicesDir := configDir + "/services"
+
+	var recreator composerefresh.PortRecreator
+	if recreateOnUpgradeEnabled() {
+		recreator = dockerPortRecreator
+	}
+
+	res, err := composerefresh.Sweep(composerefresh.Options{
+		ServicesDir: servicesDir,
+		Version:     Version,
+		Embedded:    services.ServiceMap,
+		PortManaged: services.ServiceHostPorts,
+		Recreator:   recreator,
+		Log:         func(format string, args ...any) { Log(format, args...) },
+	})
+	if err != nil {
+		Log("compose-refresh: sweep error: %v", err)
+		return
+	}
+	if res.Skipped {
+		Debug("compose-refresh: binary version unchanged (%s); no sweep", Version)
+		return
+	}
+	if len(res.Refreshed) > 0 {
+		Log("compose-refresh: refreshed citadel-owned composes: %s", strings.Join(res.Refreshed, ", "))
+	}
+	if len(res.Preserved) > 0 {
+		Log("compose-refresh: preserved hand-edited composes: %s", strings.Join(res.Preserved, ", "))
+	}
+	if len(res.Recreated) > 0 {
+		Log("compose-refresh: force-recreated (host port moved): %s", strings.Join(res.Recreated, ", "))
+	}
+}
+
+// recreateOnUpgradeEnabled reports whether the operator opted into auto
+// force-recreate of a port-moved service on boot. Default is off.
+func recreateOnUpgradeEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("CITADEL_COMPOSE_RECREATE_ON_UPGRADE"))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+// dockerPortRecreator inspects the running container's published host port and,
+// if it differs from wantHostPort, force-recreates the service from composePath
+// with the citadel host-port env injected. Returns (recreated, err). When the
+// container is not running or already publishes the wanted port, it is left
+// untouched (recreated=false).
+func dockerPortRecreator(service, composePath string, wantHostPort int) (bool, error) {
+	rt := catalog.SelectContainerRuntime()
+	containerName := "citadel-" + service
+
+	current, running := runningPublishedHostPort(rt.EngineBin, containerName)
+	if !running {
+		// Nothing running from the old file; the refreshed file will be used on
+		// the next start. Don't disturb anything.
+		return false, nil
+	}
+	if current == wantHostPort {
+		return false, nil
+	}
+
+	Log("compose-refresh: %s: host port moved %d -> %d; force-recreating", service, current, wantHostPort)
+	composeArgs := composeFileArgs(composePath, composePath)
+	composeArgs = append(composeArgs, "up", "-d", "--force-recreate")
+	args := rt.ComposeArgs(composeArgs...)
+	cmd := exec.Command(rt.Bin, args...)
+	cmd.Env = append(os.Environ(), services.HostPortEnv()...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return false, fmt.Errorf("%s", strings.TrimSpace(string(out)))
+	}
+	return true, nil
+}
+
+// runningPublishedHostPort returns the host port a running container publishes
+// (its first published port) and whether the container is running. It shells out
+// to `<engine> inspect` with a Go-template that walks NetworkSettings.Ports,
+// mirroring the inspect pattern already used in cmd/service.go. On any error or
+// a non-running/no-port container it returns (0, false).
+func runningPublishedHostPort(engineBin, containerName string) (int, bool) {
+	// {{range}} over the port map; for each binding print the HostPort. We take
+	// the first non-empty one. The template prints a space-separated list.
+	format := `{{range $p, $conf := .NetworkSettings.Ports}}{{range $conf}}{{.HostPort}} {{end}}{{end}}`
+	out, err := exec.Command(engineBin, "inspect",
+		"--format", format, containerName).Output()
+	if err != nil {
+		return 0, false
+	}
+	fields := strings.Fields(string(out))
+	for _, f := range fields {
+		if p, convErr := strconv.Atoi(f); convErr == nil && p > 0 {
+			return p, true
+		}
+	}
+	return 0, false
+}

--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -19,6 +19,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/aceteam-ai/citadel-cli/internal/catalog"
 	"github.com/aceteam-ai/citadel-cli/internal/config"
 	"github.com/aceteam-ai/citadel-cli/internal/demo"
 	"github.com/aceteam-ai/citadel-cli/internal/deskstream"
@@ -1335,10 +1336,14 @@ func ccStartService(name string) error {
 			// Include the least-privilege sandbox override when present so a
 			// TUI-installed untrusted module also starts hardened here (the
 			// override would otherwise be bypassed by this start site).
-			args := []string{"compose"}
-			args = append(args, composeFileArgs(fullComposePath, fullComposePath)...)
-			args = append(args, "-p", "citadel-"+name, "up", "-d")
-			cmd := exec.Command("docker", args...)
+			composeArgs := composeFileArgs(fullComposePath, fullComposePath)
+			composeArgs = append(composeArgs, "-p", "citadel-"+name, "up", "-d")
+			rt := catalog.SelectContainerRuntime()
+			cmd := exec.Command(rt.Bin, rt.ComposeArgs(composeArgs...)...)
+			// Inject the citadel-owned host ports so the ${CITADEL_*_HOST_PORT:?...}
+			// guard resolves; without this the TUI start button dies for
+			// llamacpp/vllm/extraction/diffusers on v2.57.0 (#426).
+			cmd.Env = composeEnv()
 			return cmd.Run()
 		}
 	}

--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -19,7 +19,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/aceteam-ai/citadel-cli/internal/catalog"
 	"github.com/aceteam-ai/citadel-cli/internal/config"
 	"github.com/aceteam-ai/citadel-cli/internal/demo"
 	"github.com/aceteam-ai/citadel-cli/internal/deskstream"
@@ -1172,7 +1171,7 @@ func gatherControlCenterData() (controlcenter.StatusData, error) {
 
 			fullComposePath := filepath.Join(configDir, service.ComposeFile)
 			if _, err := os.Stat(fullComposePath); err == nil {
-				psCmd := exec.Command("docker", "compose", "-f", fullComposePath, "ps", "--format", "json")
+				psCmd := composeCommand("-f", fullComposePath, "ps", "--format", "json")
 				if output, err := psCmd.Output(); err == nil {
 					var containers []struct {
 						State  string `json:"State"`
@@ -1338,13 +1337,11 @@ func ccStartService(name string) error {
 			// override would otherwise be bypassed by this start site).
 			composeArgs := composeFileArgs(fullComposePath, fullComposePath)
 			composeArgs = append(composeArgs, "-p", "citadel-"+name, "up", "-d")
-			rt := catalog.SelectContainerRuntime()
-			cmd := exec.Command(rt.Bin, rt.ComposeArgs(composeArgs...)...)
-			// Inject the citadel-owned host ports so the ${CITADEL_*_HOST_PORT:?...}
-			// guard resolves; without this the TUI start button dies for
-			// llamacpp/vllm/extraction/diffusers on v2.57.0 (#426).
-			cmd.Env = composeEnv()
-			return cmd.Run()
+			// composeCommand injects the citadel-owned host ports so the
+			// ${CITADEL_*_HOST_PORT:?...} guard resolves; without this the TUI
+			// start button dies for llamacpp/vllm/extraction/diffusers on
+			// v2.57.0 (#426).
+			return composeCommand(composeArgs...).Run()
 		}
 	}
 
@@ -1361,7 +1358,7 @@ func ccStopService(name string) error {
 	for _, service := range manifest.Services {
 		if service.Name == name {
 			fullComposePath := filepath.Join(configDir, service.ComposeFile)
-			cmd := exec.Command("docker", "compose", "-f", fullComposePath, "-p", "citadel-"+name, "down")
+			cmd := composeCommand("-f", fullComposePath, "-p", "citadel-"+name, "down")
 			return cmd.Run()
 		}
 	}
@@ -1379,7 +1376,7 @@ func ccRestartService(name string) error {
 	for _, service := range manifest.Services {
 		if service.Name == name {
 			fullComposePath := filepath.Join(configDir, service.ComposeFile)
-			cmd := exec.Command("docker", "compose", "-f", fullComposePath, "-p", "citadel-"+name, "restart")
+			cmd := composeCommand("-f", fullComposePath, "-p", "citadel-"+name, "restart")
 			return cmd.Run()
 		}
 	}
@@ -1402,7 +1399,7 @@ func ccGetServiceDetail(name string) *controlcenter.ServiceDetailInfo {
 			}
 
 			// Get container info via docker compose ps
-			psCmd := exec.Command("docker", "compose", "-f", fullComposePath, "-p", "citadel-"+name, "ps", "--format", "json")
+			psCmd := composeCommand("-f", fullComposePath, "-p", "citadel-"+name, "ps", "--format", "json")
 			if output, err := psCmd.Output(); err == nil {
 				var container struct {
 					ID      string `json:"ID"`
@@ -1443,7 +1440,7 @@ func ccGetServiceLogs(name string) ([]string, error) {
 	for _, service := range manifest.Services {
 		if service.Name == name {
 			fullComposePath := filepath.Join(configDir, service.ComposeFile)
-			cmd := exec.Command("docker", "compose", "-f", fullComposePath, "-p", "citadel-"+name, "logs", "--tail", "50", "--no-color")
+			cmd := composeCommand("-f", fullComposePath, "-p", "citadel-"+name, "logs", "--tail", "50", "--no-color")
 			output, err := cmd.Output()
 			if err != nil {
 				return nil, err

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/aceteam-ai/citadel-cli/internal/compose"
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
 	internalServices "github.com/aceteam-ai/citadel-cli/internal/services"
@@ -178,18 +177,12 @@ func runSingleService(serviceName string) {
 		os.Exit(1)
 	}
 
-	// Strip GPU device reservations on non-Linux platforms
+	// GPU device reservations are stripped for non-Linux hosts by startService,
+	// which writes the CPU-only variant to a TEMP file rather than mutating the
+	// materialized compose in place. Mutating it here would permanently diverge
+	// the on-disk file from the embedded template, causing the version-change
+	// re-materialization sweep to mis-flag it as operator-edited on macOS (#426).
 	composePath := filepath.Join(configDir, "services", serviceName+".yml")
-	if !platform.IsLinux() {
-		content, err := os.ReadFile(composePath)
-		if err == nil {
-			filtered, err := compose.StripGPUDevices(content)
-			if err == nil {
-				os.WriteFile(composePath, filtered, 0600)
-				fmt.Println("   ℹ️  Running in CPU-only mode (GPU acceleration unavailable on this platform)")
-			}
-		}
-	}
 
 	// Add to manifest if not present
 	if !hasService(manifest, serviceName) {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -4,7 +4,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -232,7 +231,7 @@ func restartAllServices() {
 		}
 		fmt.Printf("🔄 Restarting service: %s\n", service.Name)
 
-		composeCmd := exec.Command("docker", "compose", "-f", fullComposePath, "restart")
+		composeCmd := composeCommand("-f", fullComposePath, "restart")
 		output, err := composeCmd.CombinedOutput()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "   ❌ Failed to restart service %s: %s\n", service.Name, string(output))

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -36,6 +36,31 @@ func composeEnv() []string {
 	return append(os.Environ(), svcports.HostPortEnv()...)
 }
 
+// composeCommand builds an *exec.Cmd for a `docker/podman compose` invocation
+// against a citadel-owned compose file, guaranteeing the two invariants every
+// cmd/ (CLI + TUI) compose call site needs:
+//
+//  1. The correct container runtime: it resolves catalog.SelectContainerRuntime()
+//     (rootless podman preferred over docker, #348) and drives the invocation
+//     through rt.Bin + rt.ComposeArgs(...), never a hardcoded "docker".
+//  2. The citadel-owned host-port env (composeEnv -> services.HostPortEnv), so
+//     compose templates that defer their host publish to the guarded
+//     ${CITADEL_*_HOST_PORT:?...} form (llamacpp/vllm/extraction/diffusers, #410)
+//     resolve instead of dying on the :? guard.
+//
+// Callers pass their compose args verbatim (e.g. "-f", path, "restart" or
+// "-f", path, "-p", "citadel-"+name, "ps", "--format", "json") and invoke
+// .Run()/.Output()/.CombinedOutput() on the result. Every cmd/ compose call site
+// that interpolates a citadel compose file MUST route through this; a bare
+// exec.Command("docker", "compose", ...) reintroduces the v2.57.0 regression
+// where `citadel run --restart` and `citadel status` failed the :? guard (#426).
+func composeCommand(args ...string) *exec.Cmd {
+	rt := catalog.SelectContainerRuntime()
+	cmd := exec.Command(rt.Bin, rt.ComposeArgs(args...)...)
+	cmd.Env = composeEnv()
+	return cmd
+}
+
 // prepareCacheDirectories creates the cache directories for all services.
 func prepareCacheDirectories() error {
 	homeDir, err := os.UserHomeDir()

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/compose"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
 	"github.com/aceteam-ai/citadel-cli/internal/services"
+	svcports "github.com/aceteam-ai/citadel-cli/services"
 )
 
 // forceRecreate controls whether to prompt user when containers exist
@@ -146,6 +147,12 @@ func startService(serviceName, composeFilePath string) error {
 	composeArgs = append(composeArgs, "up", "-d")
 	args := rt.ComposeArgs(composeArgs...)
 	composeCmd := exec.Command(rt.Bin, args...)
+	// Supply the citadel-owned host ports so compose files that defer their host
+	// publish to ${CITADEL_*_HOST_PORT:?...} (llamacpp/vllm/extraction/diffusers)
+	// resolve. Without this, the :? guard added in #410 makes `docker compose up`
+	// fail at this boot-path site (only the SERVICE_START job handler injected it
+	// before). Mirrors internal/jobs.ServiceHandler.composeEnv (#426).
+	composeCmd.Env = append(os.Environ(), svcports.HostPortEnv()...)
 	output, err = composeCmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%s compose failed: %s", rt.Bin, string(output))

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -21,6 +21,21 @@ import (
 // forceRecreate controls whether to prompt user when containers exist
 var forceRecreate bool
 
+// composeEnv returns the process environment for a `docker compose` invocation
+// in the cmd/ (CLI + TUI) tree, guaranteeing the citadel-owned host-port vars
+// are present so compose templates that defer their host publish to the guarded
+// ${CITADEL_*_HOST_PORT:?...} form (llamacpp/vllm/extraction/diffusers, #410)
+// resolve.
+//
+// Before this helper, only the job-driven paths (internal/jobs) injected these
+// vars; every cmd/ compose-up site (startService, ccStartService, `citadel run`)
+// inherited a bare os.Environ() and so failed the :? guard on v2.57.0 for those
+// four services. Every compose-up site in this tree MUST build its command
+// environment from this helper. Mirrors internal/jobs.ServiceHandler.composeEnv.
+func composeEnv() []string {
+	return append(os.Environ(), svcports.HostPortEnv()...)
+}
+
 // prepareCacheDirectories creates the cache directories for all services.
 func prepareCacheDirectories() error {
 	homeDir, err := os.UserHomeDir()
@@ -152,7 +167,7 @@ func startService(serviceName, composeFilePath string) error {
 	// resolve. Without this, the :? guard added in #410 makes `docker compose up`
 	// fail at this boot-path site (only the SERVICE_START job handler injected it
 	// before). Mirrors internal/jobs.ServiceHandler.composeEnv (#426).
-	composeCmd.Env = append(os.Environ(), svcports.HostPortEnv()...)
+	composeCmd.Env = composeEnv()
 	output, err = composeCmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%s compose failed: %s", rt.Bin, string(output))

--- a/cmd/service_test.go
+++ b/cmd/service_test.go
@@ -1,0 +1,41 @@
+// cmd/service_test.go
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	svcports "github.com/aceteam-ai/citadel-cli/services"
+)
+
+// TestComposeCommandInjectsHostPortEnv is the regression guard for #426: every
+// cmd/ compose invocation must carry the citadel-owned host-port vars so compose
+// templates that guard their host publish with ${CITADEL_*_HOST_PORT:?...} (#410)
+// resolve instead of dying on the :? guard. composeCommand is the single helper
+// all such call sites route through, so asserting its env here covers all of them.
+func TestComposeCommandInjectsHostPortEnv(t *testing.T) {
+	cmd := composeCommand("-f", "/tmp/does-not-matter.yml", "ps", "--format", "json")
+
+	if cmd.Env == nil {
+		t.Fatal("composeCommand must set cmd.Env (nil inherits the bare process env, dropping the host-port vars)")
+	}
+
+	// Build a set of the command environment for subset membership checks.
+	env := make(map[string]struct{}, len(cmd.Env))
+	for _, e := range cmd.Env {
+		env[e] = struct{}{}
+	}
+
+	// Every entry HostPortEnv() emits must be present verbatim. HostPortEnv is
+	// static (four managed services), so this is non-vacuous without node config.
+	hostPortEnv := svcports.HostPortEnv()
+	if len(hostPortEnv) == 0 {
+		t.Fatal("HostPortEnv() returned no entries; the assertion below would be vacuous")
+	}
+	for _, want := range hostPortEnv {
+		if _, ok := env[want]; !ok {
+			t.Errorf("composeCommand env is missing host-port entry %q; got env:\n%s",
+				want, strings.Join(cmd.Env, "\n"))
+		}
+	}
+}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -261,7 +261,7 @@ func gatherStatusData() (dashboard.StatusData, error) {
 			if configDir != "" {
 				fullComposePath := filepath.Join(configDir, service.ComposeFile)
 				if _, err := os.Stat(fullComposePath); err == nil {
-					psCmd := exec.Command("docker", "compose", "-f", fullComposePath, "ps", "--format", "json")
+					psCmd := composeCommand("-f", fullComposePath, "ps", "--format", "json")
 					if output, err := psCmd.Output(); err == nil {
 						var containers []struct {
 							State string `json:"State"`
@@ -787,7 +787,7 @@ func printServiceInfo(w *tabwriter.Writer) {
 			continue
 		}
 
-		psCmd := exec.Command("docker", "compose", "-f", fullComposePath, "ps", "--format", "json")
+		psCmd := composeCommand("-f", fullComposePath, "ps", "--format", "json")
 		output, err := psCmd.CombinedOutput() // Use CombinedOutput to get stderr
 		if err != nil {
 			errMsg := string(output)

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -256,6 +256,17 @@ func runWork(cmd *cobra.Command, args []string) {
 	// so the OS inhibitor process is never orphaned past Citadel's lifetime.
 	defer keepAwakeMonitor.Stop()
 
+	// Refresh citadel-owned embedded compose files from the binary's templates
+	// when the version changed since this node last materialized them (#426).
+	// Must run BEFORE startManagedServices so the fresh templates (host-port fix
+	// etc.) are what compose brings up. Version-gated => a cheap no-op on an
+	// unchanged boot. Skipped entirely with --no-services.
+	if !workNoServices {
+		if _, configDir, err := findAndReadManifest(); err == nil {
+			refreshManagedComposeFiles(configDir)
+		}
+	}
+
 	// Start managed services from the manifest (unless --no-services is set).
 	//
 	// Job serving is the node's core reason to exist and must never be gated on

--- a/internal/composerefresh/composerefresh.go
+++ b/internal/composerefresh/composerefresh.go
@@ -74,6 +74,15 @@ type Options struct {
 	// Recreator, when non-nil, may force-recreate a port-managed service whose
 	// running host port moved. Nil => file-refresh only.
 	Recreator PortRecreator
+	// KnownHistoricalHashes maps service name -> set of sha256 hex hashes of
+	// compose content that a PRIOR citadel binary is known to have shipped for
+	// that service. It is the bootstrap safety net for pre-#426 nodes that have
+	// no stamp: an on-disk file matching one of these hashes is provably a
+	// citadel-written (unedited) old template, so it is safe to overwrite; a file
+	// matching none is treated as operator-edited and preserved. When empty, the
+	// bootstrap falls back to refreshing all citadel-owned files (issue-sanctioned
+	// for these env-parameterized templates) with a loud warning.
+	KnownHistoricalHashes map[string]map[string]bool
 	// Log receives warnings/hints. May be nil.
 	Log Logf
 }
@@ -196,19 +205,45 @@ func Sweep(opts Options) (Result, error) {
 		}
 
 		recordedHash, haveRecord := stamp.Hashes[name]
-		citadelWroteIt := (haveRecord && onDiskHash == recordedHash) || !stampExisted
+
+		// Decide whether the on-disk file was written by citadel (safe to
+		// overwrite) or hand-edited by the operator (must be preserved):
+		//   - stamp present: citadel wrote it iff its content matches the recorded
+		//     hash. A mismatch is a definitive hand-edit.
+		//   - no stamp (pre-#426 node): use the known-historical-hash allowlist.
+		//     A file byte-identical to a prior shipped template is citadel's; one
+		//     matching nothing is treated as operator-edited and preserved. When
+		//     no allowlist is supplied, fall back to refreshing (these templates
+		//     are citadel-owned and env-parameterized) with a loud warning.
+		var citadelWroteIt bool
+		switch {
+		case haveRecord:
+			citadelWroteIt = onDiskHash == recordedHash
+		case opts.KnownHistoricalHashes != nil:
+			// Allowlist bootstrap: a known prior template is citadel's; anything
+			// else is treated as an operator edit and preserved.
+			citadelWroteIt = opts.KnownHistoricalHashes[name][onDiskHash]
+		default:
+			// No stamp and no allowlist: refresh (these templates are
+			// citadel-owned and env-parameterized); the loud warning above already
+			// told the operator hand-edits would be reset.
+			citadelWroteIt = true
+		}
 
 		if !citadelWroteIt {
-			// Hand-edited by the operator: leave it, warn, and keep the recorded
-			// hash so we keep detecting the edit on future boots.
+			// Hand-edited by the operator: leave it, warn, and record the CURRENT
+			// on-disk hash so a future clean upgrade can re-adopt it if the
+			// operator later restores an unedited template.
 			res.Preserved = append(res.Preserved, name)
 			opts.log("compose-refresh: %s: on-disk compose was hand-edited; leaving it untouched (delete it to accept the new citadel template)", name)
-			if haveRecord {
-				newHashes[name] = recordedHash
-			}
+			newHashes[name] = onDiskHash
 			continue
 		}
 
+		// Keep the prior on-disk content so we can roll back if a subsequent
+		// force-recreate `up` fails on the new template -- a bad template must not
+		// brick the service AND destroy the previously-working file.
+		prevContent := onDisk
 		if err := writeCompose(destPath, content); err != nil {
 			opts.log("compose-refresh: %s: write failed: %v", name, err)
 			continue
@@ -220,13 +255,24 @@ func Sweep(opts Options) (Result, error) {
 		wantPort, portManaged := opts.PortManaged[name]
 		if !portManaged || opts.Recreator == nil {
 			if portManaged {
-				opts.log("compose-refresh: %s: compose file refreshed; restart the service to apply (host port -> %d)", name, wantPort)
+				// A plain citadel restart will NOT move a running container: the
+				// start path no-ops on an already-running container. The operator
+				// must recreate it (or unset CITADEL_COMPOSE_NO_RECREATE_ON_UPGRADE).
+				opts.log("compose-refresh: %s: compose file refreshed to host port %d, but a running container is not moved automatically; run `citadel stop %s && citadel start %s` to apply (or unset CITADEL_COMPOSE_NO_RECREATE_ON_UPGRADE)", name, wantPort, name, name)
 			}
 			continue
 		}
 		recreated, err := opts.Recreator(name, destPath, wantPort)
 		if err != nil {
-			opts.log("compose-refresh: %s: recreate check failed: %v", name, err)
+			// The recreate `up` failed on the new template. Restore the prior file
+			// and its recorded hash so the service is not left with a template that
+			// can't come up, and so the next boot retries.
+			opts.log("compose-refresh: %s: recreate failed, rolling back compose file: %v", name, err)
+			if rbErr := writeCompose(destPath, string(prevContent)); rbErr != nil {
+				opts.log("compose-refresh: %s: rollback write failed: %v", name, rbErr)
+			}
+			res.Refreshed = res.Refreshed[:len(res.Refreshed)-1]
+			newHashes[name] = hashContent(string(prevContent))
 			continue
 		}
 		if recreated {
@@ -247,11 +293,30 @@ func hashContent(s string) string {
 	return hex.EncodeToString(sum[:])
 }
 
-// writeCompose writes compose content with 0600 perms to protect any sensitive
-// env vars, matching the existing materialize paths (cmd.ensureComposeFile /
-// ServiceHandler.ensureEmbeddedComposeFile).
+// writeCompose atomically writes compose content with 0600 perms (to protect
+// any sensitive env vars, matching the existing materialize paths). It writes to
+// a temp file in the same directory and renames into place so a crash mid-write
+// can never leave a truncated compose file that would fail to parse.
 func writeCompose(path, content string) error {
-	return os.WriteFile(path, []byte(content), 0o600)
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".compose-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op after a successful rename
+	if _, err := tmp.WriteString(content); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
 }
 
 // readStamp loads StampFileName from dir. The second return is false when the

--- a/internal/composerefresh/composerefresh.go
+++ b/internal/composerefresh/composerefresh.go
@@ -1,0 +1,283 @@
+// Package composerefresh re-materializes citadel-owned embedded compose files
+// on a node when the running binary version differs from the version that last
+// materialized them (issue #426).
+//
+// Background: citadel materializes its embedded service compose templates
+// (services.ServiceMap) into ~/citadel-node/services/<name>.yml the first time
+// a node needs them, then treats them as create-once. A binary upgrade never
+// rewrites the on-disk copies, so template changes -- the #405/#410 host-port
+// fix (`${CITADEL_*_HOST_PORT:?...}`), image tags, healthchecks, GPU stanzas --
+// never reach already-provisioned nodes. Those nodes keep stale, hardcoded-port
+// composes forever and re-collide on the host ports #410 eliminated.
+//
+// This package runs a cheap version-gated sweep at boot that refreshes only the
+// citadel-owned files, preserving operator hand-edits, and (optionally, and
+// only when a service's published host port actually moved) force-recreates the
+// affected container. See Sweep for the full contract.
+package composerefresh
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// StampFile is the per-node record of what citadel last materialized. It lives
+// alongside the compose files it describes (ServicesDir/StampFileName) and maps
+// each citadel-owned service name to the sha256 of the embedded template content
+// citadel last wrote for it. The Version field records the binary version that
+// performed the last refresh so an unchanged boot is a cheap no-op.
+const StampFileName = ".citadel-managed.json"
+
+// managedStamp is the on-disk shape of StampFileName.
+type managedStamp struct {
+	// Version is the citadel binary version that last ran the refresh sweep.
+	Version string `json:"version"`
+	// Hashes maps service name -> sha256 hex of the embedded compose content
+	// citadel last wrote to that file. Used to prove citadel (not an operator)
+	// authored the current on-disk file before overwriting it.
+	Hashes map[string]string `json:"hashes"`
+}
+
+// Logf is a minimal logging sink so the sweep can surface warnings (hand-edited
+// files skipped, recreate hints) without importing the cmd logger.
+type Logf func(format string, args ...any)
+
+// PortRecreator is invoked after a managed compose file has been refreshed, for
+// services whose host publish citadel owns. Implementations should compare the
+// running container's published host port to wantHostPort and, if they differ
+// AND recreation is enabled, force-recreate the service from composePath. It
+// returns (recreated, err). A nil PortRecreator disables all recreation (pure
+// file-refresh mode) -- used by tests and by the conservative default.
+type PortRecreator func(service, composePath string, wantHostPort int) (bool, error)
+
+// Options configures a Sweep.
+type Options struct {
+	// ServicesDir is the node's services directory (e.g.
+	// ~/citadel-node/services). Compose files and the stamp file live here.
+	ServicesDir string
+	// Version is the running binary version. The sweep is a no-op when it
+	// matches the stamped version.
+	Version string
+	// Embedded maps citadel-owned service name -> embedded compose template
+	// content (services.ServiceMap). Only these files are ever touched.
+	Embedded map[string]string
+	// PortManaged maps citadel-owned service name -> the host port the current
+	// template publishes (services.ServiceHostPorts). Services absent here are
+	// still refreshed (templates change for image tags etc.) but never
+	// force-recreated on a port change.
+	PortManaged map[string]int
+	// Recreator, when non-nil, may force-recreate a port-managed service whose
+	// running host port moved. Nil => file-refresh only.
+	Recreator PortRecreator
+	// Log receives warnings/hints. May be nil.
+	Log Logf
+}
+
+// Result summarizes what a Sweep did, for logging and tests.
+type Result struct {
+	// Skipped is true when the stamped version already matched Version, so the
+	// sweep did no filesystem work.
+	Skipped bool
+	// Refreshed lists services whose on-disk compose file was rewritten from the
+	// embedded template this run.
+	Refreshed []string
+	// Preserved lists citadel-owned services whose on-disk file was left
+	// untouched because its content did not match the recorded citadel hash
+	// (i.e. it was hand-edited).
+	Preserved []string
+	// Recreated lists services the Recreator force-recreated due to a host-port
+	// change.
+	Recreated []string
+}
+
+func (o Options) log(format string, args ...any) {
+	if o.Log != nil {
+		o.Log(format, args...)
+	}
+}
+
+// Sweep refreshes citadel-owned compose files when the binary version changed.
+//
+// Contract:
+//
+//  1. No-op fast path: if the on-disk stamp records the same Version, return
+//     immediately (Skipped=true). Boots on an unchanged binary do no work.
+//
+//  2. Only citadel-owned files (keys in Embedded) are ever read or written.
+//     Operator-authored composes, sandbox overrides (*.sandbox.yml), .env files,
+//     and anything outside Embedded are never touched.
+//
+//  3. Operator edits are preserved. A file is refreshed only when it is safe to
+//     do so:
+//     - the file is absent (materialize it), OR
+//     - a stamp hash exists for it and the current on-disk content matches that
+//     hash (citadel wrote it and nobody edited it), OR
+//     - no stamp exists yet (bootstrap: pre-#426 nodes never wrote a stamp; the
+//     embedded composes are citadel-owned and env-parameterized so refreshing
+//     is safe -- we log a warning that hand-edits will be reset and then start
+//     stamping so future upgrades use the precise hash-match rule).
+//     If a stamp hash exists and the on-disk content does NOT match it, the file
+//     was hand-edited: it is left untouched and a warning is logged.
+//
+//  4. Force-recreate is conservative and opt-in via a non-nil Recreator. Even
+//     then, a service is only recreated when its file was refreshed AND its
+//     running published host port differs from the new template's PortManaged
+//     port. A file whose content is already current is never rewritten and never
+//     disturbs a running container.
+//
+// The stamp is rewritten at the end with the new Version and the hashes of every
+// embedded template (so the next boot can detect edits precisely). Sweep tries
+// to be resilient: a failure on one service is logged and does not abort the
+// others; only failing to persist the stamp is returned as an error.
+func Sweep(opts Options) (Result, error) {
+	var res Result
+
+	stamp, stampExisted := readStamp(opts.ServicesDir)
+
+	if stampExisted && stamp.Version == opts.Version {
+		res.Skipped = true
+		return res, nil
+	}
+
+	if err := os.MkdirAll(opts.ServicesDir, 0o755); err != nil {
+		return res, fmt.Errorf("create services dir: %w", err)
+	}
+
+	if !stampExisted {
+		opts.log("compose-refresh: no managed stamp found; treating citadel-owned composes as refreshable. Hand-edits to %s files will be reset.", "citadel-owned")
+	}
+
+	// Deterministic order for stable logs and tests.
+	names := make([]string, 0, len(opts.Embedded))
+	for name := range opts.Embedded {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	newHashes := make(map[string]string, len(names))
+
+	for _, name := range names {
+		content := opts.Embedded[name]
+		newHash := hashContent(content)
+		newHashes[name] = newHash
+
+		destPath := filepath.Join(opts.ServicesDir, name+".yml")
+		onDisk, readErr := os.ReadFile(destPath)
+
+		switch {
+		case os.IsNotExist(readErr):
+			// Absent: materialize it. Nothing to recreate (no running container
+			// from this file yet).
+			if err := writeCompose(destPath, content); err != nil {
+				opts.log("compose-refresh: %s: write failed: %v", name, err)
+				continue
+			}
+			res.Refreshed = append(res.Refreshed, name)
+			continue
+		case readErr != nil:
+			opts.log("compose-refresh: %s: read failed, skipping: %v", name, readErr)
+			// Preserve whatever hash we had so we don't lose the record.
+			if prev, ok := stamp.Hashes[name]; ok {
+				newHashes[name] = prev
+			}
+			continue
+		}
+
+		onDiskHash := hashContent(string(onDisk))
+
+		// Already current: never rewrite, never disturb the container.
+		if onDiskHash == newHash {
+			continue
+		}
+
+		recordedHash, haveRecord := stamp.Hashes[name]
+		citadelWroteIt := (haveRecord && onDiskHash == recordedHash) || !stampExisted
+
+		if !citadelWroteIt {
+			// Hand-edited by the operator: leave it, warn, and keep the recorded
+			// hash so we keep detecting the edit on future boots.
+			res.Preserved = append(res.Preserved, name)
+			opts.log("compose-refresh: %s: on-disk compose was hand-edited; leaving it untouched (delete it to accept the new citadel template)", name)
+			if haveRecord {
+				newHashes[name] = recordedHash
+			}
+			continue
+		}
+
+		if err := writeCompose(destPath, content); err != nil {
+			opts.log("compose-refresh: %s: write failed: %v", name, err)
+			continue
+		}
+		res.Refreshed = append(res.Refreshed, name)
+
+		// Only port-managed services can trigger a recreate, and only when a
+		// Recreator is wired in and the running host port actually moved.
+		wantPort, portManaged := opts.PortManaged[name]
+		if !portManaged || opts.Recreator == nil {
+			if portManaged {
+				opts.log("compose-refresh: %s: compose file refreshed; restart the service to apply (host port -> %d)", name, wantPort)
+			}
+			continue
+		}
+		recreated, err := opts.Recreator(name, destPath, wantPort)
+		if err != nil {
+			opts.log("compose-refresh: %s: recreate check failed: %v", name, err)
+			continue
+		}
+		if recreated {
+			res.Recreated = append(res.Recreated, name)
+		}
+	}
+
+	newStamp := managedStamp{Version: opts.Version, Hashes: newHashes}
+	if err := writeStamp(opts.ServicesDir, newStamp); err != nil {
+		return res, fmt.Errorf("persist managed stamp: %w", err)
+	}
+
+	return res, nil
+}
+
+func hashContent(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+// writeCompose writes compose content with 0600 perms to protect any sensitive
+// env vars, matching the existing materialize paths (cmd.ensureComposeFile /
+// ServiceHandler.ensureEmbeddedComposeFile).
+func writeCompose(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o600)
+}
+
+// readStamp loads StampFileName from dir. The second return is false when the
+// file is absent or unreadable/corrupt (treated as "no prior stamp"), which the
+// bootstrap rule in Sweep relies on.
+func readStamp(dir string) (managedStamp, bool) {
+	path := filepath.Join(dir, StampFileName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return managedStamp{Hashes: map[string]string{}}, false
+	}
+	var s managedStamp
+	if err := json.Unmarshal(data, &s); err != nil {
+		return managedStamp{Hashes: map[string]string{}}, false
+	}
+	if s.Hashes == nil {
+		s.Hashes = map[string]string{}
+	}
+	return s, true
+}
+
+func writeStamp(dir string, s managedStamp) error {
+	path := filepath.Join(dir, StampFileName)
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o600)
+}

--- a/internal/composerefresh/composerefresh_test.go
+++ b/internal/composerefresh/composerefresh_test.go
@@ -1,0 +1,291 @@
+package composerefresh
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// embeddedV2 is what the current (upgraded) binary would materialize. embeddedV1
+// is the stale template a previous binary wrote. They differ so a refresh is
+// observable.
+const (
+	embeddedV1 = "services:\n  llamacpp:\n    ports:\n      - \"8080:8080\"\n"
+	embeddedV2 = "services:\n  llamacpp:\n    ports:\n      - \"${CITADEL_LLAMACPP_HOST_PORT:?}:8080\"\n"
+)
+
+func sha(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func readStampFile(t *testing.T, dir string) managedStamp {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, StampFileName))
+	if err != nil {
+		t.Fatalf("read stamp: %v", err)
+	}
+	var s managedStamp
+	if err := json.Unmarshal(data, &s); err != nil {
+		t.Fatalf("unmarshal stamp: %v", err)
+	}
+	return s
+}
+
+func contains(list []string, want string) bool {
+	for _, s := range list {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+// baseOpts builds an Options for a single citadel-owned service (llamacpp) whose
+// current template is embeddedV2 and whose host port is managed. No recreator
+// (file-refresh only) unless a test overrides it.
+func baseOpts(dir, version string) Options {
+	return Options{
+		ServicesDir: dir,
+		Version:     version,
+		Embedded:    map[string]string{"llamacpp": embeddedV2},
+		PortManaged: map[string]int{"llamacpp": 8200},
+	}
+}
+
+// (a) An upgrade rewrites a citadel-managed file that matches the recorded hash.
+func TestSweep_RefreshesCitadelManagedFile(t *testing.T) {
+	dir := t.TempDir()
+	composePath := filepath.Join(dir, "llamacpp.yml")
+
+	// A previous binary wrote embeddedV1 and stamped its hash at version v1.
+	writeFile(t, composePath, embeddedV1)
+	prevStamp := managedStamp{Version: "v2.50.0", Hashes: map[string]string{"llamacpp": sha(embeddedV1)}}
+	if err := writeStamp(dir, prevStamp); err != nil {
+		t.Fatalf("seed stamp: %v", err)
+	}
+
+	res, err := Sweep(baseOpts(dir, "v2.57.0"))
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if res.Skipped {
+		t.Fatal("expected sweep to run (version changed), got Skipped")
+	}
+	if !contains(res.Refreshed, "llamacpp") {
+		t.Fatalf("expected llamacpp refreshed, got %+v", res)
+	}
+	got, _ := os.ReadFile(composePath)
+	if string(got) != embeddedV2 {
+		t.Fatalf("file not refreshed to new template:\n%s", got)
+	}
+	// Stamp is updated to the new version + new hash.
+	stamp := readStampFile(t, dir)
+	if stamp.Version != "v2.57.0" {
+		t.Fatalf("stamp version = %q, want v2.57.0", stamp.Version)
+	}
+	if stamp.Hashes["llamacpp"] != sha(embeddedV2) {
+		t.Fatal("stamp hash not updated to new template hash")
+	}
+}
+
+// (b) An upgrade PRESERVES a hand-edited (hash-mismatched) file.
+func TestSweep_PreservesHandEditedFile(t *testing.T) {
+	dir := t.TempDir()
+	composePath := filepath.Join(dir, "llamacpp.yml")
+
+	handEdited := embeddedV1 + "\n# operator tweak: pinned image\n"
+	writeFile(t, composePath, handEdited)
+	// The stamp records the ORIGINAL embeddedV1 hash; on-disk differs => edited.
+	prevStamp := managedStamp{Version: "v2.50.0", Hashes: map[string]string{"llamacpp": sha(embeddedV1)}}
+	if err := writeStamp(dir, prevStamp); err != nil {
+		t.Fatalf("seed stamp: %v", err)
+	}
+
+	res, err := Sweep(baseOpts(dir, "v2.57.0"))
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if contains(res.Refreshed, "llamacpp") {
+		t.Fatal("hand-edited file was refreshed; must be preserved")
+	}
+	if !contains(res.Preserved, "llamacpp") {
+		t.Fatalf("expected llamacpp preserved, got %+v", res)
+	}
+	got, _ := os.ReadFile(composePath)
+	if string(got) != handEdited {
+		t.Fatal("hand-edited file content changed")
+	}
+	// The recorded hash for the edited file is retained so future boots keep
+	// detecting the edit.
+	stamp := readStampFile(t, dir)
+	if stamp.Hashes["llamacpp"] != sha(embeddedV1) {
+		t.Fatal("recorded hash for hand-edited file was not retained")
+	}
+}
+
+// (b') First-upgrade bootstrap: pre-#426 nodes have NO stamp. Their stale
+// citadel-owned composes must still be refreshed (this is the whole target
+// population of the issue).
+func TestSweep_BootstrapNoStampRefreshes(t *testing.T) {
+	dir := t.TempDir()
+	composePath := filepath.Join(dir, "llamacpp.yml")
+	writeFile(t, composePath, embeddedV1) // stale, no stamp exists
+
+	res, err := Sweep(baseOpts(dir, "v2.57.0"))
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if res.Skipped {
+		t.Fatal("expected sweep to run on a no-stamp node")
+	}
+	if !contains(res.Refreshed, "llamacpp") {
+		t.Fatalf("no-stamp stale file must be refreshed, got %+v", res)
+	}
+	got, _ := os.ReadFile(composePath)
+	if string(got) != embeddedV2 {
+		t.Fatal("no-stamp stale file was not refreshed")
+	}
+	// A stamp is now written so subsequent upgrades use precise hash matching.
+	if _, existed := readStamp(dir); !existed {
+		t.Fatal("expected a stamp to be written after bootstrap refresh")
+	}
+}
+
+// (c) Non-citadel / operator files are never touched.
+func TestSweep_NeverTouchesOperatorFiles(t *testing.T) {
+	dir := t.TempDir()
+	// A file NOT in Embedded (operator-authored service compose).
+	operatorPath := filepath.Join(dir, "my-custom-thing.yml")
+	operatorContent := "services:\n  custom:\n    image: acme/custom\n"
+	writeFile(t, operatorPath, operatorContent)
+	// A sandbox override sibling of a managed service must also be untouched.
+	sandboxPath := filepath.Join(dir, "llamacpp.sandbox.yml")
+	sandboxContent := "services:\n  llamacpp:\n    read_only: true\n"
+	writeFile(t, sandboxPath, sandboxContent)
+	// The managed service itself is absent -> gets materialized.
+	res, err := Sweep(baseOpts(dir, "v2.57.0"))
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if got, _ := os.ReadFile(operatorPath); string(got) != operatorContent {
+		t.Fatal("operator-authored compose was modified")
+	}
+	if got, _ := os.ReadFile(sandboxPath); string(got) != sandboxContent {
+		t.Fatal("sandbox override was modified")
+	}
+	// And llamacpp was materialized (absent-file path).
+	if !contains(res.Refreshed, "llamacpp") {
+		t.Fatalf("absent managed file should be materialized, got %+v", res)
+	}
+}
+
+// (d) An unchanged-version boot is a no-op (no file writes, Skipped=true).
+func TestSweep_UnchangedVersionIsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	composePath := filepath.Join(dir, "llamacpp.yml")
+	writeFile(t, composePath, embeddedV1) // deliberately stale content
+
+	stamp := managedStamp{Version: "v2.57.0", Hashes: map[string]string{"llamacpp": sha(embeddedV2)}}
+	if err := writeStamp(dir, stamp); err != nil {
+		t.Fatalf("seed stamp: %v", err)
+	}
+	before, _ := os.Stat(composePath)
+
+	res, err := Sweep(baseOpts(dir, "v2.57.0"))
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if !res.Skipped {
+		t.Fatal("expected Skipped on unchanged version")
+	}
+	// File must be untouched even though its content is stale (version gate wins).
+	if got, _ := os.ReadFile(composePath); string(got) != embeddedV1 {
+		t.Fatal("file was modified on an unchanged-version boot")
+	}
+	after, _ := os.Stat(composePath)
+	if !before.ModTime().Equal(after.ModTime()) {
+		t.Fatal("file mtime changed on a no-op boot")
+	}
+}
+
+// (e) The version stamp is read and written correctly across a round trip.
+func TestSweep_StampRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	// No stamp initially.
+	if _, existed := readStamp(dir); existed {
+		t.Fatal("expected no stamp initially")
+	}
+
+	if _, err := Sweep(baseOpts(dir, "v2.57.0")); err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	s, existed := readStamp(dir)
+	if !existed {
+		t.Fatal("stamp not written")
+	}
+	if s.Version != "v2.57.0" {
+		t.Fatalf("stamp version = %q, want v2.57.0", s.Version)
+	}
+	if s.Hashes["llamacpp"] != sha(embeddedV2) {
+		t.Fatal("stamp hash mismatch after write")
+	}
+
+	// A second sweep at the SAME version is skipped.
+	res2, err := Sweep(baseOpts(dir, "v2.57.0"))
+	if err != nil {
+		t.Fatalf("second Sweep: %v", err)
+	}
+	if !res2.Skipped {
+		t.Fatal("second sweep at same version should be skipped")
+	}
+}
+
+// Recreate is only attempted on a port-managed service whose file was refreshed,
+// and only when a Recreator is wired in. Uses a fake recreator (no docker).
+func TestSweep_RecreateOnlyOnPortManagedRefresh(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "llamacpp.yml"), embeddedV1)
+	writeFile(t, filepath.Join(dir, "ollama.yml"), "services:\n  ollama:\n    image: old\n")
+
+	var calls []string
+	opts := Options{
+		ServicesDir: dir,
+		Version:     "v2.57.0",
+		Embedded: map[string]string{
+			"llamacpp": embeddedV2,
+			// ollama refreshes too, but it is NOT port-managed.
+			"ollama": "services:\n  ollama:\n    image: new\n",
+		},
+		PortManaged: map[string]int{"llamacpp": 8200},
+		Recreator: func(service, composePath string, wantHostPort int) (bool, error) {
+			calls = append(calls, service)
+			return true, nil // pretend the port moved and we recreated
+		},
+	}
+
+	res, err := Sweep(opts)
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if len(calls) != 1 || calls[0] != "llamacpp" {
+		t.Fatalf("recreator should be called only for port-managed llamacpp, got %v", calls)
+	}
+	if !contains(res.Recreated, "llamacpp") {
+		t.Fatalf("expected llamacpp recreated, got %+v", res)
+	}
+	if contains(res.Recreated, "ollama") {
+		t.Fatal("non-port-managed ollama must never be recreated")
+	}
+}

--- a/internal/composerefresh/composerefresh_test.go
+++ b/internal/composerefresh/composerefresh_test.go
@@ -126,11 +126,11 @@ func TestSweep_PreservesHandEditedFile(t *testing.T) {
 	if string(got) != handEdited {
 		t.Fatal("hand-edited file content changed")
 	}
-	// The recorded hash for the edited file is retained so future boots keep
-	// detecting the edit.
+	// The recorded hash tracks the CURRENT on-disk (edited) content, so a future
+	// clean upgrade can re-adopt the file if the operator restores a template.
 	stamp := readStampFile(t, dir)
-	if stamp.Hashes["llamacpp"] != sha(embeddedV1) {
-		t.Fatal("recorded hash for hand-edited file was not retained")
+	if stamp.Hashes["llamacpp"] != sha(handEdited) {
+		t.Fatal("recorded hash for hand-edited file should track on-disk content")
 	}
 }
 
@@ -159,6 +159,47 @@ func TestSweep_BootstrapNoStampRefreshes(t *testing.T) {
 	// A stamp is now written so subsequent upgrades use precise hash matching.
 	if _, existed := readStamp(dir); !existed {
 		t.Fatal("expected a stamp to be written after bootstrap refresh")
+	}
+}
+
+// (b”) Bootstrap with a known-historical-hash allowlist: a no-stamp file that
+// matches a prior shipped template is refreshed; one that matches nothing is
+// preserved as an operator edit.
+func TestSweep_BootstrapKnownHashAllowlist(t *testing.T) {
+	dir := t.TempDir()
+
+	// llamacpp: stale but byte-identical to a known prior template -> refresh.
+	managedPath := filepath.Join(dir, "llamacpp.yml")
+	writeFile(t, managedPath, embeddedV1)
+	// vllm: hand-edited, matches no known template -> preserve.
+	handEdited := "services:\n  vllm:\n    image: acme/pinned\n"
+	vllmPath := filepath.Join(dir, "vllm.yml")
+	writeFile(t, vllmPath, handEdited)
+
+	res, err := Sweep(Options{
+		ServicesDir: dir,
+		Version:     "v2.57.0",
+		Embedded: map[string]string{
+			"llamacpp": embeddedV2,
+			"vllm":     "services:\n  vllm:\n    image: new\n",
+		},
+		PortManaged: map[string]int{"llamacpp": 8200, "vllm": 8201},
+		KnownHistoricalHashes: map[string]map[string]bool{
+			"llamacpp": {sha(embeddedV1): true},
+			// vllm: only the current template is "known"; handEdited is not.
+		},
+	})
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if !contains(res.Refreshed, "llamacpp") {
+		t.Fatalf("known-hash stale file must be refreshed, got %+v", res)
+	}
+	if !contains(res.Preserved, "vllm") {
+		t.Fatalf("unknown-hash edited file must be preserved, got %+v", res)
+	}
+	if got, _ := os.ReadFile(vllmPath); string(got) != handEdited {
+		t.Fatal("hand-edited vllm was clobbered under known-hash bootstrap")
 	}
 }
 
@@ -289,3 +330,37 @@ func TestSweep_RecreateOnlyOnPortManagedRefresh(t *testing.T) {
 		t.Fatal("non-port-managed ollama must never be recreated")
 	}
 }
+
+// A failed force-recreate rolls the compose file back to its prior content so a
+// bad template can't brick the service AND destroy the working file.
+func TestSweep_RecreateFailureRollsBackFile(t *testing.T) {
+	dir := t.TempDir()
+	composePath := filepath.Join(dir, "llamacpp.yml")
+	writeFile(t, composePath, embeddedV1)
+
+	opts := baseOpts(dir, "v2.57.0")
+	opts.Recreator = func(service, composePath string, wantHostPort int) (bool, error) {
+		return false, errThrow("compose up failed: boom")
+	}
+
+	res, err := Sweep(opts)
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if contains(res.Refreshed, "llamacpp") {
+		t.Fatal("a rolled-back refresh must not be reported as Refreshed")
+	}
+	// File restored to the prior content.
+	if got, _ := os.ReadFile(composePath); string(got) != embeddedV1 {
+		t.Fatalf("file not rolled back after recreate failure:\n%s", got)
+	}
+	// Stamp records the restored (prior) content's hash so the next boot retries.
+	stamp := readStampFile(t, dir)
+	if stamp.Hashes["llamacpp"] != sha(embeddedV1) {
+		t.Fatal("stamp hash should track the rolled-back content")
+	}
+}
+
+type errThrow string
+
+func (e errThrow) Error() string { return string(e) }

--- a/services/embed_test.go
+++ b/services/embed_test.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"testing"
@@ -168,6 +170,22 @@ func TestDiffusersHostPortNonColliding(t *testing.T) {
 			t.Errorf("diffusers host port 8102 collides with the TEI embedding service (#415)")
 		case p >= 8100 && p <= 8199:
 			t.Errorf("diffusers host port %d is inside the 8100-8199 range reserved by other services and internal/apps auto-allocation (#415)", p)
+		}
+	}
+}
+
+// TestKnownComposeHashesCoverCurrentTemplates verifies the generated
+// KnownComposeHashes allowlist includes the sha256 of every CURRENT embedded
+// template. This is the bootstrap safety net for pre-#426 nodes: a node freshly
+// materialized by this binary but carrying no .citadel-managed.json stamp must
+// be recognized as citadel-written (so the re-materialization sweep does not
+// mis-flag it as operator-edited). If this fails, regenerate known_hashes.go.
+func TestKnownComposeHashesCoverCurrentTemplates(t *testing.T) {
+	for name, content := range ServiceMap {
+		sum := sha256.Sum256([]byte(content))
+		h := hex.EncodeToString(sum[:])
+		if !KnownComposeHashes[name][h] {
+			t.Errorf("KnownComposeHashes[%q] is missing the current template hash %s; regenerate services/known_hashes.go", name, h)
 		}
 	}
 }

--- a/services/known_hashes.go
+++ b/services/known_hashes.go
@@ -1,0 +1,61 @@
+// Code generated from git history of services/compose/*.yml. DO NOT EDIT BY HAND.
+// Regenerate with: go run ./services/compose/genhashes (or the shell snippet in PR #426).
+//
+// KnownComposeHashes maps each citadel-owned service to the set of sha256
+// hashes of every compose template content that a prior citadel binary shipped
+// for it. Used by internal/composerefresh to safely bootstrap pre-#426 nodes
+// that carry no .citadel-managed.json stamp: an on-disk file byte-identical to
+// one of these is provably citadel-written (never operator-edited), so it is
+// safe to re-materialize; a file matching none is preserved as an operator edit.
+package services
+
+// KnownComposeHashes is the historical-template allowlist (see file header).
+var KnownComposeHashes = map[string]map[string]bool{
+	"ollama": {
+		"423edb3435749d6b1c4047b9bfdd2851be733e42e28f189a913701b0aa491e97": true,
+		"7e97a822ad30ef8a2cc8e2c20096b24f95a12742bbe533c7bb7de43d37404869": true,
+		"fdd34b5e8019bac3330ce25e763135250d1e4ad732109aa10a6e15f2fa16b09d": true,
+	},
+	"vllm": {
+		"07588f4ef245f011396874bcdd7c6aa0c463a356c5f6601618c3b4e213be812a": true,
+		"3c19a64a6c7b5f46fac4e621b42cf9505f913759c0fe0bfb10f267b42b3782e9": true,
+		"5a6291887c9a317a19b03390a9f9d0cf2cccb2464fb06023927f1ff6095606f6": true,
+		"ad24ce421c2358d3214b71efcb57ae2e1d902c44af052e67267e1b5010761f9c": true,
+		"af0d1ba61ce68f9ab3ba0811bf0521b6e2af7c868a05051e80288c0f53735258": true,
+		"b9d3f74f83089cba9cf7dfc36cdabd18def5f3b17f2a2718ed3125aa34fed593": true,
+		"bee8e52e0a1e2cbd47450edb4731f5b63fbc1e5e717e7cc088e5405e6e548afa": true,
+		"e24ce8d2eee81f868d4e0d56324726c982d5a7e472eb82fcad54227883051d1e": true,
+		"faafb47b3ce0e7755a773177a80597defa7ee59a07d97285f55425ebe7910ef3": true,
+		"fbb22432970140a45794760f0775be51d40555aa66aa3a96142b91438776a2ae": true,
+	},
+	"llamacpp": {
+		"03985065ef91d7ea3a512b3dc3029f08e57ca72a9d6ac96e5a6c3d52d1d9f249": true,
+		"2fcefa5327f63af9d1d2fbac8e44f92ac44ca595d9fcd1cb27ec42498f084061": true,
+		"586347f463e368ff0c9d81f911c935cc8816851be64a20cb14d2b3eb0252251b": true,
+		"b0977ce71d1572e45ff818068ebd84cfb4aff57cf51f116cc8a51d3c4d9d65ca": true,
+		"b3bbfbe895ee67e0ea60da4151ef3ef40158941e892a94a8b01f05e6d36bb2ea": true,
+	},
+	"lmstudio": {
+		"01a478e9a65d0e895830a1dda476874a9d22c416aa73f48cb46f3ceda3f74d20": true,
+		"cd7b791871ae4cd2b9a8a90803aeb630d5a7282445c20e69928d1defbf412946": true,
+	},
+	"sglang": {
+		"2531d9e78484785543f196082ce38e46ef21dd1d6cd380b69665c331bc21acfb": true,
+		"2e46554d84a142f549b0481b068b14d2bc65fd02829956ea2288c089b5ad518a": true,
+	},
+	"extraction": {
+		"3f7f02536458773d7f8b22da3e7d4213b943db47c457ce669d9270ff2e0a7260": true,
+		"62e82d9afdd1fb109942a71d6f33f9289af21e9391091f5f33103423ee4f854c": true,
+		"9f826faa089bf5cba91c9437c1d9feb9e376332f15cdd6fb21539e80ebf3d45e": true,
+	},
+	"transcribe": {
+		"26407f6fde85b0f6af362b25e23b1b3be3342ecc4f47ac38ee43abf96bd719ee": true,
+		"e365f728ef81782455a2a18a00a6f7e41d377ae2375d6f6660816cc7f3e0c77d": true,
+	},
+	"diffusers": {
+		"3f2059400959adcc0f55ea8134cb492530ca65d4faf51778a68f35d0d5d9c93a": true,
+		"6d57a7a04565fe8954ffe2a2b364813ec2fe700b06f2dfb05567a1a33662d445": true,
+		"81bac6f3c78623c1c08761b1fb99718717e84891459cc50d012d02e88cdd32f7": true,
+		"83842c7faf86de64d7728e0178690f69a0819354d0f290edbcf3d40ea5f01807": true,
+	},
+}


### PR DESCRIPTION
## Context

#410 (host-port registry, #405) fixed the **embedded** compose templates (`services/compose/*.yml` now defer their host publish to `${CITADEL_*_HOST_PORT:?...}`) and injects `services.HostPortEnv()` at the job-driven compose sites. That works for **freshly materialized** nodes — but on an **existing** node the templates were already written to disk (`~/citadel-node/services/<name>.yml`) by an older binary, and **a binary upgrade never rewrote them**. Materialized citadel-owned composes were create-once (the #413 `materializeEmbeddedService` path only writes when the file is *missing*).

Consequence, verified live on node 1054 (ubuntu-gpu, v2.57.0): after upgrade, `llamacpp.yml` still had hardcoded `- "8080:8080"`, llamacpp came back up on host **8080**, and the status server could no longer bind `localhost:8080` (`address already in use`). The 8200 registry port was never used because `docker compose -f <on-disk-path>` reads the stale file, not the embedded template. Every existing node has the same stale composes for llamacpp/vllm/extraction/diffusers.

This PR makes upgrades carry template changes to already-provisioned nodes, and folds in a v2.57.0 regression on the same compose-invocation surface.

## Summary

### 1. Version-change re-materialization sweep (`internal/composerefresh`)

A version-gated sweep runs on `citadel work` startup, **before** `startManagedServices` (and before job-stream subscription), refreshing the citadel-owned embedded composes (keys in `services.ServiceMap`) from the binary's templates.

- **Scope**: only files whose name is a `ServiceMap` key. Operator-authored composes, `*.sandbox.yml` overrides, `.env`, and anything outside the managed set are never read or written.
- **Preserve operator edits**: citadel stamps a per-file sha256 in `~/citadel-node/services/.citadel-managed.json` (name→hash + last-run version) whenever it writes a compose. On sweep, a file is overwritten only if its on-disk content matches the recorded hash (proving citadel wrote it, unedited). A hash mismatch = hand-edited → left untouched + a loud warning.
- **Bootstrap for the existing fleet (no stamp yet)**: pre-#426 nodes never wrote a stamp. `services.KnownComposeHashes` (generated from git history of every `services/compose/*.yml`) is the safety net: a stampless file byte-identical to *any* prior shipped template is provably citadel-written → safe to refresh; a file matching nothing is treated as an operator edit → preserved. A test (`TestKnownComposeHashesCoverCurrentTemplates`) asserts the allowlist covers the current templates so a freshly-materialized-but-unstamped node is always recognized.
- **Idempotent / cheap**: a missing stamp always reconciles (catches crashed/half upgrades and manual binary swaps); a matching version is a no-op.
- **Atomicity + rollback**: writes are temp-file + rename; if a subsequent force-recreate `up` fails on the new template, the file is rolled back to its prior content so a bad template can't brick the service *and* destroy the working file.

### 2. Recreate-on-boot: **default ON** for a port change, opt-out

This is the design decision the brief delegated. **Default is auto force-recreate when a managed service's published host port actually moved**, opt out with `CITADEL_COMPOSE_NO_RECREATE_ON_UPGRADE=1`.

Rationale: the primary upgrade path is a hands-off auto-update that re-execs the binary in place (`syscall.Exec`) **without tearing down service containers**. The prior container keeps running on its old host port, and `startManagedServices` no-ops on an already-running container — so **file-refresh alone would never self-heal the collision on the exact fleet #426 targets**. Recreate is surgical: it fires only when the container is *running* AND its actual published host port (read via `docker/podman inspect`) differs from the new template's registry port — i.e. the broken/colliding state, not healthy inference. It runs at boot before job subscription, so the vLLM model-reload window can't eat in-flight `llm_inference` jobs. Uses `catalog.SelectContainerRuntime()` (docker or podman). In opt-out mode we log an accurate remediation hint (`citadel stop <svc> && citadel start <svc>`; a plain restart won't move a running container).

### 3. Folded-in regression: `cmd/` compose sites never injected `HostPortEnv`

`git grep HostPortEnv origin/main -- cmd/` → zero hits. Only the job-driven paths injected it, so on v2.57.0 an interactive `citadel run vllm`, the TUI start button (`ccStartService`), and the boot start path all **die on the `:?` guard** (`required variable CITADEL_VLLM_HOST_PORT is missing`) for llamacpp/vllm/extraction/diffusers. Fix: a shared `cmd.composeEnv()` helper (mirrors `jobs.ServiceHandler.composeEnv`) that every cmd compose-up site now uses; `ccStartService` also moves off hardcoded `docker` to the runtime abstraction. Also fixed `cmd/run.go`'s macOS in-place GPU-strip mutation (it permanently diverged the materialized file from the embedded template, mis-flagging it operator-edited on macOS) — it now relies on `startService`'s temp-file variant.

## Test plan

| Group | Coverage |
|-------|----------|
| `internal/composerefresh` (8 tests) | (a) refresh a stamp-matched managed file; (b) preserve a hand-edited (hash-mismatched) file; (b′) stampless bootstrap refresh; (b″) known-hash allowlist refreshes known / preserves unknown; (c) operator + sandbox files never touched; (d) unchanged-version boot is a no-op (mtime unchanged); (e) stamp read/write round trip; recreate only on port-managed refresh; recreate-failure rolls the file back |
| `services` | `TestKnownComposeHashesCoverCurrentTemplates` — allowlist covers current embedded templates |
| `go build ./...`, `go test ./...`, `gofmt -l` | all green |

**Manual live-node verification still required** (cannot be exercised without docker/a real node): upgrade an existing node (e.g. 1054), confirm the stale llamacpp/vllm/extraction/diffusers composes refresh to the `${CITADEL_*_HOST_PORT}` form, the containers move off :8080/:8100 to the 8200 block, the status server reclaims `localhost:8080`, and a hand-edited compose is left untouched with a warning. Also verify interactive `citadel run vllm` and the TUI start button now start cleanly (the folded-in HostPortEnv fix).

## Folded-in: complete the cmd/ compose host-port fix

The first pass added the host-port env to the *start* paths, but several other `cmd/` compose invocations still shelled out via a hardcoded `exec.Command("docker", "compose", ...)` with no `.Env`. On a live node this left the regression only half-fixed — **confirmed broken pre-fix**: `citadel run llamacpp --restart` and `citadel status` both died with `required variable CITADEL_VLLM_HOST_PORT is missing a value: citadel must supply CITADEL_VLLM_HOST_PORT` while interpolating the guarded `${CITADEL_*_HOST_PORT:?...}` form (#410).

Introduced one shared **`composeCommand(args ...string) *exec.Cmd`** helper next to `composeEnv()` in `cmd/service.go`. It builds every compose invocation with both invariants at once: the container-runtime abstraction (`catalog.SelectContainerRuntime()` → `rt.Bin` + `rt.ComposeArgs(...)`, so rootless podman is honored rather than a hardcoded `docker`) and `.Env = composeEnv()` (the `services.HostPortEnv()` vars). Every `cmd/` compose call site that interpolates a citadel compose file now routes through it:

| Site | Subcommand |
|------|-----------|
| `run.go` `restartAllServices` | `restart` |
| `status.go` (×2) | `ps --format json` |
| `controlcenter.go` `ccStartService` | `up -d` (already on the helper's pattern; folded through for consistency) |
| `controlcenter.go` `ccStopService` | `down` |
| `controlcenter.go` `ccRestartService` | `restart` |
| `controlcenter.go` `ccGetServiceDetail` | `ps --format json` |
| `controlcenter.go` `ccGetServiceLogs` | `logs --tail 50` |

Per-site args are preserved byte-for-byte (the ps/down/restart/logs sites keep their bare `-f` / `-p citadel-<name>` args; the sandbox override is **not** leaked onto them — it stays only on the `up` start path). Non-compose engine ops (`stop`/`rm`/`inspect`/`pull`, container-level `logs`) and whatsapp's `--env-file` path are left untouched — they don't interpolate the compose file, so the `:?` guard doesn't apply. Now-unused `os/exec` (run.go) and `catalog` (controlcenter.go) imports dropped.

Added `cmd/service_test.go` asserting `composeCommand`'s `cmd.Env` contains every `services.HostPortEnv()` entry (pure, no docker). `go build ./...`, `go test ./...`, and `gofmt -l .` all green.

## Related

#405, #410, #413.


Closes #426.

