### PR TITLE
fix(whatsapp): resolve bridge container by compose project, not hardcoded name

### DIFF
--- a/cmd/whatsapp.go
+++ b/cmd/whatsapp.go
@@ -42,6 +42,16 @@ import (
 // deployed here via the generic module-source mechanism (catalog.ResolveSource).
 const defaultWhatsAppSource = "sunapi386/whatsapp-bridge"
 
+// deployTimeout bounds the whole deploy edge (resolve module source via git clone
+// + `docker compose up`). Both underlying steps shell out to git/docker without
+// their own deadline, so an unreachable private repo or image registry could
+// otherwise hang until the caller (a 180s backend job) gives up with no error.
+// This bound guarantees DeployCompose fails fast with a descriptive message
+// instead (aceteam-ai/citadel-cli#436 Landmine 2). Image pulls of the bridge +
+// postgres over a slow link still need headroom, hence 150s (< the backend's
+// 180s job timeout).
+const deployTimeout = 150 * time.Second
+
 var (
 	waAPIKeyFlag    string // user-supplied ADMIN_API_KEY override
 	waPortFlag      int    // host port to publish the bridge on
@@ -175,45 +185,77 @@ func meshAPIURL(port int) string {
 // (which would hang a headless node job).
 func deployWhatsAppCompose(source, image string) func(servicesDir string, env map[string]string) error {
 	return func(servicesDir string, env map[string]string) error {
+		// Fail fast on a private-repo clone with missing credentials instead of
+		// blocking on an interactive git prompt (which would hang a headless job).
 		if os.Getenv("GIT_TERMINAL_PROMPT") == "" {
 			_ = os.Setenv("GIT_TERMINAL_PROMPT", "0")
 		}
-		if source == "" {
-			source = defaultWhatsAppSource
+		// Bound git's own TCP connect+overall time so an UNREACHABLE host (not just
+		// a missing credential) can't wedge the clone. catalog.ResolveSource shells
+		// out to `git` without a context, so this env var is how we cap it; it pairs
+		// with the wall-clock deployTimeout below as defense in depth.
+		if os.Getenv("GIT_HTTP_LOW_SPEED_LIMIT") == "" {
+			_ = os.Setenv("GIT_HTTP_LOW_SPEED_LIMIT", "1000")
+			_ = os.Setenv("GIT_HTTP_LOW_SPEED_TIME", "30")
 		}
-		src, err := catalog.ParseSource(source)
-		if err != nil {
-			return fmt.Errorf("invalid module source %q: %w", source, err)
+
+		// Run the whole effectful edge (resolve source via git clone + docker
+		// compose up) under a hard deadline so a missing-creds / unreachable-registry
+		// deploy reports a bounded, descriptive error rather than hanging until the
+		// caller's own timeout (aceteam-ai/citadel-cli#436 Landmine 2).
+		ctx, cancel := context.WithTimeout(context.Background(), deployTimeout)
+		defer cancel()
+
+		type result struct{ err error }
+		done := make(chan result, 1)
+		go func() { done <- result{err: deployWhatsAppComposeOnce(ctx, source, image, servicesDir, env)} }()
+
+		select {
+		case r := <-done:
+			return r.err
+		case <-ctx.Done():
+			// The git/docker subprocess may still be draining in the background, but
+			// the caller gets a prompt, actionable error instead of a silent hang.
+			return fmt.Errorf("deploying the WhatsApp bridge timed out after %s: the private module repo or its image registry is unreachable, or Docker is not responding. Check network/credentials (GITHUB_TOKEN or SSH, and `docker login`) and that `docker info` works", deployTimeout)
 		}
-		resolved, err := catalog.ResolveSource(src)
-		if err != nil {
-			// ResolveSource's clone error already explains the private-repo
-			// credential requirement (GITHUB_TOKEN / SSH / docker login).
-			return fmt.Errorf("resolve WhatsApp bridge module (needs Docker + private-repo git credentials): %w", err)
-		}
-		composeBytes, err := os.ReadFile(resolved.ComposePath)
-		if err != nil {
-			return fmt.Errorf("read resolved bridge compose %s: %w", resolved.ComposePath, err)
-		}
-		if err := os.MkdirAll(servicesDir, 0755); err != nil {
-			return fmt.Errorf("create services dir: %w", err)
-		}
-		composePath := whatsapp.ComposePath(servicesDir)
-		if err := os.WriteFile(composePath, composeBytes, 0600); err != nil {
-			return fmt.Errorf("write compose file: %w", err)
-		}
-		if image != "" {
-			env["BRIDGE_IMAGE"] = image
-		}
-		// Persist env before compose up so --env-file sees the admin key + port.
-		if err := whatsapp.SaveEnv(servicesDir, env); err != nil {
-			return fmt.Errorf("write bridge config: %w", err)
-		}
-		if err := composeUp(composePath, whatsapp.EnvPath(servicesDir)); err != nil {
-			return err
-		}
-		return nil
 	}
+}
+
+// deployWhatsAppComposeOnce performs the actual resolve + write + compose-up. It
+// is split out so deployWhatsAppCompose can run it under a hard deadline.
+func deployWhatsAppComposeOnce(ctx context.Context, source, image, servicesDir string, env map[string]string) error {
+	if source == "" {
+		source = defaultWhatsAppSource
+	}
+	src, err := catalog.ParseSource(source)
+	if err != nil {
+		return fmt.Errorf("invalid module source %q: %w", source, err)
+	}
+	resolved, err := catalog.ResolveSource(src)
+	if err != nil {
+		// ResolveSource's clone error already explains the private-repo
+		// credential requirement (GITHUB_TOKEN / SSH / docker login).
+		return fmt.Errorf("resolve WhatsApp bridge module (needs Docker + private-repo git credentials): %w", err)
+	}
+	composeBytes, err := os.ReadFile(resolved.ComposePath)
+	if err != nil {
+		return fmt.Errorf("read resolved bridge compose %s: %w", resolved.ComposePath, err)
+	}
+	if err := os.MkdirAll(servicesDir, 0755); err != nil {
+		return fmt.Errorf("create services dir: %w", err)
+	}
+	composePath := whatsapp.ComposePath(servicesDir)
+	if err := os.WriteFile(composePath, composeBytes, 0600); err != nil {
+		return fmt.Errorf("write compose file: %w", err)
+	}
+	if image != "" {
+		env["BRIDGE_IMAGE"] = image
+	}
+	// Persist env before compose up so --env-file sees the admin key + port.
+	if err := whatsapp.SaveEnv(servicesDir, env); err != nil {
+		return fmt.Errorf("write bridge config: %w", err)
+	}
+	return composeUp(ctx, whatsapp.ProjectName(servicesDir), composePath, whatsapp.EnvPath(servicesDir))
 }
 
 // whatsappProvisionDeps builds the ProvisionDeps for the local CLI, wiring the
@@ -300,7 +342,7 @@ func runWhatsAppStatus(cmd *cobra.Command, args []string) error {
 	bold := color.New(color.Bold)
 	bold.Println("WhatsApp bridge")
 
-	running := containerRunning("citadel-whatsapp-bridge")
+	running := bridgeContainerRunning(whatsapp.ProjectName(servicesDir))
 	if running {
 		fmt.Printf("  Container: %s\n", color.GreenString("running"))
 	} else {
@@ -376,7 +418,10 @@ func runWhatsAppDown(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 	fmt.Println("--- 🛑 Stopping WhatsApp bridge ---")
-	dc := exec.Command("docker", "compose", "-f", composePath, "--env-file", whatsapp.EnvPath(servicesDir), "down")
+	// Must use the SAME `-p` project the stack was brought up under, otherwise
+	// compose targets a different (empty) project and the containers survive.
+	dc := exec.Command("docker", "compose", "-p", whatsapp.ProjectName(servicesDir),
+		"-f", composePath, "--env-file", whatsapp.EnvPath(servicesDir), "down")
 	out, err := dc.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("docker compose down failed:\n%s", strings.TrimSpace(string(out)))
@@ -385,19 +430,75 @@ func runWhatsAppDown(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// composeUp runs `docker compose -f <compose> --env-file <env> up -d`.
-func composeUp(composePath, envPath string) error {
-	dc := exec.Command("docker", "compose", "-f", composePath, "--env-file", envPath, "up", "-d")
+// composeUp runs `docker compose -p <project> -f <compose> --env-file <env> up -d`.
+//
+// The explicit `-p <project>` (whatsapp.ProjectName(servicesDir)) is load-bearing:
+// the module compose no longer hardcodes `container_name`, so compose derives each
+// container's name from the project (`<project>-<service>-<index>`). Pinning the
+// project explicitly (rather than relying on compose's implicit default) keeps
+// up/down and the status check in agreement, and is the exact project the status
+// check queries with `docker compose -p <project> ps`. The value equals the old
+// implicit default (the services-dir basename) so existing volumes are preserved.
+//
+// It runs under ctx so a wedged `docker compose up` (e.g. pulling an image from an
+// unreachable registry) fails fast with a bounded, descriptive error instead of
+// hanging the caller (aceteam-ai/citadel-cli#436 Landmine 2).
+func composeUp(ctx context.Context, project, composePath, envPath string) error {
+	dc := exec.CommandContext(ctx, "docker", "compose", "-p", project,
+		"-f", composePath, "--env-file", envPath, "up", "-d")
 	out, err := dc.CombinedOutput()
 	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("docker compose up timed out after %s (is the image registry reachable and is Docker running? check with 'docker info'):\n%s",
+				deployTimeout, strings.TrimSpace(string(out)))
+		}
 		return fmt.Errorf("docker compose up failed:\n%s\n   Hint: is Docker running? Check with 'docker info'", strings.TrimSpace(string(out)))
 	}
 	return nil
 }
 
-// containerRunning reports whether a named container is in the running state.
-func containerRunning(name string) bool {
-	out, err := exec.Command("docker", "inspect", "--format", "{{.State.Status}}", name).Output()
+// bridgeContainerRunning reports whether the bridge app container of the given
+// compose project is in the running state. It resolves the container by compose
+// project (NOT a hardcoded name), so it stays correct now that the module compose
+// derives `<project>-bridge-<index>` names. Best-effort: false if Docker is
+// unavailable or no such container exists.
+//
+// It uses `docker compose -p <project> ps` scoped to the bridge service, then
+// confirms the state via `docker inspect` so a "created but not running"
+// container reads as stopped (matching the old inspect-based semantics).
+func bridgeContainerRunning(project string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	id, err := bridgeContainerID(ctx, project)
+	if err != nil || id == "" {
+		return false
+	}
+	return containerRunning(id)
+}
+
+// bridgeContainerID returns the container ID of the bridge app service in the
+// given compose project, or "" if the stack is not up. It asks compose to list
+// the `bridge` service's container id(s); `-q` prints ids of containers for the
+// project (running ones), so an empty result means the stack is down.
+func bridgeContainerID(ctx context.Context, project string) (string, error) {
+	out, err := exec.CommandContext(ctx, "docker", "compose", "-p", project,
+		"ps", "-q", whatsapp.BridgeService).Output()
+	if err != nil {
+		return "", err
+	}
+	// There is a single bridge replica; take the first non-empty line.
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if id := strings.TrimSpace(line); id != "" {
+			return id, nil
+		}
+	}
+	return "", nil
+}
+
+// containerRunning reports whether a container (by name or ID) is in the running
+// state.
+func containerRunning(nameOrID string) bool {
+	out, err := exec.Command("docker", "inspect", "--format", "{{.State.Status}}", nameOrID).Output()
 	if err != nil {
 		return false
 	}
@@ -457,7 +558,7 @@ func buildWhatsAppCallbacks() controlcenter.WhatsAppCallbacks {
 			port := portFromEnv(env)
 			st.APIKey = env["TENANT_API_KEY"]
 			st.APIURL = meshAPIURL(port)
-			st.Running = containerRunning("citadel-whatsapp-bridge")
+			st.Running = bridgeContainerRunning(whatsapp.ProjectName(servicesDir))
 			if !st.Running {
 				return st
 			}

--- a/internal/apps/container_name_collision_test.go
+++ b/internal/apps/container_name_collision_test.go
@@ -1,0 +1,89 @@
+package apps
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestWhatsAppBridgeNoHardcodedContainerName is the container-NAME analogue of
+// TestHostPortNoCollisions (the host-PORT case in hostport_collision_test.go).
+//
+// Docker container names are GLOBAL, so a hardcoded `container_name:` in a module
+// compose collides ("The container name ... is already in use") on any node that
+// already runs a stack with that name -- a dev stack, a second tenant, or a
+// half-succeeded provision -- and permanently wedges `citadel whatsapp up` /
+// WHATSAPP_PROVISION on that node (aceteam-ai/citadel-cli#436,
+// sunapi386/whatsapp-bridge#4).
+//
+// The fix removes the hardcoded names and relies on the compose PROJECT prefix
+// (`docker compose -p <project>` yields `<project>-<service>-<index>`). This test
+// guards that invariant against regression and proves the coexistence property:
+//
+//  1. the WhatsApp bridge module compose declares NO `container_name` on any
+//     service (otherwise the project prefix is bypassed and the collision is
+//     back), and
+//  2. two distinct compose projects derive DISTINCT container names for every
+//     service, so a citadel-provisioned stack can run alongside another bridge
+//     (e.g. a dev `watest` stack) on the same node without a name conflict.
+//
+// The testdata compose is a committed copy of the module's citadel/compose.yml
+// (sunapi386/whatsapp-bridge). It is intentionally NOT the citadel binary's own
+// embedded services (the bridge is a ToS-gray external module the CLI never
+// embeds); the copy lets this test pin the coupled contract from the CLI side.
+func TestWhatsAppBridgeNoHardcodedContainerName(t *testing.T) {
+	path := filepath.Join("testdata", "whatsapp-bridge.compose.yml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	var cf struct {
+		Services map[string]struct {
+			ContainerName string `yaml:"container_name"`
+		} `yaml:"services"`
+	}
+	if err := yaml.Unmarshal(data, &cf); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	if len(cf.Services) == 0 {
+		t.Fatalf("%s declares no services; testdata is stale", path)
+	}
+
+	// 1. No service may hardcode a container_name.
+	for svc, spec := range cf.Services {
+		if spec.ContainerName != "" {
+			t.Errorf("service %q hardcodes container_name %q; container names are global, so this collides on any node already running a bridge stack. Remove it and rely on the `docker compose -p <project>` prefix.", svc, spec.ContainerName)
+		}
+	}
+
+	// 2. Coexistence: two distinct projects must derive distinct container names
+	// for every service. This mirrors how a citadel-provisioned stack (its pinned
+	// project, "services") coexists with a dev stack (project "watest").
+	const projA, projB = "services", "watest"
+	seen := map[string]string{} // derived container name -> owner "project/service"
+	claim := func(project, svc string) {
+		t.Helper()
+		name := derivedContainerName(project, svc)
+		owner := project + "/" + svc
+		if prev, taken := seen[name]; taken {
+			t.Errorf("derived container name %q claimed by both %q and %q -- projects do not namespace containers", name, prev, owner)
+			return
+		}
+		seen[name] = owner
+	}
+	for svc := range cf.Services {
+		claim(projA, svc)
+		claim(projB, svc)
+	}
+}
+
+// derivedContainerName mirrors how docker compose (v2) names a service's
+// container when no explicit container_name is set: "<project>-<service>-<index>"
+// (index 1 for a single, unscaled replica).
+func derivedContainerName(project, service string) string {
+	return fmt.Sprintf("%s-%s-1", project, service)
+}

--- a/internal/apps/testdata/whatsapp-bridge.compose.yml
+++ b/internal/apps/testdata/whatsapp-bridge.compose.yml
@@ -1,0 +1,68 @@
+# Citadel service module: whatsapp-bridge (app + Postgres sidecar).
+# Started by `citadel service start whatsapp-bridge` -> `docker compose -f <this> up -d`.
+#
+# Container names are intentionally NOT hardcoded. Docker container names are
+# GLOBAL, so a fixed `container_name` collides ("The container name ... is already
+# in use") on any node that already runs a bridge stack -- a dev stack, a second
+# tenant, or a half-succeeded provision -- and wedges provisioning. Instead we let
+# compose derive `<project>-<service>-<index>` from the `-p <project>` flag, so
+# multiple stacks coexist. citadel-cli deploys this under a stable project
+# (`docker compose -p citadel-whatsapp up`) and resolves the running container via
+# `docker compose -p citadel-whatsapp ps` rather than a hardcoded name. See
+# aceteam-ai/citadel-cli#436 and sunapi386/whatsapp-bridge#4 -- the compose change
+# and the CLI status-check change are a coupled contract and must land together.
+services:
+  bridge:
+    image: ghcr.io/sunapi386/whatsapp-bridge:latest
+    restart: unless-stopped
+    ports:
+      - "${BRIDGE_PORT:-8080}:8080"
+    environment:
+      HOST: 0.0.0.0
+      PORT: 8080
+      DATABASE_URL: postgres://whatsapp:${POSTGRES_PASSWORD:-whatsapp}@db:5432/whatsapp
+      ADMIN_API_KEY: ${ADMIN_API_KEY:?ADMIN_API_KEY is required}
+      PUBLIC_URL: ${PUBLIC_URL:-}
+      # Optional per-node default egress proxy (socks5:// or http(s)://). Each
+      # Citadel node already egresses from its own mesh IP, so this is optional
+      # fine-tuning rather than required.
+      DEFAULT_PROXY_URL: ${DEFAULT_PROXY_URL:-}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      BAILEYS_LOG_LEVEL: ${BAILEYS_LOG_LEVEL:-warn}
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      # GET / is unauthenticated and returns {ok:true}; /health requires an API key.
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "require('http').get('http://localhost:8080/',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: whatsapp
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-whatsapp}
+      POSTGRES_DB: whatsapp
+    volumes:
+      # Named volume — Docker creates it automatically, so this needs no
+      # pre-created host directory (citadel-cli only pre-creates dirs for the
+      # built-in inference services).
+      - whatsapp_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U whatsapp"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  whatsapp_pgdata:

--- a/internal/whatsapp/bridge.go
+++ b/internal/whatsapp/bridge.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -29,6 +30,50 @@ import (
 
 // ServiceName is the canonical catalog/service name for the bridge module.
 const ServiceName = "whatsapp-bridge"
+
+// BridgeService is the compose service name of the bridge app (the one whose
+// health the status check probes). It matches the `services.bridge` key in the
+// module compose file.
+const BridgeService = "bridge"
+
+// ProjectName returns the docker compose project the bridge stack is deployed
+// under (`docker compose -p <project> ...`), derived from the node's services
+// directory. It is deliberately EXPLICIT rather than left to compose's default so
+// that up/down and the status check all agree on one project, but its VALUE is
+// exactly what compose would derive on its own today -- the sanitized services-dir
+// basename -- so upgrading an already-deployed node keeps its existing containers
+// and, critically, its existing `<project>_whatsapp_pgdata` volume (the Baileys
+// auth state / linked WhatsApp session). Changing this to a fresh literal would
+// orphan that volume and silently unlink the user's phone on the next `up`.
+//
+// The container-name collision fix comes from the module compose no longer
+// hardcoding `container_name`: with names now derived as `<project>-<service>-N`,
+// a citadel-managed stack coexists with any other bridge on the node (a dev
+// `watest` stack, a second tenant) instead of colliding on the global name
+// `citadel-whatsapp-bridge`. The CLI resolves the running container via
+// `docker compose -p <project> ps`, so this is the CLI half of the coupled
+// contract (aceteam-ai/citadel-cli#436 / sunapi386/whatsapp-bridge#4).
+func ProjectName(servicesDir string) string {
+	base := filepath.Base(servicesDir)
+	// Mirror docker compose's project-name sanitization: lowercase, and keep only
+	// [a-z0-9_-], collapsing anything else to '-'. An empty/degenerate result
+	// falls back to the conventional "services" (the basename used by every node
+	// today), so the value never regresses to something compose would reject.
+	var b strings.Builder
+	for _, r := range strings.ToLower(base) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	name := strings.Trim(b.String(), "-_")
+	if name == "" {
+		return "services"
+	}
+	return name
+}
 
 // DefaultPort is the bridge's published REST port.
 const DefaultPort = 8080

--- a/internal/whatsapp/bridge_test.go
+++ b/internal/whatsapp/bridge_test.go
@@ -149,3 +149,36 @@ func TestQRStringAndHealth(t *testing.T) {
 		t.Error("expected logged_in true")
 	}
 }
+
+// TestProjectNamePreservesExistingVolume is the regression guard for the
+// container-name collision fix (aceteam-ai/citadel-cli#436): the pinned compose
+// project MUST equal what compose derived implicitly before the fix (the
+// services-dir basename, "services"), otherwise upgrading an already-deployed
+// node would move its `<project>_whatsapp_pgdata` volume and silently unlink the
+// user's WhatsApp session.
+func TestProjectNamePreservesExistingVolume(t *testing.T) {
+	// Every node's bridge lives in <configDir>/services, so the project -- and
+	// thus the auth-state volume prefix -- must remain "services".
+	if got := ProjectName(filepath.Join("/home/user/citadel-node", "services")); got != "services" {
+		t.Errorf("ProjectName(...services) = %q, want %q (must match the pre-fix implicit project so the pgdata volume is preserved)", got, "services")
+	}
+}
+
+// TestProjectNameSanitizes checks the derived project is always a value docker
+// compose accepts (lowercase [a-z0-9_-], non-empty).
+func TestProjectNameSanitizes(t *testing.T) {
+	cases := map[string]string{
+		"services":        "services",
+		"Services":        "services",
+		"My Services":     "my-services",
+		"svc.dir":         "svc-dir",
+		"---":             "services", // degenerate -> fallback
+		"":                "services",
+		"node_1-services": "node_1-services",
+	}
+	for in, want := range cases {
+		if got := ProjectName(in); got != want {
+			t.Errorf("ProjectName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/whatsapp/provision.go
+++ b/internal/whatsapp/provision.go
@@ -176,7 +176,7 @@ func Provision(ctx context.Context, req ProvisionRequest, deps ProvisionDeps) (*
 	waitCtx, cancel := context.WithTimeout(ctx, readyTimeout)
 	defer cancel()
 	if err := client.WaitReady(waitCtx, readyTimeout); err != nil {
-		return nil, fmt.Errorf("bridge did not become ready: %w (check `docker logs citadel-whatsapp-bridge`)", err)
+		return nil, fmt.Errorf("bridge did not become ready: %w (check `docker compose -p %s logs %s`)", err, ProjectName(servicesDir), BridgeService)
 	}
 
 	// Mint (or reuse) the tenant. Reusing a previously minted tenant preserves an


### PR DESCRIPTION
## Context

`citadel whatsapp up` and the `WHATSAPP_PROVISION` node job deploy the Baileys WhatsApp bridge (app + Postgres) via docker compose. The bridge module compose (`sunapi386/whatsapp-bridge`, `citadel/compose.yml`) hardcoded `container_name: citadel-whatsapp-bridge` / `citadel-whatsapp-db`. Docker container names are **global**, so any node that already runs a bridge stack -- a dev stack, a second tenant, or a half-succeeded provision -- made the next `docker compose up` fail with `Conflict. The container name "/citadel-whatsapp-db" is already in use`, permanently wedging self-serve provisioning on that node. Reproduced live on a node running a dev bridge under compose project `watest` at port 8091.

Fixes aceteam-ai/citadel-cli#436. **Coupled with sunapi386/whatsapp-bridge#4 (PR: sunapi386/whatsapp-bridge#5) -- the compose change (removing `container_name`) and this status-check change are one contract and must merge together.** Merging either alone breaks the bridge status check.

## Root Cause

Container identity was a hardcoded global string instead of being namespaced by compose project. The CLI status check greped the literal `citadel-whatsapp-bridge`, coupling it to that hardcoded name. Separately, the deploy edge (git clone of the private module + `docker compose up`) had no deadline, so an unreachable registry / missing creds / unresponsive Docker produced a silent hang rather than a fast, descriptive error (surfaced live as a 180s backend timeout with nothing returned).

## Changes

**Landmine 1 -- container-name collision**
- `internal/whatsapp/bridge.go`: add `ProjectName(servicesDir)` and `BridgeService`. `ProjectName` returns the docker-compose project the stack runs under, derived (and sanitized) from the services-dir basename. Its value equals compose's **old implicit default** (`services`), so upgrading an already-deployed node keeps its existing containers and, critically, its `services_whatsapp_pgdata` volume (the Baileys auth state / linked session) instead of orphaning it.
- `cmd/whatsapp.go`: pin `-p <project>` on `up` (`composeUp`) and `down`; move the status check off the hardcoded literal to `bridgeContainerRunning(project)`, which resolves the container via `docker compose -p <project> ps -q bridge` and confirms running state with `docker inspect`. Both `runWhatsAppStatus` and the TUI status callback use it.
- `internal/whatsapp/provision.go`: update the readiness-failure hint from `docker logs citadel-whatsapp-bridge` to `docker compose -p <project> logs bridge`.

**Landmine 2 -- deploy can hang instead of failing fast** (issue #436)
- `cmd/whatsapp.go`: bound the whole `DeployCompose` edge with a 150s deadline (< the 180s backend job timeout) and run `docker compose up` under `context`. On timeout it returns a descriptive error naming the likely cause (unreachable repo/registry or unresponsive Docker) instead of hanging. `catalog.ResolveSource` shells out to `git` without a context, so git's own connect time is additionally capped via `GIT_HTTP_LOW_SPEED_*` as defense in depth.

## Migration note

An already-deployed node's old containers were literally named `citadel-whatsapp-bridge` / `citadel-whatsapp-db` but carry compose's `project=services` label. Under the new compose (no `container_name`) with `-p services`, compose reconciles them by service and recreates them as `services-bridge-1` / `services-db-1`, replacing the old ones (no port conflict, no data loss -- the named volume is preserved).

## Testing

- `go build ./...` -- clean.
- `go vet ./internal/whatsapp/... ./internal/apps/... ./cmd/...` -- clean.
- `go test ./internal/whatsapp/... ./internal/apps/... ./cmd/` -- pass. (Full `./...` intentionally not run per repo guidance about tmux-spawning test packages.)
- New `internal/apps/container_name_collision_test.go` mirrors `hostport_collision_test.go`: asserts the module compose declares **no** `container_name` and that two distinct projects (`services`, `watest`) derive non-colliding container names -- the coexistence guarantee that a node already running one bridge can be provisioned to a second one.
- New `whatsapp.ProjectName` tests guard the volume-preserving value (`services`) and project-name sanitization.

*Generated by Claude Opus 4.8*
