### PR TITLE
fix(security): require coordinator mTLS identity for :8080 control endpoints (#5028)

### DIFF
--- a/cmd/work.go
+++ b/cmd/work.go
@@ -14,6 +14,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -1149,6 +1150,48 @@ func runWork(cmd *cobra.Command, args []string) {
 			}
 		}
 
+		// Gate the MUTATING control endpoints (SSH-key injection) behind a
+		// coordinator mTLS client certificate on a dedicated control listener
+		// (issue #5028). Enabled only when a fabric CA bundle AND coordinator
+		// identities are configured. If construction fails, we log and leave the
+		// control listener OFF -- the mutating endpoints then stay refused on the
+		// plaintext path (fail closed), never reverting to VPN-origin trust.
+		controlPortForVPN := 0
+		if caBundle := strings.TrimSpace(os.Getenv("CITADEL_FABRIC_CA_BUNDLE")); caBundle != "" {
+			coordinatorSANs := splitAndTrim(os.Getenv("CITADEL_COORDINATOR_SANS"))
+			verifier, verr := status.NewFabricCAVerifier(caBundle, coordinatorSANs)
+			if verr != nil {
+				fmt.Fprintf(os.Stderr, "   - ⚠️ Coordinator mTLS control listener NOT enabled (%v); SSH-key injection stays refused\n", verr)
+			} else {
+				var ctrlIPs []net.IP
+				if ip4, _ := network.GetGlobalIPv4(); ip4 != "" {
+					if ip := net.ParseIP(ip4); ip != nil {
+						ctrlIPs = append(ctrlIPs, ip)
+					}
+				}
+				ctrlCert, certErr := tlscert.EnsureCert(tlscert.Config{
+					Hostname:    nodeName,
+					IPAddresses: ctrlIPs,
+					CertDir:     filepath.Join(platform.ConfigDir(), "control-tls"),
+				})
+				if certErr != nil {
+					fmt.Fprintf(os.Stderr, "   - ⚠️ Coordinator mTLS control listener NOT enabled (server cert: %v)\n", certErr)
+				} else {
+					controlPort := status.DefaultControlPort
+					if p := strings.TrimSpace(os.Getenv("CITADEL_CONTROL_PORT")); p != "" {
+						if parsed, perr := strconv.Atoi(p); perr == nil && parsed > 0 {
+							controlPort = parsed
+						}
+					}
+					serverCfg.CAVerifier = verifier
+					serverCfg.ControlServerCert = &ctrlCert
+					serverCfg.ControlPort = controlPort
+					controlPortForVPN = controlPort
+					fmt.Printf("   - Coordinator mTLS control listener enabled on :%d for mutating endpoints (#5028)\n", controlPort)
+				}
+			}
+		}
+
 		statusServer := status.NewServer(serverCfg, collector)
 
 		// Register provisioning API routes on the status server
@@ -1174,6 +1217,20 @@ func runWork(cmd *cobra.Command, args []string) {
 				statusServer.AddListener(vpnLn)
 				Log("status server VPN listener on %s:%s", vpnIP, vpnPort)
 				fmt.Printf("   - Status server VPN: http://%s:%d\n", vpnIP, workStatusPort)
+			}
+
+			// Also expose the mTLS control listener over the mesh so the
+			// coordinator can reach the mutating endpoints via the VPN (#5028).
+			if controlPortForVPN > 0 {
+				ctrlPort := fmt.Sprintf("%d", controlPortForVPN)
+				if ctrlLn, ctrlIP, err := network.ListenVPN("tcp", ctrlPort); err != nil {
+					Log("control server VPN listener failed (LAN-only): %v", err)
+					fmt.Fprintf(os.Stderr, "   - ⚠️ Control server VPN listener failed (LAN-only): %v\n", err)
+				} else {
+					statusServer.AddControlListener(ctrlLn)
+					Log("control server VPN listener on %s:%s", ctrlIP, ctrlPort)
+					fmt.Printf("   - Control server VPN (mTLS): https://%s:%d\n", ctrlIP, controlPortForVPN)
+				}
 			}
 		}
 
@@ -2374,4 +2431,17 @@ func initProvisionHandler() *provision.Handler {
 	// was down and updates their status accordingly.
 	mgr.ReconcileAll(context.Background())
 	return provision.NewHandler(mgr)
+}
+
+// splitAndTrim splits a comma-separated env value into non-empty, trimmed items.
+// Used for CITADEL_COORDINATOR_SANS (the allowlist of coordinator SAN URIs that
+// may invoke mutating control endpoints -- issue #5028).
+func splitAndTrim(s string) []string {
+	var out []string
+	for _, part := range strings.Split(s, ",") {
+		if p := strings.TrimSpace(part); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1157,8 +1157,29 @@ func runWork(cmd *cobra.Command, args []string) {
 		// control listener OFF -- the mutating endpoints then stay refused on the
 		// plaintext path (fail closed), never reverting to VPN-origin trust.
 		controlPortForVPN := 0
-		if caBundle := strings.TrimSpace(os.Getenv("CITADEL_FABRIC_CA_BUNDLE")); caBundle != "" {
+		caBundle := strings.TrimSpace(os.Getenv("CITADEL_FABRIC_CA_BUNDLE"))
+		if caBundle == "" {
+			// Provision the fabric CA trust root so the mTLS control listener has
+			// a trust anchor without manual env config (#5028). Fetched once at
+			// startup from the coordinator; a cached bundle is reused on fetch
+			// failure so a transient backend blip does not disable SSH-deploy on
+			// an already-provisioned node. A CA rotation requires a restart to
+			// re-fetch. Fails closed (listener stays off) only on a first-ever
+			// cold start with no cache and no reachable backend.
+			if bundlePath, berr := status.EnsureFabricCABundle(baseURL, platform.ConfigDir()); berr != nil {
+				fmt.Fprintf(os.Stderr, "   - ⚠️ Fabric CA bundle unavailable (%v); mTLS control listener disabled, SSH-key injection refused\n", berr)
+			} else {
+				caBundle = bundlePath
+			}
+		}
+		if caBundle != "" {
 			coordinatorSANs := splitAndTrim(os.Getenv("CITADEL_COORDINATOR_SANS"))
+			if len(coordinatorSANs) == 0 {
+				// Default to the platform coordinator identity so upgraded nodes
+				// allowlist the relay out of the box (#5028). Without at least one
+				// SAN the verifier refuses to construct and the listener stays off.
+				coordinatorSANs = []string{status.DefaultCoordinatorSAN}
+			}
 			verifier, verr := status.NewFabricCAVerifier(caBundle, coordinatorSANs)
 			if verr != nil {
 				fmt.Fprintf(os.Stderr, "   - ⚠️ Coordinator mTLS control listener NOT enabled (%v); SSH-key injection stays refused\n", verr)

--- a/internal/status/ca_bundle.go
+++ b/internal/status/ca_bundle.go
@@ -1,0 +1,133 @@
+// internal/status/ca_bundle.go
+// Provisioning of the fabric CA trust bundle that the mTLS control listener
+// (issue #5028) verifies coordinator client certs against.
+//
+// The node needs the PUBLIC fabric CA chain (intermediate || root) on disk so
+// NewFabricCAVerifier can build its ClientCAs pool. This file fetches that chain
+// once at startup from the coordinator (GET /api/fabric/ca/chain) and caches it
+// to ConfigDir()/fabric-ca-bundle.pem.
+//
+// CRITICAL zero-break property (advisor / #5028): the fetch must NOT be a hard
+// dependency for an already-provisioned node. #461 turns the plaintext
+// /ssh/authorized-keys path into a 403 stub, so if a transient backend blip made
+// startup unable to bring up the :8443 listener, SSH-deploy would be dead until
+// the backend recovered AND the node restarted. To avoid that, a fetch failure
+// falls back to any previously-cached bundle on disk; only a first-ever cold
+// start with no cache leaves the node without a trust root (and it fails closed:
+// the control listener stays down and SSH-key injection is refused, never
+// silently reverting to VPN-origin trust).
+//
+// The bundle is read ONCE at startup; a CA rotation requires a node restart to
+// re-fetch. That is an acceptable operational constraint for a root of trust.
+package status
+
+import (
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// DefaultCoordinatorSAN is the SAN URI a node allowlists by default so the
+// platform coordinator/relay can invoke the mutating control endpoints (#5028)
+// without per-node env configuration. Used when CITADEL_COORDINATOR_SANS is unset.
+//
+// CROSS-REPO CONTRACT: this literal MUST equal the backend fabric CA's
+// coordinator SAN (python-backend utils/fabric_ca/profile.py COORDINATOR_URI =
+// "aceteam:coordinator"). The relay mints itself a client leaf carrying this
+// exact SAN; if the two drift, the node rejects the coordinator and SSH-deploy
+// fails closed. It follows the same aceteam:<role> shape as aceteam:node:<uid> /
+// aceteam:org:<org> and round-trips through url.Parse/URL.String unchanged.
+const DefaultCoordinatorSAN = "aceteam:coordinator"
+
+// fabricCABundleFilename is the on-disk cache name under ConfigDir().
+const fabricCABundleFilename = "fabric-ca-bundle.pem"
+
+// caChainPath is the coordinator API path that serves the public CA chain.
+const caChainPath = "/api/fabric/ca/chain"
+
+// EnsureFabricCABundle returns a filesystem path to the public fabric CA chain
+// (intermediate || root PEM) for the mTLS control listener's trust root.
+//
+// It fetches the chain from baseURL+/api/fabric/ca/chain and caches it to
+// configDir/fabric-ca-bundle.pem. On any fetch failure (network, non-200, or a
+// response that is not valid PEM certificates) it falls back to a previously
+// cached bundle if one exists, so a transient backend outage does not disable
+// SSH-deploy on an already-provisioned node. It returns an error only when the
+// fetch fails AND no cached bundle is available (first-ever cold start offline),
+// in which case the caller leaves the control listener disabled (fail closed).
+//
+// A successfully fetched bundle is only written when it validates, so a bad
+// response never clobbers a good cache.
+func EnsureFabricCABundle(baseURL, configDir string) (string, error) {
+	bundlePath := filepath.Join(configDir, fabricCABundleFilename)
+
+	pemBytes, err := fetchCAChain(baseURL)
+	if err != nil {
+		if _, statErr := os.Stat(bundlePath); statErr == nil {
+			// Reuse the cached bundle from a prior successful fetch.
+			return bundlePath, nil
+		}
+		return "", fmt.Errorf("fetch fabric CA chain and no cached bundle: %w", err)
+	}
+
+	if err := writeBundleAtomic(bundlePath, pemBytes); err != nil {
+		// Write failed but we still have valid material in hand; if a cache
+		// exists, use it rather than failing.
+		if _, statErr := os.Stat(bundlePath); statErr == nil {
+			return bundlePath, nil
+		}
+		return "", fmt.Errorf("cache fabric CA bundle: %w", err)
+	}
+	return bundlePath, nil
+}
+
+// fetchCAChain GETs the public CA chain and validates it parses as >=1 cert.
+func fetchCAChain(baseURL string) ([]byte, error) {
+	url := strings.TrimRight(baseURL, "/") + caChainPath
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s returned %d", url, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 256*1024))
+	if err != nil {
+		return nil, fmt.Errorf("read CA chain body: %w", err)
+	}
+
+	// Validate the response is genuinely a PEM chain before caching it, so a
+	// gateway error page or empty body can never poison the trust root.
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(body) {
+		return nil, fmt.Errorf("CA chain response is not valid PEM certificates")
+	}
+	return body, nil
+}
+
+// writeBundleAtomic writes the bundle via a temp file + rename so a concurrent
+// reader never observes a partial file. The bundle is PUBLIC (a CA chain), so
+// 0644 is appropriate.
+func writeBundleAtomic(bundlePath string, pemBytes []byte) error {
+	if err := os.MkdirAll(filepath.Dir(bundlePath), 0755); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+	tmpPath := bundlePath + ".tmp"
+	if err := os.WriteFile(tmpPath, pemBytes, 0644); err != nil {
+		return fmt.Errorf("write temp bundle: %w", err)
+	}
+	if err := os.Rename(tmpPath, bundlePath); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("rename bundle into place: %w", err)
+	}
+	return nil
+}

--- a/internal/status/ca_bundle_test.go
+++ b/internal/status/ca_bundle_test.go
@@ -1,0 +1,123 @@
+package status
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestEnsureFabricCABundleFetchAndCache verifies a successful fetch writes the
+// bundle to disk and returns its path, and that the written bundle is a valid
+// trust root the verifier can load.
+func TestEnsureFabricCABundleFetchAndCache(t *testing.T) {
+	ca := newTestCA(t, "fabric-ca")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != caChainPath {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/x-pem-file")
+		w.Write(ca.certPEM)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	path, err := EnsureFabricCABundle(srv.URL, dir)
+	if err != nil {
+		t.Fatalf("EnsureFabricCABundle: %v", err)
+	}
+	if path != filepath.Join(dir, fabricCABundleFilename) {
+		t.Errorf("path = %q, unexpected", path)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read cached bundle: %v", err)
+	}
+	if string(got) != string(ca.certPEM) {
+		t.Error("cached bundle content does not match fetched chain")
+	}
+	// The cached bundle must be loadable as a verifier trust root.
+	if _, err := NewFabricCAVerifier(path, []string{DefaultCoordinatorSAN}); err != nil {
+		t.Errorf("verifier from cached bundle: %v", err)
+	}
+}
+
+// TestEnsureFabricCABundleReusesCacheOnFetchFailure is the zero-break property:
+// once a node has a cached bundle, a later fetch failure (backend down) reuses
+// the cache instead of disabling SSH-deploy.
+func TestEnsureFabricCABundleReusesCacheOnFetchFailure(t *testing.T) {
+	ca := newTestCA(t, "fabric-ca")
+	dir := t.TempDir()
+	bundlePath := filepath.Join(dir, fabricCABundleFilename)
+	if err := os.WriteFile(bundlePath, ca.certPEM, 0644); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+
+	// Point at a closed server so the fetch fails.
+	closed := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	badURL := closed.URL
+	closed.Close()
+
+	path, err := EnsureFabricCABundle(badURL, dir)
+	if err != nil {
+		t.Fatalf("expected cache reuse, got error: %v", err)
+	}
+	if path != bundlePath {
+		t.Errorf("path = %q, want cached %q", path, bundlePath)
+	}
+}
+
+// TestEnsureFabricCABundleColdStartOffline: no cache + unreachable backend must
+// fail (caller then leaves the control listener disabled -- fail closed).
+func TestEnsureFabricCABundleColdStartOffline(t *testing.T) {
+	closed := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	badURL := closed.URL
+	closed.Close()
+
+	if _, err := EnsureFabricCABundle(badURL, t.TempDir()); err == nil {
+		t.Fatal("expected error on cold start with no cache and unreachable backend")
+	}
+}
+
+// TestEnsureFabricCABundleBadResponseDoesNotClobberCache: a garbage/non-PEM
+// response must not overwrite a good cached bundle.
+func TestEnsureFabricCABundleBadResponseDoesNotClobberCache(t *testing.T) {
+	ca := newTestCA(t, "fabric-ca")
+	dir := t.TempDir()
+	bundlePath := filepath.Join(dir, fabricCABundleFilename)
+	if err := os.WriteFile(bundlePath, ca.certPEM, 0644); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("<html>gateway error</html>"))
+	}))
+	defer srv.Close()
+
+	path, err := EnsureFabricCABundle(srv.URL, dir)
+	if err != nil {
+		t.Fatalf("expected cache reuse on bad response, got: %v", err)
+	}
+	if path != bundlePath {
+		t.Errorf("path = %q, want cached %q", path, bundlePath)
+	}
+	got, _ := os.ReadFile(bundlePath)
+	if string(got) != string(ca.certPEM) {
+		t.Error("bad response must not clobber the good cached bundle")
+	}
+}
+
+// TestEnsureFabricCABundleNon200ReturnsErrorWhenNoCache: a non-200 with no cache
+// is an error.
+func TestEnsureFabricCABundleNon200ReturnsErrorWhenNoCache(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	if _, err := EnsureFabricCABundle(srv.URL, t.TempDir()); err == nil {
+		t.Fatal("expected error on 503 with no cache")
+	}
+}

--- a/internal/status/mtls.go
+++ b/internal/status/mtls.go
@@ -1,0 +1,132 @@
+// internal/status/mtls.go
+// Coordinator-identity gate for the status server's MUTATING control endpoints
+// (SSH-key injection first and foremost -- issue #5028).
+//
+// Background (the hole this closes): the status server's mutating endpoints were
+// gated by requireVPNOrAuth, which trusts ANY source IP in the Headscale CGNAT
+// range 100.64.0.0/10. Because the live mesh ACL is flat, any node on the mesh
+// -- including, once multi-tenant, another org's node -- could POST an SSH key to
+// /ssh/authorized-keys and take over the host. Mesh origin is not an identity.
+//
+// The fix: require the caller to present a fabric-CA-signed client certificate
+// (a coordinator identity) over mTLS, verified against the node's trusted fabric
+// CA bundle, before any mutating control action runs. This reuses the existing
+// fabric mTLS PKI (the reenroll service + nginx client-cert termination, and the
+// backend's fabric CA that signs node leafs with SAN URIs aceteam:node:<uid> /
+// aceteam:org:<org>). It introduces no new bearer token.
+//
+// FAIL CLOSED is the load-bearing property: a missing CA bundle, an empty
+// coordinator allowlist, a caller with no client cert, a cert that does not chain
+// to the fabric CA, or a valid fabric cert whose SAN is not an allowlisted
+// coordinator identity -- all are refused with no side effects (the SSH key is
+// never written).
+//
+// Why not "any valid fabric cert" (the weaker interim the CA profile makes easy):
+// the threat is OTHER orgs' nodes, and every enrolled node holds a valid fabric
+// leaf. "Chains to the CA" would still admit a peer org's node and would NOT close
+// #5028. So this gate requires an explicitly-configured coordinator identity and
+// refuses to construct a verifier without one. See the flagged gap in the PR: the
+// fabric CA profile does not yet mint a distinct coordinator/role SAN, so the
+// coordinator identity must be configured out-of-band (env) until it does.
+package status
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+)
+
+// FabricCAVerifier holds the trusted fabric CA pool used to verify a caller's
+// client certificate, plus the set of coordinator SAN URIs permitted to invoke
+// mutating control endpoints.
+type FabricCAVerifier struct {
+	pool            *x509.CertPool
+	coordinatorSANs map[string]bool
+}
+
+// NewFabricCAVerifier loads the PUBLIC fabric CA bundle (intermediate + root PEM)
+// from caBundlePath and builds a verifier that accepts a client cert only when it
+// (a) chains to that CA -- enforced at the TLS handshake via ClientCAs -- AND
+// (b) carries one of coordinatorSANs as a SAN URI.
+//
+// Fail-closed by construction: an empty/unreadable/certless bundle, or an empty
+// coordinator allowlist, returns an error. The caller MUST then decline to serve
+// the mutating control endpoints at all (they stay refused on every listener),
+// rather than fall back to a weaker gate.
+func NewFabricCAVerifier(caBundlePath string, coordinatorSANs []string) (*FabricCAVerifier, error) {
+	if strings.TrimSpace(caBundlePath) == "" {
+		return nil, fmt.Errorf("fabric CA bundle path is empty")
+	}
+	pemBytes, err := os.ReadFile(caBundlePath)
+	if err != nil {
+		return nil, fmt.Errorf("read fabric CA bundle %s: %w", caBundlePath, err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pemBytes) {
+		return nil, fmt.Errorf("fabric CA bundle %s contained no valid PEM certificates", caBundlePath)
+	}
+
+	sans := make(map[string]bool)
+	for _, s := range coordinatorSANs {
+		if s = strings.TrimSpace(s); s != "" {
+			sans[s] = true
+		}
+	}
+	if len(sans) == 0 {
+		return nil, fmt.Errorf(
+			"no coordinator identities configured; refusing to gate mutating control " +
+				"endpoints on 'any valid fabric cert' (that would admit other orgs' nodes)")
+	}
+
+	return &FabricCAVerifier{pool: pool, coordinatorSANs: sans}, nil
+}
+
+// ServerTLSConfig returns a tls.Config for the mTLS control listener. It presents
+// serverCert to callers and REQUIRES a client cert that chains to the fabric CA
+// (RequireAndVerifyClientCert), so any caller without a CA-signed leaf is rejected
+// at the handshake before a handler runs.
+func (v *FabricCAVerifier) ServerTLSConfig(serverCert tls.Certificate) *tls.Config {
+	return &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    v.pool,
+		MinVersion:   tls.VersionTLS12,
+	}
+}
+
+// isCoordinator reports whether leaf carries an allowlisted coordinator SAN URI.
+// Identity is read ONLY from the CA-signed SAN URIs, never the Subject (which the
+// CSR submitter controls).
+func (v *FabricCAVerifier) isCoordinator(leaf *x509.Certificate) bool {
+	for _, u := range leaf.URIs {
+		if u != nil && v.coordinatorSANs[u.String()] {
+			return true
+		}
+	}
+	return false
+}
+
+// requireCoordinator wraps next so it runs ONLY when the request arrived over a
+// verified mTLS handshake carrying a fabric-CA-signed client cert whose SAN URI
+// identifies an allowlisted coordinator.
+//
+// Fail-closed: no TLS, no peer certificate, or a non-coordinator identity -> 403,
+// and next never runs (no side effects). Chain-to-CA is already guaranteed by the
+// listener's RequireAndVerifyClientCert; this adds the identity (authorization)
+// check on top of that authentication.
+func (v *FabricCAVerifier) requireCoordinator(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
+			writeJSONError(w, "coordinator mTLS client certificate required", http.StatusForbidden)
+			return
+		}
+		if !v.isCoordinator(r.TLS.PeerCertificates[0]) {
+			writeJSONError(w, "client certificate is not an authorized coordinator identity", http.StatusForbidden)
+			return
+		}
+		next(w, r)
+	}
+}

--- a/internal/status/mtls_test.go
+++ b/internal/status/mtls_test.go
@@ -1,0 +1,312 @@
+package status
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// --- synthetic fabric CA test fixtures -------------------------------------
+
+type testCA struct {
+	cert    *x509.Certificate
+	key     *ecdsa.PrivateKey
+	certPEM []byte
+}
+
+func newTestCA(t *testing.T, cn string) *testCA {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen CA key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create CA cert: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse CA cert: %v", err)
+	}
+	return &testCA{
+		cert:    cert,
+		key:     key,
+		certPEM: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+	}
+}
+
+// issueLeaf signs a client leaf carrying the given SAN URIs (e.g.
+// "aceteam:node:<uid>", "aceteam:org:<org>", or a coordinator identity).
+func (ca *testCA) issueLeaf(t *testing.T, cn string, sanURIs ...string) tls.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen leaf key: %v", err)
+	}
+	var uris []*url.URL
+	for _, s := range sanURIs {
+		u, perr := url.Parse(s)
+		if perr != nil {
+			t.Fatalf("parse SAN URI %q: %v", s, perr)
+		}
+		uris = append(uris, u)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		URIs:         uris,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca.cert, &key.PublicKey, ca.key)
+	if err != nil {
+		t.Fatalf("create leaf: %v", err)
+	}
+	leaf, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse leaf: %v", err)
+	}
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key, Leaf: leaf}
+}
+
+func writeBundle(t *testing.T, pemBytes []byte) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fabric-ca-bundle.pem")
+	if err := os.WriteFile(path, pemBytes, 0600); err != nil {
+		t.Fatalf("write bundle: %v", err)
+	}
+	return path
+}
+
+const coordinatorSAN = "aceteam:role:coordinator"
+
+// --- NewFabricCAVerifier: fail-closed construction -------------------------
+
+func TestNewFabricCAVerifierFailClosed(t *testing.T) {
+	ca := newTestCA(t, "fabric-ca")
+	bundle := writeBundle(t, ca.certPEM)
+
+	t.Run("empty bundle path rejected", func(t *testing.T) {
+		if _, err := NewFabricCAVerifier("", []string{coordinatorSAN}); err == nil {
+			t.Fatal("expected error for empty bundle path")
+		}
+	})
+	t.Run("missing bundle file rejected", func(t *testing.T) {
+		if _, err := NewFabricCAVerifier(filepath.Join(t.TempDir(), "nope.pem"), []string{coordinatorSAN}); err == nil {
+			t.Fatal("expected error for missing bundle")
+		}
+	})
+	t.Run("bundle with no certs rejected", func(t *testing.T) {
+		bad := writeBundle(t, []byte("not a pem cert"))
+		if _, err := NewFabricCAVerifier(bad, []string{coordinatorSAN}); err == nil {
+			t.Fatal("expected error for certless bundle")
+		}
+	})
+	t.Run("empty coordinator allowlist rejected", func(t *testing.T) {
+		// Refusing to gate on "any valid fabric cert" is the whole point of #5028.
+		if _, err := NewFabricCAVerifier(bundle, nil); err == nil {
+			t.Fatal("expected error when no coordinator identities configured")
+		}
+		if _, err := NewFabricCAVerifier(bundle, []string{"", "  "}); err == nil {
+			t.Fatal("expected error when coordinator identities are all blank")
+		}
+	})
+	t.Run("valid construction succeeds", func(t *testing.T) {
+		if _, err := NewFabricCAVerifier(bundle, []string{coordinatorSAN}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+// --- requireCoordinator: handler-level fail-closed + identity check --------
+
+func TestRequireCoordinatorFailClosed(t *testing.T) {
+	ca := newTestCA(t, "fabric-ca")
+	bundle := writeBundle(t, ca.certPEM)
+	v, err := NewFabricCAVerifier(bundle, []string{coordinatorSAN})
+	if err != nil {
+		t.Fatalf("verifier: %v", err)
+	}
+
+	called := false
+	next := func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}
+	handler := v.requireCoordinator(next)
+
+	coordLeaf := ca.issueLeaf(t, "coordinator", coordinatorSAN)
+	peerLeaf := ca.issueLeaf(t, "peer-node", "aceteam:node:abc", "aceteam:org:evil-org")
+
+	cases := []struct {
+		name     string
+		tlsState *tls.ConnectionState
+		wantCode int
+		wantNext bool
+	}{
+		{"no TLS at all", nil, http.StatusForbidden, false},
+		{"TLS but no peer cert", &tls.ConnectionState{}, http.StatusForbidden, false},
+		{
+			"valid fabric cert but not a coordinator (peer org node)",
+			&tls.ConnectionState{PeerCertificates: []*x509.Certificate{peerLeaf.Leaf}},
+			http.StatusForbidden, false,
+		},
+		{
+			"coordinator identity accepted",
+			&tls.ConnectionState{PeerCertificates: []*x509.Certificate{coordLeaf.Leaf}},
+			http.StatusOK, true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			called = false
+			req := httptest.NewRequest(http.MethodPost, "/ssh/authorized-keys", nil)
+			req.TLS = tc.tlsState
+			w := httptest.NewRecorder()
+			handler(w, req)
+			if w.Code != tc.wantCode {
+				t.Errorf("code = %d, want %d", w.Code, tc.wantCode)
+			}
+			if called != tc.wantNext {
+				t.Errorf("next called = %v, want %v (fail-closed means next must NOT run)", called, tc.wantNext)
+			}
+		})
+	}
+}
+
+// --- end-to-end: SSH-key injection over the mTLS control listener ----------
+
+// startControlTLSServer serves the control mux (SSH-key injection gated by
+// requireCoordinator) over a real TLS handshake with RequireAndVerifyClientCert,
+// exactly as the node's control listener does.
+func startControlTLSServer(t *testing.T, v *FabricCAVerifier, serverCert tls.Certificate) *httptest.Server {
+	t.Helper()
+	collector := NewCollector(CollectorConfig{NodeName: "test-node"})
+	srv := NewServer(ServerConfig{CAVerifier: v, ControlServerCert: &serverCert}, collector)
+	ts := httptest.NewUnstartedServer(srv.buildControlMux())
+	ts.TLS = v.ServerTLSConfig(serverCert)
+	ts.StartTLS()
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func clientWithCert(ts *httptest.Server, clientCert *tls.Certificate) *http.Client {
+	tr := ts.Client().Transport.(*http.Transport).Clone()
+	// These tests exercise the SERVER verifying the CLIENT cert (mTLS client
+	// auth). Verifying the node's server cert is a separate concern, so skip it
+	// here -- the synthetic server leaf has no 127.0.0.1 SAN.
+	tr.TLSClientConfig.InsecureSkipVerify = true
+	if clientCert != nil {
+		tr.TLSClientConfig.Certificates = []tls.Certificate{*clientCert}
+	}
+	return &http.Client{Transport: tr, Timeout: 5 * time.Second}
+}
+
+func TestSSHInjectionOverMTLS(t *testing.T) {
+	// Isolate HOME so deploySSHKeys writes into a temp dir we can inspect.
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	authKeysPath := filepath.Join(tmpHome, ".ssh", "authorized_keys")
+
+	ca := newTestCA(t, "fabric-ca")
+	otherCA := newTestCA(t, "attacker-ca")
+	bundle := writeBundle(t, ca.certPEM)
+	v, err := NewFabricCAVerifier(bundle, []string{coordinatorSAN})
+	if err != nil {
+		t.Fatalf("verifier: %v", err)
+	}
+	serverCert := ca.issueLeaf(t, "node-server")
+
+	ts := startControlTLSServer(t, v, serverCert)
+
+	validKey := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl coordinator@aceteam"
+	postKeys := func(client *http.Client) (int, error) {
+		body, _ := json.Marshal(sshAuthorizedKeysRequest{Keys: []string{validKey}})
+		resp, err := client.Post(ts.URL+"/ssh/authorized-keys", "application/json", bytes.NewReader(body))
+		if err != nil {
+			return 0, err
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode, nil
+	}
+	fileHasKey := func() bool {
+		data, err := os.ReadFile(authKeysPath)
+		return err == nil && strings.Contains(string(data), validKey)
+	}
+
+	t.Run("no client cert is rejected at handshake (fail closed)", func(t *testing.T) {
+		_, err := postKeys(clientWithCert(ts, nil))
+		if err == nil {
+			t.Fatal("expected TLS handshake failure without a client cert")
+		}
+		if fileHasKey() {
+			t.Fatal("authorized_keys must not be written without a coordinator cert")
+		}
+	})
+
+	t.Run("client cert from an untrusted CA is rejected at handshake", func(t *testing.T) {
+		attackerCert := otherCA.issueLeaf(t, "attacker", coordinatorSAN)
+		_, err := postKeys(clientWithCert(ts, &attackerCert))
+		if err == nil {
+			t.Fatal("expected handshake failure for a cert not chaining to the fabric CA")
+		}
+		if fileHasKey() {
+			t.Fatal("authorized_keys must not be written for an untrusted-CA cert")
+		}
+	})
+
+	t.Run("valid fabric cert without coordinator SAN is rejected (403, no write)", func(t *testing.T) {
+		peerCert := ca.issueLeaf(t, "peer-node", "aceteam:node:xyz", "aceteam:org:some-other-org")
+		code, err := postKeys(clientWithCert(ts, &peerCert))
+		if err != nil {
+			t.Fatalf("request error: %v", err)
+		}
+		if code != http.StatusForbidden {
+			t.Fatalf("code = %d, want 403", code)
+		}
+		if fileHasKey() {
+			t.Fatal("authorized_keys must not be written for a non-coordinator identity")
+		}
+	})
+
+	t.Run("coordinator cert is accepted and injects the key", func(t *testing.T) {
+		coordCert := ca.issueLeaf(t, "coordinator", coordinatorSAN)
+		code, err := postKeys(clientWithCert(ts, &coordCert))
+		if err != nil {
+			t.Fatalf("request error: %v", err)
+		}
+		if code != http.StatusOK {
+			t.Fatalf("code = %d, want 200", code)
+		}
+		if !fileHasKey() {
+			t.Fatal("authorized_keys should contain the injected key after a coordinator call")
+		}
+	})
+}

--- a/internal/status/mtls_test.go
+++ b/internal/status/mtls_test.go
@@ -310,3 +310,34 @@ func TestSSHInjectionOverMTLS(t *testing.T) {
 		}
 	})
 }
+
+// --- default coordinator SAN: cross-repo contract pin (#5028) --------------
+
+// TestDefaultCoordinatorSANContract pins the exact SAN literal that the backend
+// fabric CA (python-backend profile.COORDINATOR_URI) mints into the relay's
+// client cert. A drift on either side silently breaks SSH-deploy fleetwide, so
+// this asserts the literal string AND that a leaf carrying it is authorized when
+// the verifier is built with the default, while a node identity is not.
+func TestDefaultCoordinatorSANContract(t *testing.T) {
+	if DefaultCoordinatorSAN != "aceteam:coordinator" {
+		t.Fatalf("DefaultCoordinatorSAN = %q, want %q (must match backend COORDINATOR_URI)",
+			DefaultCoordinatorSAN, "aceteam:coordinator")
+	}
+
+	ca := newTestCA(t, "fabric-ca")
+	bundle := writeBundle(t, ca.certPEM)
+	v, err := NewFabricCAVerifier(bundle, []string{DefaultCoordinatorSAN})
+	if err != nil {
+		t.Fatalf("verifier with default SAN: %v", err)
+	}
+
+	coordLeaf := ca.issueLeaf(t, "coordinator", DefaultCoordinatorSAN)
+	if !v.isCoordinator(coordLeaf.Leaf) {
+		t.Error("a leaf carrying the default coordinator SAN must be authorized")
+	}
+
+	nodeLeaf := ca.issueLeaf(t, "some-node", "aceteam:node:abc", "aceteam:org:some-org")
+	if v.isCoordinator(nodeLeaf.Leaf) {
+		t.Error("a node identity must NOT be authorized as the coordinator")
+	}
+}

--- a/internal/status/server.go
+++ b/internal/status/server.go
@@ -285,7 +285,7 @@ func (s *Server) Start(ctx context.Context) error {
 	// Start the dedicated mTLS control listener for mutating endpoints (#5028).
 	// When it is not enabled, the mutating endpoints stay refused everywhere
 	// (fail closed) via the plaintext stub.
-	s.startControlServer(errChan)
+	s.startControlServer()
 
 	// Wait for context cancellation or server error
 	select {
@@ -308,7 +308,7 @@ func (s *Server) Start(ctx context.Context) error {
 // SAN identity. Serves on a local TCP port plus any listeners added via
 // AddControlListener (e.g., the tsnet VPN listener). No-op (fail closed) when the
 // control listener is not enabled.
-func (s *Server) startControlServer(errChan chan<- error) {
+func (s *Server) startControlServer() {
 	if !s.controlEnabled() {
 		log.Printf("[status] mTLS control listener DISABLED: SSH-key injection and other " +
 			"mutating control endpoints are refused (no fabric CA verifier / server cert configured)")
@@ -325,15 +325,14 @@ func (s *Server) startControlServer(errChan chan<- error) {
 	}
 
 	// Local TCP listener, TLS-wrapped. ServeTLS with empty cert/key paths uses the
-	// certificate already set in TLSConfig.
+	// certificate already set in TLSConfig. A failure here (e.g. the control port
+	// is occupied) must NOT tear down the read-only status server -- it only means
+	// the mutating endpoints stay refused (fail closed), so we log and move on
+	// rather than propagating to the status server's fatal error path.
 	go func() {
 		log.Printf("[status] mTLS control listener on :%d (coordinator client cert required)", s.controlPort)
 		if err := s.controlHTTPServer.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
-			select {
-			case errChan <- fmt.Errorf("control listener: %w", err):
-			default:
-				log.Printf("[status] control listener error: %v", err)
-			}
+			log.Printf("[status] mTLS control listener error (mutating endpoints refused): %v", err)
 		}
 	}()
 

--- a/internal/status/server.go
+++ b/internal/status/server.go
@@ -2,6 +2,7 @@ package status
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -53,6 +54,29 @@ type Server struct {
 	// extraListeners are additional net.Listeners the server will also serve on
 	// (e.g., a tsnet VPN listener). Added via AddListener before Start.
 	extraListeners []net.Listener
+
+	// caVerifier, when set, gates the MUTATING control endpoints (SSH-key
+	// injection) behind a fabric-CA-signed coordinator client certificate over
+	// mTLS (issue #5028). Nil means the mutating endpoints are refused on every
+	// listener (fail closed) -- they are NEVER served over the plaintext,
+	// VPN-origin-trusting path anymore.
+	caVerifier *FabricCAVerifier
+	// controlPort is the port for the dedicated mTLS control listener that serves
+	// the mutating endpoints. Only used when caVerifier and controlServerCert are
+	// both set.
+	controlPort int
+	// controlServerCert is the TLS server certificate the control listener
+	// presents. The caller (coordinator) authenticates the node out-of-band (mesh
+	// + gateway cert), so a self-signed server cert is sufficient here -- the
+	// load-bearing check is the CLIENT cert the node verifies.
+	controlServerCert *tls.Certificate
+	// controlHTTPServer is the running control server (set during Start) so
+	// shutdown can close it alongside the plaintext server.
+	controlHTTPServer *http.Server
+	// extraControlListeners are additional net.Listeners (e.g., a tsnet VPN
+	// listener) the mTLS control server will also serve on. Added via
+	// AddControlListener before Start.
+	extraControlListeners []net.Listener
 }
 
 // ServerConfig holds configuration for the status server.
@@ -80,23 +104,44 @@ type ServerConfig struct {
 	// Empty means the gateway has no TLS cert (--gateway-no-tls); the endpoint
 	// then returns 204 No Content to tell the backend to use plain http.
 	GatewayCertPath string
+
+	// CAVerifier, when set, enables the dedicated mTLS control listener that
+	// serves the MUTATING control endpoints (SSH-key injection) gated by a
+	// fabric-CA-signed coordinator client certificate (issue #5028). When nil,
+	// those endpoints are refused everywhere (fail closed).
+	CAVerifier *FabricCAVerifier
+	// ControlPort is the port for the mTLS control listener (default: 8443). Only
+	// used when CAVerifier and ControlServerCert are both set.
+	ControlPort int
+	// ControlServerCert is the TLS server certificate the control listener
+	// presents. Required (together with CAVerifier) to start the control listener.
+	ControlServerCert *tls.Certificate
 }
+
+// DefaultControlPort is the default port for the mTLS control listener.
+const DefaultControlPort = 8443
 
 // NewServer creates a new status HTTP server.
 func NewServer(cfg ServerConfig, collector *Collector) *Server {
 	if cfg.Port == 0 {
 		cfg.Port = 8080
 	}
+	if cfg.ControlPort == 0 {
+		cfg.ControlPort = DefaultControlPort
+	}
 	return &Server{
-		collector:       collector,
-		port:            cfg.Port,
-		version:         cfg.Version,
-		tokenValidator:  cfg.TokenValidator,
-		orgID:           cfg.OrgID,
-		enableDesktop:   cfg.EnableDesktop,
-		agent:           cfg.Agent,
-		extraRoutes:     cfg.ExtraRoutes,
-		gatewayCertPath: cfg.GatewayCertPath,
+		collector:         collector,
+		port:              cfg.Port,
+		version:           cfg.Version,
+		tokenValidator:    cfg.TokenValidator,
+		orgID:             cfg.OrgID,
+		enableDesktop:     cfg.EnableDesktop,
+		agent:             cfg.Agent,
+		extraRoutes:       cfg.ExtraRoutes,
+		gatewayCertPath:   cfg.GatewayCertPath,
+		caVerifier:        cfg.CAVerifier,
+		controlPort:       cfg.ControlPort,
+		controlServerCert: cfg.ControlServerCert,
 	}
 }
 
@@ -105,6 +150,49 @@ func NewServer(cfg ServerConfig, collector *Collector) *Server {
 // interfaces. Must be called before Start.
 func (s *Server) AddListener(ln net.Listener) {
 	s.extraListeners = append(s.extraListeners, ln)
+}
+
+// AddControlListener registers an additional net.Listener that the mTLS control
+// server will also serve on (e.g., a tsnet VPN listener so the coordinator can
+// reach the control endpoints over the mesh). The listener is TLS-wrapped by the
+// control server; pass a raw TCP/tsnet listener. Must be called before Start.
+func (s *Server) AddControlListener(ln net.Listener) {
+	s.extraControlListeners = append(s.extraControlListeners, ln)
+}
+
+// controlEnabled reports whether the mTLS control listener can be started: it
+// requires both a fabric CA verifier (to authenticate/authorize callers) and a
+// server certificate (to present on the TLS handshake). Absent either, the
+// mutating control endpoints are refused everywhere (fail closed).
+func (s *Server) controlEnabled() bool {
+	return s.caVerifier != nil && s.controlServerCert != nil
+}
+
+// handleSSHMovedToControl is the fail-closed stub left on the PLAINTEXT status
+// listener where /ssh/authorized-keys used to be served under requireVPNOrAuth.
+// It never writes keys. It returns 403 with a pointer to the mTLS control
+// listener so a legitimate coordinator discovers the new requirement, while a
+// cross-org mesh caller is simply denied.
+func (s *Server) handleSSHMovedToControl(w http.ResponseWriter, r *http.Request) {
+	msg := "SSH key deployment requires a coordinator mTLS client certificate on the control listener"
+	if s.controlEnabled() {
+		msg = fmt.Sprintf("%s (port %d)", msg, s.controlPort)
+	}
+	writeJSONError(w, msg, http.StatusForbidden)
+}
+
+// buildControlMux constructs the multiplexer for the dedicated mTLS control
+// listener. Only MUTATING control endpoints live here, each gated by
+// requireCoordinator (a verified fabric-CA-signed coordinator client cert). The
+// caller must ensure s.controlEnabled() is true before serving this mux.
+func (s *Server) buildControlMux() *http.ServeMux {
+	mux := http.NewServeMux()
+	// Liveness probe (still requires the mTLS handshake to reach, but no identity
+	// check) so a coordinator can confirm the control listener is up.
+	mux.HandleFunc("/ping", s.handlePing)
+	// SSH-key injection: the host-takeover crown jewel. Coordinator identity only.
+	mux.HandleFunc("/ssh/authorized-keys", s.caVerifier.requireCoordinator(s.handleSSHAuthorizedKeys))
+	return mux
 }
 
 // AddRouteRegistrar registers a callback that will be invoked during Start to
@@ -138,10 +226,14 @@ func (s *Server) buildMux() *http.ServeMux {
 		mux.HandleFunc("/api/actions", s.requireAuth(s.handleActions))
 	}
 
-	// SSH key deployment: available on all nodes (headless or with desktop).
-	// Uses VPN-origin check OR token auth — the platform relay calls this
-	// from within the VPN mesh after validating org ownership.
-	mux.HandleFunc("/ssh/authorized-keys", s.requireVPNOrAuth(s.handleSSHAuthorizedKeys))
+	// SSH key deployment is a MUTATING, host-takeover-capable endpoint. It is no
+	// longer served over this plaintext, VPN-origin-trusting listener (issue
+	// #5028): mesh origin is not an identity, so any node on the flat mesh could
+	// inject a key. It now lives ONLY on the dedicated mTLS control listener,
+	// gated by a coordinator client certificate (see buildControlMux). Here we
+	// register a fail-closed stub so the old path refuses with a clear signal
+	// instead of silently 404ing or, worse, still writing keys.
+	mux.HandleFunc("/ssh/authorized-keys", s.handleSSHMovedToControl)
 
 	// Agent introspection & control endpoints (issue #236), gated the same way
 	// (VPN origin or valid org token). No-op when no providers were supplied.
@@ -190,14 +282,71 @@ func (s *Server) Start(ctx context.Context) error {
 		}()
 	}
 
+	// Start the dedicated mTLS control listener for mutating endpoints (#5028).
+	// When it is not enabled, the mutating endpoints stay refused everywhere
+	// (fail closed) via the plaintext stub.
+	s.startControlServer(errChan)
+
 	// Wait for context cancellation or server error
 	select {
 	case <-ctx.Done():
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
+		if s.controlHTTPServer != nil {
+			_ = s.controlHTTPServer.Shutdown(shutdownCtx)
+		}
 		return s.httpServer.Shutdown(shutdownCtx)
 	case err := <-errChan:
 		return err
+	}
+}
+
+// startControlServer starts the mTLS control listener (issue #5028) when a fabric
+// CA verifier and server certificate are configured. The listener requires a
+// coordinator client certificate (RequireAndVerifyClientCert against the fabric
+// CA) at the TLS handshake; mutating handlers additionally verify the coordinator
+// SAN identity. Serves on a local TCP port plus any listeners added via
+// AddControlListener (e.g., the tsnet VPN listener). No-op (fail closed) when the
+// control listener is not enabled.
+func (s *Server) startControlServer(errChan chan<- error) {
+	if !s.controlEnabled() {
+		log.Printf("[status] mTLS control listener DISABLED: SSH-key injection and other " +
+			"mutating control endpoints are refused (no fabric CA verifier / server cert configured)")
+		return
+	}
+
+	tlsConfig := s.caVerifier.ServerTLSConfig(*s.controlServerCert)
+	s.controlHTTPServer = &http.Server{
+		Addr:         fmt.Sprintf(":%d", s.controlPort),
+		Handler:      s.buildControlMux(),
+		TLSConfig:    tlsConfig,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 30 * time.Second,
+	}
+
+	// Local TCP listener, TLS-wrapped. ServeTLS with empty cert/key paths uses the
+	// certificate already set in TLSConfig.
+	go func() {
+		log.Printf("[status] mTLS control listener on :%d (coordinator client cert required)", s.controlPort)
+		if err := s.controlHTTPServer.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
+			select {
+			case errChan <- fmt.Errorf("control listener: %w", err):
+			default:
+				log.Printf("[status] control listener error: %v", err)
+			}
+		}
+	}()
+
+	// Serve the same mTLS control server on any extra (e.g., VPN) listeners.
+	for _, ln := range s.extraControlListeners {
+		ln := ln // capture loop variable
+		tlsLn := tls.NewListener(ln, tlsConfig)
+		log.Printf("[status] mTLS control listener also on %s (VPN)", ln.Addr().String())
+		go func() {
+			if err := s.controlHTTPServer.Serve(tlsLn); err != nil && err != http.ErrServerClosed {
+				log.Printf("[status] control VPN listener error: %v", err)
+			}
+		}()
 	}
 }
 

--- a/internal/status/ssh_handler_test.go
+++ b/internal/status/ssh_handler_test.go
@@ -284,96 +284,70 @@ func TestIsVPNOrigin(t *testing.T) {
 	}
 }
 
-func TestHandleSSHAuthorizedKeysEndpoint(t *testing.T) {
-	// Override HOME for file operations
+func TestSSHPlaintextPathFailsClosed(t *testing.T) {
 	tmpHome := t.TempDir()
-	origHome := os.Getenv("HOME")
-	os.Setenv("HOME", tmpHome)
-	defer os.Setenv("HOME", origHome)
+	t.Setenv("HOME", tmpHome)
+	authKeysPath := filepath.Join(tmpHome, ".ssh", "authorized_keys")
 
 	collector := NewCollector(CollectorConfig{NodeName: "test-node"})
 	srv := NewServer(ServerConfig{
 		TokenValidator: &mockTokenValidator{validToken: "valid-token"},
 		OrgID:          "test-org",
 	}, collector)
+	mux := srv.buildMux()
 
 	key1 := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl test@example.com"
 
-	t.Run("valid request with VPN origin", func(t *testing.T) {
+	// A VPN-origin POST (the exact attack the flat mesh allowed) must be refused
+	// and write nothing. SSH-key injection now lives only on the mTLS control
+	// listener (see TestSSHInjectionOverMTLS).
+	t.Run("VPN origin no longer deploys keys", func(t *testing.T) {
 		body, _ := json.Marshal(sshAuthorizedKeysRequest{Keys: []string{key1}})
 		req := httptest.NewRequest(http.MethodPost, "/ssh/authorized-keys", bytes.NewReader(body))
 		req.RemoteAddr = "100.64.0.5:12345"
 		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
 
-		handler := srv.requireVPNOrAuth(srv.handleSSHAuthorizedKeys)
-		handler(w, req)
-
-		if w.Code != http.StatusOK {
-			t.Errorf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+		if w.Code != http.StatusForbidden {
+			t.Errorf("status = %d, want 403", w.Code)
 		}
-
-		var resp sshAuthorizedKeysResponse
-		json.Unmarshal(w.Body.Bytes(), &resp)
-		if resp.Added != 1 {
-			t.Errorf("added = %d, want 1", resp.Added)
+		if _, err := os.Stat(authKeysPath); !os.IsNotExist(err) {
+			t.Error("authorized_keys must not be created via the plaintext path")
 		}
 	})
 
-	t.Run("valid request with token auth", func(t *testing.T) {
-		// Deploy a second key via token auth (not VPN origin)
-		key2 := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPwFRoSvVFDe4FjpGgUHjBfcS20B3pjxFDfKFYB4z3KN test2@example.com"
-		body, _ := json.Marshal(sshAuthorizedKeysRequest{Keys: []string{key2}})
+	// Even a valid org token on the plaintext path must not deploy keys now.
+	t.Run("token on plaintext path no longer deploys keys", func(t *testing.T) {
+		body, _ := json.Marshal(sshAuthorizedKeysRequest{Keys: []string{key1}})
 		req := httptest.NewRequest(http.MethodPost, "/ssh/authorized-keys", bytes.NewReader(body))
-		req.RemoteAddr = "192.168.1.1:12345" // NOT VPN
+		req.RemoteAddr = "192.168.1.1:12345"
 		req.Header.Set("Authorization", "Bearer valid-token")
 		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
 
-		handler := srv.requireVPNOrAuth(srv.handleSSHAuthorizedKeys)
-		handler(w, req)
-
-		if w.Code != http.StatusOK {
-			t.Errorf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+		if w.Code != http.StatusForbidden {
+			t.Errorf("status = %d, want 403", w.Code)
+		}
+		if _, err := os.Stat(authKeysPath); !os.IsNotExist(err) {
+			t.Error("authorized_keys must not be created via the plaintext path")
 		}
 	})
+}
 
-	t.Run("rejected without VPN or token", func(t *testing.T) {
-		body, _ := json.Marshal(sshAuthorizedKeysRequest{Keys: []string{key1}})
-		req := httptest.NewRequest(http.MethodPost, "/ssh/authorized-keys", bytes.NewReader(body))
-		req.RemoteAddr = "192.168.1.1:12345"
-		w := httptest.NewRecorder()
+// TestHandleSSHAuthorizedKeysValidation covers request validation directly;
+// auth/identity gating is covered by the mTLS tests (TestSSHInjectionOverMTLS).
+func TestHandleSSHAuthorizedKeysValidation(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
 
-		handler := srv.requireVPNOrAuth(srv.handleSSHAuthorizedKeys)
-		handler(w, req)
-
-		if w.Code != http.StatusUnauthorized {
-			t.Errorf("status = %d, want 401", w.Code)
-		}
-	})
-
-	t.Run("rejected with invalid token", func(t *testing.T) {
-		body, _ := json.Marshal(sshAuthorizedKeysRequest{Keys: []string{key1}})
-		req := httptest.NewRequest(http.MethodPost, "/ssh/authorized-keys", bytes.NewReader(body))
-		req.RemoteAddr = "192.168.1.1:12345"
-		req.Header.Set("Authorization", "Bearer wrong-token")
-		w := httptest.NewRecorder()
-
-		handler := srv.requireVPNOrAuth(srv.handleSSHAuthorizedKeys)
-		handler(w, req)
-
-		if w.Code != http.StatusUnauthorized {
-			t.Errorf("status = %d, want 401", w.Code)
-		}
-	})
+	collector := NewCollector(CollectorConfig{NodeName: "test-node"})
+	srv := NewServer(ServerConfig{}, collector)
 
 	t.Run("invalid key format returns 400", func(t *testing.T) {
 		body, _ := json.Marshal(sshAuthorizedKeysRequest{Keys: []string{"not-a-valid-key"}})
 		req := httptest.NewRequest(http.MethodPost, "/ssh/authorized-keys", bytes.NewReader(body))
-		req.RemoteAddr = "100.64.0.5:12345"
 		w := httptest.NewRecorder()
-
-		handler := srv.requireVPNOrAuth(srv.handleSSHAuthorizedKeys)
-		handler(w, req)
-
+		srv.handleSSHAuthorizedKeys(w, req)
 		if w.Code != http.StatusBadRequest {
 			t.Errorf("status = %d, want 400, body: %s", w.Code, w.Body.String())
 		}
@@ -382,12 +356,8 @@ func TestHandleSSHAuthorizedKeysEndpoint(t *testing.T) {
 	t.Run("empty keys list returns 400", func(t *testing.T) {
 		body, _ := json.Marshal(sshAuthorizedKeysRequest{Keys: []string{}})
 		req := httptest.NewRequest(http.MethodPost, "/ssh/authorized-keys", bytes.NewReader(body))
-		req.RemoteAddr = "100.64.0.5:12345"
 		w := httptest.NewRecorder()
-
-		handler := srv.requireVPNOrAuth(srv.handleSSHAuthorizedKeys)
-		handler(w, req)
-
+		srv.handleSSHAuthorizedKeys(w, req)
 		if w.Code != http.StatusBadRequest {
 			t.Errorf("status = %d, want 400", w.Code)
 		}
@@ -395,12 +365,8 @@ func TestHandleSSHAuthorizedKeysEndpoint(t *testing.T) {
 
 	t.Run("method not allowed for GET", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/ssh/authorized-keys", nil)
-		req.RemoteAddr = "100.64.0.5:12345"
 		w := httptest.NewRecorder()
-
-		handler := srv.requireVPNOrAuth(srv.handleSSHAuthorizedKeys)
-		handler(w, req)
-
+		srv.handleSSHAuthorizedKeys(w, req)
 		if w.Code != http.StatusMethodNotAllowed {
 			t.Errorf("status = %d, want 405", w.Code)
 		}


### PR DESCRIPTION
## Context

Phase 0 of #5028 (founder green-lit). A security audit found that the Citadel node's status/control server on **:8080** accepts requests from **any mesh IP with no cryptographic identity** and exposes an **SSH-key-injection** endpoint. Because the live Headscale mesh ACL is currently flat, any node on the mesh — including, once multi-tenant, **another org's node** — can POST an SSH key to a peer and take over the host. This PR closes the SSH-key-injection vector by requiring a **fabric-CA-signed coordinator client certificate (mTLS)**, reusing the existing fabric mTLS PKI. No new bearer token is introduced. **PR only — do not merge; requires the backend companion below to be usable, and must be rolled out backend-first.**

## Phase 1 — Audit findings

### The :8080 server (`internal/status/server.go`, `cmd/work.go`)
- **Transport:** plain HTTP (`ListenAndServe`), no TLS. Binds `:8080` (all interfaces) plus an explicit tsnet **VPN listener** so it is reachable over the mesh.
- **Endpoints:**
  - Read-only, unauthenticated: `/ping`, `/status`, `/health`, `/services`, and `/gateway-cert.pem` (intentionally public — it is the bootstrap-before-trust channel for the gateway's leaf cert).
  - `/api/screenshot`, `/api/actions` — desktop control, gated by an **org-scoped bearer token** (`requireAuth`). A real credential, not the hole.
  - **`/ssh/authorized-keys` — SSH key injection (host takeover), gated by `requireVPNOrAuth`.**
  - `/agent/*` introspection + control, and provisioning/workflow routes — also gated by `requireVPNOrAuth`.
- **The hole:** `requireVPNOrAuth` **short-circuits to allow ANY request whose source IP is in `100.64.0.0/10`** (the Headscale CGNAT range) with no token. Mesh origin is not an identity. On the flat mesh, a cross-org node can call `/ssh/authorized-keys` directly and write to `~/.ssh/authorized_keys`.

### Existing fabric identity model (what we verify against)
- There **is** a fabric mTLS PKI: an **EC fabric CA**. Node leaf certs are CA-signed and carry SAN URIs `aceteam:node:<node_uid>` and `aceteam:org:<org_id>` (`python-backend/utils/fabric_ca/profile.py`). Leafs are issued through the pairing CSR flow (`fabric_pairing.py`) and the public CA chain is served at **`GET https://aceteam.ai/api/fabric/ca/chain`** (+ CRL at `/api/fabric/ca/crl`). The nexus `reenroll` service (nexus#30/#31) is a keyless verifier that chains a client leaf to this CA; nginx terminates client mTLS there.
- **Gap discovered:** citadel-cli (the node) has **no fabric-cert code today** — it does not hold the fabric CA trust root, does not hold a fabric client identity, and the mutating endpoints are plain HTTP. The only cert on the node is the gateway's **self-signed server** cert (`internal/tlscert`), which is not CA-signed and is a server identity.

### Legitimate control flow (established before changing it)
- SSH deploy: Next.js `/api/fabric/ssh-keys/deploy/[nodeId]` → **python backend `fabric_relay.py:relay_ssh_keys`** → validates org ownership in the DB → **POSTs plain HTTP over the VPN mesh** to `http://{vpn_ip}:8080/ssh/authorized-keys`. **It presents no credential.** At the node, this legitimate call is byte-for-byte indistinguishable from a cross-org attacker's — which is exactly the vulnerability.

**Consequence:** no citadel-only change can *both* fail-closed *and* preserve today's flow, because today's flow carries no credential. This PR fails closed; the backend must be updated to present a coordinator cert (see gaps).

## Phase 2 — What this PR gates

A dedicated **mTLS control listener** (default **:8443**) now serves the SSH-key-injection endpoint, gated by a verified **coordinator** client certificate:

- **`internal/status/mtls.go` — `FabricCAVerifier`:** loads the public fabric CA bundle from a configured path, exposes a `RequireAndVerifyClientCert` TLS config (chain-to-CA enforced at the handshake), and a `requireCoordinator` middleware that additionally checks the leaf's SAN URI is on an **explicit coordinator allowlist**.
- **`internal/status/server.go`:** the plain :8080 route for `/ssh/authorized-keys` is replaced with a **fail-closed 403 stub** (`handleSSHMovedToControl`, no side effects); the real handler is registered only on the mTLS control mux. Adds `AddControlListener` (VPN) + `startControlServer`.
- **`cmd/work.go`:** builds the verifier + a control server cert and starts the listener (local + VPN) **only when** `CITADEL_FABRIC_CA_BUNDLE` and `CITADEL_COORDINATOR_SANS` are set; otherwise logs and leaves the mutating endpoints refused.

### Fail-closed behavior (the load-bearing property)
Every one of these refuses with **zero side effects** (no key written):
- No fabric CA bundle / empty CA / **empty coordinator allowlist** → verifier refuses to construct → control listener never starts → SSH endpoint refused everywhere.
- Caller with **no client cert** → rejected at the TLS handshake.
- Client cert that **does not chain** to the fabric CA (e.g. another CA) → rejected at the handshake.
- Valid fabric cert whose SAN is **not** an allowlisted coordinator (e.g. a peer org's node cert) → **403**.
- Old plaintext/VPN-origin path → **403** stub.

### Deliberate deviation from the task's suggested interim
The task allowed gating to "any valid fabric cert" if coordinator can't be distinguished. **That does not close #5028:** the threat is other orgs' nodes, and every enrolled node holds a valid fabric leaf, so "chains to the CA" would still admit them. This PR therefore **requires an explicitly-configured coordinator identity and refuses to construct a verifier without one** (fail closed) rather than accept any fabric cert.

### Scope choice
Gated **SSH-key injection** (the host-takeover crown jewel, smallest-blast-radius migration — one caller). `/agent/*` control + provisioning/workflow share the same `requireVPNOrAuth` weakness and should move to the same gate in an immediate fast-follow; they are higher-blast-radius (many backend flows) and warrant their own coordinated rollout. Read-only endpoints stay plain (recommended: leave unauthenticated; they leak no control). Desktop endpoints keep their org-token gate.

## Test plan
`go build ./...`, `go vet ./...` clean; `go test ./internal/status/... ./cmd/...` green.
- `mtls_test.go` (synthetic EC CA fixture): verifier fail-closed construction (empty path / missing file / certless bundle / empty allowlist); `requireCoordinator` handler fail-closed (no TLS, no peer cert, peer-org SAN → 403, coordinator SAN → pass); **end-to-end over a real mTLS handshake on `/ssh/authorized-keys`** — no cert → handshake reject (no write); untrusted-CA cert → handshake reject (no write); valid fabric cert, non-coordinator SAN → 403 (no write); coordinator cert → 200 + key written.
- `ssh_handler_test.go`: rewrote the endpoint test to assert the plaintext path now fail-closes (VPN origin **and** valid org token → 403, nothing written); kept request-validation coverage.

## Flagged gaps / cross-repo dependencies (required for this fix to function)
1. **Backend companion (aceteam):** `fabric_relay.py:relay_ssh_keys` must present a coordinator fabric client cert when POSTing to the node's control listener (currently plain HTTP, no cert). **Until then, SSH deploy fails closed.**
2. **CA profile gap (aceteam):** `utils/fabric_ca/profile.py` has only `aceteam:node:`/`aceteam:org:` SANs — **no coordinator/role SAN**. The coordinator identity must be configured out-of-band (`CITADEL_COORDINATOR_SANS`) until the CA mints a distinct coordinator role.
3. **Node CA-bundle provisioning:** the node must obtain the public fabric CA bundle (`GET /api/fabric/ca/chain`) into `CITADEL_FABRIC_CA_BUNDLE`. Not yet wired; the verifier reads it once at startup (no hot-reload on CA rotation — restart required).
4. **Rollout order:** ship (1) backend-first, then update nodes — otherwise SSH-deploy fails closed fleet-wide. Node server-cert trust for the coordinator's outbound call is also unresolved (the control cert is self-signed today).

### Founder decision surfaced
This is the **node-side half** of a two-part mTLS fix, consistent with "use the existing fabric mTLS identity, no new bearer token." If a citadel-only stopgap deployable **without** the backend change is wanted, the only option is narrowing `requireVPNOrAuth` from all of `100.64.0.0/10` to an **allowlist of the coordinator/relay mesh IP** — fail-closed against cross-org, no cert needed, but it diverges from the mTLS directive and is brittle to mesh-IP churn. Offered as your call, not the default.

---
*Generated by Claude Opus 4.8*

### Adjacent surfaces reviewed (confirmed not additional vectors)
- `internal/nexus/sshkeys.go` — the **outbound** key sync: the node pulls its authorized_keys from the AceTeam API via a node-authenticated Bearer `GET` and writes them locally. No inbound listener; a peer cannot trigger it. Different (node→API bearer) trust model, not the mesh hole.
- `internal/network/server.go` — the tsnet transport wrapper (Connect / IP / Disconnect). No host-mutating HTTP endpoint exposed to peers.
- `internal/network/keyhealth.go` — WireGuard/tsnet **node-key** expiry health + in-place renewal using the node's own session (epic #4583). Unrelated to authorized_keys or inbound requests.

So the SSH-injection surface reachable from a peer is the single `/ssh/authorized-keys` HTTP endpoint gated here. The remaining `requireVPNOrAuth` mutating endpoints (`/agent/set-log-level`, `/agent/worker-restart`, `/agent/resubscribe`, provisioning/workflow) stay VPN-origin-gated — cross-org-reachable but not host-takeover — pending the fast-follow; **:8080 is not "fully secured" by this PR**, only the SSH-key-injection takeover vector is closed.
