### PR TITLE
fix(gateway): re-provision port idempotency + live route re-wire (#449)

### DIFF
--- a/cmd/provisioned_gateway.go
+++ b/cmd/provisioned_gateway.go
@@ -302,10 +302,12 @@ func exposeModuleGatewayRoute(name, prefix, capability string, bridgePort int) e
 	}
 	routePrefix := gateway.ModuleRoutePath(prefix)
 	addr := fmt.Sprintf("127.0.0.1:%d", bridgePort)
-	// The route may not exist yet if this gateway started before the module was
-	// declared; register it (empty) then wire it.
-	ref.gw.AddUpstream(routePrefix, &gateway.Upstream{StripPrefix: true})
-	if err := ref.gw.SetUpstreamAddress(routePrefix, addr); err != nil {
+	// Wire the live route. WireModuleRoute mutates the existing upstream (or
+	// registers a new live handler if the route did not exist at Start) rather
+	// than replacing the upstream object the running proxy handler closed over --
+	// replacing it would orphan the update and leave the route on the old port
+	// until a restart (#449).
+	if err := ref.gw.WireModuleRoute(routePrefix, addr, true); err != nil {
 		return fmt.Errorf("wire module gateway route %s -> %s: %w", routePrefix, addr, err)
 	}
 	return nil
@@ -431,10 +433,14 @@ func watchProvisionedRegistry(ctx context.Context, gw *gateway.Server) {
 				if seen && prev == e.Port {
 					continue
 				}
-				routePrefix := gateway.ModuleRoutePath(e.Prefix)
-				gw.AddUpstream(routePrefix, &gateway.Upstream{StripPrefix: true})
+				// A new module OR a port change on an existing one: wire it live.
+				// WireModuleRoute mutates the existing upstream (never replaces the
+				// object the proxy handler captured), so a port change actually takes
+				// effect without a restart -- the #449 landmine where the watcher
+				// swapped in a fresh upstream and the update was orphaned.
 				if e.Port > 0 {
-					if err := gw.SetUpstreamAddress(routePrefix, fmt.Sprintf("127.0.0.1:%d", e.Port)); err == nil {
+					routePrefix := gateway.ModuleRoutePath(e.Prefix)
+					if err := gw.WireModuleRoute(routePrefix, fmt.Sprintf("127.0.0.1:%d", e.Port), true); err == nil {
 						Log("gateway picked up provisioned module %q on /modules/%s -> 127.0.0.1:%d", e.Name, e.Prefix, e.Port)
 					}
 				}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -151,6 +151,12 @@ type Server struct {
 	// module route falls back to the provision capability. Set via
 	// SetProvisionedRegistry.
 	provisionedResolver CapabilityResolver
+
+	// started is set once Start has registered the proxy handlers for the routes
+	// present at that moment. It gates WireModuleRoute: a route added AFTER Start
+	// must have its proxy handler registered live (Start's registration loop has
+	// already run), whereas a route added before Start is picked up by that loop.
+	started bool
 }
 
 // NewServer creates a new gateway server.
@@ -201,6 +207,51 @@ func (s *Server) SetUpstreamAddress(prefix, address string) error {
 	if !ok {
 		return fmt.Errorf("gateway: no upstream registered for prefix %q", prefix)
 	}
+	upstream.setAddr(address)
+	return nil
+}
+
+// WireModuleRoute points the /modules/<prefix> route at address for a LIVE
+// (post-Start) module exposure. It is the re-wire-safe counterpart to
+// AddUpstream+SetUpstreamAddress and exists to close the #449 landmine:
+//
+//   - If the route already exists, it MUTATES the existing *Upstream's address.
+//     It must not replace the map entry: registerProxy (run once at Start) closed
+//     over the original *Upstream pointer, so swapping in a new object would
+//     orphan the update -- the running proxy would keep reading the old object's
+//     address. That is exactly why a re-provision that moved the bridge port left
+//     the route dialing the dead port until a full restart re-captured it.
+//   - If the route is new and the server has already started, it creates the
+//     upstream AND registers its proxy handler live (registerProxy), so a module
+//     first exposed after Start is reachable without a restart. Before Start, it
+//     just records the route; Start's registration loop wires the handler.
+//
+// stripPrefix applies only when the route is created; for an existing route the
+// registration-time options are kept. Safe for concurrent use.
+func (s *Server) WireModuleRoute(prefix, address string, stripPrefix bool) error {
+	if prefix == "" {
+		return fmt.Errorf("gateway: WireModuleRoute requires a non-empty prefix")
+	}
+	s.mu.Lock()
+	upstream, ok := s.config.Upstreams[prefix]
+	if !ok {
+		upstream = &Upstream{StripPrefix: stripPrefix}
+		// Set the address BEFORE the handler can serve traffic so a brand-new route
+		// never has a window where its proxy is live but points nowhere (a spurious
+		// 502). registerProxy touches only the concurrency-safe mux and closes over
+		// this upstream pointer, so the per-request resolveTarget reads this address.
+		upstream.setAddr(address)
+		s.config.Upstreams[prefix] = upstream
+		// A route that appears after Start must have its handler registered here;
+		// before Start, the Start loop registers it.
+		if s.started {
+			s.registerProxy(prefix, upstream)
+		}
+		s.mu.Unlock()
+		return nil
+	}
+	s.mu.Unlock()
+	// Existing route: mutate the object the running proxy handler already captured.
 	upstream.setAddr(address)
 	return nil
 }
@@ -358,6 +409,9 @@ func (s *Server) Start(ctx context.Context) error {
 	for prefix, upstream := range s.config.Upstreams {
 		s.registerProxy(prefix, upstream)
 	}
+	// Any route added after this point (WireModuleRoute) must register its own
+	// proxy handler live, since this loop has already run.
+	s.started = true
 
 	// Root handler — returns 404 for unmatched paths or gateway info for "/"
 	s.mux.HandleFunc("/", s.handleRoot)

--- a/internal/gateway/gateway_test.go
+++ b/internal/gateway/gateway_test.go
@@ -689,3 +689,110 @@ func TestPermissionMiddleware_ModuleCapabilityDecoupled(t *testing.T) {
 		t.Errorf("services-gated module with services on: status = %d, want not-403", w.Code)
 	}
 }
+
+// TestWireModuleRouteLiveRewire is the regression guard for aceteam-ai/citadel-cli#449.
+//
+// A provisioned module's gateway route is registered (and its proxy handler
+// captured) at Start. A re-provision that moves the module to a new host port
+// must be re-wired LIVE: the running proxy handler closed over the ORIGINAL
+// *Upstream pointer, so the re-wire has to mutate that same object. The pre-fix
+// code replaced the map entry with a fresh *Upstream and set the address on the
+// orphan, leaving the live route dialing the dead port until a restart. This
+// test proves WireModuleRoute takes effect on the very next request.
+func TestWireModuleRouteLiveRewire(t *testing.T) {
+	backendA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"backend": "A", "path": r.URL.Path})
+	}))
+	defer backendA.Close()
+	backendB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"backend": "B", "path": r.URL.Path})
+	}))
+	defer backendB.Close()
+	addrA := backendA.URL[len("http://"):]
+	addrB := backendB.URL[len("http://"):]
+
+	const prefix = "/modules/whatsapp"
+
+	gw := NewServer(Config{NodeName: "test-node"})
+	// Simulate the startup registration: a route wired to backend A, its proxy
+	// handler captured, and the server marked started.
+	gw.AddUpstream(prefix, &Upstream{StripPrefix: true, Address: addrA})
+	for p, up := range gw.config.Upstreams {
+		gw.registerProxy(p, up)
+	}
+	gw.mux.HandleFunc("/", gw.handleRoot)
+	gw.started = true
+
+	route := func() map[string]string {
+		req := httptest.NewRequest(http.MethodGet, prefix+"/status", nil)
+		w := httptest.NewRecorder()
+		gw.mux.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200 (body %q)", w.Code, w.Body.String())
+		}
+		var resp map[string]string
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v (body %q)", err, w.Body.String())
+		}
+		return resp
+	}
+
+	if resp := route(); resp["backend"] != "A" {
+		t.Fatalf("before re-wire routed to %q, want A", resp["backend"])
+	}
+
+	// The re-provision moved the module to backend B. This must take effect live.
+	if err := gw.WireModuleRoute(prefix, addrB, true); err != nil {
+		t.Fatalf("WireModuleRoute: %v", err)
+	}
+	resp := route()
+	if resp["backend"] != "B" {
+		t.Fatalf("after re-wire routed to %q, want B (the #449 regression: re-wire orphaned)", resp["backend"])
+	}
+	// StripPrefix still holds: the module sees /status, not /modules/whatsapp/status.
+	if resp["path"] != "/status" {
+		t.Fatalf("forwarded path = %q, want /status", resp["path"])
+	}
+}
+
+// TestWireModuleRouteNewAfterStart proves a module first exposed AFTER Start
+// (e.g. provisioned via the CLI while `citadel work` is already running) gets a
+// live proxy handler without a restart -- the create-branch of WireModuleRoute.
+func TestWireModuleRouteNewAfterStart(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"backend": "new", "path": r.URL.Path})
+	}))
+	defer backend.Close()
+
+	gw := NewServer(Config{NodeName: "test-node"})
+	// Nothing registered at Start; the server is already running.
+	gw.mux.HandleFunc("/", gw.handleRoot)
+	gw.started = true
+
+	const prefix = "/modules/newmod"
+	if err := gw.WireModuleRoute(prefix, backend.URL[len("http://"):], true); err != nil {
+		t.Fatalf("WireModuleRoute: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, prefix+"/ping", nil)
+	w := httptest.NewRecorder()
+	gw.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %q)", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["backend"] != "new" {
+		t.Fatalf("routed to %q, want new", resp["backend"])
+	}
+	if resp["path"] != "/ping" {
+		t.Fatalf("forwarded path = %q, want /ping", resp["path"])
+	}
+}
+
+// TestWireModuleRouteRejectsEmptyPrefix guards the input contract.
+func TestWireModuleRouteRejectsEmptyPrefix(t *testing.T) {
+	gw := NewServer(Config{})
+	if err := gw.WireModuleRoute("", "127.0.0.1:9", true); err == nil {
+		t.Fatal("expected error for empty prefix")
+	}
+}

--- a/internal/whatsapp/hostport_test.go
+++ b/internal/whatsapp/hostport_test.go
@@ -221,3 +221,80 @@ func TestProvisionHonorsExplicitPort(t *testing.T) {
 		t.Errorf("api_url = %q, want it to carry the explicit port %d", res.APIURL, pinned)
 	}
 }
+
+// TestProvisionReusesPersistedPortOnReprovision is the regression guard for
+// aceteam-ai/citadel-cli#449 (root cause A): a re-provision (no explicit port)
+// must reuse the persisted BRIDGE_PORT instead of auto-selecting a new one. The
+// old bridge still holds that port at probe time, so a free-port scan would skip
+// it and churn to a new port -- which then broke the live gateway route. Here the
+// env already carries BRIDGE_PORT=8082; the provision must pass it as the
+// preferred port and redeploy on it.
+func TestProvisionReusesPersistedPortOnReprovision(t *testing.T) {
+	bridge := &fakeBridge{health: &Health{LoggedIn: false}, qr: "2@qr"}
+	deps, _ := baseDeps(t, bridge)
+	deps.MeshAPIURL = func(port int) string { return fmt.Sprintf("http://100.64.0.7:%d", port) }
+
+	dir, err := deps.ServicesDir()
+	if err != nil {
+		t.Fatalf("ServicesDir: %v", err)
+	}
+	// Simulate an existing deployment that persisted its host port.
+	if err := SaveEnv(dir, map[string]string{"BRIDGE_PORT": "8082", "ADMIN_API_KEY": "existing"}); err != nil {
+		t.Fatalf("SaveEnv: %v", err)
+	}
+
+	var gotPreferred int
+	deps.SelectHostPort = func(preferred, floor int) (int, error) {
+		gotPreferred = preferred
+		if preferred > 0 {
+			return preferred, nil
+		}
+		return 9999, nil // a fresh port, which we must NOT end up using
+	}
+	var deployPort int
+	deps.DeployCompose = func(servicesDir string, env map[string]string) error {
+		deployPort = mustAtoi(t, env["BRIDGE_PORT"])
+		return nil
+	}
+
+	res, err := Provision(context.Background(), ProvisionRequest{}, deps)
+	if err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+	if gotPreferred != 8082 {
+		t.Errorf("selectPort preferred = %d, want the persisted 8082 (idempotent reuse)", gotPreferred)
+	}
+	if deployPort != 8082 {
+		t.Errorf("redeployed on port %d, want the persisted 8082", deployPort)
+	}
+	if res.Port != 8082 {
+		t.Errorf("result Port = %d, want 8082 (reused, not churned to 9999)", res.Port)
+	}
+}
+
+// TestProvisionExplicitPortOverridesPersisted verifies an operator-pinned port
+// still wins over the persisted one on a re-provision (the override precedence is
+// unchanged by the #449 reuse logic).
+func TestProvisionExplicitPortOverridesPersisted(t *testing.T) {
+	bridge := &fakeBridge{health: &Health{LoggedIn: false}, qr: "2@qr"}
+	deps, _ := baseDeps(t, bridge)
+	deps.MeshAPIURL = func(port int) string { return fmt.Sprintf("http://100.64.0.7:%d", port) }
+
+	dir, _ := deps.ServicesDir()
+	if err := SaveEnv(dir, map[string]string{"BRIDGE_PORT": "8082"}); err != nil {
+		t.Fatalf("SaveEnv: %v", err)
+	}
+	var gotPreferred int
+	deps.SelectHostPort = func(preferred, floor int) (int, error) { gotPreferred = preferred; return preferred, nil }
+
+	res, err := Provision(context.Background(), ProvisionRequest{Port: 8095}, deps)
+	if err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+	if gotPreferred != 8095 {
+		t.Errorf("selectPort preferred = %d, want the explicit override 8095", gotPreferred)
+	}
+	if res.Port != 8095 {
+		t.Errorf("result Port = %d, want 8095", res.Port)
+	}
+}

--- a/internal/whatsapp/provision.go
+++ b/internal/whatsapp/provision.go
@@ -17,6 +17,8 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"rsc.io/qr"
@@ -164,6 +166,23 @@ type ProvisionResult struct {
 	CertRefreshURL string
 }
 
+// persistedBridgePort returns the bridge's previously-persisted BRIDGE_PORT from
+// the env map, or 0 when none is recorded or it is not a valid positive port. It
+// deliberately does NOT default to DefaultPort (8080 = citadel's own listener):
+// a re-provision must reuse only a port the deployment actually chose, never a
+// coincidental default that would misroute onto citadel's own services.
+func persistedBridgePort(env map[string]string) int {
+	v := env["BRIDGE_PORT"]
+	if v == "" {
+		return 0
+	}
+	p, err := strconv.Atoi(strings.TrimSpace(v))
+	if err != nil || p <= 0 {
+		return 0
+	}
+	return p
+}
+
 // Provision runs the full deploy -> mint -> wait -> fetch-QR flow and returns the
 // connection details. It is the single source of truth shared by the CLI
 // (`citadel whatsapp up`) and the WHATSAPP_PROVISION node job.
@@ -186,15 +205,40 @@ func Provision(ctx context.Context, req ProvisionRequest, deps ProvisionDeps) (*
 	if tenant == "" {
 		tenant = "default"
 	}
-	// Choose the host port. An explicit ProvisionRequest.Port is honored verbatim
-	// (operator override); otherwise auto-select a FREE host port so the bridge
-	// does not collide with citadel's own 8080 listener, which holds DefaultPort
-	// on every node running the agent (aceteam-ai/citadel-cli#438).
+	servicesDir, err := deps.ServicesDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve node services dir: %w", err)
+	}
+
+	env, err := LoadEnv(servicesDir)
+	if err != nil {
+		return nil, fmt.Errorf("read bridge config: %w", err)
+	}
+
+	// Choose the host port. Precedence:
+	//   1. An explicit ProvisionRequest.Port is honored verbatim (operator override).
+	//   2. Otherwise, on a RE-PROVISION, reuse the persisted BRIDGE_PORT so we do
+	//      not churn to a new host port every time (#449). The old bridge still
+	//      holds that port at probe time, so a free-port scan would skip it and
+	//      pick a new one -- and `compose up` on the same project rebinds the same
+	//      port cleanly (it recreates the container). Reusing it keeps the mesh
+	//      gateway route stable across re-provisions.
+	//   3. Otherwise auto-select a FREE host port so a first deploy does not collide
+	//      with citadel's own 8080 listener (aceteam-ai/citadel-cli#438).
+	// A bind collision on the reused port (e.g. a foreign process grabbed it while
+	// the bridge was down) still falls through to the auto-select retry below.
 	selectPort := deps.SelectHostPort
 	if selectPort == nil {
 		selectPort = func(preferred, floor int) (int, error) { return SelectHostPort(preferred, floor, nil) }
 	}
-	port, err := selectPort(req.Port, 0)
+	preferredPort := req.Port
+	if preferredPort <= 0 {
+		if persisted := persistedBridgePort(env); persisted > 0 {
+			preferredPort = persisted
+			log("reusing persisted bridge host port %d (idempotent re-provision)", persisted)
+		}
+	}
+	port, err := selectPort(preferredPort, 0)
 	if err != nil {
 		return nil, fmt.Errorf("select bridge host port: %w", err)
 	}
@@ -210,16 +254,6 @@ func Provision(ctx context.Context, req ProvisionRequest, deps ProvisionDeps) (*
 	// bind-collision retry picks a new one, so apiURL is recomputed after deploy.
 	if deps.MeshAPIURL(port) == "" {
 		return nil, fmt.Errorf("node is not connected to the AceTeam mesh network; cannot determine a reachable api_url (run `citadel login` / bring the node online first)")
-	}
-
-	servicesDir, err := deps.ServicesDir()
-	if err != nil {
-		return nil, fmt.Errorf("resolve node services dir: %w", err)
-	}
-
-	env, err := LoadEnv(servicesDir)
-	if err != nil {
-		return nil, fmt.Errorf("read bridge config: %w", err)
 	}
 
 	adminKey := env["ADMIN_API_KEY"]


### PR DESCRIPTION
Fixes two v2.64.0 regressions surfaced by re-provisioning an already-deployed module on a live node (#449). The bridge session survives and `VerifyReachable` fails loud (no false-green), but the module's mesh route was left broken until a worker restart.

## Root cause A: re-provision was not port-idempotent
`Provision` always auto-selected a free host port when no explicit override was given, ignoring the persisted `BRIDGE_PORT`. The old bridge still held that port at probe time, so the free-port scan skipped it and picked a new one (8082 -> 8083), then redeployed the bridge there.

**Fix:** load the env first and reuse the persisted `BRIDGE_PORT` as the preferred port on a re-provision (`compose up` recreates the container cleanly on the same port). A bind collision on the reused port still falls through to the existing auto-select retry (covers "a foreign process grabbed it while the bridge was down").

## Root cause B: a port change was not re-wired into the live gateway route
The post-Start re-wire paths (the worker's `ExposeGatewayRoute` and the 3s registry watcher) called `AddUpstream` with a **fresh** `*Upstream` and set the address on it. But the running proxy handler (`registerProxy`) closed over the **original** `*Upstream` pointer captured at `Start`, so the update was orphaned and the route kept dialing the dead port. Only a full `citadel work` restart re-captured the current port. This is landmine (c) ("CLI-provision-until-restart") from #448 not actually being closed.

**Fix:** new `Server.WireModuleRoute` mutates the existing captured `*Upstream` (never replaces it), and registers a live proxy handler for a genuinely new post-Start route. Both re-wire callers now use it, so a live port change takes effect on the next request without a restart.

## Tests
- `TestWireModuleRouteLiveRewire` — a route wired to backend A at Start, then re-wired to B post-Start, routes to B on the next request (the exact orphan bug).
- `TestWireModuleRouteNewAfterStart` — a module first exposed after Start gets a live handler with no restart.
- `TestProvisionReusesPersistedPortOnReprovision` / `TestProvisionExplicitPortOverridesPersisted` — re-provision reuses the persisted port; an explicit override still wins.
- Targeted packages green with `-race`; `go vet` clean.

*Generated by Claude Opus 4.8*