### PR TITLE
fix: stop control center competing for per-node jobs (#456)

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -39,6 +39,8 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/update"
 	"github.com/aceteam-ai/citadel-cli/internal/usage"
 	"github.com/aceteam-ai/citadel-cli/internal/worker"
+	"github.com/aceteam-ai/citadel-cli/internal/workflow"
+	"github.com/aceteam-ai/citadel-cli/internal/worklock"
 	"github.com/aceteam-ai/citadel-cli/services"
 	"github.com/google/uuid"
 	"github.com/shirou/gopsutil/v3/cpu"
@@ -1647,6 +1649,28 @@ func runTUIWorker(ctx context.Context, activityFn func(level, msg string)) error
 	// Load device config from file
 	deviceConfig := getDeviceConfigFromFile()
 
+	// Detect a dedicated `citadel work` worker already serving this node. If one
+	// holds the single-instance lock (issues #443/#435/#455), the control center
+	// MUST NOT compete for this node's jobs: two consumers in the same consumer
+	// group split the per-node stream non-deterministically, so node-targeted
+	// privileged jobs (WHATSAPP_PROVISION, AGENT_UPDATE) were randomly grabbed by
+	// the control-center worker and failed with "no handler" even though the real
+	// worker's binary handles them (the competing-consumer incident). When a worker
+	// is present the control center stays a read-only monitor (heartbeat/telemetry
+	// only) and lets the real worker own all job consumption.
+	//
+	// Detection is a one-shot at TUI-worker startup: the systemd worker is normally
+	// already running before the TUI opens. If a worker starts or stops later the
+	// mode is not re-evaluated until the TUI worker restarts, but that residual is
+	// benign — the "no handler" hazard is removed unconditionally by the shared
+	// handler set below (both modes register WHATSAPP_PROVISION / AGENT_UPDATE), so a
+	// transient double-consumer only reproduces the pre-existing split, never a job
+	// failure. A worker that later dies is systemd-restarted (re-taking the lock).
+	workerHeld, workerPID := worklock.IsHeld(network.GetStateDir())
+	if workerHeld {
+		activity("info", fmt.Sprintf("Dedicated worker detected (PID %d); control center runs in monitor-only mode (no job consumption)", workerPID))
+	}
+
 	// Determine job source mode
 	var source worker.JobSource
 	var streamFactory func(job *worker.Job) worker.StreamWriter
@@ -1713,7 +1737,12 @@ func runTUIWorker(ctx context.Context, activityFn func(level, msg string)) error
 			headscaleNodeID = id
 		}
 	}
-	if headscaleNodeID != "" {
+	// Only subscribe to the per-node stream when NO dedicated worker holds the lock.
+	// If a worker is present it owns the per-node stream; a second subscriber here
+	// would re-introduce the competing-consumer split.
+	if workerHeld {
+		activity("info", "Per-node stream owned by the dedicated worker; control center does not subscribe")
+	} else if headscaleNodeID != "" {
 		perNodeOrgID := ""
 		if deviceConfig != nil {
 			perNodeOrgID = deviceConfig.OrgID
@@ -1827,21 +1856,50 @@ func runTUIWorker(ctx context.Context, activityFn func(level, msg string)) error
 		}
 	}
 
+	// If a dedicated worker holds the lock, the control center does NOT run a
+	// job-consuming runner (that is the whole point of the fix). Heartbeat and
+	// telemetry are already wired above; block here in monitor-only mode until the
+	// TUI context is cancelled, letting the real worker own all job consumption.
+	if workerHeld {
+		activity("success", "Monitor mode active (dedicated worker owns jobs)")
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	// No dedicated worker on this node: the control center IS the only worker, so it
+	// must handle the FULL node-job set (legacy + workflow + AGENT_UPDATE +
+	// WHATSAPP_PROVISION), not a subset. Build handlers via the shared helper so the
+	// registered set matches `citadel work` exactly and WHATSAPP_PROVISION /
+	// AGENT_UPDATE never fail with "no handler" in a control-center-only run.
+
 	// Create worker ID
 	workerID := fmt.Sprintf("citadel-tui-%s", uuid.New().String()[:8])
 
 	// Create handlers with activity callback to route job output through TUI.
 	wsDir := resolveWorkspaceDir()
 	ccPerms := config.LoadPermissions(platform.ConfigDir())
-	handlers := worker.CreateLegacyHandlersWithOpts(worker.LegacyHandlerOpts{
-		LogFn:         activity,
-		WorkspaceDir:  wsDir,
-		ShellDisabled: !ccPerms.Shell,
+
+	// Workflow executor for WORKFLOW_RUN jobs, mirroring runWork's wiring.
+	ccWfExec := workflow.NewExecutor(workflow.ExecutorConfig{
+		Shell: workflow.ShellConfig{WorkspaceDir: wsDir},
 	})
+
+	_, ccConfigDir, _ := findAndReadManifest()
+	nodeJobOpts := nodeJobHandlerOpts{
+		LogFn:                     activity,
+		WorkspaceDir:              wsDir,
+		ConfigDir:                 ccConfigDir,
+		AllowReadOutsideWorkspace: resolveAllowReadOutsideWorkspace(),
+		ShellDisabled:             !ccPerms.Shell,
+		WorkflowExec:              ccWfExec,
+		HandlerLog:                func(format string, args ...any) { activity("info", fmt.Sprintf(format, args...)) },
+	}
+	handlers := buildNodeJobHandlers(nodeJobOpts)
 
 	// Create runner with TUI callbacks
 	runner := worker.NewRunner(source, handlers, worker.RunnerConfig{
 		WorkerID:     workerID,
+		NodeID:       headscaleNodeID,
 		AgentVersion: Version,
 		Verbose:      false,
 		ActivityFn:   activity, // Route logs through TUI
@@ -1855,6 +1913,11 @@ func runTUIWorker(ctx context.Context, activityFn func(level, msg string)) error
 	if streamFactory != nil {
 		runner.WithStreamWriterFactory(streamFactory)
 	}
+
+	// Register the node-targeted privileged handlers (AGENT_UPDATE, WHATSAPP_PROVISION)
+	// on the live runner, shared with runWork. This closes the "no handler" hazard for
+	// a control-center-only node.
+	registerPrivilegedNodeJobHandlers(runner, nodeJobOpts)
 
 	activity("success", "Worker started, listening for jobs...")
 

--- a/cmd/nodejobs.go
+++ b/cmd/nodejobs.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/aceteam-ai/citadel-cli/internal/whatsapp"
+	"github.com/aceteam-ai/citadel-cli/internal/worker"
+	"github.com/aceteam-ai/citadel-cli/internal/workflow"
+)
+
+// nodeJobHandlerOpts bundles the node/environment edges the node-job handler set
+// needs. It is shared by BOTH `citadel work` (runWork) and the control-center TUI
+// (runTUIWorker) so a control-center-only node handles the exact same node-job set
+// as the dedicated worker — no more "node vX has no handler for WHATSAPP_PROVISION"
+// when only the control center runs (the competing-consumer incident).
+type nodeJobHandlerOpts struct {
+	// WorkspaceDir is the sandbox root for file-operation handlers.
+	WorkspaceDir string
+	// ConfigDir is the citadel.yaml manifest directory (enables service handlers).
+	// May be empty (the control center historically ran without it).
+	ConfigDir string
+	// AllowReadOutsideWorkspace lets read-only file handlers escape the sandbox.
+	AllowReadOutsideWorkspace bool
+	// ShellDisabled registers SHELL_COMMAND in a refusing state (still dispatchable).
+	ShellDisabled bool
+	// LogFn routes legacy handler job output through a callback instead of stdout.
+	LogFn func(level, msg string)
+	// WorkflowExec backs the WORKFLOW_RUN handler. Required.
+	WorkflowExec *workflow.Executor
+	// HandlerLog is the plain logger the privileged handlers (AGENT_UPDATE,
+	// WHATSAPP_PROVISION) use for their own progress lines. Required.
+	HandlerLog func(format string, args ...any)
+}
+
+// buildNodeJobHandlers returns the base node-job handler set: the legacy Nexus
+// handlers (shell, file ops, service management, inference, ...) plus the workflow
+// handler. It is the initial handler slice passed to worker.NewRunner. The
+// privileged, runner-coupled handlers (AGENT_UPDATE, WHATSAPP_PROVISION) are added
+// afterward via registerPrivilegedNodeJobHandlers, because they need the live
+// runner's Drain/ActiveJobs for the "publish result, THEN restart" ordering.
+func buildNodeJobHandlers(opts nodeJobHandlerOpts) []worker.JobHandler {
+	handlers := worker.CreateLegacyHandlersWithOpts(worker.LegacyHandlerOpts{
+		LogFn:                     opts.LogFn,
+		WorkspaceDir:              opts.WorkspaceDir,
+		ConfigDir:                 opts.ConfigDir,
+		AllowReadOutsideWorkspace: opts.AllowReadOutsideWorkspace,
+		ShellDisabled:             opts.ShellDisabled,
+	})
+	if opts.WorkflowExec != nil {
+		handlers = append(handlers, workflow.NewHandler(opts.WorkflowExec))
+	}
+	return handlers
+}
+
+// registerPrivilegedNodeJobHandlers registers the node-targeted privileged handlers
+// (AGENT_UPDATE and WHATSAPP_PROVISION) onto an already-constructed runner. These
+// are the handlers whose absence caused the competing-consumer incident: they were
+// registered only in `citadel work`, so when the control center ran its own worker
+// beside the real one and grabbed a WHATSAPP_PROVISION/AGENT_UPDATE job off the
+// shared per-node stream, it failed the job with "no handler" even though the real
+// worker's binary could handle it.
+//
+// They are registered after the runner exists so AGENT_UPDATE can borrow the
+// runner's Drain/ActiveJobs to drain in-flight work before a self-restart.
+func registerPrivilegedNodeJobHandlers(runner *worker.Runner, opts nodeJobHandlerOpts) {
+	// AGENT_UPDATE (aceteam#4427): remote agent update + restart for this node.
+	runner.RegisterHandler(worker.NewAgentUpdateHandler(worker.AgentUpdateConfig{
+		Version:    Version,
+		Drain:      func() { runner.Drain() },
+		ActiveJobs: runner.ActiveJobs,
+		Log:        opts.HandlerLog,
+	}))
+
+	// WHATSAPP_PROVISION (aceteam#4454): remote-provision the Baileys bridge on the
+	// user's own node. Reuses the same `citadel whatsapp up` orchestration wired with
+	// this node's real docker/git/mesh edges.
+	runner.RegisterHandler(worker.NewWhatsAppProvisionHandler(worker.WhatsAppProvisionConfig{
+		Provision: func(ctx context.Context, req whatsapp.ProvisionRequest) (*whatsapp.ProvisionResult, error) {
+			return whatsapp.Provision(ctx, req, whatsappProvisionDeps(defaultWhatsAppSource, ""))
+		},
+		Log: opts.HandlerLog,
+	}))
+}

--- a/cmd/nodejobs_test.go
+++ b/cmd/nodejobs_test.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/worker"
+	"github.com/aceteam-ai/citadel-cli/internal/workflow"
+)
+
+// TestNodeJobHandlersCoverPrivilegedTypes pins the fix for the competing-consumer
+// incident: the shared node-job handler set (used by BOTH `citadel work` and the
+// control-center-only worker) must be able to handle the node-targeted privileged
+// job types WHATSAPP_PROVISION and AGENT_UPDATE, not just the legacy shell/file set.
+// A control-center-only node that lacks these would fail such jobs with
+// "node vX has no handler", the exact bug this change removes.
+func TestNodeJobHandlersCoverPrivilegedTypes(t *testing.T) {
+	opts := nodeJobHandlerOpts{
+		WorkspaceDir: t.TempDir(),
+		WorkflowExec: workflow.NewExecutor(workflow.ExecutorConfig{}),
+		HandlerLog:   func(string, ...any) {},
+	}
+
+	// Build the base set and register the privileged handlers exactly as both
+	// runWork and runTUIWorker do.
+	handlers := buildNodeJobHandlers(opts)
+	runner := worker.NewRunner(nil, handlers, worker.RunnerConfig{})
+	registerPrivilegedNodeJobHandlers(runner, opts)
+
+	// The two node-targeted privileged types must be dispatchable.
+	for _, jt := range []string{worker.JobTypeWhatsAppProvision, worker.JobTypeAgentUpdate} {
+		if !runner.CanHandle(jt) {
+			t.Errorf("node-job handler set does not cover %q; a control-center-only worker would fail it with 'no handler'", jt)
+		}
+	}
+
+	// Sanity: the base legacy shell handler and the workflow handler are also present
+	// so this remains the FULL set, not a privileged-only subset.
+	if !runner.CanHandle(worker.JobTypeShellCommand) {
+		t.Errorf("node-job handler set missing SHELL_COMMAND")
+	}
+	if !runner.CanHandle("WORKFLOW_RUN") {
+		t.Errorf("node-job handler set missing WORKFLOW_RUN")
+	}
+}

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -42,7 +42,6 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/update"
 	"github.com/aceteam-ai/citadel-cli/internal/usage"
 	"github.com/aceteam-ai/citadel-cli/internal/websockify"
-	"github.com/aceteam-ai/citadel-cli/internal/whatsapp"
 	"github.com/aceteam-ai/citadel-cli/internal/worker"
 	"github.com/aceteam-ai/citadel-cli/internal/workflow"
 	"github.com/aceteam-ai/citadel-cli/internal/worklock"
@@ -1696,15 +1695,21 @@ func runWork(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	// Create handlers with optional workspace for file-operation jobs.
+	// Create handlers with optional workspace for file-operation jobs. The node-job
+	// handler set (legacy + workflow, plus the privileged AGENT_UPDATE /
+	// WHATSAPP_PROVISION registered on the runner below) is built via the shared
+	// helper so the control-center TUI registers the exact same set when it is the
+	// only worker on the node.
 	workPerms := config.LoadPermissions(platform.ConfigDir())
-	handlers := worker.CreateLegacyHandlersWithOpts(worker.LegacyHandlerOpts{
+	nodeJobOpts := nodeJobHandlerOpts{
 		WorkspaceDir:              wsDir,
 		ConfigDir:                 workConfigDir,
 		AllowReadOutsideWorkspace: resolveAllowReadOutsideWorkspace(),
 		ShellDisabled:             !workPerms.Shell,
-	})
-	handlers = append(handlers, workflow.NewHandler(wfExec))
+		WorkflowExec:              wfExec,
+		HandlerLog:                func(format string, args ...any) { Log(format, args...) },
+	}
+	handlers := buildNodeJobHandlers(nodeJobOpts)
 
 	// Build job record function for usage tracking
 	var jobRecordFn func(record usage.UsageRecord)
@@ -1756,38 +1761,13 @@ func runWork(cmd *cobra.Command, args []string) {
 		runner.WithStreamWriterFactory(streamFactory)
 	}
 
-	// Register the AGENT_UPDATE job handler (issue aceteam#4427), which lets the
-	// control plane update this node's agent remotely — the fix for silent
-	// version skew (aceteam#4373). It is registered after the runner exists so it
-	// can borrow the runner's Drain/ActiveJobs for the "publish result, THEN
-	// restart" ordering, mirroring how the AutoUpdater is wired below. The handler
-	// self-restarts only when running as a managed service (CITADEL_SERVICE=true);
-	// in a foreground run it reports "restart required" instead.
-	runner.RegisterHandler(worker.NewAgentUpdateHandler(worker.AgentUpdateConfig{
-		Version:    Version,
-		Drain:      func() { runner.Drain() },
-		ActiveJobs: runner.ActiveJobs,
-		Log: func(format string, args ...any) {
-			Log(format, args...)
-		},
-	}))
-
-	// Register the WHATSAPP_PROVISION job handler (aceteam#4454), which lets the
-	// WhatsApp MCP remote-provision the Baileys bridge on the user's OWN node
-	// (sovereign / BYO-infra). It reuses the exact `citadel whatsapp up`
-	// orchestration (whatsapp.Provision) wired with this node's real docker / git
-	// / mesh edges, and is gated to the per-node stream only (deploying a
-	// container + minting creds is privileged, mirroring AGENT_UPDATE).
-	runner.RegisterHandler(worker.NewWhatsAppProvisionHandler(worker.WhatsAppProvisionConfig{
-		Provision: func(ctx context.Context, req whatsapp.ProvisionRequest) (*whatsapp.ProvisionResult, error) {
-			// Default module source/image (the CLI flags are not in scope for a
-			// remote job; the payload only carries tenant/proxy/public_url).
-			return whatsapp.Provision(ctx, req, whatsappProvisionDeps(defaultWhatsAppSource, ""))
-		},
-		Log: func(format string, args ...any) {
-			Log(format, args...)
-		},
-	}))
+	// Register the node-targeted privileged job handlers (AGENT_UPDATE aceteam#4427,
+	// WHATSAPP_PROVISION aceteam#4454) on the live runner. They are registered after
+	// the runner exists so AGENT_UPDATE can borrow the runner's Drain/ActiveJobs for
+	// the "publish result, THEN restart" ordering (mirroring the AutoUpdater below).
+	// Shared with the control-center TUI via registerPrivilegedNodeJobHandlers so a
+	// control-center-only node handles the same privileged set.
+	registerPrivilegedNodeJobHandlers(runner, nodeJobOpts)
 
 	// Start the periodic auto-updater. The goroutine always runs; whether it
 	// actually checks/installs on a given tick is decided per-tick by

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -624,3 +624,17 @@ func intFromOutput(m map[string]any, key string) int64 {
 func (r *Runner) RegisterHandler(handler JobHandler) {
 	r.handlers = append(r.handlers, handler)
 }
+
+// CanHandle reports whether any registered handler can process jobType. It is the
+// runner-level view of dispatchability, used by callers and tests to assert the
+// registered handler set covers a given job type (e.g. WHATSAPP_PROVISION /
+// AGENT_UPDATE must be present on both the dedicated worker and a control-center-only
+// worker).
+func (r *Runner) CanHandle(jobType string) bool {
+	for _, h := range r.handlers {
+		if h.CanHandle(jobType) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/worklock/isheld_test.go
+++ b/internal/worklock/isheld_test.go
@@ -1,0 +1,157 @@
+package worklock
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestIsHeldNoFile verifies the read-only detector reports not-held when no lock
+// file exists (a node with no worker ever started).
+func TestIsHeldNoFile(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "network")
+	held, pid := IsHeld(stateDir)
+	if held {
+		t.Fatalf("IsHeld on a missing lock file = held (pid %d), want not held", pid)
+	}
+}
+
+// TestIsHeldStaleReusedPID verifies that a lock FILE naming a live-but-non-citadel
+// PID (a PID reused by an unrelated program after a reboot) reports not-held: only
+// a live citadel holder counts. Mirrors Acquire's reclaim classification so a stale
+// record never wedges the control center into monitor-only mode. Linux-only because
+// the reused-PID discrimination relies on /proc/<pid>/cmdline.
+func TestIsHeldStaleReusedPID(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("reused-PID cmdline detection is Linux-only (/proc)")
+	}
+	stateDir := filepath.Join(t.TempDir(), "network")
+	path := LockPathForStateDir(stateDir)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// A live, non-citadel process stands in for a reused PID. It holds no OS lock,
+	// so the flock probe would succeed; but even seeded as the recorded holder the
+	// detector must report not-held because its cmdline is not a citadel process.
+	proc := exec.Command("sleep", "30")
+	if err := proc.Start(); err != nil {
+		t.Fatalf("spawn helper: %v", err)
+	}
+	defer func() { _ = proc.Process.Kill(); _, _ = proc.Process.Wait() }()
+
+	stale := lockRecord{PID: proc.Process.Pid, StartUnix: 1, Version: "vOLD"}
+	if err := os.WriteFile(path, encodeRecord(stale), 0o600); err != nil {
+		t.Fatalf("seed stale lock: %v", err)
+	}
+
+	held, pid := IsHeld(stateDir)
+	if held {
+		t.Fatalf("IsHeld on a stale reused-PID lock = held (pid %d), want not held", pid)
+	}
+}
+
+// TestIsHeldDeadHolder verifies a lock file whose recorded PID is dead (and no OS
+// lock is held) reports not-held.
+func TestIsHeldDeadHolder(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "network")
+	path := LockPathForStateDir(stateDir)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// PID 2^30 is far above any real PID on these platforms: guaranteed dead.
+	dead := lockRecord{PID: 1 << 30, StartUnix: 1, Version: "vOLD"}
+	if err := os.WriteFile(path, encodeRecord(dead), 0o600); err != nil {
+		t.Fatalf("seed dead lock: %v", err)
+	}
+	held, pid := IsHeld(stateDir)
+	if held {
+		t.Fatalf("IsHeld on a dead-holder lock = held (pid %d), want not held", pid)
+	}
+}
+
+// TestIsHeldLiveWorker verifies the positive path: while a live citadel process
+// holds the single-instance lock, IsHeld reports held with that holder's PID, and
+// the read-only probe does NOT disturb the holder (it can be probed repeatedly and
+// the holder still owns the lock afterward). The holder is a subprocess of this
+// test binary whose argv contains the literal "citadel" so processIsCitadel's
+// /proc cmdline check classifies it correctly. Linux-only for that reason.
+func TestIsHeldLiveWorker(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("live-holder detection uses /proc cmdline classification (Linux-only)")
+	}
+	stateDir := filepath.Join(t.TempDir(), "network")
+
+	// Spawn the helper below, which acquires the lock and blocks. The "citadel"
+	// argument makes its /proc cmdline match processIsCitadel.
+	helper := exec.Command(os.Args[0], "-test.run=TestLockHolderHelper", "--", "citadel-lock-holder")
+	helper.Env = append(os.Environ(),
+		"WORKLOCK_HELPER=1",
+		"WORKLOCK_HELPER_STATEDIR="+stateDir,
+	)
+	stdout, err := helper.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	if err := helper.Start(); err != nil {
+		t.Fatalf("start helper: %v", err)
+	}
+	defer func() { _ = helper.Process.Kill(); _, _ = helper.Process.Wait() }()
+
+	// Wait for the helper to signal it has acquired the lock.
+	buf := make([]byte, 16)
+	waitReady := make(chan struct{})
+	go func() {
+		_, _ = stdout.Read(buf)
+		close(waitReady)
+	}()
+	select {
+	case <-waitReady:
+	case <-time.After(10 * time.Second):
+		t.Fatal("helper did not acquire the lock within 10s")
+	}
+
+	held, pid := IsHeld(stateDir)
+	if !held {
+		t.Fatalf("IsHeld while a live citadel worker holds the lock = not held, want held")
+	}
+	if pid != helper.Process.Pid {
+		t.Errorf("IsHeld holder PID = %d, want helper PID %d", pid, helper.Process.Pid)
+	}
+
+	// Probing must not steal the lock: a second Acquire from THIS process must still
+	// be refused because the helper still holds it.
+	if l, err := Acquire(stateDir, "", nil); err == nil {
+		l.Release()
+		t.Fatal("Acquire succeeded after IsHeld probe; the read-only probe must not release the holder's lock")
+	}
+
+	// A repeat probe still reports held (idempotent, non-disruptive).
+	if held2, _ := IsHeld(stateDir); !held2 {
+		t.Fatal("second IsHeld probe = not held; the first probe disturbed the holder")
+	}
+}
+
+// TestLockHolderHelper is not a real test: it is the subprocess entrypoint spawned
+// by TestIsHeldLiveWorker. Gated by WORKLOCK_HELPER so it is inert during a normal
+// test run. It acquires the worker lock, prints a readiness byte, and blocks so the
+// parent can observe a live holder.
+func TestLockHolderHelper(t *testing.T) {
+	if os.Getenv("WORKLOCK_HELPER") != "1" {
+		return
+	}
+	stateDir := os.Getenv("WORKLOCK_HELPER_STATEDIR")
+	l, err := Acquire(stateDir, "vHELPER", nil)
+	if err != nil {
+		// Signal failure by exiting non-zero.
+		os.Exit(2)
+	}
+	defer l.Release()
+	// Signal readiness to the parent, then block until killed.
+	_, _ = os.Stdout.WriteString("ready\n")
+	_ = os.Stdout.Sync()
+	select {}
+}

--- a/internal/worklock/worklock_unix.go
+++ b/internal/worklock/worklock_unix.go
@@ -91,6 +91,55 @@ func Acquire(stateDir, version string, logf func(format string, args ...any)) (*
 	return &Lock{f: f, path: path}, nil
 }
 
+// IsHeld reports whether a live citadel worker currently holds the single-instance
+// lock for the node keyed to stateDir, WITHOUT acquiring, reclaiming, or otherwise
+// disturbing it. It is the read-only counterpart to Acquire, used by the control
+// center to detect a running `citadel work` before deciding whether to run its own
+// embedded job worker (issue: control-center competes for per-node-stream jobs).
+//
+// Detection mirrors Acquire's refuse-vs-reclaim logic but never mutates the lock:
+//   - A non-blocking exclusive flock probe on a SEPARATE fd tests contention. The
+//     probe fd is unlocked and closed immediately, so a successful probe never
+//     leaves the caller holding the lock (it is not the persistent worker lock).
+//   - If the probe is contended (EWOULDBLOCK) AND the recorded holder PID is a live
+//     citadel process, the lock is reported held with that PID.
+//   - A missing file, unparseable record, dead holder, or PID reused by an
+//     unrelated program reports NOT held (holderPID 0) — the same conditions under
+//     which Acquire would reclaim rather than refuse.
+//
+// A false "not held" only degrades to the pre-fix behavior (the control center may
+// run its own worker); it never steals or breaks the real worker's lock.
+func IsHeld(stateDir string) (held bool, holderPID int) {
+	path := LockPathForStateDir(stateDir)
+
+	f, err := os.OpenFile(path, os.O_RDONLY, 0o600)
+	if err != nil {
+		// No lock file (or unreadable): no worker holds it.
+		return false, 0
+	}
+	defer func() { _ = f.Close() }()
+
+	rec := readRecord(f)
+
+	// Non-blocking exclusive probe. If it succeeds, no one holds the lock; unlock
+	// immediately so this transient probe is not mistaken for a real worker lock.
+	if lockErr := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); lockErr == nil {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		return false, 0
+	} else if !errors.Is(lockErr, syscall.EWOULDBLOCK) {
+		// Unexpected flock error: fail open (report not held) so the control center
+		// stays functional rather than wedging on a probe error.
+		return false, 0
+	}
+
+	// Contended. Only a live citadel process counts as a real holder; a dead or
+	// reused PID reports not held (Acquire would reclaim it).
+	if rec.PID > 0 && processAlive(rec.PID) && processIsCitadel(rec.PID) {
+		return true, rec.PID
+	}
+	return false, 0
+}
+
 // startTime converts a record's start timestamp to a time.Time, or the zero value
 // when unknown (e.g. a legacy bare-PID lock file with no timestamp).
 func startTime(rec lockRecord) time.Time {

--- a/internal/worklock/worklock_windows.go
+++ b/internal/worklock/worklock_windows.go
@@ -66,6 +66,47 @@ func Acquire(stateDir, version string, logf func(format string, args ...any)) (*
 	return &Lock{f: f, path: path}, nil
 }
 
+// IsHeld reports whether a live citadel worker currently holds the single-instance
+// lock for the node keyed to stateDir, WITHOUT acquiring, reclaiming, or otherwise
+// disturbing it. It is the read-only counterpart to Acquire (see the Unix build for
+// the full contract): a non-blocking exclusive LockFileEx probe on a separate handle
+// detects contention, the probe is unlocked immediately, and only a live citadel
+// holder PID is reported as held. A missing/stale/reused lock reports not held.
+func IsHeld(stateDir string) (held bool, holderPID int) {
+	path := LockPathForStateDir(stateDir)
+
+	f, err := os.OpenFile(path, os.O_RDONLY, 0o600)
+	if err != nil {
+		return false, 0
+	}
+	defer func() { _ = f.Close() }()
+
+	rec := readRecord(f)
+
+	handle := windows.Handle(f.Fd())
+	var overlapped windows.Overlapped
+	lockErr := windows.LockFileEx(
+		handle,
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0, 1, 0, &overlapped,
+	)
+	if lockErr == nil {
+		// Acquired the probe lock: no one else holds it. Release immediately.
+		var unlockOverlapped windows.Overlapped
+		_ = windows.UnlockFileEx(handle, 0, 1, 0, &unlockOverlapped)
+		return false, 0
+	}
+	if lockErr != windows.ERROR_LOCK_VIOLATION {
+		// Unexpected error: fail open (report not held).
+		return false, 0
+	}
+
+	if rec.PID > 0 && processAlive(rec.PID) && processIsCitadel(rec.PID) {
+		return true, rec.PID
+	}
+	return false, 0
+}
+
 // startTime converts a record's start timestamp to a time.Time, or the zero value
 // when unknown (e.g. a legacy bare-PID lock file with no timestamp).
 func startTime(rec lockRecord) time.Time {


### PR DESCRIPTION
## Context

Diagnosed on a live node: `WHATSAPP_PROVISION` jobs failed with `node vX has no handler for it (update the node)` even though the node was correctly updated and the real `citadel work` worker's binary registers the handler. Its journal showed zero receipts of the job. Hours were lost because the node looked correct. `SHELL_COMMAND` kept working, which masked the problem.

The cause: the control-center TUI (bare `citadel`) starts its OWN embedded job worker that consumes the SAME per-node stream in the SAME consumer group as `citadel work`. When both run, node-targeted privileged jobs are randomly grabbed by the control-center worker — which registered only the legacy handler subset — and fail with "no handler". Closes #456.

## Root cause

1. **Competing consumer.** `cmd/controlcenter.go` subscribed to the per-node stream (`apiSrc.AddQueue(nodeQueueName(...))`) and ran its own runner. Two consumers in one consumer group split the stream non-deterministically.
2. **Subset handler set.** The control-center runner registered only `CreateLegacyHandlersWithOpts(...)`. `WHATSAPP_PROVISION` (aceteam#4454) and `AGENT_UPDATE` (aceteam#4427) were registered only in `cmd/work.go`.

## Fix

Both invariants now hold:

1. **No competing consumer.** New read-only `worklock.IsHeld(stateDir) (bool, pid)` — a non-blocking flock probe plus the same liveness/identity classification as `Acquire`, and it never disturbs the holder. When a dedicated `citadel work` holds the lock, the control center does NOT subscribe to the per-node stream and does NOT run a job-consuming runner; it stays a read-only monitor (heartbeat/telemetry still run). Detection is a one-shot at TUI-worker startup (documented in-code); the residual is benign because of fix 2.
2. **Standalone control-center stays fully capable.** Shared helper (`buildNodeJobHandlers` + `registerPrivilegedNodeJobHandlers` in `cmd/nodejobs.go`) registers legacy + workflow + `AGENT_UPDATE` + `WHATSAPP_PROVISION`, called from BOTH `work.go` and `controlcenter.go`. A control-center-only node now handles the full node-job set, removing the "no handler" hazard regardless of which worker runs.

Also adds `Runner.CanHandle` (read-only dispatchability view) for the test below.

## Test plan

- `internal/worklock`: `IsHeld` reports not-held on a missing file, stale/dead PID, and reused (live non-citadel) PID; reports held (with holder PID) while a live citadel subprocess holds the lock, and the probe does not steal the lock (a subsequent `Acquire` is still refused and a repeat probe still reports held).
- `cmd`: shared handler set covers `WHATSAPP_PROVISION` + `AGENT_UPDATE` (and still `SHELL_COMMAND` + `WORKFLOW_RUN`) via `runner.CanHandle`.
- `go build ./...` clean; `go vet` clean on changed packages; `go test ./internal/worklock/... ./internal/worker/... ./cmd/...` (targeted) green.

## Files changed

- `internal/worklock/worklock_unix.go`, `worklock_windows.go` — add `IsHeld`
- `internal/worklock/isheld_test.go` — new tests
- `cmd/nodejobs.go` — shared node-job handler helpers
- `cmd/nodejobs_test.go` — shared-set coverage test
- `cmd/work.go` — use shared helper; drop now-unused whatsapp import
- `cmd/controlcenter.go` — detect running worker; monitor-only when held; full handler set when standalone
- `internal/worker/runner.go` — add `Runner.CanHandle`

*Generated by Claude Opus 4.8*
