### PR TITLE
feat(status): generic network-activity idle detection for non-vLLM services (#433)

### DIFF
--- a/internal/status/collector.go
+++ b/internal/status/collector.go
@@ -29,6 +29,7 @@ type Collector struct {
 	capabilities   *NodeCapabilities     // cached capabilities (set once at startup)
 	idleTracker    *IdleTracker          // metrics-based per-service idle detection (aceteam#4472 / citadel #416)
 	fpIdleTracker  *FootprintIdleTracker // footprint-derived idle for engines #416 can't scrape (citadel #421)
+	netIdleTracker *IdleTracker          // network-activity idle for non-vLLM services (citadel #433)
 }
 
 // ServiceConfig holds the configuration for a service from the manifest.
@@ -58,6 +59,7 @@ func NewCollector(cfg CollectorConfig) *Collector {
 		capabilities:   cfg.Capabilities,
 		idleTracker:    NewIdleTracker(IdleThresholdSeconds()),
 		fpIdleTracker:  NewFootprintIdleTracker(),
+		netIdleTracker: NewIdleTracker(IdleThresholdSeconds()),
 	}
 }
 

--- a/internal/status/footprint.go
+++ b/internal/status/footprint.go
@@ -206,12 +206,14 @@ func parseStatsOutput(out string) map[string]containerStats {
 			usedStr = usedStr[:idx]
 		}
 		cs.ramBytes = parseMemBytes(usedStr)
-		// NetIO is "<rx> / <tx>"; sum both sides. Optional field: when present we
-		// mark hasNet so the generic idle path can distinguish a real "zero
-		// traffic" reading from an absent column.
+		// NetIO is "<rx> / <tx>"; sum both sides. Optional field. hasNet is set
+		// ONLY when a real byte value parsed: a runtime that reports "--" / "-- /
+		// --" (host-networked or stats-unavailable containers) is an UNKNOWN
+		// reading, not a real zero, and must not drive the idle tracker toward a
+		// false idle. So an unparseable NetIO cell leaves hasNet=false and the
+		// generic idle path falls through to the footprint heuristic.
 		if len(fields) >= 4 {
-			cs.netBytes = parseNetIO(fields[3])
-			cs.hasNet = true
+			cs.netBytes, cs.hasNet = parseNetIO(fields[3])
 		}
 		res[name] = cs
 	}
@@ -219,15 +221,43 @@ func parseStatsOutput(out string) map[string]containerStats {
 }
 
 // parseNetIO parses a docker/podman NetIO cell like "1.2kB / 3.4MB" (received /
-// transmitted) into the summed byte total. Either side missing or unparseable
-// contributes 0, so a malformed cell yields 0 rather than a panic.
-func parseNetIO(s string) uint64 {
+// transmitted) into the summed byte total. The bool reports whether at least
+// one side parsed to a real byte value: a cell like "--", "-- / --", or empty
+// (host-networked or stats-unavailable containers) yields (0, false) so callers
+// treat it as UNKNOWN rather than a real "zero traffic" reading. This is the
+// fail-safe gate for the generic idle path -- an unknown reading must never
+// look like a flat zero counter that goes idle. A genuine "0B / 0B" reading
+// parses as (0, true): a real, quiet container.
+func parseNetIO(s string) (uint64, bool) {
 	rx, tx := s, ""
 	if idx := strings.Index(s, "/"); idx >= 0 {
 		rx = s[:idx]
 		tx = s[idx+1:]
 	}
-	return parseMemBytes(strings.TrimSpace(rx)) + parseMemBytes(strings.TrimSpace(tx))
+	rxB, rxOK := parseNetSide(strings.TrimSpace(rx))
+	txB, txOK := parseNetSide(strings.TrimSpace(tx))
+	if !rxOK && !txOK {
+		return 0, false
+	}
+	return rxB + txB, true
+}
+
+// parseNetSide parses one side of a NetIO cell into bytes, reporting whether it
+// was a real numeric value. An empty or non-numeric token (e.g. "--", the
+// placeholder docker/podman print when NetIO is unavailable) returns (0,false).
+// A real "0B" returns (0,true). It reuses parseMemBytes for the unit math but
+// distinguishes "parsed to zero" from "could not parse" by requiring a leading
+// digit, which parseMemBytes alone (which maps garbage to 0) cannot.
+func parseNetSide(s string) (uint64, bool) {
+	if s == "" {
+		return 0, false
+	}
+	// A real value starts with a digit (optionally after a sign, though NetIO is
+	// never negative). "--" and other placeholders do not.
+	if s[0] < '0' || s[0] > '9' {
+		return 0, false
+	}
+	return parseMemBytes(s), true
 }
 
 // parsePercent parses a value like "74.31%" or "74.31" into a float. Returns
@@ -705,6 +735,16 @@ func (c *Collector) attachDerivedIdle(containerName string, fp *ServiceFootprint
 	// nothing), never fabricate an idle signal from an unknown reading.
 	if c.netIdleTracker != nil && fp.HasNet {
 		n := c.netIdleTracker.RecordActivityCounter(containerName, fp.NetBytes)
+		// GPU-busy override: a container can pin the GPU (a batch diffusers /
+		// fine-tune job) while sending no network traffic, so a network-silent
+		// verdict of "idle" would be a dangerous false idle on a node doing real
+		// work. If the GPU is actively utilized, the container is NOT idle
+		// regardless of the network counter. We deliberately do NOT fold CPU in
+		// here -- an agent process idling above the CPU floor is exactly the case
+		// #433 exists to catch, so only the unambiguous GPU-hot signal overrides.
+		if n.Idle && fp.HasGPU && fp.GPUUtilPercent > idleGPUThresholdPercent {
+			n.Idle = false
+		}
 		*dst = &n
 		return
 	}

--- a/internal/status/footprint.go
+++ b/internal/status/footprint.go
@@ -47,6 +47,21 @@ type ServiceFootprint struct {
 	// HasGPU reports whether GPU stats were available at all, so a "0.0G / 0%"
 	// footprint can be rendered as "n/a" instead of a misleading zero.
 	HasGPU bool `json:"has_gpu"`
+	// NetBytes is the container's cumulative network I/O (rx + tx) in bytes as
+	// reported by `docker/podman stats` NetIO. It is a monotonic counter (reset
+	// only on container restart) and is the request-agnostic activity signal the
+	// generic idle path uses for services that expose no vLLM-style request
+	// metrics (Claude Code, OpenClaw, Hermes, ...). 0 when the stats read did not
+	// include a NetIO column. See citadel-cli#433.
+	NetBytes uint64 `json:"net_bytes"`
+	// HasNet reports whether NetBytes came from an actual NetIO reading (as
+	// opposed to a runtime/format that omitted the column). This is the fail-safe
+	// discriminator for the generic idle path: a genuinely-zero NetBytes with
+	// HasNet=true is a real "no traffic" signal, but NetBytes=0 with HasNet=false
+	// means "unknown" and MUST NOT be fed to the idle tracker (an unread counter
+	// would look flat forever and false-idle a busy container). Not serialized;
+	// it is an internal collection detail.
+	HasNet bool `json:"-"`
 }
 
 // heavyRAMBytes is the RSS threshold above which an idle managed service is
@@ -118,6 +133,8 @@ func CollectFootprints(ctx context.Context, containerNames []string) map[string]
 		if s, ok := stats[name]; ok {
 			fp.CPUPercent = s.cpuPercent
 			fp.RAMBytes = s.ramBytes
+			fp.NetBytes = s.netBytes
+			fp.HasNet = s.hasNet
 		}
 		if hasGPU {
 			fp.GPUUtilPercent = gpuUtil
@@ -130,15 +147,20 @@ func CollectFootprints(ctx context.Context, containerNames []string) map[string]
 	return out
 }
 
-// containerStats holds the CPU% and RAM parsed from one `stats` row.
+// containerStats holds the CPU%, RAM, and cumulative network I/O parsed from
+// one `stats` row.
 type containerStats struct {
 	cpuPercent float64
 	ramBytes   uint64
+	netBytes   uint64
+	hasNet     bool
 }
 
 // statsFormat is the Go-template format string passed to `stats --format`. Tab
-// separated so a container name with a space can't break parsing.
-const statsFormat = "{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}"
+// separated so a container name with a space can't break parsing. NetIO (rx/tx)
+// is included for the generic, request-agnostic idle signal (citadel-cli#433);
+// both docker and podman expose the {{.NetIO}} field.
+const statsFormat = "{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.NetIO}}"
 
 // collectContainerStats runs one `<engine> stats --no-stream` over ALL running
 // containers and returns a name -> {cpu%, ram} map. No container names are
@@ -155,9 +177,12 @@ func collectContainerStats(ctx context.Context, engineBin string) map[string]con
 }
 
 // parseStatsOutput parses the tab-separated `stats --format` output into a
-// name -> {cpu%, ram} map. Lines that don't parse are skipped. Exported field
-// units follow docker/podman conventions: CPUPerc like "74.31%", MemUsage like
-// "6.1GiB / 62.0GiB" (we take the used side).
+// name -> {cpu%, ram, net} map. Lines that don't parse are skipped. Exported
+// field units follow docker/podman conventions: CPUPerc like "74.31%", MemUsage
+// like "6.1GiB / 62.0GiB" (we take the used side), NetIO like "1.2kB / 3.4MB"
+// (rx / tx, summed). The NetIO column is optional: a 3-field row (older format
+// or a runtime that omits NetIO) still parses with netBytes=0, so this stays
+// backward compatible with the pre-#433 statsFormat.
 func parseStatsOutput(out string) map[string]containerStats {
 	res := map[string]containerStats{}
 	sc := bufio.NewScanner(strings.NewReader(out))
@@ -181,9 +206,28 @@ func parseStatsOutput(out string) map[string]containerStats {
 			usedStr = usedStr[:idx]
 		}
 		cs.ramBytes = parseMemBytes(usedStr)
+		// NetIO is "<rx> / <tx>"; sum both sides. Optional field: when present we
+		// mark hasNet so the generic idle path can distinguish a real "zero
+		// traffic" reading from an absent column.
+		if len(fields) >= 4 {
+			cs.netBytes = parseNetIO(fields[3])
+			cs.hasNet = true
+		}
 		res[name] = cs
 	}
 	return res
+}
+
+// parseNetIO parses a docker/podman NetIO cell like "1.2kB / 3.4MB" (received /
+// transmitted) into the summed byte total. Either side missing or unparseable
+// contributes 0, so a malformed cell yields 0 rather than a panic.
+func parseNetIO(s string) uint64 {
+	rx, tx := s, ""
+	if idx := strings.Index(s, "/"); idx >= 0 {
+		rx = s[:idx]
+		tx = s[idx+1:]
+	}
+	return parseMemBytes(strings.TrimSpace(rx)) + parseMemBytes(strings.TrimSpace(tx))
 }
 
 // parsePercent parses a value like "74.31%" or "74.31" into a float. Returns
@@ -618,22 +662,56 @@ func (c *Collector) attachFootprints(status *NodeStatus) {
 	}
 }
 
-// attachDerivedIdle fills in a footprint-derived idle signal when the
-// metrics-based path (#420) left one absent. This is what surfaces idleness for
-// engines with no scrapeable request counters (diffusers, ollama) — the exact
-// #421 blind spot. When #420 already attached an IdleState (e.g. for vLLM), it
-// is authoritative and left untouched. The tracker is always fed so its
-// per-container idle clock stays warm regardless of which signal wins.
+// attachDerivedIdle fills in a per-service idle signal when the metrics-based
+// path (#420, vLLM request counters) left one absent. There are two generic
+// fallbacks, in precedence order:
+//
+//  1. vLLM request-counter idle (#420): authoritative when present, left
+//     untouched here.
+//  2. Network-activity idle (#433): a request-agnostic signal derived from the
+//     container's cumulative NetIO, folded through the shared IdleTracker so it
+//     honors SERVICE_IDLE_THRESHOLD_SECONDS. This is the auto-stop parity path
+//     for agent-app containers (Claude Code, OpenClaw, Hermes) that emit no
+//     vLLM metrics — a Node process idling above the CPU floor would never be
+//     caught by the CPU/GPU heuristic below.
+//  3. Footprint (CPU/GPU) idle (#421): the last-resort heuristic, on a fixed
+//     60s clock, that powers the TUI "heavy AND idle" eviction warning.
+//
+// The footprint tracker is ALWAYS fed (its per-container 60s clock must stay
+// warm so the #421 heavy-and-idle warning keeps working) but its state is only
+// EMITTED when neither the vLLM nor the network-activity signal produced one.
+// The network signal is preferred over CPU/GPU for auto-stop because it does
+// not false-idle a busy-but-low-CPU agent process, and because it respects the
+// operator-configured threshold rather than a hardcoded 60s.
 func (c *Collector) attachDerivedIdle(containerName string, fp *ServiceFootprint, dst **IdleState) {
-	if c.fpIdleTracker == nil {
+	// Feed the footprint tracker unconditionally so its heavy-and-idle clock
+	// keeps advancing regardless of which signal is emitted.
+	var footprintIdle *IdleState
+	if c.fpIdleTracker != nil {
+		f := c.fpIdleTracker.Observe(containerName, fp)
+		footprintIdle = &f
+	}
+
+	if *dst != nil {
+		return // vLLM request-counter idle is authoritative
+	}
+
+	// Network-activity idle: preferred generic signal (#433). Fed ONLY when the
+	// stats read actually produced a NetIO reading for this container. If NetIO
+	// was absent (older format / runtime without the column), fp.HasNet is false
+	// and we do NOT feed the tracker: an unread, permanently-flat counter would
+	// otherwise look idle after the threshold and could auto-stop a busy
+	// container. Fail-safe = fall through to the footprint heuristic (or emit
+	// nothing), never fabricate an idle signal from an unknown reading.
+	if c.netIdleTracker != nil && fp.HasNet {
+		n := c.netIdleTracker.RecordActivityCounter(containerName, fp.NetBytes)
+		*dst = &n
 		return
 	}
-	derived := c.fpIdleTracker.Observe(containerName, fp)
-	if *dst != nil {
-		return // metrics-based idle signal is authoritative
+
+	if footprintIdle != nil {
+		*dst = footprintIdle
 	}
-	d := derived
-	*dst = &d
 }
 
 // FormatFootprint renders a one-line footprint summary for the TUI, e.g.

--- a/internal/status/footprint_test.go
+++ b/internal/status/footprint_test.go
@@ -418,23 +418,30 @@ func TestStatsFilterByCandidateName(t *testing.T) {
 }
 
 // TestParseNetIO checks the "<rx> / <tx>" NetIO cell parses to the summed byte
-// total, and that garbage/partial cells degrade to 0 without panicking.
+// total, and -- critically for the fail-safe -- that a placeholder/unavailable
+// cell ("--", "-- / --", empty) is reported as UNKNOWN (ok=false), not a real
+// zero. A genuine "0B / 0B" is a real, quiet reading (ok=true).
 func TestParseNetIO(t *testing.T) {
 	cases := []struct {
-		in   string
-		want uint64
+		in     string
+		want   uint64
+		wantOK bool
 	}{
-		{"0B / 0B", 0},
-		{"1.0kB / 2.0kB", 3000},            // decimal kB, summed
-		{"1.5MB / 0B", 1_500_000},          // one side only
-		{"1.0MiB / 1.0MiB", 2 * (1 << 20)}, // binary MiB, summed
-		{"", 0},
-		{"garbage", 0},
-		{"5kB", 5000}, // no separator -> whole cell treated as rx
+		{"0B / 0B", 0, true},                     // real quiet container
+		{"1.0kB / 2.0kB", 3000, true},            // decimal kB, summed
+		{"1.5MB / 0B", 1_500_000, true},          // one side only
+		{"1.0MiB / 1.0MiB", 2 * (1 << 20), true}, // binary MiB, summed
+		{"5kB", 5000, true},                      // no separator -> rx only
+		{"", 0, false},                           // empty -> unknown
+		{"-- / --", 0, false},                    // docker placeholder -> unknown
+		{"--", 0, false},                         // half placeholder -> unknown
+		{"garbage", 0, false},                    // non-numeric -> unknown
+		{"1.0kB / --", 1000, true},               // one real side is enough
 	}
 	for _, c := range cases {
-		if got := parseNetIO(c.in); got != c.want {
-			t.Errorf("parseNetIO(%q) = %d, want %d", c.in, got, c.want)
+		got, ok := parseNetIO(c.in)
+		if got != c.want || ok != c.wantOK {
+			t.Errorf("parseNetIO(%q) = (%d,%v), want (%d,%v)", c.in, got, ok, c.want, c.wantOK)
 		}
 	}
 }
@@ -475,6 +482,25 @@ func TestParseStatsOutput_ThreeFieldStillParses(t *testing.T) {
 	}
 	if s.cpuPercent != 74.31 {
 		t.Errorf("cpu = %v, want 74.31 (3-field row must still parse)", s.cpuPercent)
+	}
+}
+
+// TestParseStatsOutput_PlaceholderNetIsUnknown is the fail-safe parser test: a
+// 4-field row whose NetIO is the docker/podman "--" placeholder (host-networked
+// or stats-unavailable container) must set hasNet=false, so the generic idle
+// path treats it as unknown and never as a real zero-traffic reading.
+func TestParseStatsOutput_PlaceholderNetIsUnknown(t *testing.T) {
+	out := "citadel-hostnet\t3.0%\t256MiB / 62.0GiB\t-- / --\n"
+	got := parseStatsOutput(out)
+	s, ok := got["citadel-hostnet"]
+	if !ok {
+		t.Fatalf("missing citadel-hostnet row: %v", got)
+	}
+	if s.hasNet {
+		t.Fatalf("expected hasNet false for a '-- / --' NetIO placeholder")
+	}
+	if s.cpuPercent != 3.0 {
+		t.Errorf("cpu = %v, want 3.0 (row must still parse for CPU/RAM)", s.cpuPercent)
 	}
 }
 
@@ -533,6 +559,57 @@ func TestAttachDerivedIdle_VLLMSignalIsAuthoritative(t *testing.T) {
 	c.attachDerivedIdle("citadel-vllm", fp, &dst)
 	if dst != existing {
 		t.Fatalf("expected the vLLM idle signal to be left untouched, got %+v", dst)
+	}
+}
+
+// TestAttachDerivedIdle_GPUHotOverridesNetworkIdle guards the dangerous false
+// idle: a container that pins the GPU (a batch diffusers / fine-tune job) but
+// sends no network traffic. The flat NetIO counter would otherwise report idle
+// after the threshold and make it an auto-stop candidate while it is doing real
+// GPU work. The GPU-hot override must keep it active.
+func TestAttachDerivedIdle_GPUHotOverridesNetworkIdle(t *testing.T) {
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	c := newNetTestCollector(300, &now)
+
+	// Baseline: GPU already hot, flat network.
+	fp := &ServiceFootprint{CPUPercent: 1, RAMBytes: 8 << 30, NetBytes: 1000, HasNet: true, HasGPU: true, GPUUtilPercent: 95}
+	var dst *IdleState
+	c.attachDerivedIdle("citadel-diffusers", fp, &dst)
+	if dst == nil || dst.Idle {
+		t.Fatalf("expected not idle at baseline, got %+v", dst)
+	}
+
+	// 300s later, network still flat, GPU still hot -> the net signal alone would
+	// say idle, but the GPU override keeps it active.
+	now = now.Add(300 * time.Second)
+	fp2 := &ServiceFootprint{CPUPercent: 1, RAMBytes: 8 << 30, NetBytes: 1000, HasNet: true, HasGPU: true, GPUUtilPercent: 95}
+	dst = nil
+	c.attachDerivedIdle("citadel-diffusers", fp2, &dst)
+	if dst == nil {
+		t.Fatalf("expected a signal, got nil")
+	}
+	if dst.Idle {
+		t.Fatalf("GPU-busy container must not be reported idle despite flat NetIO, got %+v", dst)
+	}
+}
+
+// TestAttachDerivedIdle_NetworkIdleWhenGPUQuiet confirms the GPU override does
+// NOT suppress a legitimately idle service: flat network AND a quiet GPU means
+// truly idle, so the service should flip idle after the threshold.
+func TestAttachDerivedIdle_NetworkIdleWhenGPUQuiet(t *testing.T) {
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	c := newNetTestCollector(300, &now)
+
+	fp := &ServiceFootprint{CPUPercent: 1, RAMBytes: 8 << 30, NetBytes: 1000, HasNet: true, HasGPU: true, GPUUtilPercent: 0}
+	var dst *IdleState
+	c.attachDerivedIdle("citadel-idle-gpu", fp, &dst) // baseline
+
+	now = now.Add(300 * time.Second)
+	fp2 := &ServiceFootprint{CPUPercent: 1, RAMBytes: 8 << 30, NetBytes: 1000, HasNet: true, HasGPU: true, GPUUtilPercent: 0}
+	dst = nil
+	c.attachDerivedIdle("citadel-idle-gpu", fp2, &dst)
+	if dst == nil || !dst.Idle {
+		t.Fatalf("expected idle when both network and GPU are quiet, got %+v", dst)
 	}
 }
 

--- a/internal/status/footprint_test.go
+++ b/internal/status/footprint_test.go
@@ -417,6 +417,158 @@ func TestStatsFilterByCandidateName(t *testing.T) {
 	}
 }
 
+// TestParseNetIO checks the "<rx> / <tx>" NetIO cell parses to the summed byte
+// total, and that garbage/partial cells degrade to 0 without panicking.
+func TestParseNetIO(t *testing.T) {
+	cases := []struct {
+		in   string
+		want uint64
+	}{
+		{"0B / 0B", 0},
+		{"1.0kB / 2.0kB", 3000},            // decimal kB, summed
+		{"1.5MB / 0B", 1_500_000},          // one side only
+		{"1.0MiB / 1.0MiB", 2 * (1 << 20)}, // binary MiB, summed
+		{"", 0},
+		{"garbage", 0},
+		{"5kB", 5000}, // no separator -> whole cell treated as rx
+	}
+	for _, c := range cases {
+		if got := parseNetIO(c.in); got != c.want {
+			t.Errorf("parseNetIO(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+// TestParseStatsOutput_WithNetIO verifies the 4-field (post-#433) stats row is
+// parsed with netBytes populated and hasNet=true.
+func TestParseStatsOutput_WithNetIO(t *testing.T) {
+	// "{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.NetIO}}"
+	out := "citadel-claude\t1.2%\t512MiB / 62.0GiB\t3.0kB / 1.0kB\n"
+	got := parseStatsOutput(out)
+	s, ok := got["citadel-claude"]
+	if !ok {
+		t.Fatalf("missing citadel-claude row: %v", got)
+	}
+	if !s.hasNet {
+		t.Fatalf("expected hasNet true for a 4-field row")
+	}
+	if s.netBytes != 4000 {
+		t.Errorf("netBytes = %d, want 4000 (3kB + 1kB)", s.netBytes)
+	}
+}
+
+// TestParseStatsOutput_ThreeFieldStillParses guards backward compatibility: a
+// row without the NetIO column (older statsFormat / a runtime that omits it)
+// must still parse for CPU+RAM, with hasNet=false and netBytes=0.
+func TestParseStatsOutput_ThreeFieldStillParses(t *testing.T) {
+	out := "citadel-vllm\t74.31%\t6.1GiB / 62.0GiB\n"
+	got := parseStatsOutput(out)
+	s, ok := got["citadel-vllm"]
+	if !ok {
+		t.Fatalf("missing citadel-vllm row: %v", got)
+	}
+	if s.hasNet {
+		t.Fatalf("expected hasNet false for a 3-field (no NetIO) row")
+	}
+	if s.netBytes != 0 {
+		t.Errorf("netBytes = %d, want 0 when NetIO absent", s.netBytes)
+	}
+	if s.cpuPercent != 74.31 {
+		t.Errorf("cpu = %v, want 74.31 (3-field row must still parse)", s.cpuPercent)
+	}
+}
+
+// newNetTestCollector builds a Collector wired with only the trackers the
+// generic idle path needs, with an injectable clock on the network tracker.
+func newNetTestCollector(thresholdSeconds int, clock *time.Time) *Collector {
+	c := &Collector{
+		fpIdleTracker:  NewFootprintIdleTracker(),
+		netIdleTracker: NewIdleTracker(thresholdSeconds),
+	}
+	c.netIdleTracker.now = func() time.Time { return *clock }
+	c.fpIdleTracker.now = func() time.Time { return *clock }
+	return c
+}
+
+// TestAttachDerivedIdle_NetworkSignalGoesIdle exercises the #433 generic path
+// end to end through attachDerivedIdle: a container whose NetIO stays flat past
+// the configured threshold is emitted as idle, honoring the shared idle
+// threshold rather than the footprint's fixed 60s clock.
+func TestAttachDerivedIdle_NetworkSignalGoesIdle(t *testing.T) {
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	c := newNetTestCollector(300, &now)
+
+	// Busy: NetIO climbing. Even with CPU above the footprint idle floor, we care
+	// about the network signal here.
+	fp := &ServiceFootprint{CPUPercent: 40, RAMBytes: 1 << 30, NetBytes: 1000, HasNet: true, GPUUtilPercent: -1}
+	var dst *IdleState
+	c.attachDerivedIdle("citadel-agent", fp, &dst)
+	if dst == nil || dst.Idle {
+		t.Fatalf("expected a not-idle signal on first sample, got %+v", dst)
+	}
+
+	// Flat NetIO for the full threshold -> idle.
+	now = now.Add(300 * time.Second)
+	fp2 := &ServiceFootprint{CPUPercent: 40, RAMBytes: 1 << 30, NetBytes: 1000, HasNet: true, GPUUtilPercent: -1}
+	dst = nil
+	c.attachDerivedIdle("citadel-agent", fp2, &dst)
+	if dst == nil || !dst.Idle {
+		t.Fatalf("expected idle after 300s flat NetIO, got %+v", dst)
+	}
+	if dst.IdleSeconds != 300 {
+		t.Errorf("idle_seconds = %d, want 300", dst.IdleSeconds)
+	}
+}
+
+// TestAttachDerivedIdle_VLLMSignalIsAuthoritative confirms the network path does
+// not overwrite an already-present vLLM request-counter idle signal.
+func TestAttachDerivedIdle_VLLMSignalIsAuthoritative(t *testing.T) {
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	c := newNetTestCollector(300, &now)
+
+	// Pretend the metrics path already attached a busy vLLM idle state.
+	existing := &IdleState{Idle: false, IdleSeconds: 5}
+	dst := existing
+	fp := &ServiceFootprint{CPUPercent: 1, NetBytes: 1000, HasNet: true, GPUUtilPercent: -1}
+	c.attachDerivedIdle("citadel-vllm", fp, &dst)
+	if dst != existing {
+		t.Fatalf("expected the vLLM idle signal to be left untouched, got %+v", dst)
+	}
+}
+
+// TestAttachDerivedIdle_UnknownNetFailsSafeActive is the core fail-safe test: a
+// container whose stats read produced NO NetIO column (HasNet=false) must NOT be
+// fed to the network idle tracker. Otherwise a permanently-flat unread counter
+// would look idle after the threshold and could auto-stop a busy container. With
+// footprint activity present (CPU high) it stays busy; the network path never
+// fabricates an idle signal from an unknown reading.
+func TestAttachDerivedIdle_UnknownNetFailsSafeActive(t *testing.T) {
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	c := newNetTestCollector(300, &now)
+
+	// CPU is well above the footprint idle floor -> the fallback footprint signal
+	// reports busy. NetIO is absent (HasNet=false) so the net path is skipped.
+	fp := &ServiceFootprint{CPUPercent: 90, RAMBytes: 1 << 30, NetBytes: 0, HasNet: false, GPUUtilPercent: -1}
+
+	var dst *IdleState
+	c.attachDerivedIdle("citadel-busy", fp, &dst)
+	if dst == nil {
+		t.Fatalf("expected a footprint fallback idle signal, got nil")
+	}
+	if dst.Idle {
+		t.Fatalf("busy container with unknown NetIO must never be reported idle, got %+v", dst)
+	}
+
+	// Even after a long gap, with NetIO still unknown and CPU busy, it stays
+	// active -- proving the unread net counter never drives it idle.
+	now = now.Add(3600 * time.Second)
+	dst = nil
+	c.attachDerivedIdle("citadel-busy", fp, &dst)
+	if dst == nil || dst.Idle {
+		t.Fatalf("busy container with unknown NetIO must stay active, got %+v", dst)
+	}
+}
+
 func TestPidSubtree_WalksChildren(t *testing.T) {
 	// Synthetic /proc adjacency: 1000 -> 1001 -> 1002, plus an unrelated 2000.
 	children := map[int][]int{

--- a/internal/status/idle.go
+++ b/internal/status/idle.go
@@ -154,6 +154,50 @@ func (t *IdleTracker) RecordSample(key string, total, active float64, hasTotal b
 	return t.record(key, engineMetrics{total: total, active: active, hasTotal: hasTotal})
 }
 
+// RecordActivityCounter folds a monotonic activity counter (e.g. a container's
+// cumulative network I/O in bytes) into the tracked idle state for key. It is
+// the generic, request-agnostic idle path for services that expose no
+// vLLM-style request metrics (Claude Code, OpenClaw, Hermes, ...): any increase
+// in the counter since the last sample is treated as a request, refreshing
+// last_request_at; a flat counter accumulates idle_seconds until the configured
+// threshold flips Idle=true. See citadel-cli#433.
+//
+// Reset semantics differ deliberately from the vLLM request-counter path. For
+// vLLM, a counter DROP means an engine restart with the model already resident,
+// so record() does NOT refresh last_request_at (the drop is not a real request).
+// For a container network counter, a DROP means the container itself just
+// restarted, which is fresh activity (a brand-new, busy container). Treating
+// that as idle would let a just-restarted service be auto-stopped immediately on
+// a stale idle age. So a drop here refreshes last_request_at: restart == active.
+func (t *IdleTracker) RecordActivityCounter(key string, counter uint64) IdleState {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	now := t.now()
+	e, ok := t.entries[key]
+	if !ok {
+		// First observation: seed the baseline. We cannot know when the last
+		// activity happened before tracking began, so treat "now" as the
+		// reference point for idle_seconds and prove no request yet.
+		e = &idleEntry{startedAt: now, lastRequestAt: now}
+		t.entries[key] = e
+	}
+
+	c := float64(counter)
+	// Any change from the prior sample is activity: an increase is new traffic,
+	// a decrease means the container restarted (its counter reset) which is
+	// itself fresh activity. Only a byte-for-byte identical counter is "quiet".
+	changed := e.haveLastTotal && c != e.lastTotal
+	if changed {
+		e.lastRequestAt = now
+		e.haveRequest = true
+	}
+	e.lastTotal = c
+	e.haveLastTotal = true
+
+	return t.stateLocked(e, now)
+}
+
 // stateLocked computes the IdleState for an entry. Caller must hold t.mu.
 func (t *IdleTracker) stateLocked(e *idleEntry, now time.Time) IdleState {
 	idleFor := now.Sub(e.lastRequestAt)

--- a/internal/status/idle_test.go
+++ b/internal/status/idle_test.go
@@ -173,6 +173,117 @@ func TestIdleTracker_SeparateKeysTrackedIndependently(t *testing.T) {
 	}
 }
 
+func TestRecordActivityCounter_FirstSampleSeedsBaseline(t *testing.T) {
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	tr := newTestTracker(300, &now)
+
+	// First observation of a generic (non-vLLM) service: unknown history, so
+	// idle_seconds is 0 and no request is proven yet. This is the fail-safe seed:
+	// a service we just started tracking is never immediately "idle".
+	st := tr.RecordActivityCounter("claude-code", 1000)
+	if st.Idle {
+		t.Fatalf("expected not idle on first activity sample")
+	}
+	if st.IdleSeconds != 0 {
+		t.Fatalf("expected idle_seconds 0 on first sample, got %d", st.IdleSeconds)
+	}
+	if st.LastRequestAt != nil {
+		t.Fatalf("expected no last_request_at before any activity is proven, got %v", st.LastRequestAt)
+	}
+}
+
+func TestRecordActivityCounter_AdvanceResetsIdleClock(t *testing.T) {
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	tr := newTestTracker(300, &now)
+
+	tr.RecordActivityCounter("openclaw", 1000) // baseline
+	now = now.Add(200 * time.Second)
+	// Net bytes climbed: the container did work, so the idle clock resets and
+	// last_request_at is now.
+	st := tr.RecordActivityCounter("openclaw", 5000)
+	if st.Idle {
+		t.Fatalf("expected not idle right after network activity")
+	}
+	if st.IdleSeconds != 0 {
+		t.Fatalf("expected idle_seconds 0 after activity, got %d", st.IdleSeconds)
+	}
+	if st.LastRequestAt == nil || !st.LastRequestAt.Equal(now) {
+		t.Fatalf("expected last_request_at %v after activity, got %v", now, st.LastRequestAt)
+	}
+}
+
+func TestRecordActivityCounter_GoesIdleAfterThreshold(t *testing.T) {
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	tr := newTestTracker(300, &now)
+
+	tr.RecordActivityCounter("hermes", 1000) // baseline at t=0
+	now = now.Add(30 * time.Second)
+	tr.RecordActivityCounter("hermes", 2000) // activity at t=30s
+
+	// 299s of a flat counter: still under the 300s threshold.
+	now = now.Add(299 * time.Second)
+	st := tr.RecordActivityCounter("hermes", 2000)
+	if st.Idle {
+		t.Fatalf("expected not idle at 299s (< threshold)")
+	}
+	if st.IdleSeconds != 299 {
+		t.Fatalf("expected idle_seconds 299, got %d", st.IdleSeconds)
+	}
+
+	// One more second at a flat counter: exactly at threshold -> idle.
+	now = now.Add(1 * time.Second)
+	st = tr.RecordActivityCounter("hermes", 2000)
+	if !st.Idle {
+		t.Fatalf("expected idle at 300s (>= threshold), idle_seconds=%d", st.IdleSeconds)
+	}
+	if st.IdleSeconds != 300 {
+		t.Fatalf("expected idle_seconds 300, got %d", st.IdleSeconds)
+	}
+}
+
+func TestRecordActivityCounter_RestartResetIsActiveNotIdle(t *testing.T) {
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	tr := newTestTracker(300, &now)
+
+	tr.RecordActivityCounter("agent", 1_000_000) // baseline: a long-lived container
+	now = now.Add(1000 * time.Second)            // long idle gap
+
+	// The container restarted: its cumulative NetIO counter dropped to a small
+	// value. Unlike the vLLM request-counter path (where a reset is NOT a
+	// request), a network-counter reset means the container itself is brand new
+	// and busy. It MUST reset the idle clock, otherwise a just-restarted service
+	// would report a stale multi-minute idle age and be auto-stopped immediately.
+	st := tr.RecordActivityCounter("agent", 500)
+	if st.Idle {
+		t.Fatalf("expected a just-restarted container to be active, not idle")
+	}
+	if st.IdleSeconds != 0 {
+		t.Fatalf("expected idle_seconds 0 after a restart, got %d", st.IdleSeconds)
+	}
+	if st.LastRequestAt == nil || !st.LastRequestAt.Equal(now) {
+		t.Fatalf("expected last_request_at %v after restart, got %v", now, st.LastRequestAt)
+	}
+}
+
+func TestRecordActivityCounter_FlatFromStartGoesIdle(t *testing.T) {
+	// A service that never transmits after tracking begins accumulates idle from
+	// the tracking-start baseline and eventually flips idle -- this is the
+	// intended auto-stop trigger for a genuinely-quiet agent app.
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	tr := newTestTracker(300, &now)
+
+	tr.RecordActivityCounter("idle-agent", 42) // baseline
+	now = now.Add(300 * time.Second)
+	st := tr.RecordActivityCounter("idle-agent", 42) // still 42: no traffic at all
+	if !st.Idle {
+		t.Fatalf("expected idle after threshold with a flat counter, idle_seconds=%d", st.IdleSeconds)
+	}
+	// No request was ever proven, so last_request_at stays absent.
+	if st.LastRequestAt != nil {
+		t.Fatalf("expected no last_request_at when no activity was ever seen, got %v", st.LastRequestAt)
+	}
+}
+
 func TestParsePrometheusMetrics_VLLM(t *testing.T) {
 	body := strings.Join([]string{
 		"# HELP vllm:request_success_total Count of successful requests.",


### PR DESCRIPTION
## Context

Closes #433
Part of aceteam-ai/aceteam#4588 (BYOC agent hosting)

Idle detection (`internal/status/idle.go`) previously had a **vLLM-only** metrics dialect: it scrapes `/metrics` for `vllm:request_success_total` / `vllm:num_requests_running`. Agent-app containers (Claude Code, OpenClaw, Hermes) and other non-vLLM services emit no such metrics, so they never registered idle and never became auto-stop candidates. That breaks the Fly-style autostop-when-idle story for the BYOC agent-hosting slice.

There is already a footprint-derived idle heuristic from #421 (`FootprintIdleTracker`), but it is CPU/GPU-utilization based on a **hardcoded 60s clock** and ignores `SERVICE_IDLE_THRESHOLD_SECONDS`. That is the wrong proxy for a Node-based agent process: it idles above the 2% CPU floor (so never registers idle) or dips below during a long LLM/network wait (so false-idles). This PR adds the right generic signal.

## The generic idle signal: container network I/O delta

I chose the container's **cumulative network I/O (NetIO rx+tx)** as the generic activity signal:

- **Nearly free.** It reuses the single batched `docker/podman stats` pass that #421 already runs on the heartbeat path (the codebase deliberately makes exactly one stats call). No new exec, no per-app cooperation, no health-endpoint contract.
- **Service-agnostic.** Every container has NetIO; an agent app talking to an LLM, an API, or a user is transmitting bytes. A parked container is not.
- **Reuses the tested idle logic.** NetIO is a monotonic counter, folded straight into the existing `IdleTracker` (counter-advance = activity, configurable threshold, seed-on-first-sample) via a new `RecordActivityCounter` method. It emits the same inline `IdleState` shape (`idle` / `idle_seconds` / `last_request_at`) the platform usage monitoring (aceteam #4502/#4513) expects.

Alternatives considered and rejected: TCP connection counting (`/proc/net/tcp` conflates idle keep-alive/websocket connections as "in use", netns-fiddly); handler-dispatch timestamps (miss direct user/API traffic); per-app health/last-activity endpoint (requires every image to expose a standard field).

I confirmed `{{.NetIO}}` is exposed by the docker runtime and yields the expected `"rx / tx"` format (e.g. `4.18MB / 173MB`) before relying on it.

## How it coexists with the vLLM dialect

The vLLM path is **completely unchanged** (dialect, scraping, tests). Precedence in `attachDerivedIdle`:

1. **vLLM request-counter idle (#420)** - authoritative when present, left untouched.
2. **Network-activity idle (#433, this PR)** - the generic fallback, honors `SERVICE_IDLE_THRESHOLD_SECONDS`.
3. **Footprint CPU/GPU idle (#421)** - last-resort heuristic on the fixed 60s clock. Still fed unconditionally so the "heavy AND idle" TUI eviction warning keeps working, but only emitted when neither signal above produced one.

## Restart-reset semantics (the non-obvious bit)

The vLLM path deliberately does NOT refresh `last_request_at` on a counter reset (a vLLM counter drop = engine restart with the model already resident, not a request). For a **container network counter**, a drop means the **container itself just restarted** and is brand-new/busy. Reusing the vLLM guard verbatim would leave a just-restarted service reporting a stale multi-minute idle age -> immediate auto-stop candidate. So `RecordActivityCounter` treats a counter drop as **fresh activity (active), not idle**.

## Env gating + fail-safe (never idle on unknown)

Auto-stop stays gated by the existing #416 env (`SERVICE_AUTO_STOP_WHEN_IDLE` default OFF, `SERVICE_AUTO_STOP_IDLE_SECONDS` / `SERVICE_IDLE_THRESHOLD_SECONDS` default 300s). This PR only *emits* the idle signal; it does not stop anything.

**Fail-safe = unknown treated as active, never idle**, enforced in three places:

1. **No NetIO column** (`HasNet=false`, older format / runtime without the field): never fed to the tracker -> falls through to the footprint heuristic. A busy container with no NetIO reading is never falsely idled.
2. **Placeholder NetIO** (`--` / `-- / --`, what docker/podman print for host-networked or stats-unavailable containers): `parseNetIO` returns `(0, ok=false)` so `hasNet` stays false. This is distinct from a genuine `0B / 0B`, which is a real quiet reading (`ok=true`). Without this, an unread counter reads as a flat zero and false-idles a busy container.
3. **GPU-hot override**: a container pinning the GPU (batch diffusers / fine-tune) while sending no network traffic would be idled by the flat NetIO counter. When the net verdict is idle but `GPUUtilPercent` is above the idle threshold, we force active. CPU is deliberately NOT folded in - an agent idling above the CPU floor is exactly what #433 must still catch.

## Changes

- `internal/status/footprint.go`: add `NetBytes` / `HasNet` to `ServiceFootprint`; extend `statsFormat` with `{{.NetIO}}`; `parseNetIO` returns `(bytes, ok)` distinguishing real-zero from unknown; rework `attachDerivedIdle` for the 3-tier precedence + GPU-hot override + fail-safe.
- `internal/status/idle.go`: add `RecordActivityCounter` with restart-reset = active semantics.
- `internal/status/collector.go`: add a dedicated `netIdleTracker *IdleTracker` keyed by container name.

## Limitations / follow-up

- The #416 auto-stop reconciler (`autostop.go`) lives on the unmerged `feat/416` branch, not on `main`, so this PR can only *emit* the correct signal - it cannot wire or test the reconciler here. The reconciler already treats an absent `IdleState` as "don't stop", so it consumes this signal unchanged once merged.
- "Verify on node 1054 with a non-vLLM service" (from the issue) is a documented phase-2 follow-up; the issue itself says "build after the routing slice is proven."
- For footprint-only engines the emitted idle now comes from the net tracker (`SERVICE_IDLE_THRESHOLD_SECONDS`, default 300s) instead of the CPU/GPU heuristic's fixed 60s. The #421 heavy-and-idle TUI warning therefore surfaces at the configured threshold rather than 60s. This is a conscious tradeoff (still far better than the 38-minute #421 incident) and keeps a single configurable knob.
- NetIO is a coarse proxy: a service doing background polling/keep-alive chatter reads as active. That is the intentionally-conservative direction (bias toward NOT auto-stopping) for a fail-safe eviction feature; the dangerous direction (GPU-hot but network-silent) is handled by the override above.

## Testing

`go build ./...` -> exit 0
`go vet ./...` -> exit 0 (whole module)
`go test ./...` -> all packages `ok` (whole module)

```
$ go test ./internal/status/... -run 'ActivityCounter|AttachDerivedIdle|ParseNetIO|ParseStatsOutput|IdleTracker' -v
--- PASS: TestParseStatsOutput
--- PASS: TestParseStatsOutput_SkipsHeaderAndBlank
--- PASS: TestFootprintIdleTracker_AccumulatesAndFlips
--- PASS: TestFootprintIdleTracker_ActivityResets
--- PASS: TestParseNetIO
--- PASS: TestParseStatsOutput_WithNetIO
--- PASS: TestParseStatsOutput_ThreeFieldStillParses
--- PASS: TestParseStatsOutput_PlaceholderNetIsUnknown
--- PASS: TestAttachDerivedIdle_NetworkSignalGoesIdle
--- PASS: TestAttachDerivedIdle_VLLMSignalIsAuthoritative
--- PASS: TestAttachDerivedIdle_GPUHotOverridesNetworkIdle
--- PASS: TestAttachDerivedIdle_NetworkIdleWhenGPUQuiet
--- PASS: TestAttachDerivedIdle_UnknownNetFailsSafeActive
--- PASS: TestIdleTracker_FirstSampleSeedsBaseline
--- PASS: TestIdleTracker_CounterAdvanceRefreshesLastRequest
--- PASS: TestIdleTracker_GoesIdleAfterThreshold
--- PASS: TestIdleTracker_ActiveGaugeKeepsBusy
--- PASS: TestIdleTracker_CounterResetDoesNotFalsePositive
--- PASS: TestIdleTracker_SeparateKeysTrackedIndependently
--- PASS: TestRecordActivityCounter_FirstSampleSeedsBaseline
--- PASS: TestRecordActivityCounter_AdvanceResetsIdleClock
--- PASS: TestRecordActivityCounter_GoesIdleAfterThreshold
--- PASS: TestRecordActivityCounter_RestartResetIsActiveNotIdle
--- PASS: TestRecordActivityCounter_FlatFromStartGoesIdle
--- PASS: TestIdleTracker_Observe_ScrapesLiveEndpoint
--- PASS: TestIdleTracker_Observe_UnknownEngine
ok  	github.com/aceteam-ai/citadel-cli/internal/status
```

New-path coverage: net-activity advance resets the idle clock; flat NetIO past threshold -> idle; restart (bytes drop) -> active not idle; unknown NetIO (`HasNet=false`) fails safe to active; placeholder `-- / --` -> unknown; GPU-hot overrides network idle; GPU-quiet still goes idle; vLLM signal remains authoritative; NetIO parse + backward-compatible 3-field parse.

---
*Generated by Claude Opus 4.8*