### PR TITLE
fix: stop telling users to set WHATSAPP_ALLOW_PRIVATE_NETWORK for mesh bridges

### DIFF
--- a/cmd/whatsapp.go
+++ b/cmd/whatsapp.go
@@ -20,6 +20,8 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -553,9 +555,37 @@ func printConnectDetails(port int, apiKey string) {
 	fmt.Println("  In AceTeam, call the whatsapp_connect MCP tool with the values above:")
 	fmt.Printf("    whatsapp_connect(api_url=%q, api_key=%q)\n", apiURL, apiKey)
 	fmt.Println()
-	fmt.Println(color.YellowString("  Note: the bridge is on the private mesh, so the AceTeam backend must run with"))
-	fmt.Println(color.YellowString("        WHATSAPP_ALLOW_PRIVATE_NETWORK=true to dial it. If you expose the bridge"))
-	fmt.Println(color.YellowString("        on a public hostname instead, that backend flag is not needed."))
+	if whatsappNonMeshPrivateHost(apiURL) {
+		fmt.Println(color.YellowString("  Note: this api_url is a non-mesh private host, so the AceTeam backend must"))
+		fmt.Println(color.YellowString("        run with WHATSAPP_ALLOW_PRIVATE_NETWORK=true to dial it. The flag is"))
+		fmt.Println(color.YellowString("        only for non-mesh private hosts, not for the mesh."))
+	} else {
+		fmt.Println("  The bridge is reachable over the mesh by default; no backend flag is needed.")
+	}
+}
+
+// whatsappNonMeshPrivateHost reports whether the host in apiURL is a private
+// RFC1918 address that is NOT on the mesh (100.64.0.0/10, CGNAT). The aceteam
+// backend's SSRF guard allows the mesh range by default, so only a non-mesh
+// private host needs WHATSAPP_ALLOW_PRIVATE_NETWORK=true. Unparseable hosts
+// (empty, hostname, or the off-mesh placeholder) count as non-private, so no
+// flag note is shown.
+func whatsappNonMeshPrivateHost(apiURL string) bool {
+	if apiURL == "" {
+		return false
+	}
+	u, err := url.Parse(apiURL)
+	if err != nil {
+		return false
+	}
+	ip := net.ParseIP(u.Hostname())
+	if ip == nil {
+		return false
+	}
+	if _, mesh, err := net.ParseCIDR("100.64.0.0/10"); err == nil && mesh.Contains(ip) {
+		return false
+	}
+	return ip.IsPrivate()
 }
 
 // buildWhatsAppCallbacks wires the WhatsApp page's lifecycle hooks to the same

--- a/internal/tui/controlcenter/whatsapp_page.go
+++ b/internal/tui/controlcenter/whatsapp_page.go
@@ -2,6 +2,8 @@ package controlcenter
 
 import (
 	"fmt"
+	"net"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -9,6 +11,35 @@ import (
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
+
+// meshCGNAT is the Headscale mesh range (CGNAT 100.64.0.0/10). The aceteam
+// backend's SSRF guard allows this range by default, so a bridge advertised on a
+// mesh host is reachable with NO extra backend flag.
+var _, meshCGNAT, _ = net.ParseCIDR("100.64.0.0/10")
+
+// isNonMeshPrivateHost reports whether the host in apiURL is a private RFC1918
+// address that is NOT on the mesh (100.64.0.0/10). Only such hosts need the
+// backend WHATSAPP_ALLOW_PRIVATE_NETWORK flag; mesh and public hosts do not.
+// A host that cannot be parsed as an IP (empty URL, hostname, placeholder) is
+// treated as non-private so no flag hint is shown.
+func isNonMeshPrivateHost(apiURL string) bool {
+	if apiURL == "" {
+		return false
+	}
+	u, err := url.Parse(apiURL)
+	if err != nil {
+		return false
+	}
+	host := u.Hostname()
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	if meshCGNAT != nil && meshCGNAT.Contains(ip) {
+		return false
+	}
+	return ip.IsPrivate()
+}
 
 // WhatsAppStatus is a snapshot of the bridge module state, produced by the
 // WhatsAppCallbacks.Status hook (wired from cmd so this page never imports
@@ -327,8 +358,12 @@ func (p *WhatsAppPage) render() {
 			sb.WriteString(fmt.Sprintf("   api_key:  [aqua]%s[-]\n", st.APIKey))
 		}
 		sb.WriteString("   [gray]Call whatsapp_connect(api_url, api_key) in AceTeam.[-]\n")
-		sb.WriteString("   [yellow]Backend needs WHATSAPP_ALLOW_PRIVATE_NETWORK=true[-]\n")
-		sb.WriteString("   [yellow]to reach the bridge over the private mesh.[-]\n")
+		if isNonMeshPrivateHost(st.APIURL) {
+			sb.WriteString("   [yellow]This is a non-mesh private host, so the backend[-]\n")
+			sb.WriteString("   [yellow]needs WHATSAPP_ALLOW_PRIVATE_NETWORK=true to dial it.[-]\n")
+		} else {
+			sb.WriteString("   [gray]Reachable over the mesh by default -- no backend flag needed.[-]\n")
+		}
 	}
 
 	// Busy / error.


### PR DESCRIPTION
## Context

The Control Center TUI and the `citadel whatsapp` CLI both unconditionally told users that the AceTeam backend needs `WHATSAPP_ALLOW_PRIVATE_NETWORK=true` to reach a self-hosted WhatsApp bridge "over the private mesh." That is false for the normal case.

## Root Cause

The backend's SSRF guard (`_blocked_address_reason`) allows the Headscale mesh range (CGNAT `100.64.0.0/10`) by default with no env flag. The `WHATSAPP_ALLOW_PRIVATE_NETWORK` flag only gates other RFC1918 private ranges (`192.168.x`, `10.x`, `172.16.x`). Self-hosted bridges are advertised on the node's mesh IP (`100.64.x`), so the flag is essentially never needed. The unconditional yellow warning was misleading and prompted users to set a flag they do not need.

## Changes

- `internal/tui/controlcenter/whatsapp_page.go`: parse `st.APIURL`, check host membership in `100.64.0.0/10`. Show the `WHATSAPP_ALLOW_PRIVATE_NETWORK` hint only for a non-mesh private host; otherwise state it is reachable over the mesh by default with no flag needed.
- `cmd/whatsapp.go`: same conditional in `printConnectDetails` for the printed connect note.

Mesh hosts and public hosts get no flag mention. Unparseable hosts (empty, hostname, or the off-mesh `<this-node-network-ip>` placeholder) are treated as non-private, so no false flag hint appears.

## Testing

`go build ./...` succeeds. Copy-only change; no behavior beyond the printed/rendered note.

Generated by Claude Opus 4.8
