### PR TITLE
ci: build+push claudecode-service image to GHCR

### DIFF
--- a/.github/workflows/build-claudecode-service.yml
+++ b/.github/workflows/build-claudecode-service.yml
@@ -1,0 +1,63 @@
+name: Build claudecode-service image
+
+# Builds and publishes the headless Claude Code agent-runtime sidecar to GHCR as
+# ghcr.io/aceteam-ai/claudecode-service. The node compose files
+# (services/compose/claudecode.yml and services/claudecode-service/compose.yml)
+# pull this image when a node provisions the "claudecode" runtime (Child C of the
+# BYOC agent-hosting epic aceteam-ai/aceteam#4588), so the image MUST exist in the
+# registry for every node other than the node-1054 live-proof box (which carries
+# a local claudecode-service:local image). See aceteam-ai/citadel-cli#442.
+#
+# Triggers only when the service source changes on main (or manually), so
+# ordinary Go PRs don't rebuild the image. We intentionally do NOT build on
+# pull_request: gating an unmerged PR on an image build adds no signal -- the
+# first real build runs post-merge on main where it can be watched. Use
+# workflow_dispatch to build a branch on demand.
+# Tags: `latest` on main plus the commit SHA for pinning/rollback.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "services/claudecode-service/**"
+      - ".github/workflows/build-claudecode-service.yml"
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE: ghcr.io/aceteam-ai/claudecode-service
+
+jobs:
+  build:
+    name: Build + push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: services/claudecode-service
+          file: services/claudecode-service/Dockerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/services/claudecode-service/README.md
+++ b/services/claudecode-service/README.md
@@ -97,3 +97,54 @@ Builds the image, starts a mock Anthropic proxy + mock reply receiver, runs a
 turn, and asserts the fast ack, the Anthropic-shaped proxy request, and the
 well-formed `{reply}` POST with raw-key auth. See the PR "Testing" section for
 sample output.
+
+## Verifying the chown+gosu path under rootless podman
+
+The entrypoint (`entrypoint.sh`) starts as container-root, `chown`s the
+bind-mounted state dir to the in-container `claude` user (uid 10001), then drops
+privileges with `gosu`. This was validated under **docker**, where container-root
+is real host root and the chown is unconditional. Citadel prefers **rootless
+podman**, where the id-mapping differs and must be checked separately:
+
+- Container-root (uid 0) maps to the **operator's host uid**, not real root.
+- In-container uid 10001 maps to a **subuid** from the operator's
+  `/etc/subuid` range (must span >= 10001; the podman default 65536 does).
+- A host-owned bind-mount source appears inside the container owned by a
+  mapped uid, so the `chown -R claude:claude` is still needed and must succeed
+  under the userns (podman keeps `CAP_CHOWN` within the mapped range).
+
+CI cannot exercise this: GitHub's `ubuntu-latest` runner has no rootless-podman
+userns set up and this repo's constraint forbids `go test ./...`, so treat the
+following as the **documented manual verification** (run once on any Linux host
+with rootless podman, e.g. a citadel node):
+
+```sh
+# 0. Prereqs (rootless podman + a subuid range covering 10001):
+podman info --format '{{.Host.Security.Rootless}}'   # must print: true
+grep "^$(id -un):" /etc/subuid                        # count must be >= 10001
+
+# 1. Build (or pull the published image) and prep a host-owned state dir:
+podman build -t claudecode-service:podman-check services/claudecode-service
+STATE="$(mktemp -d)"; ls -land "$STATE"               # owned by your host uid
+
+# 2. Boot the entrypoint's fixup path only (override CMD to inspect ownership),
+#    mounting the host dir on the state volume exactly as compose does:
+podman run --rm \
+  -v "$STATE":/home/claude/.claude:Z \
+  -e CLAUDE_CONFIG_DIR=/home/claude/.claude \
+  claudecode-service:podman-check \
+  sh -c 'id && stat -c "%u:%U owns %n" /home/claude/.claude && touch /home/claude/.claude/probe && echo OK'
+
+# Expect: the entrypoint chowns the dir, gosu drops to `claude` (uid=10001),
+# and the `touch` succeeds (no EACCES) -> prints `OK`.
+
+# 3. Confirm the write is visible on the host under the mapped subuid:
+ls -lan "$STATE"/probe && rm -rf "$STATE"
+```
+
+Pass criteria: step 2 prints `uid=10001(claude) ... OK` (privilege drop worked
+and the mounted state dir is writable), and step 3 shows the probe file on the
+host owned by the mapped subuid (not your uid), confirming the userns chown took
+effect. If the `touch` fails with `EACCES`, the operator's `/etc/subuid` range
+does not cover 10001 -- widen it (`podman system migrate` after editing) and
+re-run.


### PR DESCRIPTION
## Problem

The Claude Code node runtime (services/claudecode-service, #434) references
`ghcr.io/aceteam-ai/claudecode-service:latest` in its compose/module files, but
the image was only ever built **locally** (in the smoke test, never pushed).
Any node other than the node-1054 live-proof box (which carries a local
`claudecode-service:local` image) fails to pull it. Landmine from
`/latent-landmine-review` on #434.

## What this does

**1. Publishes the image.** Adds `.github/workflows/build-claudecode-service.yml`,
which builds and pushes `ghcr.io/aceteam-ai/claudecode-service` tagged with both
`:latest` and the commit `:sha` (for pinning/rollback).

This mirrors the existing `build-diffusers-service.yml` **exactly**: the only
lines that differ are the build `context`/`file` paths and the `IMAGE` name.
Same mechanics:
- GHCR login via `docker/login-action@v3` with `${{ github.actor }}` +
  `${{ secrets.GITHUB_TOKEN }}` (the auth the repo already uses -- no new secret).
- `docker/setup-buildx-action@v3` + `docker/build-push-action@v6` with
  `type=gha` build cache.
- `permissions: packages: write`, `concurrency` cancel-in-progress.
- Trigger: `push` to `main` path-filtered to `services/claudecode-service/**`
  (plus the workflow file) + `workflow_dispatch` for on-demand branch builds.
  Deliberately **not** on `pull_request` (an unmerged image build adds no signal;
  the first real build runs post-merge on main where it can be watched) -- same
  rationale documented in the diffusers workflow.

**2. Rootless-podman verification (second half of #442).** The entrypoint's
`chown`+`gosu` privilege-drop was validated under **docker**, where container-root
is real host root. Citadel prefers **rootless podman**, where uid 0 maps to the
operator's host uid and in-container uid 10001 maps to a subuid -- a different
path. CI cannot exercise this: `ubuntu-latest` has no rootless-podman userns set
up, and this repo forbids `go test ./...`. So this is a **documented manual
verification** (added to `services/claudecode-service/README.md`): a copy-paste
sequence that builds under podman, mounts a host-owned state dir, boots the
entrypoint, and asserts the chown succeeds, `gosu` drops to uid 10001, and the
state dir is writable (no EACCES) with the write visible on the host under the
mapped subuid. Includes the `/etc/subuid` prereq (range must cover 10001) and
the remedy if it doesn't.

## Testing

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build-claudecode-service.yml'))"` -> parses clean.
- Structural diff vs `build-diffusers-service.yml`: only `context`/`file`/`IMAGE`
  differ; every action version + auth step is identical.
- Did **not** run `go test ./...` (crashes this environment).

Closes #442
Part of aceteam-ai/aceteam#4747

---
Generated by Claude Opus 4.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)