### PR TITLE
fix(services): launch SERVICE_START extended instance payloads (#462)

### DIFF
--- a/internal/jobs/instance_store.go
+++ b/internal/jobs/instance_store.go
@@ -1,0 +1,155 @@
+// internal/jobs/instance_store.go
+//
+// Persistent registry of payload-launched agent-runtime instances (BYOC, e.g.
+// Claude Code on your own node -- citadel-cli#462 / aceteam#4588).
+//
+// These instances are launched from an inline SERVICE_START payload (image, env,
+// host port, state volume) rather than a name in the node's citadel.yaml or the
+// embedded ServiceMap. They are DELIBERATELY kept out of citadel.yaml: the
+// desired-state reconciler (internal/reconcile, #353/#4273) treats citadel.yaml
+// as a projection of the control-plane DesiredState and would read anything it
+// finds there but not in DesiredState as drift-to-uninstall. Recording these
+// instances in a separate store keeps them clear of that reconcile domain while
+// still giving SERVICE_STOP / SERVICE_STATUS a way to find a container that
+// exists in neither manifest.
+package jobs
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// InstanceRecord is the persisted spec of one payload-launched instance. It
+// holds everything SERVICE_STOP / SERVICE_STATUS (and a future reconcile
+// relaunch) need to act on the container without re-consulting the platform.
+type InstanceRecord struct {
+	// ServiceName is the platform-assigned service name (e.g. "ac-<shortcode>").
+	// It is the key the platform uses on STOP/STATUS and the suffix of the
+	// docker container name.
+	ServiceName string `json:"service_name"`
+	// InstanceID is the platform instance id (for cross-reference/logging).
+	InstanceID string `json:"instance_id,omitempty"`
+	// ContainerName is the docker container name ("citadel-<service_name>").
+	ContainerName string `json:"container_name"`
+	// Image is the validated container image reference.
+	Image string `json:"image"`
+	// HostPort is the host port the container's HTTP endpoint is published on.
+	HostPort int `json:"host_port"`
+	// ContainerPort is the in-container port the host port maps to.
+	ContainerPort int `json:"container_port"`
+	// StateVolumePath is the resolved (absolute) host path mounted for durable
+	// per-instance state.
+	StateVolumePath string `json:"state_volume_path"`
+	// StateMountPath is the container path StateVolumePath is mounted at.
+	StateMountPath string `json:"state_mount_path"`
+}
+
+// instanceStore persists the set of payload-launched instances to a JSON file.
+type instanceStore struct {
+	mu   sync.Mutex
+	path string
+}
+
+// instanceStorePath returns ~/.citadel/instances/state.json (mirrors the
+// per-app store in internal/apps). Kept under ~/.citadel (a citadel data dir),
+// NOT under the citadel.yaml config dir, to keep these records out of the
+// manifest/reconcile surface.
+func instanceStorePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+	return filepath.Join(home, ".citadel", "instances", "state.json"), nil
+}
+
+// newInstanceStore opens (or lazily creates) the store at the default path.
+func newInstanceStore() (*instanceStore, error) {
+	path, err := instanceStorePath()
+	if err != nil {
+		return nil, err
+	}
+	return &instanceStore{path: path}, nil
+}
+
+// load reads the current record set. A missing file is an empty set, not an
+// error, so the first launch on a fresh node works.
+func (s *instanceStore) load() (map[string]InstanceRecord, error) {
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]InstanceRecord{}, nil
+		}
+		return nil, fmt.Errorf("failed to read instance store %s: %w", s.path, err)
+	}
+	records := map[string]InstanceRecord{}
+	if len(data) == 0 {
+		return records, nil
+	}
+	if err := json.Unmarshal(data, &records); err != nil {
+		return nil, fmt.Errorf("failed to parse instance store %s: %w", s.path, err)
+	}
+	return records, nil
+}
+
+// save writes the record set atomically (temp file + rename).
+func (s *instanceStore) save(records map[string]InstanceRecord) error {
+	if err := os.MkdirAll(filepath.Dir(s.path), 0700); err != nil {
+		return fmt.Errorf("failed to create instance store dir: %w", err)
+	}
+	data, err := json.MarshalIndent(records, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal instance store: %w", err)
+	}
+	tmp := s.path + ".tmp"
+	// 0600: env in the record set may reference sensitive values.
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return fmt.Errorf("failed to write instance store: %w", err)
+	}
+	if err := os.Rename(tmp, s.path); err != nil {
+		return fmt.Errorf("failed to persist instance store: %w", err)
+	}
+	return nil
+}
+
+// Get returns the record for a service name, if present.
+func (s *instanceStore) Get(serviceName string) (InstanceRecord, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	records, err := s.load()
+	if err != nil {
+		return InstanceRecord{}, false, err
+	}
+	rec, ok := records[serviceName]
+	return rec, ok, nil
+}
+
+// Put upserts a record (keyed by ServiceName) and persists.
+func (s *instanceStore) Put(rec InstanceRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	records, err := s.load()
+	if err != nil {
+		return err
+	}
+	records[rec.ServiceName] = rec
+	return s.save(records)
+}
+
+// Delete removes a record by service name and persists. Deleting a
+// non-existent record is a no-op (idempotent).
+func (s *instanceStore) Delete(serviceName string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	records, err := s.load()
+	if err != nil {
+		return err
+	}
+	if _, ok := records[serviceName]; !ok {
+		return nil
+	}
+	delete(records, serviceName)
+	return s.save(records)
+}

--- a/internal/jobs/instance_store_test.go
+++ b/internal/jobs/instance_store_test.go
@@ -1,0 +1,54 @@
+// internal/jobs/instance_store_test.go
+package jobs
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func newTestStore(t *testing.T) *instanceStore {
+	t.Helper()
+	return &instanceStore{path: filepath.Join(t.TempDir(), "instances", "state.json")}
+}
+
+func TestInstanceStore_PutGetDelete(t *testing.T) {
+	s := newTestStore(t)
+
+	// Missing file -> empty, not found, no error.
+	if _, ok, err := s.Get("ac-x"); err != nil || ok {
+		t.Fatalf("Get on empty store: ok=%v err=%v", ok, err)
+	}
+
+	rec := InstanceRecord{
+		ServiceName:     "ac-x",
+		InstanceID:      "i-1",
+		ContainerName:   "citadel-ac-x",
+		Image:           "ghcr.io/aceteam-ai/claudecode-service:latest",
+		HostPort:        18789,
+		ContainerPort:   8787,
+		StateVolumePath: "/home/citadel/citadel-cache/instances/i-1",
+		StateMountPath:  "/state",
+	}
+	if err := s.Put(rec); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	got, ok, err := s.Get("ac-x")
+	if err != nil || !ok {
+		t.Fatalf("Get after Put: ok=%v err=%v", ok, err)
+	}
+	if got != rec {
+		t.Errorf("round-trip mismatch:\n got %+v\nwant %+v", got, rec)
+	}
+
+	// Delete is idempotent.
+	if err := s.Delete("ac-x"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, ok, _ := s.Get("ac-x"); ok {
+		t.Errorf("record still present after Delete")
+	}
+	if err := s.Delete("ac-x"); err != nil {
+		t.Errorf("Delete of absent record should be no-op, got %v", err)
+	}
+}

--- a/internal/jobs/service_handler.go
+++ b/internal/jobs/service_handler.go
@@ -43,6 +43,10 @@ type ServiceHandler struct {
 	// workspace (e.g. the transcribe sidecar) resolve to an absolute path even
 	// when the worker was started without CITADEL_WORKSPACE in its environment.
 	WorkspaceDir string
+	// instances is the registry of payload-launched agent-runtime instances
+	// (BYOC, citadel-cli#462), lazily initialized. These live outside
+	// citadel.yaml, so SERVICE_STOP / SERVICE_STATUS find them here.
+	instances *instanceStore
 }
 
 // NewServiceHandler creates a ServiceHandler rooted at configDir.
@@ -79,6 +83,31 @@ func (h *ServiceHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error)
 	}
 
 	ctx.Log("info", "     - [Job %s] Service %s: %s", job.ID, job.Type, svcName)
+
+	// Extended-payload launch path (BYOC agent runtimes, citadel-cli#462). A
+	// SERVICE_START that carries an inline spec (image/env/host_port/volume) is
+	// launched from the payload; it does not exist in citadel.yaml or the
+	// embedded ServiceMap. The name-based manifest path below is left untouched
+	// for embedded services.
+	if job.Type == "SERVICE_START" && payloadHasInlineSpec(job.Payload) {
+		return h.serviceStartPayload(ctx, job)
+	}
+
+	// SERVICE_STOP / SERVICE_STATUS for a previously payload-launched instance:
+	// it is in neither the manifest nor the embedded map, so resolve it from the
+	// instance store before falling through to the manifest path.
+	if job.Type == "SERVICE_STOP" || job.Type == "SERVICE_STATUS" {
+		if rec, ok, sErr := h.instanceStore().Get(svcName); sErr != nil {
+			ctx.Log("warning", "     - [Job %s] instance store read failed: %v", job.ID, sErr)
+		} else if ok {
+			switch job.Type {
+			case "SERVICE_STATUS":
+				return h.serviceStatusPayload(rec)
+			case "SERVICE_STOP":
+				return h.serviceStopPayload(ctx, rec)
+			}
+		}
+	}
 
 	// Load manifest and validate service name against it.
 	manifest, err := h.loadManifest()

--- a/internal/jobs/service_handler_payload_test.go
+++ b/internal/jobs/service_handler_payload_test.go
@@ -1,0 +1,81 @@
+// internal/jobs/service_handler_payload_test.go
+package jobs
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+// newHandlerWithStore returns a ServiceHandler whose instance store is a
+// throwaway temp file, so payload STOP/STATUS resolution is tested without
+// touching the real ~/.citadel.
+func newHandlerWithStore(t *testing.T) *ServiceHandler {
+	t.Helper()
+	h := NewServiceHandler(t.TempDir())
+	h.instances = &instanceStore{path: filepath.Join(t.TempDir(), "instances.json")}
+	return h
+}
+
+// TestExecute_PayloadStartRejectsDisallowedImage proves the extended-payload
+// branch is reached (an image-bearing SERVICE_START does not hit the manifest
+// path) and that registry validation runs before any docker call.
+func TestExecute_PayloadStartRejectsDisallowedImage(t *testing.T) {
+	h := newHandlerWithStore(t)
+	job := &nexus.Job{
+		ID:   "j1",
+		Type: "SERVICE_START",
+		Payload: map[string]string{
+			"service":           "ac-x",
+			"image":             "docker.io/library/nginx", // disallowed registry
+			"host_port":         "18789",
+			"state_volume_path": "~/citadel-cache/instances/x",
+		},
+	}
+	_, err := h.Execute(JobContext{}, job)
+	if err == nil {
+		t.Fatal("expected error for disallowed image, got nil")
+	}
+	if want := "not from an allowed registry"; !strings.Contains(err.Error(), want) {
+		t.Errorf("error = %q, want substring %q", err.Error(), want)
+	}
+}
+
+// TestExecute_PayloadStatusFromStore proves SERVICE_STATUS resolves a
+// payload-launched instance from the instance store (it is in neither the
+// manifest nor the embedded ServiceMap) and returns a status result without
+// falling through to the manifest lookup.
+func TestExecute_PayloadStatusFromStore(t *testing.T) {
+	h := newHandlerWithStore(t)
+	if err := h.instances.Put(InstanceRecord{
+		ServiceName:   "ac-x",
+		ContainerName: "citadel-ac-x",
+		Image:         "ghcr.io/aceteam-ai/claudecode-service:latest",
+		HostPort:      18789,
+		ContainerPort: 8787,
+	}); err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+
+	job := &nexus.Job{ID: "j2", Type: "SERVICE_STATUS", Payload: map[string]string{"service": "ac-x"}}
+	out, err := h.Execute(JobContext{}, job)
+	if err != nil {
+		t.Fatalf("Execute STATUS: %v", err)
+	}
+	var res serviceResult
+	if err := json.Unmarshal(out, &res); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if res.Name != "ac-x" || res.Action != "status" || res.Kind != "docker" {
+		t.Errorf("unexpected status result: %+v", res)
+	}
+	// docker is not present in the unit-test env, so the container is not
+	// running -- the point is that STATUS resolved via the store and returned a
+	// well-formed result rather than "not found in manifest".
+	if res.Running {
+		t.Errorf("expected Running=false in unit env, got true")
+	}
+}

--- a/internal/jobs/service_payload.go
+++ b/internal/jobs/service_payload.go
@@ -1,0 +1,496 @@
+// internal/jobs/service_payload.go
+//
+// Extended SERVICE_START handling: launch an agent-runtime container directly
+// from an inline job payload (image / env / host_port / state volume) instead
+// of resolving a service NAME against the node's citadel.yaml or the embedded
+// ServiceMap. This is the node-side receiver (Child C) for the BYOC agent-host
+// launch contract the platform dispatches (aceteam#4588 / #4590,
+// aceteam/python-backend/utils/instance_node_dispatch.py: NodeServiceSpec).
+//
+// Contract (what the platform actually sends, verified in aceteam#5134):
+//
+//	{
+//	  "service":           "ac-<shortcode>",             // container name suffix + STOP/STATUS key
+//	  "instance_id":       "<uuid>",
+//	  "image":             "ghcr.io/aceteam-ai/claudecode-service:latest",
+//	  "env":               {"ANTHROPIC_BASE_URL": "...", ...},  // JSON object
+//	  "host_port":         18789,                        // constant today (NOT per-instance)
+//	  "state_volume_path": "~/citadel-cache/instances/<id>",   // literal ~, node-expanded
+//	  "state_mount_path":  "/state"
+//	}
+//
+// The platform does NOT read back the launched endpoint; it reaches the
+// container at host_port over the mesh. So the host port is published VERBATIM,
+// never re-allocated. The env carries no PORT or CLAUDE_CONFIG_DIR, so this
+// handler injects both: PORT so the wrapper listens on the port we publish, and
+// CLAUDE_CONFIG_DIR = state_mount_path so Claude Code writes its state INTO the
+// mounted per-instance volume (the entrypoint chowns CLAUDE_CONFIG_DIR
+// generically, so durability works without a container change).
+package jobs
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+	embeddedservices "github.com/aceteam-ai/citadel-cli/services"
+)
+
+// containerNamePrefix is the docker container-name prefix shared with the
+// manifest path (isDockerServiceRunning / dockerServiceEndpoint both look up
+// "citadel-<service>"), so those helpers work unchanged for payload instances.
+const containerNamePrefix = "citadel-"
+
+// defaultStateMountPath mirrors the platform's DEFAULT_STATE_MOUNT_PATH. Used
+// only when the payload omits state_mount_path.
+const defaultStateMountPath = "/state"
+
+// defaultContainerPort is the wrapper's fixed internal contract port
+// (services/claudecode-service/wrapper.py PORT default). Used when the payload
+// env carries no PORT of its own.
+const defaultContainerPort = 8787
+
+// allowedImageRegistryPrefixes restricts payload-launched images to AceTeam's
+// official registry namespace. This mirrors the trust model in internal/catalog
+// (only operator-trusted sources may run): the payload arrives over the
+// authenticated per-node job stream, but an image reference is still a
+// code-execution grant, so it is constrained to the namespace that publishes
+// the vetted BYOC runtime images (claudecode-service, and future agent
+// runtimes). Widen this deliberately, not implicitly.
+var allowedImageRegistryPrefixes = []string{
+	"ghcr.io/aceteam-ai/",
+}
+
+// instanceSpec is the validated, node-resolved form of an extended
+// SERVICE_START payload, ready to launch.
+type instanceSpec struct {
+	ServiceName   string
+	InstanceID    string
+	ContainerName string
+	Image         string
+	Env           map[string]string
+	HostPort      int
+	ContainerPort int
+	// StateVolumePath is the absolute, ~-expanded, validated host path.
+	StateVolumePath string
+	StateMountPath  string
+}
+
+// payloadHasInlineSpec reports whether a job payload is the extended,
+// self-contained launch form (carries an "image") rather than the legacy
+// name-only {"service": name} form. This is the switch that keeps the existing
+// manifest/embedded path untouched: only an image-bearing SERVICE_START takes
+// the payload-launch branch.
+func payloadHasInlineSpec(payload map[string]string) bool {
+	return strings.TrimSpace(payload["image"]) != ""
+}
+
+// parseInstanceSpec validates an extended SERVICE_START payload and resolves it
+// into a launchable instanceSpec. homeDir is the node owner's home directory
+// (injected for testability); it is used to expand a leading "~" in the state
+// volume path and to bound that path to the citadel data dir.
+//
+// Pure apart from the passed-in homeDir: it performs no I/O, so it is
+// table-testable without Docker or a filesystem.
+func parseInstanceSpec(payload map[string]string, homeDir string) (*instanceSpec, error) {
+	serviceName := strings.TrimSpace(payload["service"])
+	if serviceName == "" {
+		return nil, fmt.Errorf("payload missing 'service' name")
+	}
+	if err := validateServiceName(serviceName); err != nil {
+		return nil, err
+	}
+
+	image := strings.TrimSpace(payload["image"])
+	if err := validateImageRef(image); err != nil {
+		return nil, err
+	}
+
+	env, err := parseEnvField(payload["env"])
+	if err != nil {
+		return nil, err
+	}
+
+	hostPort, err := parsePort(payload["host_port"])
+	if err != nil {
+		return nil, fmt.Errorf("invalid host_port: %w", err)
+	}
+	if err := validateHostPort(hostPort); err != nil {
+		return nil, err
+	}
+
+	mountPath := strings.TrimSpace(payload["state_mount_path"])
+	if mountPath == "" {
+		mountPath = defaultStateMountPath
+	}
+	if !strings.HasPrefix(mountPath, "/") {
+		return nil, fmt.Errorf("state_mount_path %q must be an absolute container path", mountPath)
+	}
+
+	volPath, err := resolveStateVolumePath(payload["state_volume_path"], homeDir)
+	if err != nil {
+		return nil, err
+	}
+
+	// Container port: honor an explicit PORT in the payload env, else the
+	// wrapper's default. The host port is published to this in-container port.
+	containerPort := defaultContainerPort
+	if p, ok := env["PORT"]; ok {
+		parsed, perr := parsePort(p)
+		if perr != nil {
+			return nil, fmt.Errorf("invalid env PORT: %w", perr)
+		}
+		containerPort = parsed
+	}
+
+	return &instanceSpec{
+		ServiceName:     serviceName,
+		InstanceID:      strings.TrimSpace(payload["instance_id"]),
+		ContainerName:   containerNamePrefix + serviceName,
+		Image:           image,
+		Env:             env,
+		HostPort:        hostPort,
+		ContainerPort:   containerPort,
+		StateVolumePath: volPath,
+		StateMountPath:  mountPath,
+	}, nil
+}
+
+// validateServiceName rejects names that could break out of the "citadel-<name>"
+// container-name arg or a docker flag position. Allows the platform's
+// "ac-<shortcode>" shape (alphanumerics, dash, underscore, dot).
+func validateServiceName(name string) error {
+	if strings.HasPrefix(name, "-") {
+		return fmt.Errorf("invalid service name %q: must not start with '-'", name)
+	}
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case r == '-' || r == '_' || r == '.':
+		default:
+			return fmt.Errorf("invalid service name %q: only [A-Za-z0-9._-] allowed", name)
+		}
+	}
+	return nil
+}
+
+// validateImageRef enforces the registry allowlist and rejects a reference that
+// could be read as a docker flag.
+func validateImageRef(image string) error {
+	if image == "" {
+		return fmt.Errorf("payload missing 'image'")
+	}
+	if strings.HasPrefix(image, "-") {
+		return fmt.Errorf("invalid image %q: must not start with '-'", image)
+	}
+	for _, prefix := range allowedImageRegistryPrefixes {
+		if strings.HasPrefix(image, prefix) {
+			return nil
+		}
+	}
+	return fmt.Errorf("image %q is not from an allowed registry (allowed: %s)",
+		image, strings.Join(allowedImageRegistryPrefixes, ", "))
+}
+
+// validateHostPort keeps a payload from publishing on a port citadel's own
+// listeners own (gateway, status server, VNC, terminal, ...). The host-port
+// registry (services/ports.go) is used here for VALIDATION only -- the port is
+// assigned by the platform, not re-allocated -- so a payload can never collide
+// with a citadel-internal listener.
+func validateHostPort(port int) error {
+	if port < 1 || port > 65535 {
+		return fmt.Errorf("host_port %d out of range", port)
+	}
+	if name, reserved := embeddedservices.ReservedCitadelPorts[port]; reserved {
+		return fmt.Errorf("host_port %d is reserved for citadel's %s listener", port, name)
+	}
+	return nil
+}
+
+// parseEnvField decodes the "env" payload field. The worker->nexus.Job adapter
+// json-encodes non-scalar payload values (see internal/worker/handler_adapter.go),
+// so env arrives here as a JSON object string. An empty field is an empty env.
+func parseEnvField(raw string) (map[string]string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return map[string]string{}, nil
+	}
+	var env map[string]string
+	if err := json.Unmarshal([]byte(raw), &env); err != nil {
+		return nil, fmt.Errorf("invalid env payload (expected JSON object of string->string): %w", err)
+	}
+	for k := range env {
+		if strings.TrimSpace(k) == "" {
+			return nil, fmt.Errorf("env contains an empty key")
+		}
+	}
+	return env, nil
+}
+
+// parsePort parses a port that may arrive as an int-valued string (e.g. "18789")
+// or, defensively, a float-valued one from a JSON number.
+func parsePort(raw string) (int, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, fmt.Errorf("empty")
+	}
+	if n, err := strconv.Atoi(raw); err == nil {
+		return n, nil
+	}
+	f, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%q is not a number", raw)
+	}
+	return int(f), nil
+}
+
+// resolveStateVolumePath expands a leading "~" to homeDir, makes the path
+// absolute, and bounds it to a citadel data dir. Docker's -v does NOT expand
+// "~" (unlike compose), so the node must do it. Bounding it to
+// <home>/citadel-cache or <home>/.citadel rejects a host-path mount that would
+// escape the citadel data area (e.g. "/etc" or "~/.ssh").
+func resolveStateVolumePath(raw, homeDir string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("payload missing 'state_volume_path'")
+	}
+	if homeDir == "" {
+		return "", fmt.Errorf("cannot resolve state_volume_path: home directory unknown")
+	}
+
+	expanded := raw
+	switch {
+	case raw == "~":
+		expanded = homeDir
+	case strings.HasPrefix(raw, "~/"):
+		expanded = filepath.Join(homeDir, raw[2:])
+	}
+
+	abs, err := filepath.Abs(expanded)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve state_volume_path %q: %w", raw, err)
+	}
+	abs = filepath.Clean(abs)
+
+	allowedBases := []string{
+		filepath.Join(homeDir, "citadel-cache"),
+		filepath.Join(homeDir, ".citadel"),
+	}
+	for _, base := range allowedBases {
+		if abs == base || strings.HasPrefix(abs, base+string(filepath.Separator)) {
+			return abs, nil
+		}
+	}
+	return "", fmt.Errorf(
+		"state_volume_path %q resolves to %q, which is outside the citadel data dir (allowed: %s)",
+		raw, abs, strings.Join(allowedBases, ", "))
+}
+
+// buildDockerRunArgs assembles the `docker run` arguments for a spec. Pure
+// (spec in, args out) so the port/volume/env wiring is testable without Docker.
+// The image is placed last, after all flags, so it can never be read as a flag.
+func buildDockerRunArgs(spec *instanceSpec) []string {
+	args := []string{
+		"run", "-d",
+		"--name", spec.ContainerName,
+		// Survive node reboot/upgrade with no citadel loop (nothing else
+		// auto-starts these). STOP does an explicit `docker rm`, so this does
+		// not resurrect a deliberately stopped instance.
+		"--restart", "unless-stopped",
+		// Publish on loopback only: the citadel gateway/mesh reaches services on
+		// 127.0.0.1, matching the manifest services' host publish.
+		"-p", fmt.Sprintf("127.0.0.1:%d:%d", spec.HostPort, spec.ContainerPort),
+		"-v", fmt.Sprintf("%s:%s", spec.StateVolumePath, spec.StateMountPath),
+	}
+
+	// Inject the durability + port env unless the payload already set them, so
+	// the runtime writes into the mounted volume and listens on the published
+	// port. Explicit payload values win.
+	injected := map[string]string{
+		"CLAUDE_CONFIG_DIR": spec.StateMountPath,
+		"PORT":              strconv.Itoa(spec.ContainerPort),
+	}
+	for k, v := range injected {
+		if _, ok := spec.Env[k]; !ok {
+			args = append(args, "-e", k+"="+v)
+		}
+	}
+
+	// Env passed as-is. Sorted for deterministic arg order (stable tests, stable
+	// logs); docker does not care about ordering.
+	for _, k := range sortedKeys(spec.Env) {
+		args = append(args, "-e", k+"="+spec.Env[k])
+	}
+
+	args = append(args, spec.Image)
+	return args
+}
+
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	// Simple insertion sort avoids pulling in sort for a tiny map and keeps the
+	// dependency surface minimal; env maps are small.
+	for i := 1; i < len(keys); i++ {
+		for j := i; j > 0 && keys[j-1] > keys[j]; j-- {
+			keys[j-1], keys[j] = keys[j], keys[j-1]
+		}
+	}
+	return keys
+}
+
+// ---------------------------------------------------------------------------
+// Handler entry points (payload-launched instances)
+// ---------------------------------------------------------------------------
+
+// serviceStartPayload launches (or reports already-running) a container from an
+// extended SERVICE_START payload and records it in the instance store so
+// SERVICE_STOP / SERVICE_STATUS can find it later.
+func (h *ServiceHandler) serviceStartPayload(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("cannot resolve home directory for payload launch: %w", err)
+	}
+	spec, err := parseInstanceSpec(job.Payload, homeDir)
+	if err != nil {
+		return nil, fmt.Errorf("invalid SERVICE_START payload: %w", err)
+	}
+
+	ctx.Log("info", "     - [Job %s] Launching instance %s from payload (image=%s, host_port=%d)",
+		job.ID, spec.ServiceName, spec.Image, spec.HostPort)
+
+	// Idempotent start: if the container is already running, report it (and keep
+	// the store in sync) rather than failing on a duplicate name.
+	if h.isDockerServiceRunning(spec.ServiceName) {
+		if err := h.recordInstance(spec); err != nil {
+			ctx.Log("warning", "     - [Job %s] instance %s running but store update failed: %v", job.ID, spec.ServiceName, err)
+		}
+		return h.instanceResult(spec, "start", true, "")
+	}
+
+	// Ensure the state volume dir exists on the host before mounting. The
+	// container entrypoint chowns it to the runtime user, so host ownership is
+	// fine; it just has to exist.
+	if err := os.MkdirAll(spec.StateVolumePath, 0700); err != nil {
+		return nil, fmt.Errorf("failed to create state volume dir %s: %w", spec.StateVolumePath, err)
+	}
+
+	// A stale stopped container with the same name would block `docker run
+	// --name`; remove it first (best-effort).
+	_ = exec.Command("docker", "rm", "-f", spec.ContainerName).Run()
+
+	cmd := exec.Command("docker", buildDockerRunArgs(spec)...)
+	if out, runErr := cmd.CombinedOutput(); runErr != nil {
+		return json.Marshal(serviceResult{
+			Name: spec.ServiceName, Running: false, Kind: "docker",
+			Action: "start", Error: strings.TrimSpace(string(out)),
+			Message: fmt.Sprintf("failed to launch %s: %s", spec.ServiceName, strings.TrimSpace(string(out))),
+		})
+	}
+
+	if err := h.recordInstance(spec); err != nil {
+		// The container is up; a store write failure must not report failure to
+		// the platform, but it does mean STOP/STATUS may miss it. Surface it.
+		ctx.Log("warning", "     - [Job %s] launched %s but failed to persist instance record: %v",
+			job.ID, spec.ServiceName, err)
+	}
+
+	return h.instanceResult(spec, "start", true, "")
+}
+
+// serviceStatusPayload reports the status of a payload-launched instance.
+func (h *ServiceHandler) serviceStatusPayload(rec InstanceRecord) ([]byte, error) {
+	running := h.isDockerServiceRunning(rec.ServiceName)
+	return json.Marshal(serviceResult{
+		Name:    rec.ServiceName,
+		Running: running,
+		Kind:    "docker",
+		Action:  "status",
+		Message: fmt.Sprintf("%s is %s (docker)", rec.ServiceName, boolToStatus(running)),
+	})
+}
+
+// serviceStopPayload stops and removes a payload-launched instance's container
+// and drops it from the instance store. The state volume on disk is left
+// intact so a later start reattaches the same durable state.
+func (h *ServiceHandler) serviceStopPayload(ctx JobContext, rec InstanceRecord) ([]byte, error) {
+	if h.isDockerServiceRunning(rec.ServiceName) || h.dockerContainerExists(rec.ContainerName) {
+		cmd := exec.Command("docker", "rm", "-f", rec.ContainerName)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return json.Marshal(serviceResult{
+				Name: rec.ServiceName, Running: h.isDockerServiceRunning(rec.ServiceName), Kind: "docker",
+				Action: "stop", Error: strings.TrimSpace(string(out)),
+				Message: fmt.Sprintf("failed to stop %s: %s", rec.ServiceName, strings.TrimSpace(string(out))),
+			})
+		}
+	}
+	if err := h.instanceStore().Delete(rec.ServiceName); err != nil {
+		ctx.Log("warning", "     - instance %s stopped but store cleanup failed: %v", rec.ServiceName, err)
+	}
+	return json.Marshal(serviceResult{
+		Name: rec.ServiceName, Running: false, Kind: "docker",
+		Action: "stop", Message: fmt.Sprintf("%s stopped successfully", rec.ServiceName),
+	})
+}
+
+// instanceResult builds the success result for a payload instance, including
+// the reachable endpoint derived from the published port.
+func (h *ServiceHandler) instanceResult(spec *instanceSpec, action string, running bool, errMsg string) ([]byte, error) {
+	res := serviceResult{
+		Name: spec.ServiceName, Running: running, Kind: "docker",
+		Action: action, Error: errMsg,
+	}
+	endpoint := fmt.Sprintf("127.0.0.1:%d", spec.HostPort)
+	res.Endpoint = endpoint
+	if running {
+		res.Message = fmt.Sprintf("%s started successfully; reachable at %s", spec.ServiceName, endpoint)
+	} else {
+		res.Message = fmt.Sprintf("%s is not running", spec.ServiceName)
+	}
+	return json.Marshal(res)
+}
+
+// recordInstance persists a launched instance's spec.
+func (h *ServiceHandler) recordInstance(spec *instanceSpec) error {
+	return h.instanceStore().Put(InstanceRecord{
+		ServiceName:     spec.ServiceName,
+		InstanceID:      spec.InstanceID,
+		ContainerName:   spec.ContainerName,
+		Image:           spec.Image,
+		HostPort:        spec.HostPort,
+		ContainerPort:   spec.ContainerPort,
+		StateVolumePath: spec.StateVolumePath,
+		StateMountPath:  spec.StateMountPath,
+	})
+}
+
+// instanceStore returns the handler's instance store, creating it on first use.
+func (h *ServiceHandler) instanceStore() *instanceStore {
+	if h.instances == nil {
+		s, err := newInstanceStore()
+		if err != nil {
+			// A store we cannot open degrades to a no-op-ish store rooted at a
+			// path that will error on write; callers log the error. Returning a
+			// zero-value store keeps the nil-check simple.
+			h.instances = &instanceStore{}
+			_ = err
+		} else {
+			h.instances = s
+		}
+	}
+	return h.instances
+}
+
+// dockerContainerExists reports whether a container with the given name exists
+// in any state (running or exited), so STOP can remove a stopped instance.
+func (h *ServiceHandler) dockerContainerExists(containerName string) bool {
+	cmd := exec.Command("docker", "inspect", "--format", "{{.Name}}", containerName)
+	return cmd.Run() == nil
+}

--- a/internal/jobs/service_payload_test.go
+++ b/internal/jobs/service_payload_test.go
@@ -1,0 +1,272 @@
+// internal/jobs/service_payload_test.go
+package jobs
+
+import (
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	embeddedservices "github.com/aceteam-ai/citadel-cli/services"
+)
+
+const testHome = "/home/citadel"
+
+// basePayload is a valid extended SERVICE_START payload as the platform sends
+// it (aceteam/python-backend/utils/instance_node_dispatch.py). env arrives as a
+// JSON string because the worker->nexus.Job adapter json-encodes nested values.
+func basePayload() map[string]string {
+	return map[string]string{
+		"service":           "ac-pond-steel-bone-6655",
+		"instance_id":       "11111111-2222-3333-4444-555555555555",
+		"image":             "ghcr.io/aceteam-ai/claudecode-service:latest",
+		"env":               `{"ANTHROPIC_BASE_URL":"https://proxy.example","ACETEAM_INSTANCE_ID":"i-1"}`,
+		"host_port":         "18789",
+		"state_volume_path": "~/citadel-cache/instances/i-1",
+		"state_mount_path":  "/state",
+	}
+}
+
+func TestPayloadHasInlineSpec(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload map[string]string
+		want    bool
+	}{
+		{"extended with image", map[string]string{"service": "ac-x", "image": "ghcr.io/aceteam-ai/x"}, true},
+		{"legacy name-only", map[string]string{"service": "vllm"}, false},
+		{"blank image", map[string]string{"service": "vllm", "image": "  "}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := payloadHasInlineSpec(tt.payload); got != tt.want {
+				t.Errorf("payloadHasInlineSpec = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseInstanceSpec_Valid(t *testing.T) {
+	spec, err := parseInstanceSpec(basePayload(), testHome)
+	if err != nil {
+		t.Fatalf("parseInstanceSpec: %v", err)
+	}
+	if spec.ServiceName != "ac-pond-steel-bone-6655" {
+		t.Errorf("ServiceName = %q", spec.ServiceName)
+	}
+	if spec.ContainerName != "citadel-ac-pond-steel-bone-6655" {
+		t.Errorf("ContainerName = %q", spec.ContainerName)
+	}
+	if spec.HostPort != 18789 {
+		t.Errorf("HostPort = %d, want 18789", spec.HostPort)
+	}
+	// No PORT in env -> wrapper default container port.
+	if spec.ContainerPort != defaultContainerPort {
+		t.Errorf("ContainerPort = %d, want %d", spec.ContainerPort, defaultContainerPort)
+	}
+	// ~ expanded and bounded to the citadel data dir.
+	wantVol := filepath.Join(testHome, "citadel-cache", "instances", "i-1")
+	if spec.StateVolumePath != wantVol {
+		t.Errorf("StateVolumePath = %q, want %q", spec.StateVolumePath, wantVol)
+	}
+	if spec.StateMountPath != "/state" {
+		t.Errorf("StateMountPath = %q", spec.StateMountPath)
+	}
+	wantEnv := map[string]string{"ANTHROPIC_BASE_URL": "https://proxy.example", "ACETEAM_INSTANCE_ID": "i-1"}
+	if !reflect.DeepEqual(spec.Env, wantEnv) {
+		t.Errorf("Env = %v, want %v", spec.Env, wantEnv)
+	}
+}
+
+func TestParseInstanceSpec_Defaults(t *testing.T) {
+	p := basePayload()
+	delete(p, "state_mount_path") // omitted -> default /state
+	p["env"] = `{"PORT":"9000"}`  // explicit container port
+	spec, err := parseInstanceSpec(p, testHome)
+	if err != nil {
+		t.Fatalf("parseInstanceSpec: %v", err)
+	}
+	if spec.StateMountPath != defaultStateMountPath {
+		t.Errorf("StateMountPath = %q, want %q", spec.StateMountPath, defaultStateMountPath)
+	}
+	if spec.ContainerPort != 9000 {
+		t.Errorf("ContainerPort = %d, want 9000 (from env PORT)", spec.ContainerPort)
+	}
+}
+
+func TestParseInstanceSpec_Rejects(t *testing.T) {
+	reservedPort := "" // filled below with a real reserved port
+	for p := range embeddedservices.ReservedCitadelPorts {
+		reservedPort = itoa(p)
+		break
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(map[string]string)
+		errSub string
+	}{
+		{"missing service", func(p map[string]string) { delete(p, "service") }, "missing 'service'"},
+		{"service starts with dash", func(p map[string]string) { p["service"] = "-evil" }, "must not start with '-'"},
+		{"service bad chars", func(p map[string]string) { p["service"] = "ac/../x" }, "only [A-Za-z0-9._-]"},
+		{"image not allowed registry", func(p map[string]string) { p["image"] = "docker.io/library/nginx" }, "not from an allowed registry"},
+		{"image flag injection", func(p map[string]string) { p["image"] = "-v/etc:/etc" }, "must not start with '-'"},
+		{"missing image", func(p map[string]string) { delete(p, "image") }, "missing 'image'"},
+		{"bad env json", func(p map[string]string) { p["env"] = "not-json" }, "invalid env payload"},
+		{"empty env key", func(p map[string]string) { p["env"] = `{"":"v"}` }, "empty key"},
+		{"host_port not a number", func(p map[string]string) { p["host_port"] = "abc" }, "invalid host_port"},
+		{"host_port reserved", func(p map[string]string) { p["host_port"] = reservedPort }, "reserved for citadel"},
+		{"volume outside data dir", func(p map[string]string) { p["state_volume_path"] = "/etc" }, "outside the citadel data dir"},
+		{"volume traversal via ~", func(p map[string]string) { p["state_volume_path"] = "~/../../etc/passwd" }, "outside the citadel data dir"},
+		{"relative mount path", func(p map[string]string) { p["state_mount_path"] = "state" }, "must be an absolute container path"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := basePayload()
+			tt.mutate(p)
+			_, err := parseInstanceSpec(p, testHome)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.errSub)
+			}
+			if !strings.Contains(err.Error(), tt.errSub) {
+				t.Errorf("error = %q, want substring %q", err.Error(), tt.errSub)
+			}
+		})
+	}
+}
+
+func TestResolveStateVolumePath(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    string
+		wantErr bool
+	}{
+		{"tilde slash under cache", "~/citadel-cache/instances/x", filepath.Join(testHome, "citadel-cache/instances/x"), false},
+		{"bare tilde is home not allowed", "~", "", true},
+		{"absolute under .citadel", filepath.Join(testHome, ".citadel/instances/x"), filepath.Join(testHome, ".citadel/instances/x"), false},
+		{"escape to etc", "/etc/passwd", "", true},
+		{"prefix sibling not matched", filepath.Join(testHome, "citadel-cache-evil/x"), "", true},
+		{"empty", "", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveStateVolumePath(tt.raw, testHome)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateImageRef(t *testing.T) {
+	tests := []struct {
+		image   string
+		wantErr bool
+	}{
+		{"ghcr.io/aceteam-ai/claudecode-service:latest", false},
+		{"ghcr.io/aceteam-ai/hermes@sha256:abc", false},
+		{"docker.io/library/nginx", true},
+		{"ghcr.io/evil-org/backdoor", true},
+		{"", true},
+		{"-malicious", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.image, func(t *testing.T) {
+			err := validateImageRef(tt.image)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateImageRef(%q) err = %v, wantErr %v", tt.image, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestBuildDockerRunArgs(t *testing.T) {
+	spec := &instanceSpec{
+		ServiceName:     "ac-x",
+		ContainerName:   "citadel-ac-x",
+		Image:           "ghcr.io/aceteam-ai/claudecode-service:latest",
+		Env:             map[string]string{"ANTHROPIC_BASE_URL": "https://p"},
+		HostPort:        18789,
+		ContainerPort:   8787,
+		StateVolumePath: "/home/citadel/citadel-cache/instances/i-1",
+		StateMountPath:  "/state",
+	}
+	args := buildDockerRunArgs(spec)
+	joined := strings.Join(args, " ")
+
+	// Image must be the final arg (never read as a flag).
+	if args[len(args)-1] != spec.Image {
+		t.Errorf("image is not the last arg: %v", args)
+	}
+	wantContains := []string{
+		"--name citadel-ac-x",
+		"--restart unless-stopped",
+		"-p 127.0.0.1:18789:8787",
+		"-v /home/citadel/citadel-cache/instances/i-1:/state",
+		"-e CLAUDE_CONFIG_DIR=/state", // durability injection
+		"-e PORT=8787",                // publish-port injection
+		"-e ANTHROPIC_BASE_URL=https://p",
+	}
+	for _, want := range wantContains {
+		if !strings.Contains(joined, want) {
+			t.Errorf("docker run args missing %q\n got: %s", want, joined)
+		}
+	}
+}
+
+func TestBuildDockerRunArgs_PayloadEnvWins(t *testing.T) {
+	// If the payload already sets CLAUDE_CONFIG_DIR/PORT, do not double-inject.
+	spec := &instanceSpec{
+		ServiceName:     "ac-x",
+		ContainerName:   "citadel-ac-x",
+		Image:           "ghcr.io/aceteam-ai/claudecode-service:latest",
+		Env:             map[string]string{"CLAUDE_CONFIG_DIR": "/custom", "PORT": "8787"},
+		HostPort:        18789,
+		ContainerPort:   8787,
+		StateVolumePath: "/home/citadel/citadel-cache/instances/i-1",
+		StateMountPath:  "/state",
+	}
+	args := buildDockerRunArgs(spec)
+	n := 0
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == "-e" && strings.HasPrefix(args[i+1], "CLAUDE_CONFIG_DIR=") {
+			n++
+			if args[i+1] != "CLAUDE_CONFIG_DIR=/custom" {
+				t.Errorf("payload CLAUDE_CONFIG_DIR not honored: %q", args[i+1])
+			}
+		}
+	}
+	if n != 1 {
+		t.Errorf("expected exactly one CLAUDE_CONFIG_DIR env, got %d", n)
+	}
+}
+
+// itoa avoids importing strconv just for the reserved-port table above.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	if neg {
+		b = append([]byte{'-'}, b...)
+	}
+	return string(b)
+}

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -49,6 +50,13 @@ func (a *LegacyHandlerAdapter) Execute(ctx context.Context, job *Job, stream Str
 	// Redis payloads arrive via json.Unmarshal, so numbers are float64 and
 	// booleans are bool. Coerce all values to strings so handlers can parse
 	// them with strconv.
+	//
+	// Scalars keep their fmt.Sprint form (so existing handlers' strconv/bool
+	// parsing is unchanged). NESTED values (a JSON object or array -- e.g. the
+	// SERVICE_START "env" map, citadel-cli#462) are json-encoded instead of
+	// fmt.Sprint'd: fmt.Sprint on a map yields the unparseable Go form
+	// "map[K:v]", which loses the structure. This is a shared chokepoint for
+	// every legacy handler, so the change is deliberately limited to maps/slices.
 	if job.Payload != nil {
 		nexusJob.Payload = make(map[string]string)
 		for k, v := range job.Payload {
@@ -57,6 +65,12 @@ func (a *LegacyHandlerAdapter) Execute(ctx context.Context, job *Job, stream Str
 				nexusJob.Payload[k] = val
 			case nil:
 				// skip nil values
+			case map[string]any, []any:
+				if encoded, err := json.Marshal(val); err == nil {
+					nexusJob.Payload[k] = string(encoded)
+				} else {
+					nexusJob.Payload[k] = fmt.Sprint(val)
+				}
 			default:
 				nexusJob.Payload[k] = fmt.Sprint(val)
 			}

--- a/internal/worker/handler_adapter_test.go
+++ b/internal/worker/handler_adapter_test.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -140,6 +141,66 @@ func TestLegacyHandlerAdapterPayloadConversion(t *testing.T) {
 	}
 
 	_ = capturedJob // silence unused variable
+}
+
+// TestLegacyHandlerAdapterPayloadEncoding verifies the map[string]any ->
+// map[string]string down-conversion: scalars keep their fmt.Sprint form
+// (unchanged behavior for existing handlers), while nested objects/arrays are
+// json-encoded so their structure survives (the SERVICE_START "env" map,
+// citadel-cli#462). Without this, fmt.Sprint on a map yields the unparseable Go
+// "map[K:v]" form.
+func TestLegacyHandlerAdapterPayloadEncoding(t *testing.T) {
+	handler := &TestLegacyHandler{output: "ok"}
+	adapter := NewLegacyHandlerAdapter("SERVICE_START", handler)
+
+	job := &Job{
+		ID:   "job-enc",
+		Type: "SERVICE_START",
+		Payload: map[string]any{
+			"service":   "ac-x",                             // scalar string
+			"host_port": float64(18789),                     // JSON number -> "18789"
+			"flag":      true,                               // bool -> "true"
+			"env":       map[string]any{"K": "v", "A": "b"}, // nested object -> JSON
+			"ports":     []any{float64(1), float64(2)},      // nested array -> JSON
+			"skip":      nil,                                // dropped
+		},
+	}
+
+	if _, err := adapter.Execute(context.Background(), job, &NoOpStreamWriter{}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	got := handler.capturedPayload
+
+	// Scalars unchanged.
+	if got["service"] != "ac-x" {
+		t.Errorf("service = %q, want ac-x", got["service"])
+	}
+	if got["host_port"] != "18789" {
+		t.Errorf("host_port = %q, want 18789 (scalar untouched)", got["host_port"])
+	}
+	if got["flag"] != "true" {
+		t.Errorf("flag = %q, want true (scalar untouched)", got["flag"])
+	}
+	// nil dropped.
+	if _, ok := got["skip"]; ok {
+		t.Errorf("nil value should be dropped, got %q", got["skip"])
+	}
+	// Nested object -> parseable JSON (round-trips to the same map).
+	var env map[string]string
+	if err := json.Unmarshal([]byte(got["env"]), &env); err != nil {
+		t.Fatalf("env is not JSON: %q (%v)", got["env"], err)
+	}
+	if env["K"] != "v" || env["A"] != "b" {
+		t.Errorf("env round-trip = %v, want map[A:b K:v]", env)
+	}
+	// Nested array -> parseable JSON.
+	var ports []int
+	if err := json.Unmarshal([]byte(got["ports"]), &ports); err != nil {
+		t.Fatalf("ports is not JSON: %q (%v)", got["ports"], err)
+	}
+	if len(ports) != 2 || ports[0] != 1 || ports[1] != 2 {
+		t.Errorf("ports round-trip = %v, want [1 2]", ports)
+	}
 }
 
 func TestCreateLegacyHandlers(t *testing.T) {


### PR DESCRIPTION
## Context

E2E prod verification (aceteam#5134) found BYOC Claude Code hosting (aceteam#4588 Child C) **dead on arrival**: the platform dispatches an *extended* `SERVICE_START` (image / env / host_port / state_volume, service name `ac-<shortcode>`), but the node's handler (`internal/jobs/service_handler.go`) only resolved a service **name** against `citadel.yaml` or the embedded `ServiceMap` — so every BYOC launch returned `service "ac-…" not found in manifest`. The runtime image (#432/#434), CI publish (#459), and host-port fix (#460) shipped; this is the missing node-side receiver.

## Root cause

Two independent gaps:
1. The `SERVICE_START` handler ignored `image`/`env`/`host_port`/`state_volume_path` entirely — there was no code path that launches a container from an inline payload.
2. The worker→`nexus.Job` payload adapter down-converts `map[string]any`→`map[string]string` with `fmt.Sprint`, which turns the nested `env` object into the unparseable Go form `map[K:v]` — so even a new handler couldn't recover the env.

## Solution

- **Extended-payload launch path** (`internal/jobs/service_payload.go`): an image-bearing `SERVICE_START` is launched via `docker run` from the payload. The legacy name-based manifest/embedded path is untouched (branch keys on presence of `image`).
- **Host port**: published **verbatim** from the payload (`127.0.0.1:<host_port>:<container_port>`). The platform reaches the container at `host_port` over the mesh and does **not** read back an endpoint, so re-allocation would break it. The host-port registry (`services/ports.go` `ReservedCitadelPorts`) is used for **validation only** — reject a payload that would collide with a citadel-internal listener.
- **Durability**: mount `state_volume_path` (leading `~` expanded node-side; `docker -v` does not expand it) at `state_mount_path` (default `/state`), and inject `CLAUDE_CONFIG_DIR=<mount>` + `PORT=<container_port>` so the runtime writes into the per-instance volume and listens on the published port. State dir is per-instance (`~/citadel-cache/instances/<id>`), never the shared `~/citadel-cache/claudecode`. The container entrypoint already chowns `CLAUDE_CONFIG_DIR` generically, so no image change is needed.
- **Symmetry**: `SERVICE_STOP`/`SERVICE_STATUS` resolve payload instances from a separate store (`~/.citadel/instances/state.json`), since they exist in neither the manifest nor the embedded map.
- **Security**: image restricted to an allowed-registry prefix (`ghcr.io/aceteam-ai/`, mirroring the `internal/catalog` trust model); state-volume mounts bounded to the citadel data dir (rejects `/etc`, `~/.ssh`, `~/..` traversal); service name / image validated against docker-flag injection; env passed as-is.
- **Adapter fix** (`internal/worker/handler_adapter.go`): nested map/slice payload values are json-encoded (scalars keep `fmt.Sprint`, so existing handlers are unchanged). Shared chokepoint — covered by a dedicated test.

### Reconcile-loop landmine (self-check)

Payload instances are deliberately kept **out of** `citadel.yaml` and `modules.lock`. `internal/reconcile` is not wired into the live worker today (only type references), and when it is (#353/#4273) its `ListInstalled` enumerates lockfile modules, never arbitrary `docker ps` — so `ac-*` containers can never be read as drift-to-uninstall. Containers launch with `--restart unless-stopped`, surviving reboot/upgrade with no citadel loop; `STOP` does an explicit `docker rm -f`.

## Test plan

| Area | Test | What it proves |
| --- | --- | --- |
| Branch routing | `TestExecute_PayloadStartRejectsDisallowedImage` | image-bearing `SERVICE_START` hits the payload branch (not the manifest lookup); registry validation runs before any docker call |
| STOP/STATUS symmetry | `TestExecute_PayloadStatusFromStore` | `SERVICE_STATUS` resolves an `ac-*` instance from the store, returns a well-formed result (not "not found in manifest") |
| Payload parse | `TestParseInstanceSpec_Valid` / `_Defaults` | env JSON decode, `~` expansion, per-instance path, container-port from env `PORT` else default |
| Validation | `TestParseInstanceSpec_Rejects` (12 cases) | rejects bad service name, non-allowlisted / flag-injection image, bad env JSON, reserved/invalid host port, out-of-data-dir & traversal volume, relative mount |
| Volume bounding | `TestResolveStateVolumePath` | `~` expand + bound to `citadel-cache`/`.citadel`; rejects `/etc`, prefix-sibling escape |
| Registry allowlist | `TestValidateImageRef` | allows `ghcr.io/aceteam-ai/*`, rejects other registries and `-` prefixes |
| docker run wiring | `TestBuildDockerRunArgs` / `_PayloadEnvWins` | `-p 127.0.0.1:18789:8787`, `-v …:/state`, injected `CLAUDE_CONFIG_DIR`/`PORT`, image last; payload env overrides injection |
| Store | `TestInstanceStore_PutGetDelete` | round-trip + idempotent delete + missing-file = empty |
| Adapter encoding | `TestLegacyHandlerAdapterPayloadEncoding` | nested map/slice → parseable JSON; scalars (`host_port`, bool) untouched; nil dropped |

`go build ./...`, `go test ./...`, `go vet`, and `gofmt -l .` all clean.

## Contract mismatch vs the platform's actual payload

Grounded against `aceteam/python-backend/utils/instance_node_dispatch.py` (`NodeServiceSpec`) and `utils/instances/runtimeProviders.ts`:

- **`host_port` is a hardcoded `18789` for every instance** (`runtimeProviders.ts: const hostPort = 18789`), not per-instance. A second `ac-*` instance on the same node will collide on the host port; this handler surfaces that as a clear docker "port already allocated" error rather than failing silently. Assigning unique host ports is a **platform-side** change (out of scope here).
- The platform env omits `PORT` and `CLAUDE_CONFIG_DIR` (confirmed in `buildCitadelNodeEnv`); this handler injects both. If the platform later sends them, the payload values win.
- The image-name drift (`claude-code-node`) called out in #462 exists only in **aceteam** test fixtures; there are **zero** `claude-code-node` references in citadel-cli (all correct `claudecode-service`). Nothing to change in this repo.

Closes #462

*Generated by Claude Opus 4.8*
