### PR TITLE
fix: route claudecode module host port through the host-port registry (#458 Gap 2)

### DIFF
--- a/internal/apps/hostport_collision_test.go
+++ b/internal/apps/hostport_collision_test.go
@@ -113,6 +113,7 @@ func publishedHostPorts(composeYAML string) ([]int, error) {
 		services.EnvVLLMHostPort:       services.VLLMHostPort,
 		services.EnvExtractionHostPort: services.ExtractionHostPort,
 		services.EnvDiffusersHostPort:  services.DiffusersHostPort,
+		services.EnvClaudecodeHostPort: services.ClaudecodeHostPort,
 	}
 
 	var out []int

--- a/services/claudecode-service/compose.yml
+++ b/services/claudecode-service/compose.yml
@@ -1,17 +1,19 @@
 # Module compose for the headless Claude Code runtime (citadel-cli#432).
 #
-# This is the MODULE-install variant of services/compose/claudecode.yml. The two
-# differ in ONE way: the standalone file defers the host port to citadel via
-# ${CITADEL_CLAUDECODE_HOST_PORT:?...}; this module file publishes the LITERAL
-# host port 8204 declared in service.yaml, because the module-install path does
-# not inject that env var (only the four built-in ports.go services get it).
-# Everything else is identical.
+# This is the MODULE-install variant of services/compose/claudecode.yml. As of
+# #458 the two are IDENTICAL in their port publish: both defer the host port to
+# citadel via ${CITADEL_CLAUDECODE_HOST_PORT:?...}. claudecode is now registered
+# in services/ports.go, so HostPortEnv() injects CITADEL_CLAUDECODE_HOST_PORT
+# (=8204) on every citadel compose-up site -- including `citadel run <module>`
+# via startService -> composeEnv. This removes the literal 8204 so a second
+# agent-runtime module (Hermes/OpenClaw, aceteam#4591) can take 8205 from the
+# registry instead of colliding on a hardcoded port.
 services:
   claudecode:
     image: ghcr.io/aceteam-ai/claudecode-service:latest
     container_name: citadel-claudecode
     ports:
-      - "8204:8787"
+      - "${CITADEL_CLAUDECODE_HOST_PORT:?citadel must supply CITADEL_CLAUDECODE_HOST_PORT}:8787"
     volumes:
       # Entrypoint (root) chowns this mount to the claude user, then drops
       # privileges -- a fresh host-owned dir "just works" with no pre-create.

--- a/services/claudecode-service/service.yaml
+++ b/services/claudecode-service/service.yaml
@@ -6,11 +6,15 @@
 # resolves it via `citadel service catalog` / module install.
 #
 # The standalone compose lives at services/compose/claudecode.yml and is what the
-# live-proof uses via `docker compose -f ... up`. This manifest declares a LITERAL
-# host port (8204) because the module path does NOT inject
-# CITADEL_CLAUDECODE_HOST_PORT the way the built-in ports.go registry does for the
-# four core services -- so the module compose (compose.yml alongside this file)
-# publishes a fixed host port instead of the ${...} guard.
+# live-proof uses via `docker compose -f ... up`. As of #458 claudecode is
+# registered in the services/ports.go host-port registry (CITADEL_CLAUDECODE_HOST_PORT
+# = 8204), so the module compose (compose.yml alongside this file) defers its host
+# publish to ${CITADEL_CLAUDECODE_HOST_PORT:?...} exactly like the built-in
+# services -- HostPortEnv() injects it on every citadel compose-up site. The
+# `host: 8204` below stays authoritative: it must equal the registry value (it is
+# what the install-time port-conflict pre-check and the collision-guard test read),
+# and keeping the next agent-runtime module out of 8204 is precisely the point of
+# the registry.
 schema_version: 2
 name: claudecode
 version: 0.1.0

--- a/services/ports.go
+++ b/services/ports.go
@@ -31,6 +31,15 @@ const (
 	EnvVLLMHostPort       = "CITADEL_VLLM_HOST_PORT"
 	EnvExtractionHostPort = "CITADEL_EXTRACTION_HOST_PORT"
 	EnvDiffusersHostPort  = "CITADEL_DIFFUSERS_HOST_PORT"
+	// EnvClaudecodeHostPort carries the host port for the claudecode
+	// agent-runtime module (aceteam-ai/citadel-cli#458). Unlike the four inference
+	// services above, claudecode ships as an installable catalog MODULE (its
+	// compose lives in aceteam-ai/citadel-services, not the embedded ServiceMap),
+	// but it is registered here so its host port is injected by the same
+	// HostPortEnv() mechanism. That is what lets a second agent-runtime module
+	// (Hermes/OpenClaw, aceteam#4591) claim the next slot in the 8200 block instead
+	// of every module hardcoding a literal 8204 and colliding.
+	EnvClaudecodeHostPort = "CITADEL_CLAUDECODE_HOST_PORT"
 )
 
 // Citadel-assigned host ports for the pre-packaged compose services. These are
@@ -51,6 +60,12 @@ const (
 	ExtractionHostPort = 8202
 	// diffusers: was host 8102 (collided with the TEI embedding upstream).
 	DiffusersHostPort = 8203
+	// claudecode: the first agent-runtime MODULE (#458). Next free slot in the
+	// 8200 block, above the apps 8100-8199 range. The wrapper's internal contract
+	// port is 8787; this is the host publish. Kept in this registry so the next
+	// agent-runtime module (Hermes/OpenClaw) is allocated 8205 rather than
+	// re-hardcoding 8204.
+	ClaudecodeHostPort = 8204
 )
 
 // ServiceHostPorts maps service name -> citadel-assigned host port for every
@@ -62,6 +77,7 @@ var ServiceHostPorts = map[string]int{
 	"vllm":       VLLMHostPort,
 	"extraction": ExtractionHostPort,
 	"diffusers":  DiffusersHostPort,
+	"claudecode": ClaudecodeHostPort,
 }
 
 // serviceHostPortEnv maps each managed service to the compose env-var that
@@ -71,6 +87,7 @@ var serviceHostPortEnv = map[string]string{
 	"vllm":       EnvVLLMHostPort,
 	"extraction": EnvExtractionHostPort,
 	"diffusers":  EnvDiffusersHostPort,
+	"claudecode": EnvClaudecodeHostPort,
 }
 
 // HostPortEnv returns "KEY=value" entries for every citadel-managed host port,


### PR DESCRIPTION
## Context

`Closes #458` (Gap 2 — host-port registry injection).
`Part of aceteam-ai/aceteam#4747`.

The paired catalog half (Gap 1, publish `claudecode` to the catalog) is a
separate draft PR against **aceteam-ai/citadel-services**:
aceteam-ai/citadel-services#(feat/publish-claudecode-module).

## Root cause

The `claudecode` agent-runtime module published a **literal** host port `8204`
in its compose and did **not** inject `CITADEL_CLAUDECODE_HOST_PORT` the way the
four built-in inference services do in `services/ports.go`. A second
agent-runtime module (Hermes/OpenClaw, aceteam#4591) landing in the 8200 block
would collide on a hardcoded port with no registry to arbitrate — a latent
"hardcoded-matches-today" landmine.

## Changes

- **`services/ports.go`** — add `EnvClaudecodeHostPort` /
  `ClaudecodeHostPort` (8204) and register `claudecode` in `ServiceHostPorts`
  + `serviceHostPortEnv`, so `HostPortEnv()` injects
  `CITADEL_CLAUDECODE_HOST_PORT` at every citadel compose-up site
  (`startService` → `composeEnv`, and the `internal/jobs` handlers).
- **`services/claudecode-service/compose.yml`** — defer the host publish to
  `${CITADEL_CLAUDECODE_HOST_PORT:?...}` instead of literal `8204`, exactly like
  llamacpp/vllm/extraction/diffusers.
- **`services/claudecode-service/service.yaml`** — refresh the stale comment;
  `host: 8204` stays as the authoritative registry-matching value (read by the
  install-time port-conflict pre-check and the collision-guard test).
- **`internal/apps/hostport_collision_test.go`** — extend the env-var map so
  `${CITADEL_CLAUDECODE_HOST_PORT}` resolves to the registry value.

## Why it's safe

`claudecode` is a **catalog module**, not an embedded `ServiceMap` entry, so
registering it is inert for the compose-refresh sweep (`internal/composerefresh`,
keys off `Embedded`) and status-engine probes (named engines only). It only
takes effect where `HostPortEnv()` is injected.

## Testing

- `go build ./...` — clean.
- `go test ./internal/apps -run TestHostPortNoCollisions` — pass.
- `go test ./internal/composerefresh ./services/...` — pass.
- `docker compose -f services/claudecode-service/compose.yml config` with
  `CITADEL_CLAUDECODE_HOST_PORT=8204` publishes `8204:8787`; without it, the
  `:?` guard fails loudly — matching the built-in services' behavior.
- Not run: `go test ./...` (crashes this env per repo policy).

Generated by Claude Opus 4.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)