### PR TITLE
feat(node): renew Headscale node key while online + harden no-authkey reconnect (#4583)

### DIFF
--- a/cmd/keyrenew.go
+++ b/cmd/keyrenew.go
@@ -1,0 +1,167 @@
+// cmd/keyrenew.go
+// Background node-key renewal loop for the self-healing fabric node identity
+// baseline (epic #4583, citadel side of backend PR #4584).
+//
+// While a node is healthy and online, this loop periodically inspects its
+// Headscale node-key expiry and, when the key is approaching expiry, refreshes
+// it IN PLACE using the node's own device token — never the offline
+// authkey-mint recovery path. Keeping the key fresh while online means the
+// session never lapses, so an ordinary restart re-establishes through the
+// existing no-authkey reconnect and the 403 authkey-mint path is never reached.
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/network"
+)
+
+// keyRenewCheckInterval is how often the loop inspects key-expiry health. Key
+// lifetimes are measured in days and the renewal threshold is 24h, so an hourly
+// check is far more frequent than needed — cheap insurance that a node briefly
+// offline around its threshold still renews on a subsequent tick.
+const keyRenewCheckInterval = time.Hour
+
+// keyRenewEnvInterval overrides the check interval (in seconds) and doubles as
+// the opt-out switch: a non-positive value disables the loop entirely, matching
+// the footprint sampler's gating convention (CITADEL_FOOTPRINT_INTERVAL<=0).
+const keyRenewEnvInterval = "CITADEL_KEY_RENEW_INTERVAL"
+
+// keyRenewIntervalFromEnv resolves the check interval and whether the loop is
+// enabled. Unset uses the default; a positive value overrides; a non-positive
+// value disables.
+func keyRenewIntervalFromEnv() (time.Duration, bool) {
+	raw := os.Getenv(keyRenewEnvInterval)
+	if raw == "" {
+		return keyRenewCheckInterval, true
+	}
+	var secs int
+	if _, err := fmt.Sscanf(raw, "%d", &secs); err != nil {
+		return keyRenewCheckInterval, true
+	}
+	if secs <= 0 {
+		return 0, false
+	}
+	return time.Duration(secs) * time.Second, true
+}
+
+// startNodeKeyRenewer launches the background node-key renewal loop unless it is
+// disabled via --no-key-renew or a non-positive CITADEL_KEY_RENEW_INTERVAL. It
+// no-ops when the node is not in API mode (no device token to fetch a fresh
+// authkey with) since renewal has no admin-free path without it.
+func startNodeKeyRenewer(ctx context.Context, deviceConfig *DeviceConfig) {
+	if workNoKeyRenew {
+		Debug("node-key renewer disabled (--no-key-renew)")
+		return
+	}
+	interval, enabled := keyRenewIntervalFromEnv()
+	if !enabled {
+		Debug("node-key renewer disabled (%s<=0)", keyRenewEnvInterval)
+		return
+	}
+	if deviceConfig == nil || deviceConfig.DeviceAPIToken == "" {
+		Debug("node-key renewer disabled (no device token)")
+		return
+	}
+
+	apiBaseURL := deviceConfig.APIBaseURL
+	if apiBaseURL == "" {
+		apiBaseURL = authServiceURL
+	}
+
+	go runNodeKeyRenewer(ctx, deviceConfig.DeviceAPIToken, apiBaseURL, interval)
+	fmt.Printf("   - Node-key renewer: every %s (renews within %s of expiry)\n",
+		interval, network.DefaultRenewThreshold)
+}
+
+// runNodeKeyRenewer is the loop body: on each tick, inspect key health and renew
+// in place if the key is approaching (or past) expiry. Extracted so the tick
+// logic is straightforward and the enable/gating decisions live in the caller.
+func runNodeKeyRenewer(ctx context.Context, deviceToken, apiBaseURL string, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			checkAndRenewNodeKey(ctx, deviceToken, apiBaseURL)
+		}
+	}
+}
+
+// checkAndRenewNodeKey performs a single inspect-and-maybe-renew cycle. It is a
+// no-op unless the key is within the renewal threshold of expiry (or already
+// expired). Failures are logged and swallowed — a transient renewal miss is
+// recoverable on the next tick, and a hard failure (e.g. an old device token
+// lacking the authkey scope) must not crash the node.
+func checkAndRenewNodeKey(ctx context.Context, deviceToken, apiBaseURL string) {
+	if !network.IsGlobalConnected() {
+		// Not online — the reconnect/recovery path owns re-establishing the
+		// session; there is no live key to renew in place.
+		return
+	}
+
+	health, err := network.InspectGlobalNodeKey(ctx)
+	if err != nil {
+		Debug("node-key health check failed: %v", err)
+		return
+	}
+	if health == nil {
+		return
+	}
+
+	switch health.Status {
+	case network.KeyNoExpiry, network.KeyHealthy:
+		if health.Expiry != nil {
+			Debug("node key healthy (expires %s)", health.Expiry.Format(time.RFC3339))
+		} else {
+			Debug("node key healthy (no expiry set)")
+		}
+		return
+	case network.KeyRenewSoon, network.KeyExpired:
+		when := "soon"
+		if health.Expiry != nil {
+			when = health.Expiry.Format(time.RFC3339)
+		}
+		Log("node key %s (expiry=%s); renewing in place...", health.Status, when)
+	}
+
+	// Fetch a fresh authkey using the node's own device token, then re-authorize
+	// the running tsnet server in place (preserves IP + VPN listeners).
+	fetchCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	freshKey, err := network.FetchFreshAuthkey(fetchCtx, apiBaseURL, deviceToken)
+	cancel()
+	if err != nil {
+		// The 403 landmine: an OLD device token minted before the
+		// device_authkey:write scope was granted (aceteam #4432) cannot fetch a
+		// fresh authkey. The node is not broken — a persistent (non-ephemeral,
+		// backend PR #4584) node still self-heals via the no-authkey reconnect on
+		// restart — but it cannot renew online. Surface the exact remedy.
+		if network.IsAuthkeyScopeError(err) {
+			Log("node-key renewal blocked: device token predates the authkey scope; "+
+				"re-run 'citadel init' to enable online self-renewal (%v)", err)
+			fmt.Fprintln(os.Stderr, "   - Warning: node-key auto-renewal is disabled for this node.")
+			fmt.Fprintln(os.Stderr, "     Its device token predates the self-renewal scope. Re-run "+
+				"'citadel init' to enable it. The node still reconnects on restart.")
+			return
+		}
+		Log("node-key renewal: could not fetch fresh authkey: %v", err)
+		return
+	}
+
+	if err := network.RenewGlobalNodeKey(ctx, freshKey); err != nil {
+		Log("node-key renewal: in-place reauth failed: %v", err)
+		return
+	}
+	// Start() is async: it applies the fresh authkey to the running state
+	// machine, which re-authorizes the node key without dropping the connection
+	// (IP + VPN listeners preserved). If the key were somehow rejected, the next
+	// tick still sees KeyRenewSoon and retries, so a single miss is self-healing.
+	Log("node-key in-place reauth triggered with fresh authkey (IP + listeners preserved)")
+	fmt.Println("   - Node key refreshed before expiry (session preserved)")
+}

--- a/cmd/keyrenew_test.go
+++ b/cmd/keyrenew_test.go
@@ -1,0 +1,84 @@
+// cmd/keyrenew_test.go
+package cmd
+
+import (
+	"testing"
+	"time"
+)
+
+func TestKeyRenewIntervalFromEnv(t *testing.T) {
+	tests := []struct {
+		name        string
+		env         string
+		wantEnabled bool
+		wantDur     time.Duration
+	}{
+		{
+			name:        "unset uses default and is enabled",
+			env:         "",
+			wantEnabled: true,
+			wantDur:     keyRenewCheckInterval,
+		},
+		{
+			name:        "positive value overrides interval",
+			env:         "300",
+			wantEnabled: true,
+			wantDur:     300 * time.Second,
+		},
+		{
+			name:        "zero disables the loop",
+			env:         "0",
+			wantEnabled: false,
+		},
+		{
+			name:        "negative disables the loop",
+			env:         "-1",
+			wantEnabled: false,
+		},
+		{
+			name:        "non-numeric falls back to default enabled",
+			env:         "abc",
+			wantEnabled: true,
+			wantDur:     keyRenewCheckInterval,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.env == "" {
+				t.Setenv(keyRenewEnvInterval, "")
+			} else {
+				t.Setenv(keyRenewEnvInterval, tt.env)
+			}
+			dur, enabled := keyRenewIntervalFromEnv()
+			if enabled != tt.wantEnabled {
+				t.Fatalf("enabled = %v, want %v", enabled, tt.wantEnabled)
+			}
+			if tt.wantEnabled && dur != tt.wantDur {
+				t.Errorf("duration = %v, want %v", dur, tt.wantDur)
+			}
+		})
+	}
+}
+
+// TestStartNodeKeyRenewer_NoDeviceToken verifies the renewer is a safe no-op
+// when there is no device token (direct-Redis mode). It must not panic or start
+// a goroutine that would fail.
+func TestStartNodeKeyRenewer_NoDeviceToken(t *testing.T) {
+	// nil config -> no-op
+	startNodeKeyRenewer(t.Context(), nil)
+
+	// config without a token -> no-op
+	startNodeKeyRenewer(t.Context(), &DeviceConfig{})
+}
+
+// TestNoKeyRenewFlagRegistered verifies the --no-key-renew opt-out is wired up.
+func TestNoKeyRenewFlagRegistered(t *testing.T) {
+	flag := workCmd.Flags().Lookup("no-key-renew")
+	if flag == nil {
+		t.Fatal("--no-key-renew flag not registered on work command")
+	}
+	if flag.DefValue != "false" {
+		t.Errorf("--no-key-renew default = %q, want %q", flag.DefValue, "false")
+	}
+}

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -89,6 +89,10 @@ var (
 	// Footprint sampler flag
 	workNoFootprint bool
 
+	// Node-key renewer flag (epic #4583): disable the background loop that
+	// refreshes the Headscale node key before expiry while online.
+	workNoKeyRenew bool
+
 	// Auto-update (periodic self-update) flags
 	workAutoUpdate         bool
 	workAutoUpdateInterval string
@@ -734,6 +738,14 @@ func runWork(cmd *cobra.Command, args []string) {
 	// design: one container-stats exec + one GPU read per tick (default 60s), never
 	// per-service. Disabled by --no-footprint or CITADEL_FOOTPRINT_INTERVAL<=0.
 	startFootprintSampler(ctx, nodeName, workManifest)
+
+	// Start the background node-key renewer (epic #4583). While the node is
+	// healthy and online, it refreshes the Headscale node key before it expires,
+	// re-authorizing in place with the node's own device token — so a long-lived
+	// session never lapses and an ordinary restart re-establishes via the
+	// no-authkey reconnect, never hitting the offline authkey-mint 403 path.
+	// No-op in direct-Redis mode (no device token) or when disabled.
+	startNodeKeyRenewer(ctx, deviceConfig)
 
 	// Default consumer group to node identity when --group is not explicitly set.
 	workGroup = resolveConsumerGroup(workGroup, headscaleNodeID, nodeName)
@@ -2091,6 +2103,7 @@ func init() {
 	// Update check flags (deprecated - update check now runs on all commands via root.go)
 	workCmd.Flags().BoolVar(&workNoUpdate, "no-update", false, "(Deprecated) No longer has any effect - use 'citadel update disable' instead")
 	workCmd.Flags().BoolVar(&workNoFootprint, "no-footprint", false, "Disable the background resource-footprint sampler")
+	workCmd.Flags().BoolVar(&workNoKeyRenew, "no-key-renew", false, "Disable the background Headscale node-key renewer (renews the key before expiry while online)")
 	workCmd.Flags().MarkDeprecated("no-update", "use 'citadel update disable' to disable auto-update checks")
 
 	// Auto-update (periodic self-update) flags

--- a/internal/network/keyhealth.go
+++ b/internal/network/keyhealth.go
@@ -1,0 +1,168 @@
+// internal/network/keyhealth.go
+// Node-key health inspection + in-place renewal for the self-healing fabric
+// node identity baseline (epic #4583).
+//
+// Background: a Citadel node authenticates its tsnet/WireGuard session with a
+// Headscale preauth-derived node key. tsnet does NOT proactively renew that key
+// — it only re-authorizes when Start() is called with a fresh authkey (or via
+// interactive login, which is useless headless). If Nexus mints keys with an
+// expiry, a long-lived session's node key can EXPIRE while the node is online,
+// dropping it off the mesh. The defense: while healthy and online, notice the
+// approaching expiry and re-authorize IN PLACE using the node's own
+// already-authenticated session, so the key never lapses and the offline 403
+// authkey-mint path is never reached.
+package network
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"tailscale.com/ipn"
+)
+
+// KeyStatus classifies the health of the node's Headscale key relative to its
+// expiry time. It is the output of the pure keyRenewalDecision function so the
+// decision logic can be tested without a live node.
+type KeyStatus int
+
+const (
+	// KeyNoExpiry means the key has no expiry set (nil/zero KeyExpiry). This is
+	// the durable-baseline healthy state — a non-expiring key never needs
+	// proactive renewal, so the renewer treats it as a no-op.
+	KeyNoExpiry KeyStatus = iota
+	// KeyHealthy means the key has an expiry but it is comfortably in the
+	// future (more than the renewal threshold away). No action needed.
+	KeyHealthy
+	// KeyRenewSoon means the key expires within the renewal threshold. The
+	// renewer should refresh it now, while still online, before it lapses.
+	KeyRenewSoon
+	// KeyExpired means the key has already expired. The session is (or is about
+	// to be) stale; an in-place renewal is still worth attempting before falling
+	// through to the heavier reconnect/recovery path.
+	KeyExpired
+)
+
+func (s KeyStatus) String() string {
+	switch s {
+	case KeyNoExpiry:
+		return "no-expiry"
+	case KeyHealthy:
+		return "healthy"
+	case KeyRenewSoon:
+		return "renew-soon"
+	case KeyExpired:
+		return "expired"
+	default:
+		return "unknown"
+	}
+}
+
+// DefaultRenewThreshold is how far ahead of expiry the renewer refreshes the
+// node key. Headscale/Nexus preauth key lifetimes are typically measured in
+// days; refreshing a day early leaves ample margin for a node that is briefly
+// offline (asleep, network blip) to still renew on its next healthy tick
+// without ever lapsing.
+const DefaultRenewThreshold = 24 * time.Hour
+
+// keyRenewalDecision classifies a key's health from its expiry time. It is a
+// pure function (no I/O) so the branching — especially the nil/zero "no expiry"
+// case — is unit-testable without a live node.
+//
+// A nil or zero keyExpiry means the key does not expire; that is the healthy
+// durable-baseline state, NOT an "unknown, act now" state, so it maps to
+// KeyNoExpiry (a no-op for the renewer).
+func keyRenewalDecision(keyExpiry *time.Time, now time.Time, threshold time.Duration) KeyStatus {
+	if keyExpiry == nil || keyExpiry.IsZero() {
+		return KeyNoExpiry
+	}
+	if !now.Before(*keyExpiry) {
+		return KeyExpired
+	}
+	if keyExpiry.Sub(now) <= threshold {
+		return KeyRenewSoon
+	}
+	return KeyHealthy
+}
+
+// NodeKeyHealth holds the observed key-expiry state for the global server.
+type NodeKeyHealth struct {
+	// Status is the classification relative to the renewal threshold.
+	Status KeyStatus
+	// Expiry is the key's expiry time, if the control plane reported one.
+	// Nil means the key does not expire (durable baseline).
+	Expiry *time.Time
+	// Expired mirrors tailscale's own Self.Expired flag (the control plane's
+	// authoritative view), independent of our threshold arithmetic.
+	Expired bool
+}
+
+// InspectGlobalNodeKey reads the global server's self status and classifies the
+// node key's expiry health using the default renewal threshold. Returns a nil
+// health (and no error) when not connected — there is no key to inspect.
+func InspectGlobalNodeKey(ctx context.Context) (*NodeKeyHealth, error) {
+	return InspectGlobalNodeKeyWithThreshold(ctx, DefaultRenewThreshold)
+}
+
+// InspectGlobalNodeKeyWithThreshold is InspectGlobalNodeKey with an explicit
+// renewal threshold (used by the background loop and by tests).
+func InspectGlobalNodeKeyWithThreshold(ctx context.Context, threshold time.Duration) (*NodeKeyHealth, error) {
+	s := Global()
+	if s == nil {
+		return nil, nil
+	}
+
+	lc, err := s.LocalClient()
+	if err != nil {
+		return nil, fmt.Errorf("local client: %w", err)
+	}
+
+	status, err := lc.Status(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("status: %w", err)
+	}
+	if status.Self == nil {
+		// Netmap not populated yet (e.g. just after connect). Treat as
+		// unknown-but-benign: no expiry data means nothing to renew right now.
+		return &NodeKeyHealth{Status: KeyNoExpiry}, nil
+	}
+
+	expiry := status.Self.KeyExpiry
+	return &NodeKeyHealth{
+		Status:  keyRenewalDecision(expiry, time.Now(), threshold),
+		Expiry:  expiry,
+		Expired: status.Self.Expired,
+	}, nil
+}
+
+// RenewGlobalNodeKey re-authorizes the RUNNING global tsnet server in place with
+// a fresh authkey, without tearing down the connection. It calls the local
+// backend's Start with the new AuthKey — the same mechanism as
+// `tailscale up --auth-key` — so the machine key (and thus the node's IP) and
+// all existing tsnet listeners (status/terminal/gateway bound at startup) are
+// preserved. This is what makes online renewal safe versus the offline
+// ReconnectWithAuthKey path, which spins up a second tsnet.Server and requires a
+// disruptive Disconnect first.
+//
+// The caller supplies the fresh authkey (fetched via FetchFreshAuthkey using the
+// node's own device token — no admin scope beyond what the node already holds).
+func RenewGlobalNodeKey(ctx context.Context, authKey string) error {
+	if authKey == "" {
+		return fmt.Errorf("empty authkey")
+	}
+	s := Global()
+	if s == nil {
+		return fmt.Errorf("not connected to AceTeam Network")
+	}
+	lc, err := s.LocalClient()
+	if err != nil {
+		return fmt.Errorf("local client: %w", err)
+	}
+	// Start applies the new AuthKey to the already-running state machine,
+	// re-authorizing the node key in place. UpdatePrefs is left nil so existing
+	// prefs (and Persist, i.e. the machine key) are preserved.
+	if err := lc.Start(ctx, ipn.Options{AuthKey: authKey}); err != nil {
+		return fmt.Errorf("in-place reauth: %w", err)
+	}
+	return nil
+}

--- a/internal/network/keyhealth_test.go
+++ b/internal/network/keyhealth_test.go
@@ -1,0 +1,112 @@
+// internal/network/keyhealth_test.go
+package network
+
+import (
+	"testing"
+	"time"
+)
+
+func TestKeyRenewalDecision(t *testing.T) {
+	now := time.Date(2026, 7, 2, 12, 0, 0, 0, time.UTC)
+	threshold := 24 * time.Hour
+
+	ptr := func(t time.Time) *time.Time { return &t }
+
+	tests := []struct {
+		name      string
+		keyExpiry *time.Time
+		want      KeyStatus
+	}{
+		{
+			name:      "nil expiry is the durable-baseline no-op",
+			keyExpiry: nil,
+			want:      KeyNoExpiry,
+		},
+		{
+			name:      "zero expiry is treated as no expiry",
+			keyExpiry: ptr(time.Time{}),
+			want:      KeyNoExpiry,
+		},
+		{
+			name:      "expiry far in the future is healthy",
+			keyExpiry: ptr(now.Add(10 * 24 * time.Hour)),
+			want:      KeyHealthy,
+		},
+		{
+			name:      "expiry just past the threshold is healthy",
+			keyExpiry: ptr(now.Add(threshold + time.Minute)),
+			want:      KeyHealthy,
+		},
+		{
+			name:      "expiry exactly at the threshold renews",
+			keyExpiry: ptr(now.Add(threshold)),
+			want:      KeyRenewSoon,
+		},
+		{
+			name:      "expiry within the threshold renews",
+			keyExpiry: ptr(now.Add(2 * time.Hour)),
+			want:      KeyRenewSoon,
+		},
+		{
+			name:      "expiry exactly now is expired",
+			keyExpiry: ptr(now),
+			want:      KeyExpired,
+		},
+		{
+			name:      "expiry in the past is expired",
+			keyExpiry: ptr(now.Add(-time.Hour)),
+			want:      KeyExpired,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := keyRenewalDecision(tt.keyExpiry, now, threshold)
+			if got != tt.want {
+				t.Errorf("keyRenewalDecision() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKeyStatusString(t *testing.T) {
+	cases := map[KeyStatus]string{
+		KeyNoExpiry:   "no-expiry",
+		KeyHealthy:    "healthy",
+		KeyRenewSoon:  "renew-soon",
+		KeyExpired:    "expired",
+		KeyStatus(99): "unknown",
+	}
+	for status, want := range cases {
+		if got := status.String(); got != want {
+			t.Errorf("KeyStatus(%d).String() = %q, want %q", status, got, want)
+		}
+	}
+}
+
+func TestInspectGlobalNodeKey_NotConnected(t *testing.T) {
+	// With no global server set, inspection returns nil health, no error —
+	// there is no key to inspect.
+	ClearGlobal()
+	health, err := InspectGlobalNodeKey(t.Context())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if health != nil {
+		t.Errorf("expected nil health when not connected, got %+v", health)
+	}
+}
+
+func TestRenewGlobalNodeKey_Guards(t *testing.T) {
+	ClearGlobal()
+
+	// Empty authkey is rejected before touching any server.
+	if err := RenewGlobalNodeKey(t.Context(), ""); err == nil {
+		t.Error("expected error for empty authkey")
+	}
+
+	// Not connected is rejected.
+	if err := RenewGlobalNodeKey(t.Context(), "tskey-fake"); err == nil {
+		t.Error("expected error when not connected")
+	}
+}

--- a/internal/network/reauth.go
+++ b/internal/network/reauth.go
@@ -21,16 +21,36 @@ type authkeyResponse struct {
 	Message   string `json:"message,omitempty"`
 }
 
+// ErrAuthkeyScope is returned when the platform rejects a fresh-authkey request
+// because the device token lacks the device_authkey:write scope. A token minted
+// before that scope was granted (aceteam #4432) hits this. It is a recoverable,
+// operator-actionable condition (re-run 'citadel init'), NOT a broken node — a
+// persistent (non-ephemeral, backend PR #4584) node still self-heals via the
+// no-authkey reconnect on restart. Callers should surface the remedy rather than
+// treat it as fatal. Wrapped so errors.Is works.
+var ErrAuthkeyScope = errors.New("device token lacks device_authkey:write scope")
+
+// IsAuthkeyScopeError reports whether err is (or wraps) the authkey-scope
+// rejection, so callers (e.g. the online node-key renewer) can distinguish the
+// "old token, re-init to enable self-renewal" case from generic failures.
+func IsAuthkeyScopeError(err error) bool {
+	return errors.Is(err, ErrAuthkeyScope)
+}
+
 // FetchFreshAuthkey requests a new Headscale preauth key from the platform
 // using the device API token (act_*). The token authenticates the device
 // and the platform generates a single-use key scoped to the device's org.
 //
-// PREREQUISITE: The device API token must have /api/fabric/authkey/generate
-// in its allowedEndpoints list. Current device tokens (created by the
-// device-auth approve flow) are scoped to /api/fabric/redis/** and
-// /api/fabric/worker-config only — this endpoint must be added to the
-// allowlist in utils/deviceApiKeys.ts for auto-heal to work.
-// See: https://github.com/aceteam-ai/aceteam/issues/175
+// PREREQUISITE: The device API token must carry the device_authkey:write scope
+// and have /api/fabric/authkey/generate in its allowedEndpoints list. Tokens
+// minted by the device-auth approve flow have carried both since aceteam #4432.
+// A token minted BEFORE that grant is rejected with HTTP 403; the token is not
+// regenerated on citadel upgrade, only by re-running 'citadel init'. That case
+// is returned as ErrAuthkeyScope so callers can surface the exact remedy rather
+// than treat a recoverable old-token node as broken.
+// See: https://github.com/aceteam-ai/aceteam/issues/175 (original grant),
+//
+//	https://github.com/aceteam-ai/aceteam/pull/4584 (durable-key baseline).
 //
 // Returns the preauth key string or an error.
 func FetchFreshAuthkey(ctx context.Context, apiBaseURL, deviceAPIToken string) (string, error) {
@@ -69,6 +89,15 @@ func FetchFreshAuthkey(ctx context.Context, apiBaseURL, deviceAPIToken string) (
 	}
 
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		// A 403 here is most often the missing device_authkey:write scope on an
+		// old device token (minted before aceteam #4432). Classify it so callers
+		// (the online node-key renewer, reconnect) can tell the operator the exact
+		// remedy: re-run 'citadel init'. A persistent node still self-heals on
+		// restart via the no-authkey reconnect, so this is not a broken node.
+		if resp.StatusCode == http.StatusForbidden {
+			return "", fmt.Errorf("%w (HTTP 403) — re-run 'citadel init' to re-authenticate with the "+
+				"self-renewal scope; this node still reconnects on restart: %s", ErrAuthkeyScope, string(body))
+		}
 		return "", fmt.Errorf("device API token rejected (HTTP %d) — re-run 'citadel init' to re-authenticate: %s", resp.StatusCode, string(body))
 	}
 

--- a/internal/network/reauth_test.go
+++ b/internal/network/reauth_test.go
@@ -57,6 +57,43 @@ func TestFetchFreshAuthkey_Unauthorized(t *testing.T) {
 	t.Logf("Got expected error: %v", err)
 }
 
+func TestFetchFreshAuthkey_ForbiddenIsScopeError(t *testing.T) {
+	// A 403 means the device token lacks device_authkey:write (an old token
+	// minted before aceteam #4432). It must be classified as ErrAuthkeyScope so
+	// the online renewer can surface the "re-run citadel init" remedy instead of
+	// treating a recoverable node as broken.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`{"error":"Missing required scope 'device_authkey:write'"}`))
+	}))
+	defer server.Close()
+
+	_, err := FetchFreshAuthkey(context.Background(), server.URL, "act_old_token")
+	if err == nil {
+		t.Fatal("FetchFreshAuthkey() expected error for 403 response")
+	}
+	if !IsAuthkeyScopeError(err) {
+		t.Errorf("expected ErrAuthkeyScope for 403, got %v", err)
+	}
+}
+
+func TestIsAuthkeyScopeError_False(t *testing.T) {
+	// A 401 (bad token) is NOT a scope error — it should not be misclassified.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":"Invalid API key"}`))
+	}))
+	defer server.Close()
+
+	_, err := FetchFreshAuthkey(context.Background(), server.URL, "act_bad_token")
+	if err == nil {
+		t.Fatal("expected error for 401 response")
+	}
+	if IsAuthkeyScopeError(err) {
+		t.Errorf("401 should not be classified as a scope error: %v", err)
+	}
+}
+
 func TestFetchFreshAuthkey_EmptyAuthkey(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Context

Citadel side of the **P0 durable-key baseline** for the self-healing fabric node identity epic (**#4583**), sibling to backend PR **#4584**.

We hit this live: a node dropped off the VPN mesh on restart and could not rejoin without an admin. The failure mode has two halves:

1. **Registration ephemerality** (backend, #4584) — re-authed nodes were minted *ephemeral* Headscale keys, so an offline node vanished from Headscale and had to re-register on restart. #4584 makes registration keys non-ephemeral so a persistent node stays registered across an outage and the *existing* no-authkey reconnect re-establishes the session.
2. **Node-key expiry** (this PR) — even a persistent node's Headscale preauth-derived **node key can EXPIRE** over a long-lived session. **tsnet with a preauth AuthKey does not proactively renew node keys** — it only re-authorizes when `Start()` is called with a fresh authkey (interactive login is useless headless). So a healthy, online, long-running node can silently lapse its key, drop off the mesh, and then dead-end in the offline recovery path — which historically hit the `device_authkey:write` **403 landmine**.

The defense: while the node is healthy and online, notice the approaching expiry and re-authorize **in place** using the node's own already-authenticated session, so the key never lapses and the offline mint path is never reached.

## tsnet: what it does vs. what this adds

| | Behavior |
|---|---|
| **tsnet auto-renew?** | No. A preauth `AuthKey` authorizes once; the node key expires per Headscale policy and tsnet does not refresh it on its own. |
| **This PR's renewal** | In-place reauth via `LocalClient.Start(ipn.Options{AuthKey: fresh})` — the same mechanism as `tailscale up --auth-key`. Applies a fresh authkey to the **running** state machine, re-authorizing the node key **without tearing down the connection**. The machine key (and thus the node's IP) and all VPN listeners (`status`/`terminal`/`gateway`) bound at `citadel work` startup are preserved. |
| **Why not `ReconnectWithAuthKey`?** | That path is built for the *offline/stale* case: it spins up a **second** `tsnet.Server` on the same state dir and needs a disruptive `Disconnect()` first — which kills the startup-bound VPN listeners, leaving the node "connected" but unreachable for node-targeted jobs until a restart. Wrong tool for online renewal. |

The **scope is already granted**: device tokens have carried `device_authkey:write` + the `/api/fabric/authkey/generate` allowlist entry since aceteam **#4432** (citadel #383), so the node's own token can mint a fresh key — no admin path. The renewer relocates the only remaining landmine to **token vintage**: a token minted *before* #4432 will 403. We handle that gracefully (below) rather than crash a node that still self-heals on restart.

## Summary

- **`internal/network/keyhealth.go`** — pure `keyRenewalDecision(keyExpiry, now, threshold)` classifier (`KeyNoExpiry`/`KeyHealthy`/`KeyRenewSoon`/`KeyExpired`). **nil/zero `KeyExpiry` = non-expiring durable-baseline key = no-op**, not "unknown, act." Plus `InspectGlobalNodeKey` (reads `Status().Self.KeyExpiry`/`Expired`) and `RenewGlobalNodeKey` (in-place `LocalClient.Start` reauth). Default renewal threshold: 24h before expiry.
- **`cmd/keyrenew.go`** — background renewer loop started by `citadel work`, **gated like the footprint sampler**: `--no-key-renew` flag or `CITADEL_KEY_RENEW_INTERVAL<=0`. No-op in direct-Redis mode (no device token). On each tick: inspect health; if within threshold (or expired), fetch a fresh authkey with the node's own token and reauth in place. A single miss self-heals on the next tick.
- **`internal/network/reauth.go`** — classify the 403 as `ErrAuthkeyScope` (`IsAuthkeyScopeError`) so an **old device token** (pre-#4432) surfaces the exact remedy — *"re-run `citadel init` to enable online self-renewal; this node still reconnects on restart"* — instead of failing opaquely. Refreshed the stale issue-#175 comment.

**Reconnect ordering is unchanged and already correct**: `work.go` and `attemptVPNRecovery` try the no-authkey path first (3× retry) and only reach the authkey-mint path on `ErrStaleState`; `reconnect --force` (clear state + mint) stays an explicit operator choice. "Harden" here = the 403 classification + honest operator messaging, not a reorder.

## Test plan

| Group | Coverage |
|---|---|
| `keyRenewalDecision` (table-driven) | nil expiry, zero expiry, far-future healthy, just-past-threshold healthy, exactly-at-threshold renew, within-threshold renew, exactly-now expired, past expired |
| `KeyStatus.String` | all statuses + unknown |
| `InspectGlobalNodeKey` / `RenewGlobalNodeKey` guards | nil server -> nil health no error; empty authkey + not-connected rejected |
| `FetchFreshAuthkey` 403 | classified as `ErrAuthkeyScope`; 401 is **not** misclassified |
| `keyRenewIntervalFromEnv` | unset default, positive override, `0`/negative disable, non-numeric fallback |
| Renewer wiring | no-device-token no-op; `--no-key-renew` flag registered, default false |

`go test ./...` green, `go vet` + `gofmt -l` clean.

## Manual node-test plan (why draft)

Two facts can't be verified headless and gate marking this ready:

1. **Does Nexus/Headscale populate `Self.KeyExpiry`?** On a live node running `citadel work`, inspect key expiry (`citadel status` / worker log). If it is always `nil`, keys don't expire in this deployment and the renewer is **correctly inert** (`KeyNoExpiry` no-op) — confirm that's expected before relying on it.
2. **Online renewal preserves the session.** With a node whose key does have an expiry, set `CITADEL_KEY_RENEW_INTERVAL` low (e.g. `60`) and a short threshold so the loop fires, then confirm: the "Node key refreshed before expiry" log appears, the node's **IP is unchanged**, and node-targeted jobs (`terminal_exec`, `code_*`) still route to it (VPN listeners survived).
3. **Old-token 403 fallback.** On a node whose device token predates #4432, confirm renewal logs the `ErrAuthkeyScope` remedy ("re-run `citadel init`") and the node keeps running (no crash), then re-run `citadel init` and confirm renewal succeeds.
4. **Persistent-restart, no 403.** Restart a persistent (non-ephemeral, #4584) node and confirm it reconnects via the **no-authkey** path with no authkey-mint 403.

## Related

- Epic: **#4583** (self-healing fabric node identity)
- Backend sibling: **#4584** (non-ephemeral node registration keys)
- Scope grant this depends on: aceteam **#4432** / citadel **#383** (`device_authkey:write`)
- Advances **#4313** (Fabric PKI / signed sandbox capabilities) — shared identity direction
