### PR TITLE
fix(worker): single-instance guard + loud identity-churn warning (#443, #435)

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -346,9 +346,15 @@ func runControlCenter() {
 							cc.AddActivity("success", "VPN reconnected (IP preserved)")
 							networkConnected = true
 						} else {
-							// Clear state and connect fresh (new IP)
-							_ = network.ClearState()
+							// Clear state and connect fresh (new IP) — IDENTITY-CHURN
+							// path. Warn loudly (same reasoning as recoverStaleVPN): the
+							// persisted identity could not be re-authorized, so the node
+							// re-registers with a new id/IP/device key. Root cause is
+							// usually ephemeral registration; durable fix is #4584/#4583.
 							hostname, _ := os.Hostname()
+							warnIdentityChurn(hostname)
+							cc.AddActivity("warning", "Node identity reset (new id/IP); re-run 'citadel init' to stop churn")
+							_ = network.ClearState()
 							freshCtx, freshCancel := context.WithTimeout(ctx, 15*time.Second)
 							config := network.ServerConfig{
 								Hostname:   hostname,

--- a/cmd/reconnect.go
+++ b/cmd/reconnect.go
@@ -177,6 +177,19 @@ func recoverStaleVPN(ctx context.Context, deviceConfig *DeviceConfig, hostname, 
 	}
 
 	// Attempt 2: clear state and connect from scratch (new IP/hostname).
+	//
+	// THIS IS THE IDENTITY-CHURN PATH. Reaching here means the persisted machine
+	// identity in tailscaled.state could not be re-authorized even with a fresh
+	// authkey — so we are about to discard it and register as a brand-new node.
+	// That mints a new fabric/Headscale node id, a new mesh IP, and (on the
+	// backend) a new device key. The usual root cause is an EPHEMERAL Headscale
+	// registration: when the node went offline, Headscale removed the ephemeral
+	// node, so the persisted machine key no longer maps to any node and only a
+	// fresh registration succeeds. The durable fix is backend PR #4584 (register
+	// non-ephemerally) so an offline node is never removed; see aceteam #4583.
+	// Warn loudly so this is diagnosable in the field rather than silent.
+	warnIdentityChurn(hostname)
+
 	// Before clearing, reclaim the stale Headscale node so the dashboard
 	// doesn't accumulate duplicate entries on every restart (issue #246).
 	if deviceConfig.DeviceAPIToken != "" && hostname != "" {
@@ -205,6 +218,24 @@ func recoverStaleVPN(ctx context.Context, deviceConfig *DeviceConfig, hostname, 
 	return VPNRecoveryResult{
 		Err: fmt.Errorf("all recovery attempts failed: %w", connectErr),
 	}
+}
+
+// warnIdentityChurn emits a prominent, structured warning that the node is about
+// to lose its persisted identity and re-register as a new node. This is the
+// symptom of an ephemeral Headscale registration (the node was removed while
+// offline); the durable fix is non-ephemeral registration (backend #4584 /
+// aceteam #4583). Surfacing it loudly makes the churn diagnosable in the field
+// instead of a silent id/IP/device-key change.
+func warnIdentityChurn(hostname string) {
+	Log("IDENTITY CHURN: reusing persisted identity failed; re-registering '%s' as a NEW node "+
+		"(new fabric id + new mesh IP + new device key). Likely cause: ephemeral Headscale "+
+		"registration removed the node while offline. Durable fix: non-ephemeral registration "+
+		"(aceteam #4583 / backend #4584). One-time migration: re-run 'citadel init' so this node "+
+		"re-registers with a persistent key.", hostname)
+	fmt.Fprintln(os.Stderr, "   - WARNING: node identity is being reset (new node id, new IP, new device key).")
+	fmt.Fprintln(os.Stderr, "     Cause: the persisted identity could not be re-authorized (likely an ephemeral")
+	fmt.Fprintln(os.Stderr, "     registration removed while offline). This node will keep working but appears as a")
+	fmt.Fprintln(os.Stderr, "     new node. To stop recurring churn, re-run 'citadel init' to re-register persistently.")
 }
 
 func init() {

--- a/cmd/reconnect_test.go
+++ b/cmd/reconnect_test.go
@@ -58,6 +58,26 @@ type testError struct{ msg string }
 
 func (e *testError) Error() string { return e.msg }
 
+// TestWarnIdentityChurnDoesNotPanic verifies the churn warning helper runs
+// cleanly with any hostname (including empty). It is called on the destructive
+// ClearState path so it must never itself fail.
+func TestWarnIdentityChurnDoesNotPanic(t *testing.T) {
+	warnIdentityChurn("test-node")
+	warnIdentityChurn("")
+}
+
+// TestWorkNoSingleInstanceFlag verifies the single-instance guard opt-out flag is
+// registered on the work command and defaults to enforcing the guard (false).
+func TestWorkNoSingleInstanceFlag(t *testing.T) {
+	flag := workCmd.Flags().Lookup("no-single-instance")
+	if flag == nil {
+		t.Fatal("--no-single-instance flag not registered on work command")
+	}
+	if flag.DefValue != "false" {
+		t.Errorf("--no-single-instance default = %q, want %q (guard on by default)", flag.DefValue, "false")
+	}
+}
+
 // TestRecoverStaleVPNNoToken verifies recovery fails with a clear error
 // when no device API token is available. Uses recoverStaleVPN directly
 // to avoid live VerifyOrReconnect I/O.

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -44,6 +44,7 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/whatsapp"
 	"github.com/aceteam-ai/citadel-cli/internal/worker"
 	"github.com/aceteam-ai/citadel-cli/internal/workflow"
+	"github.com/aceteam-ai/citadel-cli/internal/worklock"
 	"github.com/google/uuid"
 	goredis "github.com/redis/go-redis/v9"
 	"github.com/spf13/cobra"
@@ -89,6 +90,11 @@ var (
 
 	// Footprint sampler flag
 	workNoFootprint bool
+
+	// Single-instance guard flag (issues #443 / #435): when true, skip the
+	// per-node worker lock so a second worker may run intentionally (e.g. a debug
+	// direct-Redis worker alongside the API-mode one in development).
+	workNoSingleInstance bool
 
 	// Node-key renewer flag (epic #4583): disable the background loop that
 	// refreshes the Headscale node key before expiry while online.
@@ -289,6 +295,36 @@ func sleepCtx(ctx context.Context, d time.Duration) bool {
 func runWork(cmd *cobra.Command, args []string) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	// Single-instance guard (issues #443 / #435). Refuse to start a second worker
+	// for the same node so a stale duplicate can never run beside the systemd unit.
+	// Duplicate workers split job routing non-deterministically, double the
+	// control-plane request volume (contributing to the 429 self-DoS in #443), and
+	// race on the shared tsnet state dir — the amplifier behind the identity churn.
+	// Keyed to the resolved network state dir, so every invocation on this box that
+	// converges on the same node identity also converges on the same lock. The lock
+	// is an OS advisory lock, released by the kernel on process death, so a crashed
+	// worker never blocks its own restart. Skipped with --no-single-instance for
+	// intentional side-by-side runs (e.g. a second debug-redis worker in dev).
+	if !workNoSingleInstance {
+		lock, lockErr := worklock.Acquire(network.GetStateDir(), Log)
+		if lockErr != nil {
+			var running *worklock.ErrAlreadyRunning
+			if errors.As(lockErr, &running) {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", running)
+				fmt.Fprintln(os.Stderr, "\nAnother 'citadel work' is already serving this node.")
+				fmt.Fprintln(os.Stderr, "Stop it first (e.g. 'systemctl --user stop citadel' or kill the PID above),")
+				fmt.Fprintln(os.Stderr, "or pass --no-single-instance to run a second worker intentionally.")
+				os.Exit(1)
+			}
+			// Non-contention lock error (e.g. unwritable dir): warn but do not block
+			// the worker — the guard is defense in depth, not a hard prerequisite.
+			fmt.Fprintf(os.Stderr, "   - Warning: could not acquire single-instance lock: %v\n", lockErr)
+		} else {
+			Log("acquired single-instance worker lock (%s)", lock.Path())
+			defer lock.Release()
+		}
+	}
 
 	// Managed services this worker started (populated by the async startup
 	// goroutine below, read by the shutdown hook). Guarded by a mutex because
@@ -2243,6 +2279,7 @@ func init() {
 	// Update check flags (deprecated - update check now runs on all commands via root.go)
 	workCmd.Flags().BoolVar(&workNoUpdate, "no-update", false, "(Deprecated) No longer has any effect - use 'citadel update disable' instead")
 	workCmd.Flags().BoolVar(&workNoFootprint, "no-footprint", false, "Disable the background resource-footprint sampler")
+	workCmd.Flags().BoolVar(&workNoSingleInstance, "no-single-instance", false, "Allow a second worker to run for this node (skips the single-instance lock)")
 	workCmd.Flags().BoolVar(&workNoKeyRenew, "no-key-renew", false, "Disable the background Headscale node-key renewer (renews the key before expiry while online)")
 	workCmd.Flags().MarkDeprecated("no-update", "use 'citadel update disable' to disable auto-update checks")
 

--- a/internal/worklock/worklock.go
+++ b/internal/worklock/worklock.go
@@ -1,0 +1,101 @@
+// Package worklock provides a single-instance guard for the Citadel worker
+// (`citadel work`), keyed to a node's state directory.
+//
+// Why this exists (issues #443 / #435): a stale duplicate worker running beside
+// the systemd-managed one is the amplifier behind the node-identity churn
+// incident. Two workers for the same node:
+//   - split job routing non-deterministically (an AGENT_UPDATE landed on a stale
+//     old-version worker: "node 2.57.0 has no handler"),
+//   - double the control-plane request volume (contributing to the 429 self-DoS),
+//   - race on the same tsnet state directory, which can trigger a re-register
+//     under a NEW fabric id + new mesh IP (the churn).
+//
+// The guard makes a second `citadel work` for the same node STRUCTURALLY unable
+// to start: the first holder takes an exclusive OS advisory lock on a lock file
+// inside the node's config dir, and any second invocation is refused with a clear
+// message naming the holding PID. The lock is keyed to the resolved state dir, so
+// every invocation on the same box (root service, sudo interactive, distinct
+// service user) that converges on the same node identity also converges on the
+// same lock.
+//
+// Robustness: the lock is an OS advisory lock (flock on Unix, LockFileEx on
+// Windows), so it is released automatically by the kernel when the holding
+// process dies — a crashed worker never leaves a lock that blocks restart. As an
+// additional clarity layer, the lock file records the holder PID so a refusal can
+// name it, and a stale lock whose recorded PID is dead is reclaimed with an
+// explanatory log rather than an opaque failure.
+package worklock
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+// LockFileName is the name of the lock file placed inside the node config dir.
+// It lives next to the "network" state subdirectory rather than inside it so it
+// is never swept away by network.ClearState (which RemoveAll's the network dir).
+const LockFileName = "citadel-work.lock"
+
+// LockPathForStateDir derives the lock file path from a resolved network state
+// directory (network.GetStateDir(), e.g. <node>/network). The lock is placed in
+// the PARENT (the node config dir) so it survives a network-state reset and so a
+// single node has exactly one worker lock regardless of how state is resolved.
+func LockPathForStateDir(stateDir string) string {
+	// stateDir is typically <nodeConfigDir>/network; the lock belongs in
+	// <nodeConfigDir>. filepath.Dir of a trailing-slash-free path gives the parent.
+	parent := filepath.Dir(filepath.Clean(stateDir))
+	return filepath.Join(parent, LockFileName)
+}
+
+// staleLockAction is the decision for what to do when a lock file already exists
+// with a recorded holder PID.
+type staleLockAction int
+
+const (
+	// actionRefuse: the holder is alive (or presumed alive) — refuse to start.
+	actionRefuse staleLockAction = iota
+	// actionReclaim: the recorded holder PID is dead — the lock is stale and may
+	// be reclaimed.
+	actionReclaim
+)
+
+// decideStaleLock is the pure classifier for a pre-existing lock file. It never
+// touches the OS: callers pass the recorded holder PID, this process's PID, and
+// whether the holder is alive. Kept pure so the reclaim-vs-refuse policy is unit
+// tested without spawning processes.
+//
+//   - holderPID <= 0 (unreadable/empty lock file): reclaim — a garbage lock file
+//     must never permanently block a worker.
+//   - holderPID == selfPID: reclaim — our own stale record (e.g. same PID reused
+//     across a fast restart within this process's lifetime is not possible, but a
+//     re-run recording our PID is safe to overwrite).
+//   - holderAlive == false: reclaim — the recorded process is gone.
+//   - otherwise: refuse — a live process holds the node.
+func decideStaleLock(holderPID, selfPID int, holderAlive bool) staleLockAction {
+	if holderPID <= 0 {
+		return actionReclaim
+	}
+	if holderPID == selfPID {
+		return actionReclaim
+	}
+	if !holderAlive {
+		return actionReclaim
+	}
+	return actionRefuse
+}
+
+// ErrAlreadyRunning is returned by Acquire when another live worker holds the
+// lock for the same node. It carries the holder PID for a clear operator message.
+type ErrAlreadyRunning struct {
+	// PID is the recorded holder PID, or 0 if it could not be read.
+	PID int
+	// Path is the lock file path, for diagnostics.
+	Path string
+}
+
+func (e *ErrAlreadyRunning) Error() string {
+	if e.PID > 0 {
+		return fmt.Sprintf("another citadel worker is already running for this node (PID %d, lock %s)", e.PID, e.Path)
+	}
+	return fmt.Sprintf("another citadel worker is already running for this node (lock %s)", e.Path)
+}

--- a/internal/worklock/worklock_test.go
+++ b/internal/worklock/worklock_test.go
@@ -1,0 +1,120 @@
+package worklock
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestDecideStaleLock(t *testing.T) {
+	const self = 4242
+	tests := []struct {
+		name       string
+		holderPID  int
+		selfPID    int
+		holderLive bool
+		want       staleLockAction
+	}{
+		{"empty lock file (pid 0) reclaims", 0, self, false, actionReclaim},
+		{"negative pid reclaims", -1, self, false, actionReclaim},
+		{"own pid recorded reclaims", self, self, true, actionReclaim},
+		{"dead holder reclaims", 1234, self, false, actionReclaim},
+		{"live holder refuses", 1234, self, true, actionRefuse},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := decideStaleLock(tt.holderPID, tt.selfPID, tt.holderLive)
+			if got != tt.want {
+				t.Fatalf("decideStaleLock(%d,%d,%v) = %v, want %v",
+					tt.holderPID, tt.selfPID, tt.holderLive, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLockPathForStateDir(t *testing.T) {
+	// The lock must live in the PARENT of the network state dir so ClearState
+	// (which RemoveAll's the network dir) never deletes it.
+	got := LockPathForStateDir("/home/u/citadel-node/network")
+	want := filepath.FromSlash("/home/u/citadel-node/" + LockFileName)
+	if got != want {
+		t.Fatalf("LockPathForStateDir = %q, want %q", got, want)
+	}
+
+	// Trailing slash must not change the result.
+	got2 := LockPathForStateDir("/home/u/citadel-node/network/")
+	if got2 != want {
+		t.Fatalf("LockPathForStateDir(trailing slash) = %q, want %q", got2, want)
+	}
+}
+
+// TestAcquireSecondIsRejected verifies the core guarantee: while one holder has
+// the lock, a second Acquire on the same node is refused with *ErrAlreadyRunning
+// carrying the holder PID. A third attempt succeeds once the first releases.
+func TestAcquireSecondIsRejected(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "network")
+
+	first, err := Acquire(stateDir, nil)
+	if err != nil {
+		t.Fatalf("first Acquire failed: %v", err)
+	}
+	if first == nil {
+		t.Fatal("first Acquire returned nil lock")
+	}
+
+	// Second acquire while first is held: must be refused.
+	second, err := Acquire(stateDir, nil)
+	if err == nil {
+		second.Release()
+		t.Fatal("second Acquire succeeded while first held the lock; expected refusal")
+	}
+	are, ok := err.(*ErrAlreadyRunning)
+	if !ok {
+		t.Fatalf("second Acquire error = %T (%v), want *ErrAlreadyRunning", err, err)
+	}
+	if are.PID <= 0 {
+		t.Errorf("ErrAlreadyRunning.PID = %d, want the holder PID (>0)", are.PID)
+	}
+
+	// Release the first and confirm a new Acquire now succeeds (lock reusable).
+	first.Release()
+	third, err := Acquire(stateDir, nil)
+	if err != nil {
+		t.Fatalf("Acquire after Release failed: %v", err)
+	}
+	third.Release()
+}
+
+// TestReleaseIdempotent verifies Release can be called multiple times safely.
+func TestReleaseIdempotent(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "network")
+	l, err := Acquire(stateDir, nil)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+	l.Release()
+	l.Release() // must not panic
+}
+
+// TestStaleLockReclaimed simulates a dead prior holder: a lock file exists with a
+// PID that is not alive, and no live process holds the OS lock. Acquire must
+// reclaim it (the flock/LockFileEx is free once the prior process exited).
+func TestStaleLockReclaimed(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "network")
+
+	// Hold and release to leave a lock file behind with a now-defunct PID record.
+	first, err := Acquire(stateDir, nil)
+	if err != nil {
+		t.Fatalf("first Acquire failed: %v", err)
+	}
+	// Simulate a crash where the file is NOT removed but the lock is freed on exit
+	// by closing the fd without Remove. We cannot easily fork here, so we rely on
+	// Release freeing the OS lock; the reclaim path is exercised by decideStaleLock
+	// unit tests. This test asserts re-acquire works after the OS lock is free.
+	first.Release()
+
+	got, err := Acquire(stateDir, func(string, ...any) {})
+	if err != nil {
+		t.Fatalf("re-Acquire after prior holder exited failed: %v", err)
+	}
+	got.Release()
+}

--- a/internal/worklock/worklock_unix.go
+++ b/internal/worklock/worklock_unix.go
@@ -1,0 +1,129 @@
+//go:build !windows
+
+package worklock
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// Lock is a held single-instance worker lock. Call Release (or rely on process
+// exit) to relinquish it.
+type Lock struct {
+	f    *os.File
+	path string
+}
+
+// Acquire takes an exclusive, non-blocking advisory lock on the worker lock file
+// derived from stateDir. On success it returns a *Lock and writes this process's
+// PID into the file for diagnostics.
+//
+// If another live worker holds the lock, it returns *ErrAlreadyRunning. If the
+// lock file exists but its recorded holder PID is dead, the lock is reclaimed
+// (flock already guarantees the kernel freed a dead holder's lock; the PID check
+// only drives the human-readable log via logf).
+//
+// logf, if non-nil, receives a single informational line when a stale lock is
+// reclaimed. Pass nil to stay silent.
+func Acquire(stateDir string, logf func(format string, args ...any)) (*Lock, error) {
+	path := LockPathForStateDir(stateDir)
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("worklock: create lock dir: %w", err)
+	}
+
+	// Open (or create) the lock file. We keep the fd open for the lifetime of the
+	// worker; the flock is tied to this open file description and is released by
+	// the kernel on close or process exit.
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("worklock: open lock file %s: %w", path, err)
+	}
+
+	// Non-blocking exclusive lock. If a live process holds it, flock returns
+	// EWOULDBLOCK immediately (no hang).
+	if lockErr := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); lockErr != nil {
+		// Could not take the lock. Read the recorded holder PID for a clear message.
+		holderPID := readPID(f)
+		_ = f.Close()
+		if errors.Is(lockErr, syscall.EWOULDBLOCK) {
+			return nil, &ErrAlreadyRunning{PID: holderPID, Path: path}
+		}
+		return nil, fmt.Errorf("worklock: flock %s: %w", path, lockErr)
+	}
+
+	// We hold the lock. If a stale PID was recorded by a dead prior holder, note
+	// the reclaim for the operator. (flock already let us in, so the prior holder
+	// is definitively gone; this is purely explanatory.)
+	if prevPID := readPID(f); prevPID > 0 && prevPID != os.Getpid() {
+		if decideStaleLock(prevPID, os.Getpid(), processAlive(prevPID)) == actionReclaim && logf != nil {
+			logf("worklock: reclaimed stale worker lock from dead PID %d (%s)", prevPID, path)
+		}
+	}
+
+	// Record our PID. Truncate first so a shorter PID never leaves trailing bytes.
+	if err := f.Truncate(0); err == nil {
+		_, _ = f.WriteAt([]byte(strconv.Itoa(os.Getpid())+"\n"), 0)
+		_ = f.Sync()
+	}
+
+	return &Lock{f: f, path: path}, nil
+}
+
+// Release relinquishes the lock and removes the lock file. Safe to call more than
+// once. The advisory lock is also released automatically on process exit even if
+// Release is never called.
+func (l *Lock) Release() {
+	if l == nil || l.f == nil {
+		return
+	}
+	// Remove the file before unlocking/closing so a racing Acquire either sees no
+	// file (and creates a fresh one) or blocks on our still-held lock — never
+	// observes a half-released lock.
+	_ = os.Remove(l.path)
+	_ = syscall.Flock(int(l.f.Fd()), syscall.LOCK_UN)
+	_ = l.f.Close()
+	l.f = nil
+}
+
+// Path returns the lock file path (for diagnostics).
+func (l *Lock) Path() string {
+	if l == nil {
+		return ""
+	}
+	return l.path
+}
+
+// readPID reads and parses the PID recorded in an open lock file. Returns 0 if
+// the file is empty or unparseable.
+func readPID(f *os.File) int {
+	buf := make([]byte, 32)
+	n, _ := f.ReadAt(buf, 0)
+	if n <= 0 {
+		return 0
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(buf[:n])))
+	if err != nil || pid <= 0 {
+		return 0
+	}
+	return pid
+}
+
+// processAlive reports whether a process with the given PID is currently alive.
+// On Unix, signal 0 probes existence without affecting the process: nil error or
+// EPERM (exists but not ours to signal) both mean alive; ESRCH means gone.
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	if err == nil {
+		return true
+	}
+	return errors.Is(err, syscall.EPERM)
+}

--- a/internal/worklock/worklock_windows.go
+++ b/internal/worklock/worklock_windows.go
@@ -1,0 +1,122 @@
+//go:build windows
+
+package worklock
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+// Lock is a held single-instance worker lock (Windows).
+type Lock struct {
+	f    *os.File
+	path string
+}
+
+// Acquire takes an exclusive, non-blocking lock on the worker lock file derived
+// from stateDir using LockFileEx with LOCKFILE_FAIL_IMMEDIATELY. Windows advisory
+// locks are released by the OS when the owning handle is closed or the process
+// exits, so a crashed worker never leaves a blocking lock.
+func Acquire(stateDir string, logf func(format string, args ...any)) (*Lock, error) {
+	path := LockPathForStateDir(stateDir)
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("worklock: create lock dir: %w", err)
+	}
+
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("worklock: open lock file %s: %w", path, err)
+	}
+
+	handle := windows.Handle(f.Fd())
+	var overlapped windows.Overlapped
+	// Lock the first byte exclusively, failing immediately if held.
+	lockErr := windows.LockFileEx(
+		handle,
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0, 1, 0, &overlapped,
+	)
+	if lockErr != nil {
+		holderPID := readPID(f)
+		_ = f.Close()
+		// ERROR_LOCK_VIOLATION (33) is the "already held" signal.
+		if lockErr == windows.ERROR_LOCK_VIOLATION {
+			return nil, &ErrAlreadyRunning{PID: holderPID, Path: path}
+		}
+		return nil, fmt.Errorf("worklock: LockFileEx %s: %w", path, lockErr)
+	}
+
+	if prevPID := readPID(f); prevPID > 0 && prevPID != os.Getpid() {
+		if decideStaleLock(prevPID, os.Getpid(), processAlive(prevPID)) == actionReclaim && logf != nil {
+			logf("worklock: reclaimed stale worker lock from dead PID %d (%s)", prevPID, path)
+		}
+	}
+
+	if err := f.Truncate(0); err == nil {
+		_, _ = f.WriteAt([]byte(strconv.Itoa(os.Getpid())+"\n"), 0)
+		_ = f.Sync()
+	}
+
+	return &Lock{f: f, path: path}, nil
+}
+
+// Release relinquishes the lock and removes the lock file.
+func (l *Lock) Release() {
+	if l == nil || l.f == nil {
+		return
+	}
+	handle := windows.Handle(l.f.Fd())
+	var overlapped windows.Overlapped
+	_ = windows.UnlockFileEx(handle, 0, 1, 0, &overlapped)
+	_ = l.f.Close()
+	_ = os.Remove(l.path)
+	l.f = nil
+}
+
+// Path returns the lock file path (for diagnostics).
+func (l *Lock) Path() string {
+	if l == nil {
+		return ""
+	}
+	return l.path
+}
+
+func readPID(f *os.File) int {
+	buf := make([]byte, 32)
+	n, _ := f.ReadAt(buf, 0)
+	if n <= 0 {
+		return 0
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(buf[:n])))
+	if err != nil || pid <= 0 {
+		return 0
+	}
+	return pid
+}
+
+// processAlive reports whether a process with the given PID is alive on Windows.
+// OpenProcess with QUERY_LIMITED_INFORMATION succeeds for a live process; failure
+// (e.g. ERROR_INVALID_PARAMETER for a gone PID) means not alive.
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer windows.CloseHandle(h)
+	var code uint32
+	if err := windows.GetExitCodeProcess(h, &code); err != nil {
+		// Handle opened but state unknown; treat as alive to be safe (refuse).
+		return true
+	}
+	const stillActive = 259 // STILL_ACTIVE
+	return code == stillActive
+}


### PR DESCRIPTION
## Context

Keystone fix behind #443 / #435 and the field incident where a node lost its identity on restart: fabric/Headscale node id churned (1069 -> 1063), its mesh IP changed (100.64.0.5 -> 100.64.0.61), and a NEW device key was minted. That cascade caused device-key sprawl, rate-limit counters keyed to a throwaway identity, non-deterministic job routing (a stale duplicate worker on an old binary answered an AGENT_UPDATE: "node 2.57.0 has no handler"), and the 429 self-DoS in #443.

This PR makes the two structural amplifiers of that churn impossible: a duplicate worker, and a silent identity reset.

## Root Cause

Verified by tracing the connect/register path (`internal/network/singleton.go`, `cmd/reconnect.go`, `cmd/work.go`):

1. **Duplicate worker.** A stale manually-launched worker ran beside the systemd unit. Two workers for one node split job routing non-deterministically, double control-plane request volume, and race on the shared tsnet state dir.
2. **Ephemeral registration -> identity reset.** The node was registered with an **ephemeral** Headscale authkey. When it went offline, Headscale removed the node, so on restart the persisted machine key in `tailscaled.state` no longer mapped to any Headscale node and only a fresh registration succeeded — minting a new fabric id + new mesh IP + new device key.

Important finding: the client reconnect **ordering is already correct** (#435 / #246). `VerifyOrReconnect` reuses the persisted `tailscaled.state` (no-authkey), then `ReconnectWithAuthKey` re-authorizes the SAME machine key (IP-preserving), and only falls to `ClearState` + fresh register as a last resort. The durable "never churn" guarantee requires the registration to be **non-ephemeral**, which is a **backend** change (#4584, epic #4583) — the client cannot make an ephemeral node persist. So on the client the remaining structural work is: (a) the single-instance guard, and (b) making the last-resort churn loud and diagnosable instead of silent.

## Changes

- **`internal/worklock/`** (new, cross-platform): per-node single-instance lock.
  - `worklock_unix.go` — `flock(LOCK_EX|LOCK_NB)`; `worklock_windows.go` — `LockFileEx` with fail-immediately.
  - Keyed to `network.GetStateDir()`, which is *designed* to converge every invocation context (root systemd service, sudo interactive, distinct service user) on one path via the machine-global pointer file. So the systemd worker and a manual `sudo citadel work` take the **same** lock and mutually exclude — the exact duplicate case.
  - A second worker is refused with `*ErrAlreadyRunning` carrying the holder PID. A dead holder's lock is reclaimed automatically (the kernel releases advisory locks on process death, so a crashed worker never blocks its own restart, even if deferred cleanup never ran).
  - Lock file lives in the **parent** of the `network/` state dir so `network.ClearState()` (which `RemoveAll`s `network/`) never deletes it.
  - Pure `decideStaleLock(holderPID, selfPID, holderAlive)` classifier for unit testing.
- **`cmd/work.go`**: acquire the guard at the very top of `runWork`, before any network connect or service startup; `defer lock.Release()`. New `--no-single-instance` flag (default off = guard on) for intentional dev side-by-side runs. A non-contention lock error (e.g. unwritable dir) warns but does not block — defense in depth, not a hard prerequisite.
- **`cmd/reconnect.go`**: `warnIdentityChurn()` emits a loud, structured warning right before the destructive `ClearState` re-register path, naming the ephemeral-registration root cause and the one-time `citadel init` re-register-as-persistent migration.
- **`cmd/controlcenter.go`**: same churn warning on its inline stale-recovery `ClearState` branch, so both re-register paths are consistent.

## What shipped vs deferred

- **Shipped (client baseline):** single-instance guard; verified identity-reuse-on-reconnect ordering; loud ephemeral->persistent churn detection + migration guidance.
- **Deferred to backend:** the actual non-ephemeral **registration** so an offline node is never removed (#4584 / epic #4583). Until that lands, an ephemeral node can still churn once — but it now (a) can't be shadowed by a duplicate worker, and (b) says exactly why and how to fix it (`citadel init`) instead of churning silently.

## Testing

- `go build ./...` (linux) and `GOOS=windows go build` of `worklock` + `cmd` — clean.
- `go vet ./internal/worklock/... ./internal/network/... ./cmd/` and `gofmt -l` — clean.
- `go test ./internal/worklock/... ./internal/network/... ./internal/instance/... ./cmd/` — pass.
- New tests: `decideStaleLock` table (reclaim vs refuse), `LockPathForStateDir` (parent placement, trailing slash), second-Acquire-is-rejected with holder PID + reusable-after-Release, idempotent Release, stale-lock reclaim, `--no-single-instance` flag default, `warnIdentityChurn` no-panic.
- Skipped the tmux-spawning packages (`internal/tmux`, `internal/jobs`, `internal/terminal`, `internal/tmuxinstall`) per the known tmux-crash-with-bg-agents issue; none were touched.

Refs #443, #435, #4583.

*Generated by Claude Opus 4.8*
