### PR TITLE
feat(node): node identity store — keypair + CSR + leaf storage (#4583 P2 PR-0)

### DIFF
--- a/cmd/ensure_identity_smoke_test.go
+++ b/cmd/ensure_identity_smoke_test.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func selfSignedPEM(t *testing.T) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: "test-ca"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+}
+
+// TestEnsureNodeIdentity_WiringSmoke confirms the init-path wiring actually
+// generates a 0600 key and caches the CA chain via a mock backend.
+func TestEnsureNodeIdentity_WiringSmoke(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	chain := selfSignedPEM(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/fabric/ca/chain" {
+			_, _ = w.Write([]byte(chain))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	ensureNodeIdentity(srv.URL)
+
+	keyPath := filepath.Join(home, ".citadel-cli", "identity", "node.key")
+	info, err := os.Stat(keyPath)
+	if err != nil {
+		t.Fatalf("expected key at %s: %v", keyPath, err)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
+		t.Fatalf("key perms = %o, want 0600", info.Mode().Perm())
+	}
+	chainPath := filepath.Join(home, ".citadel-cli", "identity", "ca-chain.pem")
+	if _, err := os.Stat(chainPath); err != nil {
+		t.Fatalf("expected CA chain cached: %v", err)
+	}
+}
+
+// TestEnsureNodeIdentity_FailOpenOn503 confirms a 503 CA does not error out and
+// still leaves a key (fail-open).
+func TestEnsureNodeIdentity_FailOpenOn503(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	ensureNodeIdentity(srv.URL) // must not panic/exit
+
+	keyPath := filepath.Join(home, ".citadel-cli", "identity", "node.key")
+	if _, err := os.Stat(keyPath); err != nil {
+		t.Fatalf("key should exist even when CA is 503: %v", err)
+	}
+	chainPath := filepath.Join(home, ".citadel-cli", "identity", "ca-chain.pem")
+	if _, err := os.Stat(chainPath); err == nil {
+		t.Fatal("chain should NOT be written on 503")
+	}
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/aceteam-ai/citadel-cli/internal/network"
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+	"github.com/aceteam-ai/citadel-cli/internal/nodeidentity"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
 	"github.com/aceteam-ai/citadel-cli/internal/tui"
 	"github.com/aceteam-ai/citadel-cli/internal/ui"
@@ -85,6 +87,13 @@ and system user configuration (requires sudo).`,
 		Debug("auth-service: %s", authServiceURL)
 		Debug("nexus: %s", nexusURL)
 		Debug("config dir: %s", platform.ConfigDir())
+
+		// Establish the node's cryptographic identity (EC P-256 keypair) and
+		// best-effort cache the fabric CA trust chain. Prerequisite for mTLS
+		// self-reenrollment (P2, #4583). Fully fail-open: any error here is
+		// logged at debug and init proceeds exactly as before — a node with no
+		// CA/cert must pair and run identically to today.
+		ensureNodeIdentity(authServiceURL)
 
 		// Handle --relogin: force fresh authentication while preserving network identity
 		// We disconnect but keep tsnet state (machine key) to preserve IP address
@@ -1556,6 +1565,41 @@ func reclaimStaleNodeByHostname(apiToken, hostname string) {
 		fmt.Printf("   Reclaimed stale node '%s' (previous registration cleaned up)\n", hostname)
 	}
 	Debug("reclaim result: %s", result.Message)
+}
+
+// ensureNodeIdentity establishes the node's cryptographic identity (PR-0 of P2,
+// #4583): it ensures an EC P-256 keypair exists on disk (0600, never
+// transmitted) and best-effort caches the public fabric CA trust chain.
+//
+// Idempotent: on re-run it loads the existing key rather than rotating it, so a
+// node keeps a stable identity across `citadel init` invocations.
+//
+// Fully fail-open. The backend fabric CA is not activated fleet-wide yet, so
+// every failure path here is logged at debug and swallowed — a node with no
+// key, no CA, or a hung CA endpoint pairs and runs exactly as it does today.
+// The stored key + chain only become load-bearing once P2's mTLS self-reenroll
+// lands and consumes them.
+func ensureNodeIdentity(baseURL string) {
+	store := nodeidentity.Default()
+
+	if _, err := store.GetOrCreateKey(); err != nil {
+		// Non-fatal: a node without an identity key simply pairs with an authkey
+		// as before. Do NOT os.Exit — this must never block init.
+		Debug("node identity keypair unavailable (non-fatal): %v", err)
+		return
+	}
+	Debug("node identity key ready at %s", store.KeyPath())
+
+	// Fetch the public CA chain with a short timeout so a hung endpoint never
+	// stalls the init happy path. 503 (CA not activated) degrades silently.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	client := &http.Client{Timeout: 5 * time.Second}
+	if err := store.FetchCAChain(ctx, baseURL, client); err != nil {
+		Debug("fabric CA chain fetch skipped (non-fatal): %v", err)
+		return
+	}
+	Debug("fabric CA chain cached at %s", store.CAChainPath())
 }
 
 type DockerPsResult struct {

--- a/internal/nodeidentity/nodeidentity.go
+++ b/internal/nodeidentity/nodeidentity.go
@@ -1,0 +1,279 @@
+// Package nodeidentity manages a fabric node's cryptographic identity: an
+// EC P-256 keypair whose private half never leaves the node, a PKCS#10 CSR
+// derived from it, and the CA-signed leaf certificate + trust chain the node
+// receives at pairing time.
+//
+// This is PR-0 of P2, Epic #4583 (self-healing fabric node identity). The
+// keypair + CSR are the prerequisite for mTLS self-reenrollment: a future
+// `citadel reconnect` will present the stored leaf over mTLS to a self-scoped
+// re-enrollment endpoint. Until the backend fabric CA is activated, everything
+// on the cert path is best-effort and fail-open — a node with no CA/cert pairs
+// and runs exactly as it does today.
+//
+// Storage layout (under platform.ConfigDir()/identity/):
+//
+//	node.key       EC P-256 private key (PKCS#8 PEM, 0600, never transmitted)
+//	node.crt       CA-signed leaf certificate (PEM, public, 0644)
+//	ca-chain.pem   fabric CA trust chain: intermediate || root (PEM, public, 0644)
+//
+// TPM: citadel has no TPM abstraction today (no internal/platform TPM seam),
+// so the private key is software-protected via 0600 file permissions. TPM
+// sealing is a follow-up once a platform TPM abstraction exists — see #4583.
+package nodeidentity
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
+)
+
+const (
+	// dirName is the identity subdirectory under the citadel config dir.
+	dirName = "identity"
+
+	keyFileName     = "node.key"
+	leafFileName    = "node.crt"
+	caChainFileName = "ca-chain.pem"
+
+	// keyPerms restricts the private key to owner read/write only. The private
+	// key must NEVER be transmitted, logged, or made group/world-readable.
+	keyPerms = 0o600
+	// pubPerms are used for the leaf and CA chain, which are public material.
+	pubPerms = 0o644
+	dirPerms = 0o700
+
+	pemTypeECPrivateKey = "PRIVATE KEY" // PKCS#8
+	pemTypeCSR          = "CERTIFICATE REQUEST"
+	pemTypeCertificate  = "CERTIFICATE"
+)
+
+// Store is a filesystem-backed node identity store rooted at a directory.
+// The zero value is not usable; construct one with New or Default.
+type Store struct {
+	dir string
+}
+
+// Default returns a Store rooted at platform.ConfigDir()/identity, matching the
+// location and pattern citadel already uses for config.yaml and the device
+// token (see cmd/init.go, internal/tlscert).
+func Default() *Store {
+	return &Store{dir: filepath.Join(platform.ConfigDir(), dirName)}
+}
+
+// New returns a Store rooted at an explicit directory. Used in tests to avoid
+// touching the real config dir.
+func New(dir string) *Store {
+	return &Store{dir: dir}
+}
+
+// Dir returns the identity store directory.
+func (s *Store) Dir() string { return s.dir }
+
+// KeyPath returns the absolute path to the private key file.
+func (s *Store) KeyPath() string { return filepath.Join(s.dir, keyFileName) }
+
+// LeafPath returns the absolute path to the leaf certificate file.
+func (s *Store) LeafPath() string { return filepath.Join(s.dir, leafFileName) }
+
+// CAChainPath returns the absolute path to the CA trust chain file.
+func (s *Store) CAChainPath() string { return filepath.Join(s.dir, caChainFileName) }
+
+// HasKey reports whether a private key is already present on disk.
+func (s *Store) HasKey() bool {
+	_, err := os.Stat(s.KeyPath())
+	return err == nil
+}
+
+// HasLeaf reports whether a leaf certificate is already present on disk.
+func (s *Store) HasLeaf() bool {
+	_, err := os.Stat(s.LeafPath())
+	return err == nil
+}
+
+// GetOrCreateKey returns the node's EC P-256 private key, generating and
+// persisting a fresh one (0600) if none exists yet. This is idempotent: on
+// subsequent calls it loads the existing key from disk so the node keeps a
+// stable identity across `citadel init` re-runs.
+func (s *Store) GetOrCreateKey() (*ecdsa.PrivateKey, error) {
+	if s.HasKey() {
+		return s.loadKey()
+	}
+	return s.generateKey()
+}
+
+// generateKey creates a new EC P-256 keypair and writes the private key to
+// disk with 0600 permissions. The private key bytes never leave this function
+// except to be written to the owner-only file.
+func (s *Store) generateKey() (*ecdsa.PrivateKey, error) {
+	if err := os.MkdirAll(s.dir, dirPerms); err != nil {
+		return nil, fmt.Errorf("create identity dir: %w", err)
+	}
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate EC P-256 key: %w", err)
+	}
+
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return nil, fmt.Errorf("marshal private key: %w", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: pemTypeECPrivateKey, Bytes: der})
+
+	// Write 0600 explicitly; also chmod in case the file already existed with
+	// looser perms (umask can widen the WriteFile mode).
+	if err := os.WriteFile(s.KeyPath(), keyPEM, keyPerms); err != nil {
+		return nil, fmt.Errorf("write private key: %w", err)
+	}
+	if err := os.Chmod(s.KeyPath(), keyPerms); err != nil {
+		return nil, fmt.Errorf("chmod private key: %w", err)
+	}
+	return key, nil
+}
+
+// loadKey reads and parses the persisted private key.
+func (s *Store) loadKey() (*ecdsa.PrivateKey, error) {
+	data, err := os.ReadFile(s.KeyPath())
+	if err != nil {
+		return nil, fmt.Errorf("read private key: %w", err)
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("private key file is not valid PEM")
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse private key: %w", err)
+	}
+	key, ok := parsed.(*ecdsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("private key is not an EC key (got %T)", parsed)
+	}
+	return key, nil
+}
+
+// GenerateCSR produces a PEM-encoded PKCS#10 certificate signing request
+// carrying the node's public key. The Subject is intentionally minimal: the
+// backend fabric CA uses ONLY the CSR's public key and assigns identity
+// (node_uid / org_id) server-side, so the Subject/SAN are ignored (P1 of
+// #4583). The private key is used only to sign the CSR and is never included
+// in the output.
+func (s *Store) GenerateCSR(key *ecdsa.PrivateKey) ([]byte, error) {
+	if key == nil {
+		return nil, fmt.Errorf("nil private key")
+	}
+	tmpl := &x509.CertificateRequest{
+		// Minimal subject; backend ignores it. A CN of "citadel-node" is purely
+		// cosmetic for anyone inspecting the CSR.
+		Subject:            pkix.Name{CommonName: "citadel-node"},
+		SignatureAlgorithm: x509.ECDSAWithSHA256,
+	}
+	der, err := x509.CreateCertificateRequest(rand.Reader, tmpl, key)
+	if err != nil {
+		return nil, fmt.Errorf("create CSR: %w", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: pemTypeCSR, Bytes: der}), nil
+}
+
+// StoreLeaf persists the CA-signed leaf certificate and the CA trust chain
+// returned by the pairing flow. Both are public material, written with normal
+// (0644) perms. Either argument may be empty (back-compat: an older backend or
+// an un-activated CA returns no cert) in which case the corresponding file is
+// left untouched and no error is returned.
+//
+// leafPEM and chainPEM are validated as parseable PEM certificate(s) before
+// being written; malformed input is rejected rather than silently stored.
+func (s *Store) StoreLeaf(leafPEM, chainPEM string) error {
+	if leafPEM == "" && chainPEM == "" {
+		return nil
+	}
+	if err := os.MkdirAll(s.dir, dirPerms); err != nil {
+		return fmt.Errorf("create identity dir: %w", err)
+	}
+	if leafPEM != "" {
+		if err := validateCertPEM(leafPEM); err != nil {
+			return fmt.Errorf("leaf cert: %w", err)
+		}
+		if err := os.WriteFile(s.LeafPath(), []byte(leafPEM), pubPerms); err != nil {
+			return fmt.Errorf("write leaf cert: %w", err)
+		}
+	}
+	if chainPEM != "" {
+		if err := validateCertPEM(chainPEM); err != nil {
+			return fmt.Errorf("ca chain: %w", err)
+		}
+		if err := os.WriteFile(s.CAChainPath(), []byte(chainPEM), pubPerms); err != nil {
+			return fmt.Errorf("write ca chain: %w", err)
+		}
+	}
+	return nil
+}
+
+// StoreCAChain persists just the CA trust chain (e.g. fetched from
+// GET /api/fabric/ca/chain). Public material, 0644. Empty input is a no-op.
+func (s *Store) StoreCAChain(chainPEM string) error {
+	if chainPEM == "" {
+		return nil
+	}
+	if err := validateCertPEM(chainPEM); err != nil {
+		return fmt.Errorf("ca chain: %w", err)
+	}
+	if err := os.MkdirAll(s.dir, dirPerms); err != nil {
+		return fmt.Errorf("create identity dir: %w", err)
+	}
+	if err := os.WriteFile(s.CAChainPath(), []byte(chainPEM), pubPerms); err != nil {
+		return fmt.Errorf("write ca chain: %w", err)
+	}
+	return nil
+}
+
+// LoadLeaf reads and parses the stored leaf certificate.
+func (s *Store) LoadLeaf() (*x509.Certificate, error) {
+	data, err := os.ReadFile(s.LeafPath())
+	if err != nil {
+		return nil, fmt.Errorf("read leaf cert: %w", err)
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("leaf cert file is not valid PEM")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse leaf cert: %w", err)
+	}
+	return cert, nil
+}
+
+// validateCertPEM confirms that data contains at least one parseable X.509
+// certificate. It walks every PEM block so a chain (multiple certs) is fully
+// validated.
+func validateCertPEM(data string) error {
+	rest := []byte(data)
+	found := 0
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != pemTypeCertificate {
+			return fmt.Errorf("unexpected PEM block type %q", block.Type)
+		}
+		if _, err := x509.ParseCertificate(block.Bytes); err != nil {
+			return fmt.Errorf("parse certificate: %w", err)
+		}
+		found++
+	}
+	if found == 0 {
+		return fmt.Errorf("no certificate found in PEM data")
+	}
+	return nil
+}

--- a/internal/nodeidentity/nodeidentity_test.go
+++ b/internal/nodeidentity/nodeidentity_test.go
@@ -1,0 +1,264 @@
+package nodeidentity
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	return New(filepath.Join(t.TempDir(), "identity"))
+}
+
+func TestGetOrCreateKey_GeneratesP256WithSecurePerms(t *testing.T) {
+	s := newTestStore(t)
+
+	key, err := s.GetOrCreateKey()
+	if err != nil {
+		t.Fatalf("GetOrCreateKey: %v", err)
+	}
+	if key.Curve != elliptic.P256() {
+		t.Fatalf("expected P-256 curve, got %v", key.Curve.Params().Name)
+	}
+
+	info, err := os.Stat(s.KeyPath())
+	if err != nil {
+		t.Fatalf("stat key: %v", err)
+	}
+	// Permission bits are meaningless on Windows; assert only on unix.
+	if runtime.GOOS != "windows" {
+		if perm := info.Mode().Perm(); perm != 0o600 {
+			t.Fatalf("expected key perms 0600, got %o", perm)
+		}
+	}
+}
+
+func TestGetOrCreateKey_Idempotent(t *testing.T) {
+	s := newTestStore(t)
+
+	k1, err := s.GetOrCreateKey()
+	if err != nil {
+		t.Fatalf("first GetOrCreateKey: %v", err)
+	}
+	k2, err := s.GetOrCreateKey()
+	if err != nil {
+		t.Fatalf("second GetOrCreateKey: %v", err)
+	}
+	if k1.D.Cmp(k2.D) != 0 {
+		t.Fatal("key changed across calls; expected the same persisted key")
+	}
+}
+
+func TestKeyRoundTripsFromDisk(t *testing.T) {
+	s := newTestStore(t)
+	orig, err := s.GetOrCreateKey()
+	if err != nil {
+		t.Fatalf("GetOrCreateKey: %v", err)
+	}
+
+	// Fresh Store pointed at the same dir must load the identical key.
+	loaded, err := New(s.Dir()).GetOrCreateKey()
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if orig.D.Cmp(loaded.D) != 0 {
+		t.Fatal("reloaded private key differs from original")
+	}
+	if orig.PublicKey.X.Cmp(loaded.PublicKey.X) != 0 || orig.PublicKey.Y.Cmp(loaded.PublicKey.Y) != 0 {
+		t.Fatal("reloaded public key differs from original")
+	}
+}
+
+func TestKeyFileIsPKCS8Private_NotACSR(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.GetOrCreateKey(); err != nil {
+		t.Fatalf("GetOrCreateKey: %v", err)
+	}
+	data, err := os.ReadFile(s.KeyPath())
+	if err != nil {
+		t.Fatalf("read key: %v", err)
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		t.Fatal("key is not PEM")
+	}
+	if block.Type != pemTypeECPrivateKey {
+		t.Fatalf("expected PEM type %q, got %q", pemTypeECPrivateKey, block.Type)
+	}
+	if _, err := x509.ParsePKCS8PrivateKey(block.Bytes); err != nil {
+		t.Fatalf("key file is not a parseable PKCS#8 private key: %v", err)
+	}
+}
+
+func TestGenerateCSR_ValidPKCS10WithMatchingPublicKey(t *testing.T) {
+	s := newTestStore(t)
+	key, err := s.GetOrCreateKey()
+	if err != nil {
+		t.Fatalf("GetOrCreateKey: %v", err)
+	}
+
+	csrPEM, err := s.GenerateCSR(key)
+	if err != nil {
+		t.Fatalf("GenerateCSR: %v", err)
+	}
+
+	block, _ := pem.Decode(csrPEM)
+	if block == nil {
+		t.Fatal("CSR is not PEM")
+	}
+	if block.Type != pemTypeCSR {
+		t.Fatalf("expected PEM type %q, got %q", pemTypeCSR, block.Type)
+	}
+
+	csr, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse CSR: %v", err)
+	}
+	if err := csr.CheckSignature(); err != nil {
+		t.Fatalf("CSR self-signature invalid: %v", err)
+	}
+
+	csrPub, ok := csr.PublicKey.(*ecdsa.PublicKey)
+	if !ok {
+		t.Fatalf("CSR public key is not ECDSA: %T", csr.PublicKey)
+	}
+	if csrPub.X.Cmp(key.PublicKey.X) != 0 || csrPub.Y.Cmp(key.PublicKey.Y) != 0 {
+		t.Fatal("CSR public key does not match the node private key")
+	}
+}
+
+func TestGenerateCSR_NeverLeaksPrivateKey(t *testing.T) {
+	s := newTestStore(t)
+	key, err := s.GetOrCreateKey()
+	if err != nil {
+		t.Fatalf("GetOrCreateKey: %v", err)
+	}
+	csrPEM, err := s.GenerateCSR(key)
+	if err != nil {
+		t.Fatalf("GenerateCSR: %v", err)
+	}
+
+	// The raw private scalar D must not appear anywhere in the CSR bytes.
+	dBytes := key.D.Bytes()
+	if bytesContains(csrPEM, dBytes) {
+		t.Fatal("CSR output contains the private key scalar D")
+	}
+	// A CSR must contain no PRIVATE KEY PEM block.
+	rest := csrPEM
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type == pemTypeECPrivateKey || block.Type == "EC PRIVATE KEY" {
+			t.Fatalf("CSR PEM unexpectedly contains a private key block %q", block.Type)
+		}
+	}
+}
+
+func TestGenerateCSR_NilKey(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.GenerateCSR(nil); err == nil {
+		t.Fatal("expected error for nil key")
+	}
+}
+
+// makeCert produces a minimal self-signed cert PEM for store/parse tests.
+func makeCert(t *testing.T, cn string) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: pemTypeCertificate, Bytes: der}))
+}
+
+func TestStoreLeaf_PersistsAndParses(t *testing.T) {
+	s := newTestStore(t)
+	leaf := makeCert(t, "leaf")
+	chain := makeCert(t, "intermediate") + makeCert(t, "root")
+
+	if err := s.StoreLeaf(leaf, chain); err != nil {
+		t.Fatalf("StoreLeaf: %v", err)
+	}
+	if !s.HasLeaf() {
+		t.Fatal("HasLeaf false after StoreLeaf")
+	}
+
+	cert, err := s.LoadLeaf()
+	if err != nil {
+		t.Fatalf("LoadLeaf: %v", err)
+	}
+	if cert.Subject.CommonName != "leaf" {
+		t.Fatalf("unexpected leaf CN %q", cert.Subject.CommonName)
+	}
+
+	// Chain file must contain both certs.
+	chainData, err := os.ReadFile(s.CAChainPath())
+	if err != nil {
+		t.Fatalf("read chain: %v", err)
+	}
+	if err := validateCertPEM(string(chainData)); err != nil {
+		t.Fatalf("stored chain invalid: %v", err)
+	}
+
+	if runtime.GOOS != "windows" {
+		info, _ := os.Stat(s.LeafPath())
+		if perm := info.Mode().Perm(); perm != 0o644 {
+			t.Fatalf("expected leaf perms 0644, got %o", perm)
+		}
+	}
+}
+
+func TestStoreLeaf_EmptyIsNoOp(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.StoreLeaf("", ""); err != nil {
+		t.Fatalf("StoreLeaf empty: %v", err)
+	}
+	if s.HasLeaf() {
+		t.Fatal("leaf file created from empty input")
+	}
+}
+
+func TestStoreLeaf_RejectsMalformedPEM(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.StoreLeaf("not a cert", ""); err == nil {
+		t.Fatal("expected error for malformed leaf PEM")
+	}
+	if s.HasLeaf() {
+		t.Fatal("malformed leaf was written to disk")
+	}
+}
+
+func bytesContains(haystack, needle []byte) bool {
+	if len(needle) == 0 || len(needle) > len(haystack) {
+		return false
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if string(haystack[i:i+len(needle)]) == string(needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/nodeidentity/pairing.go
+++ b/internal/nodeidentity/pairing.go
@@ -1,0 +1,124 @@
+package nodeidentity
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// PairingStartRequest is the additive-cert-aware body posted to
+// POST /api/fabric/pairing/start. CSRPem and MachineID are optional and, when
+// present, ask the backend to issue a fabric CA leaf cert alongside the authkey
+// (P1 of #4583). When omitted the request is byte-for-byte the authkey-only
+// request the backend has always accepted, so this is fully back-compatible.
+type PairingStartRequest struct {
+	Code      string   `json:"code"`
+	NodeInfo  NodeInfo `json:"node_info"`
+	CSRPem    string   `json:"csr_pem,omitempty"`
+	MachineID string   `json:"machine_id,omitempty"`
+}
+
+// NodeInfo mirrors the backend's optional hardware/identity metadata.
+type NodeInfo struct {
+	Hostname string `json:"hostname,omitempty"`
+	GPU      string `json:"gpu,omitempty"`
+	IP       string `json:"ip,omitempty"`
+}
+
+// PairingStatusResponse is the polled response from
+// GET /api/fabric/pairing/{code}/status. LeafPem/ChainPem/NodeUID are populated
+// only when the node sent a CSR at start AND the backend fabric CA is
+// activated; all three are nil/empty in authkey-only mode.
+type PairingStatusResponse struct {
+	Status   string `json:"status"`
+	Authkey  string `json:"authkey,omitempty"`
+	LeafPem  string `json:"leaf_pem,omitempty"`
+	ChainPem string `json:"chain_pem,omitempty"`
+	NodeUID  string `json:"node_uid,omitempty"`
+}
+
+// BuildPairingStartRequest assembles a pairing-start body that carries the
+// node's CSR and machine_id. The CSR is generated from the store's key
+// (creating the key on first use). Callers that don't want a cert can build the
+// request without this helper; this helper always attaches the cert fields.
+//
+// It never returns the private key and never logs it.
+func (s *Store) BuildPairingStartRequest(code string, node NodeInfo, machineID string) (*PairingStartRequest, error) {
+	key, err := s.GetOrCreateKey()
+	if err != nil {
+		return nil, fmt.Errorf("node identity key: %w", err)
+	}
+	csrPEM, err := s.GenerateCSR(key)
+	if err != nil {
+		return nil, fmt.Errorf("generate CSR: %w", err)
+	}
+	return &PairingStartRequest{
+		Code:      code,
+		NodeInfo:  node,
+		CSRPem:    string(csrPEM),
+		MachineID: machineID,
+	}, nil
+}
+
+// StoreLeafFromStatus persists any leaf + chain the pairing status response
+// carried. It is the "results flow up" half of pairing: back-compat safe (no-op
+// when the backend returned no cert) and best-effort (a store failure is
+// returned but the caller should treat it as non-fatal — pairing succeeds on
+// the authkey alone).
+func (s *Store) StoreLeafFromStatus(resp *PairingStatusResponse) (stored bool, err error) {
+	if resp == nil || (resp.LeafPem == "" && resp.ChainPem == "") {
+		return false, nil
+	}
+	if err := s.StoreLeaf(resp.LeafPem, resp.ChainPem); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// FetchCAChain GETs the public fabric CA trust chain from
+// {baseURL}/api/fabric/ca/chain and caches it in the store. The chain is public
+// material and requires no auth.
+//
+// Degrades gracefully: if the CA is not activated the endpoint returns 503, in
+// which case FetchCAChain returns ErrCANotActivated and stores nothing. Callers
+// on the pairing/init path must treat any error here as non-fatal.
+func (s *Store) FetchCAChain(ctx context.Context, baseURL string, client *http.Client) error {
+	if client == nil {
+		client = &http.Client{Timeout: 15 * time.Second}
+	}
+	url := baseURL + "/api/fabric/ca/chain"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("build CA chain request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("fetch CA chain: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusServiceUnavailable {
+		return ErrCANotActivated
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("fetch CA chain: unexpected status %d", resp.StatusCode)
+	}
+
+	buf := new(bytes.Buffer)
+	if _, err := buf.ReadFrom(resp.Body); err != nil {
+		return fmt.Errorf("read CA chain body: %w", err)
+	}
+	return s.StoreCAChain(buf.String())
+}
+
+// ErrCANotActivated indicates the backend fabric CA is not yet configured
+// (HTTP 503 from /api/fabric/ca/chain). Callers should degrade gracefully.
+var ErrCANotActivated = fmt.Errorf("fabric CA not activated")
+
+// jsonMarshal is a tiny indirection so tests can confirm the wire shape.
+func (r *PairingStartRequest) jsonMarshal() ([]byte, error) {
+	return json.Marshal(r)
+}

--- a/internal/nodeidentity/pairing_test.go
+++ b/internal/nodeidentity/pairing_test.go
@@ -1,0 +1,187 @@
+package nodeidentity
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestBuildPairingStartRequest_IncludesCSRAndMachineID(t *testing.T) {
+	s := newTestStore(t)
+
+	req, err := s.BuildPairingStartRequest("ABC123", NodeInfo{Hostname: "node-1"}, "machine-abc")
+	if err != nil {
+		t.Fatalf("BuildPairingStartRequest: %v", err)
+	}
+	if req.Code != "ABC123" {
+		t.Fatalf("unexpected code %q", req.Code)
+	}
+	if req.MachineID != "machine-abc" {
+		t.Fatalf("unexpected machine_id %q", req.MachineID)
+	}
+	if req.NodeInfo.Hostname != "node-1" {
+		t.Fatalf("unexpected hostname %q", req.NodeInfo.Hostname)
+	}
+	if req.CSRPem == "" {
+		t.Fatal("csr_pem is empty")
+	}
+
+	// The csr_pem must be a valid, parseable CSR whose key matches the store key.
+	block, _ := pem.Decode([]byte(req.CSRPem))
+	if block == nil || block.Type != pemTypeCSR {
+		t.Fatal("csr_pem is not a CERTIFICATE REQUEST PEM")
+	}
+	if _, err := x509.ParseCertificateRequest(block.Bytes); err != nil {
+		t.Fatalf("csr_pem not parseable: %v", err)
+	}
+
+	// And the key must have been created on disk with 0600.
+	if !s.HasKey() {
+		t.Fatal("key was not persisted")
+	}
+}
+
+func TestPairingStartRequest_WireShape(t *testing.T) {
+	s := newTestStore(t)
+	req, err := s.BuildPairingStartRequest("XYZ789", NodeInfo{Hostname: "h"}, "mid")
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	raw, err := req.jsonMarshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, k := range []string{"code", "node_info", "csr_pem", "machine_id"} {
+		if _, ok := m[k]; !ok {
+			t.Fatalf("wire body missing key %q; got %v", k, m)
+		}
+	}
+}
+
+func TestPairingStartRequest_OmitsCertFieldsWhenAbsent(t *testing.T) {
+	// A plain authkey-only request must not emit csr_pem/machine_id at all,
+	// preserving byte-for-byte back-compat with the legacy body.
+	req := &PairingStartRequest{Code: "ABC123", NodeInfo: NodeInfo{Hostname: "h"}}
+	raw, err := req.jsonMarshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := m["csr_pem"]; ok {
+		t.Fatal("csr_pem should be omitted when empty")
+	}
+	if _, ok := m["machine_id"]; ok {
+		t.Fatal("machine_id should be omitted when empty")
+	}
+}
+
+func TestStoreLeafFromStatus_StoresWhenPresent(t *testing.T) {
+	s := newTestStore(t)
+	leaf := makeCert(t, "leaf")
+	chain := makeCert(t, "root")
+
+	stored, err := s.StoreLeafFromStatus(&PairingStatusResponse{
+		Status:   "confirmed",
+		Authkey:  "tskey-abc",
+		LeafPem:  leaf,
+		ChainPem: chain,
+		NodeUID:  "node-uid-123",
+	})
+	if err != nil {
+		t.Fatalf("StoreLeafFromStatus: %v", err)
+	}
+	if !stored {
+		t.Fatal("expected stored=true")
+	}
+	if !s.HasLeaf() {
+		t.Fatal("leaf not persisted")
+	}
+}
+
+func TestStoreLeafFromStatus_NoOpWhenBackendReturnsNoCert(t *testing.T) {
+	s := newTestStore(t)
+
+	// Authkey-only response (older backend / CA not activated): pairing must
+	// succeed, no cert stored, no error.
+	stored, err := s.StoreLeafFromStatus(&PairingStatusResponse{
+		Status:  "confirmed",
+		Authkey: "tskey-abc",
+	})
+	if err != nil {
+		t.Fatalf("StoreLeafFromStatus: %v", err)
+	}
+	if stored {
+		t.Fatal("expected stored=false for authkey-only response")
+	}
+	if s.HasLeaf() {
+		t.Fatal("leaf created despite no cert in response")
+	}
+}
+
+func TestStoreLeafFromStatus_NilResponse(t *testing.T) {
+	s := newTestStore(t)
+	stored, err := s.StoreLeafFromStatus(nil)
+	if err != nil || stored {
+		t.Fatalf("expected (false,nil), got (%v,%v)", stored, err)
+	}
+}
+
+func TestFetchCAChain_StoresChainOn200(t *testing.T) {
+	chain := makeCert(t, "intermediate") + makeCert(t, "root")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/fabric/ca/chain" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/x-pem-file")
+		_, _ = w.Write([]byte(chain))
+	}))
+	defer srv.Close()
+
+	s := newTestStore(t)
+	if err := s.FetchCAChain(context.Background(), srv.URL, srv.Client()); err != nil {
+		t.Fatalf("FetchCAChain: %v", err)
+	}
+	data, err := readFile(s.CAChainPath())
+	if err != nil {
+		t.Fatalf("read chain: %v", err)
+	}
+	if err := validateCertPEM(data); err != nil {
+		t.Fatalf("stored chain invalid: %v", err)
+	}
+}
+
+func TestFetchCAChain_DegradesOn503(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	s := newTestStore(t)
+	err := s.FetchCAChain(context.Background(), srv.URL, srv.Client())
+	if !errors.Is(err, ErrCANotActivated) {
+		t.Fatalf("expected ErrCANotActivated, got %v", err)
+	}
+	// Nothing stored on degrade.
+	if _, statErr := readFile(s.CAChainPath()); statErr == nil {
+		t.Fatal("chain file written despite 503")
+	}
+}
+
+func readFile(path string) (string, error) {
+	b, err := os.ReadFile(path)
+	return string(b), err
+}


### PR DESCRIPTION
## Context

A fabric node that drops off the VPN mesh today **cannot recover without an administrator** (Epic #4583) — we hit it live on node 1054. The fix is to give each node an **mTLS client certificate** whose private key never leaves the box: identity becomes proof-of-possession, not a replayable bearer token, and self-scoped re-enrollment ("this node may only re-enroll itself") becomes free.

That epic breaks down as: **P0** durable-key baseline (shipped, #435) → **P1** backend CA + leaf issuance (merged to aceteam main) → **P2** mTLS self-heal → **P3** unify + revoke. P1 stood up the CA: `fabric_pairing.py` now accepts an optional `csr_pem` + `machine_id` at pairing start and returns a signed leaf + CA chain in the pairing `/status` response, and `GET /api/fabric/ca/chain` serves the public chain. **Nothing on the node generated the keypair/CSR or stored the leaf** — this PR is that prerequisite (**P2 PR-0**).

This is **fail-open**: the fleet backend CA is not activated yet, so a node with no CA/cert must pair and run *exactly* as today. The cert store is best-effort until P2's reenroll lands and consumes it.

## Summary

New `internal/nodeidentity` package + a small, fail-open hook in `cmd/init.go`.

| Piece | What / why |
|---|---|
| **Keypair + store** | EC P-256 keypair generated on `citadel init`; private key at `ConfigDir()/identity/node.key`, **0600, never transmitted or logged**. Idempotent — re-running init loads the existing key rather than rotating it, so the node keeps a stable identity. Matches the `config.yaml`-at-`ConfigDir()` pattern citadel already uses for the device token. |
| **CSR generation** | PEM PKCS#10 CSR carrying the public key. Subject is minimal on purpose — the backend fabric CA uses **only** the public key and assigns `node_uid`/`org_id` server-side, so Subject/SAN are ignored. |
| **Leaf + chain storage** | Parses `leaf_pem` / `chain_pem` / `node_uid` from the pairing `/status` response and persists leaf + chain (public, 0644). Malformed PEM is rejected, not silently stored. Back-compat: when the backend returns no cert (older backend / CA not activated), stores nothing and proceeds on the authkey. |
| **CA chain fetch** | `FetchCAChain` GETs `/api/fabric/ca/chain` and caches the trust anchor. 503 (CA not activated) → `ErrCANotActivated`, stores nothing, degrades silently. |
| **Pairing request builder** | `BuildPairingStartRequest` attaches `csr_pem` + `machine_id` **additively** — a request without them is byte-for-byte the legacy authkey-only body (`omitempty`). This is the library surface the future pairing/reenroll consumer calls; per the epic, pairing is the enrollment bootstrap. |
| **`cmd/init.go` wiring** | `ensureNodeIdentity(authServiceURL)` runs early on every init path (device-auth, `--authkey`, verified). It ensures the key exists and best-effort caches the CA chain behind a **5s timeout** so a hung endpoint never stalls init. **Every failure is `Debug`-logged and swallowed — never `os.Exit`.** |

### Scope note — why the CSR isn't sent from `init` in this PR

`citadel init` uses the OAuth **device-auth** flow, whose backend does not accept a CSR. Leaf issuance lives **only** in the Python `/fabric/pairing/*` QR flow (the enrollment bootstrap named in the #4583 architecture table), and citadel has no pairing HTTP client yet. Rather than build a whole QR pairing client here (out of scope for "identity store"), this PR ships the identity primitives + the CSR-carrying request/response types + parse/store, and the `citadel init` hook that generates the key and caches the CA chain. The CSR-send wiring lands where the P2 reenroll/pairing consumer lives — it imports `BuildPairingStartRequest` / `StoreLeafFromStatus` and needs no changes here.

## TPM status

Citadel has **no TPM abstraction** today (no `internal/platform` TPM seam). Per the task, the private key is **software-protected via 0600 file permissions** as the fallback, and TPM sealing is a **follow-up** once a platform TPM abstraction exists — not built from scratch here.

## Test plan

All tests mock HTTP; no live backend.

| Group | Coverage |
|---|---|
| Keypair | P-256 curve, 0600 perms, idempotence (no rotation on re-run), disk round-trip, key file is PKCS#8 private (not a CSR) |
| CSR | valid parseable PKCS#10, self-signature checks, public key matches the store key, **never leaks private key** (scalar D absent, no PRIVATE KEY block), nil-key error |
| Leaf/chain | persist + parse, empty is no-op, malformed PEM rejected, 0644 perms |
| Pairing | `BuildPairingStartRequest` includes csr_pem+machine_id and a valid CSR; wire shape has all 4 keys; **omits** csr_pem/machine_id when absent (byte-for-byte legacy body); `StoreLeafFromStatus` stores when present, no-ops on authkey-only / nil |
| CA fetch | stores chain on 200, `ErrCANotActivated` + nothing stored on 503 |
| init wiring | fresh init lands a 0600 key + cached chain; **503 CA fails open** (key persists, no chain) |

`go test ./...` green, `gofmt -l .` clean, `go vet` clean.

### Manual E2E (needs P1 backend deployed + CA activated — why this is a draft)

1. Deploy a backend with the P1 fabric CA configured/activated.
2. On a fresh node, run `citadel init` → confirm `ConfigDir()/identity/node.key` exists at 0600 and `ca-chain.pem` is cached.
3. Drive a pairing session that sends the CSR (once the pairing consumer exists) → confirm the backend issues a leaf and `node.crt` is stored, with `node_uid` matching the backend.
4. Re-run `citadel init` → confirm the key is **not** rotated.
5. With the CA **not** activated, confirm init still pairs and runs (fail-open).

## Related

- Epic #4583 — Self-healing fabric node identity (mTLS PKI). This is **P2 PR-0**.
- P0 baseline: #435 (durable keys / renew-while-online).
- P1 backend CA + leaf issuance: merged to aceteam main (`fabric_pairing.py`, `fabric_ca.py`).
- Advances #4313 (shared fabric CA); the P2 reenroll endpoint is the first consumer of this identity store.
