### PR TITLE
feat(services): headless Claude Code agent-runtime for BYOC hosting (#432)

### DIFF
--- a/services/claudecode-service/Dockerfile
+++ b/services/claudecode-service/Dockerfile
@@ -1,0 +1,69 @@
+# Headless Claude Code agent-runtime image for a Citadel node
+# (aceteam-ai/citadel-cli#432). Built and published as
+# ghcr.io/aceteam-ai/claudecode-service (see services/compose/claudecode.yml).
+#
+# This is CPU-only: the model runs remotely via the AceTeam fabric proxy (pointed
+# at by the ANTHROPIC_* env), so there is NO CUDA/torch/GPU here. The image
+# bundles the Claude Code CLI (a Node package) plus a tiny Python/FastAPI wrapper
+# (wrapper.py) that bridges AceTeam's chat routing seam to a headless `claude -p`
+# turn. No secrets are baked in -- all auth is via env at run time.
+#
+# Base is the Node LTS slim image because the CLI is distributed on npm; we layer
+# a system python3 + FastAPI/uvicorn on top for the wrapper.
+FROM node:22-bookworm-slim
+
+# System deps:
+#   python3 + venv/pip  -> run the wrapper
+#   git                 -> Claude Code shells out to git for repo-aware turns
+#   ca-certificates     -> TLS to the fabric proxy and the platform callback
+#   tini                -> proper PID 1 / signal handling for the long-lived server
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python3 python3-venv python3-pip git ca-certificates tini \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install the Claude Code CLI globally. Pin via CLAUDE_CODE_VERSION build-arg for
+# reproducible images; defaults to latest. The package speaks the Anthropic
+# Messages API, so pointing ANTHROPIC_BASE_URL at the fabric proxy is the whole
+# trick -- no code change, no wrapper around the CLI.
+ARG CLAUDE_CODE_VERSION=latest
+RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} \
+    && npm cache clean --force
+
+# Wrapper deps in an isolated venv (avoids Debian's PEP 668 externally-managed
+# marker); put the venv on PATH so `python`/`uvicorn` resolve to it.
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv "$VIRTUAL_ENV"
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt
+
+COPY wrapper.py /app/wrapper.py
+
+# Non-root runtime user with a real home. Claude Code state lives under
+# $HOME/.claude (redirected explicitly via CLAUDE_CONFIG_DIR so it always matches
+# the mounted volume regardless of $HOME resolution). The compose file bind-mounts
+# a node-disk dir here so config/sessions persist across restarts.
+RUN useradd --create-home --uid 10001 --shell /usr/sbin/nologin claude \
+    && mkdir -p /home/claude/.claude \
+    && chown -R claude:claude /home/claude /app
+ENV HOME=/home/claude
+ENV CLAUDE_CONFIG_DIR=/home/claude/.claude
+
+# Fixed internal contract port for the wrapper HTTP server (the compose file maps
+# the citadel-owned host port to this).
+ENV PORT=8787
+
+# Keep the container fully local: no auto-update fetch, no telemetry beacon, so
+# the only external traffic is to ANTHROPIC_BASE_URL (the fabric proxy) and the
+# AceTeam reply callback. These honor the same knobs Claude Code documents.
+ENV DISABLE_AUTOUPDATER=1
+ENV CLAUDE_CODE_ENABLE_TELEMETRY=0
+
+USER claude
+WORKDIR /app
+EXPOSE 8787
+
+# tini as PID 1 for clean signal handling of the long-lived uvicorn server.
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["sh", "-c", "uvicorn wrapper:app --host 0.0.0.0 --port ${PORT}"]

--- a/services/claudecode-service/Dockerfile
+++ b/services/claudecode-service/Dockerfile
@@ -17,9 +17,11 @@ FROM node:22-bookworm-slim
 #   git                 -> Claude Code shells out to git for repo-aware turns
 #   ca-certificates     -> TLS to the fabric proxy and the platform callback
 #   tini                -> proper PID 1 / signal handling for the long-lived server
+#   gosu                -> drop from root to the claude user in the entrypoint,
+#                          after fixing ownership of the bind-mounted state dir
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        python3 python3-venv python3-pip git ca-certificates tini \
+        python3 python3-venv python3-pip git ca-certificates tini gosu \
     && rm -rf /var/lib/apt/lists/*
 
 # Install the Claude Code CLI globally. Pin via CLAUDE_CODE_VERSION build-arg for
@@ -39,14 +41,17 @@ COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r /app/requirements.txt
 
 COPY wrapper.py /app/wrapper.py
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 
 # Non-root runtime user with a real home. Claude Code state lives under
 # $HOME/.claude (redirected explicitly via CLAUDE_CONFIG_DIR so it always matches
 # the mounted volume regardless of $HOME resolution). The compose file bind-mounts
-# a node-disk dir here so config/sessions persist across restarts.
-RUN useradd --create-home --uid 10001 --shell /usr/sbin/nologin claude \
+# a node-disk dir here so config/sessions persist across restarts; the entrypoint
+# chowns that mount to `claude` at boot (a host bind-mount is not owned by 10001).
+RUN useradd --create-home --uid 10001 --shell /bin/sh claude \
     && mkdir -p /home/claude/.claude \
-    && chown -R claude:claude /home/claude /app
+    && chown -R claude:claude /home/claude /app \
+    && chmod +x /usr/local/bin/entrypoint.sh
 ENV HOME=/home/claude
 ENV CLAUDE_CONFIG_DIR=/home/claude/.claude
 
@@ -60,10 +65,14 @@ ENV PORT=8787
 ENV DISABLE_AUTOUPDATER=1
 ENV CLAUDE_CODE_ENABLE_TELEMETRY=0
 
-USER claude
+# NB: we deliberately do NOT set `USER claude` here. The container starts as root
+# so entrypoint.sh can chown the bind-mounted state dir; it then drops to the
+# claude user via gosu before exec'ing the server (so `claude` never runs as
+# root, which it refuses to do under --dangerously-skip-permissions anyway).
 WORKDIR /app
 EXPOSE 8787
 
-# tini as PID 1 for clean signal handling of the long-lived uvicorn server.
-ENTRYPOINT ["/usr/bin/tini", "--"]
+# tini as PID 1 for clean signal handling of the long-lived uvicorn server;
+# entrypoint.sh fixes the mount ownership and drops privileges.
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/entrypoint.sh"]
 CMD ["sh", "-c", "uvicorn wrapper:app --host 0.0.0.0 --port ${PORT}"]

--- a/services/claudecode-service/README.md
+++ b/services/claudecode-service/README.md
@@ -1,0 +1,94 @@
+# Headless Claude Code agent-runtime (Citadel BYOC)
+
+Phase-1 flagship runtime for the BYOC agent-hosting story
+(aceteam-ai/citadel-cli#432, Child C of aceteam-ai/aceteam#4588). A Claude Code
+CLI turn driven headlessly by a tiny HTTP wrapper, with the model pointed at the
+AceTeam fabric proxy. A full turn runs on your own node with **no external
+Anthropic API key** -- agent AND model on your metal, the differentiator Fly
+cannot match.
+
+## How it works
+
+```
+  platform  --POST /hooks/agent-->  wrapper (FastAPI)  --claude -p-->  Claude Code CLI
+  (routing seam)   (fast 200 ack)    async turn         --Messages API-->  ANTHROPIC_BASE_URL
+                                                                            (fabric proxy)
+  platform  <--POST /api/instances/{id}/reply--  wrapper   (assistant text)
+```
+
+- Inbound `POST /hooks/agent` with `Authorization: Bearer hooks_{GATEWAY_KEY}`
+  and `{"message","name"}`. The wrapper validates the token, **ACKs fast** with
+  `200 {"delivered": true}`, and runs the turn on a background thread.
+- The turn shells out to `claude -p "<message>" --output-format json
+  --dangerously-skip-permissions`, capturing the assistant text from the JSON
+  `result` field.
+- On completion it POSTs `{"reply": "<text>"}` (or `{"error": "..."}` on
+  failure) to `{PLATFORM_URL}/api/instances/{INSTANCE_ID}/reply` with
+  `Authorization: Bearer {GATEWAY_KEY}` (the **raw** key, not `hooks_`-prefixed).
+- `GET /health` backs the compose healthcheck and reports the proxy wiring.
+
+The wrapper listens on the **fixed internal port 8787**. The compose file maps
+the citadel-owned host port to it.
+
+## Env it needs
+
+| Env | Meaning |
+|-----|---------|
+| `ACETEAM_INSTANCE_ID` | instance id, used in the reply URL path |
+| `ACETEAM_PLATFORM_URL` | base URL to POST replies to (e.g. `https://aceteam.ai`) |
+| `ACETEAM_GATEWAY_KEY` | raw gateway key: inbound validated vs `hooks_`+it, outbound auth with it |
+| `ANTHROPIC_BASE_URL` | fabric proxy base URL (Anthropic-compatible) |
+| `ANTHROPIC_AUTH_TOKEN` | Bearer token for the proxy (sent as `Authorization: Bearer`) |
+| `ANTHROPIC_MODEL` | model id served by the proxy |
+| `ANTHROPIC_SMALL_FAST_MODEL` | optional haiku-tier model for Claude Code sub-tasks |
+| `CITADEL_CLAUDECODE_HOST_PORT` | host port for the wrapper (standalone compose; citadel supplies it) |
+
+The image bakes in `DISABLE_AUTOUPDATER=1` and `CLAUDE_CODE_ENABLE_TELEMETRY=0`
+so the only external traffic is to `ANTHROPIC_BASE_URL` and the reply callback.
+
+## State volume ("permanent home")
+
+Claude Code state (config, sessions, projects) lives at
+`/home/claude/.claude` inside the container (via `CLAUDE_CONFIG_DIR`) and is
+bind-mounted from `~/citadel-cache/claudecode` on the node, so it accumulates
+across restarts.
+
+## Run it (standalone / live-proof)
+
+```sh
+CITADEL_CLAUDECODE_HOST_PORT=8204 \
+ACETEAM_INSTANCE_ID=<id> \
+ACETEAM_PLATFORM_URL=https://aceteam.ai \
+ACETEAM_GATEWAY_KEY=<raw-key> \
+ANTHROPIC_BASE_URL=<fabric-proxy-url> \
+ANTHROPIC_AUTH_TOKEN=<proxy-token> \
+ANTHROPIC_MODEL=<model-id> \
+docker compose -f services/compose/claudecode.yml up
+```
+
+## Install as a module
+
+Publish `service.yaml` + `compose.yml` from this directory as
+`services/claudecode/{service.yaml,compose.yml}` in a catalog repo
+(e.g. `aceteam-ai/citadel-services`). The module `compose.yml` publishes the
+literal host port `8204` (the module path does not inject
+`CITADEL_CLAUDECODE_HOST_PORT`).
+
+## Build the image
+
+```sh
+docker build -t ghcr.io/aceteam-ai/claudecode-service:latest \
+  services/claudecode-service
+# pin the CLI: --build-arg CLAUDE_CODE_VERSION=<x.y.z>
+```
+
+## Local smoke test (no real infra)
+
+```sh
+python3 services/claudecode-service/smoke_test.py
+```
+
+Builds the image, starts a mock Anthropic proxy + mock reply receiver, runs a
+turn, and asserts the fast ack, the Anthropic-shaped proxy request, and the
+well-formed `{reply}` POST with raw-key auth. See the PR "Testing" section for
+sample output.

--- a/services/claudecode-service/README.md
+++ b/services/claudecode-service/README.md
@@ -53,6 +53,11 @@ Claude Code state (config, sessions, projects) lives at
 bind-mounted from `~/citadel-cache/claudecode` on the node, so it accumulates
 across restarts.
 
+The container starts as root, its entrypoint chowns this mount to the non-root
+`claude` user (uid 10001), then drops privileges via `gosu` -- so a fresh
+host-owned mount "just works" with no manual pre-create. `claude` never runs as
+root (which it refuses under `--dangerously-skip-permissions` anyway).
+
 ## Run it (standalone / live-proof)
 
 ```sh

--- a/services/claudecode-service/compose.yml
+++ b/services/claudecode-service/compose.yml
@@ -1,0 +1,34 @@
+# Module compose for the headless Claude Code runtime (citadel-cli#432).
+#
+# This is the MODULE-install variant of services/compose/claudecode.yml. The two
+# differ in ONE way: the standalone file defers the host port to citadel via
+# ${CITADEL_CLAUDECODE_HOST_PORT:?...}; this module file publishes the LITERAL
+# host port 8204 declared in service.yaml, because the module-install path does
+# not inject that env var (only the four built-in ports.go services get it).
+# Everything else is identical.
+services:
+  claudecode:
+    image: ghcr.io/aceteam-ai/claudecode-service:latest
+    container_name: citadel-claudecode
+    ports:
+      - "8204:8787"
+    volumes:
+      - ~/citadel-cache/claudecode:/home/claude/.claude
+    environment:
+      - ACETEAM_INSTANCE_ID=${ACETEAM_INSTANCE_ID:?set ACETEAM_INSTANCE_ID}
+      - ACETEAM_PLATFORM_URL=${ACETEAM_PLATFORM_URL:?set ACETEAM_PLATFORM_URL}
+      - ACETEAM_GATEWAY_KEY=${ACETEAM_GATEWAY_KEY:?set ACETEAM_GATEWAY_KEY}
+      - ANTHROPIC_BASE_URL=${ANTHROPIC_BASE_URL:?set ANTHROPIC_BASE_URL to the fabric proxy}
+      - ANTHROPIC_AUTH_TOKEN=${ANTHROPIC_AUTH_TOKEN:?set ANTHROPIC_AUTH_TOKEN for the proxy}
+      - ANTHROPIC_MODEL=${ANTHROPIC_MODEL:?set ANTHROPIC_MODEL}
+      - ANTHROPIC_SMALL_FAST_MODEL=${ANTHROPIC_SMALL_FAST_MODEL:-}
+      - PORT=8787
+      - CLAUDE_CONFIG_DIR=/home/claude/.claude
+      - CLAUDECODE_TURN_TIMEOUT=${CLAUDECODE_TURN_TIMEOUT:-600}
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8787/health')"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+    restart: unless-stopped

--- a/services/claudecode-service/compose.yml
+++ b/services/claudecode-service/compose.yml
@@ -13,6 +13,8 @@ services:
     ports:
       - "8204:8787"
     volumes:
+      # Entrypoint (root) chowns this mount to the claude user, then drops
+      # privileges -- a fresh host-owned dir "just works" with no pre-create.
       - ~/citadel-cache/claudecode:/home/claude/.claude
     environment:
       - ACETEAM_INSTANCE_ID=${ACETEAM_INSTANCE_ID:?set ACETEAM_INSTANCE_ID}

--- a/services/claudecode-service/entrypoint.sh
+++ b/services/claudecode-service/entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Entrypoint for the headless Claude Code runtime (citadel-cli#432).
+#
+# The container runs the wrapper + `claude` as the NON-root `claude` user
+# (uid 10001), and the compose file bind-mounts the node dir
+# ~/citadel-cache/claudecode onto CLAUDE_CONFIG_DIR (/home/claude/.claude) so
+# Claude Code state persists across restarts. A bind-mount source is owned by
+# whoever created it on the host (root or the operator's uid), NOT 10001 -- so
+# without this fixup, Claude Code's first-run config/session writes into the
+# mounted dir fail with EACCES.
+#
+# Fix: start as root (this script's PID via tini), chown the state dir to the
+# claude user, then drop to that user via gosu to exec the server. Claude Code
+# refuses --dangerously-skip-permissions as root, so dropping to a real user is
+# also required for the turn to run at all.
+set -e
+
+STATE_DIR="${CLAUDE_CONFIG_DIR:-/home/claude/.claude}"
+mkdir -p "$STATE_DIR"
+# Only chown when needed (a large persisted state dir shouldn't be re-chowned
+# top-to-bottom on every boot). If the top dir is already claude-owned, assume
+# the tree is fine.
+if [ "$(stat -c '%u' "$STATE_DIR")" != "10001" ]; then
+    chown -R claude:claude "$STATE_DIR"
+fi
+
+exec gosu claude "$@"

--- a/services/claudecode-service/requirements.txt
+++ b/services/claudecode-service/requirements.txt
@@ -1,0 +1,4 @@
+# HTTP wrapper deps for the headless Claude Code runtime. CPU-only, tiny: the
+# model runs remotely via the fabric proxy, so there is no ML stack here.
+fastapi==0.115.6
+uvicorn==0.34.0

--- a/services/claudecode-service/service.yaml
+++ b/services/claudecode-service/service.yaml
@@ -1,0 +1,88 @@
+# Citadel module manifest for the headless Claude Code agent-runtime
+# (aceteam-ai/citadel-cli#432). This is the module-install path: it mirrors the
+# schema consumed by internal/catalog (ServiceManifest). To ship as an
+# installable module, publish this dir as services/claudecode/{service.yaml,
+# compose.yml} in a catalog repo (e.g. aceteam-ai/citadel-services); citadel then
+# resolves it via `citadel service catalog` / module install.
+#
+# The standalone compose lives at services/compose/claudecode.yml and is what the
+# live-proof uses via `docker compose -f ... up`. This manifest declares a LITERAL
+# host port (8204) because the module path does NOT inject
+# CITADEL_CLAUDECODE_HOST_PORT the way the built-in ports.go registry does for the
+# four core services -- so the module compose (compose.yml alongside this file)
+# publishes a fixed host port instead of the ${...} guard.
+schema_version: 2
+name: claudecode
+version: 0.1.0
+description: >-
+  Headless Claude Code agent-runtime. Runs a full Claude Code turn on your own
+  node with the model pointed at the AceTeam fabric proxy -- agent AND model on
+  your metal, no external Anthropic API key.
+category: agent-runtime
+author: AceTeam
+license: Apache-2.0
+homepage: https://github.com/aceteam-ai/citadel-cli/issues/432
+
+requires:
+  # CPU-only: the model path is the remote fabric proxy, so no GPU is needed.
+  gpu: false
+  arch: [amd64, arm64]
+
+ports:
+  # The wrapper listens on the fixed internal contract port 8787; the module
+  # publishes it on host 8204 (next free slot in citadel's 8200+ module block,
+  # clear of the reserved ports and the 8100-8199 apps range).
+  - host: 8204
+    container: 8787
+    protocol: tcp
+    description: Claude Code runtime wrapper HTTP (/hooks/agent, /health)
+
+config:
+  - name: ACETEAM_INSTANCE_ID
+    description: Instance id used in the reply URL path.
+    required: true
+  - name: ACETEAM_PLATFORM_URL
+    description: Base URL to POST replies to (e.g. https://aceteam.ai).
+    required: true
+  - name: ACETEAM_GATEWAY_KEY
+    description: >-
+      Raw gateway key. Inbound /hooks/agent is validated against hooks_+key;
+      outbound replies auth with the raw key.
+    required: true
+  - name: ANTHROPIC_BASE_URL
+    description: Fabric proxy base URL (Anthropic-compatible).
+    required: true
+  - name: ANTHROPIC_AUTH_TOKEN
+    description: Bearer token for the fabric proxy.
+    required: true
+  - name: ANTHROPIC_MODEL
+    description: Model id served by the proxy.
+    required: true
+  - name: ANTHROPIC_SMALL_FAST_MODEL
+    description: Optional small/fast (haiku-tier) model for Claude Code sub-tasks.
+    required: false
+
+health_check:
+  endpoint: /health
+  port: 8787
+  interval: 10s
+  timeout: 5s
+  retries: 12
+
+volumes:
+  - name: claude-state
+    host: ~/citadel-cache/claudecode
+    container: /home/claude/.claude
+    description: >-
+      Claude Code config/sessions/projects -- the "permanent home". Persists
+      across restarts on the node disk.
+
+# Namespaced routing tag so this node becomes routable as a Claude Code runtime
+# without a CLI change.
+node_tags:
+  - runtime:claudecode
+
+tags:
+  - agent
+  - claude-code
+  - byoc

--- a/services/claudecode-service/smoke_test.py
+++ b/services/claudecode-service/smoke_test.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Local docker smoke test for the headless Claude Code runtime (citadel-cli#432).
+
+Proves the full turn contract WITHOUT any real infrastructure:
+
+  1. Build the runtime image (docker build).
+  2. Start a MOCK Anthropic proxy that returns a canned Messages response and
+     records that it received an Anthropic-shaped request (Bearer auth,
+     /v1/messages, a `model` + `messages` body).
+  3. Start a MOCK AceTeam reply receiver.
+  4. Run the container pointed at both mocks, POST a /hooks/agent turn, and assert:
+       (a) fast 200 {"delivered": true} ack,
+       (b) the mock proxy received an Anthropic-shaped request,
+       (c) the mock receiver got a well-formed {"reply": ...} POST carrying
+           Authorization: Bearer <RAW gateway key> (not hooks_-prefixed).
+
+The mock proxy answers both the streaming (SSE) and non-streaming shapes of the
+Anthropic Messages API, so it satisfies `claude -p` regardless of whether the CLI
+requests a stream. The canned assistant text is echoed back to the receiver,
+proving the model output flows end-to-end with NO real Anthropic API key.
+
+Run:  python3 services/claudecode-service/smoke_test.py
+Requires: docker, python3 (stdlib only).
+"""
+
+import json
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+IMAGE = "citadel-claudecode-service:smoke"
+CONTAINER = "citadel-claudecode-smoke"
+GATEWAY_KEY = "smoke-gateway-key-123"
+INSTANCE_ID = "inst_smoke_1"
+CANNED_REPLY = "Hello from the fabric proxy. 2 plus 2 is 4."
+HOST_PORT = 8299  # ephemeral host port for the wrapper during the test
+
+SERVICE_DIR = Path(__file__).resolve().parent
+# docker build context is this service dir (Dockerfile + wrapper.py + requirements).
+
+
+# --- Shared record of what the mocks observed (asserted at the end) -----------
+observed = {
+    "proxy_hits": [],   # list of dicts: {path, auth, model, has_messages}
+    "reply_body": None,  # parsed JSON of the reply POST
+    "reply_auth": None,  # Authorization header on the reply POST
+}
+observed_lock = threading.Lock()
+
+
+class MockProxyHandler(BaseHTTPRequestHandler):
+    """Mock Anthropic-compatible fabric proxy: answers POST /v1/messages."""
+
+    def log_message(self, *args):  # silence default logging
+        pass
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", "0"))
+        raw = self.rfile.read(length) if length else b"{}"
+        try:
+            body = json.loads(raw or b"{}")
+        except json.JSONDecodeError:
+            body = {}
+
+        with observed_lock:
+            observed["proxy_hits"].append(
+                {
+                    "path": self.path,
+                    "auth": self.headers.get("Authorization"),
+                    "model": body.get("model"),
+                    "has_messages": isinstance(body.get("messages"), list),
+                    "stream": bool(body.get("stream")),
+                }
+            )
+
+        # Only the Messages endpoint is meaningful; anything else 404s.
+        if not self.path.startswith("/v1/messages"):
+            self.send_response(404)
+            self.end_headers()
+            self.wfile.write(b'{"error":"not found"}')
+            return
+
+        if body.get("stream"):
+            self._send_sse()
+        else:
+            self._send_json()
+
+    def _send_json(self):
+        payload = {
+            "id": "msg_smoke",
+            "type": "message",
+            "role": "assistant",
+            "model": "smoke-model",
+            "content": [{"type": "text", "text": CANNED_REPLY}],
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 5, "output_tokens": 12},
+        }
+        data = json.dumps(payload).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _send_sse(self):
+        """Emit the Anthropic Messages streaming (SSE) event sequence."""
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.end_headers()
+
+        def event(kind, obj):
+            chunk = f"event: {kind}\ndata: {json.dumps(obj)}\n\n".encode("utf-8")
+            self.wfile.write(chunk)
+            self.wfile.flush()
+
+        event(
+            "message_start",
+            {
+                "type": "message_start",
+                "message": {
+                    "id": "msg_smoke",
+                    "type": "message",
+                    "role": "assistant",
+                    "model": "smoke-model",
+                    "content": [],
+                    "stop_reason": None,
+                    "usage": {"input_tokens": 5, "output_tokens": 0},
+                },
+            },
+        )
+        event(
+            "content_block_start",
+            {"type": "content_block_start", "index": 0,
+             "content_block": {"type": "text", "text": ""}},
+        )
+        event(
+            "content_block_delta",
+            {"type": "content_block_delta", "index": 0,
+             "delta": {"type": "text_delta", "text": CANNED_REPLY}},
+        )
+        event("content_block_stop", {"type": "content_block_stop", "index": 0})
+        event(
+            "message_delta",
+            {"type": "message_delta",
+             "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+             "usage": {"output_tokens": 12}},
+        )
+        event("message_stop", {"type": "message_stop"})
+
+
+class MockReceiverHandler(BaseHTTPRequestHandler):
+    """Mock AceTeam platform: records the reply POST to /api/instances/.../reply."""
+
+    def log_message(self, *args):
+        pass
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", "0"))
+        raw = self.rfile.read(length) if length else b"{}"
+        try:
+            body = json.loads(raw or b"{}")
+        except json.JSONDecodeError:
+            body = {}
+        with observed_lock:
+            observed["reply_body"] = body
+            observed["reply_auth"] = self.headers.get("Authorization")
+        resp = json.dumps({"accepted": True}).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(resp)))
+        self.end_headers()
+        self.wfile.write(resp)
+
+
+def start_server(handler):
+    srv = ThreadingHTTPServer(("0.0.0.0", 0), handler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return srv, srv.server_address[1]
+
+
+def sh(cmd, **kw):
+    print(f"$ {' '.join(cmd)}", flush=True)
+    return subprocess.run(cmd, **kw)
+
+
+def cleanup():
+    subprocess.run(["docker", "rm", "-f", CONTAINER],
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def main() -> int:
+    # 1. Build the image.
+    r = sh(["docker", "build", "-t", IMAGE, str(SERVICE_DIR)])
+    if r.returncode != 0:
+        print("FAIL: docker build failed", file=sys.stderr)
+        return 1
+
+    # 2 + 3. Start the mock proxy and mock receiver on the host.
+    proxy_srv, proxy_port = start_server(MockProxyHandler)
+    recv_srv, recv_port = start_server(MockReceiverHandler)
+    print(f"mock proxy on :{proxy_port}  mock receiver on :{recv_port}", flush=True)
+
+    cleanup()
+
+    # The container reaches host services via host.docker.internal (mapped to the
+    # host gateway). Works on Docker Desktop natively and on Linux via the
+    # host-gateway alias we add below.
+    host_alias = "host.docker.internal"
+    base_url = f"http://{host_alias}:{proxy_port}"
+    platform_url = f"http://{host_alias}:{recv_port}"
+
+    run_cmd = [
+        "docker", "run", "-d", "--name", CONTAINER,
+        "--add-host", "host.docker.internal:host-gateway",
+        "-p", f"{HOST_PORT}:8787",
+        "-e", f"ACETEAM_INSTANCE_ID={INSTANCE_ID}",
+        "-e", f"ACETEAM_PLATFORM_URL={platform_url}",
+        "-e", f"ACETEAM_GATEWAY_KEY={GATEWAY_KEY}",
+        "-e", f"ANTHROPIC_BASE_URL={base_url}",
+        "-e", "ANTHROPIC_AUTH_TOKEN=smoke-proxy-token",
+        "-e", "ANTHROPIC_MODEL=smoke-model",
+        IMAGE,
+    ]
+    r = sh(run_cmd)
+    if r.returncode != 0:
+        print("FAIL: docker run failed", file=sys.stderr)
+        return 1
+
+    try:
+        # Wait for /health to come up.
+        health_url = f"http://127.0.0.1:{HOST_PORT}/health"
+        ok = False
+        for _ in range(30):
+            try:
+                with urllib.request.urlopen(health_url, timeout=2) as resp:
+                    if resp.status == 200:
+                        ok = True
+                        break
+            except Exception:
+                time.sleep(1)
+        if not ok:
+            print("FAIL: wrapper /health never came up", file=sys.stderr)
+            sh(["docker", "logs", CONTAINER])
+            return 1
+        print("PASS: /health is up", flush=True)
+
+        # 4. POST an inbound turn and assert a FAST ack (before the turn finishes).
+        turn_url = f"http://127.0.0.1:{HOST_PORT}/hooks/agent"
+        req = urllib.request.Request(
+            turn_url,
+            data=json.dumps({"message": "what is 2+2?", "name": "smoke"}).encode(),
+            method="POST",
+        )
+        req.add_header("Content-Type", "application/json")
+        req.add_header("Authorization", f"Bearer hooks_{GATEWAY_KEY}")
+        t0 = time.time()
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            ack = json.loads(resp.read())
+            ack_status = resp.status
+        ack_ms = (time.time() - t0) * 1000
+        with observed_lock:
+            reply_already = observed["reply_body"] is not None
+        if ack_status != 200 or ack.get("delivered") is not True:
+            print(f"FAIL: bad ack: {ack_status} {ack}", file=sys.stderr)
+            return 1
+        # Fast-ack ORDERING: the ack must return before the reply POST lands.
+        if reply_already:
+            print("FAIL: reply arrived before the ack returned (not async)",
+                  file=sys.stderr)
+            return 1
+        print(f"PASS: fast ack {ack} in {ack_ms:.0f}ms, before reply POST", flush=True)
+
+        # Reject a bad bearer token (auth check).
+        bad = urllib.request.Request(
+            turn_url,
+            data=json.dumps({"message": "x", "name": "y"}).encode(),
+            method="POST",
+        )
+        bad.add_header("Content-Type", "application/json")
+        bad.add_header("Authorization", "Bearer wrong")
+        try:
+            urllib.request.urlopen(bad, timeout=5)
+            print("FAIL: bad bearer token was accepted", file=sys.stderr)
+            return 1
+        except urllib.error.HTTPError as exc:
+            if exc.code != 401:
+                print(f"FAIL: bad token gave {exc.code}, want 401", file=sys.stderr)
+                return 1
+        print("PASS: bad bearer token rejected with 401", flush=True)
+
+        # Wait for the turn to complete and the reply to reach the receiver.
+        reply = None
+        for _ in range(60):
+            with observed_lock:
+                reply = observed["reply_body"]
+                reply_auth = observed["reply_auth"]
+            if reply is not None:
+                break
+            time.sleep(1)
+
+        if reply is None:
+            print("FAIL: mock receiver never got a reply POST", file=sys.stderr)
+            sh(["docker", "logs", CONTAINER])
+            return 1
+
+        # (b) the mock proxy received an Anthropic-shaped request.
+        with observed_lock:
+            hits = list(observed["proxy_hits"])
+        msg_hits = [h for h in hits if h["path"].startswith("/v1/messages")]
+        if not msg_hits:
+            print(f"FAIL: proxy got no /v1/messages request; hits={hits}",
+                  file=sys.stderr)
+            return 1
+        h = msg_hits[0]
+        if not (h["auth"] == "Bearer smoke-proxy-token" and h["has_messages"]):
+            print(f"FAIL: proxy request not Anthropic-shaped: {h}", file=sys.stderr)
+            return 1
+        print(f"PASS: proxy got Anthropic-shaped request: {h}", flush=True)
+
+        # (c) reply is well-formed and auth is the RAW key (not hooks_-prefixed).
+        if "reply" not in reply and "error" not in reply:
+            print(f"FAIL: reply body has neither reply nor error: {reply}",
+                  file=sys.stderr)
+            return 1
+        if "error" in reply:
+            print(f"FAIL: turn ended in error: {reply['error']}", file=sys.stderr)
+            sh(["docker", "logs", CONTAINER])
+            return 1
+        if reply_auth != f"Bearer {GATEWAY_KEY}":
+            print(f"FAIL: reply auth is {reply_auth!r}, want raw Bearer key",
+                  file=sys.stderr)
+            return 1
+        if reply_auth == f"Bearer hooks_{GATEWAY_KEY}":
+            print("FAIL: reply used the hooks_-prefixed token", file=sys.stderr)
+            return 1
+        print(f"PASS: receiver got well-formed reply with RAW-key auth: {reply}",
+              flush=True)
+
+        # The canned model text should have flowed through end-to-end.
+        if CANNED_REPLY not in reply["reply"]:
+            print(f"WARN: canned text not found verbatim in reply "
+                  f"(CLI may reshape it): {reply['reply']!r}", flush=True)
+        else:
+            print("PASS: canned fabric-proxy text flowed end-to-end", flush=True)
+
+        print("\nSMOKE TEST PASSED", flush=True)
+        return 0
+    finally:
+        proxy_srv.shutdown()
+        recv_srv.shutdown()
+        cleanup()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/claudecode-service/smoke_test.py
+++ b/services/claudecode-service/smoke_test.py
@@ -26,6 +26,7 @@ Requires: docker, python3 (stdlib only).
 import json
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 import urllib.error
@@ -207,6 +208,15 @@ def main() -> int:
 
     cleanup()
 
+    # Mount a HOST-OWNED state dir onto the container's CLAUDE_CONFIG_DIR, exactly
+    # as the compose file does on a node. The host dir is owned by the test
+    # runner's uid, NOT the container's claude user (uid 10001) -- this reproduces
+    # the live-deploy bind-mount permission path, so the entrypoint's chown fixup
+    # is actually exercised (a no-volume run would silently use the image's own
+    # claude-owned dir and never catch the EACCES landmine).
+    state_dir = tempfile.mkdtemp(prefix="cc-smoke-state-")
+    print(f"host-owned state dir: {state_dir}", flush=True)
+
     # The container reaches host services via host.docker.internal (mapped to the
     # host gateway). Works on Docker Desktop natively and on Linux via the
     # host-gateway alias we add below.
@@ -218,6 +228,7 @@ def main() -> int:
         "docker", "run", "-d", "--name", CONTAINER,
         "--add-host", "host.docker.internal:host-gateway",
         "-p", f"{HOST_PORT}:8787",
+        "-v", f"{state_dir}:/home/claude/.claude",
         "-e", f"ACETEAM_INSTANCE_ID={INSTANCE_ID}",
         "-e", f"ACETEAM_PLATFORM_URL={platform_url}",
         "-e", f"ACETEAM_GATEWAY_KEY={GATEWAY_KEY}",
@@ -348,12 +359,28 @@ def main() -> int:
         else:
             print("PASS: canned fabric-proxy text flowed end-to-end", flush=True)
 
+        # (d) State persistence: the turn ran as non-root against a host-owned
+        # mount, so the entrypoint chown fixup worked -- confirm Claude Code
+        # actually wrote state into the mounted "permanent home".
+        state_entries = list(Path(state_dir).rglob("*"))
+        if not state_entries:
+            print(f"WARN: no state written under the mounted dir {state_dir} "
+                  "(permanent-home persistence unverified)", flush=True)
+        else:
+            sample = ", ".join(
+                sorted(p.name for p in Path(state_dir).iterdir())[:6]
+            )
+            print(f"PASS: Claude Code wrote state to the mounted dir ({sample})",
+                  flush=True)
+
         print("\nSMOKE TEST PASSED", flush=True)
         return 0
     finally:
         proxy_srv.shutdown()
         recv_srv.shutdown()
         cleanup()
+        subprocess.run(["rm", "-rf", state_dir],
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
 
 if __name__ == "__main__":

--- a/services/claudecode-service/wrapper.py
+++ b/services/claudecode-service/wrapper.py
@@ -1,0 +1,240 @@
+"""Headless Claude Code agent-runtime wrapper for Citadel (aceteam-ai/citadel-cli#432).
+
+This is the phase-1 flagship BYOC agent runtime: a tiny HTTP server that bridges
+AceTeam's chat routing seam (aceteam #4593) to a headless Claude Code CLI turn.
+The model is pointed at the AceTeam fabric proxy (an Anthropic-compatible
+endpoint) via the ANTHROPIC_* env, so a full turn runs with NO external Anthropic
+API key -- the "agent AND model on your own metal" story that Fly cannot match.
+
+Contract (pinned by the routing-seam PR #4593 -- do NOT change it):
+
+  Inbound (platform -> this container):
+    POST /hooks/agent
+    Authorization: Bearer hooks_{GATEWAY_KEY}
+    { "message": "<user text>", "name": "<label>" }
+  We validate the bearer token equals "hooks_" + the container's gateway key,
+  then ACK FAST with 200 {"delivered": true} and process the turn on a
+  background thread (the caller expects a quick delivery ack, not a blocking
+  model turn).
+
+  Outbound (this container -> platform), when the turn finishes:
+    POST {PLATFORM_URL}/api/instances/{INSTANCE_ID}/reply
+    Authorization: Bearer {GATEWAY_KEY}          # RAW key, NOT hooks_-prefixed
+    { "reply": "<assistant text>" }              # on success
+    { "error": "<user-facing message>" }         # on terminal failure
+  Expect 200 {"accepted": true}.
+
+Everything is driven by env (no secrets baked into the image); see the compose
+file services/compose/claudecode.yml and the README in this directory.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+
+from fastapi import FastAPI, Header, HTTPException, Request
+
+# --- Container env contract (set by the runtime provider; read here) ----------
+# The instance id, used in the reply URL path.
+INSTANCE_ID = os.environ.get("ACETEAM_INSTANCE_ID", "")
+# Base URL to POST replies to (e.g. https://aceteam.ai). Trailing slash trimmed.
+PLATFORM_URL = os.environ.get("ACETEAM_PLATFORM_URL", "").rstrip("/")
+# Raw gateway key: inbound is validated against "hooks_"+key; outbound auths with key.
+GATEWAY_KEY = os.environ.get("ACETEAM_GATEWAY_KEY", "")
+
+# Model env is consumed by the `claude` CLI directly (it speaks the Anthropic
+# Messages API): ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN / ANTHROPIC_MODEL /
+# ANTHROPIC_SMALL_FAST_MODEL. We do not read them here -- we only pass the
+# process environment through to the subprocess -- but we surface them on /health
+# so an operator can confirm the fabric-proxy wiring without shell access.
+ANTHROPIC_BASE_URL = os.environ.get("ANTHROPIC_BASE_URL", "")
+ANTHROPIC_MODEL = os.environ.get("ANTHROPIC_MODEL", "")
+
+# Fixed internal port the wrapper listens on inside the container. The compose
+# file maps ${CITADEL_CLAUDECODE_HOST_PORT} on the host to this. Kept as an env
+# so the Dockerfile CMD and this module agree on one value.
+PORT = int(os.environ.get("PORT", "8787"))
+
+# Hard ceiling on a single Claude Code turn. A wedged turn posts {error} rather
+# than hanging the instance forever. Override via CLAUDECODE_TURN_TIMEOUT.
+TURN_TIMEOUT_SECONDS = int(os.environ.get("CLAUDECODE_TURN_TIMEOUT", "600"))
+
+# Where Claude Code keeps its state (config, sessions, projects). Mounted as a
+# node-disk volume by the compose file so it accumulates across restarts.
+CLAUDE_STATE_DIR = os.environ.get("CLAUDE_CONFIG_DIR", "/home/claude/.claude")
+
+app = FastAPI(title="citadel-claudecode-runtime")
+
+
+def _expected_inbound_bearer() -> str:
+    """The inbound Authorization value the platform must present."""
+    return f"hooks_{GATEWAY_KEY}"
+
+
+def _run_claude_turn(message: str) -> str:
+    """Drive one headless Claude Code turn and return the assistant text.
+
+    Raises RuntimeError on non-zero exit / timeout / unparseable output so the
+    caller can post a terminal {error}.
+    """
+    # `claude -p` = non-interactive "print" mode: run one turn and exit.
+    # --output-format json gives a single, stable JSON envelope whose "result"
+    # field is the final assistant text (far more robust to parse than scraping
+    # free-form stdout). We pass the user message as the positional prompt.
+    #
+    # --dangerously-skip-permissions: the container IS the sandbox (isolated,
+    # non-root, its own state volume), and there is no human to answer an
+    # interactive tool-approval prompt in a headless turn. Without it a turn
+    # that reaches for bash/edit would block forever.
+    cmd = [
+        "claude",
+        "-p",
+        message,
+        "--output-format",
+        "json",
+        "--dangerously-skip-permissions",
+    ]
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=TURN_TIMEOUT_SECONDS,
+            # Inherit the process env so ANTHROPIC_* reaches the CLI. Force the
+            # state dir so it matches the mounted volume regardless of $HOME.
+            env={**os.environ, "CLAUDE_CONFIG_DIR": CLAUDE_STATE_DIR},
+        )
+    except subprocess.TimeoutExpired:
+        raise RuntimeError(
+            f"Claude Code turn timed out after {TURN_TIMEOUT_SECONDS}s"
+        )
+
+    if proc.returncode != 0:
+        # Surface the tail of stderr so the terminal error is actionable, but
+        # keep it short -- it goes to a user-facing chat.
+        err = (proc.stderr or proc.stdout or "").strip()
+        tail = err[-800:] if err else "(no output)"
+        raise RuntimeError(f"Claude Code exited {proc.returncode}: {tail}")
+
+    stdout = (proc.stdout or "").strip()
+    if not stdout:
+        raise RuntimeError("Claude Code produced no output")
+
+    # Parse the JSON envelope. The `-p --output-format json` envelope carries the
+    # assistant text under "result"; be liberal about a couple of alternative
+    # shapes so a CLI-version change in the field name doesn't break the turn.
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError:
+        # Not JSON (e.g. text output-format) -- treat the raw stdout as the reply.
+        return stdout
+
+    if isinstance(payload, dict):
+        if payload.get("is_error"):
+            raise RuntimeError(
+                f"Claude Code reported an error: {payload.get('result') or payload}"
+            )
+        for key in ("result", "text", "response"):
+            val = payload.get(key)
+            if isinstance(val, str) and val:
+                return val
+    # Fell through -- return the serialized payload rather than losing the turn.
+    return stdout
+
+
+def _post_reply(body: dict) -> None:
+    """POST the outbound reply/error to the platform callback (best-effort)."""
+    if not PLATFORM_URL or not INSTANCE_ID:
+        print(
+            "claudecode: PLATFORM_URL/INSTANCE_ID unset; cannot post reply",
+            file=sys.stderr,
+            flush=True,
+        )
+        return
+    url = f"{PLATFORM_URL}/api/instances/{INSTANCE_ID}/reply"
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(url, data=data, method="POST")
+    req.add_header("Content-Type", "application/json")
+    # Outbound auth is the RAW gateway key -- NOT the hooks_-prefixed inbound token.
+    req.add_header("Authorization", f"Bearer {GATEWAY_KEY}")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            resp.read()
+    except urllib.error.HTTPError as exc:
+        print(
+            f"claudecode: reply POST to {url} failed: {exc.code} {exc.reason}",
+            file=sys.stderr,
+            flush=True,
+        )
+    except Exception as exc:  # network error, DNS, etc.
+        print(f"claudecode: reply POST to {url} failed: {exc}", file=sys.stderr, flush=True)
+
+
+def _process_turn(message: str) -> None:
+    """Background worker: run the turn, then post reply or error."""
+    try:
+        reply = _run_claude_turn(message)
+        _post_reply({"reply": reply})
+    except Exception as exc:  # any terminal failure -> user-facing {error}
+        _post_reply({"error": str(exc)})
+
+
+@app.get("/health")
+def health():
+    """Liveness probe for the compose healthcheck.
+
+    Answers immediately and reports the fabric-proxy wiring so an operator can
+    confirm the model path without shell access. Does not invoke the CLI.
+    """
+    return {
+        "status": "ok",
+        "instance_id": INSTANCE_ID or None,
+        "platform_url": PLATFORM_URL or None,
+        "anthropic_base_url": ANTHROPIC_BASE_URL or None,
+        "model": ANTHROPIC_MODEL or None,
+        "gateway_key_configured": bool(GATEWAY_KEY),
+        "state_dir": CLAUDE_STATE_DIR,
+    }
+
+
+@app.post("/hooks/agent")
+async def hooks_agent(request: Request, authorization: str = Header(default="")):
+    """Inbound turn from the platform routing seam.
+
+    Validates the bearer token, ACKs fast, and processes the turn asynchronously.
+    """
+    if not GATEWAY_KEY:
+        # Misconfigured container -- fail loud rather than accept unauthenticated turns.
+        raise HTTPException(status_code=503, detail="gateway key not configured")
+
+    expected = f"Bearer {_expected_inbound_bearer()}"
+    if authorization != expected:
+        raise HTTPException(status_code=401, detail="invalid bearer token")
+
+    try:
+        body = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="invalid JSON body")
+
+    message = body.get("message") if isinstance(body, dict) else None
+    if not isinstance(message, str) or not message:
+        raise HTTPException(status_code=400, detail="missing 'message'")
+
+    # ACK FAST: hand the (blocking) model turn to a background thread so the
+    # inbound request returns a delivery ack immediately. daemon=True so a
+    # container stop never hangs on an in-flight turn.
+    threading.Thread(target=_process_turn, args=(message,), daemon=True).start()
+
+    return {"delivered": True}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=PORT)

--- a/services/compose/claudecode.yml
+++ b/services/compose/claudecode.yml
@@ -1,0 +1,62 @@
+# services/compose/claudecode.yml
+#
+# Headless Claude Code agent-runtime for a Citadel node (aceteam-ai/citadel-cli
+# #432, Child C of the BYOC agent-hosting epic aceteam-ai/aceteam#4588).
+#
+# This is the phase-1 flagship BYOC runtime: a Claude Code CLI turn driven
+# headlessly by a tiny HTTP wrapper (services/claudecode-service), with the model
+# pointed at the AceTeam fabric proxy via the ANTHROPIC_* env. A full turn runs
+# with NO external Anthropic API key -- agent AND model on your own metal.
+#
+# The wrapper listens on a FIXED internal port 8787 (its own contract port, like
+# diffusers' 7860). The HOST port is owned by citadel and supplied via
+# CITADEL_CLAUDECODE_HOST_PORT; the :? guard fails loudly if it is missing. This
+# is CPU-only -- the model path is the remote fabric proxy, so there is NO GPU
+# reservation (contrast diffusers/vllm).
+#
+# Standalone run (the live-proof path -- operator supplies the env):
+#   CITADEL_CLAUDECODE_HOST_PORT=8204 \
+#   ACETEAM_INSTANCE_ID=... ACETEAM_PLATFORM_URL=https://aceteam.ai \
+#   ACETEAM_GATEWAY_KEY=... \
+#   ANTHROPIC_BASE_URL=... ANTHROPIC_AUTH_TOKEN=... ANTHROPIC_MODEL=... \
+#   docker compose -f services/compose/claudecode.yml up
+
+services:
+  claudecode:
+    image: ghcr.io/aceteam-ai/claudecode-service:latest
+    container_name: citadel-claudecode
+    ports:
+      - "${CITADEL_CLAUDECODE_HOST_PORT:?citadel must supply CITADEL_CLAUDECODE_HOST_PORT}:8787"
+    volumes:
+      # The "permanent home": Claude Code config, sessions, and projects persist
+      # on the node disk across restarts. Path matches CLAUDE_CONFIG_DIR and the
+      # non-root claude user's home in the image.
+      - ~/citadel-cache/claudecode:/home/claude/.claude
+    environment:
+      # --- AceTeam routing-seam contract (aceteam #4593) ---
+      # Instance id used in the reply URL path.
+      - ACETEAM_INSTANCE_ID=${ACETEAM_INSTANCE_ID:?set ACETEAM_INSTANCE_ID}
+      # Base URL to POST replies to (e.g. https://aceteam.ai).
+      - ACETEAM_PLATFORM_URL=${ACETEAM_PLATFORM_URL:?set ACETEAM_PLATFORM_URL}
+      # Raw gateway key: inbound validated against hooks_+key; outbound auths with key.
+      - ACETEAM_GATEWAY_KEY=${ACETEAM_GATEWAY_KEY:?set ACETEAM_GATEWAY_KEY}
+
+      # --- Model path: point Claude Code at the fabric proxy (Anthropic-compatible) ---
+      - ANTHROPIC_BASE_URL=${ANTHROPIC_BASE_URL:?set ANTHROPIC_BASE_URL to the fabric proxy}
+      - ANTHROPIC_AUTH_TOKEN=${ANTHROPIC_AUTH_TOKEN:?set ANTHROPIC_AUTH_TOKEN for the proxy}
+      - ANTHROPIC_MODEL=${ANTHROPIC_MODEL:?set ANTHROPIC_MODEL}
+      # Optional: small/fast (haiku-tier) model for Claude Code's cheap sub-tasks.
+      - ANTHROPIC_SMALL_FAST_MODEL=${ANTHROPIC_SMALL_FAST_MODEL:-}
+
+      # --- Wrapper knobs (sane defaults; override only if needed) ---
+      - PORT=8787
+      - CLAUDE_CONFIG_DIR=/home/claude/.claude
+      - CLAUDECODE_TURN_TIMEOUT=${CLAUDECODE_TURN_TIMEOUT:-600}
+    healthcheck:
+      # Hits the wrapper /health on the fixed internal contract port.
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8787/health')"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+    restart: unless-stopped

--- a/services/compose/claudecode.yml
+++ b/services/compose/claudecode.yml
@@ -30,7 +30,9 @@ services:
     volumes:
       # The "permanent home": Claude Code config, sessions, and projects persist
       # on the node disk across restarts. Path matches CLAUDE_CONFIG_DIR and the
-      # non-root claude user's home in the image.
+      # non-root claude user's home in the image. The container's entrypoint runs
+      # as root, chowns this mount to the claude user (uid 10001), then drops
+      # privileges -- so a fresh host-owned dir "just works" with no pre-create.
       - ~/citadel-cache/claudecode:/home/claude/.claude
     environment:
       # --- AceTeam routing-seam contract (aceteam #4593) ---


### PR DESCRIPTION
## What

Phase-1 flagship BYOC agent runtime (Child C of aceteam-ai/aceteam#4588): a **headless Claude Code CLI** that hosts on a Citadel node with the model pointed at the AceTeam fabric proxy, so a full turn runs with **no external Anthropic API key** -- agent AND model on your own metal.

Delivered as a **pure image + compose + installable module -- no citadel Go change** (`go build ./...` and `go vet ./...` clean). The four core `ports.go` services are untouched.

## The image

`ghcr.io/aceteam-ai/claudecode-service` (`services/claudecode-service/Dockerfile`): `node:22-bookworm-slim` + the `@anthropic-ai/claude-code` CLI + a tiny Python/FastAPI wrapper. Non-root (`claude`, uid 10001), **CPU-only** (no GPU reservation -- the model path is the remote fabric proxy). Bakes in `DISABLE_AUTOUPDATER=1` and `CLAUDE_CODE_ENABLE_TELEMETRY=0` so the only external traffic is to `ANTHROPIC_BASE_URL` and the reply callback. No secrets baked in -- all auth via env.

## The wrapper (`wrapper.py`) -- routing-seam contract (#4593)

- **Inbound** `POST /hooks/agent` with `Authorization: Bearer hooks_{GATEWAY_KEY}` and `{"message","name"}`. Validates the token, **ACKs fast** `200 {"delivered": true}`, and runs the turn on a **background daemon thread** so the inbound request never blocks on the model turn.
- Drives `claude -p "<message>" --output-format json --dangerously-skip-permissions`, capturing the assistant text from the JSON `result` field (falls back to raw stdout / alternate keys defensively).
- **Outbound** on completion: `POST {PLATFORM_URL}/api/instances/{INSTANCE_ID}/reply` with `Authorization: Bearer {GATEWAY_KEY}` (the **raw** key, not `hooks_`-prefixed), body `{"reply": ...}` -- or `{"error": ...}` on non-zero exit / timeout / unparseable output.
- `GET /health` backs the compose healthcheck and reports the proxy wiring.

Wrapper listens on the **fixed internal port 8787**; compose maps the citadel host port to it.

## Env

`ACETEAM_INSTANCE_ID`, `ACETEAM_PLATFORM_URL`, `ACETEAM_GATEWAY_KEY`, `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_MODEL`, optional `ANTHROPIC_SMALL_FAST_MODEL`, and `CITADEL_CLAUDECODE_HOST_PORT` (standalone-compose host-port guard). Full table in `services/claudecode-service/README.md`.

## State volume (the "permanent home")

Claude Code state lives at `/home/claude/.claude` (via `CLAUDE_CONFIG_DIR`), bind-mounted from `~/citadel-cache/claudecode` on the node, so config/sessions persist across restarts.

## Files

- `services/claudecode-service/{Dockerfile,wrapper.py,requirements.txt,smoke_test.py,service.yaml,compose.yml,README.md}`
- `services/compose/claudecode.yml` -- standalone-runnable compose (citadel host-port guard).

`service.yaml` + `compose.yml` are the installable-module variant (literal host port 8204, since the module path does not inject `CITADEL_CLAUDECODE_HOST_PORT`).

## Non-root + bind-mount permission (the live-deploy landmine, fixed)

A host bind-mount onto `/home/claude/.claude` is owned by the operator's uid, not the container's `claude` user (uid 10001), so Claude Code's first-run writes into the mounted state dir would hit **EACCES** on a real node. The container now starts as root, an **entrypoint chowns the state dir to `claude` then drops privileges via `gosu`** (and `claude` refuses `--dangerously-skip-permissions` as root anyway). A fresh host-owned mount "just works" -- **no manual pre-create needed**. The smoke test mounts a host-owned dir so it exercises exactly this path.

## Testing

`python3 services/claudecode-service/smoke_test.py` builds the image, starts a **mock Anthropic proxy** (canned Messages response, handles both SSE and JSON; records the request) and a **mock reply receiver**, mounts a **host-owned** state dir (reproducing the live bind-mount), runs the container, POSTs a `/hooks/agent` turn, and asserts (a) fast 200 ack **before** the reply POST lands, (b) the proxy got an Anthropic-shaped `/v1/messages` request with `Authorization: Bearer <proxy token>`, (c) the receiver got a well-formed `{reply}` POST with `Authorization: Bearer <raw gateway key>`, plus a bad-bearer-token 401. Passed (exit 0):

```
mock proxy on :NNNNN  mock receiver on :NNNNN
host-owned state dir: /tmp/cc-smoke-state-xxxx
$ docker run -d --name citadel-claudecode-smoke --add-host host.docker.internal:host-gateway -p 8299:8787 -v <host-owned>:/home/claude/.claude ...
PASS: /health is up
PASS: fast ack {'delivered': True} in 8ms, before reply POST
PASS: bad bearer token rejected with 401
PASS: proxy got Anthropic-shaped request: {'path': '/v1/messages?beta=true', 'auth': 'Bearer smoke-proxy-token', 'model': 'smoke-model', 'has_messages': True, 'stream': True}
PASS: receiver got well-formed reply with RAW-key auth: {'reply': 'Hello from the fabric proxy. 2 plus 2 is 4.'}
PASS: canned fabric-proxy text flowed end-to-end

SMOKE TEST PASSED
```

The real CLI hits `/v1/messages?beta=true` with `stream: true`, and the full turn completed against the mock proxy running as **non-root against a host-owned mount** with **no real Anthropic API key** -- proving the fully-local loop and the deploy permission path. Separately verified (direct `claude -p` run) that state persists into the mount: `.claude.json`, `projects/`, `sessions/`, `backups/` all land under `/home/claude/.claude`, owned by `claude` -- confirming the "permanent home".

---
*Generated by Claude Opus 4.8*
