### PR TITLE
fix(worklock): reused-PID liveness check for the worker singleton guard

### DIFF
--- a/cmd/work.go
+++ b/cmd/work.go
@@ -308,7 +308,7 @@ func runWork(cmd *cobra.Command, args []string) {
 	// worker never blocks its own restart. Skipped with --no-single-instance for
 	// intentional side-by-side runs (e.g. a second debug-redis worker in dev).
 	if !workNoSingleInstance {
-		lock, lockErr := worklock.Acquire(network.GetStateDir(), Log)
+		lock, lockErr := worklock.Acquire(network.GetStateDir(), Version, Log)
 		if lockErr != nil {
 			var running *worklock.ErrAlreadyRunning
 			if errors.As(lockErr, &running) {

--- a/internal/worklock/worklock.go
+++ b/internal/worklock/worklock.go
@@ -27,8 +27,12 @@
 package worklock
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
 )
 
 // LockFileName is the name of the lock file placed inside the node config dir.
@@ -60,18 +64,25 @@ const (
 )
 
 // decideStaleLock is the pure classifier for a pre-existing lock file. It never
-// touches the OS: callers pass the recorded holder PID, this process's PID, and
-// whether the holder is alive. Kept pure so the reclaim-vs-refuse policy is unit
-// tested without spawning processes.
+// touches the OS: callers pass the recorded holder PID, this process's PID,
+// whether the holder is alive, and whether the live holder is actually a citadel
+// process. Kept pure so the reclaim-vs-refuse policy is unit tested without
+// spawning processes.
 //
 //   - holderPID <= 0 (unreadable/empty lock file): reclaim — a garbage lock file
 //     must never permanently block a worker.
-//   - holderPID == selfPID: reclaim — our own stale record (e.g. same PID reused
-//     across a fast restart within this process's lifetime is not possible, but a
-//     re-run recording our PID is safe to overwrite).
+//   - holderPID == selfPID: reclaim — our own stale record is safe to overwrite.
 //   - holderAlive == false: reclaim — the recorded process is gone.
-//   - otherwise: refuse — a live process holds the node.
-func decideStaleLock(holderPID, selfPID int, holderAlive bool) staleLockAction {
+//   - holderAlive but holderIsCitadel == false: reclaim — the recorded PID was
+//     reused by an unrelated process (e.g. after a reboot the PID counter wrapped
+//     onto some other program). A reused PID must never be mistaken for a live
+//     worker and permanently wedge startup.
+//   - otherwise: refuse — a live citadel process holds the node.
+//
+// holderIsCitadel is only consulted when holderAlive is true; callers pass a
+// best-effort value (true on platforms where the cmdline cannot be inspected, so
+// the guard fails closed and still refuses).
+func decideStaleLock(holderPID, selfPID int, holderAlive, holderIsCitadel bool) staleLockAction {
 	if holderPID <= 0 {
 		return actionReclaim
 	}
@@ -81,21 +92,74 @@ func decideStaleLock(holderPID, selfPID int, holderAlive bool) staleLockAction {
 	if !holderAlive {
 		return actionReclaim
 	}
+	if !holderIsCitadel {
+		return actionReclaim
+	}
 	return actionRefuse
 }
 
+// lockRecord is the JSON payload written into the lock file. It carries enough
+// context to (a) print an actionable refusal naming the holder and when it
+// started, and (b) detect a reused PID (a rebooted box whose PID counter wrapped
+// onto some other process) by cross-checking liveness + cmdline at read time.
+type lockRecord struct {
+	PID       int    `json:"pid"`
+	StartUnix int64  `json:"start_unix"`
+	Version   string `json:"version,omitempty"`
+}
+
+// encodeRecord serializes a lock record to the bytes written into the lock file.
+func encodeRecord(rec lockRecord) []byte {
+	b, err := json.Marshal(rec)
+	if err != nil {
+		// Marshalling a fixed struct of scalars cannot realistically fail; fall
+		// back to a bare PID line so the file is at least human-readable.
+		return []byte(strconv.Itoa(rec.PID) + "\n")
+	}
+	return append(b, '\n')
+}
+
+// decodeRecord parses lock file bytes. It accepts both the JSON record format and
+// a legacy bare-PID line (older workers wrote only the PID), so an in-place
+// upgrade never misreads a lock file written by a prior version.
+func decodeRecord(data []byte) lockRecord {
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" {
+		return lockRecord{}
+	}
+	if strings.HasPrefix(trimmed, "{") {
+		var rec lockRecord
+		if err := json.Unmarshal([]byte(trimmed), &rec); err == nil {
+			return rec
+		}
+		return lockRecord{}
+	}
+	// Legacy bare-PID format.
+	if pid, err := strconv.Atoi(trimmed); err == nil && pid > 0 {
+		return lockRecord{PID: pid}
+	}
+	return lockRecord{}
+}
+
 // ErrAlreadyRunning is returned by Acquire when another live worker holds the
-// lock for the same node. It carries the holder PID for a clear operator message.
+// lock for the same node. It carries the holder PID and start time for a clear,
+// actionable operator message.
 type ErrAlreadyRunning struct {
 	// PID is the recorded holder PID, or 0 if it could not be read.
 	PID int
+	// StartTime is the recorded holder start time, or the zero value if unknown.
+	StartTime time.Time
 	// Path is the lock file path, for diagnostics.
 	Path string
 }
 
 func (e *ErrAlreadyRunning) Error() string {
 	if e.PID > 0 {
-		return fmt.Sprintf("another citadel worker is already running for this node (PID %d, lock %s)", e.PID, e.Path)
+		started := "unknown time"
+		if !e.StartTime.IsZero() {
+			started = e.StartTime.Format(time.RFC3339)
+		}
+		return fmt.Sprintf("citadel worker already running (PID %d, started %s); refusing to start a second instance", e.PID, started)
 	}
-	return fmt.Sprintf("another citadel worker is already running for this node (lock %s)", e.Path)
+	return "citadel worker already running; refusing to start a second instance"
 }

--- a/internal/worklock/worklock_test.go
+++ b/internal/worklock/worklock_test.go
@@ -1,33 +1,147 @@
 package worklock
 
 import (
+	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestDecideStaleLock(t *testing.T) {
 	const self = 4242
 	tests := []struct {
-		name       string
-		holderPID  int
-		selfPID    int
-		holderLive bool
-		want       staleLockAction
+		name        string
+		holderPID   int
+		selfPID     int
+		holderLive  bool
+		holderIsCit bool
+		want        staleLockAction
 	}{
-		{"empty lock file (pid 0) reclaims", 0, self, false, actionReclaim},
-		{"negative pid reclaims", -1, self, false, actionReclaim},
-		{"own pid recorded reclaims", self, self, true, actionReclaim},
-		{"dead holder reclaims", 1234, self, false, actionReclaim},
-		{"live holder refuses", 1234, self, true, actionRefuse},
+		{"empty lock file (pid 0) reclaims", 0, self, false, false, actionReclaim},
+		{"negative pid reclaims", -1, self, false, false, actionReclaim},
+		{"own pid recorded reclaims", self, self, true, true, actionReclaim},
+		{"dead holder reclaims", 1234, self, false, false, actionReclaim},
+		{"live citadel holder refuses", 1234, self, true, true, actionRefuse},
+		{"live NON-citadel holder (reused PID) reclaims", 1234, self, true, false, actionReclaim},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := decideStaleLock(tt.holderPID, tt.selfPID, tt.holderLive)
+			got := decideStaleLock(tt.holderPID, tt.selfPID, tt.holderLive, tt.holderIsCit)
 			if got != tt.want {
-				t.Fatalf("decideStaleLock(%d,%d,%v) = %v, want %v",
-					tt.holderPID, tt.selfPID, tt.holderLive, got, tt.want)
+				t.Fatalf("decideStaleLock(%d,%d,live=%v,cit=%v) = %v, want %v",
+					tt.holderPID, tt.selfPID, tt.holderLive, tt.holderIsCit, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestRecordRoundTrip verifies the lock record encodes to JSON and decodes back,
+// and that a legacy bare-PID lock file still parses (so an in-place upgrade never
+// misreads a file written by an older worker).
+func TestRecordRoundTrip(t *testing.T) {
+	in := lockRecord{PID: 4321, StartUnix: 1700000000, Version: "v2.65.0"}
+	out := decodeRecord(encodeRecord(in))
+	if out != in {
+		t.Fatalf("round-trip record = %+v, want %+v", out, in)
+	}
+
+	// Legacy bare-PID line.
+	legacy := decodeRecord([]byte("9876\n"))
+	if legacy.PID != 9876 || legacy.StartUnix != 0 || legacy.Version != "" {
+		t.Fatalf("legacy decode = %+v, want PID=9876 with no start/version", legacy)
+	}
+
+	// Empty / garbage yields a zero record (never a false live-holder).
+	if got := decodeRecord([]byte("   \n")); got.PID != 0 {
+		t.Fatalf("empty decode PID = %d, want 0", got.PID)
+	}
+	if got := decodeRecord([]byte("not-a-pid")); got.PID != 0 {
+		t.Fatalf("garbage decode PID = %d, want 0", got.PID)
+	}
+}
+
+// TestAcquireStampsRecord verifies a fresh acquire records this process's PID, a
+// start timestamp, and the supplied version into the lock file.
+func TestAcquireStampsRecord(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "network")
+	l, err := Acquire(stateDir, "v9.9.9", nil)
+	if err != nil {
+		t.Fatalf("Acquire failed: %v", err)
+	}
+	defer l.Release()
+
+	data, err := os.ReadFile(l.Path())
+	if err != nil {
+		t.Fatalf("read lock file: %v", err)
+	}
+	rec := decodeRecord(data)
+	if rec.PID != os.Getpid() {
+		t.Errorf("record PID = %d, want %d", rec.PID, os.Getpid())
+	}
+	if rec.StartUnix <= 0 {
+		t.Errorf("record StartUnix = %d, want > 0", rec.StartUnix)
+	}
+	if rec.Version != "v9.9.9" {
+		t.Errorf("record Version = %q, want %q", rec.Version, "v9.9.9")
+	}
+}
+
+// TestReusedPIDReclaimed simulates the reused-PID wedge: a stale lock file records
+// a PID that is alive but belongs to an unrelated (non-citadel) process. Because
+// no live citadel worker holds the OS lock, Acquire must reclaim it rather than
+// refuse forever. On Linux we spawn a real short-lived non-citadel process and use
+// its PID as the recorded holder; the /proc cmdline check then classifies it as a
+// reused PID. On non-Linux (no /proc), processIsCitadel is a no-op returning true,
+// so this test is Linux-only.
+func TestReusedPIDReclaimed(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("reused-PID cmdline detection is Linux-only (/proc)")
+	}
+	stateDir := filepath.Join(t.TempDir(), "network")
+	path := LockPathForStateDir(stateDir)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Spawn a live, non-citadel process to stand in for a PID that was reused by an
+	// unrelated program after a reboot. It sleeps long enough to stay alive for the
+	// duration of this test.
+	proc := exec.Command("sleep", "30")
+	if err := proc.Start(); err != nil {
+		t.Fatalf("spawn helper process: %v", err)
+	}
+	defer func() { _ = proc.Process.Kill(); _, _ = proc.Process.Wait() }()
+
+	// Seed a stale record naming the live-but-non-citadel PID. No process holds the
+	// OS lock, so Acquire should reclaim (alive but cmdline != citadel).
+	stale := lockRecord{PID: proc.Process.Pid, StartUnix: 1, Version: "vOLD"}
+	if err := os.WriteFile(path, encodeRecord(stale), 0o600); err != nil {
+		t.Fatalf("seed stale lock: %v", err)
+	}
+
+	reclaimed := false
+	l, err := Acquire(stateDir, "vNEW", func(string, ...any) { reclaimed = true })
+	if err != nil {
+		t.Fatalf("Acquire should reclaim a stale reused-PID lock, got error: %v", err)
+	}
+	defer l.Release()
+	if !reclaimed {
+		t.Errorf("expected a reclaim log for the reused non-citadel PID, got none")
+	}
+}
+
+// TestErrAlreadyRunningMessage pins the exact operator-facing refusal wording.
+func TestErrAlreadyRunningMessage(t *testing.T) {
+	e := &ErrAlreadyRunning{PID: 4242, StartTime: time.Unix(1700000000, 0), Path: "/x/citadel-work.lock"}
+	got := e.Error()
+	if !strings.Contains(got, "citadel worker already running (PID 4242, started ") {
+		t.Errorf("message = %q, missing expected prefix", got)
+	}
+	if !strings.Contains(got, "refusing to start a second instance") {
+		t.Errorf("message = %q, missing refusal clause", got)
 	}
 }
 
@@ -53,7 +167,7 @@ func TestLockPathForStateDir(t *testing.T) {
 func TestAcquireSecondIsRejected(t *testing.T) {
 	stateDir := filepath.Join(t.TempDir(), "network")
 
-	first, err := Acquire(stateDir, nil)
+	first, err := Acquire(stateDir, "", nil)
 	if err != nil {
 		t.Fatalf("first Acquire failed: %v", err)
 	}
@@ -62,7 +176,7 @@ func TestAcquireSecondIsRejected(t *testing.T) {
 	}
 
 	// Second acquire while first is held: must be refused.
-	second, err := Acquire(stateDir, nil)
+	second, err := Acquire(stateDir, "", nil)
 	if err == nil {
 		second.Release()
 		t.Fatal("second Acquire succeeded while first held the lock; expected refusal")
@@ -77,7 +191,7 @@ func TestAcquireSecondIsRejected(t *testing.T) {
 
 	// Release the first and confirm a new Acquire now succeeds (lock reusable).
 	first.Release()
-	third, err := Acquire(stateDir, nil)
+	third, err := Acquire(stateDir, "", nil)
 	if err != nil {
 		t.Fatalf("Acquire after Release failed: %v", err)
 	}
@@ -87,7 +201,7 @@ func TestAcquireSecondIsRejected(t *testing.T) {
 // TestReleaseIdempotent verifies Release can be called multiple times safely.
 func TestReleaseIdempotent(t *testing.T) {
 	stateDir := filepath.Join(t.TempDir(), "network")
-	l, err := Acquire(stateDir, nil)
+	l, err := Acquire(stateDir, "", nil)
 	if err != nil {
 		t.Fatalf("Acquire failed: %v", err)
 	}
@@ -102,7 +216,7 @@ func TestStaleLockReclaimed(t *testing.T) {
 	stateDir := filepath.Join(t.TempDir(), "network")
 
 	// Hold and release to leave a lock file behind with a now-defunct PID record.
-	first, err := Acquire(stateDir, nil)
+	first, err := Acquire(stateDir, "", nil)
 	if err != nil {
 		t.Fatalf("first Acquire failed: %v", err)
 	}
@@ -112,7 +226,7 @@ func TestStaleLockReclaimed(t *testing.T) {
 	// unit tests. This test asserts re-acquire works after the OS lock is free.
 	first.Release()
 
-	got, err := Acquire(stateDir, func(string, ...any) {})
+	got, err := Acquire(stateDir, "", func(string, ...any) {})
 	if err != nil {
 		t.Fatalf("re-Acquire after prior holder exited failed: %v", err)
 	}

--- a/internal/worklock/worklock_unix.go
+++ b/internal/worklock/worklock_unix.go
@@ -3,13 +3,13 @@
 package worklock
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
-	"strings"
 	"syscall"
+	"time"
 )
 
 // Lock is a held single-instance worker lock. Call Release (or rely on process
@@ -20,17 +20,21 @@ type Lock struct {
 }
 
 // Acquire takes an exclusive, non-blocking advisory lock on the worker lock file
-// derived from stateDir. On success it returns a *Lock and writes this process's
-// PID into the file for diagnostics.
+// derived from stateDir. On success it returns a *Lock and writes a JSON record
+// (this process's PID, start time, and version) into the file.
 //
-// If another live worker holds the lock, it returns *ErrAlreadyRunning. If the
-// lock file exists but its recorded holder PID is dead, the lock is reclaimed
-// (flock already guarantees the kernel freed a dead holder's lock; the PID check
-// only drives the human-readable log via logf).
+// Refuse-vs-reclaim uses two layers. The OS advisory lock (flock) is authoritative:
+// the kernel frees it on process death, so a crashed worker never wedges its own
+// restart. On top of that, an explicit liveness + identity check (is the recorded
+// PID alive AND actually a citadel process, via /proc/<pid>/cmdline) guards against
+// a reused PID: if the flock is contended but the recorded holder is dead or has
+// been reused by an unrelated program, the lock is reclaimed rather than refused.
+// If a live citadel process holds it, Acquire returns *ErrAlreadyRunning naming the
+// holder PID and start time.
 //
-// logf, if non-nil, receives a single informational line when a stale lock is
-// reclaimed. Pass nil to stay silent.
-func Acquire(stateDir string, logf func(format string, args ...any)) (*Lock, error) {
+// version is stamped into the record (may be empty). logf, if non-nil, receives a
+// single informational line when a stale lock is reclaimed; pass nil to stay silent.
+func Acquire(stateDir, version string, logf func(format string, args ...any)) (*Lock, error) {
 	path := LockPathForStateDir(stateDir)
 
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
@@ -48,31 +52,52 @@ func Acquire(stateDir string, logf func(format string, args ...any)) (*Lock, err
 	// Non-blocking exclusive lock. If a live process holds it, flock returns
 	// EWOULDBLOCK immediately (no hang).
 	if lockErr := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); lockErr != nil {
-		// Could not take the lock. Read the recorded holder PID for a clear message.
-		holderPID := readPID(f)
+		if !errors.Is(lockErr, syscall.EWOULDBLOCK) {
+			_ = f.Close()
+			return nil, fmt.Errorf("worklock: flock %s: %w", path, lockErr)
+		}
+		// The lock is contended. Cross-check the recorded holder before refusing:
+		// only a live citadel process is a real duplicate worth refusing. (A reused
+		// PID cannot actually hold the flock, but this keeps the refusal message
+		// honest and the identity check consistent between paths.)
+		rec := readRecord(f)
 		_ = f.Close()
-		if errors.Is(lockErr, syscall.EWOULDBLOCK) {
-			return nil, &ErrAlreadyRunning{PID: holderPID, Path: path}
+		if rec.PID > 0 && processAlive(rec.PID) && processIsCitadel(rec.PID) {
+			return nil, &ErrAlreadyRunning{PID: rec.PID, StartTime: startTime(rec), Path: path}
 		}
-		return nil, fmt.Errorf("worklock: flock %s: %w", path, lockErr)
+		// Holder is dead / not a citadel process yet the flock is still reported
+		// held (rare, e.g. an unrelated fd on the same file). Surface a clear error
+		// rather than silently overwriting a lock we do not actually hold.
+		return nil, &ErrAlreadyRunning{PID: rec.PID, StartTime: startTime(rec), Path: path}
 	}
 
-	// We hold the lock. If a stale PID was recorded by a dead prior holder, note
-	// the reclaim for the operator. (flock already let us in, so the prior holder
-	// is definitively gone; this is purely explanatory.)
-	if prevPID := readPID(f); prevPID > 0 && prevPID != os.Getpid() {
-		if decideStaleLock(prevPID, os.Getpid(), processAlive(prevPID)) == actionReclaim && logf != nil {
-			logf("worklock: reclaimed stale worker lock from dead PID %d (%s)", prevPID, path)
+	// We hold the lock. If a stale record was left by a prior holder, note the
+	// reclaim for the operator. flock already let us in, so any prior holder is
+	// gone; the identity check keeps the log accurate for a reused PID.
+	if prev := readRecord(f); prev.PID > 0 && prev.PID != os.Getpid() {
+		if decideStaleLock(prev.PID, os.Getpid(), processAlive(prev.PID), processIsCitadel(prev.PID)) == actionReclaim && logf != nil {
+			logf("worklock: reclaimed stale worker lock from PID %d (%s)", prev.PID, path)
 		}
 	}
 
-	// Record our PID. Truncate first so a shorter PID never leaves trailing bytes.
+	// Record our identity. Truncate first so a shorter record never leaves
+	// trailing bytes from a longer prior one.
 	if err := f.Truncate(0); err == nil {
-		_, _ = f.WriteAt([]byte(strconv.Itoa(os.Getpid())+"\n"), 0)
+		rec := lockRecord{PID: os.Getpid(), StartUnix: time.Now().Unix(), Version: version}
+		_, _ = f.WriteAt(encodeRecord(rec), 0)
 		_ = f.Sync()
 	}
 
 	return &Lock{f: f, path: path}, nil
+}
+
+// startTime converts a record's start timestamp to a time.Time, or the zero value
+// when unknown (e.g. a legacy bare-PID lock file with no timestamp).
+func startTime(rec lockRecord) time.Time {
+	if rec.StartUnix <= 0 {
+		return time.Time{}
+	}
+	return time.Unix(rec.StartUnix, 0)
 }
 
 // Release relinquishes the lock and removes the lock file. Safe to call more than
@@ -99,19 +124,16 @@ func (l *Lock) Path() string {
 	return l.path
 }
 
-// readPID reads and parses the PID recorded in an open lock file. Returns 0 if
-// the file is empty or unparseable.
-func readPID(f *os.File) int {
-	buf := make([]byte, 32)
+// readRecord reads and parses the lock record from an open lock file. Returns a
+// zero record if the file is empty or unparseable. Handles both the JSON record
+// format and a legacy bare-PID line.
+func readRecord(f *os.File) lockRecord {
+	buf := make([]byte, 512)
 	n, _ := f.ReadAt(buf, 0)
 	if n <= 0 {
-		return 0
+		return lockRecord{}
 	}
-	pid, err := strconv.Atoi(strings.TrimSpace(string(buf[:n])))
-	if err != nil || pid <= 0 {
-		return 0
-	}
-	return pid
+	return decodeRecord(buf[:n])
 }
 
 // processAlive reports whether a process with the given PID is currently alive.
@@ -126,4 +148,26 @@ func processAlive(pid int) bool {
 		return true
 	}
 	return errors.Is(err, syscall.EPERM)
+}
+
+// processIsCitadel reports whether the process with the given PID is a citadel
+// process. On Linux it reads /proc/<pid>/cmdline (NUL-separated argv) and checks
+// for "citadel". This guards against a reused PID: after a reboot the PID counter
+// can wrap onto an unrelated program, and that program must not be mistaken for a
+// live worker. On non-Linux Unix (macOS), /proc is unavailable, so this returns
+// true (fail closed: keep refusing on an alive PID) — the flock is already the
+// authoritative singleton there.
+func processIsCitadel(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+	if err != nil {
+		// /proc absent (macOS) or unreadable: fail closed and treat as citadel so
+		// an alive holder is still refused; the flock remains the hard guard.
+		return true
+	}
+	// cmdline is NUL-separated; normalize to spaces and lowercase for a robust
+	// substring match against the binary name in argv[0] or later args.
+	return bytes.Contains(bytes.ToLower(bytes.ReplaceAll(data, []byte{0}, []byte{' '})), []byte("citadel"))
 }

--- a/internal/worklock/worklock_windows.go
+++ b/internal/worklock/worklock_windows.go
@@ -6,8 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
-	"strings"
+	"time"
 
 	"golang.org/x/sys/windows"
 )
@@ -22,7 +21,7 @@ type Lock struct {
 // from stateDir using LockFileEx with LOCKFILE_FAIL_IMMEDIATELY. Windows advisory
 // locks are released by the OS when the owning handle is closed or the process
 // exits, so a crashed worker never leaves a blocking lock.
-func Acquire(stateDir string, logf func(format string, args ...any)) (*Lock, error) {
+func Acquire(stateDir, version string, logf func(format string, args ...any)) (*Lock, error) {
 	path := LockPathForStateDir(stateDir)
 
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
@@ -43,27 +42,37 @@ func Acquire(stateDir string, logf func(format string, args ...any)) (*Lock, err
 		0, 1, 0, &overlapped,
 	)
 	if lockErr != nil {
-		holderPID := readPID(f)
+		rec := readRecord(f)
 		_ = f.Close()
 		// ERROR_LOCK_VIOLATION (33) is the "already held" signal.
 		if lockErr == windows.ERROR_LOCK_VIOLATION {
-			return nil, &ErrAlreadyRunning{PID: holderPID, Path: path}
+			return nil, &ErrAlreadyRunning{PID: rec.PID, StartTime: startTime(rec), Path: path}
 		}
 		return nil, fmt.Errorf("worklock: LockFileEx %s: %w", path, lockErr)
 	}
 
-	if prevPID := readPID(f); prevPID > 0 && prevPID != os.Getpid() {
-		if decideStaleLock(prevPID, os.Getpid(), processAlive(prevPID)) == actionReclaim && logf != nil {
-			logf("worklock: reclaimed stale worker lock from dead PID %d (%s)", prevPID, path)
+	if prev := readRecord(f); prev.PID > 0 && prev.PID != os.Getpid() {
+		if decideStaleLock(prev.PID, os.Getpid(), processAlive(prev.PID), processIsCitadel(prev.PID)) == actionReclaim && logf != nil {
+			logf("worklock: reclaimed stale worker lock from PID %d (%s)", prev.PID, path)
 		}
 	}
 
 	if err := f.Truncate(0); err == nil {
-		_, _ = f.WriteAt([]byte(strconv.Itoa(os.Getpid())+"\n"), 0)
+		rec := lockRecord{PID: os.Getpid(), StartUnix: time.Now().Unix(), Version: version}
+		_, _ = f.WriteAt(encodeRecord(rec), 0)
 		_ = f.Sync()
 	}
 
 	return &Lock{f: f, path: path}, nil
+}
+
+// startTime converts a record's start timestamp to a time.Time, or the zero value
+// when unknown (e.g. a legacy bare-PID lock file with no timestamp).
+func startTime(rec lockRecord) time.Time {
+	if rec.StartUnix <= 0 {
+		return time.Time{}
+	}
+	return time.Unix(rec.StartUnix, 0)
 }
 
 // Release relinquishes the lock and removes the lock file.
@@ -87,17 +96,21 @@ func (l *Lock) Path() string {
 	return l.path
 }
 
-func readPID(f *os.File) int {
-	buf := make([]byte, 32)
+func readRecord(f *os.File) lockRecord {
+	buf := make([]byte, 512)
 	n, _ := f.ReadAt(buf, 0)
 	if n <= 0 {
-		return 0
+		return lockRecord{}
 	}
-	pid, err := strconv.Atoi(strings.TrimSpace(string(buf[:n])))
-	if err != nil || pid <= 0 {
-		return 0
-	}
-	return pid
+	return decodeRecord(buf[:n])
+}
+
+// processIsCitadel reports whether the given PID is a citadel process. On Windows
+// there is no cheap /proc/<pid>/cmdline equivalent, so this is a best-effort no-op
+// that returns true (fail closed): an alive holder is still refused, and the
+// LockFileEx advisory lock remains the authoritative singleton guard.
+func processIsCitadel(pid int) bool {
+	return pid > 0
 }
 
 // processAlive reports whether a process with the given PID is alive on Windows.


### PR DESCRIPTION
## Problem

A node ended up with a split-brain worker. The systemd-managed `citadel work`
(`CITADEL_SERVICE=true`) kept running an OLD in-memory binary after an update
swapped the on-disk binary and the unit never restarted (`NRestarts=0`). The
running worker's handler set no longer matched the installed binary, so a
dispatched job failed with `unsupported job type "WHATSAPP_PROVISION": node
v2.65.0 has no handler for it` even though that binary registers the handler
unconditionally. Separately, a second `citadel` process was easy to launch by
hand.

The worker single-instance guard already shipped in #446 (per-node flock /
LockFileEx keyed to `network.GetStateDir()`), which structurally blocks a second
`citadel work`. This PR closes the remaining sharp edge the incident exposed:
the lock's liveness check only verified that the recorded PID *existed*. After a
reboot the PID counter can wrap onto an unrelated program, and that alive-but-
unrelated PID would be treated as a live worker and refuse startup, wedging the
node until an operator cleared the lock by hand.

## Solution

Build on the existing `internal/worklock` guard (no new parallel mechanism):

- **Richer lock record.** The lock file now stores a JSON record `{pid, start
  time, version}` instead of a bare PID line. `decodeRecord` still accepts the
  legacy bare-PID format, so an in-place upgrade never misreads a lock file
  written by an older worker.
- **PID-reuse / identity check.** New `processIsCitadel(pid)` reads
  `/proc/<pid>/cmdline` on Linux and checks for `citadel`. A recorded PID that
  is alive but has been reused by an unrelated program is no longer mistaken for
  a live worker; the lock is reclaimed instead of wedging. Non-Linux is a
  best-effort no-op returning `true` (fail closed; the OS advisory lock remains
  the authoritative singleton there).
- **Refuse-vs-reclaim policy.** `decideStaleLock` gains a `holderIsCitadel`
  input: reclaim when the holder is dead OR alive-but-not-citadel; refuse only
  for a live citadel holder. flock/LockFileEx stays authoritative (a crashed
  worker never blocks its own restart, kernel-released).
- **Actionable refusal.** `ErrAlreadyRunning` now carries the holder start time
  and prints the exact message:

  ```
  citadel worker already running (PID <n>, started <t>); refusing to start a second instance
  ```

- `Acquire` takes a `version` string stamped into the record; `cmd/work.go`
  passes `cmd.Version`.

`citadel work` is the only entry point that starts the persistent worker loop
(there is no `up.go`/`agent.go` in this tree), and it is the only caller of
`worklock.Acquire`. Read-only/short commands (status, logs, version, nodes) do
not acquire the lock and are unaffected. The guard releases on clean shutdown
(`defer` + SIGINT/SIGTERM handling already in `runWork`).

## IPC follow-up (not in this PR)

The maintainer floated "maybe IPC: ask the running singleton to do it." That is
a larger design (a control socket, a request/response protocol, versioned
compatibility). This PR intentionally implements only lock-and-refuse — the
must-have. A future PR could add a control socket so a second invocation hands
its request to the live singleton instead of exiting, and so an operator can
query/trigger a graceful reload of the running worker (which would also let a
stale in-memory binary be told to re-exec after an on-disk swap).

## Test plan

`go build ./...` passes. Targeted (avoids the full-suite tmux crash here):

```
env -u TMUX TMUX_TMPDIR=/tmp/x go test ./internal/worklock/...  # ok
env -u TMUX TMUX_TMPDIR=/tmp/x go test ./cmd/ -run Work         # ok
```

Unit tests (all `t.TempDir`, no external state):

- fresh acquire succeeds and stamps `{pid, start, version}` into the record
- second acquire refused while held (`*ErrAlreadyRunning` with holder PID)
- stale dead-PID lock reclaimed; release frees it; release idempotent
- record round-trip incl. legacy bare-PID format and empty/garbage → zero record
- reused live **non-citadel** PID reclaimed (Linux: spawns a real `sleep`
  process and records its PID)
- refusal message wording pinned

Generated by Claude Opus 4.8