### PR TITLE
fix(worker): in-process backoff on Redis-API connect, honor 429 (#443)

### DIFF
--- a/cmd/work.go
+++ b/cmd/work.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"os"
@@ -155,6 +156,134 @@ Examples:
   # Run without auto-starting services
   citadel work --no-services`,
 	Run: runWork,
+}
+
+// Connect-retry backoff bounds. A failed control-plane connect is recoverable,
+// so we retry in-process rather than exiting and letting systemd storm.
+// These are vars (not consts) so tests can shrink them without real-time sleeps.
+var (
+	connectBackoffInitial = 2 * time.Second
+	connectBackoffMax     = 2 * time.Minute
+	// connectRateLimitChunk bounds a SINGLE sleep even when the server asks for
+	// a very long wait (e.g. retry_after: 86400). We sleep in chunks and re-check
+	// ctx between them so a 24h reset never blocks shutdown -- but we keep
+	// sleeping until the full server-requested interval has elapsed before
+	// retrying, so we never poll tighter than retry_after (no hammering, #443).
+	connectRateLimitChunk = 90 * time.Second
+)
+
+// apiConnector is the subset of APISource that connectWithBackoff needs.
+// Kept as an interface so tests can exercise the backoff loop without a live API.
+type apiConnector interface {
+	Connect(ctx context.Context) error
+}
+
+// connectWithBackoff retries source.Connect until it succeeds or ctx is
+// cancelled. Transient failures use exponential backoff with jitter; a 429
+// rate-limit response is honored via its retry_after/reset_at hint (capped per
+// sleep so shutdown stays responsive). Returns a non-nil error only when the
+// context is cancelled (clean shutdown), never on a connect failure -- the
+// process stays up and keeps retrying rather than dying into a restart storm.
+func connectWithBackoff(ctx context.Context, source apiConnector) error {
+	backoff := connectBackoffInitial
+	attempt := 0
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		attempt++
+		err := source.Connect(ctx)
+		if err == nil {
+			if attempt > 1 {
+				Log("connected to Redis API after %d attempt(s)", attempt)
+			}
+			return nil
+		}
+
+		// If the context was cancelled mid-connect, this is a clean shutdown.
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		// Decide how long to wait before the next attempt.
+		if rle, ok := redisapi.AsRateLimitError(err); ok {
+			// Honor the server's backoff IN FULL: sleep the whole requested
+			// interval before retrying so we never poll tighter than retry_after
+			// (that tight-loop is exactly what burned the daily quota, #443). The
+			// sleep is chunked and ctx-aware so a 24h reset still yields instantly
+			// to shutdown. Reset the generic backoff -- the server is the
+			// authority here.
+			wait := rle.Wait(time.Now())
+			if wait <= 0 {
+				wait = backoff
+			}
+			backoff = connectBackoffInitial
+			Log("Redis API rate limited (limit=%d window=%q); honoring server backoff of %s before retry: %v",
+				rle.Limit, rle.Window, wait, err)
+			if !sleepUntilCtx(ctx, time.Now().Add(wait)) {
+				return ctx.Err()
+			}
+			continue
+		}
+
+		// Generic transient failure: exponential backoff with jitter.
+		sleep := jitter(backoff)
+		Log("Redis API connect failed (attempt %d), retrying in %s: %v", attempt, sleep, err)
+		backoff *= 2
+		if backoff > connectBackoffMax {
+			backoff = connectBackoffMax
+		}
+		if !sleepCtx(ctx, sleep) {
+			return ctx.Err()
+		}
+	}
+}
+
+// sleepUntilCtx sleeps until deadline, waking in bounded chunks so it stays
+// responsive to ctx cancellation even for very long waits (e.g. a 24h 429
+// reset). Returns true if the deadline was reached, false if ctx was cancelled.
+func sleepUntilCtx(ctx context.Context, deadline time.Time) bool {
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return ctx.Err() == nil
+		}
+		chunk := remaining
+		if chunk > connectRateLimitChunk {
+			chunk = connectRateLimitChunk
+		}
+		if !sleepCtx(ctx, chunk) {
+			return false
+		}
+	}
+}
+
+// jitter returns d perturbed by +/-20% to avoid a thundering herd of nodes
+// retrying in lockstep after a shared backend blip.
+func jitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return 0
+	}
+	delta := float64(d) * 0.2
+	return time.Duration(float64(d) - delta + rand.Float64()*2*delta)
+}
+
+// sleepCtx sleeps for d or until ctx is cancelled. Returns true if the full
+// sleep elapsed, false if the context was cancelled first (so backoff loops
+// stay immediately responsive to SIGTERM / graceful shutdown).
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	if d <= 0 {
+		return ctx.Err() == nil
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
 }
 
 func runWork(cmd *cobra.Command, args []string) {
@@ -483,10 +612,21 @@ func runWork(cmd *cobra.Command, args []string) {
 			LogFn: func(_ string, msg string) { Log("%s", msg) },
 		})
 
-		// Connect early so client is available for heartbeat
-		if err := apiSource.Connect(ctx); err != nil {
-			fmt.Fprintf(os.Stderr, "Error: Failed to connect to Redis API: %v\n", err)
-			os.Exit(1)
+		// Connect early so client is available for heartbeat.
+		//
+		// A failed control-plane connect is expected and recoverable (auth blip,
+		// mesh churn, backend deploy, rate limit), NOT fatal. Exiting here would
+		// let systemd relaunch us every ~10s; each restart re-pings the same
+		// endpoint, and if it is rate limited (HTTP 429) that restart storm burns
+		// the node's daily Redis-API quota and hard-locks it for ~24h -- the node
+		// self-DoSes (issue #443). Instead retry IN-PROCESS with exponential
+		// backoff + jitter, honoring any 429 retry_after/reset_at, and stay
+		// responsive to shutdown via ctx.
+		if err := connectWithBackoff(ctx, apiSource); err != nil {
+			// The only way this returns an error is context cancellation
+			// (SIGTERM / graceful shutdown), which is a clean exit, not a crash.
+			Log("worker connect aborted: %v", err)
+			return
 		}
 
 		// Enable WebSocket for real-time pub/sub (heartbeat, streaming responses)

--- a/cmd/work_backoff_test.go
+++ b/cmd/work_backoff_test.go
@@ -1,0 +1,191 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/redisapi"
+)
+
+// mockConnector implements apiConnector, returning a scripted sequence of
+// errors before succeeding. It records how many times Connect was called.
+type mockConnector struct {
+	errs  []error // returned in order; nil means success
+	calls int32
+}
+
+func (m *mockConnector) Connect(ctx context.Context) error {
+	n := atomic.AddInt32(&m.calls, 1)
+	idx := int(n - 1)
+	if idx < len(m.errs) {
+		return m.errs[idx]
+	}
+	return nil // success once the script is exhausted
+}
+
+// withFastBackoff shrinks the backoff bounds for the duration of a test so the
+// retry loop does not sleep for real seconds.
+func withFastBackoff(t *testing.T) {
+	t.Helper()
+	origInitial, origMax, origChunk := connectBackoffInitial, connectBackoffMax, connectRateLimitChunk
+	connectBackoffInitial = time.Millisecond
+	connectBackoffMax = 5 * time.Millisecond
+	connectRateLimitChunk = time.Millisecond
+	t.Cleanup(func() {
+		connectBackoffInitial, connectBackoffMax, connectRateLimitChunk = origInitial, origMax, origChunk
+	})
+}
+
+func TestConnectWithBackoff_RetriesGenericErrorThenSucceeds(t *testing.T) {
+	withFastBackoff(t)
+
+	m := &mockConnector{errs: []error{
+		errors.New("dial tcp: connection refused"),
+		errors.New("dial tcp: connection refused"),
+		nil,
+	}}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := connectWithBackoff(ctx, m)
+	if err != nil {
+		t.Fatalf("connectWithBackoff returned error, want nil (should retry, not exit): %v", err)
+	}
+	if got := atomic.LoadInt32(&m.calls); got != 3 {
+		t.Errorf("Connect called %d times, want 3 (2 failures + 1 success)", got)
+	}
+}
+
+func TestConnectWithBackoff_Retries429ThenSucceeds(t *testing.T) {
+	withFastBackoff(t)
+
+	// A short retry_after: the loop must honor the hint (sleep, then retry
+	// in-process) rather than exiting fatally.
+	rle := &redisapi.RateLimitError{
+		StatusCode: 429,
+		Message:    "Rate limit exceeded",
+		Limit:      50000,
+		Window:     "day",
+		RetryAfter: 5 * time.Millisecond,
+	}
+	m := &mockConnector{errs: []error{rle, nil}}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := connectWithBackoff(ctx, m)
+	if err != nil {
+		t.Fatalf("connectWithBackoff returned error on 429, want nil (should back off, not exit): %v", err)
+	}
+	if got := atomic.LoadInt32(&m.calls); got != 2 {
+		t.Errorf("Connect called %d times, want 2 (1 rate-limited + 1 success)", got)
+	}
+}
+
+// TestConnectWithBackoff_429LongResetYieldsToShutdown proves the key #443
+// property: a 429 with a very long retry_after (the 86400s that caused the
+// 24h lockout) does NOT block shutdown. The chunked, ctx-aware sleep must
+// yield to cancellation quickly, and the process must never retry tighter than
+// the server hint in the meantime.
+func TestConnectWithBackoff_429LongResetYieldsToShutdown(t *testing.T) {
+	// Use a real (long) chunk so the test would hang if the sleep were not
+	// ctx-aware; cancellation must still be near-instant.
+	origChunk := connectRateLimitChunk
+	connectRateLimitChunk = 90 * time.Second
+	t.Cleanup(func() { connectRateLimitChunk = origChunk })
+
+	rle := &redisapi.RateLimitError{
+		StatusCode: 429,
+		Message:    "Rate limit exceeded",
+		Limit:      50000,
+		Window:     "day",
+		RetryAfter: 86400 * time.Second, // the value that caused the 24h lockout
+	}
+	m := &mockConnector{errs: []error{rle, rle, rle}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() { done <- connectWithBackoff(ctx, m) }()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("returned %v, want context.Canceled", err)
+		}
+		if elapsed := time.Since(start); elapsed > 2*time.Second {
+			t.Errorf("took %s to honor cancellation on an 86400s retry_after; sleep not ctx-aware", elapsed)
+		}
+		// Must NOT have hammered: only the first Connect (which got the 429).
+		if got := atomic.LoadInt32(&m.calls); got != 1 {
+			t.Errorf("Connect called %d times during the honored backoff, want 1 (no hammering)", got)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("connectWithBackoff blocked on an 86400s retry_after instead of yielding to shutdown")
+	}
+}
+
+func TestConnectWithBackoff_RespectsContextCancellation(t *testing.T) {
+	// Backoff sleeps must respect ctx so systemctl stop / SIGTERM is immediate.
+	// Use the real (long) backoff so the test would hang if cancellation were
+	// not honored during the sleep.
+	origInitial := connectBackoffInitial
+	connectBackoffInitial = 10 * time.Second
+	t.Cleanup(func() { connectBackoffInitial = origInitial })
+
+	m := &mockConnector{errs: []error{
+		errors.New("connection refused"), // forces entry into the backoff sleep
+		errors.New("connection refused"),
+		errors.New("connection refused"),
+	}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel shortly after the loop enters its first (10s) backoff sleep.
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() { done <- connectWithBackoff(ctx, m) }()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("connectWithBackoff returned %v, want context.Canceled", err)
+		}
+		if elapsed := time.Since(start); elapsed > 2*time.Second {
+			t.Errorf("connectWithBackoff took %s to honor cancellation; sleep not ctx-aware", elapsed)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("connectWithBackoff did not return after context cancellation (backoff sleep ignored ctx)")
+	}
+}
+
+func TestSleepCtx_ReturnsFalseOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+	if sleepCtx(ctx, time.Hour) {
+		t.Error("sleepCtx returned true despite cancellation")
+	}
+}
+
+func TestSleepCtx_CompletesFullSleep(t *testing.T) {
+	ctx := context.Background()
+	if !sleepCtx(ctx, 5*time.Millisecond) {
+		t.Error("sleepCtx returned false for a completed sleep")
+	}
+}

--- a/install.sh
+++ b/install.sh
@@ -471,12 +471,20 @@ setup_systemd_service() {
 Description=Citadel Worker - AceTeam Sovereign Compute
 After=network-online.target docker.service
 Wants=network-online.target docker.service
+# Defense in depth against a crash-loop self-DoS (#443): if the process keeps
+# failing fast, enter a cooldown instead of a 10s restart storm.
+StartLimitIntervalSec=300
+StartLimitBurst=5
 
 [Service]
 Type=simple
 ExecStart=${INSTALL_DIR}/${BINARY_NAME} work
 Restart=on-failure
+# Exponential restart backoff (10s -> 5m). The worker also backs off in-process
+# on a failed control-plane connect, so this is a secondary safety net (#443).
 RestartSec=10
+RestartSteps=5
+RestartMaxDelaySec=300
 Environment=HOME=/root
 WorkingDirectory=/root
 

--- a/internal/redisapi/client.go
+++ b/internal/redisapi/client.go
@@ -111,6 +111,12 @@ func (c *Client) Ping(ctx context.Context) error {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+		// A 429 carries a structured rate-limit hint (retry_after/reset_at).
+		// Return it as a typed error so the connect-retry loop can honor the
+		// server's backoff instead of hammering into the daily quota (#443).
+		if resp.StatusCode == http.StatusTooManyRequests {
+			return parseRateLimitError(resp.StatusCode, string(body))
+		}
 		return fmt.Errorf("ping failed with status %d: %s", resp.StatusCode, string(body))
 	}
 

--- a/internal/redisapi/errors.go
+++ b/internal/redisapi/errors.go
@@ -1,0 +1,108 @@
+package redisapi
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// RateLimitError is returned when the API responds with HTTP 429 (Too Many
+// Requests). It carries the structured hint from the response body so callers
+// can honor the server's backoff request instead of hammering the endpoint.
+//
+// The Redis-API 429 body looks like:
+//
+//	{"error":"Rate limit exceeded","limit":50000,"window":"day",
+//	 "retry_after":86400,"reset_at":"2026-07-04T02:28:33Z"}
+//
+// Honoring retry_after/reset_at is what prevents the worker crash-loop from
+// self-DoSing into the daily quota (issue #443).
+type RateLimitError struct {
+	// StatusCode is the HTTP status (always 429 for this type).
+	StatusCode int
+	// Message is the human-readable error from the body ("Rate limit exceeded").
+	Message string
+	// Limit is the quota ceiling (e.g. 50000), 0 if not reported.
+	Limit int
+	// Window is the quota window (e.g. "day"), empty if not reported.
+	Window string
+	// RetryAfter is the server-requested wait before retrying. Zero if the
+	// body did not include a usable hint.
+	RetryAfter time.Duration
+	// ResetAt is when the quota resets. Zero if not reported.
+	ResetAt time.Time
+	// Body is the raw response body for logging/debugging.
+	Body string
+}
+
+func (e *RateLimitError) Error() string {
+	if e.RetryAfter > 0 {
+		return fmt.Sprintf("rate limited (status %d): %s (retry after %s)", e.StatusCode, e.Message, e.RetryAfter)
+	}
+	return fmt.Sprintf("rate limited (status %d): %s", e.StatusCode, e.Message)
+}
+
+// Wait returns how long the caller should sleep before retrying, given the
+// current time. It prefers RetryAfter, falling back to the remaining time until
+// ResetAt. Returns 0 if no hint is available (caller should use its own
+// backoff) or the window has already passed.
+func (e *RateLimitError) Wait(now time.Time) time.Duration {
+	if e.RetryAfter > 0 {
+		return e.RetryAfter
+	}
+	if !e.ResetAt.IsZero() {
+		if d := e.ResetAt.Sub(now); d > 0 {
+			return d
+		}
+	}
+	return 0
+}
+
+// rateLimitBody mirrors the JSON shape of the 429 response.
+type rateLimitBody struct {
+	Error      string `json:"error"`
+	Limit      int    `json:"limit"`
+	Window     string `json:"window"`
+	RetryAfter int64  `json:"retry_after"` // seconds
+	ResetAt    string `json:"reset_at"`    // RFC3339
+}
+
+// parseRateLimitError builds a RateLimitError from a 429 response body. It
+// always returns a non-nil error so callers can rely on the type even when the
+// body is empty or malformed.
+func parseRateLimitError(statusCode int, body string) *RateLimitError {
+	e := &RateLimitError{
+		StatusCode: statusCode,
+		Message:    "rate limit exceeded",
+		Body:       body,
+	}
+
+	var parsed rateLimitBody
+	if err := json.Unmarshal([]byte(body), &parsed); err == nil {
+		if parsed.Error != "" {
+			e.Message = parsed.Error
+		}
+		e.Limit = parsed.Limit
+		e.Window = parsed.Window
+		if parsed.RetryAfter > 0 {
+			e.RetryAfter = time.Duration(parsed.RetryAfter) * time.Second
+		}
+		if parsed.ResetAt != "" {
+			if t, terr := time.Parse(time.RFC3339, parsed.ResetAt); terr == nil {
+				e.ResetAt = t
+			}
+		}
+	}
+
+	return e
+}
+
+// AsRateLimitError extracts a *RateLimitError from an error chain, if present.
+func AsRateLimitError(err error) (*RateLimitError, bool) {
+	var rle *RateLimitError
+	if errors.As(err, &rle) {
+		return rle, true
+	}
+	return nil, false
+}

--- a/internal/redisapi/errors_test.go
+++ b/internal/redisapi/errors_test.go
@@ -1,0 +1,96 @@
+package redisapi
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestParseRateLimitError_FullBody(t *testing.T) {
+	body := `{"error":"Rate limit exceeded","limit":50000,"window":"day",` +
+		`"retry_after":86400,"reset_at":"2026-07-04T02:28:33Z"}`
+
+	e := parseRateLimitError(429, body)
+	if e.StatusCode != 429 {
+		t.Errorf("StatusCode = %d, want 429", e.StatusCode)
+	}
+	if e.Message != "Rate limit exceeded" {
+		t.Errorf("Message = %q, want %q", e.Message, "Rate limit exceeded")
+	}
+	if e.Limit != 50000 {
+		t.Errorf("Limit = %d, want 50000", e.Limit)
+	}
+	if e.Window != "day" {
+		t.Errorf("Window = %q, want day", e.Window)
+	}
+	if e.RetryAfter != 86400*time.Second {
+		t.Errorf("RetryAfter = %s, want 86400s", e.RetryAfter)
+	}
+	wantReset, _ := time.Parse(time.RFC3339, "2026-07-04T02:28:33Z")
+	if !e.ResetAt.Equal(wantReset) {
+		t.Errorf("ResetAt = %s, want %s", e.ResetAt, wantReset)
+	}
+}
+
+func TestParseRateLimitError_EmptyBody(t *testing.T) {
+	// Must still return a usable typed error, never nil, so the connect loop
+	// can treat any 429 as rate-limited.
+	e := parseRateLimitError(429, "")
+	if e == nil {
+		t.Fatal("parseRateLimitError returned nil for empty body")
+	}
+	if e.StatusCode != 429 {
+		t.Errorf("StatusCode = %d, want 429", e.StatusCode)
+	}
+	if e.RetryAfter != 0 {
+		t.Errorf("RetryAfter = %s, want 0", e.RetryAfter)
+	}
+}
+
+func TestRateLimitError_Wait(t *testing.T) {
+	now := time.Date(2026, 7, 3, 0, 0, 0, 0, time.UTC)
+
+	// retry_after takes precedence.
+	e := &RateLimitError{RetryAfter: 30 * time.Second, ResetAt: now.Add(time.Hour)}
+	if got := e.Wait(now); got != 30*time.Second {
+		t.Errorf("Wait (retry_after) = %s, want 30s", got)
+	}
+
+	// Falls back to reset_at when no retry_after.
+	e = &RateLimitError{ResetAt: now.Add(10 * time.Minute)}
+	if got := e.Wait(now); got != 10*time.Minute {
+		t.Errorf("Wait (reset_at) = %s, want 10m", got)
+	}
+
+	// Past reset_at yields 0 (no hint) so caller falls back to its own backoff.
+	e = &RateLimitError{ResetAt: now.Add(-time.Minute)}
+	if got := e.Wait(now); got != 0 {
+		t.Errorf("Wait (past reset) = %s, want 0", got)
+	}
+
+	// No hints at all -> 0.
+	e = &RateLimitError{}
+	if got := e.Wait(now); got != 0 {
+		t.Errorf("Wait (no hints) = %s, want 0", got)
+	}
+}
+
+func TestAsRateLimitError(t *testing.T) {
+	rle := parseRateLimitError(429, `{"error":"nope"}`)
+
+	// Wrapped in a chain (mirrors the %w wrap in APISource.Connect / Ping).
+	wrapped := fmt.Errorf("failed to connect to Redis API: %w", rle)
+	got, ok := AsRateLimitError(wrapped)
+	if !ok {
+		t.Fatal("AsRateLimitError did not unwrap a wrapped RateLimitError")
+	}
+	if got != rle {
+		t.Errorf("AsRateLimitError returned %v, want %v", got, rle)
+	}
+
+	// A non-rate-limit error must not match.
+	if _, ok := AsRateLimitError(errors.New("some other failure")); ok {
+		t.Error("AsRateLimitError matched a non-rate-limit error")
+	}
+}

--- a/internal/service/systemd.go
+++ b/internal/service/systemd.go
@@ -55,12 +55,21 @@ func generateUserUnit(description, execLine string) string {
 Description=%s
 After=network-online.target
 Wants=network-online.target
+# Defense in depth against a crash-loop self-DoS (#443): if the process keeps
+# failing fast, enter a cooldown instead of a 10s restart storm.
+StartLimitIntervalSec=300
+StartLimitBurst=5
 
 [Service]
 Type=simple
 ExecStart=%s
 Restart=on-failure
+# Exponential restart backoff: start at 10s and grow to 5m so a genuinely
+# failing start does not hammer the control plane. The worker also backs off
+# in-process, so this is a secondary safety net.
 RestartSec=10
+RestartSteps=5
+RestartMaxDelaySec=300
 StandardOutput=journal+console
 StandardError=journal+console
 Environment=CITADEL_SERVICE=true
@@ -96,12 +105,21 @@ Description=%s
 Documentation=https://github.com/aceteam-ai/citadel-cli
 After=network-online.target docker.service
 Wants=network-online.target
+# Defense in depth against a crash-loop self-DoS (#443): if the process keeps
+# failing fast, enter a cooldown instead of a 10s restart storm.
+StartLimitIntervalSec=300
+StartLimitBurst=5
 
 [Service]
 Type=simple
 ExecStart=%s
 Restart=on-failure
+# Exponential restart backoff: start at 10s and grow to 5m so a genuinely
+# failing start does not hammer the control plane. The worker also backs off
+# in-process, so this is a secondary safety net.
 RestartSec=10
+RestartSteps=5
+RestartMaxDelaySec=300
 User=%s
 Group=%s
 Environment=HOME=%s

--- a/internal/service/systemd_test.go
+++ b/internal/service/systemd_test.go
@@ -29,6 +29,11 @@ func TestGenerateUnitFile_UserMode(t *testing.T) {
 		{"exec start", "ExecStart=/usr/local/bin/citadel work --gateway"},
 		{"restart", "Restart=on-failure"},
 		{"restart sec", "RestartSec=10"},
+		// Crash-loop hardening (#443): exponential restart backoff + start-limit cooldown.
+		{"restart steps", "RestartSteps=5"},
+		{"restart max delay", "RestartMaxDelaySec=300"},
+		{"start limit interval", "StartLimitIntervalSec=300"},
+		{"start limit burst", "StartLimitBurst=5"},
 		{"env var", "Environment=CITADEL_SERVICE=true"},
 		{"wanted by", "WantedBy=default.target"},
 		{"output", "StandardOutput=journal+console"},

--- a/internal/worker/api_source.go
+++ b/internal/worker/api_source.go
@@ -98,22 +98,31 @@ func (s *APISource) log(level, format string, args ...interface{}) {
 }
 
 // Connect establishes connection to the API.
+//
+// This may be retried: the connect-with-backoff loop in cmd/work.go calls it
+// repeatedly until a ping succeeds (issue #443). So we must NOT retain a client
+// whose ping failed -- otherwise a subsequent call would short-circuit on the
+// "already connected" guard and report success without ever verifying the
+// endpoint. The client is only assigned to s.client once the ping succeeds, and
+// the ping error is wrapped with %w so callers can still type-assert a 429
+// (redisapi.RateLimitError) through the chain.
 func (s *APISource) Connect(ctx context.Context) error {
-	// Skip if already connected
+	// Skip if already connected and verified.
 	if s.client != nil {
 		return nil
 	}
 
-	s.client = redisapi.NewClient(redisapi.ClientConfig{
+	client := redisapi.NewClient(redisapi.ClientConfig{
 		BaseURL:   s.config.BaseURL,
 		Token:     s.config.Token,
 		DebugFunc: s.config.DebugFunc,
 	})
 
-	// Verify connection
-	if err := s.client.Ping(ctx); err != nil {
+	// Verify connection before retaining the client.
+	if err := client.Ping(ctx); err != nil {
 		return fmt.Errorf("failed to connect to Redis API: %w", err)
 	}
+	s.client = client
 
 	s.log("info", "   - API: %s", s.config.BaseURL)
 	s.log("info", "   - Worker ID: %s", s.client.WorkerID())

--- a/internal/worker/api_source_connect_test.go
+++ b/internal/worker/api_source_connect_test.go
@@ -1,0 +1,73 @@
+package worker
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/redisapi"
+)
+
+// TestAPISource_Connect_RetriesAfterFailedPing verifies that a failed ping does
+// NOT leave a client cached (which would make the next Connect short-circuit and
+// falsely report success). The connect-with-backoff loop (#443) relies on
+// Connect actually re-pinging on each call.
+func TestAPISource_Connect_RetriesAfterFailedPing(t *testing.T) {
+	var pings int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&pings, 1)
+		if n <= 2 {
+			// First two pings fail (simulate transient outage / rate limit).
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":"Rate limit exceeded","limit":50000,"window":"day","retry_after":1}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	s := NewAPISource(APISourceConfig{BaseURL: srv.URL, Token: "t"})
+	ctx := context.Background()
+
+	// First attempt: 429. Must return an error that unwraps to RateLimitError,
+	// and must NOT retain the client.
+	err := s.Connect(ctx)
+	if err == nil {
+		t.Fatal("first Connect returned nil, want error on 429")
+	}
+	if _, ok := redisapi.AsRateLimitError(err); !ok {
+		t.Errorf("first Connect error does not unwrap to RateLimitError: %v", err)
+	}
+	if s.client != nil {
+		t.Fatal("client retained after failed ping; a retry would short-circuit and skip re-ping")
+	}
+
+	// Second attempt: still 429.
+	if err := s.Connect(ctx); err == nil {
+		t.Fatal("second Connect returned nil, want error on 429")
+	}
+	if s.client != nil {
+		t.Fatal("client retained after second failed ping")
+	}
+
+	// Third attempt: success. Client is retained.
+	if err := s.Connect(ctx); err != nil {
+		t.Fatalf("third Connect returned error, want success: %v", err)
+	}
+	if s.client == nil {
+		t.Fatal("client not retained after successful ping")
+	}
+	if got := atomic.LoadInt32(&pings); got != 3 {
+		t.Errorf("ping hit %d times, want 3 (each Connect re-pings until success)", got)
+	}
+
+	// Fourth attempt: already connected, should short-circuit without a ping.
+	if err := s.Connect(ctx); err != nil {
+		t.Fatalf("fourth Connect (already connected) returned error: %v", err)
+	}
+	if got := atomic.LoadInt32(&pings); got != 3 {
+		t.Errorf("ping hit %d times after already-connected Connect, want 3 (no extra ping)", got)
+	}
+}

--- a/packer/scripts/04-citadel.sh
+++ b/packer/scripts/04-citadel.sh
@@ -108,11 +108,20 @@ Requires=docker.service
 # Only start if citadel init has been run (manifest exists)
 ConditionPathExists=/etc/citadel/citadel.yaml
 
+# Defense in depth against a crash-loop self-DoS (#443): if the process keeps
+# failing fast, enter a cooldown instead of a 10s restart storm.
+StartLimitIntervalSec=300
+StartLimitBurst=5
+
 [Service]
 Type=simple
 ExecStart=/usr/local/bin/citadel work
 Restart=always
+# Exponential restart backoff (10s -> 5m). The worker also backs off in-process
+# on a failed control-plane connect, so this is a secondary safety net (#443).
 RestartSec=10
+RestartSteps=5
+RestartMaxDelaySec=300
 User=citadel
 Group=docker
 Environment=HOME=/home/citadel

--- a/services/citadel-worker.service
+++ b/services/citadel-worker.service
@@ -2,12 +2,20 @@
 Description=Citadel Worker - AceTeam Sovereign Compute
 After=network-online.target docker.service
 Wants=network-online.target docker.service
+# Defense in depth against a crash-loop self-DoS (#443): if the process keeps
+# failing fast, enter a cooldown instead of a 10s restart storm.
+StartLimitIntervalSec=300
+StartLimitBurst=5
 
 [Service]
 Type=simple
 ExecStart=/usr/local/bin/citadel work
 Restart=on-failure
+# Exponential restart backoff (10s -> 5m). The worker also backs off in-process
+# on a failed control-plane connect, so this is a secondary safety net (#443).
 RestartSec=10
+RestartSteps=5
+RestartMaxDelaySec=300
 Environment=HOME=/root
 WorkingDirectory=/root
 


### PR DESCRIPTION
## Context
Fixes #443. On node `ubuntu-gpu` the Citadel worker got stuck in a systemd
restart storm and locked itself out of the Redis job API for ~24h. Journal:

```
Error: Failed to connect to Redis API: ping failed with status 429:
{"error":"Rate limit exceeded","limit":50000,"window":"day","retry_after":86400,...}
citadel.service: Main process exited, code=exited, status=1/FAILURE
citadel.service: Scheduled restart job, restart counter is at 5.
```

## Root Cause
The worker treated a failed Redis-API connect at startup as fatal and called
`os.Exit(1)` (`cmd/work.go`). The systemd unit ships `Restart=on-failure` with
`RestartSec=10`, so it relaunched every ~10s, re-pinging the same rate-limited
endpoint and getting 429 again. Over hours the restart storm consumed the
node's 50,000 requests/day Redis-API quota, so every attempt then returned
`retry_after: 86400` and the node was hard-locked until `reset_at`. Crash-loop +
no backoff = the node self-DoSes.

A secondary latent bug: `APISource.Connect` cached the client on the first call
and short-circuited on `s.client != nil`, so a retry after a failed ping would
have reported success without re-verifying the endpoint.

## Changes
- **`cmd/work.go`**: replaced the fatal `os.Exit(1)` on connect failure with
  `connectWithBackoff`, an in-process retry loop. Transient failures use
  exponential backoff (2s -> 2m) with +/-20% jitter. A 429 is detected and its
  server hint honored in full. All sleeps are ctx-aware (`sleepCtx` /
  `sleepUntilCtx`, chunked at 90s) so `systemctl stop` / SIGTERM is immediate
  even on an 86400s reset. The function returns only on context cancellation
  (clean shutdown), never on a connect failure.
- **`internal/redisapi/errors.go`** (new): `RateLimitError` type + parser for the
  structured 429 body (`retry_after`, `reset_at`, `limit`, `window`), plus
  `AsRateLimitError` to unwrap it from an error chain. `Wait()` prefers
  `retry_after`, falls back to time-until-`reset_at`.
- **`internal/redisapi/client.go`**: `Ping` returns the typed `RateLimitError`
  on HTTP 429 instead of a flat formatted string.
- **`internal/worker/api_source.go`**: only retain the client after a successful
  ping, so retries actually re-verify (fixes the short-circuit landmine). The
  ping error is `%w`-wrapped so callers can still type-assert the 429.
- **Defense in depth (repo owns these unit templates)**: added exponential
  restart backoff (`RestartSteps=5`, `RestartMaxDelaySec=300`) and a start-limit
  cooldown (`StartLimitIntervalSec=300`, `StartLimitBurst=5`) to
  `internal/service/systemd.go` (user + system units), `services/citadel-worker.service`,
  `install.sh`, and `packer/scripts/04-citadel.sh`.

The server-side 50,000/day limit is unchanged; this is purely client-side
resilience.

### Backoff mechanism
1. Generic connect error -> exponential backoff + jitter, capped at 2m.
2. 429 -> read `retry_after` (or remaining time to `reset_at`) and sleep the
   full requested interval before retrying, so we never poll tighter than the
   server hint (that tight loop is what burned the quota). The sleep is chunked
   at 90s and re-checks `ctx` between chunks, so a 24h reset never blocks
   shutdown yet never hammers.
3. On success mid-retry, a recovery line is logged and the loop returns.

## Testing
`go build ./...`, `go vet` on all touched packages, and targeted tests (full
suite skipped to avoid tmux-spawning test packages):

- `internal/redisapi`: 429 body parse (full/empty), `Wait()` precedence,
  `AsRateLimitError` unwrap. PASS
- `cmd/`: 429 retries then succeeds; generic error retries then succeeds; an
  86400s `retry_after` yields to shutdown in <2s without hammering (1 Connect
  call); backoff respects context cancellation; `sleepCtx` cancel/complete. PASS
- `internal/worker`: `Connect` re-pings after a failed ping (no stale client
  cache) and short-circuits once connected. PASS
- `internal/service`: unit template now contains the new restart-backoff /
  start-limit directives. PASS

## Punts
- Single-worker guard (fix direction #4 in the issue) and node-identity churn
  are out of scope here; they warrant a separate change. Not addressed.

*Generated by Claude Opus 4.8*
