### PR TITLE
fix(gateway): registry-driven exposure of provisioned modules on the tsnet mesh (#447)

### DIFF
--- a/cmd/provisioned_gateway.go
+++ b/cmd/provisioned_gateway.go
@@ -325,7 +325,11 @@ func backfillWhatsAppRegistryEntry() {
 	if err != nil {
 		return
 	}
-	port := portFromEnv(env)
+	// Require an EXPLICIT persisted BRIDGE_PORT. Do NOT fall back to
+	// whatsapp.DefaultPort (8080) here: 8080 is citadel's own status listener, so
+	// wiring a route to it on an old deployment that never persisted BRIDGE_PORT
+	// would misroute the module route into the status server.
+	port := explicitBridgePort(env)
 	if port <= 0 {
 		return
 	}
@@ -335,6 +339,22 @@ func backfillWhatsAppRegistryEntry() {
 		Port:       port,
 		Capability: whatsappGatewayCapability,
 	})
+}
+
+// explicitBridgePort returns the bridge's persisted BRIDGE_PORT, or 0 when the
+// env file does not carry one. Unlike portFromEnv it never defaults to
+// whatsapp.DefaultPort (8080 = citadel's own status port), so a route is only
+// wired to a port the deployment actually chose.
+func explicitBridgePort(env map[string]string) int {
+	v := env["BRIDGE_PORT"]
+	if v == "" {
+		return 0
+	}
+	var p int
+	if _, err := fmt.Sscanf(v, "%d", &p); err == nil && p > 0 {
+		return p
+	}
+	return 0
 }
 
 // watchProvisionedRegistry polls the registry file and registers/wires any module

--- a/cmd/provisioned_gateway.go
+++ b/cmd/provisioned_gateway.go
@@ -1,0 +1,243 @@
+// cmd/provisioned_gateway.go
+//
+// Wiring that makes a provisioned, dynamically-ported service (starting with the
+// WhatsApp bridge) reachable by the AceTeam backend over the tsnet mesh
+// (aceteam-ai/citadel-cli#447).
+//
+// The problem: only the status (:8080), terminal (:7860), and HTTPS gateway
+// (:8443) servers bind a tsnet listener on the node VPN IP at startup. A
+// provisioned bridge binds an auto-selected FREE host port that nothing on the
+// tsnet stack listens on, so advertising http://<vpn-ip>:<bridge-port> hands the
+// backend an unreachable address.
+//
+// The fix (gateway-route approach): the gateway already binds a tsnet listener
+// on the node VPN IP. We register a stable route (gateway.WhatsAppRoutePrefix)
+// up front with an EMPTY upstream; when the bridge is provisioned on some host
+// port, ExposeGatewayRoute points that route at 127.0.0.1:<bridge-port>. The
+// backend then reaches the bridge at <scheme>://<vpn-ip>:<gateway-port>/whatsapp
+// and the gateway strips the prefix, forwarding to the bridge unchanged.
+//
+// The gateway instance lives in runWork's scope and is created only when the
+// gateway is enabled, so it is shared with the WHATSAPP_PROVISION handler (and
+// the local CLI, which shares whatsappProvisionDeps) through the package-level
+// hook set by setProvisionedServiceGateway. When no gateway is running the hook
+// is nil and Provision relies on VerifyReachable to fail loud rather than report
+// a false-green.
+package cmd
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/gateway"
+	"github.com/aceteam-ai/citadel-cli/internal/network"
+	"github.com/aceteam-ai/citadel-cli/internal/whatsapp"
+)
+
+// meshHTTPClient builds an HTTP client for the node's OWN reachability probe of
+// its gateway route. The gateway serves a self-signed cert (see tlscert), so the
+// node's local probe skips verification -- it is dialing its own loopback/mesh
+// IP, not a third party, purely to confirm the route is wired. This does not
+// change how the backend reaches the bridge.
+func meshHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec G402 -- self-signed gateway cert, local self-probe only
+		},
+	}
+}
+
+// DefaultGatewayPort is the gateway's default HTTPS port (matches the
+// --gateway-port default in cmd/work.go). The mesh URL for a provisioned service
+// is deterministic from this port + the node's mesh IP, so the CLI and TUI can
+// advertise the reachable gateway-route URL even from a process that is not
+// itself running the gateway (the gateway runs in a separate `citadel work`).
+const DefaultGatewayPort = 8443
+
+// provisionedGatewayRef holds the live gateway server (for in-process route
+// registration) plus the facts needed to build the reachable mesh URL. It is set
+// by setProvisionedServiceGateway when runWork starts the in-process gateway.
+type provisionedGatewayRef struct {
+	gw     *gateway.Server
+	port   int  // the gateway's HTTPS/HTTP port (workGatewayPort)
+	useTLS bool // false only when --gateway-no-tls
+}
+
+var (
+	provisionedGatewayMu  sync.RWMutex
+	provisionedGatewayCur *provisionedGatewayRef
+)
+
+// setProvisionedServiceGateway records the live gateway so provisioned-service
+// deps can register routes and compute reachable mesh URLs. Called from runWork
+// after the gateway is created. Passing gw==nil clears it.
+func setProvisionedServiceGateway(gw *gateway.Server, port int, useTLS bool) {
+	provisionedGatewayMu.Lock()
+	defer provisionedGatewayMu.Unlock()
+	if gw == nil {
+		provisionedGatewayCur = nil
+		return
+	}
+	provisionedGatewayCur = &provisionedGatewayRef{gw: gw, port: port, useTLS: useTLS}
+}
+
+// getProvisionedServiceGateway returns the current gateway ref, or nil.
+func getProvisionedServiceGateway() *provisionedGatewayRef {
+	provisionedGatewayMu.RLock()
+	defer provisionedGatewayMu.RUnlock()
+	return provisionedGatewayCur
+}
+
+// gatewayPortAndTLS returns the gateway port + TLS posture to use when building
+// the mesh URL. It prefers the live in-process gateway (exact facts) and falls
+// back to the defaults (8443, TLS on) so a separate CLI/TUI process advertises
+// the same reachable URL the node's `citadel work` gateway serves.
+func gatewayPortAndTLS() (port int, useTLS bool) {
+	if ref := getProvisionedServiceGateway(); ref != nil {
+		return ref.port, ref.useTLS
+	}
+	return DefaultGatewayPort, true
+}
+
+// gatewayRouteURL builds the mesh URL a service exposed under prefix is reachable
+// at: <scheme>://<vpnIP>:<port><prefix>. Pure so it is unit-testable. Returns ""
+// for an empty vpnIP (off-mesh).
+func gatewayRouteURL(useTLS bool, vpnIP string, port int, prefix string) string {
+	if vpnIP == "" {
+		return ""
+	}
+	scheme := "https"
+	if !useTLS {
+		scheme = "http"
+	}
+	return fmt.Sprintf("%s://%s:%d%s", scheme, vpnIP, port, prefix)
+}
+
+// whatsappMeshAPIURL returns the reachable gateway-route mesh URL for the
+// WhatsApp bridge, or "" when the node is off-mesh.
+//
+// It intentionally ignores the bridge host port: the backend reaches the bridge
+// through the gateway route, not the raw port. The port argument is kept to
+// satisfy ProvisionDeps.MeshAPIURL's signature (and it is what ExposeGatewayRoute
+// wires the route to). The URL is deterministic from the gateway port so it is
+// correct whether or not this exact process is the one running the gateway (the
+// gateway typically runs in a separate `citadel work`); the route wiring is
+// handled by exposeWhatsAppGatewayRoute in-process and by the gateway's
+// startup self-registration from the persisted BRIDGE_PORT.
+func whatsappMeshAPIURL(_ int) string {
+	ip := meshIPv4()
+	port, useTLS := gatewayPortAndTLS()
+	return gatewayRouteURL(useTLS, ip, port, gateway.WhatsAppRoutePrefix)
+}
+
+// meshIPv4 resolves this node's mesh IPv4, priming the network singleton the
+// same way meshAPIURL (cmd/whatsapp.go) does. Returns "" when off-mesh.
+func meshIPv4() string {
+	if !network.HasState() {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	network.VerifyOrReconnect(ctx)
+	ip, err := network.GetGlobalIPv4()
+	if err != nil || ip == "" {
+		if st, serr := network.GetGlobalStatus(ctx); serr == nil && st.IPv4 != "" {
+			return st.IPv4
+		}
+		return ""
+	}
+	return ip
+}
+
+// exposeWhatsAppGatewayRoute points the gateway's WhatsApp route at the bridge's
+// loopback host port. It is ProvisionDeps.ExposeGatewayRoute for the WhatsApp
+// bridge.
+//
+// In the WHATSAPP_PROVISION worker path the gateway runs IN THIS PROCESS, so we
+// wire the route live and it takes effect immediately. In the local CLI path
+// (`citadel whatsapp up` without `citadel work` in the same process) there is no
+// in-process gateway to update; the route is instead registered by the node's
+// separate `citadel work` gateway at startup from the persisted BRIDGE_PORT (see
+// registerProvisionedWhatsAppRoute). A nil ref is therefore NOT a hard failure
+// here -- but Provision's VerifyReachable step still runs, so if no gateway is
+// reachable at all the provision fails loud rather than false-greening.
+func exposeWhatsAppGatewayRoute(bridgePort int) error {
+	ref := getProvisionedServiceGateway()
+	if ref == nil {
+		// No in-process gateway; rely on the work gateway's startup
+		// self-registration + VerifyReachable. Not an error.
+		return nil
+	}
+	addr := fmt.Sprintf("127.0.0.1:%d", bridgePort)
+	if err := ref.gw.SetUpstreamAddress(gateway.WhatsAppRoutePrefix, addr); err != nil {
+		return fmt.Errorf("register bridge gateway route %s -> %s: %w", gateway.WhatsAppRoutePrefix, addr, err)
+	}
+	return nil
+}
+
+// registerProvisionedWhatsAppRoute registers the WhatsApp gateway route on gw and,
+// if the bridge is already deployed (its env file carries BRIDGE_PORT), points
+// the route at that host port. Called from runWork when the gateway is built so:
+//   - a bridge provisioned by a PRIOR process (or a prior worker run) is exposed
+//     immediately on gateway (re)start, and
+//   - the route exists up front so the in-process worker handler only needs
+//     SetUpstreamAddress (SetUpstreamAddress errors if the route is absent).
+//
+// The route is always registered (even with no bridge yet) so a later provision
+// can wire it; until then its empty upstream yields a 502, which VerifyReachable
+// treats as unreachable.
+func registerProvisionedWhatsAppRoute(gw *gateway.Server) {
+	// Register the route with an empty upstream; StripPrefix so the bridge's own
+	// paths (/health, /qr.txt, /admin/tenants, ...) map through unchanged.
+	gw.AddUpstream(gateway.WhatsAppRoutePrefix, &gateway.Upstream{StripPrefix: true})
+
+	// If a bridge is already deployed, wire its persisted port now.
+	servicesDir, err := servicesDirForNode()
+	if err != nil {
+		return
+	}
+	if !whatsapp.IsDeployed(servicesDir) {
+		return
+	}
+	env, err := whatsapp.LoadEnv(servicesDir)
+	if err != nil {
+		return
+	}
+	port := portFromEnv(env)
+	if port <= 0 {
+		return
+	}
+	_ = gw.SetUpstreamAddress(gateway.WhatsAppRoutePrefix, fmt.Sprintf("127.0.0.1:%d", port))
+}
+
+// verifyBridgeReachable confirms the backend-facing api_url is reachable from
+// this node's own mesh identity by GETting the bridge root through it. It is
+// ProvisionDeps.VerifyReachable. The bridge's GET / is unauthenticated and
+// returns 200 once up, so a 200 (or any non-5xx from the bridge) proves the
+// end-to-end mesh path works; a dial failure or a gateway 502 proves it does
+// not.
+func verifyBridgeReachable(ctx context.Context, apiURL string) error {
+	c := meshHTTPClient()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL+"/", nil)
+	if err != nil {
+		return fmt.Errorf("build reachability request: %w", err)
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return fmt.Errorf("GET %s/: %w", apiURL, err)
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+	// A 502 from the gateway means the route has no live upstream (the exact
+	// failure we guard against). Any 5xx is treated as unreachable.
+	if resp.StatusCode >= 500 {
+		return fmt.Errorf("reachability probe to %s/ returned HTTP %d (bridge not exposed on the mesh)", apiURL, resp.StatusCode)
+	}
+	return nil
+}

--- a/cmd/provisioned_gateway.go
+++ b/cmd/provisioned_gateway.go
@@ -1,72 +1,139 @@
 // cmd/provisioned_gateway.go
 //
-// Wiring that makes a provisioned, dynamically-ported service (starting with the
-// WhatsApp bridge) reachable by the AceTeam backend over the tsnet mesh
-// (aceteam-ai/citadel-cli#447).
+// Generic wiring that makes ANY provisioned, dynamically-ported module reachable
+// by the AceTeam backend over the tsnet mesh (aceteam-ai/citadel-cli#447), driven
+// entirely by the provisioned-service registry and the module's manifest
+// gateway: block. Adding a new module requires ZERO changes here.
 //
 // The problem: only the status (:8080), terminal (:7860), and HTTPS gateway
 // (:8443) servers bind a tsnet listener on the node VPN IP at startup. A
-// provisioned bridge binds an auto-selected FREE host port that nothing on the
-// tsnet stack listens on, so advertising http://<vpn-ip>:<bridge-port> hands the
+// provisioned module binds an auto-selected FREE host port that nothing on the
+// tsnet stack listens on, so advertising http://<vpn-ip>:<module-port> hands the
 // backend an unreachable address.
 //
-// The fix (gateway-route approach): the gateway already binds a tsnet listener
-// on the node VPN IP. We register a stable route (gateway.WhatsAppRoutePrefix)
-// up front with an EMPTY upstream; when the bridge is provisioned on some host
-// port, ExposeGatewayRoute points that route at 127.0.0.1:<bridge-port>. The
-// backend then reaches the bridge at <scheme>://<vpn-ip>:<gateway-port>/whatsapp
-// and the gateway strips the prefix, forwarding to the bridge unchanged.
-//
-// The gateway instance lives in runWork's scope and is created only when the
-// gateway is enabled, so it is shared with the WHATSAPP_PROVISION handler (and
-// the local CLI, which shares whatsappProvisionDeps) through the package-level
-// hook set by setProvisionedServiceGateway. When no gateway is running the hook
-// is nil and Provision relies on VerifyReachable to fail loud rather than report
-// a false-green.
+// The fix (gateway-route approach): the gateway already binds a tsnet listener on
+// the node VPN IP. For each registered module it registers a stable route
+// (gateway.ModuleRoutePath(prefix), i.e. /modules/<prefix>) with an EMPTY
+// upstream; when the module is deployed on some host port, the route is pointed
+// at 127.0.0.1:<port>. The backend then reaches the module at
+// <scheme>://<vpn-ip>:<gateway-port>/modules/<prefix> and the gateway strips the
+// prefix, forwarding to the module unchanged.
 package cmd
 
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/gateway"
 	"github.com/aceteam-ai/citadel-cli/internal/network"
+	"github.com/aceteam-ai/citadel-cli/internal/provisionedservice"
 	"github.com/aceteam-ai/citadel-cli/internal/whatsapp"
 )
 
-// meshHTTPClient builds an HTTP client for the node's OWN reachability probe of
-// its gateway route. The gateway serves a self-signed cert (see tlscert), so the
-// node's local probe skips verification -- it is dialing its own loopback/mesh
-// IP, not a third party, purely to confirm the route is wired. This does not
-// change how the backend reaches the bridge.
-func meshHTTPClient() *http.Client {
-	return &http.Client{
-		Timeout: 10 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec G402 -- self-signed gateway cert, local self-probe only
-		},
-	}
-}
-
 // DefaultGatewayPort is the gateway's default HTTPS port (matches the
-// --gateway-port default in cmd/work.go). The mesh URL for a provisioned service
-// is deterministic from this port + the node's mesh IP, so the CLI and TUI can
-// advertise the reachable gateway-route URL even from a process that is not
-// itself running the gateway (the gateway runs in a separate `citadel work`).
+// --gateway-port default in cmd/work.go). Used only as a last-resort fallback
+// when the persisted gateway facts file is absent (landmine b): the mesh URL for
+// a provisioned module is otherwise read from the file the running `citadel work`
+// gateway wrote, so a separate CLI/TUI process advertises the port/TLS the
+// gateway actually serves rather than assuming this compile-time default.
 const DefaultGatewayPort = 8443
 
+// gatewayFactsFileName is the small node-state file the running gateway writes at
+// startup so out-of-process callers (CLI/TUI) build the mesh URL from the ACTUAL
+// port + TLS posture + cert path instead of assuming 8443/https (landmine b).
+const gatewayFactsFileName = "gateway-facts.json"
+
+// gatewayFacts is the persisted {port, useTLS, certPath} the gateway serves.
+// certPath lets the reachability probe trust the gateway's own self-signed cert
+// (landmine a) rather than skipping verification.
+type gatewayFacts struct {
+	Port     int    `json:"port"`
+	UseTLS   bool   `json:"use_tls"`
+	CertPath string `json:"cert_path"`
+}
+
+// provisionedStateDirOverride, when non-empty, replaces network.GetStateDir() as
+// the base dir for the gateway-facts file and the provisioned-service registry.
+// Tests set it to a temp dir so they never read/write the real node state (which
+// GetStateDir resolves from machine-global config/pointer files that a unit test
+// cannot cleanly isolate via env vars). Empty in production.
+var provisionedStateDirOverride string
+
+// provisionedStateDir returns the base dir for the gateway-facts file and the
+// provisioned-service registry, honoring the test override.
+func provisionedStateDir() string {
+	if provisionedStateDirOverride != "" {
+		return provisionedStateDirOverride
+	}
+	return network.GetStateDir()
+}
+
+// gatewayFactsPath is the persisted gateway-facts file inside the node state dir.
+func gatewayFactsPath() string {
+	return filepath.Join(provisionedStateDir(), gatewayFactsFileName)
+}
+
+// writeGatewayFacts persists the live gateway facts so out-of-process callers can
+// build a reachable mesh URL and verify against the real cert. Best-effort: a
+// write failure only degrades out-of-process URL accuracy to the compile-time
+// fallback, it does not stop the gateway.
+func writeGatewayFacts(f gatewayFacts) error {
+	data, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := gatewayFactsPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// readGatewayFacts loads the persisted gateway facts, or (zero, false) when the
+// file is absent/unreadable (the caller then uses the compile-time fallback).
+func readGatewayFacts() (gatewayFacts, bool) {
+	data, err := os.ReadFile(gatewayFactsPath())
+	if err != nil {
+		return gatewayFacts{}, false
+	}
+	var f gatewayFacts
+	if err := json.Unmarshal(data, &f); err != nil {
+		return gatewayFacts{}, false
+	}
+	if f.Port <= 0 {
+		return gatewayFacts{}, false
+	}
+	return f, true
+}
+
+// provisionedRegistry returns the node's provisioned-service registry, backed by
+// a file in the node state dir (the single source of truth for which modules are
+// exposed and under which capability).
+func provisionedRegistry() *provisionedservice.Registry {
+	return provisionedservice.New(provisionedservice.DefaultPath(provisionedStateDir()))
+}
+
 // provisionedGatewayRef holds the live gateway server (for in-process route
-// registration) plus the facts needed to build the reachable mesh URL. It is set
-// by setProvisionedServiceGateway when runWork starts the in-process gateway.
+// wiring) plus the facts needed to build the reachable mesh URL. It is set by
+// setProvisionedServiceGateway when runWork starts the in-process gateway.
 type provisionedGatewayRef struct {
-	gw     *gateway.Server
-	port   int  // the gateway's HTTPS/HTTP port (workGatewayPort)
-	useTLS bool // false only when --gateway-no-tls
+	gw       *gateway.Server
+	port     int    // the gateway's HTTPS/HTTP port (workGatewayPort)
+	useTLS   bool   // false only when --gateway-no-tls
+	certPath string // path to the gateway's self-signed cert (empty when no-TLS)
 }
 
 var (
@@ -74,17 +141,17 @@ var (
 	provisionedGatewayCur *provisionedGatewayRef
 )
 
-// setProvisionedServiceGateway records the live gateway so provisioned-service
-// deps can register routes and compute reachable mesh URLs. Called from runWork
-// after the gateway is created. Passing gw==nil clears it.
-func setProvisionedServiceGateway(gw *gateway.Server, port int, useTLS bool) {
+// setProvisionedServiceGateway records the live gateway so provisioned-module
+// deps can wire routes and compute reachable mesh URLs. Called from runWork after
+// the gateway is created. Passing gw==nil clears it.
+func setProvisionedServiceGateway(gw *gateway.Server, port int, useTLS bool, certPath string) {
 	provisionedGatewayMu.Lock()
 	defer provisionedGatewayMu.Unlock()
 	if gw == nil {
 		provisionedGatewayCur = nil
 		return
 	}
-	provisionedGatewayCur = &provisionedGatewayRef{gw: gw, port: port, useTLS: useTLS}
+	provisionedGatewayCur = &provisionedGatewayRef{gw: gw, port: port, useTLS: useTLS, certPath: certPath}
 }
 
 // getProvisionedServiceGateway returns the current gateway ref, or nil.
@@ -94,20 +161,24 @@ func getProvisionedServiceGateway() *provisionedGatewayRef {
 	return provisionedGatewayCur
 }
 
-// gatewayPortAndTLS returns the gateway port + TLS posture to use when building
-// the mesh URL. It prefers the live in-process gateway (exact facts) and falls
-// back to the defaults (8443, TLS on) so a separate CLI/TUI process advertises
-// the same reachable URL the node's `citadel work` gateway serves.
-func gatewayPortAndTLS() (port int, useTLS bool) {
+// gatewayFactsForURL returns the port + TLS posture + cert path to use when
+// building the mesh URL / reachability probe. Precedence: the live in-process
+// gateway (exact facts), else the persisted facts file the running `citadel work`
+// wrote (landmine b), else the compile-time default (8443, TLS on, no cert -> the
+// probe cannot verify and must skip).
+func gatewayFactsForURL() gatewayFacts {
 	if ref := getProvisionedServiceGateway(); ref != nil {
-		return ref.port, ref.useTLS
+		return gatewayFacts{Port: ref.port, UseTLS: ref.useTLS, CertPath: ref.certPath}
 	}
-	return DefaultGatewayPort, true
+	if f, ok := readGatewayFacts(); ok {
+		return f
+	}
+	return gatewayFacts{Port: DefaultGatewayPort, UseTLS: true}
 }
 
-// gatewayRouteURL builds the mesh URL a service exposed under prefix is reachable
-// at: <scheme>://<vpnIP>:<port><prefix>. Pure so it is unit-testable. Returns ""
-// for an empty vpnIP (off-mesh).
+// gatewayRouteURL builds the mesh URL a module exposed under prefix is reachable
+// at: <scheme>://<vpnIP>:<port>/modules/<prefix>. Pure so it is unit-testable.
+// Returns "" for an empty vpnIP (off-mesh).
 func gatewayRouteURL(useTLS bool, vpnIP string, port int, prefix string) string {
 	if vpnIP == "" {
 		return ""
@@ -116,24 +187,25 @@ func gatewayRouteURL(useTLS bool, vpnIP string, port int, prefix string) string 
 	if !useTLS {
 		scheme = "http"
 	}
-	return fmt.Sprintf("%s://%s:%d%s", scheme, vpnIP, port, prefix)
+	return fmt.Sprintf("%s://%s:%d%s", scheme, vpnIP, port, gateway.ModuleRoutePath(prefix))
 }
 
-// whatsappMeshAPIURL returns the reachable gateway-route mesh URL for the
-// WhatsApp bridge, or "" when the node is off-mesh.
-//
-// It intentionally ignores the bridge host port: the backend reaches the bridge
-// through the gateway route, not the raw port. The port argument is kept to
-// satisfy ProvisionDeps.MeshAPIURL's signature (and it is what ExposeGatewayRoute
-// wires the route to). The URL is deterministic from the gateway port so it is
-// correct whether or not this exact process is the one running the gateway (the
-// gateway typically runs in a separate `citadel work`); the route wiring is
-// handled by exposeWhatsAppGatewayRoute in-process and by the gateway's
-// startup self-registration from the persisted BRIDGE_PORT.
-func whatsappMeshAPIURL(_ int) string {
+// moduleMeshAPIURL returns the reachable gateway-route mesh URL for the module
+// exposed under the given prefix, or "" when the node is off-mesh. It is
+// deterministic from the persisted gateway facts (port/TLS), so it is correct
+// whether or not this exact process runs the gateway.
+func moduleMeshAPIURL(prefix string) string {
 	ip := meshIPv4()
-	port, useTLS := gatewayPortAndTLS()
-	return gatewayRouteURL(useTLS, ip, port, gateway.WhatsAppRoutePrefix)
+	f := gatewayFactsForURL()
+	return gatewayRouteURL(f.UseTLS, ip, f.Port, prefix)
+}
+
+// whatsappMeshAPIURL is WhatsApp's ProvisionDeps.MeshAPIURL: a thin closure over
+// the generic moduleMeshAPIURL. The bridge host port is ignored (the backend
+// reaches the module through the gateway route, not the raw port); the argument
+// is kept to satisfy the MeshAPIURL(port) signature.
+func whatsappMeshAPIURL(_ int) string {
+	return moduleMeshAPIURL(whatsappGatewayPrefix)
 }
 
 // meshIPv4 resolves this node's mesh IPv4, priming the network singleton the
@@ -155,55 +227,99 @@ func meshIPv4() string {
 	return ip
 }
 
-// exposeWhatsAppGatewayRoute points the gateway's WhatsApp route at the bridge's
-// loopback host port. It is ProvisionDeps.ExposeGatewayRoute for the WhatsApp
-// bridge.
+// exposeModuleGatewayRoute points the live gateway's /modules/<prefix> route at
+// the module's loopback host port and records the deployment in the registry
+// (so a later gateway restart or a separate process picks it up). It is the
+// generic ProvisionDeps.ExposeGatewayRoute.
 //
-// In the WHATSAPP_PROVISION worker path the gateway runs IN THIS PROCESS, so we
-// wire the route live and it takes effect immediately. In the local CLI path
+// When the gateway runs IN THIS PROCESS (the WHATSAPP_PROVISION worker path) the
+// route is wired live and takes effect immediately. In the local CLI path
 // (`citadel whatsapp up` without `citadel work` in the same process) there is no
-// in-process gateway to update; the route is instead registered by the node's
-// separate `citadel work` gateway at startup from the persisted BRIDGE_PORT (see
-// registerProvisionedWhatsAppRoute). A nil ref is therefore NOT a hard failure
-// here -- but Provision's VerifyReachable step still runs, so if no gateway is
-// reachable at all the provision fails loud rather than false-greening.
-func exposeWhatsAppGatewayRoute(bridgePort int) error {
+// in-process gateway to update; the registry write is still made, and the running
+// gateway's registry watcher (landmine c) picks it up without a restart. A nil
+// ref is therefore NOT a hard failure here -- Provision's VerifyReachable step
+// still runs, so if no gateway is reachable at all the provision fails loud.
+func exposeModuleGatewayRoute(name, prefix, capability string, bridgePort int) error {
+	// Persist the exposure first so any gateway (this process's or a separate
+	// `citadel work`) can wire it. This is the single source of truth.
+	if err := provisionedRegistry().Register(provisionedservice.Entry{
+		Name:       name,
+		Prefix:     prefix,
+		Port:       bridgePort,
+		Capability: capability,
+	}); err != nil {
+		return fmt.Errorf("record module %q in provisioned-service registry: %w", name, err)
+	}
+
 	ref := getProvisionedServiceGateway()
 	if ref == nil {
-		// No in-process gateway; rely on the work gateway's startup
-		// self-registration + VerifyReachable. Not an error.
+		// No in-process gateway; the running gateway's watcher wires it from the
+		// registry entry just written. Not an error.
 		return nil
 	}
+	routePrefix := gateway.ModuleRoutePath(prefix)
 	addr := fmt.Sprintf("127.0.0.1:%d", bridgePort)
-	if err := ref.gw.SetUpstreamAddress(gateway.WhatsAppRoutePrefix, addr); err != nil {
-		return fmt.Errorf("register bridge gateway route %s -> %s: %w", gateway.WhatsAppRoutePrefix, addr, err)
+	// The route may not exist yet if this gateway started before the module was
+	// declared; register it (empty) then wire it.
+	ref.gw.AddUpstream(routePrefix, &gateway.Upstream{StripPrefix: true})
+	if err := ref.gw.SetUpstreamAddress(routePrefix, addr); err != nil {
+		return fmt.Errorf("wire module gateway route %s -> %s: %w", routePrefix, addr, err)
 	}
 	return nil
 }
 
-// registerProvisionedWhatsAppRoute registers the WhatsApp gateway route on gw and,
-// if the bridge is already deployed (its env file carries BRIDGE_PORT), points
-// the route at that host port. Called from runWork when the gateway is built so:
-//   - a bridge provisioned by a PRIOR process (or a prior worker run) is exposed
-//     immediately on gateway (re)start, and
-//   - the route exists up front so the in-process worker handler only needs
-//     SetUpstreamAddress (SetUpstreamAddress errors if the route is absent).
-//
-// The route is always registered (even with no bridge yet) so a later provision
-// can wire it; until then its empty upstream yields a 502, which VerifyReachable
-// treats as unreachable.
-func registerProvisionedWhatsAppRoute(gw *gateway.Server) {
-	// Register the route with an empty upstream; StripPrefix so the bridge's own
-	// paths (/health, /qr.txt, /admin/tenants, ...) map through unchanged.
-	gw.AddUpstream(gateway.WhatsAppRoutePrefix, &gateway.Upstream{StripPrefix: true})
+// exposeWhatsAppGatewayRoute is WhatsApp's ProvisionDeps.ExposeGatewayRoute: a
+// thin closure over the generic exposeModuleGatewayRoute with WhatsApp's manifest
+// defaults.
+func exposeWhatsAppGatewayRoute(bridgePort int) error {
+	return exposeModuleGatewayRoute(whatsapp.ServiceName, whatsappGatewayPrefix, whatsappGatewayCapability, bridgePort)
+}
 
-	// If a bridge is already deployed, wire its persisted port now.
+// registerProvisionedModuleRoutes registers a /modules/<prefix> route on gw for
+// EVERY module recorded in the provisioned-service registry, wiring the route to
+// the module's persisted port when known. Called from runWork when the gateway is
+// built so a module provisioned by a PRIOR process (or a prior worker run) is
+// exposed immediately on gateway (re)start. Returns the entries it registered so
+// the caller can print them in the route table.
+//
+// The WhatsApp bridge predates the registry, so this also self-heals: if the
+// bridge is deployed (its env file carries BRIDGE_PORT) but has no registry entry
+// yet, it is registered here with WhatsApp's manifest defaults so existing
+// deployments keep working without any manual migration.
+func registerProvisionedModuleRoutes(gw *gateway.Server) []provisionedservice.Entry {
+	backfillWhatsAppRegistryEntry()
+
+	entries, err := provisionedRegistry().List()
+	if err != nil {
+		Log("provisioned-service registry read failed: %v", err)
+		return nil
+	}
+	for _, e := range entries {
+		routePrefix := gateway.ModuleRoutePath(e.Prefix)
+		gw.AddUpstream(routePrefix, &gateway.Upstream{StripPrefix: true})
+		if e.Port > 0 {
+			_ = gw.SetUpstreamAddress(routePrefix, fmt.Sprintf("127.0.0.1:%d", e.Port))
+		}
+	}
+	return entries
+}
+
+// backfillWhatsAppRegistryEntry ensures a deployed-but-unregistered WhatsApp
+// bridge (from before the registry existed) gets a registry entry with the
+// WhatsApp manifest defaults, so existing deployments are exposed after upgrade
+// without any operator action. No-op when the bridge is not deployed or already
+// registered.
+func backfillWhatsAppRegistryEntry() {
 	servicesDir, err := servicesDirForNode()
 	if err != nil {
 		return
 	}
 	if !whatsapp.IsDeployed(servicesDir) {
 		return
+	}
+	reg := provisionedRegistry()
+	if _, found := reg.CapabilityForPrefix(whatsappGatewayPrefix); found {
+		return // already registered
 	}
 	env, err := whatsapp.LoadEnv(servicesDir)
 	if err != nil {
@@ -213,22 +329,81 @@ func registerProvisionedWhatsAppRoute(gw *gateway.Server) {
 	if port <= 0 {
 		return
 	}
-	_ = gw.SetUpstreamAddress(gateway.WhatsAppRoutePrefix, fmt.Sprintf("127.0.0.1:%d", port))
+	_ = reg.Register(provisionedservice.Entry{
+		Name:       whatsapp.ServiceName,
+		Prefix:     whatsappGatewayPrefix,
+		Port:       port,
+		Capability: whatsappGatewayCapability,
+	})
 }
 
-// verifyBridgeReachable confirms the backend-facing api_url is reachable from
-// this node's own mesh identity by GETting the bridge root through it. It is
-// ProvisionDeps.VerifyReachable. The bridge's GET / is unauthenticated and
-// returns 200 once up, so a 200 (or any non-5xx from the bridge) proves the
-// end-to-end mesh path works; a dial failure or a gateway 502 proves it does
-// not.
-func verifyBridgeReachable(ctx context.Context, apiURL string) error {
-	c := meshHTTPClient()
+// watchProvisionedRegistry polls the registry file and registers/wires any module
+// that appears (or whose port changes) while the gateway is already running
+// (landmine c: a module provisioned via the CLI while `citadel work` is up would
+// otherwise never get wired until a restart). A lightweight poll is used rather
+// than a file-watch dependency: the registry changes rarely and the poll is cheap
+// (a small JSON read). It exits when ctx is cancelled.
+func watchProvisionedRegistry(ctx context.Context, gw *gateway.Server) {
+	reg := provisionedRegistry()
+	known := map[string]int{} // prefix -> wired port
+	// Seed with what registerProvisionedModuleRoutes already wired at startup.
+	if entries, err := reg.List(); err == nil {
+		for _, e := range entries {
+			known[e.Prefix] = e.Port
+		}
+	}
+	ticker := time.NewTicker(3 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			entries, err := reg.List()
+			if err != nil {
+				continue
+			}
+			for _, e := range entries {
+				prev, seen := known[e.Prefix]
+				if seen && prev == e.Port {
+					continue
+				}
+				routePrefix := gateway.ModuleRoutePath(e.Prefix)
+				gw.AddUpstream(routePrefix, &gateway.Upstream{StripPrefix: true})
+				if e.Port > 0 {
+					if err := gw.SetUpstreamAddress(routePrefix, fmt.Sprintf("127.0.0.1:%d", e.Port)); err == nil {
+						Log("gateway picked up provisioned module %q on /modules/%s -> 127.0.0.1:%d", e.Name, e.Prefix, e.Port)
+					}
+				}
+				known[e.Prefix] = e.Port
+			}
+		}
+	}
+}
+
+// verifyModuleReachable confirms the backend-facing api_url is reachable from
+// this node's own mesh identity by GETting the module root through it. It is the
+// generic ProvisionDeps.VerifyReachable.
+//
+// Landmine a: it does NOT use InsecureSkipVerify. The gateway serves a self-signed
+// cert; a correctly-configured consumer verifies TLS against it. So this probe
+// mirrors that consumer -- it loads the gateway's own cert (from the persisted
+// facts) into a CA pool and verifies against it (ServerName = the node VPN IP).
+// If verification fails, it fails loud, matching what the real backend would see.
+// (Only when the gateway runs --gateway-no-tls does the URL become http and no
+// verification is needed.) The remaining BACKEND-SIDE dependency -- the backend
+// must trust this same cert (or the node runs --gateway-no-tls) -- is flagged in
+// the PR, not papered over.
+func verifyModuleReachable(ctx context.Context, apiURL string) error {
+	client, err := meshVerifyingClient()
+	if err != nil {
+		return fmt.Errorf("build reachability client: %w", err)
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL+"/", nil)
 	if err != nil {
 		return fmt.Errorf("build reachability request: %w", err)
 	}
-	resp, err := c.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("GET %s/: %w", apiURL, err)
 	}
@@ -237,7 +412,47 @@ func verifyBridgeReachable(ctx context.Context, apiURL string) error {
 	// A 502 from the gateway means the route has no live upstream (the exact
 	// failure we guard against). Any 5xx is treated as unreachable.
 	if resp.StatusCode >= 500 {
-		return fmt.Errorf("reachability probe to %s/ returned HTTP %d (bridge not exposed on the mesh)", apiURL, resp.StatusCode)
+		return fmt.Errorf("reachability probe to %s/ returned HTTP %d (module not exposed on the mesh)", apiURL, resp.StatusCode)
 	}
 	return nil
+}
+
+// verifyBridgeReachable is WhatsApp's ProvisionDeps.VerifyReachable: an alias for
+// the generic verifyModuleReachable.
+func verifyBridgeReachable(ctx context.Context, apiURL string) error {
+	return verifyModuleReachable(ctx, apiURL)
+}
+
+// meshVerifyingClient builds an HTTP client whose TLS config VERIFIES the
+// gateway's self-signed cert (landmine a), loaded from the persisted gateway
+// facts, instead of skipping verification. When the gateway runs without TLS
+// (no cert on disk) a plain client is returned (the URL is http). When TLS is on
+// but the cert cannot be loaded, it returns an error rather than silently
+// skipping verification -- a false-green must never re-enter here.
+func meshVerifyingClient() (*http.Client, error) {
+	f := gatewayFactsForURL()
+	if !f.UseTLS {
+		return &http.Client{Timeout: 10 * time.Second}, nil
+	}
+	if f.CertPath == "" {
+		return nil, fmt.Errorf("gateway TLS is on but its certificate path is unknown (is `citadel work` running with the gateway?); cannot verify reachability without trusting the gateway cert")
+	}
+	pem, err := os.ReadFile(f.CertPath)
+	if err != nil {
+		return nil, fmt.Errorf("read gateway cert %s: %w", f.CertPath, err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pem) {
+		return nil, fmt.Errorf("gateway cert %s is not valid PEM", f.CertPath)
+	}
+	return &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:    pool,
+				ServerName: meshIPv4(), // the SAN the gateway cert carries for the mesh
+				MinVersion: tls.VersionTLS12,
+			},
+		},
+	}, nil
 }

--- a/cmd/provisioned_gateway.go
+++ b/cmd/provisioned_gateway.go
@@ -52,13 +52,17 @@ const DefaultGatewayPort = 8443
 // port + TLS posture + cert path instead of assuming 8443/https (landmine b).
 const gatewayFactsFileName = "gateway-facts.json"
 
-// gatewayFacts is the persisted {port, useTLS, certPath} the gateway serves.
-// certPath lets the reachability probe trust the gateway's own self-signed cert
-// (landmine a) rather than skipping verification.
+// gatewayFacts is the persisted {port, useTLS, certPath, statusPort} the gateway
+// serves. certPath lets the reachability probe trust the gateway's own
+// self-signed cert (landmine a) rather than skipping verification. statusPort is
+// the plaintext status server's port, used to build the cert_refresh_url the
+// backend re-fetches the gateway cert from on rotation (it is served
+// unauthenticated over the mesh by the status server, NOT the TLS gateway).
 type gatewayFacts struct {
-	Port     int    `json:"port"`
-	UseTLS   bool   `json:"use_tls"`
-	CertPath string `json:"cert_path"`
+	Port       int    `json:"port"`
+	UseTLS     bool   `json:"use_tls"`
+	CertPath   string `json:"cert_path"`
+	StatusPort int    `json:"status_port,omitempty"`
 }
 
 // provisionedStateDirOverride, when non-empty, replaces network.GetStateDir() as
@@ -130,10 +134,11 @@ func provisionedRegistry() *provisionedservice.Registry {
 // wiring) plus the facts needed to build the reachable mesh URL. It is set by
 // setProvisionedServiceGateway when runWork starts the in-process gateway.
 type provisionedGatewayRef struct {
-	gw       *gateway.Server
-	port     int    // the gateway's HTTPS/HTTP port (workGatewayPort)
-	useTLS   bool   // false only when --gateway-no-tls
-	certPath string // path to the gateway's self-signed cert (empty when no-TLS)
+	gw         *gateway.Server
+	port       int    // the gateway's HTTPS/HTTP port (workGatewayPort)
+	useTLS     bool   // false only when --gateway-no-tls
+	certPath   string // path to the gateway's self-signed cert (empty when no-TLS)
+	statusPort int    // the plaintext status server's port (cert_refresh_url source)
 }
 
 var (
@@ -144,14 +149,14 @@ var (
 // setProvisionedServiceGateway records the live gateway so provisioned-module
 // deps can wire routes and compute reachable mesh URLs. Called from runWork after
 // the gateway is created. Passing gw==nil clears it.
-func setProvisionedServiceGateway(gw *gateway.Server, port int, useTLS bool, certPath string) {
+func setProvisionedServiceGateway(gw *gateway.Server, port int, useTLS bool, certPath string, statusPort int) {
 	provisionedGatewayMu.Lock()
 	defer provisionedGatewayMu.Unlock()
 	if gw == nil {
 		provisionedGatewayCur = nil
 		return
 	}
-	provisionedGatewayCur = &provisionedGatewayRef{gw: gw, port: port, useTLS: useTLS, certPath: certPath}
+	provisionedGatewayCur = &provisionedGatewayRef{gw: gw, port: port, useTLS: useTLS, certPath: certPath, statusPort: statusPort}
 }
 
 // getProvisionedServiceGateway returns the current gateway ref, or nil.
@@ -168,7 +173,7 @@ func getProvisionedServiceGateway() *provisionedGatewayRef {
 // probe cannot verify and must skip).
 func gatewayFactsForURL() gatewayFacts {
 	if ref := getProvisionedServiceGateway(); ref != nil {
-		return gatewayFacts{Port: ref.port, UseTLS: ref.useTLS, CertPath: ref.certPath}
+		return gatewayFacts{Port: ref.port, UseTLS: ref.useTLS, CertPath: ref.certPath, StatusPort: ref.statusPort}
 	}
 	if f, ok := readGatewayFacts(); ok {
 		return f
@@ -206,6 +211,44 @@ func moduleMeshAPIURL(prefix string) string {
 // is kept to satisfy the MeshAPIURL(port) signature.
 func whatsappMeshAPIURL(_ int) string {
 	return moduleMeshAPIURL(whatsappGatewayPrefix)
+}
+
+// gatewayCertPEM reads the current gateway leaf cert PEM off disk (the same cert
+// the running `citadel work` gateway serves on the mesh) so the backend can trust
+// it out-of-band. It returns "" when the gateway runs --gateway-no-tls (no cert
+// on disk / CertPath unknown) or the cert cannot be read -- an empty value tells
+// the backend to fall back to plain http. The PEM is a PUBLIC leaf cert, safe to
+// hand out; it is regenerated in place whenever the mesh IP changes
+// (tlscert.sansMatch), so a read here always yields the current cert.
+func gatewayCertPEM() string {
+	f := gatewayFactsForURL()
+	if !f.UseTLS || f.CertPath == "" {
+		return ""
+	}
+	data, err := os.ReadFile(f.CertPath)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+// certRefreshURL builds the plaintext refresh URL the backend re-fetches the
+// gateway cert from on rotation: http://<mesh-ip>:<status-port>/gateway-cert.pem.
+// It uses the SAME mesh IP as the module api_url and the persisted status port.
+// Returns "" when off-mesh or the status port is unknown (nothing to point at).
+// The refresh channel is deliberately the PLAINTEXT status server, not the TLS
+// gateway: the backend needs a bootstrap path that does not require already
+// trusting the cert it is fetching.
+func certRefreshURL() string {
+	ip := meshIPv4()
+	if ip == "" {
+		return ""
+	}
+	f := gatewayFactsForURL()
+	if f.StatusPort <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("http://%s:%d/gateway-cert.pem", ip, f.StatusPort)
 }
 
 // meshIPv4 resolves this node's mesh IPv4, priming the network singleton the

--- a/cmd/provisioned_gateway_test.go
+++ b/cmd/provisioned_gateway_test.go
@@ -54,7 +54,7 @@ func TestGatewayRouteURL(t *testing.T) {
 func TestGatewayFactsForURL_PersistedFile(t *testing.T) {
 	// Isolate the node state dir so we read/write a temp facts file.
 	setProvisionedStateDir(t)
-	setProvisionedServiceGateway(nil, 0, false, "") // no in-process gateway
+	setProvisionedServiceGateway(nil, 0, false, "", 0) // no in-process gateway
 
 	// Absent file -> compile-time fallback.
 	f := gatewayFactsForURL()
@@ -81,7 +81,7 @@ func TestGatewayFactsForURL_PersistedFile(t *testing.T) {
 // cert, with ServerName matching a SAN the test cert carries (127.0.0.1).
 func TestVerifyModuleReachable_TrustedCert(t *testing.T) {
 	setProvisionedStateDir(t)
-	setProvisionedServiceGateway(nil, 0, false, "")
+	setProvisionedServiceGateway(nil, 0, false, "", 0)
 
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -113,7 +113,7 @@ func TestVerifyModuleReachable_TrustedCert(t *testing.T) {
 // than the one the probe trusts fails verification (no false-green, landmine a).
 func TestVerifyModuleReachable_UntrustedCert(t *testing.T) {
 	setProvisionedStateDir(t)
-	setProvisionedServiceGateway(nil, 0, false, "")
+	setProvisionedServiceGateway(nil, 0, false, "", 0)
 
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -136,7 +136,7 @@ func TestVerifyModuleReachable_UntrustedCert(t *testing.T) {
 // gateway) still fail loud.
 func TestVerifyModuleReachable_502(t *testing.T) {
 	setProvisionedStateDir(t)
-	setProvisionedServiceGateway(nil, 0, false, "")
+	setProvisionedServiceGateway(nil, 0, false, "", 0)
 	if err := writeGatewayFacts(gatewayFacts{Port: 8080, UseTLS: false}); err != nil {
 		t.Fatal(err)
 	}
@@ -152,7 +152,7 @@ func TestVerifyModuleReachable_502(t *testing.T) {
 
 func TestVerifyModuleReachable_DialFail(t *testing.T) {
 	setProvisionedStateDir(t)
-	setProvisionedServiceGateway(nil, 0, false, "")
+	setProvisionedServiceGateway(nil, 0, false, "", 0)
 	if err := writeGatewayFacts(gatewayFacts{Port: 8080, UseTLS: false}); err != nil {
 		t.Fatal(err)
 	}
@@ -168,7 +168,7 @@ func TestVerifyModuleReachable_DialFail(t *testing.T) {
 // error rather than silently skip verification (the false-green we removed).
 func TestMeshVerifyingClient_TLSNoCertFailsLoud(t *testing.T) {
 	setProvisionedStateDir(t)
-	setProvisionedServiceGateway(nil, 0, false, "")
+	setProvisionedServiceGateway(nil, 0, false, "", 0)
 	if err := writeGatewayFacts(gatewayFacts{Port: 8443, UseTLS: true, CertPath: ""}); err != nil {
 		t.Fatal(err)
 	}
@@ -183,7 +183,7 @@ func TestMeshVerifyingClient_TLSNoCertFailsLoud(t *testing.T) {
 // (landmine c).
 func TestExposeModuleGatewayRoute_NoGatewayRecordsRegistry(t *testing.T) {
 	setProvisionedStateDir(t)
-	setProvisionedServiceGateway(nil, 0, false, "")
+	setProvisionedServiceGateway(nil, 0, false, "", 0)
 
 	if err := exposeModuleGatewayRoute("mymod", "mymod", "provision", 8137); err != nil {
 		t.Fatalf("exposeModuleGatewayRoute with no gateway = %v, want nil (soft no-op)", err)

--- a/cmd/provisioned_gateway_test.go
+++ b/cmd/provisioned_gateway_test.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestGatewayRouteURL covers the pure mesh-URL builder: scheme selection and the
+// off-mesh empty-IP case.
+func TestGatewayRouteURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		useTLS bool
+		ip     string
+		port   int
+		prefix string
+		want   string
+	}{
+		{"https default", true, "100.64.0.7", 8443, "/whatsapp", "https://100.64.0.7:8443/whatsapp"},
+		{"http no-tls", false, "100.64.0.7", 8443, "/whatsapp", "http://100.64.0.7:8443/whatsapp"},
+		{"custom port", true, "100.64.0.9", 9443, "/whatsapp", "https://100.64.0.9:9443/whatsapp"},
+		{"off-mesh empty ip", true, "", 8443, "/whatsapp", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := gatewayRouteURL(tc.useTLS, tc.ip, tc.port, tc.prefix)
+			if got != tc.want {
+				t.Errorf("gatewayRouteURL() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestVerifyBridgeReachable_OK: a 200 from the (gateway-fronted) bridge root
+// means the mesh path works.
+func TestVerifyBridgeReachable_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			t.Errorf("probe path = %q, want /", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	if err := verifyBridgeReachable(context.Background(), srv.URL); err != nil {
+		t.Fatalf("verifyBridgeReachable() = %v, want nil for a 200 root", err)
+	}
+}
+
+// TestVerifyBridgeReachable_502: the gateway returns 502 when the route has no
+// live upstream -- the exact unreachable-bridge failure #447 guards against.
+func TestVerifyBridgeReachable_502(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	err := verifyBridgeReachable(context.Background(), srv.URL)
+	if err == nil {
+		t.Fatal("expected an unreachable error for a 502, got nil")
+	}
+	if !strings.Contains(err.Error(), "502") {
+		t.Errorf("error = %q, want it to mention the 502", err.Error())
+	}
+}
+
+// TestVerifyBridgeReachable_DialFail: nothing listening -> unreachable.
+func TestVerifyBridgeReachable_DialFail(t *testing.T) {
+	// A closed server address (started then immediately closed) reliably refuses.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+
+	if err := verifyBridgeReachable(context.Background(), url); err == nil {
+		t.Fatal("expected a dial error against a closed listener, got nil")
+	}
+}
+
+// TestGatewayPortAndTLS_DefaultsWhenNoGateway verifies the CLI/TUI advertise the
+// deterministic gateway URL (8443, TLS) when this process is not the one running
+// the gateway.
+func TestGatewayPortAndTLS_DefaultsWhenNoGateway(t *testing.T) {
+	setProvisionedServiceGateway(nil, 0, false) // ensure cleared
+	port, useTLS := gatewayPortAndTLS()
+	if port != DefaultGatewayPort {
+		t.Errorf("port = %d, want default %d", port, DefaultGatewayPort)
+	}
+	if !useTLS {
+		t.Error("useTLS = false, want true by default")
+	}
+}
+
+// TestExposeWhatsAppGatewayRoute_NoGatewayIsSoftNoop verifies the local CLI path
+// (no in-process gateway) does not hard-fail on route exposure -- the separate
+// `citadel work` gateway self-registers, and VerifyReachable is the real guard.
+func TestExposeWhatsAppGatewayRoute_NoGatewayIsSoftNoop(t *testing.T) {
+	setProvisionedServiceGateway(nil, 0, false)
+	if err := exposeWhatsAppGatewayRoute(8137); err != nil {
+		t.Fatalf("exposeWhatsAppGatewayRoute with no gateway = %v, want nil (soft no-op)", err)
+	}
+}

--- a/cmd/provisioned_gateway_test.go
+++ b/cmd/provisioned_gateway_test.go
@@ -2,14 +2,28 @@ package cmd
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/gateway"
 )
 
-// TestGatewayRouteURL covers the pure mesh-URL builder: scheme selection and the
-// off-mesh empty-IP case.
+// TestGatewayRouteURL covers the pure mesh-URL builder: scheme selection, the
+// /modules/<prefix> convention, and the off-mesh empty-IP case.
 func TestGatewayRouteURL(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -19,10 +33,10 @@ func TestGatewayRouteURL(t *testing.T) {
 		prefix string
 		want   string
 	}{
-		{"https default", true, "100.64.0.7", 8443, "/whatsapp", "https://100.64.0.7:8443/whatsapp"},
-		{"http no-tls", false, "100.64.0.7", 8443, "/whatsapp", "http://100.64.0.7:8443/whatsapp"},
-		{"custom port", true, "100.64.0.9", 9443, "/whatsapp", "https://100.64.0.9:9443/whatsapp"},
-		{"off-mesh empty ip", true, "", 8443, "/whatsapp", ""},
+		{"https default", true, "100.64.0.7", 8443, "whatsapp", "https://100.64.0.7:8443/modules/whatsapp"},
+		{"http no-tls", false, "100.64.0.7", 8443, "whatsapp", "http://100.64.0.7:8443/modules/whatsapp"},
+		{"custom port", true, "100.64.0.9", 9443, "mymod", "https://100.64.0.9:9443/modules/mymod"},
+		{"off-mesh empty ip", true, "", 8443, "whatsapp", ""},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -34,71 +48,241 @@ func TestGatewayRouteURL(t *testing.T) {
 	}
 }
 
-// TestVerifyBridgeReachable_OK: a 200 from the (gateway-fronted) bridge root
-// means the mesh path works.
-func TestVerifyBridgeReachable_OK(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/" {
-			t.Errorf("probe path = %q, want /", r.URL.Path)
-		}
+// TestGatewayFactsForURL_PersistedFile verifies the out-of-process builder READS
+// the persisted gateway-facts file (landmine b) rather than assuming 8443/https,
+// and falls back to the compile-time default when the file is absent.
+func TestGatewayFactsForURL_PersistedFile(t *testing.T) {
+	// Isolate the node state dir so we read/write a temp facts file.
+	setProvisionedStateDir(t)
+	setProvisionedServiceGateway(nil, 0, false, "") // no in-process gateway
+
+	// Absent file -> compile-time fallback.
+	f := gatewayFactsForURL()
+	if f.Port != DefaultGatewayPort || !f.UseTLS {
+		t.Fatalf("fallback facts = %+v, want port %d TLS on", f, DefaultGatewayPort)
+	}
+
+	// Persisted file -> its values win over the default.
+	if err := writeGatewayFacts(gatewayFacts{Port: 9443, UseTLS: false, CertPath: "/x/cert.pem"}); err != nil {
+		t.Fatalf("writeGatewayFacts: %v", err)
+	}
+	f = gatewayFactsForURL()
+	if f.Port != 9443 || f.UseTLS {
+		t.Fatalf("persisted facts = %+v, want port 9443 TLS off", f)
+	}
+	if f.CertPath != "/x/cert.pem" {
+		t.Fatalf("cert path = %q, want /x/cert.pem", f.CertPath)
+	}
+}
+
+// TestVerifyModuleReachable_TrustedCert: with TLS on, the probe VERIFIES against
+// the gateway's own cert (landmine a) -- a server presenting that trusted cert is
+// reachable. Uses httptest's TLS server and points the persisted facts at its
+// cert, with ServerName matching a SAN the test cert carries (127.0.0.1).
+func TestVerifyModuleReachable_TrustedCert(t *testing.T) {
+	setProvisionedStateDir(t)
+	setProvisionedServiceGateway(nil, 0, false, "")
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
 
-	if err := verifyBridgeReachable(context.Background(), srv.URL); err != nil {
-		t.Fatalf("verifyBridgeReachable() = %v, want nil for a 200 root", err)
+	// Persist the server's cert as the "gateway cert" the probe must trust.
+	certPath := writeServerCert(t, srv)
+	if err := writeGatewayFacts(gatewayFacts{Port: 8443, UseTLS: true, CertPath: certPath}); err != nil {
+		t.Fatalf("writeGatewayFacts: %v", err)
+	}
+
+	// httptest's cert carries SAN 127.0.0.1/[::1]; meshVerifyingClient sets
+	// ServerName from meshIPv4 (empty off-mesh), so verify with an explicit client
+	// mirroring meshVerifyingClient but ServerName=127.0.0.1 to match the SAN.
+	client := verifyingClientFor(t, certPath, "127.0.0.1")
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/", nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("verifying client against trusted cert: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
 }
 
-// TestVerifyBridgeReachable_502: the gateway returns 502 when the route has no
-// live upstream -- the exact unreachable-bridge failure #447 guards against.
-func TestVerifyBridgeReachable_502(t *testing.T) {
+// TestVerifyModuleReachable_UntrustedCert: a server presenting a DIFFERENT cert
+// than the one the probe trusts fails verification (no false-green, landmine a).
+func TestVerifyModuleReachable_UntrustedCert(t *testing.T) {
+	setProvisionedStateDir(t)
+	setProvisionedServiceGateway(nil, 0, false, "")
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Trust an UNRELATED self-signed cert, so the real server's cert does not
+	// verify. (Both httptest TLS servers share Go's built-in cert, so we must mint
+	// a genuinely different one.)
+	otherCert := writeUnrelatedCert(t)
+
+	client := verifyingClientFor(t, otherCert, "127.0.0.1")
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/", nil)
+	if _, err := client.Do(req); err == nil {
+		t.Fatal("expected a TLS verification error against an untrusted cert, got nil")
+	}
+}
+
+// TestVerifyModuleReachable_502 / DialFail through the plain-HTTP path (no-TLS
+// gateway) still fail loud.
+func TestVerifyModuleReachable_502(t *testing.T) {
+	setProvisionedStateDir(t)
+	setProvisionedServiceGateway(nil, 0, false, "")
+	if err := writeGatewayFacts(gatewayFacts{Port: 8080, UseTLS: false}); err != nil {
+		t.Fatal(err)
+	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadGateway)
 	}))
 	defer srv.Close()
-
-	err := verifyBridgeReachable(context.Background(), srv.URL)
-	if err == nil {
-		t.Fatal("expected an unreachable error for a 502, got nil")
-	}
-	if !strings.Contains(err.Error(), "502") {
-		t.Errorf("error = %q, want it to mention the 502", err.Error())
+	err := verifyModuleReachable(context.Background(), srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "502") {
+		t.Fatalf("verifyModuleReachable(502) = %v, want an error mentioning 502", err)
 	}
 }
 
-// TestVerifyBridgeReachable_DialFail: nothing listening -> unreachable.
-func TestVerifyBridgeReachable_DialFail(t *testing.T) {
-	// A closed server address (started then immediately closed) reliably refuses.
+func TestVerifyModuleReachable_DialFail(t *testing.T) {
+	setProvisionedStateDir(t)
+	setProvisionedServiceGateway(nil, 0, false, "")
+	if err := writeGatewayFacts(gatewayFacts{Port: 8080, UseTLS: false}); err != nil {
+		t.Fatal(err)
+	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	url := srv.URL
 	srv.Close()
-
-	if err := verifyBridgeReachable(context.Background(), url); err == nil {
+	if err := verifyModuleReachable(context.Background(), url); err == nil {
 		t.Fatal("expected a dial error against a closed listener, got nil")
 	}
 }
 
-// TestGatewayPortAndTLS_DefaultsWhenNoGateway verifies the CLI/TUI advertise the
-// deterministic gateway URL (8443, TLS) when this process is not the one running
-// the gateway.
-func TestGatewayPortAndTLS_DefaultsWhenNoGateway(t *testing.T) {
-	setProvisionedServiceGateway(nil, 0, false) // ensure cleared
-	port, useTLS := gatewayPortAndTLS()
-	if port != DefaultGatewayPort {
-		t.Errorf("port = %d, want default %d", port, DefaultGatewayPort)
+// TestMeshVerifyingClient_TLSNoCertFailsLoud: TLS on but no known cert path must
+// error rather than silently skip verification (the false-green we removed).
+func TestMeshVerifyingClient_TLSNoCertFailsLoud(t *testing.T) {
+	setProvisionedStateDir(t)
+	setProvisionedServiceGateway(nil, 0, false, "")
+	if err := writeGatewayFacts(gatewayFacts{Port: 8443, UseTLS: true, CertPath: ""}); err != nil {
+		t.Fatal(err)
 	}
-	if !useTLS {
-		t.Error("useTLS = false, want true by default")
+	if _, err := meshVerifyingClient(); err == nil {
+		t.Fatal("expected an error when TLS is on but the cert path is unknown, got nil")
 	}
 }
 
-// TestExposeWhatsAppGatewayRoute_NoGatewayIsSoftNoop verifies the local CLI path
-// (no in-process gateway) does not hard-fail on route exposure -- the separate
-// `citadel work` gateway self-registers, and VerifyReachable is the real guard.
-func TestExposeWhatsAppGatewayRoute_NoGatewayIsSoftNoop(t *testing.T) {
-	setProvisionedServiceGateway(nil, 0, false)
-	if err := exposeWhatsAppGatewayRoute(8137); err != nil {
-		t.Fatalf("exposeWhatsAppGatewayRoute with no gateway = %v, want nil (soft no-op)", err)
+// TestExposeModuleGatewayRoute_NoGatewayRecordsRegistry verifies the local CLI
+// path (no in-process gateway) does not hard-fail, and STILL records the module
+// in the registry so the running `citadel work` gateway's watcher picks it up
+// (landmine c).
+func TestExposeModuleGatewayRoute_NoGatewayRecordsRegistry(t *testing.T) {
+	setProvisionedStateDir(t)
+	setProvisionedServiceGateway(nil, 0, false, "")
+
+	if err := exposeModuleGatewayRoute("mymod", "mymod", "provision", 8137); err != nil {
+		t.Fatalf("exposeModuleGatewayRoute with no gateway = %v, want nil (soft no-op)", err)
+	}
+	cap, ok := provisionedRegistry().CapabilityForPrefix("mymod")
+	if !ok || cap != "provision" {
+		t.Fatalf("registry after expose: (%q,%v), want (provision,true) -- the CLI must record it for the watcher", cap, ok)
+	}
+}
+
+// --- test helpers ---
+
+// setProvisionedStateDir points the gateway-facts + registry files at a temp dir
+// for the duration of the test, so a unit test never touches real node state.
+func setProvisionedStateDir(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	prev := provisionedStateDirOverride
+	provisionedStateDirOverride = dir
+	t.Cleanup(func() { provisionedStateDirOverride = prev })
+}
+
+// certToPEM encodes a raw DER certificate as PEM.
+func certToPEM(der []byte) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+// writeUnrelatedCert mints a fresh self-signed cert (unrelated to httptest's
+// built-in one) and writes it to a temp PEM file, returning the path. Used to
+// prove an untrusted cert fails verification.
+func writeUnrelatedCert(t *testing.T) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(42),
+		Subject:      pkix.Name{CommonName: "unrelated-test-ca"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "unrelated.crt")
+	if err := os.WriteFile(path, certToPEM(der), 0600); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+	return path
+}
+
+// newCertPool builds an x509 pool trusting the given PEM cert.
+func newCertPool(t *testing.T, pemBytes []byte) *x509.CertPool {
+	t.Helper()
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pemBytes) {
+		t.Fatal("AppendCertsFromPEM failed on test cert")
+	}
+	return pool
+}
+
+// writeServerCert writes a TLS test server's leaf cert to a temp PEM file and
+// returns the path.
+func writeServerCert(t *testing.T, srv *httptest.Server) string {
+	t.Helper()
+	cert := srv.Certificate()
+	pemBytes := certToPEM(cert.Raw)
+	path := filepath.Join(t.TempDir(), "server.crt")
+	if err := os.WriteFile(path, pemBytes, 0600); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+	return path
+}
+
+// verifyingClientFor builds an https client that trusts only the cert at
+// certPath and uses the given ServerName (to match the cert SAN). It mirrors
+// meshVerifyingClient but with an explicit ServerName so the test does not depend
+// on mesh IP resolution.
+func verifyingClientFor(t *testing.T, certPath, serverName string) *http.Client {
+	t.Helper()
+	pem, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatalf("read cert: %v", err)
+	}
+	pool := newCertPool(t, pem)
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: pool, ServerName: serverName, MinVersion: tls.VersionTLS12},
+		},
+	}
+}
+
+// TestGatewayRoutePathConvention pins the /modules/<prefix> convention shared with
+// the gateway package.
+func TestGatewayRoutePathConvention(t *testing.T) {
+	if got := gateway.ModuleRoutePath("whatsapp"); got != "/modules/whatsapp" {
+		t.Fatalf("ModuleRoutePath = %q, want /modules/whatsapp", got)
 	}
 }

--- a/cmd/provisioned_gateway_test.go
+++ b/cmd/provisioned_gateway_test.go
@@ -279,6 +279,23 @@ func verifyingClientFor(t *testing.T, certPath, serverName string) *http.Client 
 	}
 }
 
+// TestExplicitBridgePort verifies the backfill port reader requires an explicit
+// BRIDGE_PORT and never falls back to 8080 (citadel's own status port).
+func TestExplicitBridgePort(t *testing.T) {
+	if got := explicitBridgePort(map[string]string{}); got != 0 {
+		t.Errorf("no BRIDGE_PORT -> %d, want 0 (must NOT default to 8080)", got)
+	}
+	if got := explicitBridgePort(map[string]string{"BRIDGE_PORT": "8137"}); got != 8137 {
+		t.Errorf("BRIDGE_PORT=8137 -> %d, want 8137", got)
+	}
+	if got := explicitBridgePort(map[string]string{"BRIDGE_PORT": "0"}); got != 0 {
+		t.Errorf("BRIDGE_PORT=0 -> %d, want 0", got)
+	}
+	if got := explicitBridgePort(map[string]string{"BRIDGE_PORT": "nope"}); got != 0 {
+		t.Errorf("BRIDGE_PORT=nope -> %d, want 0", got)
+	}
+}
+
 // TestGatewayRoutePathConvention pins the /modules/<prefix> convention shared with
 // the gateway package.
 func TestGatewayRoutePathConvention(t *testing.T) {

--- a/cmd/whatsapp.go
+++ b/cmd/whatsapp.go
@@ -42,6 +42,22 @@ import (
 // deployed here via the generic module-source mechanism (catalog.ResolveSource).
 const defaultWhatsAppSource = "sunapi386/whatsapp-bridge"
 
+// WhatsApp's gateway-exposure defaults. The WhatsApp bridge manifest lives in the
+// sunapi386/whatsapp-bridge repo (not editable here); once it declares a
+// gateway: block (prefix/port_env/capability) the registry-driven path uses that
+// verbatim. Until then -- and to keep existing deployments working across upgrade
+// -- citadel defaults WhatsApp to these values, which match the required manifest
+// block documented in the PR:
+//
+//	gateway:
+//	  prefix: whatsapp
+//	  port_env: BRIDGE_PORT
+//	  capability: provision
+const (
+	whatsappGatewayPrefix     = "whatsapp"
+	whatsappGatewayCapability = "provision"
+)
+
 // deployTimeout bounds the whole deploy edge (resolve module source via git clone
 // + `docker compose up`). Both underlying steps shell out to git/docker without
 // their own deadline, so an unreachable private repo or image registry could
@@ -518,12 +534,13 @@ func printConnectDetails(port int, apiKey string) {
 
 	apiURL := whatsappMeshAPIURL(port)
 	if apiURL == "" {
-		gwPort, useTLS := gatewayPortAndTLS()
+		gf := gatewayFactsForURL()
+		gwPort := gf.Port
 		scheme := "https"
-		if !useTLS {
+		if !gf.UseTLS {
 			scheme = "http"
 		}
-		apiURL = fmt.Sprintf("%s://<this-node-network-ip>:%d%s", scheme, gwPort, gateway.WhatsAppRoutePrefix)
+		apiURL = fmt.Sprintf("%s://<this-node-network-ip>:%d%s", scheme, gwPort, gateway.ModuleRoutePath(whatsappGatewayPrefix))
 		fmt.Println(color.YellowString("  (node is not connected to the AceTeam Network -- substitute its mesh IP below)"))
 	}
 	fmt.Printf("  api_url:  %s\n", color.CyanString(apiURL))

--- a/cmd/whatsapp.go
+++ b/cmd/whatsapp.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/catalog"
-	"github.com/aceteam-ai/citadel-cli/internal/network"
+	"github.com/aceteam-ai/citadel-cli/internal/gateway"
 	"github.com/aceteam-ai/citadel-cli/internal/tui/controlcenter"
 	"github.com/aceteam-ai/citadel-cli/internal/whatsapp"
 	"github.com/fatih/color"
@@ -150,31 +150,10 @@ func bridgeBaseURL(port int) string {
 	return fmt.Sprintf("http://127.0.0.1:%d", port)
 }
 
-// meshAPIURL returns the api_url the aceteam backend should use: the node's
-// network (mesh) IP and the published port. Returns "" if the node is not
-// connected to the network. It primes the network singleton first (mirroring
-// status.go) so it works from a fresh process where the global server has not
-// yet been initialized.
-func meshAPIURL(port int) string {
-	if !network.HasState() {
-		return ""
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	// VerifyOrReconnect initializes the global server if needed.
-	network.VerifyOrReconnect(ctx)
-
-	ip, err := network.GetGlobalIPv4()
-	if err != nil || ip == "" {
-		// Fall back to the status snapshot, which also primes the singleton.
-		if st, serr := network.GetGlobalStatus(ctx); serr == nil && st.IPv4 != "" {
-			ip = st.IPv4
-		} else {
-			return ""
-		}
-	}
-	return fmt.Sprintf("http://%s:%d", ip, port)
-}
+// The api_url the aceteam backend uses to reach a provisioned bridge is now the
+// gateway-route mesh URL (whatsappMeshAPIURL in cmd/provisioned_gateway.go), not
+// a raw http://<vpn-ip>:<bridge-port> that nothing on the tsnet stack listens on
+// (aceteam-ai/citadel-cli#447).
 
 // deployWhatsAppCompose resolves the bridge module source (git clone of the
 // private repo), materializes its compose into the node's services dir, and
@@ -269,7 +248,15 @@ func whatsappProvisionDeps(source, image string) whatsapp.ProvisionDeps {
 		NewBridgeClient: func(port int, adminKey string) whatsapp.BridgeClient {
 			return whatsapp.NewClient(bridgeBaseURL(port), adminKey)
 		},
-		MeshAPIURL: meshAPIURL,
+		// The bridge is reached by the backend through the gateway route on the
+		// mesh (not a raw host port nothing listens on) -- aceteam-ai/citadel-cli
+		// #447. whatsappMeshAPIURL returns the gateway-route URL,
+		// exposeWhatsAppGatewayRoute wires that route to the bridge's host port,
+		// and verifyBridgeReachable fails loud if the end-to-end mesh path is not
+		// actually reachable (instead of a false-green).
+		MeshAPIURL:         whatsappMeshAPIURL,
+		ExposeGatewayRoute: exposeWhatsAppGatewayRoute,
+		VerifyReachable:    verifyBridgeReachable,
 		Log: func(format string, args ...any) {
 			fmt.Printf("   - "+format+"\n", args...)
 		},
@@ -377,7 +364,7 @@ func runWhatsAppStatus(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if api := meshAPIURL(port); api != "" {
+	if api := whatsappMeshAPIURL(port); api != "" {
 		fmt.Printf("  api_url:   %s\n", api)
 	}
 	return nil
@@ -529,9 +516,14 @@ func printConnectDetails(port int, apiKey string) {
 	fmt.Println()
 	bold.Println("Register this bridge in AceTeam:")
 
-	apiURL := meshAPIURL(port)
+	apiURL := whatsappMeshAPIURL(port)
 	if apiURL == "" {
-		apiURL = fmt.Sprintf("http://<this-node-network-ip>:%d", port)
+		gwPort, useTLS := gatewayPortAndTLS()
+		scheme := "https"
+		if !useTLS {
+			scheme = "http"
+		}
+		apiURL = fmt.Sprintf("%s://<this-node-network-ip>:%d%s", scheme, gwPort, gateway.WhatsAppRoutePrefix)
 		fmt.Println(color.YellowString("  (node is not connected to the AceTeam Network -- substitute its mesh IP below)"))
 	}
 	fmt.Printf("  api_url:  %s\n", color.CyanString(apiURL))
@@ -564,7 +556,7 @@ func buildWhatsAppCallbacks() controlcenter.WhatsAppCallbacks {
 			env, _ := whatsapp.LoadEnv(servicesDir)
 			port := portFromEnv(env)
 			st.APIKey = env["TENANT_API_KEY"]
-			st.APIURL = meshAPIURL(port)
+			st.APIURL = whatsappMeshAPIURL(port)
 			st.Running = bridgeContainerRunning(whatsapp.ProjectName(servicesDir))
 			if !st.Running {
 				return st
@@ -601,7 +593,7 @@ func buildWhatsAppCallbacks() controlcenter.WhatsAppCallbacks {
 				return "", "", err
 			}
 			env, _ := whatsapp.LoadEnv(servicesDir)
-			return meshAPIURL(portFromEnv(env)), env["TENANT_API_KEY"], nil
+			return whatsappMeshAPIURL(portFromEnv(env)), env["TENANT_API_KEY"], nil
 		},
 		Stop: func() error {
 			return runWhatsAppDown(whatsappDownCmd, nil)

--- a/cmd/whatsapp.go
+++ b/cmd/whatsapp.go
@@ -273,6 +273,10 @@ func whatsappProvisionDeps(source, image string) whatsapp.ProvisionDeps {
 		MeshAPIURL:         whatsappMeshAPIURL,
 		ExposeGatewayRoute: exposeWhatsAppGatewayRoute,
 		VerifyReachable:    verifyBridgeReachable,
+		// Hand the backend the gateway cert to trust (the api_url is an https
+		// gateway route) plus the plaintext URL to re-fetch it from on rotation.
+		GatewayCertPEM: gatewayCertPEM,
+		CertRefreshURL: certRefreshURL,
 		Log: func(format string, args ...any) {
 			fmt.Printf("   - "+format+"\n", args...)
 		},

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1586,16 +1586,31 @@ func runWork(cmd *cobra.Command, args []string) {
 			WebSocket:   true,
 		})
 
-		// Expose provisioned services (WhatsApp bridge) on the mesh through the
-		// gateway (aceteam-ai/citadel-cli#447). The bridge binds an auto-selected
+		// Expose provisioned MODULES on the mesh through the gateway
+		// (aceteam-ai/citadel-cli#447), driven entirely by the provisioned-service
+		// registry -- no per-module code here. Each module binds an auto-selected
 		// free host port that nothing on the tsnet stack listens on, so it is
-		// reached only via this gateway route (StripPrefix so its own paths map
-		// through). Register it up front (wired to the persisted BRIDGE_PORT if a
-		// bridge is already deployed) and publish the gateway so the in-process
-		// WHATSAPP_PROVISION handler can point the route at a freshly-provisioned
-		// bridge live.
-		registerProvisionedWhatsAppRoute(gw)
-		setProvisionedServiceGateway(gw, workGatewayPort, !workGatewayNoTLS)
+		// reached only via a /modules/<prefix> gateway route (StripPrefix so its own
+		// paths map through). Wire the registry so module routes are gated by the
+		// capability each module DECLARED, register every recorded module up front
+		// (wired to its persisted port when deployed), and publish the gateway so the
+		// in-process provision handler can wire a freshly-provisioned module live.
+		gwCertPath := ""
+		if !workGatewayNoTLS {
+			gwCertPath = tlscert.CertPath(workGatewayCertDir)
+		}
+		provReg := provisionedRegistry()
+		gw.SetProvisionedRegistry(provReg)
+		provisionedEntries := registerProvisionedModuleRoutes(gw)
+		setProvisionedServiceGateway(gw, workGatewayPort, !workGatewayNoTLS, gwCertPath)
+		// Persist the live gateway facts so an out-of-process CLI/TUI builds a
+		// reachable mesh URL and verifies against the real cert (landmines a + b).
+		if err := writeGatewayFacts(gatewayFacts{Port: workGatewayPort, UseTLS: !workGatewayNoTLS, CertPath: gwCertPath}); err != nil {
+			Log("could not persist gateway facts (out-of-process URL falls back to defaults): %v", err)
+		}
+		// Watch the registry so a module provisioned via the CLI while this gateway
+		// is already running gets wired without a restart (landmine c).
+		go watchProvisionedRegistry(ctx, gw)
 
 		// Add VPN listener (TLS-wrapped) so the gateway is reachable over tsnet.
 		// Bind to the explicit assigned VPN IP (not ":port"); see network.ListenVPN
@@ -1633,7 +1648,13 @@ func runWork(cmd *cobra.Command, args []string) {
 		fmt.Printf("     /v1/embeddings           -> %s (TEI embeddings)\n", embeddingAddr)
 		fmt.Printf("     /vnc/...                 -> %s (websockify)\n", vncAddr)
 		fmt.Printf("     /terminal/...            -> %s (terminal)\n", termAddr)
-		fmt.Printf("     /whatsapp/...            -> provisioned WhatsApp bridge (dynamic port)\n")
+		for _, e := range provisionedEntries {
+			target := "dynamic port (not yet deployed)"
+			if e.Port > 0 {
+				target = fmt.Sprintf("127.0.0.1:%d", e.Port)
+			}
+			fmt.Printf("     /modules/%s/...  -> %s (provisioned module %q, cap %q)\n", e.Prefix, target, e.Name, e.Capability)
+		}
 
 		if len(vpnIPs) > 0 {
 			fmt.Printf("   - Gateway VPN: %s://%s:%d\n", scheme, vpnIPs[0], workGatewayPort)

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1586,6 +1586,17 @@ func runWork(cmd *cobra.Command, args []string) {
 			WebSocket:   true,
 		})
 
+		// Expose provisioned services (WhatsApp bridge) on the mesh through the
+		// gateway (aceteam-ai/citadel-cli#447). The bridge binds an auto-selected
+		// free host port that nothing on the tsnet stack listens on, so it is
+		// reached only via this gateway route (StripPrefix so its own paths map
+		// through). Register it up front (wired to the persisted BRIDGE_PORT if a
+		// bridge is already deployed) and publish the gateway so the in-process
+		// WHATSAPP_PROVISION handler can point the route at a freshly-provisioned
+		// bridge live.
+		registerProvisionedWhatsAppRoute(gw)
+		setProvisionedServiceGateway(gw, workGatewayPort, !workGatewayNoTLS)
+
 		// Add VPN listener (TLS-wrapped) so the gateway is reachable over tsnet.
 		// Bind to the explicit assigned VPN IP (not ":port"); see network.ListenVPN
 		// and issue #286.
@@ -1622,6 +1633,7 @@ func runWork(cmd *cobra.Command, args []string) {
 		fmt.Printf("     /v1/embeddings           -> %s (TEI embeddings)\n", embeddingAddr)
 		fmt.Printf("     /vnc/...                 -> %s (websockify)\n", vncAddr)
 		fmt.Printf("     /terminal/...            -> %s (terminal)\n", termAddr)
+		fmt.Printf("     /whatsapp/...            -> provisioned WhatsApp bridge (dynamic port)\n")
 
 		if len(vpnIPs) > 0 {
 			fmt.Printf("   - Gateway VPN: %s://%s:%d\n", scheme, vpnIPs[0], workGatewayPort)

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1109,6 +1109,14 @@ func runWork(cmd *cobra.Command, args []string) {
 			Agent:   agentProviders,
 		}
 
+		// Publish the gateway's self-signed leaf cert at GET /gateway-cert.pem so
+		// the backend can trust it out-of-band and re-fetch on rotation. The path
+		// is the same one the gateway block below serves from; empty when the
+		// gateway runs --gateway-no-tls (endpoint then returns 204 = use http).
+		if workGateway && !workGatewayNoTLS {
+			serverCfg.GatewayCertPath = tlscert.CertPath(workGatewayCertDir)
+		}
+
 		// Wire up desktop API auth if org ID is available
 		statusOrgID := ""
 		if deviceConfig != nil {
@@ -1602,10 +1610,12 @@ func runWork(cmd *cobra.Command, args []string) {
 		provReg := provisionedRegistry()
 		gw.SetProvisionedRegistry(provReg)
 		provisionedEntries := registerProvisionedModuleRoutes(gw)
-		setProvisionedServiceGateway(gw, workGatewayPort, !workGatewayNoTLS, gwCertPath)
+		setProvisionedServiceGateway(gw, workGatewayPort, !workGatewayNoTLS, gwCertPath, workStatusPort)
 		// Persist the live gateway facts so an out-of-process CLI/TUI builds a
 		// reachable mesh URL and verifies against the real cert (landmines a + b).
-		if err := writeGatewayFacts(gatewayFacts{Port: workGatewayPort, UseTLS: !workGatewayNoTLS, CertPath: gwCertPath}); err != nil {
+		// StatusPort is persisted too so a separate process can build the plaintext
+		// cert_refresh_url (http://<ip>:<status-port>/gateway-cert.pem).
+		if err := writeGatewayFacts(gatewayFacts{Port: workGatewayPort, UseTLS: !workGatewayNoTLS, CertPath: gwCertPath, StatusPort: workStatusPort}); err != nil {
 			Log("could not persist gateway facts (out-of-process URL falls back to defaults): %v", err)
 		}
 		// Watch the registry so a module provisioned via the CLI while this gateway

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 
@@ -65,6 +66,14 @@ type ServiceManifest struct {
 	Config        []ConfigVar   `yaml:"config"`
 	HealthCheck   HealthCheck   `yaml:"health_check"`
 	Volumes       []VolumeMount `yaml:"volumes"`
+	// Gateway is the OPTIONAL declaration that this module should be exposed on
+	// the node's tsnet gateway under /modules/<prefix>/. It is what generalizes
+	// provisioned-service exposure: a module that binds an auto-selected free host
+	// port (unreachable on the tsnet stack) declares its prefix + which env var
+	// holds its chosen port + which capability gates the route, and the gateway
+	// wires it with ZERO gateway source changes. Absent block means the module is
+	// not exposed on the gateway.
+	Gateway *GatewaySpec `yaml:"gateway"`
 	// Tags are display/search tags (free-form), used by `catalog list/search`.
 	Tags []string `yaml:"tags"`
 	// NodeTags are namespaced key:value routing tags (e.g. "engine:tei",
@@ -122,6 +131,88 @@ type SandboxResources struct {
 	Memory string `yaml:"memory"`
 	// PIDs is the pids_limit. Zero -> default.
 	PIDs int `yaml:"pids"`
+}
+
+// GatewaySpec is the optional gateway-exposure block of a module manifest. It
+// declares that the module should be reachable on the node's tsnet gateway under
+// /modules/<Prefix>/. All three fields are data the gateway consumes without any
+// per-module code:
+//
+//	gateway:
+//	  prefix: whatsapp        # route slug; served under /modules/whatsapp/
+//	  port_env: BRIDGE_PORT   # persisted env var holding the module's host port
+//	  capability: provision   # existing permission that gates the route
+type GatewaySpec struct {
+	// Prefix is the route slug. The gateway serves the module under
+	// /modules/<Prefix>/ (StripPrefix), so the module's own paths (/health,
+	// /qr.txt, ...) map through unchanged. Validated: lowercase alphanumeric +
+	// dash, non-empty, no slashes or "..".
+	Prefix string `yaml:"prefix"`
+	// PortEnv is the name of the persisted env var (in the module's env file) that
+	// holds the module's chosen host port. The provision flow reads this to learn
+	// which loopback port to wire the route to.
+	PortEnv string `yaml:"port_env"`
+	// Capability is the existing permission (one of the config.Permissions fields:
+	// console/desktop/files/services/ssh/provision/shell) that gates the route.
+	// Empty defaults to "provision" (provisioning is what deploys a module).
+	Capability string `yaml:"capability"`
+}
+
+// GatewayCapabilities is the set of permission names a GatewaySpec.Capability may
+// name. It mirrors the config.Permissions fields. Kept here (not importing
+// config) to avoid a catalog->config dependency; validated against this set.
+var GatewayCapabilities = map[string]bool{
+	"console":   true,
+	"desktop":   true,
+	"files":     true,
+	"services":  true,
+	"ssh":       true,
+	"provision": true,
+	"shell":     true,
+}
+
+// DefaultGatewayCapability is the capability a GatewaySpec falls back to when its
+// manifest omits one.
+const DefaultGatewayCapability = "provision"
+
+// prefixPattern matches a valid gateway prefix: lowercase alphanumeric plus dash,
+// at least one char, no leading/trailing dash required but no slashes or dots so
+// it can never inject a path segment or traverse (".." / "a/b").
+var prefixPattern = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+
+// Validate checks the gateway block and returns the effective (defaulted)
+// capability. It rejects a prefix that could inject a path segment or traverse,
+// and a capability outside the known permission set. A nil spec is valid (the
+// module is simply not exposed) and returns ("", nil) -- callers check for nil
+// before Validate when they need the not-exposed distinction.
+func (g *GatewaySpec) Validate() error {
+	if g == nil {
+		return nil
+	}
+	if g.Prefix == "" {
+		return fmt.Errorf("gateway.prefix is required when a gateway block is present")
+	}
+	// Reject anything that is not a clean slug BEFORE the regex, so the error names
+	// the exact injection risk (defense in depth with prefixPattern).
+	if strings.ContainsAny(g.Prefix, "/\\") || strings.Contains(g.Prefix, "..") {
+		return fmt.Errorf("gateway.prefix %q must not contain slashes or '..' (path injection)", g.Prefix)
+	}
+	if !prefixPattern.MatchString(g.Prefix) {
+		return fmt.Errorf("gateway.prefix %q must be lowercase alphanumeric and dashes only", g.Prefix)
+	}
+	if g.Capability != "" && !GatewayCapabilities[g.Capability] {
+		return fmt.Errorf("gateway.capability %q is not a known permission (want one of console/desktop/files/services/ssh/provision/shell)", g.Capability)
+	}
+	return nil
+}
+
+// EffectiveCapability returns the capability that gates the route, applying the
+// provision default for an empty value. Call Validate first.
+func (g *GatewaySpec) EffectiveCapability() string {
+	if g == nil || g.Capability == "" {
+		return DefaultGatewayCapability
+	}
+	return g.Capability
 }
 
 // Requirements describes what a service needs from the host.

--- a/internal/catalog/gateway_spec_test.go
+++ b/internal/catalog/gateway_spec_test.go
@@ -1,0 +1,111 @@
+package catalog
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestGatewayBlockParses: a manifest with a gateway: block unmarshals into the
+// GatewaySpec fields.
+func TestGatewayBlockParses(t *testing.T) {
+	src := `
+name: whatsapp-bridge
+version: 1.0.0
+gateway:
+  prefix: whatsapp
+  port_env: BRIDGE_PORT
+  capability: provision
+`
+	var m ServiceManifest
+	if err := yaml.Unmarshal([]byte(src), &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m.Gateway == nil {
+		t.Fatal("Gateway is nil, want parsed block")
+	}
+	if m.Gateway.Prefix != "whatsapp" {
+		t.Errorf("prefix = %q, want whatsapp", m.Gateway.Prefix)
+	}
+	if m.Gateway.PortEnv != "BRIDGE_PORT" {
+		t.Errorf("port_env = %q, want BRIDGE_PORT", m.Gateway.PortEnv)
+	}
+	if m.Gateway.Capability != "provision" {
+		t.Errorf("capability = %q, want provision", m.Gateway.Capability)
+	}
+	if err := m.Gateway.Validate(); err != nil {
+		t.Errorf("Validate on a good block: %v", err)
+	}
+}
+
+// TestGatewayBlockAbsent: no gateway: block leaves Gateway nil (module not
+// exposed), and Validate on nil is fine.
+func TestGatewayBlockAbsent(t *testing.T) {
+	var m ServiceManifest
+	if err := yaml.Unmarshal([]byte("name: plain\nversion: 1.0.0\n"), &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m.Gateway != nil {
+		t.Errorf("Gateway = %+v, want nil for a manifest with no gateway block", m.Gateway)
+	}
+	if err := m.Gateway.Validate(); err != nil {
+		t.Errorf("Validate on nil gateway: %v", err)
+	}
+}
+
+// TestGatewayCapabilityDefaults: an omitted capability yields the provision
+// default; a present one is honored.
+func TestGatewayCapabilityDefaults(t *testing.T) {
+	g := &GatewaySpec{Prefix: "svc", PortEnv: "PORT"}
+	if err := g.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if got := g.EffectiveCapability(); got != DefaultGatewayCapability {
+		t.Errorf("EffectiveCapability = %q, want %q", got, DefaultGatewayCapability)
+	}
+	g2 := &GatewaySpec{Prefix: "svc", Capability: "services"}
+	if got := g2.EffectiveCapability(); got != "services" {
+		t.Errorf("EffectiveCapability = %q, want services", got)
+	}
+}
+
+// TestGatewayPrefixValidation: slashes, "..", empty, uppercase, and unknown
+// capabilities are all rejected; clean slugs pass.
+func TestGatewayPrefixValidation(t *testing.T) {
+	bad := []struct {
+		name string
+		spec GatewaySpec
+		want string // substring the error should mention
+	}{
+		{"slash", GatewaySpec{Prefix: "a/b"}, "slashes"},
+		{"backslash", GatewaySpec{Prefix: "a\\b"}, "slashes"},
+		{"traversal", GatewaySpec{Prefix: ".."}, "'..'"},
+		{"embedded traversal", GatewaySpec{Prefix: "a..b"}, "'..'"},
+		{"empty", GatewaySpec{Prefix: ""}, "required"},
+		{"uppercase", GatewaySpec{Prefix: "WhatsApp"}, "lowercase"},
+		{"space", GatewaySpec{Prefix: "a b"}, "lowercase"},
+		{"unknown capability", GatewaySpec{Prefix: "svc", Capability: "root"}, "not a known permission"},
+	}
+	for _, tc := range bad {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.spec.Validate()
+			if err == nil {
+				t.Fatalf("Validate(%+v) = nil, want error", tc.spec)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not mention %q", err.Error(), tc.want)
+			}
+		})
+	}
+
+	good := []string{"whatsapp", "my-module", "svc1", "a-b-c", "x"}
+	for _, p := range good {
+		t.Run("ok:"+p, func(t *testing.T) {
+			g := GatewaySpec{Prefix: p}
+			if err := g.Validate(); err != nil {
+				t.Errorf("Validate(%q) = %v, want nil", p, err)
+			}
+		})
+	}
+}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -31,6 +31,16 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/config"
 )
 
+// WhatsAppRoutePrefix is the gateway path prefix under which the provisioned
+// WhatsApp bridge is exposed on the mesh. The backend reaches the bridge at
+// https://<node-vpn-ip>:<gateway-port><WhatsAppRoutePrefix> and the gateway
+// strips the prefix before forwarding to the bridge's loopback port, so the
+// bridge's own paths (/health, /qr.txt, /admin/tenants, ...) map through
+// unchanged. This is the first consumer of the generic provisioned-service
+// exposure; new provisioned services follow the same pattern with their own
+// prefix.
+const WhatsAppRoutePrefix = "/whatsapp"
+
 // Config holds configuration for the gateway server.
 type Config struct {
 	// Port is the HTTPS port to listen on (default: 8443).
@@ -54,6 +64,15 @@ type Config struct {
 // Upstream describes a backend service to proxy to.
 type Upstream struct {
 	// Address is the backend address (e.g., "127.0.0.1:8080").
+	//
+	// For most upstreams the address is fixed at registration time. For a
+	// dynamically-provisioned service (e.g. the WhatsApp bridge, which binds an
+	// auto-selected free host port AFTER the gateway has already started), the
+	// address is not known when the route is registered. Such a route is
+	// registered up front with an empty Address and its target is set later via
+	// Server.SetUpstreamAddress; reads go through addr() so a live proxy always
+	// forwards to the current target. Direct field reads are avoided in the proxy
+	// hot path for exactly that reason.
 	Address string
 
 	// StripPrefix removes the matched prefix before forwarding.
@@ -63,6 +82,30 @@ type Upstream struct {
 
 	// WebSocket indicates this upstream handles WebSocket connections.
 	WebSocket bool
+
+	// mu guards dynAddr for upstreams whose target is set after registration.
+	mu sync.RWMutex
+	// dynAddr, when non-empty, overrides Address. It is set via
+	// Server.SetUpstreamAddress for dynamically-provisioned upstreams.
+	dynAddr string
+}
+
+// addr returns the current backend address, preferring a dynamically-set
+// address over the static one. Safe for concurrent use.
+func (u *Upstream) addr() string {
+	u.mu.RLock()
+	defer u.mu.RUnlock()
+	if u.dynAddr != "" {
+		return u.dynAddr
+	}
+	return u.Address
+}
+
+// setAddr updates the dynamic backend address. Safe for concurrent use.
+func (u *Upstream) setAddr(a string) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.dynAddr = a
 }
 
 // Server is the HTTPS reverse proxy gateway.
@@ -121,6 +164,24 @@ func (s *Server) AddUpstream(pathPrefix string, upstream *Upstream) {
 	s.config.Upstreams[pathPrefix] = upstream
 }
 
+// SetUpstreamAddress updates the backend address of an already-registered
+// upstream. It is the mechanism a dynamically-provisioned service uses to point
+// a route (registered up front with an empty Address) at its real host port once
+// that port is known -- e.g. the WhatsApp bridge binds an auto-selected free
+// port after the gateway has started. Returns an error if no upstream is
+// registered for the given prefix. Safe to call after Start (reads go through
+// the per-request resolveTarget in registerProxy).
+func (s *Server) SetUpstreamAddress(prefix, address string) error {
+	s.mu.RLock()
+	upstream, ok := s.config.Upstreams[prefix]
+	s.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("gateway: no upstream registered for prefix %q", prefix)
+	}
+	upstream.setAddr(address)
+	return nil
+}
+
 // SetPermissions sets the capability permissions for route filtering.
 // When nil, all routes are allowed. Must be called before Start.
 func (s *Server) SetPermissions(p *config.Permissions) {
@@ -165,6 +226,13 @@ func categoryForPath(path string) string {
 	}
 	// Provisioning
 	if path == "/provision" || strings.HasPrefix(path, "/provision/") {
+		return "provision"
+	}
+	// Provisioned services (e.g. the WhatsApp bridge) are reached by the backend
+	// through a gateway route registered by the provision flow. Gate them behind
+	// the same Provision capability that deployed them: if the operator disables
+	// provisioning, the provisioned service is no longer reachable either.
+	if path == "/whatsapp" || strings.HasPrefix(path, "/whatsapp/") {
 		return "provision"
 	}
 	// Everything else (health, status, ping, root, unknown) is always allowed
@@ -272,17 +340,38 @@ func (s *Server) Start(ctx context.Context) error {
 }
 
 // registerProxy sets up the reverse proxy handler for a given path prefix.
+//
+// The upstream target is resolved per request (via upstream.addr()) rather than
+// captured once, so a dynamically-provisioned upstream whose address is set
+// after Start (see SetUpstreamAddress) is honored on the next request without
+// re-registering the route. An unset target yields a 502 rather than a panic.
 func (s *Server) registerProxy(prefix string, upstream *Upstream) {
-	target, err := url.Parse("http://" + upstream.Address)
-	if err != nil {
-		log.Printf("[Gateway] invalid upstream address %q for %s: %v", upstream.Address, prefix, err)
-		return
+	// resolveTarget returns the current upstream URL, or nil when the upstream
+	// has no address yet (dynamic upstream not provisioned).
+	resolveTarget := func() *url.URL {
+		addr := upstream.addr()
+		if addr == "" {
+			return nil
+		}
+		target, err := url.Parse("http://" + addr)
+		if err != nil {
+			log.Printf("[Gateway] invalid upstream address %q for %s: %v", addr, prefix, err)
+			return nil
+		}
+		return target
 	}
 
 	proxy := &httputil.ReverseProxy{
 		Director: func(req *http.Request) {
-			req.URL.Scheme = target.Scheme
-			req.URL.Host = target.Host
+			target := resolveTarget()
+			if target == nil {
+				// Signal unavailability to the transport so ErrorHandler runs.
+				req.URL.Scheme = "http"
+				req.URL.Host = "gateway-upstream-unset.invalid"
+			} else {
+				req.URL.Scheme = target.Scheme
+				req.URL.Host = target.Host
+			}
 			req.Header.Set("X-Forwarded-For", req.RemoteAddr)
 			req.Header.Set("X-Forwarded-Proto", "https")
 			if s.config.NodeName != "" {
@@ -297,16 +386,24 @@ func (s *Server) registerProxy(prefix string, upstream *Upstream) {
 			}
 		},
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
-			log.Printf("[Gateway] proxy error for %s -> %s: %v", r.URL.Path, upstream.Address, err)
+			log.Printf("[Gateway] proxy error for %s -> %s: %v", r.URL.Path, upstream.addr(), err)
 			http.Error(w, fmt.Sprintf(`{"error":"upstream unavailable","upstream":"%s"}`, prefix), http.StatusBadGateway)
 		},
 	}
 
 	// For WebSocket upstreams, we need to handle the Upgrade header
 	if upstream.WebSocket {
+		wsProxy := func(w http.ResponseWriter, r *http.Request) {
+			target := resolveTarget()
+			if target == nil {
+				http.Error(w, fmt.Sprintf(`{"error":"upstream unavailable","upstream":"%s"}`, prefix), http.StatusBadGateway)
+				return
+			}
+			s.proxyWebSocket(w, r, target, prefix, upstream.StripPrefix)
+		}
 		s.mux.HandleFunc(prefix+"/", func(w http.ResponseWriter, r *http.Request) {
 			if isWebSocketUpgrade(r) {
-				s.proxyWebSocket(w, r, target, prefix, upstream.StripPrefix)
+				wsProxy(w, r)
 				return
 			}
 			proxy.ServeHTTP(w, r)
@@ -314,7 +411,7 @@ func (s *Server) registerProxy(prefix string, upstream *Upstream) {
 		// Also handle the exact prefix (no trailing slash)
 		s.mux.HandleFunc(prefix, func(w http.ResponseWriter, r *http.Request) {
 			if isWebSocketUpgrade(r) {
-				s.proxyWebSocket(w, r, target, prefix, upstream.StripPrefix)
+				wsProxy(w, r)
 				return
 			}
 			proxy.ServeHTTP(w, r)

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -31,15 +31,32 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/config"
 )
 
-// WhatsAppRoutePrefix is the gateway path prefix under which the provisioned
-// WhatsApp bridge is exposed on the mesh. The backend reaches the bridge at
-// https://<node-vpn-ip>:<gateway-port><WhatsAppRoutePrefix> and the gateway
-// strips the prefix before forwarding to the bridge's loopback port, so the
-// bridge's own paths (/health, /qr.txt, /admin/tenants, ...) map through
-// unchanged. This is the first consumer of the generic provisioned-service
-// exposure; new provisioned services follow the same pattern with their own
-// prefix.
-const WhatsAppRoutePrefix = "/whatsapp"
+// ModuleRoutePrefix is the namespace under which EVERY provisioned module is
+// exposed on the mesh: the gateway serves a module declaring gateway.prefix=<p>
+// at /modules/<p>/ and strips the /modules/<p> prefix before forwarding to the
+// module's loopback port, so the module's own paths (/health, /qr.txt, ...) map
+// through unchanged. Namespacing under /modules/ prevents collision with builtin
+// routes (/terminal, /vnc, /provision, ...) and between modules. Which prefixes
+// exist, at which port, and under which capability is DATA in the
+// provisioned-service registry -- not code here.
+const ModuleRoutePrefix = "/modules/"
+
+// ModuleRoutePath returns the gateway route path for a module prefix:
+// "/modules/<prefix>". Used by both the gateway (route registration) and the
+// out-of-process URL builder so the convention lives in one place.
+func ModuleRoutePath(prefix string) string {
+	return ModuleRoutePrefix + prefix
+}
+
+// CapabilityResolver reports which capability gates the module served under the
+// given gateway prefix (the <p> in /modules/<p>/...), and whether such a module
+// is registered. The gateway holds one (backed by the provisioned-service
+// registry) so categoryForPath can gate module routes from declared data instead
+// of a hardcoded switch. A nil resolver (or unknown prefix) falls back to the
+// provision capability, so a module route is never accidentally left ungated.
+type CapabilityResolver interface {
+	CapabilityForPrefix(prefix string) (capability string, found bool)
+}
 
 // Config holds configuration for the gateway server.
 type Config struct {
@@ -66,8 +83,8 @@ type Upstream struct {
 	// Address is the backend address (e.g., "127.0.0.1:8080").
 	//
 	// For most upstreams the address is fixed at registration time. For a
-	// dynamically-provisioned service (e.g. the WhatsApp bridge, which binds an
-	// auto-selected free host port AFTER the gateway has already started), the
+	// dynamically-provisioned module (which binds an auto-selected free host port
+	// AFTER the gateway has already started), the
 	// address is not known when the route is registered. Such a route is
 	// registered up front with an empty Address and its target is set later via
 	// Server.SetUpstreamAddress; reads go through addr() so a live proxy always
@@ -128,6 +145,12 @@ type Server struct {
 	// extraListeners are additional net.Listeners the server will also serve on
 	// (e.g., a TLS-wrapped tsnet VPN listener). Added via AddListener before Start.
 	extraListeners []net.Listener
+
+	// provisionedResolver maps a /modules/<prefix>/ request to the capability the
+	// owning module declared (via the provisioned-service registry). When nil, a
+	// module route falls back to the provision capability. Set via
+	// SetProvisionedRegistry.
+	provisionedResolver CapabilityResolver
 }
 
 // NewServer creates a new gateway server.
@@ -165,10 +188,10 @@ func (s *Server) AddUpstream(pathPrefix string, upstream *Upstream) {
 }
 
 // SetUpstreamAddress updates the backend address of an already-registered
-// upstream. It is the mechanism a dynamically-provisioned service uses to point
+// upstream. It is the mechanism a dynamically-provisioned module uses to point
 // a route (registered up front with an empty Address) at its real host port once
-// that port is known -- e.g. the WhatsApp bridge binds an auto-selected free
-// port after the gateway has started. Returns an error if no upstream is
+// that port is known -- a module binds an auto-selected free host port after the
+// gateway has started. Returns an error if no upstream is
 // registered for the given prefix. Safe to call after Start (reads go through
 // the per-request resolveTarget in registerProxy).
 func (s *Server) SetUpstreamAddress(prefix, address string) error {
@@ -190,6 +213,18 @@ func (s *Server) SetPermissions(p *config.Permissions) {
 	s.permissions = p
 }
 
+// SetProvisionedRegistry wires the resolver the permission layer uses to gate
+// /modules/<prefix>/ requests by the capability the owning module declared.
+// Passing nil clears it (module routes then fall back to the provision
+// capability). Safe to call after Start (the permission check reads it under the
+// lock), so the running gateway can adopt a registry that gains entries over
+// time. Typically the caller passes a *provisionedservice.Registry.
+func (s *Server) SetProvisionedRegistry(r CapabilityResolver) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.provisionedResolver = r
+}
+
 // SetMetering enables ACET token metering on the gateway. When set,
 // OpenAI-compatible API requests are intercepted to extract token usage
 // and record billing transactions. Must be called before Start.
@@ -199,8 +234,50 @@ func (s *Server) SetMetering(m *MeteringMiddleware) {
 	s.metering = m
 }
 
-// categoryForPath returns the permission category for a request path, or ""
-// if the path should always be allowed (health, status, ping, root).
+// modulePrefixFromPath extracts the module prefix from a /modules/<prefix>/...
+// (or exact /modules/<prefix>) request path, or "" if the path is not a module
+// route. It is the inverse of ModuleRoutePath.
+func modulePrefixFromPath(path string) string {
+	if !strings.HasPrefix(path, ModuleRoutePrefix) {
+		return ""
+	}
+	rest := strings.TrimPrefix(path, ModuleRoutePrefix)
+	if rest == "" {
+		return ""
+	}
+	// The prefix is the first path segment; anything after the next slash is the
+	// module's own path.
+	if i := strings.IndexByte(rest, '/'); i >= 0 {
+		return rest[:i]
+	}
+	return rest
+}
+
+// categoryForRequest returns the permission category gating a request path. For
+// builtin routes it uses the stable hardcoded mapping (categoryForPath). For a
+// /modules/<prefix>/ route it consults the provisioned-service registry (via
+// resolver) for the capability the owning module DECLARED, defaulting to
+// "provision" when the resolver is nil or the prefix is unknown -- so a module
+// route is never left ungated. This is the registry-driven replacement for the
+// old hardcoded per-module switch.
+func categoryForRequest(path string, resolver CapabilityResolver) string {
+	if prefix := modulePrefixFromPath(path); prefix != "" {
+		if resolver != nil {
+			if capability, found := resolver.CapabilityForPrefix(prefix); found && capability != "" {
+				return capability
+			}
+		}
+		// Unknown/registry-less module route: fall back to provision rather than
+		// leaving it open (fail closed).
+		return "provision"
+	}
+	return categoryForPath(path)
+}
+
+// categoryForPath returns the permission category for a BUILTIN request path, or
+// "" if the path should always be allowed (health, status, ping, root). Module
+// routes (/modules/<prefix>/) are handled by categoryForRequest, which layers a
+// registry lookup on top of this.
 func categoryForPath(path string) string {
 	// Terminal/console
 	if path == "/terminal" || strings.HasPrefix(path, "/terminal/") {
@@ -228,14 +305,9 @@ func categoryForPath(path string) string {
 	if path == "/provision" || strings.HasPrefix(path, "/provision/") {
 		return "provision"
 	}
-	// Provisioned services (e.g. the WhatsApp bridge) are reached by the backend
-	// through a gateway route registered by the provision flow. Gate them behind
-	// the same Provision capability that deployed them: if the operator disables
-	// provisioning, the provisioned service is no longer reachable either.
-	if path == "/whatsapp" || strings.HasPrefix(path, "/whatsapp/") {
-		return "provision"
-	}
-	// Everything else (health, status, ping, root, unknown) is always allowed
+	// Everything else (health, status, ping, root, unknown) is always allowed.
+	// Provisioned-module routes (/modules/<prefix>/) are gated by
+	// categoryForRequest via the registry, not here.
 	return ""
 }
 
@@ -245,24 +317,27 @@ func (s *Server) permissionMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		s.mu.RLock()
 		perms := s.permissions
+		resolver := s.provisionedResolver
 		s.mu.RUnlock()
 
 		if perms != nil {
-			category := categoryForPath(r.URL.Path)
+			category := categoryForRequest(r.URL.Path, resolver)
 			blocked := false
 			switch category {
 			case "console":
 				blocked = !perms.Console
 			case "desktop":
 				blocked = !perms.Desktop
+			case "files":
+				blocked = !perms.Files
 			case "services":
 				blocked = !perms.Services
 			case "ssh":
 				blocked = !perms.SSH
 			case "provision":
 				blocked = !perms.Provision
-				// "files" is not currently routed through the gateway but is
-				// included in the permission model for future use.
+			case "shell":
+				blocked = !perms.Shell
 			}
 			if blocked {
 				w.Header().Set("Content-Type", "application/json")

--- a/internal/gateway/gateway_test.go
+++ b/internal/gateway/gateway_test.go
@@ -520,3 +520,76 @@ func TestPermissionMiddleware_NilPermissionsAllowsAll(t *testing.T) {
 		t.Error("nil permissions should not block any route")
 	}
 }
+
+// TestSetUpstreamAddress_DynamicRoute verifies a route registered up front with
+// an empty upstream returns 502 until its address is set, then proxies to the
+// backend once SetUpstreamAddress wires it. This is the mechanism that exposes a
+// dynamically-provisioned service (the WhatsApp bridge) on the mesh gateway
+// (aceteam-ai/citadel-cli#447).
+func TestSetUpstreamAddress_DynamicRoute(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"backend": "bridge", "path": r.URL.Path})
+	}))
+	defer backend.Close()
+	backendAddr := backend.URL[len("http://"):]
+
+	gw := NewServer(Config{NodeName: "test-node"})
+	// Registered up front with NO address (dynamic upstream), StripPrefix like the
+	// real WhatsApp route.
+	gw.AddUpstream(WhatsAppRoutePrefix, &Upstream{StripPrefix: true})
+	for prefix, upstream := range gw.config.Upstreams {
+		gw.registerProxy(prefix, upstream)
+	}
+	gw.mux.HandleFunc("/", gw.handleRoot)
+	handler := gw.BuildHandler()
+
+	// Before wiring: a 502 (upstream unset), NOT a panic or a 200.
+	req := httptest.NewRequest(http.MethodGet, WhatsAppRoutePrefix+"/health", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("unwired route status = %d, want 502", w.Code)
+	}
+
+	// Wire the route to the backend.
+	if err := gw.SetUpstreamAddress(WhatsAppRoutePrefix, backendAddr); err != nil {
+		t.Fatalf("SetUpstreamAddress: %v", err)
+	}
+
+	// After wiring: proxies through, prefix stripped (bridge sees /health).
+	req = httptest.NewRequest(http.MethodGet, WhatsAppRoutePrefix+"/health", nil)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("wired route status = %d, want 200", w.Code)
+	}
+	var got map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if got["backend"] != "bridge" {
+		t.Errorf("backend = %q, want bridge", got["backend"])
+	}
+	if got["path"] != "/health" {
+		t.Errorf("forwarded path = %q, want /health (prefix stripped)", got["path"])
+	}
+}
+
+// TestSetUpstreamAddress_UnknownPrefix verifies setting an address on an
+// unregistered prefix errors rather than silently no-oping.
+func TestSetUpstreamAddress_UnknownPrefix(t *testing.T) {
+	gw := NewServer(Config{})
+	if err := gw.SetUpstreamAddress("/nope", "127.0.0.1:9999"); err == nil {
+		t.Fatal("expected an error for an unregistered prefix, got nil")
+	}
+}
+
+// TestCategoryForPath_WhatsApp verifies the WhatsApp route is gated by the
+// provision capability (so disabling provisioning also blocks the bridge).
+func TestCategoryForPath_WhatsApp(t *testing.T) {
+	for _, p := range []string{"/whatsapp", "/whatsapp/health", "/whatsapp/admin/tenants"} {
+		if got := categoryForPath(p); got != "provision" {
+			t.Errorf("categoryForPath(%q) = %q, want provision", p, got)
+		}
+	}
+}

--- a/internal/gateway/gateway_test.go
+++ b/internal/gateway/gateway_test.go
@@ -534,9 +534,10 @@ func TestSetUpstreamAddress_DynamicRoute(t *testing.T) {
 	backendAddr := backend.URL[len("http://"):]
 
 	gw := NewServer(Config{NodeName: "test-node"})
-	// Registered up front with NO address (dynamic upstream), StripPrefix like the
-	// real WhatsApp route.
-	gw.AddUpstream(WhatsAppRoutePrefix, &Upstream{StripPrefix: true})
+	// Registered up front with NO address (dynamic upstream), StripPrefix like a
+	// real module route under /modules/<prefix>.
+	routePrefix := ModuleRoutePath("whatsapp")
+	gw.AddUpstream(routePrefix, &Upstream{StripPrefix: true})
 	for prefix, upstream := range gw.config.Upstreams {
 		gw.registerProxy(prefix, upstream)
 	}
@@ -544,7 +545,7 @@ func TestSetUpstreamAddress_DynamicRoute(t *testing.T) {
 	handler := gw.BuildHandler()
 
 	// Before wiring: a 502 (upstream unset), NOT a panic or a 200.
-	req := httptest.NewRequest(http.MethodGet, WhatsAppRoutePrefix+"/health", nil)
+	req := httptest.NewRequest(http.MethodGet, routePrefix+"/health", nil)
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 	if w.Code != http.StatusBadGateway {
@@ -552,12 +553,12 @@ func TestSetUpstreamAddress_DynamicRoute(t *testing.T) {
 	}
 
 	// Wire the route to the backend.
-	if err := gw.SetUpstreamAddress(WhatsAppRoutePrefix, backendAddr); err != nil {
+	if err := gw.SetUpstreamAddress(routePrefix, backendAddr); err != nil {
 		t.Fatalf("SetUpstreamAddress: %v", err)
 	}
 
-	// After wiring: proxies through, prefix stripped (bridge sees /health).
-	req = httptest.NewRequest(http.MethodGet, WhatsAppRoutePrefix+"/health", nil)
+	// After wiring: proxies through, prefix stripped (module sees /health).
+	req = httptest.NewRequest(http.MethodGet, routePrefix+"/health", nil)
 	w = httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
@@ -584,12 +585,107 @@ func TestSetUpstreamAddress_UnknownPrefix(t *testing.T) {
 	}
 }
 
-// TestCategoryForPath_WhatsApp verifies the WhatsApp route is gated by the
-// provision capability (so disabling provisioning also blocks the bridge).
-func TestCategoryForPath_WhatsApp(t *testing.T) {
-	for _, p := range []string{"/whatsapp", "/whatsapp/health", "/whatsapp/admin/tenants"} {
-		if got := categoryForPath(p); got != "provision" {
-			t.Errorf("categoryForPath(%q) = %q, want provision", p, got)
+// stubResolver is a test CapabilityResolver: it maps declared prefixes to
+// capabilities and reports not-found for the rest.
+type stubResolver map[string]string
+
+func (s stubResolver) CapabilityForPrefix(prefix string) (string, bool) {
+	c, ok := s[prefix]
+	return c, ok
+}
+
+// TestModulePrefixFromPath covers extracting the module prefix from a route path.
+func TestModulePrefixFromPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"/modules/whatsapp", "whatsapp"},
+		{"/modules/whatsapp/health", "whatsapp"},
+		{"/modules/whatsapp/admin/tenants", "whatsapp"},
+		{"/modules/my-mod/x", "my-mod"},
+		{"/modules/", ""},
+		{"/modules", ""},
+		{"/terminal", ""},
+		{"/health", ""},
+	}
+	for _, tt := range tests {
+		if got := modulePrefixFromPath(tt.path); got != tt.want {
+			t.Errorf("modulePrefixFromPath(%q) = %q, want %q", tt.path, got, tt.want)
 		}
+	}
+}
+
+// TestCategoryForRequest_ModuleRoute verifies a /modules/<prefix>/ request maps
+// to the capability the resolver (registry) records, defaults to provision for
+// an unknown prefix or nil resolver, and leaves builtin routes untouched.
+func TestCategoryForRequest_ModuleRoute(t *testing.T) {
+	resolver := stubResolver{"whatsapp": "provision", "readmod": "services"}
+
+	// Registered module -> its declared capability.
+	for _, p := range []string{"/modules/whatsapp", "/modules/whatsapp/health", "/modules/whatsapp/admin/tenants"} {
+		if got := categoryForRequest(p, resolver); got != "provision" {
+			t.Errorf("categoryForRequest(%q) = %q, want provision", p, got)
+		}
+	}
+	// A module that declares a DIFFERENT capability (data-plane decoupled from
+	// provision) is gated by that one.
+	if got := categoryForRequest("/modules/readmod/health", resolver); got != "services" {
+		t.Errorf("categoryForRequest(readmod) = %q, want services", got)
+	}
+	// Unknown prefix -> fail closed to provision.
+	if got := categoryForRequest("/modules/unknown/x", resolver); got != "provision" {
+		t.Errorf("categoryForRequest(unknown) = %q, want provision (fail closed)", got)
+	}
+	// Nil resolver -> module routes still gated (provision), builtin unchanged.
+	if got := categoryForRequest("/modules/whatsapp/health", nil); got != "provision" {
+		t.Errorf("categoryForRequest(nil resolver) = %q, want provision", got)
+	}
+	if got := categoryForRequest("/terminal", resolver); got != "console" {
+		t.Errorf("categoryForRequest(/terminal) = %q, want console", got)
+	}
+	if got := categoryForRequest("/health", resolver); got != "" {
+		t.Errorf("categoryForRequest(/health) = %q, want \"\"", got)
+	}
+}
+
+// TestPermissionMiddleware_ModuleCapabilityDecoupled verifies a module can
+// declare a capability OTHER than provision, so revoking provision does not kill
+// its route (landmine d). The read module is gated by services here.
+func TestPermissionMiddleware_ModuleCapabilityDecoupled(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+	backendAddr := backend.URL[len("http://"):]
+
+	gw := NewServer(Config{NodeName: "test-node"})
+	waPrefix := ModuleRoutePath("whatsapp")
+	svcPrefix := ModuleRoutePath("readmod")
+	gw.AddUpstream(waPrefix, &Upstream{Address: backendAddr, StripPrefix: true})
+	gw.AddUpstream(svcPrefix, &Upstream{Address: backendAddr, StripPrefix: true})
+	for prefix, upstream := range gw.config.Upstreams {
+		gw.registerProxy(prefix, upstream)
+	}
+	gw.mux.HandleFunc("/", gw.handleRoot)
+
+	gw.SetProvisionedRegistry(stubResolver{"whatsapp": "provision", "readmod": "services"})
+	// Provision OFF, services ON: the provision-gated module is blocked, the
+	// services-gated module still serves.
+	gw.SetPermissions(&config.Permissions{Provision: false, Services: true})
+	handler := gw.BuildHandler()
+
+	req := httptest.NewRequest(http.MethodGet, waPrefix+"/health", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("provision-gated module with provision off: status = %d, want 403", w.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, svcPrefix+"/health", nil)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code == http.StatusForbidden {
+		t.Errorf("services-gated module with services on: status = %d, want not-403", w.Code)
 	}
 }

--- a/internal/provisionedservice/registry.go
+++ b/internal/provisionedservice/registry.go
@@ -1,0 +1,213 @@
+// Package provisionedservice is the single source of truth for which provisioned
+// modules are exposed on the node's tsnet gateway and under which capability.
+//
+// A provisioned module (e.g. the WhatsApp bridge) binds an auto-selected free
+// host port that nothing on the tsnet stack listens on. It is reached only
+// through a gateway route registered under /modules/<prefix>/, which the gateway
+// strips before forwarding to the module's loopback port. Which modules get a
+// route, under what capability, and at which port is data -- not code. This
+// registry persists that data to a small JSON file in the node state dir so:
+//
+//   - the running gateway can register/wire every declared module at startup and
+//     pick up new ones without a restart (it watches this file), and
+//   - the gateway's permission layer can map any /modules/<prefix>/... request to
+//     the capability the owning module declared, with no hardcoded per-module
+//     switch.
+//
+// Adding a future module therefore requires ZERO gateway source changes: the
+// module's manifest declares its gateway: block, the provision flow writes an
+// Entry here, and the gateway reacts.
+package provisionedservice
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+)
+
+// registryFileName is the JSON file (in the node state dir) that persists the
+// set of exposed provisioned modules.
+const registryFileName = "provisioned-services.json"
+
+// DefaultCapability is the permission that gates a module's gateway route when
+// its manifest does not declare one. Provisioning is what deploys a module, so a
+// module's route defaults to being gated by the same provision capability.
+const DefaultCapability = "provision"
+
+// Entry is one exposed provisioned module. It is the persisted, on-disk shape.
+type Entry struct {
+	// Name is the module's catalog/service name (stable identity, the key for
+	// Remove). Distinct from Prefix so two names could in principle share nothing
+	// but the prefix stays the route slug.
+	Name string `json:"name"`
+	// Prefix is the route slug: the gateway serves the module under
+	// /modules/<prefix>/. Lowercase alphanumeric + dash, no slashes (validated at
+	// the manifest layer; see catalog.GatewaySpec).
+	Prefix string `json:"prefix"`
+	// Port is the module's chosen loopback host port. Zero means "declared but not
+	// yet deployed": the route is registered but its upstream is unset (502 until
+	// the module is deployed and the port is wired).
+	Port int `json:"port"`
+	// Capability is the permission that gates the module's route (one of the
+	// config.Permissions fields). Empty is treated as DefaultCapability by readers.
+	Capability string `json:"capability"`
+}
+
+// Registry is a mutex-guarded, file-backed set of exposed provisioned modules.
+// It is safe for concurrent use. The file is the single source of truth; every
+// operation reads/writes it so separate processes (the CLI provisioning a module
+// and the `citadel work` gateway) see each other's changes.
+type Registry struct {
+	path string
+	mu   sync.Mutex
+}
+
+// New returns a Registry backed by the given file path. The file need not exist
+// yet; List returns empty until the first Register.
+func New(path string) *Registry {
+	return &Registry{path: path}
+}
+
+// Path returns the backing file path (useful for a file watcher).
+func (r *Registry) Path() string { return r.path }
+
+// DefaultPath returns the registry file path inside the given node state dir.
+// Callers pass network.GetStateDir() so the file colocates with the node's other
+// persisted state and resolves consistently across sudo/user contexts.
+func DefaultPath(stateDir string) string {
+	return filepath.Join(stateDir, registryFileName)
+}
+
+// load reads the file into a slice. A missing file is an empty registry (not an
+// error). Caller holds r.mu.
+func (r *Registry) load() ([]Entry, error) {
+	data, err := os.ReadFile(r.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read provisioned-service registry: %w", err)
+	}
+	if len(data) == 0 {
+		return nil, nil
+	}
+	var entries []Entry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return nil, fmt.Errorf("parse provisioned-service registry %s: %w", r.path, err)
+	}
+	return entries, nil
+}
+
+// save writes the slice atomically (temp file + rename) so a concurrent reader
+// never sees a half-written file. Caller holds r.mu.
+func (r *Registry) save(entries []Entry) error {
+	// Stable order for deterministic output and readable diffs.
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
+	data, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode provisioned-service registry: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(r.path), 0755); err != nil {
+		return fmt.Errorf("create state dir for provisioned-service registry: %w", err)
+	}
+	tmp := r.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return fmt.Errorf("write provisioned-service registry: %w", err)
+	}
+	if err := os.Rename(tmp, r.path); err != nil {
+		return fmt.Errorf("replace provisioned-service registry: %w", err)
+	}
+	return nil
+}
+
+// Register adds or updates an entry keyed by Name (an existing entry with the
+// same Name is replaced, so re-provisioning a module updates its port/capability
+// in place). Prefix must be non-empty; an empty Capability is stored as
+// DefaultCapability so readers never have to special-case it.
+func (r *Registry) Register(e Entry) error {
+	if e.Name == "" {
+		return fmt.Errorf("provisionedservice.Register: empty name")
+	}
+	if e.Prefix == "" {
+		return fmt.Errorf("provisionedservice.Register: empty prefix for %q", e.Name)
+	}
+	if e.Capability == "" {
+		e.Capability = DefaultCapability
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	entries, err := r.load()
+	if err != nil {
+		return err
+	}
+	replaced := false
+	for i := range entries {
+		if entries[i].Name == e.Name {
+			entries[i] = e
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		entries = append(entries, e)
+	}
+	return r.save(entries)
+}
+
+// Remove deletes the entry with the given Name. Removing an absent name is a
+// no-op (no error), so teardown is idempotent.
+func (r *Registry) Remove(name string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	entries, err := r.load()
+	if err != nil {
+		return err
+	}
+	out := entries[:0]
+	for _, e := range entries {
+		if e.Name != name {
+			out = append(out, e)
+		}
+	}
+	return r.save(out)
+}
+
+// List returns a copy of all registered entries (empty when the file is absent).
+func (r *Registry) List() ([]Entry, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	entries, err := r.load()
+	if err != nil {
+		return nil, err
+	}
+	// Normalize the capability on read so callers always see a concrete value.
+	for i := range entries {
+		if entries[i].Capability == "" {
+			entries[i].Capability = DefaultCapability
+		}
+	}
+	return entries, nil
+}
+
+// CapabilityForPrefix returns the capability gating the module served under the
+// given prefix, and whether such a module is registered. A registered module
+// with an empty stored capability reports DefaultCapability. This is the lookup
+// the gateway's permission layer uses to gate /modules/<prefix>/... requests.
+func (r *Registry) CapabilityForPrefix(prefix string) (capability string, found bool) {
+	entries, err := r.List()
+	if err != nil {
+		return "", false
+	}
+	for _, e := range entries {
+		if e.Prefix == prefix {
+			if e.Capability == "" {
+				return DefaultCapability, true
+			}
+			return e.Capability, true
+		}
+	}
+	return "", false
+}

--- a/internal/provisionedservice/registry_test.go
+++ b/internal/provisionedservice/registry_test.go
@@ -123,7 +123,7 @@ func TestConcurrentRegister(t *testing.T) {
 	r := newTestRegistry(t)
 	const n = 20
 	var wg sync.WaitGroup
-	for i := 0; i < n; i++ {
+	for i := range n {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()

--- a/internal/provisionedservice/registry_test.go
+++ b/internal/provisionedservice/registry_test.go
@@ -1,0 +1,144 @@
+package provisionedservice
+
+import (
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func newTestRegistry(t *testing.T) *Registry {
+	t.Helper()
+	return New(filepath.Join(t.TempDir(), registryFileName))
+}
+
+// TestListEmptyWhenAbsent: a registry whose file has never been written lists
+// empty without error.
+func TestListEmptyWhenAbsent(t *testing.T) {
+	r := newTestRegistry(t)
+	entries, err := r.List()
+	if err != nil {
+		t.Fatalf("List on absent file: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("List = %v, want empty", entries)
+	}
+}
+
+// TestRegisterListRoundTrip: an entry survives a round-trip through the file and
+// an empty capability is defaulted.
+func TestRegisterListRoundTrip(t *testing.T) {
+	r := newTestRegistry(t)
+	if err := r.Register(Entry{Name: "mod-a", Prefix: "mod-a", Port: 8137}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	// A fresh Registry over the same file (separate process semantics).
+	r2 := New(r.Path())
+	entries, err := r2.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len = %d, want 1", len(entries))
+	}
+	e := entries[0]
+	if e.Name != "mod-a" || e.Prefix != "mod-a" || e.Port != 8137 {
+		t.Fatalf("entry = %+v, want name/prefix mod-a port 8137", e)
+	}
+	if e.Capability != DefaultCapability {
+		t.Fatalf("capability = %q, want default %q", e.Capability, DefaultCapability)
+	}
+}
+
+// TestRegisterReplacesByName: re-registering the same name updates in place
+// rather than duplicating.
+func TestRegisterReplacesByName(t *testing.T) {
+	r := newTestRegistry(t)
+	if err := r.Register(Entry{Name: "mod", Prefix: "mod", Port: 1, Capability: "provision"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Register(Entry{Name: "mod", Prefix: "mod", Port: 2, Capability: "services"}); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := r.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len = %d, want 1 (replace, not append)", len(entries))
+	}
+	if entries[0].Port != 2 || entries[0].Capability != "services" {
+		t.Fatalf("entry = %+v, want port 2 cap services", entries[0])
+	}
+}
+
+// TestRemove: removing an entry drops it; removing an absent name is a no-op.
+func TestRemove(t *testing.T) {
+	r := newTestRegistry(t)
+	_ = r.Register(Entry{Name: "a", Prefix: "a"})
+	_ = r.Register(Entry{Name: "b", Prefix: "b"})
+	if err := r.Remove("a"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if err := r.Remove("does-not-exist"); err != nil {
+		t.Fatalf("Remove absent = %v, want nil (idempotent)", err)
+	}
+	entries, _ := r.List()
+	if len(entries) != 1 || entries[0].Name != "b" {
+		t.Fatalf("after remove entries = %+v, want only b", entries)
+	}
+}
+
+// TestCapabilityForPrefix: lookup returns the module's capability, defaults an
+// empty stored capability, and reports not-found for an unknown prefix.
+func TestCapabilityForPrefix(t *testing.T) {
+	r := newTestRegistry(t)
+	_ = r.Register(Entry{Name: "wa", Prefix: "whatsapp", Capability: "provision"})
+	_ = r.Register(Entry{Name: "svc", Prefix: "svc"}) // empty -> default
+
+	if cap, ok := r.CapabilityForPrefix("whatsapp"); !ok || cap != "provision" {
+		t.Fatalf("whatsapp -> (%q,%v), want (provision,true)", cap, ok)
+	}
+	if cap, ok := r.CapabilityForPrefix("svc"); !ok || cap != DefaultCapability {
+		t.Fatalf("svc -> (%q,%v), want (%q,true)", cap, ok, DefaultCapability)
+	}
+	if cap, ok := r.CapabilityForPrefix("nope"); ok || cap != "" {
+		t.Fatalf("nope -> (%q,%v), want (\"\",false)", cap, ok)
+	}
+}
+
+// TestRegisterRejectsEmpty: name and prefix are required.
+func TestRegisterRejectsEmpty(t *testing.T) {
+	r := newTestRegistry(t)
+	if err := r.Register(Entry{Prefix: "p"}); err == nil {
+		t.Error("expected error for empty name")
+	}
+	if err := r.Register(Entry{Name: "n"}); err == nil {
+		t.Error("expected error for empty prefix")
+	}
+}
+
+// TestConcurrentRegister exercises the mutex: many goroutines register distinct
+// names concurrently and all survive. Run with -race to catch data races.
+func TestConcurrentRegister(t *testing.T) {
+	r := newTestRegistry(t)
+	const n = 20
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			name := string(rune('a'+i%26)) + "-" + string(rune('0'+i/26))
+			if err := r.Register(Entry{Name: name, Prefix: name, Port: 8000 + i}); err != nil {
+				t.Errorf("concurrent Register: %v", err)
+			}
+		}(i)
+	}
+	wg.Wait()
+	entries, err := r.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(entries) != n {
+		t.Fatalf("len = %d, want %d (no lost updates)", len(entries), n)
+	}
+}

--- a/internal/status/gateway_cert_test.go
+++ b/internal/status/gateway_cert_test.go
@@ -60,8 +60,9 @@ func TestHandleGatewayCert_NoTLS(t *testing.T) {
 }
 
 // TestHandleGatewayCert_MissingFile verifies that a configured-but-missing cert
-// file returns 204 (TLS configured but cert not yet on disk) rather than 500, so
-// the backend can retry from cert_refresh_url once the gateway writes the cert.
+// file (TLS on, cert not yet written -- a cold-start race) returns 503, NOT 204,
+// so the backend retries from cert_refresh_url rather than mis-downgrading to
+// plain http against a TLS gateway.
 func TestHandleGatewayCert_MissingFile(t *testing.T) {
 	server := NewServer(ServerConfig{GatewayCertPath: filepath.Join(t.TempDir(), "absent.pem")}, NewCollector(CollectorConfig{}))
 	mux := server.buildMux()
@@ -70,8 +71,8 @@ func TestHandleGatewayCert_MissingFile(t *testing.T) {
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("status = %d, want 204", w.Code)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", w.Code)
 	}
 }
 

--- a/internal/status/gateway_cert_test.go
+++ b/internal/status/gateway_cert_test.go
@@ -1,0 +1,95 @@
+package status
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const testCertPEM = `-----BEGIN CERTIFICATE-----
+MIIB+zCCAWSgAwIBAgIQ test-gateway-leaf-cert-placeholder
+-----END CERTIFICATE-----
+`
+
+// TestHandleGatewayCert_ServesPEM verifies that GET /gateway-cert.pem returns the
+// on-disk gateway leaf cert PEM with the x-pem-file content type and HTTP 200.
+func TestHandleGatewayCert_ServesPEM(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "cert.pem")
+	if err := os.WriteFile(certPath, []byte(testCertPEM), 0600); err != nil {
+		t.Fatalf("write test cert: %v", err)
+	}
+
+	server := NewServer(ServerConfig{GatewayCertPath: certPath}, NewCollector(CollectorConfig{}))
+	mux := server.buildMux()
+
+	req := httptest.NewRequest(http.MethodGet, "/gateway-cert.pem", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/x-pem-file" {
+		t.Errorf("Content-Type = %q, want application/x-pem-file", ct)
+	}
+	if w.Body.String() != testCertPEM {
+		t.Errorf("body = %q, want the cert PEM", w.Body.String())
+	}
+}
+
+// TestHandleGatewayCert_NoTLS verifies that when no cert path is configured (the
+// gateway runs --gateway-no-tls), the endpoint returns 204 No Content so the
+// backend falls back to plain http.
+func TestHandleGatewayCert_NoTLS(t *testing.T) {
+	server := NewServer(ServerConfig{GatewayCertPath: ""}, NewCollector(CollectorConfig{}))
+	mux := server.buildMux()
+
+	req := httptest.NewRequest(http.MethodGet, "/gateway-cert.pem", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", w.Code)
+	}
+	if w.Body.Len() != 0 {
+		t.Errorf("body should be empty, got %q", w.Body.String())
+	}
+}
+
+// TestHandleGatewayCert_MissingFile verifies that a configured-but-missing cert
+// file returns 204 (TLS configured but cert not yet on disk) rather than 500, so
+// the backend can retry from cert_refresh_url once the gateway writes the cert.
+func TestHandleGatewayCert_MissingFile(t *testing.T) {
+	server := NewServer(ServerConfig{GatewayCertPath: filepath.Join(t.TempDir(), "absent.pem")}, NewCollector(CollectorConfig{}))
+	mux := server.buildMux()
+
+	req := httptest.NewRequest(http.MethodGet, "/gateway-cert.pem", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", w.Code)
+	}
+}
+
+// TestHandleGatewayCert_MethodNotAllowed verifies non-GET is rejected.
+func TestHandleGatewayCert_MethodNotAllowed(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "cert.pem")
+	if err := os.WriteFile(certPath, []byte(testCertPEM), 0600); err != nil {
+		t.Fatalf("write test cert: %v", err)
+	}
+	server := NewServer(ServerConfig{GatewayCertPath: certPath}, NewCollector(CollectorConfig{}))
+	mux := server.buildMux()
+
+	req := httptest.NewRequest(http.MethodPost, "/gateway-cert.pem", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", w.Code)
+	}
+}

--- a/internal/status/server.go
+++ b/internal/status/server.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -30,6 +31,14 @@ type Server struct {
 	tokenValidator terminal.TokenValidator
 	orgID          string
 	enableDesktop  bool
+
+	// gatewayCertPath is the on-disk path to the gateway's self-signed leaf cert
+	// PEM. When set, the status server serves it unauthenticated at
+	// GET /gateway-cert.pem so the backend can fetch (and re-fetch on rotation)
+	// the cert it must trust to reach this node's TLS gateway. Empty means the
+	// gateway runs without TLS (--gateway-no-tls), in which case the endpoint
+	// returns 204 No Content to signal "use plain http".
+	gatewayCertPath string
 
 	// agent provides the data/actions backing the /agent/* introspection &
 	// control endpoints (issue #236). Nil disables those routes.
@@ -63,6 +72,14 @@ type ServerConfig struct {
 	// HTTP routes on the status server's mux. This allows external packages
 	// (e.g., workflow) to add endpoints without modifying the status package.
 	ExtraRoutes func(mux *http.ServeMux)
+
+	// GatewayCertPath is the on-disk path to the gateway's self-signed leaf cert
+	// PEM. When non-empty, GET /gateway-cert.pem serves that PEM unauthenticated
+	// (a public leaf cert is safe to hand out) so the backend can fetch the cert
+	// it must trust to reach this node's TLS gateway, and re-fetch it on rotation.
+	// Empty means the gateway has no TLS cert (--gateway-no-tls); the endpoint
+	// then returns 204 No Content to tell the backend to use plain http.
+	GatewayCertPath string
 }
 
 // NewServer creates a new status HTTP server.
@@ -71,14 +88,15 @@ func NewServer(cfg ServerConfig, collector *Collector) *Server {
 		cfg.Port = 8080
 	}
 	return &Server{
-		collector:      collector,
-		port:           cfg.Port,
-		version:        cfg.Version,
-		tokenValidator: cfg.TokenValidator,
-		orgID:          cfg.OrgID,
-		enableDesktop:  cfg.EnableDesktop,
-		agent:          cfg.Agent,
-		extraRoutes:    cfg.ExtraRoutes,
+		collector:       collector,
+		port:            cfg.Port,
+		version:         cfg.Version,
+		tokenValidator:  cfg.TokenValidator,
+		orgID:           cfg.OrgID,
+		enableDesktop:   cfg.EnableDesktop,
+		agent:           cfg.Agent,
+		extraRoutes:     cfg.ExtraRoutes,
+		gatewayCertPath: cfg.GatewayCertPath,
 	}
 }
 
@@ -107,6 +125,13 @@ func (s *Server) buildMux() *http.ServeMux {
 	mux.HandleFunc("/status", s.handleStatus)
 	mux.HandleFunc("/health", s.handleHealth)
 	mux.HandleFunc("/services", s.handleServices)
+
+	// Publish the gateway's self-signed leaf cert so the backend can trust it
+	// out-of-band (and re-fetch on rotation). Served unauthenticated over the
+	// plaintext status server so it is a bootstrap channel that does not require
+	// already trusting the cert being fetched. A public leaf cert is safe to hand
+	// out. Returns 204 when the gateway runs without TLS.
+	mux.HandleFunc("/gateway-cert.pem", s.handleGatewayCert)
 
 	if s.tokenValidator != nil && s.enableDesktop {
 		mux.HandleFunc("/api/screenshot", s.requireAuth(s.handleScreenshot))
@@ -258,6 +283,43 @@ func (s *Server) handlePing(w http.ResponseWriter, r *http.Request) {
 		"status":    "pong",
 		"timestamp": time.Now().UTC().Format(time.RFC3339),
 	})
+}
+
+// handleGatewayCert serves the gateway's current self-signed leaf cert PEM so the
+// backend can trust it out-of-band and re-fetch it after a rotation.
+// GET /gateway-cert.pem
+//
+// Unauthenticated by design: the response is a PUBLIC leaf cert (safe to hand
+// out), and this is the bootstrap/refresh channel the backend uses BEFORE it
+// trusts the cert, so it must not require the very trust it establishes. It reads
+// the current PEM from disk on every request so a rotated cert (the gateway
+// regenerates it in place when the mesh IP changes) is always served fresh.
+//
+// Returns 204 No Content when the gateway has no TLS cert (--gateway-no-tls),
+// signaling the backend to reach the node over plain http instead.
+func (s *Server) handleGatewayCert(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.gatewayCertPath == "" {
+		// No TLS cert configured: the gateway runs --gateway-no-tls. Tell the
+		// backend to use plain http.
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	pem, err := os.ReadFile(s.gatewayCertPath)
+	if err != nil {
+		// The gateway is configured for TLS but its cert is not (yet) on disk.
+		// Surface it as a 204 so the backend falls back to plain http rather than
+		// erroring; the caller can re-fetch from cert_refresh_url once the gateway
+		// has written the cert.
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	w.Header().Set("Content-Type", "application/x-pem-file")
+	w.WriteHeader(http.StatusOK)
+	w.Write(pem)
 }
 
 func (s *Server) requireAuth(next http.HandlerFunc) http.HandlerFunc {

--- a/internal/status/server.go
+++ b/internal/status/server.go
@@ -296,7 +296,9 @@ func (s *Server) handlePing(w http.ResponseWriter, r *http.Request) {
 // regenerates it in place when the mesh IP changes) is always served fresh.
 //
 // Returns 204 No Content when the gateway has no TLS cert (--gateway-no-tls),
-// signaling the backend to reach the node over plain http instead.
+// signaling the backend to reach the node over plain http instead. Returns 503
+// when TLS is configured but the cert is not yet on disk (a cold-start race) so
+// the backend retries rather than mis-downgrading to http.
 func (s *Server) handleGatewayCert(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -310,11 +312,13 @@ func (s *Server) handleGatewayCert(w http.ResponseWriter, r *http.Request) {
 	}
 	pem, err := os.ReadFile(s.gatewayCertPath)
 	if err != nil {
-		// The gateway is configured for TLS but its cert is not (yet) on disk.
-		// Surface it as a 204 so the backend falls back to plain http rather than
-		// erroring; the caller can re-fetch from cert_refresh_url once the gateway
-		// has written the cert.
-		w.WriteHeader(http.StatusNoContent)
+		// TLS IS configured (path is set) but the cert is not on disk yet -- a
+		// brief cold-start race before the gateway writes it. Do NOT return 204
+		// here: 204 means "TLS off, use plain http", and downgrading to http
+		// against a TLS gateway would fail. Return 503 so the backend RETRIES
+		// (from cert_refresh_url) once the cert exists, instead of mis-detecting
+		// the node as no-TLS.
+		w.WriteHeader(http.StatusServiceUnavailable)
 		return
 	}
 	w.Header().Set("Content-Type", "application/x-pem-file")

--- a/internal/whatsapp/provision.go
+++ b/internal/whatsapp/provision.go
@@ -69,10 +69,37 @@ type ProvisionDeps struct {
 	NewBridgeClient func(port int, adminKey string) BridgeClient
 
 	// MeshAPIURL returns the api_url the shared backend must use to reach this
-	// bridge: the node's mesh (Headscale) IP and the published port. It returns
-	// "" when the node is not connected to the mesh, which Provision treats as a
+	// bridge over the mesh. It MUST return an actually-reachable URL -- the
+	// gateway route form (https://<node-vpn-ip>:<gateway-port>/whatsapp), NOT a
+	// raw http://<vpn-ip>:<bridge-port> that nothing on the tsnet stack listens
+	// on. Only the status/terminal/gateway servers bind a tsnet listener on the
+	// node VPN IP; a provisioned bridge on an auto-selected host port is reached
+	// only through the gateway route (aceteam-ai/citadel-cli#447).
+	//
+	// The port argument is the bridge's host port; the returned URL is the
+	// gateway route (independent of that port -- the gateway strips the prefix
+	// and forwards to the bridge port set via ExposeGatewayRoute). It returns ""
+	// when the node is not connected to the mesh, which Provision treats as a
 	// hard error (the backend cannot reach a loopback address).
 	MeshAPIURL func(port int) string
+
+	// ExposeGatewayRoute points the gateway's provisioned-service route at the
+	// bridge's loopback host port so the mesh URL returned by MeshAPIURL is
+	// actually reachable. It is the side effect that makes the bridge reachable
+	// on the tsnet mesh (the gateway already binds a tsnet listener on the node
+	// VPN IP; this just wires the /whatsapp route to 127.0.0.1:<bridgePort>).
+	// Nil means "no gateway to register with" -- Provision then relies purely on
+	// VerifyReachable to catch an unreachable bridge (fail loud, not false-green).
+	ExposeGatewayRoute func(bridgePort int) error
+
+	// VerifyReachable confirms the backend-facing api_url is actually reachable
+	// from the node's own mesh identity (e.g. GET the bridge root through the
+	// gateway route). Provision calls it after deploy + route-exposure and BEFORE
+	// computing already_linked / returning success, so an unexposed or wedged
+	// bridge fails loud with an actionable error instead of a structural
+	// false-green (aceteam-ai/citadel-cli#447). Nil skips the check (used by unit
+	// tests that stub the whole flow); real wiring always provides it.
+	VerifyReachable func(ctx context.Context, apiURL string) error
 
 	// GenerateAdminKey mints a fresh admin secret when none is stored yet.
 	// Defaults to GenerateAdminKey.
@@ -230,12 +257,37 @@ func Provision(ctx context.Context, req ProvisionRequest, deps ProvisionDeps) (*
 		return nil, fmt.Errorf("node left the AceTeam mesh network during provisioning; cannot determine a reachable api_url")
 	}
 
+	// Expose the bridge on the tsnet-reachable surface: point the gateway's
+	// provisioned-service route at the bridge's loopback host port. Without this
+	// the api_url above resolves to the gateway's VPN listener but the route has
+	// no upstream, so the backend gets a 502 -- the exact "bridge unreachable"
+	// this fixes (aceteam-ai/citadel-cli#447). A registration failure is fatal:
+	// returning success with an unreachable api_url is the false-green we are
+	// eliminating.
+	if deps.ExposeGatewayRoute != nil {
+		if err := deps.ExposeGatewayRoute(port); err != nil {
+			return nil, fmt.Errorf("expose bridge on the mesh gateway: %w", err)
+		}
+	}
+
 	client := deps.NewBridgeClient(port, adminKey)
 	log("waiting for the bridge to become ready")
 	waitCtx, cancel := context.WithTimeout(ctx, readyTimeout)
 	defer cancel()
 	if err := client.WaitReady(waitCtx, readyTimeout); err != nil {
 		return nil, fmt.Errorf("bridge did not become ready: %w (check `docker compose -p %s logs %s`)", err, ProjectName(servicesDir), BridgeService)
+	}
+
+	// Verify the backend-facing api_url is actually reachable from the node's own
+	// mesh identity BEFORE returning success or computing already_linked. The
+	// loopback bridge being up (WaitReady, above) does NOT prove the mesh path
+	// works: the gateway route or the tsnet listener could be missing. This is
+	// the check that turns the old structural false-green (report success on an
+	// unreachable bridge) into a loud, actionable failure (#447).
+	if deps.VerifyReachable != nil {
+		if err := deps.VerifyReachable(waitCtx, apiURL); err != nil {
+			return nil, fmt.Errorf("bridge is up locally but its mesh api_url %s is NOT reachable: %w -- the backend would not be able to reach it. Ensure `citadel work` is running with the gateway enabled (it exposes provisioned services on the mesh)", apiURL, err)
+		}
 	}
 
 	// Mint (or reuse) the tenant. Reusing a previously minted tenant preserves an

--- a/internal/whatsapp/provision.go
+++ b/internal/whatsapp/provision.go
@@ -70,8 +70,8 @@ type ProvisionDeps struct {
 
 	// MeshAPIURL returns the api_url the shared backend must use to reach this
 	// bridge over the mesh. It MUST return an actually-reachable URL -- the
-	// gateway route form (https://<node-vpn-ip>:<gateway-port>/whatsapp), NOT a
-	// raw http://<vpn-ip>:<bridge-port> that nothing on the tsnet stack listens
+	// gateway route form (https://<node-vpn-ip>:<gateway-port>/modules/<prefix>),
+	// NOT a raw http://<vpn-ip>:<bridge-port> that nothing on the tsnet stack listens
 	// on. Only the status/terminal/gateway servers bind a tsnet listener on the
 	// node VPN IP; a provisioned bridge on an auto-selected host port is reached
 	// only through the gateway route (aceteam-ai/citadel-cli#447).
@@ -87,7 +87,7 @@ type ProvisionDeps struct {
 	// bridge's loopback host port so the mesh URL returned by MeshAPIURL is
 	// actually reachable. It is the side effect that makes the bridge reachable
 	// on the tsnet mesh (the gateway already binds a tsnet listener on the node
-	// VPN IP; this just wires the /whatsapp route to 127.0.0.1:<bridgePort>).
+	// VPN IP; this just wires the /modules/<prefix> route to 127.0.0.1:<bridgePort>).
 	// Nil means "no gateway to register with" -- Provision then relies purely on
 	// VerifyReachable to catch an unreachable bridge (fail loud, not false-green).
 	ExposeGatewayRoute func(bridgePort int) error

--- a/internal/whatsapp/provision.go
+++ b/internal/whatsapp/provision.go
@@ -115,6 +115,18 @@ type ProvisionDeps struct {
 	// simulate an occupied port without touching the network stack.
 	SelectHostPort func(preferred, floor int) (int, error)
 
+	// GatewayCertPEM returns the current gateway self-signed leaf cert PEM the
+	// backend must trust to reach the https gateway-route api_url. It returns ""
+	// when the gateway runs without TLS or the cert is unavailable (the backend
+	// then uses plain http). Nil leaves ProvisionResult.GatewayCertPEM empty (so
+	// older wiring without this dep degrades gracefully to no-cert).
+	GatewayCertPEM func() string
+
+	// CertRefreshURL returns the plaintext URL the backend re-fetches the gateway
+	// cert from on rotation (http://<mesh-ip>:<status-port>/gateway-cert.pem), or
+	// "" when off-mesh / status port unknown. Nil leaves the field empty.
+	CertRefreshURL func() string
+
 	// ReadyTimeout bounds the WaitReady poll. Zero uses 90s.
 	ReadyTimeout time.Duration
 
@@ -141,6 +153,15 @@ type ProvisionResult struct {
 	// AlreadyLinked is true when the tenant already has a live WhatsApp session
 	// (no QR is needed).
 	AlreadyLinked bool
+	// GatewayCertPEM is the current gateway self-signed leaf cert PEM the backend
+	// must trust to reach APIURL (which is an https gateway route). Empty when the
+	// gateway runs without TLS (--gateway-no-tls) or the cert is unavailable, in
+	// which case the backend uses plain http. A public leaf cert, safe to serve.
+	GatewayCertPEM string
+	// CertRefreshURL is the plaintext URL the backend re-fetches the gateway cert
+	// from on rotation: http://<mesh-ip>:<status-port>/gateway-cert.pem. Empty when
+	// the node is off-mesh or the status server's port is unknown.
+	CertRefreshURL string
 }
 
 // Provision runs the full deploy -> mint -> wait -> fetch-QR flow and returns the
@@ -321,6 +342,16 @@ func Provision(ctx context.Context, req ProvisionRequest, deps ProvisionDeps) (*
 		APIKey: tenantKey,
 		Tenant: tenant,
 		Port:   port,
+	}
+	// Publish the gateway cert (so the backend can trust the https api_url) and the
+	// plaintext refresh URL (so it re-fetches on rotation). Both deps are optional:
+	// a nil dep leaves the corresponding field empty, which the backend treats as
+	// "no cert / use http" and "no refresh channel".
+	if deps.GatewayCertPEM != nil {
+		result.GatewayCertPEM = deps.GatewayCertPEM()
+	}
+	if deps.CertRefreshURL != nil {
+		result.CertRefreshURL = deps.CertRefreshURL()
 	}
 
 	// If the tenant is already linked, there is no QR to scan.

--- a/internal/whatsapp/provision_test.go
+++ b/internal/whatsapp/provision_test.go
@@ -311,3 +311,53 @@ func TestQRDataURL(t *testing.T) {
 		t.Errorf("decoded bytes are not a PNG (magic = %x)", raw[:min(8, len(raw))])
 	}
 }
+
+// TestProvisionPopulatesCertFields verifies the provision result carries the
+// gateway cert PEM + plaintext cert refresh URL from the injected deps (the
+// node half of the cert-publish contract, aceteam-ai/citadel-cli#448).
+func TestProvisionPopulatesCertFields(t *testing.T) {
+	bridge := &fakeBridge{health: &Health{}, qr: "x"}
+	deps, _ := baseDeps(t, bridge)
+	deps.GatewayCertPEM = func() string { return "-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----\n" }
+	deps.CertRefreshURL = func() string { return "http://100.64.0.7:8080/gateway-cert.pem" }
+
+	res, err := Provision(context.Background(), ProvisionRequest{}, deps)
+	if err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+	if res.GatewayCertPEM != "-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----\n" {
+		t.Errorf("GatewayCertPEM = %q, want the injected PEM", res.GatewayCertPEM)
+	}
+	if res.CertRefreshURL != "http://100.64.0.7:8080/gateway-cert.pem" {
+		t.Errorf("CertRefreshURL = %q, want the injected refresh URL", res.CertRefreshURL)
+	}
+}
+
+// TestProvisionCertFieldsEmptyOffMeshOrNoTLS verifies that when the cert deps
+// report no cert / off-mesh (empty strings) or are nil, the result fields stay
+// empty (older backends ignore them; omitempty on the wire keys).
+func TestProvisionCertFieldsEmptyOffMeshOrNoTLS(t *testing.T) {
+	// Case 1: deps present but return "" (gateway --gateway-no-tls / off-mesh).
+	bridge := &fakeBridge{health: &Health{}, qr: "x"}
+	deps, _ := baseDeps(t, bridge)
+	deps.GatewayCertPEM = func() string { return "" }
+	deps.CertRefreshURL = func() string { return "" }
+	res, err := Provision(context.Background(), ProvisionRequest{}, deps)
+	if err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+	if res.GatewayCertPEM != "" || res.CertRefreshURL != "" {
+		t.Errorf("cert fields should be empty when deps return empty, got pem=%q url=%q", res.GatewayCertPEM, res.CertRefreshURL)
+	}
+
+	// Case 2: deps entirely absent (nil) -> fields remain empty, no panic.
+	bridge2 := &fakeBridge{health: &Health{}, qr: "x"}
+	deps2, _ := baseDeps(t, bridge2)
+	res2, err := Provision(context.Background(), ProvisionRequest{}, deps2)
+	if err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+	if res2.GatewayCertPEM != "" || res2.CertRefreshURL != "" {
+		t.Errorf("cert fields should be empty when deps are nil, got pem=%q url=%q", res2.GatewayCertPEM, res2.CertRefreshURL)
+	}
+}

--- a/internal/whatsapp/provision_test.go
+++ b/internal/whatsapp/provision_test.go
@@ -183,6 +183,91 @@ func TestProvisionReusesExistingTenant(t *testing.T) {
 	}
 }
 
+// TestProvisionExposesGatewayRouteWithBridgePort verifies Provision wires the
+// gateway route to the bridge's chosen host port (aceteam-ai/citadel-cli#447).
+func TestProvisionExposesGatewayRouteWithBridgePort(t *testing.T) {
+	bridge := &fakeBridge{health: &Health{LoggedIn: false}, qr: "q"}
+	deps, _ := baseDeps(t, bridge)
+	// Pin an explicit port so the assertion is deterministic (operator override
+	// is honored verbatim).
+	var exposedPort int
+	exposeCalls := 0
+	deps.ExposeGatewayRoute = func(bridgePort int) error {
+		exposeCalls++
+		exposedPort = bridgePort
+		return nil
+	}
+	if _, err := Provision(context.Background(), ProvisionRequest{Port: 8137}, deps); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+	if exposeCalls != 1 {
+		t.Fatalf("ExposeGatewayRoute calls = %d, want 1", exposeCalls)
+	}
+	if exposedPort != 8137 {
+		t.Errorf("exposed bridge port = %d, want 8137 (the published host port)", exposedPort)
+	}
+}
+
+// TestProvisionExposeGatewayRouteErrorIsFatal verifies a route-exposure failure
+// fails the provision loud rather than returning a false-green with an
+// unreachable api_url.
+func TestProvisionExposeGatewayRouteErrorIsFatal(t *testing.T) {
+	bridge := &fakeBridge{health: &Health{LoggedIn: false}, qr: "q"}
+	deps, _ := baseDeps(t, bridge)
+	deps.ExposeGatewayRoute = func(int) error { return errors.New("no gateway running") }
+	_, err := Provision(context.Background(), ProvisionRequest{}, deps)
+	if err == nil || !strings.Contains(err.Error(), "gateway") {
+		t.Fatalf("expected a loud gateway-exposure error, got %v", err)
+	}
+}
+
+// TestProvisionVerifyReachableFailsBeforeAlreadyLinked is the core #447 guard:
+// when the mesh api_url is NOT reachable, Provision must fail loud EVEN IF the
+// tenant is already linked (the false-green we hit). The health probe says
+// logged-in, but the reachability check must run first and sink the provision.
+func TestProvisionVerifyReachableFailsBeforeAlreadyLinked(t *testing.T) {
+	bridge := &fakeBridge{health: &Health{LoggedIn: true}, qr: ""}
+	deps, _ := baseDeps(t, bridge)
+	verifyCalls := 0
+	deps.VerifyReachable = func(ctx context.Context, apiURL string) error {
+		verifyCalls++
+		return errors.New("HTTP 502 (bridge not exposed on the mesh)")
+	}
+	res, err := Provision(context.Background(), ProvisionRequest{}, deps)
+	if err == nil {
+		t.Fatalf("expected a loud unreachable error, got success res=%+v", res)
+	}
+	if verifyCalls != 1 {
+		t.Errorf("VerifyReachable calls = %d, want 1 (must run before already_linked)", verifyCalls)
+	}
+	if !strings.Contains(err.Error(), "reachable") {
+		t.Errorf("error = %q, want it to explain the bridge is not reachable", err.Error())
+	}
+}
+
+// TestProvisionVerifyReachableReceivesMeshAPIURL asserts the reachability probe
+// is handed the same api_url the result advertises (so the check is meaningful).
+func TestProvisionVerifyReachableReceivesMeshAPIURL(t *testing.T) {
+	bridge := &fakeBridge{health: &Health{LoggedIn: false}, qr: "q"}
+	deps, _ := baseDeps(t, bridge)
+	deps.MeshAPIURL = func(port int) string { return "https://100.64.0.7:8443/whatsapp" }
+	var gotURL string
+	deps.VerifyReachable = func(ctx context.Context, apiURL string) error {
+		gotURL = apiURL
+		return nil
+	}
+	res, err := Provision(context.Background(), ProvisionRequest{}, deps)
+	if err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+	if gotURL != "https://100.64.0.7:8443/whatsapp" {
+		t.Errorf("VerifyReachable got api_url %q, want the gateway-route URL", gotURL)
+	}
+	if res.APIURL != "https://100.64.0.7:8443/whatsapp" {
+		t.Errorf("result api_url = %q, want the gateway-route URL", res.APIURL)
+	}
+}
+
 func TestProvisionQRFetchErrorIsNonFatal(t *testing.T) {
 	bridge := &fakeBridge{health: &Health{LoggedIn: false}, qrErr: errors.New("transient")}
 	deps, _ := baseDeps(t, bridge)

--- a/internal/worker/whatsapp_provision.go
+++ b/internal/worker/whatsapp_provision.go
@@ -23,7 +23,10 @@
 //	  "api_key": "<per-tenant wab_ key>",
 //	  "qr":      "data:image/png;base64,...",  // "" when already linked
 //	  "tenant":  "<name>",
-//	  "status":  "provisioned" | "already_linked"
+//	  "status":  "provisioned" | "already_linked",
+//	  // Optional cert-publish contract (#448), omitted when off-mesh / no-TLS:
+//	  "gateway_cert_pem": "-----BEGIN CERTIFICATE-----...", // trust to reach api_url
+//	  "cert_refresh_url": "http://<mesh-ip>:<status-port>/gateway-cert.pem"
 //	}
 //
 // # Privilege gating
@@ -139,6 +142,17 @@ func (h *WhatsAppProvisionHandler) Execute(ctx context.Context, job *Job, stream
 		"qr":      qrDataURL,
 		"tenant":  res.Tenant,
 		"status":  status,
+	}
+	// Optional cert-publish contract (aceteam-ai/citadel-cli#448): hand the backend
+	// the gateway leaf cert to trust (the api_url is an https gateway route) plus
+	// the plaintext URL to re-fetch it from on rotation. Omitted (omitempty) when
+	// the gateway runs --gateway-no-tls or the node is off-mesh, so older backends
+	// that ignore these keys are unaffected.
+	if res.GatewayCertPEM != "" {
+		doc["gateway_cert_pem"] = res.GatewayCertPEM
+	}
+	if res.CertRefreshURL != "" {
+		doc["cert_refresh_url"] = res.CertRefreshURL
 	}
 	out, err := json.Marshal(doc)
 	if err != nil {

--- a/internal/worker/whatsapp_provision_test.go
+++ b/internal/worker/whatsapp_provision_test.go
@@ -209,3 +209,57 @@ func TestWhatsAppProvisionCanHandle(t *testing.T) {
 		t.Error("CanHandle(AGENT_UPDATE) = true, want false")
 	}
 }
+
+// TestWhatsAppProvisionEmitsCertFields verifies the handler serializes the
+// gateway_cert_pem + cert_refresh_url keys when the provision result carries them
+// (the cert-publish contract, aceteam-ai/citadel-cli#448).
+func TestWhatsAppProvisionEmitsCertFields(t *testing.T) {
+	h := NewWhatsAppProvisionHandler(WhatsAppProvisionConfig{
+		Provision: func(ctx context.Context, req whatsapp.ProvisionRequest) (*whatsapp.ProvisionResult, error) {
+			return &whatsapp.ProvisionResult{
+				APIURL:         "https://100.64.0.9:8443/modules/whatsapp",
+				APIKey:         "wab_key",
+				Tenant:         "default",
+				GatewayCertPEM: "-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----\n",
+				CertRefreshURL: "http://100.64.0.9:8080/gateway-cert.pem",
+			}, nil
+		},
+	})
+	res, err := h.Execute(context.Background(), whatsappJob(perNodeQueue, nil), &NoOpStreamWriter{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	doc := decodeOutput(t, res)
+	if doc["gateway_cert_pem"] != "-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----\n" {
+		t.Errorf("gateway_cert_pem = %v, want the cert PEM", doc["gateway_cert_pem"])
+	}
+	if doc["cert_refresh_url"] != "http://100.64.0.9:8080/gateway-cert.pem" {
+		t.Errorf("cert_refresh_url = %v, want the refresh url", doc["cert_refresh_url"])
+	}
+}
+
+// TestWhatsAppProvisionOmitsEmptyCertFields verifies the two cert keys are
+// omitted entirely when the result carries no cert (off-mesh / --gateway-no-tls),
+// so older backends that never read them are unaffected.
+func TestWhatsAppProvisionOmitsEmptyCertFields(t *testing.T) {
+	h := NewWhatsAppProvisionHandler(WhatsAppProvisionConfig{
+		Provision: func(ctx context.Context, req whatsapp.ProvisionRequest) (*whatsapp.ProvisionResult, error) {
+			return &whatsapp.ProvisionResult{
+				APIURL: "http://100.64.0.9:8080",
+				APIKey: "wab_key",
+				Tenant: "default",
+			}, nil
+		},
+	})
+	res, err := h.Execute(context.Background(), whatsappJob(perNodeQueue, nil), &NoOpStreamWriter{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	doc := decodeOutput(t, res)
+	if _, ok := doc["gateway_cert_pem"]; ok {
+		t.Errorf("gateway_cert_pem must be omitted when empty, got %v", doc["gateway_cert_pem"])
+	}
+	if _, ok := doc["cert_refresh_url"]; ok {
+		t.Errorf("cert_refresh_url must be omitted when empty, got %v", doc["cert_refresh_url"])
+	}
+}


### PR DESCRIPTION
## Context

Closes #447. Follow-up to the WhatsApp provision landmine wave (#438/#440/#443).

A provisioned module (starting with the WhatsApp bridge) binds an auto-selected free host port. Only the status, terminal, and HTTPS gateway servers bind a tsnet listener on the node VPN IP, so advertising `http://<vpn-ip>:<module-port>` hands the backend an unreachable address. The first cut of this PR fixed that but HARDCODED WhatsApp into the gateway. This rework makes exposure DRIVEN BY MODULE-DECLARED DATA IN A REGISTRY, so adding any future module requires ZERO gateway source changes.

## Mechanism kept / hardcoding removed

Kept (the reusable primitive is correct): the mutable-upstream mechanism in `internal/gateway/gateway.go` -- `Upstream.addr()/setAddr()`, `Server.SetUpstreamAddress(prefix, addr)`, the per-request `resolveTarget` in `registerProxy` (502-until-wired, not panic), and `StripPrefix`.

Removed (the hardcoding that proved the design was wrong):
- `gateway.WhatsAppRoutePrefix` const and the hand-written `/whatsapp` branch in `categoryForPath`.
- cmd's WhatsApp-specific `registerProvisionedWhatsAppRoute` and `whatsappMeshAPIURL` body (now thin closures over generic equivalents).

## Generalized design

### 1. Module manifest declares its own gateway exposure
`internal/catalog/catalog.go` adds an optional `gateway:` block to the module manifest:

```yaml
gateway:
  prefix: whatsapp        # route slug; served under /modules/whatsapp/
  port_env: BRIDGE_PORT   # persisted env var holding the module's chosen host port
  capability: provision   # existing permission that gates the route; default provision
```

`GatewaySpec.Validate()` rejects a prefix with slashes / `..` / uppercase / spaces (path-injection safe: lowercase-alphanumeric-dash only) and a capability outside the known permission set (console/desktop/files/services/ssh/provision/shell). An absent block means the module is not exposed. `EffectiveCapability()` defaults an empty capability to `provision`.

### 2. Generic provisioned-service registry (`internal/provisionedservice/`)
A file-backed (JSON in the node state dir via `network.GetStateDir()`), mutex-guarded, atomically-written registry. Each entry: `{name, prefix, port, capability}`. API: `Register`, `Remove`, `List`, `CapabilityForPrefix`. This is the single source of truth for which modules are exposed and under what capability. Route convention: every module is served under `/modules/<prefix>/` with StripPrefix, so its own paths (`/health`, `/qr.txt`, `/admin/tenants`, ...) map through unchanged. Namespacing under `/modules/` prevents collision with builtin routes and between modules.

### 3. Registry-driven categoryForPath
`categoryForRequest(path, resolver)` keeps the stable builtin route mappings hardcoded and adds a fallthrough: a `/modules/<prefix>/...` request is gated by the capability the registry records for `<prefix>`, defaulting to `provision` when the resolver is nil or the prefix is unknown (fail closed). The gateway gets the resolver via `Server.SetProvisionedRegistry(CapabilityResolver)`; a `*provisionedservice.Registry` satisfies the interface.

### 4. Gateway startup registers ALL provisioned modules
`cmd/work.go` wires the registry into the gateway, then `registerProvisionedModuleRoutes(gw)` registers a `/modules/<prefix>` route for every registry entry (wired to its persisted port when deployed) and prints each generically in the route table. No WhatsApp-specific call remains.

### 5. Generic moduleMeshAPIURL(prefix)
Returns `<scheme>://<vpn-ip>:<gateway-port>/modules/<prefix>` from the persisted gateway facts. WhatsApp's `ProvisionDeps.MeshAPIURL` / `ExposeGatewayRoute` / `VerifyReachable` become thin closures over the generic implementations, parameterized by WhatsApp's prefix/port_env/capability.

### WhatsApp manifest block (documented, not editable here)
The WhatsApp bridge manifest lives in `sunapi386/whatsapp-bridge` (outside this repo). Once it declares the block below, the registry-driven path uses it verbatim. Until then, and to keep existing deployments working across upgrade, citadel defaults WhatsApp to exactly these values, and `backfillWhatsAppRegistryEntry` self-heals a deployed-but-unregistered bridge on gateway (re)start with no manual migration:

```yaml
gateway:
  prefix: whatsapp
  port_env: BRIDGE_PORT
  capability: provision
```

## Four landmine fixes

**a) False-green via `InsecureSkipVerify`.** The old reachability probe set `InsecureSkipVerify: true`, proving only that the node reaches its own gateway with verification OFF, not that the real BACKEND (which may verify TLS against the gateway's self-signed cert) can read. `verifyModuleReachable` now loads the gateway's own cert (from the persisted facts) into a CA pool and verifies against it (ServerName = node VPN IP), mirroring a correctly-configured consumer. TLS on with no known cert fails loud rather than silently skipping verification.

**b) Hardcoded gateway port/TLS drift.** The gateway `{port, useTLS, certPath}` were only in-memory, so out-of-process URL builders assumed 8443/https. `citadel work` now persists them to `gateway-facts.json` in the node state dir; the URL builder and reachability probe READ that file, with the compile-time `8443/https` only as last-resort fallback when the file is absent.

**c) CLI-path provision unreachable until worker restart.** A module provisioned via the CLI while `citadel work` is already running was never wired (the gateway self-registered routes only at startup). `exposeModuleGatewayRoute` now writes the registry first, and the running gateway runs `watchProvisionedRegistry`: a lightweight 3s poll of the registry file (no new fsnotify dependency) that registers/wires new or changed entries live, no restart.

**d) Data-plane coupled to provision capability.** Reads previously flowed through the same provision-gated route, so revoking provision silently killed reads on already-linked modules. The module-declared `capability` now flows manifest -> registry -> `categoryForRequest`, so a module can declare (e.g.) `services` to decouple its data-plane. The permission switch now honors `files`/`shell` too. Finer per-method gating is out of scope, but the hardcoded coupling is gone.

Extra landmine caught in review: `backfillWhatsAppRegistryEntry` uses `explicitBridgePort`, which requires an EXPLICIT persisted `BRIDGE_PORT` and never falls back to `whatsapp.DefaultPort` (8080 = citadel's own status listener), so an old deployment without a persisted port cannot misroute `/modules/whatsapp` into the status server.

## Flagged: backend-side cert-trust dependency (needs a call)

Landmine a fixes the NODE-side false-green, but the real consumer is the AceTeam backend. For the backend to reach the module over the mesh at the advertised `https://<vpn-ip>:<gateway-port>/modules/<prefix>` URL, the backend must either:
- trust the node's self-signed gateway cert (distribute/pin it), or
- the node runs `citadel work --gateway-no-tls`, which is acceptable because tsnet already encrypts end-to-end; the advertised scheme then flips to `http`.

This PR does not change the backend. Decision needed: standardize on `--gateway-no-tls` for mesh-fronted modules (simplest, tsnet already encrypts), or build cert distribution to the backend.

## Out of scope (noted)
- Registry `Remove` / route un-wiring on teardown (a stale route returns 502 once the container is down, which is safe).
- Finer-grained per-method capability gating within a module route.

## Testing

`go build ./...` and `go vet` clean. Did NOT run `go test ./...` (tmux crash). Ran targeted (all pass):
- `internal/provisionedservice/` -- Register/Remove/List/CapabilityForPrefix round-trip through the file, replace-by-name, idempotent remove, empty-field rejection, concurrent Register (passes `-race`).
- `internal/catalog/` -- `gateway:` block parses; prefix validation rejects slashes/`..`/empty/uppercase; capability defaults to provision and rejects unknowns.
- `internal/gateway/` -- `modulePrefixFromPath`, `categoryForRequest` returns the registered module's capability (and provision for unknown/nil, fail closed), a module declaring a non-provision capability is gated by it, dynamic-route 502-until-wired + StripPrefix still passes (passes `-race`).
- `cmd/` -- `gatewayRouteURL` builds the `/modules/<prefix>` URL; facts file is read (landmine b) with fallback; `verifyModuleReachable` passes against a server presenting the trusted cert and FAILS against an untrusted cert / 502 / dial-fail (landmine a); TLS-on-with-no-cert fails loud; `exposeModuleGatewayRoute` records the registry even with no in-process gateway (landmine c); `explicitBridgePort` never defaults to 8080.
- `internal/worker/` and `internal/provision/` -- existing WHATSAPP_PROVISION handler tests green with the generic deps.

*Generated by Claude Opus 4.8*


---

## Cert-publish contract (node half of "backend trusts the node gateway cert")

Follows up the "Decision needed" above by shipping the NODE half so the backend can trust the self-signed gateway cert without any manual key distribution. The backend fetches the cert to trust it, and re-fetches on rotation.

**Status-server endpoint (plaintext bootstrap channel):**
- `GET /gateway-cert.pem` on the status server (unauthenticated; a public leaf cert is safe to serve, and this is the bootstrap path the backend uses *before* it trusts the cert).
  - `200` `application/x-pem-file` with the current gateway leaf PEM (read from disk per request, so a rotated cert is served fresh).
  - `204 No Content` when the gateway runs `--gateway-no-tls` (no cert path) -> backend uses plain `http`.
  - `503 Service Unavailable` when TLS is configured but the cert is not yet on disk (a cold-start race) -> backend retries rather than mis-downgrading to `http` against a TLS gateway.

**Provision-result fields (returned to the backend by `WHATSAPP_PROVISION`):**
Alongside the existing `api_url`, two new OPTIONAL snake_case keys (`omitempty`, so older backends ignore them):
- `gateway_cert_pem` -- the current gateway leaf cert PEM the backend must trust to reach the `https` gateway-route `api_url`. Empty/omitted when off-mesh or `--gateway-no-tls`.
- `cert_refresh_url` -- the plaintext URL to re-fetch the cert from on rotation: `http://<mesh-ip>:<status-port>/gateway-cert.pem`. Built from the same mesh IP as `api_url` and the status server's persisted port. Empty/omitted when off-mesh or the status port is unknown.

The status port is now persisted in `gateway-facts.json` (`status_port`) so an out-of-process CLI/TUI builds the same `cert_refresh_url`.

**Backend flow:** fetch `gateway_cert_pem` (or `cert_refresh_url`) -> add to its trust store -> reach `api_url` over TLS; on a cert rotation (mesh IP change regenerates the cert in place) re-fetch from `cert_refresh_url`.

**Targeted tests (all pass; did NOT run `go test ./...`):**
- `internal/status/` -- `GET /gateway-cert.pem` returns the PEM + `application/x-pem-file` (200); `204` when no cert path; `503` when path set but file missing; non-GET -> 405.
- `internal/whatsapp/` -- provision result carries `gateway_cert_pem` + `cert_refresh_url` from the deps; empty when deps return "" or are nil.
- `internal/worker/` -- the `WHATSAPP_PROVISION` output JSON includes both keys when present and omits them when empty.

*Generated by Claude Opus 4.8*
