### PR TITLE
feat(meeting-bot): MEETING_JOIN handler + audio capture + meeting capability (#5098)

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -271,6 +271,12 @@ func runControlCenter() {
 			SaveRendering: func(r *config.Rendering) error {
 				return config.SaveRendering(platform.ConfigDir(), r)
 			},
+			LoadMeeting: func() *config.Meeting {
+				return config.LoadMeeting(platform.ConfigDir())
+			},
+			SaveMeeting: func(m *config.Meeting) error {
+				return config.SaveMeeting(platform.ConfigDir(), m)
+			},
 			// SetFullscreenEnabled is intentionally left nil: tview cannot swap the
 			// terminal's alternate-screen mode on a running app. Today the toggle only
 			// persists the preference; wiring a launch-time consumer that reads it at

--- a/docs/capability-toggles.md
+++ b/docs/capability-toggles.md
@@ -1,0 +1,52 @@
+# Capability Toggles
+
+Node capabilities in Citadel are **config toggles, default opted-in**. A node
+that has the dependencies for a capability advertises it (and registers the
+matching job handler) out of the box; the operator may **opt out** from the
+Control Center, and the platform may set the same value **programmatically** via
+`APPLY_DEVICE_CONFIG`. This mirrors the opt-out model already used for anonymous
+telemetry (`internal/config/telemetry.go`).
+
+## The pattern
+
+Each capability toggle is a small per-concern config file in
+`platform.ConfigDir()` with a default-true value, following the
+Telemetry/KeepAwake shape:
+
+- **Config** (`internal/config/<cap>.go`): a struct with one bool, a
+  `Default<Cap>()` returning **enabled**, and `Load<Cap>` / `Save<Cap>`. Absent
+  file or absent key falls back to the default (enabled).
+- **Detector** (`internal/capabilities/detector.go`): the capability is
+  advertised only when `Load<Cap>(...).<Enabled> && depsPresent`. The toggle
+  gates advertisement; the deps gate feasibility. Both must hold.
+- **Handler** (`internal/worker/handler_adapter.go`): the job handler registers
+  under the same `Load<Cap>(...).<Enabled>` gate, so a node that does not
+  advertise the tag also refuses the job.
+- **Control Center** (`internal/tui/controlcenter/settings_page.go`): a numbered
+  toggle in the Settings pane that `Save<Cap>`s the flip. Applies on the next
+  worker start / capability detection.
+- **Programmatic** (`internal/jobs/config_handler.go`): `DeviceConfig` carries a
+  `*bool` field (pointer so an omitted field is a no-op, not a silent opt-out).
+  When non-nil, `APPLY_DEVICE_CONFIG` writes the **same** per-concern config file
+  the detector and Control Center use.
+
+### Precedence
+
+There is a **single persisted toggle** per capability. Both the Control Center
+and `APPLY_DEVICE_CONFIG` write that one file, so the effective value is
+**last-writer-wins**, defaulting to **enabled** when neither has written it. (The
+org owns the node config, so a device-config push re-applying an opt-out over a
+local change is intentional — same as VNC/SSH.)
+
+## Concrete instance: the `meeting` capability (aceteam#5098)
+
+The auto-join meeting notetaker is the first capability wired this way:
+
+- Config: `internal/config/meeting.go` — key `meeting_enabled` in `meeting.yaml`,
+  default **true**.
+- Advertised as the `meeting` tag when `meeting_enabled` is set **and** the audio
+  + Chromium + Xvfb deps are present.
+- Control Center: Settings pane, toggle **5** ("Meeting Notetaker").
+- Programmatic: `DeviceConfig.MeetingEnabled *bool` (`meetingEnabled` in the
+  APPLY_DEVICE_CONFIG payload), driven by the platform's `citadel_config` MCP
+  tool.

--- a/internal/capabilities/detector.go
+++ b/internal/capabilities/detector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"os"
 	"os/exec"
 	"regexp"
 	"runtime"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
+	"github.com/aceteam-ai/citadel-cli/internal/update"
 )
 
 const detectionTimeout = 5 * time.Second
@@ -446,16 +448,31 @@ func detectCPU() []Capability {
 // the pure meetingCapable predicate so the gating logic itself is unit-testable
 // without a live audio stack or browser.
 func detectMeetingCapability() bool {
-	return meetingCapable(
+	return meetingTagEnabled(meetingCapable(
 		platform.AudioStackAvailable(),
 		platform.ChromiumAvailable(),
 		platform.XvfbAvailable(),
-	)
+	))
 }
 
-// meetingCapable is the pure gating predicate for the `meeting` tag: all three
-// dependencies (audio capture, Chromium, Xvfb) must be present. Extracted so the
-// AND-of-deps logic is testable in isolation from the shell-outs.
+// meetingTagEnabled reports whether the `meeting` tag should be advertised: the
+// operator opt-in (CITADEL_MEETING_ENABLED) must be set AND the node's deps must
+// be present. The meeting-join flow is unverified, so nodes stay dormant (never
+// advertise, never subscribe to the org meeting queue) until an operator opts in.
+func meetingTagEnabled(depsOK bool) bool {
+	return meetingEnabled() && depsOK
+}
+
+// meetingEnabled reports whether the operator has opted into the meeting-join
+// capability via CITADEL_MEETING_ENABLED (truthy: 1/true/yes/on, case-insensitive).
+// Defaults to disabled when unset.
+func meetingEnabled() bool {
+	return update.IsTruthy(os.Getenv("CITADEL_MEETING_ENABLED"))
+}
+
+// meetingCapable is the pure gating predicate for the `meeting` tag deps: all
+// three dependencies (audio capture, Chromium, Xvfb) must be present. Extracted
+// so the AND-of-deps logic is testable in isolation from the shell-outs.
 func meetingCapable(audioOK, chromeOK, xvfbOK bool) bool {
 	return audioOK && chromeOK && xvfbOK
 }

--- a/internal/capabilities/detector.go
+++ b/internal/capabilities/detector.go
@@ -182,6 +182,14 @@ func DetectNodeCapabilities() *NodeCapabilities {
 		}
 	}
 
+	// Advertise the meeting-notetaker capability only when this node can actually
+	// run one: a working audio-capture stack (PulseAudio + ffmpeg + pactl), a
+	// launchable Chromium, and Xvfb for the headless virtual display. Backend
+	// routes MEETING_JOIN jobs to nodes carrying this tag (aceteam#5098).
+	if detectMeetingCapability() {
+		caps.Tags = append(caps.Tags, "meeting")
+	}
+
 	// Always add cpu:general
 	caps.Tags = append(caps.Tags, "cpu:general")
 
@@ -431,6 +439,25 @@ func detectOllamaModels() []Capability {
 
 func detectCPU() []Capability {
 	return []Capability{{Tag: "cpu:general", Category: "cpu", Description: "General CPU compute"}}
+}
+
+// detectMeetingCapability reports whether this node can run the auto-join meeting
+// notetaker (aceteam#5098). It composes the three real dependency probes through
+// the pure meetingCapable predicate so the gating logic itself is unit-testable
+// without a live audio stack or browser.
+func detectMeetingCapability() bool {
+	return meetingCapable(
+		platform.AudioStackAvailable(),
+		platform.ChromiumAvailable(),
+		platform.XvfbAvailable(),
+	)
+}
+
+// meetingCapable is the pure gating predicate for the `meeting` tag: all three
+// dependencies (audio capture, Chromium, Xvfb) must be present. Extracted so the
+// AND-of-deps logic is testable in isolation from the shell-outs.
+func meetingCapable(audioOK, chromeOK, xvfbOK bool) bool {
+	return audioOK && chromeOK && xvfbOK
 }
 
 // NormalizeGPUName converts a full GPU name to a short tag-friendly identifier.

--- a/internal/capabilities/detector.go
+++ b/internal/capabilities/detector.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"os"
 	"os/exec"
 	"regexp"
 	"runtime"
@@ -12,8 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aceteam-ai/citadel-cli/internal/config"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
-	"github.com/aceteam-ai/citadel-cli/internal/update"
 )
 
 const detectionTimeout = 5 * time.Second
@@ -444,11 +443,13 @@ func detectCPU() []Capability {
 }
 
 // detectMeetingCapability reports whether this node can run the auto-join meeting
-// notetaker (aceteam#5098). It composes the three real dependency probes through
-// the pure meetingCapable predicate so the gating logic itself is unit-testable
-// without a live audio stack or browser.
+// notetaker (aceteam#5098). It ANDs the persisted config toggle (default-on, the
+// house opt-out convention) with the three real dependency probes, composed
+// through the pure meetingTagEnabled predicate so the gating logic itself is
+// unit-testable without a live audio stack, browser, or config file.
 func detectMeetingCapability() bool {
-	return meetingTagEnabled(meetingCapable(
+	enabled := config.LoadMeeting(platform.ConfigDir()).MeetingEnabled
+	return meetingTagEnabled(enabled, meetingCapable(
 		platform.AudioStackAvailable(),
 		platform.ChromiumAvailable(),
 		platform.XvfbAvailable(),
@@ -456,18 +457,12 @@ func detectMeetingCapability() bool {
 }
 
 // meetingTagEnabled reports whether the `meeting` tag should be advertised: the
-// operator opt-in (CITADEL_MEETING_ENABLED) must be set AND the node's deps must
-// be present. The meeting-join flow is unverified, so nodes stay dormant (never
-// advertise, never subscribe to the org meeting queue) until an operator opts in.
-func meetingTagEnabled(depsOK bool) bool {
-	return meetingEnabled() && depsOK
-}
-
-// meetingEnabled reports whether the operator has opted into the meeting-join
-// capability via CITADEL_MEETING_ENABLED (truthy: 1/true/yes/on, case-insensitive).
-// Defaults to disabled when unset.
-func meetingEnabled() bool {
-	return update.IsTruthy(os.Getenv("CITADEL_MEETING_ENABLED"))
+// persisted meeting toggle must be enabled AND the node's deps must be present.
+// The toggle defaults on (see config.DefaultMeeting), so a dep-capable node
+// advertises unless the operator has explicitly opted out (via the Control
+// Center or an APPLY_DEVICE_CONFIG push).
+func meetingTagEnabled(enabled, depsOK bool) bool {
+	return enabled && depsOK
 }
 
 // meetingCapable is the pure gating predicate for the `meeting` tag deps: all

--- a/internal/capabilities/detector_test.go
+++ b/internal/capabilities/detector_test.go
@@ -404,3 +404,31 @@ func TestMeetingCapable(t *testing.T) {
 		t.Error(`ValidateTag("meeting") = false; the meeting tag would be dropped`)
 	}
 }
+
+func TestMeetingTagEnabled(t *testing.T) {
+	// The meeting-join flow is unverified, so the tag is gated behind the
+	// CITADEL_MEETING_ENABLED operator opt-in AND the node deps. Even with deps
+	// present, an unset/falsey toggle must keep the node dormant (no advertise).
+	cases := []struct {
+		name   string
+		toggle string
+		depsOK bool
+		want   bool
+	}{
+		{"toggle on, deps present -> advertise", "true", true, true},
+		{"toggle 1, deps present -> advertise", "1", true, true},
+		{"toggle yes uppercase, deps present -> advertise", "YES", true, true},
+		{"toggle on, deps missing -> no advertise", "true", false, false},
+		{"toggle off, deps present -> no advertise", "false", true, false},
+		{"toggle empty, deps present -> no advertise", "", true, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Setenv("CITADEL_MEETING_ENABLED", c.toggle)
+			if got := meetingTagEnabled(c.depsOK); got != c.want {
+				t.Errorf("meetingTagEnabled(depsOK=%v) with CITADEL_MEETING_ENABLED=%q = %v, want %v",
+					c.depsOK, c.toggle, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/capabilities/detector_test.go
+++ b/internal/capabilities/detector_test.go
@@ -378,3 +378,29 @@ func TestResolveQueuesWithEngines(t *testing.T) {
 		}
 	}
 }
+
+func TestMeetingCapable(t *testing.T) {
+	// The meeting tag requires ALL three deps: audio stack, Chromium, and Xvfb.
+	cases := []struct {
+		audio, chrome, xvfb bool
+		want                bool
+	}{
+		{true, true, true, true},
+		{false, true, true, false},
+		{true, false, true, false},
+		{true, true, false, false},
+		{false, false, false, false},
+	}
+	for _, c := range cases {
+		if got := meetingCapable(c.audio, c.chrome, c.xvfb); got != c.want {
+			t.Errorf("meetingCapable(audio=%v,chrome=%v,xvfb=%v) = %v, want %v",
+				c.audio, c.chrome, c.xvfb, got, c.want)
+		}
+	}
+
+	// The "meeting" tag itself must be a valid capability tag or the live
+	// aggregator would silently drop it.
+	if !ValidateTag("meeting") {
+		t.Error(`ValidateTag("meeting") = false; the meeting tag would be dropped`)
+	}
+}

--- a/internal/capabilities/detector_test.go
+++ b/internal/capabilities/detector_test.go
@@ -406,28 +406,26 @@ func TestMeetingCapable(t *testing.T) {
 }
 
 func TestMeetingTagEnabled(t *testing.T) {
-	// The meeting-join flow is unverified, so the tag is gated behind the
-	// CITADEL_MEETING_ENABLED operator opt-in AND the node deps. Even with deps
-	// present, an unset/falsey toggle must keep the node dormant (no advertise).
+	// The `meeting` tag advertises only when the persisted toggle is enabled AND
+	// the node deps are present. The toggle defaults on (config.DefaultMeeting),
+	// so the default+deps case advertises; an explicit opt-out keeps it off even
+	// with deps present.
 	cases := []struct {
-		name   string
-		toggle string
-		depsOK bool
-		want   bool
+		name    string
+		enabled bool
+		depsOK  bool
+		want    bool
 	}{
-		{"toggle on, deps present -> advertise", "true", true, true},
-		{"toggle 1, deps present -> advertise", "1", true, true},
-		{"toggle yes uppercase, deps present -> advertise", "YES", true, true},
-		{"toggle on, deps missing -> no advertise", "true", false, false},
-		{"toggle off, deps present -> no advertise", "false", true, false},
-		{"toggle empty, deps present -> no advertise", "", true, false},
+		{"enabled (default), deps present -> advertise", true, true, true},
+		{"enabled, deps missing -> no advertise", true, false, false},
+		{"opted out, deps present -> no advertise", false, true, false},
+		{"opted out, deps missing -> no advertise", false, false, false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			t.Setenv("CITADEL_MEETING_ENABLED", c.toggle)
-			if got := meetingTagEnabled(c.depsOK); got != c.want {
-				t.Errorf("meetingTagEnabled(depsOK=%v) with CITADEL_MEETING_ENABLED=%q = %v, want %v",
-					c.depsOK, c.toggle, got, c.want)
+			if got := meetingTagEnabled(c.enabled, c.depsOK); got != c.want {
+				t.Errorf("meetingTagEnabled(enabled=%v, depsOK=%v) = %v, want %v",
+					c.enabled, c.depsOK, got, c.want)
 			}
 		})
 	}

--- a/internal/config/meeting.go
+++ b/internal/config/meeting.go
@@ -1,0 +1,72 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Meeting controls the auto-join meeting-notetaker capability. It follows the
+// same opt-out (default-true) model as Telemetry: a node that has the audio +
+// browser dependencies advertises the `meeting` tag and registers the
+// MEETING_JOIN handler out of the box, and the operator may turn it off. This
+// is the house convention for node capabilities — capabilities are config
+// toggles, default opted-in, with a Control Center opt-out and a programmatic
+// path (APPLY_DEVICE_CONFIG) that writes this same persisted value.
+type Meeting struct {
+	// MeetingEnabled gates the `meeting` capability. When true (and the node's
+	// audio/browser deps are present) the node advertises the `meeting` tag and
+	// registers the MEETING_JOIN handler. When false the node stays out of the
+	// meeting queue regardless of deps. Defaults to true (opt-out) so meeting
+	// nodes work out of the box; the Control Center settings pane discloses the
+	// default-on behavior and offers the toggle.
+	MeetingEnabled bool `yaml:"meeting_enabled" json:"meeting_enabled"`
+}
+
+const meetingFile = "meeting.yaml"
+
+// DefaultMeeting returns a Meeting struct with the capability enabled.
+// Default-on is intentional: it matches the house convention that capabilities
+// are opt-out, so a dep-capable node joins meetings without extra setup.
+func DefaultMeeting() *Meeting {
+	return &Meeting{
+		MeetingEnabled: true,
+	}
+}
+
+// LoadMeeting reads meeting settings from the config directory.
+// If the file doesn't exist, returns defaults (enabled).
+// Partial files preserve defaults for absent keys (unmarshal into a
+// pre-initialized struct), mirroring LoadTelemetry.
+func LoadMeeting(configDir string) *Meeting {
+	m := DefaultMeeting()
+
+	data, err := os.ReadFile(filepath.Join(configDir, meetingFile))
+	if err != nil {
+		return m
+	}
+
+	// yaml.Unmarshal only overwrites keys present in the file, so an absent
+	// key keeps its default (true) value.
+	_ = yaml.Unmarshal(data, m)
+	return m
+}
+
+// SaveMeeting writes meeting settings to the config directory.
+// The Control Center settings pane calls this when the operator toggles the
+// flag, and the APPLY_DEVICE_CONFIG handler calls it when the platform pushes
+// an explicit value.
+func SaveMeeting(configDir string, m *Meeting) error {
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+
+	data, err := yaml.Marshal(m)
+	if err != nil {
+		return fmt.Errorf("marshal meeting: %w", err)
+	}
+
+	return os.WriteFile(filepath.Join(configDir, meetingFile), data, 0644)
+}

--- a/internal/config/meeting_test.go
+++ b/internal/config/meeting_test.go
@@ -1,0 +1,72 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultMeeting(t *testing.T) {
+	m := DefaultMeeting()
+	if !m.MeetingEnabled {
+		t.Errorf("DefaultMeeting should be enabled (opt-out), got %+v", m)
+	}
+}
+
+func TestLoadMeeting_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	m := LoadMeeting(dir)
+	if !m.MeetingEnabled {
+		t.Errorf("LoadMeeting with no file should default to enabled, got %+v", m)
+	}
+}
+
+func TestMeetingSaveAndLoadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	original := &Meeting{MeetingEnabled: false}
+
+	if err := SaveMeeting(dir, original); err != nil {
+		t.Fatalf("SaveMeeting: %v", err)
+	}
+
+	loaded := LoadMeeting(dir)
+	if loaded.MeetingEnabled != original.MeetingEnabled {
+		t.Errorf("round trip mismatch: saved %+v, loaded %+v", original, loaded)
+	}
+}
+
+func TestLoadMeeting_DisabledFromFile(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte("meeting_enabled: false\n")
+	if err := os.WriteFile(filepath.Join(dir, "meeting.yaml"), data, 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	m := LoadMeeting(dir)
+	if m.MeetingEnabled {
+		t.Error("meeting_enabled should be false from file")
+	}
+}
+
+func TestLoadMeeting_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte("not: [valid: yaml: {{{")
+	if err := os.WriteFile(filepath.Join(dir, "meeting.yaml"), data, 0644); err != nil {
+		t.Fatalf("write invalid yaml: %v", err)
+	}
+
+	m := LoadMeeting(dir)
+	if !m.MeetingEnabled {
+		t.Errorf("invalid YAML should return defaults (enabled), got %+v", m)
+	}
+}
+
+func TestSaveMeeting_CreatesDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "dir")
+	if err := SaveMeeting(dir, DefaultMeeting()); err != nil {
+		t.Fatalf("SaveMeeting should create nested dirs: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "meeting.yaml")); err != nil {
+		t.Errorf("meeting file should exist after save: %v", err)
+	}
+}

--- a/internal/jobs/config_handler.go
+++ b/internal/jobs/config_handler.go
@@ -12,11 +12,20 @@ import (
 	"path/filepath"
 	"regexp"
 
+	citadelconfig "github.com/aceteam-ai/citadel-cli/internal/config"
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
 	"github.com/aceteam-ai/citadel-cli/services"
 	"gopkg.in/yaml.v3"
 )
+
+// enabledLabel renders a human-readable enabled/disabled label for result lines.
+func enabledLabel(enabled bool) string {
+	if enabled {
+		return "enabled"
+	}
+	return "disabled"
+}
 
 // serviceNamePattern validates service names to prevent path traversal.
 // Only allows lowercase alphanumeric characters and hyphens.
@@ -34,6 +43,12 @@ type DeviceConfig struct {
 	AlertOnHighTemp         bool     `json:"alertOnHighTemp"`
 	VNCEnabled              bool     `json:"vncEnabled"`
 	VNCPassword             string   `json:"vncPassword,omitempty"`
+	// MeetingEnabled is the programmatic path for the `meeting` capability opt-out
+	// (aceteam#5098). It is a pointer so an omitted field (nil) leaves the node's
+	// persisted toggle untouched — a plain bool would default to false and silently
+	// opt every node out the moment any device config is applied. A non-nil value
+	// writes the same meeting.yaml the Control Center toggle and detector use.
+	MeetingEnabled *bool `json:"meetingEnabled,omitempty"`
 }
 
 // ConfigHandler handles APPLY_DEVICE_CONFIG jobs.
@@ -81,6 +96,20 @@ func (h *ConfigHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) 
 	}
 
 	result := fmt.Sprintf("Manifest updated successfully for device '%s'", config.DeviceName)
+
+	// Apply the meeting-capability opt-out (aceteam#5098) when the platform pushed
+	// an explicit value. This writes the same persisted meeting.yaml the Control
+	// Center toggle and the capability detector read, so the device-config path and
+	// the local toggle converge on one effective value (default-on when neither
+	// wrote it). Written to platform.ConfigDir() — the per-concern config location,
+	// which the detector reads — not h.ConfigDir (the manifest dir).
+	if config.MeetingEnabled != nil {
+		if err := citadelconfig.SaveMeeting(platform.ConfigDir(), &citadelconfig.Meeting{MeetingEnabled: *config.MeetingEnabled}); err != nil {
+			result += fmt.Sprintf("\nWarning: failed to persist meeting toggle: %v", err)
+		} else {
+			result += fmt.Sprintf("\nMeeting capability %s", enabledLabel(*config.MeetingEnabled))
+		}
+	}
 
 	// Start services if autoStartServices is enabled
 	if config.AutoStartServices && len(config.Services) > 0 {

--- a/internal/jobs/config_handler_test.go
+++ b/internal/jobs/config_handler_test.go
@@ -1,0 +1,45 @@
+package jobs
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestDeviceConfig_MeetingEnabledUnmarshal verifies the *bool distinguishes an
+// absent field (nil -> leave the persisted toggle untouched) from an explicit
+// false (opt out). A plain bool would collapse both to false and silently opt
+// every node out whenever any device config is applied.
+func TestDeviceConfig_MeetingEnabledUnmarshal(t *testing.T) {
+	t.Run("absent -> nil", func(t *testing.T) {
+		var c DeviceConfig
+		if err := json.Unmarshal([]byte(`{"deviceName":"n"}`), &c); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if c.MeetingEnabled != nil {
+			t.Errorf("absent meetingEnabled should be nil, got %v", *c.MeetingEnabled)
+		}
+	})
+
+	t.Run("explicit false -> non-nil false", func(t *testing.T) {
+		var c DeviceConfig
+		if err := json.Unmarshal([]byte(`{"meetingEnabled":false}`), &c); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if c.MeetingEnabled == nil {
+			t.Fatal("explicit meetingEnabled:false should be non-nil")
+		}
+		if *c.MeetingEnabled {
+			t.Errorf("explicit meetingEnabled:false should be false, got true")
+		}
+	})
+
+	t.Run("explicit true -> non-nil true", func(t *testing.T) {
+		var c DeviceConfig
+		if err := json.Unmarshal([]byte(`{"meetingEnabled":true}`), &c); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if c.MeetingEnabled == nil || !*c.MeetingEnabled {
+			t.Errorf("explicit meetingEnabled:true should be non-nil true, got %v", c.MeetingEnabled)
+		}
+	})
+}

--- a/internal/jobs/meeting_join.go
+++ b/internal/jobs/meeting_join.go
@@ -1,0 +1,426 @@
+// internal/jobs/meeting_join.go
+//
+// MEETING_JOIN handler (issue #5098, epic #5097 — the sovereign auto-join Google
+// Meet notetaker). Orchestrates the deterministic scaffolding around the one
+// hardware-dependent piece (audio capture, already shipped in
+// platform/audio.go): create a per-meeting null sink, launch a sibling meeting
+// browser routed into that sink, run the Meet join flow, record the call, detect
+// the end, transcribe node-locally, and return a structured result. Every byte
+// (audio + transcript) stays on the user's machine.
+//
+// IMPORTANT (unverified): the Google Meet join flow and end-detection below are
+// BEST-GUESS DOM interactions. They are NOT verified end-to-end — a human must
+// run this against a live meet.google.com call and confirm/swap the selectors and
+// heuristics in the LIVE-TUNING block before this can be trusted. Everything is
+// isolated so tuning is a single-file edit.
+package jobs
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
+)
+
+// defaultBotDisplayName is the name the bot enters in Meet's pre-join name field
+// when the job does not specify one.
+const defaultBotDisplayName = "AceTeam Notetaker"
+
+// Timeouts and cadence for the join/record/end lifecycle. Generous defaults;
+// max_duration_seconds (when supplied) is a HARD cap layered on top.
+const (
+	// meetPageSettle waits for the Meet pre-join page to render its controls
+	// after navigation before we start poking at the DOM.
+	meetPageSettle = 5 * time.Second
+	// admitTimeout bounds how long we wait in the "asking to join" lobby for a
+	// host to admit the bot before giving up.
+	admitTimeout = 3 * time.Minute
+	// meetingPollInterval is how often we re-check admission / meeting-end state.
+	meetingPollInterval = 5 * time.Second
+	// defaultMeetingMaxDuration is the absolute safety cap when a job omits
+	// max_duration_seconds, so a bot can never sit in a call forever.
+	defaultMeetingMaxDuration = 4 * time.Hour
+)
+
+// ---------------------------------------------------------------------------
+// LIVE-TUNING REQUIRED
+//
+// Everything in this block is a best-guess against Google Meet's DOM and has NOT
+// been verified against a live call. A human must confirm/replace each selector,
+// button label, and heuristic during the live-Meet session. Kept together so
+// that tuning is a one-place edit.
+//   verified against real Google Meet on: <NOT YET VERIFIED>
+// ---------------------------------------------------------------------------
+const (
+	// meetNameInputSelector: the pre-join "Your name" text field shown to
+	// not-signed-in participants. Best-guess aria-label match.
+	meetNameInputSelector = `input[type="text"][aria-label*="name" i]`
+	// meetIsAdmittedJS returns true once the in-call toolbar is present and the
+	// pre-join / lobby UI is gone. Best-guess: presence of the leave-call button.
+	meetIsAdmittedJS = `(function(){` +
+		`return !!document.querySelector('button[aria-label*="Leave call" i],button[aria-label*="Leave" i][data-tooltip*="Leave" i]');` +
+		`})()`
+	// meetIsEndedJS returns true when the call has ended or the bot was removed:
+	// Meet swaps to a "You've left the meeting" / "Return to home screen" state.
+	// Best-guess text scan.
+	meetIsEndedJS = `(function(){` +
+		`var t=(document.body&&document.body.innerText||"");` +
+		`return /you (?:left|.?ve left) the meeting|return to home screen|you.?ve been removed|call ended/i.test(t);` +
+		`})()`
+	// meetParticipantCountJS returns the current participant count if Meet exposes
+	// it in the toolbar, else -1. Used as a secondary end signal (bot alone).
+	// Best-guess: the people-count pill's numeric text.
+	meetParticipantCountJS = `(function(){` +
+		`var el=document.querySelector('[aria-label*="participant" i] , [data-participant-count]');` +
+		`if(!el)return -1;var m=(el.getAttribute('data-participant-count')||el.innerText||"").match(/\d+/);` +
+		`return m?parseInt(m[0],10):-1;})()`
+)
+
+// meetJoinButtonLabels are the visible button texts Meet uses for the join
+// action, in priority order. "Ask to join" appears when the bot needs host
+// admission; "Join now" appears when it can enter directly. LIVE-TUNING: confirm
+// exact casing/locale against a real call.
+var meetJoinButtonLabels = []string{"Ask to join", "Join now", "Join"}
+
+// meetDismissButtonLabels are best-guess labels for the permission / "continue
+// without microphone|camera" prompts Meet shows before the join button. Clicking
+// them is best-effort (non-fatal). LIVE-TUNING: confirm against a real call.
+var meetDismissButtonLabels = []string{
+	"Continue without microphone",
+	"Continue without camera",
+	"Continue without microphone and camera",
+	"Got it",
+	"Dismiss",
+}
+
+// clickButtonByTextJS builds a JS expression that clicks the FIRST visible
+// button/[role=button] whose trimmed text matches (case-insensitively) any of the
+// given labels, returning the matched label or throwing when none is found. The
+// throw lets the caller distinguish "clicked" from "no such button" (cdpEvaluate
+// maps a JS throw to a Go error). labels are json.Marshal-escaped.
+func clickButtonByTextJS(labels []string) string {
+	arr, _ := json.Marshal(labels)
+	return `(function(){var labels=` + string(arr) + `.map(function(s){return s.toLowerCase();});` +
+		`var btns=Array.prototype.slice.call(document.querySelectorAll('button,[role="button"]'));` +
+		`for(var i=0;i<btns.length;i++){var b=btns[i];` +
+		`var txt=(b.innerText||b.textContent||"").trim().toLowerCase();` +
+		`if(!txt)continue;` +
+		`for(var j=0;j<labels.length;j++){if(txt===labels[j]||txt.indexOf(labels[j])!==-1){b.click();return labels[j];}}}` +
+		`throw new Error("no button matched labels");})()`
+}
+
+// clickButtonByTextOptionalJS is like clickButtonByTextJS but returns "" instead
+// of throwing when nothing matches — for best-effort dismissals where a missing
+// prompt is normal.
+func clickButtonByTextOptionalJS(labels []string) string {
+	arr, _ := json.Marshal(labels)
+	return `(function(){var labels=` + string(arr) + `.map(function(s){return s.toLowerCase();});` +
+		`var btns=Array.prototype.slice.call(document.querySelectorAll('button,[role="button"]'));` +
+		`for(var i=0;i<btns.length;i++){var b=btns[i];` +
+		`var txt=(b.innerText||b.textContent||"").trim().toLowerCase();` +
+		`if(!txt)continue;` +
+		`for(var j=0;j<labels.length;j++){if(txt===labels[j]||txt.indexOf(labels[j])!==-1){b.click();return labels[j];}}}` +
+		`return "";})()`
+}
+
+// meetingJoinParams is the typed, validated job payload.
+type meetingJoinParams struct {
+	MeetingURL         string
+	MeetingID          string
+	BotDisplayName     string
+	MaxDurationSeconds int // 0 means "unset"; the handler applies defaultMeetingMaxDuration
+}
+
+// parseMeetingJoinParams validates and normalizes the raw string payload. Payload
+// values arrive as strings (the worker adapter coerces JSON numbers via
+// fmt.Sprint), so numeric fields are parsed tolerantly.
+func parseMeetingJoinParams(payload map[string]string) (meetingJoinParams, error) {
+	p := meetingJoinParams{
+		MeetingURL:     strings.TrimSpace(payload["meeting_url"]),
+		MeetingID:      strings.TrimSpace(payload["meeting_id"]),
+		BotDisplayName: strings.TrimSpace(payload["bot_display_name"]),
+	}
+	if p.MeetingURL == "" {
+		return meetingJoinParams{}, fmt.Errorf("job payload missing required 'meeting_url' field")
+	}
+	if p.MeetingID == "" {
+		return meetingJoinParams{}, fmt.Errorf("job payload missing required 'meeting_id' field")
+	}
+	if p.BotDisplayName == "" {
+		p.BotDisplayName = defaultBotDisplayName
+	}
+	if raw := strings.TrimSpace(payload["max_duration_seconds"]); raw != "" {
+		secs, err := parsePositiveSeconds(raw)
+		if err != nil {
+			return meetingJoinParams{}, fmt.Errorf("invalid 'max_duration_seconds': %w", err)
+		}
+		p.MaxDurationSeconds = secs
+	}
+	return p, nil
+}
+
+// parsePositiveSeconds parses a duration-in-seconds field that may arrive as an
+// int string ("300") or a float string ("300.0", from a JSON number coerced by
+// fmt.Sprint). Rejects non-positive values.
+func parsePositiveSeconds(raw string) (int, error) {
+	if n, err := strconv.Atoi(raw); err == nil {
+		if n <= 0 {
+			return 0, fmt.Errorf("must be positive, got %d", n)
+		}
+		return n, nil
+	}
+	f, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return 0, fmt.Errorf("not a number: %q", raw)
+	}
+	if f <= 0 {
+		return 0, fmt.Errorf("must be positive, got %v", f)
+	}
+	return int(f), nil
+}
+
+// maxDuration resolves the effective hard cap for a run.
+func (p meetingJoinParams) maxDuration() time.Duration {
+	if p.MaxDurationSeconds > 0 {
+		return time.Duration(p.MaxDurationSeconds) * time.Second
+	}
+	return defaultMeetingMaxDuration
+}
+
+// sanitizeMeetingFilename keeps only filename-safe characters so a meeting id
+// cannot traverse out of the meetings dir or produce an odd path. Mirrors the
+// spirit of platform.sanitizeSinkSuffix but for a filesystem name.
+func sanitizeMeetingFilename(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	if b.Len() == 0 {
+		return "meeting"
+	}
+	return b.String()
+}
+
+// meetingWavPath builds the absolute path the recording is written to under the
+// workspace, namespaced in a meetings/ subdir keyed by the sanitized meeting id.
+func meetingWavPath(workspaceDir, meetingID string) string {
+	return filepath.Join(workspaceDir, "meetings", sanitizeMeetingFilename(meetingID)+".wav")
+}
+
+// MeetingJoinHandler handles MEETING_JOIN jobs. It reuses the transcribe handler
+// (same workspace) to turn the recording into a transcript node-locally.
+type MeetingJoinHandler struct {
+	WorkspaceDir string
+	transcriber  *TranscribeAudioHandler
+}
+
+// NewMeetingJoinHandler constructs a handler rooted at the node workspace.
+func NewMeetingJoinHandler(workspace string) *MeetingJoinHandler {
+	return &MeetingJoinHandler{
+		WorkspaceDir: workspace,
+		transcriber:  NewTranscribeAudioHandler(workspace),
+	}
+}
+
+// Execute runs the full join → record → transcribe lifecycle and returns a JSON
+// document (transcript + wav path + status). The browser and null sink are torn
+// down on every exit path, including errors.
+func (h *MeetingJoinHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	if h.WorkspaceDir == "" {
+		return nil, fmt.Errorf("MEETING_JOIN requires a configured workspace directory")
+	}
+	p, err := parseMeetingJoinParams(job.Payload)
+	if err != nil {
+		return nil, err
+	}
+	ctx.Log("info", "     - [Job %s] MEETING_JOIN %s (id=%s, bot=%q)", job.ID, p.MeetingURL, p.MeetingID, p.BotDisplayName)
+
+	// Create the per-meeting null sink FIRST so the browser's PULSE_SINK target
+	// exists at launch. rec.Stop unloads the sink even if we never Start it, so
+	// deferring it here covers a browser-launch failure after LoadSink.
+	rec := platform.NewNullSinkRecorder(p.MeetingID)
+	if err := rec.LoadSink(); err != nil {
+		return nil, fmt.Errorf("load meeting audio sink: %w", err)
+	}
+	defer func() { _, _ = rec.Stop() }()
+
+	// Launch the sibling meeting browser routed into the sink.
+	br := platform.NewMeetingBrowser(rec.SinkName())
+	if err := br.Start(); err != nil {
+		return nil, fmt.Errorf("start meeting browser: %w", err)
+	}
+	defer func() { _ = br.Close() }()
+
+	// Run the (unverified) Meet join flow.
+	if err := h.runJoinFlow(ctx, br, p); err != nil {
+		return nil, fmt.Errorf("meeting join flow: %w", err)
+	}
+
+	// Admitted: begin recording. Ensure the meetings/ dir exists first — ffmpeg's
+	// -y does NOT create parent directories.
+	wavPath := meetingWavPath(h.WorkspaceDir, p.MeetingID)
+	if err := os.MkdirAll(filepath.Dir(wavPath), 0o700); err != nil {
+		return nil, fmt.Errorf("create meetings dir: %w", err)
+	}
+	if err := rec.Start(wavPath); err != nil {
+		return nil, fmt.Errorf("start recording: %w", err)
+	}
+	ctx.Log("info", "     - [Job %s] recording meeting to %s", job.ID, wavPath)
+
+	// Stay in the call until it ends or the hard cap trips.
+	endStatus := h.waitForMeetingEnd(ctx, br, p)
+
+	// Finalize the recording (also unloads the sink; the deferred Stop is then a
+	// harmless no-op). Take the path from Stop so we transcribe exactly what was
+	// written.
+	recordedPath, stopErr := rec.Stop()
+	if stopErr != nil {
+		ctx.Log("warn", "     - [Job %s] recorder stop reported: %v", job.ID, stopErr)
+	}
+	if recordedPath == "" {
+		recordedPath = wavPath
+	}
+
+	// Transcribe node-locally by reusing the transcribe handler in-process.
+	transcript, tErr := h.transcribe(ctx, job, recordedPath)
+	if tErr != nil {
+		// Return a structured partial result rather than failing outright: the
+		// recording succeeded and is on disk; transcription can be retried.
+		out, _ := json.Marshal(map[string]any{
+			"status":         "recorded_transcription_failed",
+			"meeting_id":     p.MeetingID,
+			"audio_path":     recordedPath,
+			"end_reason":     endStatus,
+			"transcript":     nil,
+			"transcript_err": tErr.Error(),
+		})
+		return out, nil
+	}
+
+	out, _ := json.Marshal(map[string]any{
+		"status":     "completed",
+		"meeting_id": p.MeetingID,
+		"audio_path": recordedPath,
+		"end_reason": endStatus,
+		"transcript": json.RawMessage(transcript),
+	})
+	return out, nil
+}
+
+// runJoinFlow drives the best-guess Google Meet pre-join sequence. UNVERIFIED —
+// see the LIVE-TUNING block. Non-fatal steps (permission dismissals, name entry
+// when signed in) log and continue; the join click and admission are fatal.
+func (h *MeetingJoinHandler) runJoinFlow(ctx JobContext, br *platform.MeetingBrowser, p meetingJoinParams) error {
+	if err := br.Navigate(p.MeetingURL); err != nil {
+		return fmt.Errorf("navigate to meeting url: %w", err)
+	}
+	time.Sleep(meetPageSettle)
+
+	// Best-effort: dismiss any camera/mic permission or "continue without …"
+	// prompts. A missing prompt is normal, so this never fails the flow.
+	if _, err := br.Evaluate(clickButtonByTextOptionalJS(meetDismissButtonLabels)); err != nil {
+		ctx.Log("warn", "     - permission-prompt dismissal errored (non-fatal): %v", err)
+	}
+
+	// Best-effort: type the bot's display name into the pre-join name field. A
+	// signed-in session has no name field, so a miss here is non-fatal.
+	if err := br.Type(meetNameInputSelector, p.BotDisplayName); err != nil {
+		ctx.Log("warn", "     - could not set bot name (non-fatal, may be signed in): %v", err)
+	}
+
+	// Fatal: click the join/ask-to-join button.
+	if _, err := br.Evaluate(clickButtonByTextJS(meetJoinButtonLabels)); err != nil {
+		return fmt.Errorf("click join button: %w", err)
+	}
+
+	// Fatal: wait until admitted (in-call toolbar appears) or timeout.
+	return h.waitUntilAdmitted(ctx, br, p)
+}
+
+// waitUntilAdmitted polls the admission heuristic until the bot is in-call or the
+// lobby timeout elapses.
+func (h *MeetingJoinHandler) waitUntilAdmitted(ctx JobContext, br *platform.MeetingBrowser, p meetingJoinParams) error {
+	deadline := time.Now().Add(admitTimeout)
+	for time.Now().Before(deadline) {
+		if v, err := br.Evaluate(meetIsAdmittedJS); err == nil {
+			if b, ok := v.(bool); ok && b {
+				ctx.Log("info", "     - admitted to meeting %s", p.MeetingID)
+				return nil
+			}
+		} else {
+			ctx.Log("warn", "     - admission check errored (retrying): %v", err)
+		}
+		time.Sleep(meetingPollInterval)
+	}
+	return fmt.Errorf("not admitted to meeting within %s (host did not let the bot in, or admission selector is stale)", admitTimeout)
+}
+
+// waitForMeetingEnd blocks until the call ends (end heuristic true, or the bot is
+// left alone), or until the hard duration cap trips. Returns a short reason
+// string for the result. It never errors: reaching the cap or an unreadable DOM
+// still yields a valid recording to transcribe.
+func (h *MeetingJoinHandler) waitForMeetingEnd(ctx JobContext, br *platform.MeetingBrowser, p meetingJoinParams) string {
+	deadline := time.Now().Add(p.maxDuration())
+	for time.Now().Before(deadline) {
+		if v, err := br.Evaluate(meetIsEndedJS); err == nil {
+			if b, ok := v.(bool); ok && b {
+				return "call_ended"
+			}
+		}
+		// Secondary signal: everyone else left and the bot is alone.
+		if v, err := br.Evaluate(meetParticipantCountJS); err == nil {
+			if n, ok := toInt(v); ok && n >= 0 && n <= 1 {
+				return "alone_in_call"
+			}
+		}
+		time.Sleep(meetingPollInterval)
+	}
+	ctx.Log("info", "     - max meeting duration (%s) reached; leaving", p.maxDuration())
+	return "max_duration_reached"
+}
+
+// transcribe reuses the TRANSCRIBE_AUDIO handler in-process by handing it a
+// synthetic job whose audio_path points at the recording under the workspace.
+func (h *MeetingJoinHandler) transcribe(ctx JobContext, job *nexus.Job, wavPath string) ([]byte, error) {
+	synthetic := &nexus.Job{
+		ID:   job.ID + "-transcribe",
+		Type: JobTypeTranscribeAudioType,
+		Payload: map[string]string{
+			"audio_path": wavPath,
+		},
+	}
+	return h.transcriber.Execute(ctx, synthetic)
+}
+
+// JobTypeTranscribeAudioType is the wire type string for the transcription job,
+// duplicated here as a local const because the worker package (which owns the
+// canonical JobType constants) imports this package, not the reverse. Kept in
+// sync with worker.JobTypeTranscribeAudio.
+const JobTypeTranscribeAudioType = "TRANSCRIBE_AUDIO"
+
+// toInt coerces a JS-by-value number (float64 over the wire) or an int to int.
+func toInt(v any) (int, bool) {
+	switch n := v.(type) {
+	case float64:
+		return int(n), true
+	case int:
+		return n, true
+	case int64:
+		return int(n), true
+	}
+	return 0, false
+}
+
+// Ensure MeetingJoinHandler implements JobHandler.
+var _ JobHandler = (*MeetingJoinHandler)(nil)

--- a/internal/jobs/meeting_join.go
+++ b/internal/jobs/meeting_join.go
@@ -55,7 +55,9 @@ const (
 // been verified against a live call. A human must confirm/replace each selector,
 // button label, and heuristic during the live-Meet session. Kept together so
 // that tuning is a one-place edit.
-//   verified against real Google Meet on: <NOT YET VERIFIED>
+//
+//	verified against real Google Meet on: <NOT YET VERIFIED>
+//
 // ---------------------------------------------------------------------------
 const (
 	// meetNameInputSelector: the pre-join "Your name" text field shown to

--- a/internal/jobs/meeting_join_test.go
+++ b/internal/jobs/meeting_join_test.go
@@ -97,12 +97,12 @@ func TestParseMeetingJoinParams_MaxDuration(t *testing.T) {
 
 func TestSanitizeMeetingFilename(t *testing.T) {
 	cases := map[string]string{
-		"mtg-123":                 "mtg-123",
-		"abc_DEF":                 "abc_DEF",
-		"../../etc/passwd":        "______etc_passwd",
-		"a/b\\c":                  "a_b_c",
-		"":                        "meeting",
-		"550e8400-e29b-41d4":      "550e8400-e29b-41d4",
+		"mtg-123":            "mtg-123",
+		"abc_DEF":            "abc_DEF",
+		"../../etc/passwd":   "______etc_passwd",
+		"a/b\\c":             "a_b_c",
+		"":                   "meeting",
+		"550e8400-e29b-41d4": "550e8400-e29b-41d4",
 	}
 	for in, want := range cases {
 		if got := sanitizeMeetingFilename(in); got != want {

--- a/internal/jobs/meeting_join_test.go
+++ b/internal/jobs/meeting_join_test.go
@@ -1,0 +1,199 @@
+package jobs
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+func TestParseMeetingJoinParams_Valid(t *testing.T) {
+	p, err := parseMeetingJoinParams(map[string]string{
+		"meeting_url":          "https://meet.google.com/abc-defg-hij",
+		"meeting_id":           "mtg-123",
+		"bot_display_name":     "Custom Bot",
+		"max_duration_seconds": "600",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.MeetingURL != "https://meet.google.com/abc-defg-hij" {
+		t.Errorf("MeetingURL = %q", p.MeetingURL)
+	}
+	if p.MeetingID != "mtg-123" {
+		t.Errorf("MeetingID = %q", p.MeetingID)
+	}
+	if p.BotDisplayName != "Custom Bot" {
+		t.Errorf("BotDisplayName = %q", p.BotDisplayName)
+	}
+	if p.MaxDurationSeconds != 600 {
+		t.Errorf("MaxDurationSeconds = %d", p.MaxDurationSeconds)
+	}
+}
+
+func TestParseMeetingJoinParams_DefaultsBotName(t *testing.T) {
+	p, err := parseMeetingJoinParams(map[string]string{
+		"meeting_url": "https://meet.google.com/x",
+		"meeting_id":  "id1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.BotDisplayName != defaultBotDisplayName {
+		t.Errorf("expected default bot name %q, got %q", defaultBotDisplayName, p.BotDisplayName)
+	}
+	if p.MaxDurationSeconds != 0 {
+		t.Errorf("expected unset max duration, got %d", p.MaxDurationSeconds)
+	}
+	// Unset max duration resolves to the safety cap.
+	if p.maxDuration() != defaultMeetingMaxDuration {
+		t.Errorf("maxDuration() = %v, want default %v", p.maxDuration(), defaultMeetingMaxDuration)
+	}
+}
+
+func TestParseMeetingJoinParams_MissingRequired(t *testing.T) {
+	cases := map[string]map[string]string{
+		"missing url": {"meeting_id": "id1"},
+		"missing id":  {"meeting_url": "https://meet.google.com/x"},
+		"blank url":   {"meeting_url": "   ", "meeting_id": "id1"},
+		"empty":       {},
+	}
+	for name, payload := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parseMeetingJoinParams(payload); err == nil {
+				t.Errorf("expected error for %s, got nil", name)
+			}
+		})
+	}
+}
+
+func TestParseMeetingJoinParams_MaxDuration(t *testing.T) {
+	// Float string (JSON number coerced via fmt.Sprint) is accepted and truncated.
+	p, err := parseMeetingJoinParams(map[string]string{
+		"meeting_url":          "https://meet.google.com/x",
+		"meeting_id":           "id1",
+		"max_duration_seconds": "300.0",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.MaxDurationSeconds != 300 {
+		t.Errorf("MaxDurationSeconds = %d, want 300", p.MaxDurationSeconds)
+	}
+
+	// Non-positive and non-numeric are rejected.
+	for _, bad := range []string{"0", "-5", "abc"} {
+		if _, err := parseMeetingJoinParams(map[string]string{
+			"meeting_url":          "https://meet.google.com/x",
+			"meeting_id":           "id1",
+			"max_duration_seconds": bad,
+		}); err == nil {
+			t.Errorf("expected error for max_duration_seconds=%q, got nil", bad)
+		}
+	}
+}
+
+func TestSanitizeMeetingFilename(t *testing.T) {
+	cases := map[string]string{
+		"mtg-123":                 "mtg-123",
+		"abc_DEF":                 "abc_DEF",
+		"../../etc/passwd":        "______etc_passwd",
+		"a/b\\c":                  "a_b_c",
+		"":                        "meeting",
+		"550e8400-e29b-41d4":      "550e8400-e29b-41d4",
+	}
+	for in, want := range cases {
+		if got := sanitizeMeetingFilename(in); got != want {
+			t.Errorf("sanitizeMeetingFilename(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestMeetingWavPath(t *testing.T) {
+	got := meetingWavPath("/ws", "mtg-1")
+	want := filepath.Join("/ws", "meetings", "mtg-1.wav")
+	if got != want {
+		t.Errorf("meetingWavPath = %q, want %q", got, want)
+	}
+	// A traversal-y meeting id cannot escape the meetings dir.
+	got = meetingWavPath("/ws", "../../evil")
+	if !strings.HasPrefix(got, filepath.Join("/ws", "meetings")) {
+		t.Errorf("meetingWavPath escaped meetings dir: %q", got)
+	}
+}
+
+func TestParsePositiveSeconds(t *testing.T) {
+	ok := map[string]int{"1": 1, "300": 300, "300.0": 300, "59.9": 59}
+	for in, want := range ok {
+		got, err := parsePositiveSeconds(in)
+		if err != nil {
+			t.Errorf("parsePositiveSeconds(%q) errored: %v", in, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("parsePositiveSeconds(%q) = %d, want %d", in, got, want)
+		}
+	}
+	for _, bad := range []string{"0", "-1", "-2.5", "", "nan-ish", "abc"} {
+		if _, err := parsePositiveSeconds(bad); err == nil {
+			t.Errorf("expected error for %q, got nil", bad)
+		}
+	}
+}
+
+func TestClickButtonByTextJS(t *testing.T) {
+	labels := []string{"Ask to join", "Join now"}
+	js := clickButtonByTextJS(labels)
+	arr, _ := json.Marshal(labels)
+	if !strings.Contains(js, string(arr)) {
+		t.Errorf("clickButtonByTextJS did not embed labels array; got: %s", js)
+	}
+	if !strings.Contains(js, "throw new Error") {
+		t.Errorf("clickButtonByTextJS must throw when no button matches; got: %s", js)
+	}
+	// Optional variant returns "" instead of throwing.
+	opt := clickButtonByTextOptionalJS(labels)
+	if strings.Contains(opt, "throw new Error") {
+		t.Errorf("optional variant must not throw; got: %s", opt)
+	}
+	if !strings.Contains(opt, `return "";`) {
+		t.Errorf("optional variant must return empty string on no match; got: %s", opt)
+	}
+}
+
+func TestToInt(t *testing.T) {
+	cases := []struct {
+		in   any
+		want int
+		ok   bool
+	}{
+		{float64(3), 3, true},
+		{int(5), 5, true},
+		{int64(7), 7, true},
+		{"nope", 0, false},
+		{nil, 0, false},
+	}
+	for _, c := range cases {
+		got, ok := toInt(c.in)
+		if ok != c.ok || got != c.want {
+			t.Errorf("toInt(%v) = (%d,%v), want (%d,%v)", c.in, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+func TestMeetingJoin_MissingWorkspace(t *testing.T) {
+	h := NewMeetingJoinHandler("")
+	_, err := h.Execute(JobContext{}, &nexus.Job{
+		ID:   "m1",
+		Type: JobTypeTranscribeAudioType,
+		Payload: map[string]string{
+			"meeting_url": "https://meet.google.com/x",
+			"meeting_id":  "id1",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error when workspace is unconfigured")
+	}
+}

--- a/internal/platform/audio.go
+++ b/internal/platform/audio.go
@@ -6,15 +6,15 @@
 //
 // The mechanism is the standard meeting-bot audio path, proven on a real node
 // before this code was written:
-//   1. Create a dedicated PulseAudio *null sink* (`pactl load-module
-//      module-null-sink`). A null sink is a virtual output that plays to nowhere
-//      but exposes a `.monitor` source carrying whatever was written to it.
-//   2. Launch the browser with `PULSE_SINK=<sinkName>` in its environment so
-//      libpulse routes THAT process's audio to our sink (per-process routing —
-//      other node audio is untouched). See withPulseSink.
-//   3. Record the sink's `.monitor` with ffmpeg to a WAV file in the node
-//      workspace, where the whisper sidecar (read-only /workspace mount) can
-//      then transcribe it.
+//  1. Create a dedicated PulseAudio *null sink* (`pactl load-module
+//     module-null-sink`). A null sink is a virtual output that plays to nowhere
+//     but exposes a `.monitor` source carrying whatever was written to it.
+//  2. Launch the browser with `PULSE_SINK=<sinkName>` in its environment so
+//     libpulse routes THAT process's audio to our sink (per-process routing —
+//     other node audio is untouched). See withPulseSink.
+//  3. Record the sink's `.monitor` with ffmpeg to a WAV file in the node
+//     workspace, where the whisper sidecar (read-only /workspace mount) can
+//     then transcribe it.
 //
 // Why PulseAudio+ffmpeg and not in-browser capture: OS-level capture isolates
 // the call audio from any other sound on the node, yields a clean on-disk file,

--- a/internal/platform/audio.go
+++ b/internal/platform/audio.go
@@ -1,0 +1,239 @@
+// internal/platform/audio.go
+//
+// Meeting-audio capture: record exactly the sound a meeting-bot browser plays,
+// with nothing else on the node mixed in (issue #5098, epic #5097 — the
+// sovereign auto-join notetaker).
+//
+// The mechanism is the standard meeting-bot audio path, proven on a real node
+// before this code was written:
+//   1. Create a dedicated PulseAudio *null sink* (`pactl load-module
+//      module-null-sink`). A null sink is a virtual output that plays to nowhere
+//      but exposes a `.monitor` source carrying whatever was written to it.
+//   2. Launch the browser with `PULSE_SINK=<sinkName>` in its environment so
+//      libpulse routes THAT process's audio to our sink (per-process routing —
+//      other node audio is untouched). See withPulseSink.
+//   3. Record the sink's `.monitor` with ffmpeg to a WAV file in the node
+//      workspace, where the whisper sidecar (read-only /workspace mount) can
+//      then transcribe it.
+//
+// Why PulseAudio+ffmpeg and not in-browser capture: OS-level capture isolates
+// the call audio from any other sound on the node, yields a clean on-disk file,
+// and does not depend on tab focus or a fragile getDisplayMedia handshake.
+//
+// Deployment note: the node must have a running PulseAudio-protocol server
+// (native pulseaudio OR pipewire-pulse) reachable by the citadel process — i.e.
+// PULSE_SERVER / XDG_RUNTIME_DIR resolve to a live server. audioStackAvailable
+// reports this so the node only advertises the `meeting` capability when capture
+// can actually work.
+package platform
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+// meetingSinkPrefix namespaces the null sinks this package creates so orphan
+// reaping and diagnostics can find them, and so they never collide with a
+// user's real sinks.
+const meetingSinkPrefix = "citadel_meeting_"
+
+// EnvPulseSink is the libpulse environment variable that pins the default sink
+// for a client process's streams. Setting it on the browser's env is what routes
+// the browser (and only the browser) into our null sink.
+const EnvPulseSink = "PULSE_SINK"
+
+// audioStackAvailable reports whether this node can capture meeting audio: the
+// pactl and ffmpeg binaries exist AND a PulseAudio-protocol server is reachable
+// (`pactl info` succeeds). Used both by capability detection (advertise the
+// `meeting` tag only when true) and by the recorder as a pre-flight so failures
+// surface as an actionable message rather than a mid-record ffmpeg crash.
+func audioStackAvailable() bool {
+	if !isCommandAvailable("pactl") || !isCommandAvailable("ffmpeg") {
+		return false
+	}
+	// `pactl info` returns non-zero when no server is reachable. Bound it so a
+	// hung server cannot wedge capability detection.
+	cmd := exec.Command("pactl", "info")
+	done := make(chan error, 1)
+	if err := cmd.Start(); err != nil {
+		return false
+	}
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		return err == nil
+	case <-time.After(3 * time.Second):
+		_ = cmd.Process.Kill()
+		return false
+	}
+}
+
+// withPulseSink returns env with PULSE_SINK set to sinkName, replacing any
+// inherited value, so the launched process routes its audio to exactly our sink.
+// Pure (mirrors withDisplay) so the browser launcher can compose display + sink.
+func withPulseSink(env []string, sinkName string) []string {
+	out := make([]string, 0, len(env)+1)
+	for _, kv := range env {
+		if strings.HasPrefix(kv, EnvPulseSink+"=") {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return append(out, EnvPulseSink+"="+sinkName)
+}
+
+// buildAudioFFmpegArgs constructs the ffmpeg command line that records a pulse
+// monitor source to a mono 16 kHz WAV — the format faster-whisper wants (16 kHz
+// mono is whisper's native input, so we downsample once here rather than in the
+// sidecar). Pure function so the arg set is unit-testable without ffmpeg.
+func buildAudioFFmpegArgs(monitorSource, outPath string) []string {
+	return []string{
+		"-hide_banner", "-loglevel", "error",
+		"-f", "pulse", "-i", monitorSource,
+		"-ac", "1", "-ar", "16000",
+		"-y", outPath,
+	}
+}
+
+// NullSinkRecorder owns one null sink and its ffmpeg recorder for a single
+// meeting. Lifecycle: LoadSink (before the browser launches, so PULSE_SINK has a
+// target) → the caller launches the browser with SinkName() in its env → Start
+// (once joined) → Stop (finalize the WAV and unload the sink). Safe for
+// concurrent use; the reaper goroutine owns the single ffmpeg Wait(), mirroring
+// CobrowseManager's process handling.
+type NullSinkRecorder struct {
+	mu       sync.Mutex
+	sinkName string
+	moduleID string // pactl module index, needed to unload the sink
+	outPath  string
+	cmd      *exec.Cmd     // the ffmpeg recorder
+	exited   chan struct{} // closed by the reaper when ffmpeg exits
+}
+
+// NewNullSinkRecorder creates a recorder bound to a unique sink name. The name is
+// namespaced and caller-suffixed (e.g. a meeting id) so parallel meetings on one
+// node never share a sink.
+func NewNullSinkRecorder(idSuffix string) *NullSinkRecorder {
+	return &NullSinkRecorder{sinkName: meetingSinkPrefix + sanitizeSinkSuffix(idSuffix)}
+}
+
+// sanitizeSinkSuffix keeps only characters PulseAudio accepts in a sink name so a
+// meeting id (which may contain dashes) cannot produce an invalid module load.
+func sanitizeSinkSuffix(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	if b.Len() == 0 {
+		return "session"
+	}
+	return b.String()
+}
+
+// SinkName is the null sink's name; put it in the browser env via withPulseSink.
+func (r *NullSinkRecorder) SinkName() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.sinkName
+}
+
+// monitorSource is the source name ffmpeg records from.
+func (r *NullSinkRecorder) monitorSource() string {
+	return r.sinkName + ".monitor"
+}
+
+// LoadSink creates the null sink. Call before launching the browser so the
+// browser's PULSE_SINK target exists at launch. Idempotent-ish: refuses if a sink
+// is already loaded on this recorder.
+func (r *NullSinkRecorder) LoadSink() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.moduleID != "" {
+		return fmt.Errorf("null sink %q already loaded (module %s)", r.sinkName, r.moduleID)
+	}
+	if !audioStackAvailable() {
+		return fmt.Errorf("audio capture unavailable: need pactl + ffmpeg and a running PulseAudio/pipewire-pulse server")
+	}
+	out, err := exec.Command("pactl", "load-module", "module-null-sink",
+		"sink_name="+r.sinkName,
+		"sink_properties=device.description="+r.sinkName,
+	).Output()
+	if err != nil {
+		return fmt.Errorf("load null sink %q: %w", r.sinkName, err)
+	}
+	id := strings.TrimSpace(string(out))
+	if id == "" {
+		return fmt.Errorf("load null sink %q: pactl returned no module id", r.sinkName)
+	}
+	r.moduleID = id
+	return nil
+}
+
+// Start begins recording the sink monitor to outPath. LoadSink must have run.
+func (r *NullSinkRecorder) Start(outPath string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.moduleID == "" {
+		return fmt.Errorf("cannot record: null sink not loaded (call LoadSink first)")
+	}
+	if r.cmd != nil {
+		return fmt.Errorf("recorder already started")
+	}
+	cmd := exec.Command("ffmpeg", buildAudioFFmpegArgs(r.monitorSource(), outPath)...)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start ffmpeg recorder: %w", err)
+	}
+	r.cmd = cmd
+	r.outPath = outPath
+	exited := make(chan struct{})
+	r.exited = exited
+	go func() {
+		_ = cmd.Wait()
+		close(exited)
+	}()
+	return nil
+}
+
+// Stop finalizes the recording and unloads the sink. It sends ffmpeg SIGINT so it
+// writes a valid WAV trailer, waits bounded for the reaper, then unloads the
+// module. Safe to call once; safe when never started. Returns the recorded file
+// path so the caller can hand it to transcription.
+func (r *NullSinkRecorder) Stop() (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var firstErr error
+	if r.cmd != nil && r.cmd.Process != nil {
+		// SIGINT lets ffmpeg flush and finalize the WAV; a hard Kill can leave a
+		// truncated file that whisper then fails to open.
+		if err := r.cmd.Process.Signal(os.Interrupt); err != nil && !isProcessGoneErr(err) {
+			firstErr = fmt.Errorf("signal ffmpeg: %w", err)
+		}
+		if r.exited != nil {
+			select {
+			case <-r.exited:
+			case <-time.After(10 * time.Second):
+				_ = r.cmd.Process.Kill()
+			}
+		}
+	}
+	r.cmd = nil
+	r.exited = nil
+	if r.moduleID != "" {
+		if err := exec.Command("pactl", "unload-module", r.moduleID).Run(); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("unload null sink %q (module %s): %w", r.sinkName, r.moduleID, err)
+		}
+		r.moduleID = ""
+	}
+	return r.outPath, firstErr
+}

--- a/internal/platform/audio_test.go
+++ b/internal/platform/audio_test.go
@@ -54,11 +54,11 @@ func TestBuildAudioFFmpegArgs(t *testing.T) {
 
 func TestSanitizeSinkSuffix(t *testing.T) {
 	cases := map[string]string{
-		"abc123":                      "abc123",
-		"meeting-2026-07-07":          "meeting_2026_07_07",
-		"a/b\\c":                      "a_b_c",
-		"":                            "session",
-		"550e8400-e29b-41d4-a716":     "550e8400_e29b_41d4_a716",
+		"abc123":                  "abc123",
+		"meeting-2026-07-07":      "meeting_2026_07_07",
+		"a/b\\c":                  "a_b_c",
+		"":                        "session",
+		"550e8400-e29b-41d4-a716": "550e8400_e29b_41d4_a716",
 	}
 	for in, want := range cases {
 		if got := sanitizeSinkSuffix(in); got != want {

--- a/internal/platform/audio_test.go
+++ b/internal/platform/audio_test.go
@@ -1,0 +1,150 @@
+package platform
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWithPulseSink(t *testing.T) {
+	// Replaces an inherited PULSE_SINK and preserves other vars.
+	env := []string{"HOME=/root", "PULSE_SINK=old", "DISPLAY=:99"}
+	got := withPulseSink(env, "citadel_meeting_abc")
+	var sinkCount int
+	var sawHome, sawDisplay bool
+	for _, kv := range got {
+		if strings.HasPrefix(kv, EnvPulseSink+"=") {
+			sinkCount++
+			if kv != "PULSE_SINK=citadel_meeting_abc" {
+				t.Errorf("PULSE_SINK not overridden: %q", kv)
+			}
+		}
+		if kv == "HOME=/root" {
+			sawHome = true
+		}
+		if kv == "DISPLAY=:99" {
+			sawDisplay = true
+		}
+	}
+	if sinkCount != 1 {
+		t.Errorf("expected exactly one PULSE_SINK entry, got %d", sinkCount)
+	}
+	if !sawHome || !sawDisplay {
+		t.Errorf("withPulseSink dropped unrelated env vars: home=%v display=%v", sawHome, sawDisplay)
+	}
+}
+
+func TestBuildAudioFFmpegArgs(t *testing.T) {
+	args := buildAudioFFmpegArgs("citadel_meeting_x.monitor", "/w/meetings/x.wav")
+	joined := strings.Join(args, " ")
+	for _, want := range []string{
+		"-f pulse", "-i citadel_meeting_x.monitor",
+		"-ac 1", "-ar 16000", "-y /w/meetings/x.wav",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("ffmpeg args missing %q; got: %s", want, joined)
+		}
+	}
+}
+
+func TestSanitizeSinkSuffix(t *testing.T) {
+	cases := map[string]string{
+		"abc123":                      "abc123",
+		"meeting-2026-07-07":          "meeting_2026_07_07",
+		"a/b\\c":                      "a_b_c",
+		"":                            "session",
+		"550e8400-e29b-41d4-a716":     "550e8400_e29b_41d4_a716",
+	}
+	for in, want := range cases {
+		if got := sanitizeSinkSuffix(in); got != want {
+			t.Errorf("sanitizeSinkSuffix(%q)=%q want %q", in, got, want)
+		}
+	}
+}
+
+// TestNullSinkRecorder_CapturesAudio is an integration test that proves the full
+// capture path on a node with a real PulseAudio/pipewire-pulse server: load a
+// null sink, record its monitor, play a tone into the sink, and assert the WAV is
+// non-silent. It skips where the audio stack is absent (e.g. CI), matching this
+// repo's convention that hardware-dependent paths are covered by integration
+// tests that no-op without the stack.
+func TestNullSinkRecorder_CapturesAudio(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping audio integration test in -short mode")
+	}
+	if !audioStackAvailable() {
+		t.Skip("no PulseAudio/pipewire-pulse server + ffmpeg/pactl on this host; skipping capture test")
+	}
+
+	rec := NewNullSinkRecorder("gotest_" + strconv.Itoa(os.Getpid()))
+	// Safety net: unload the sink even if the test fails before Stop.
+	defer func() {
+		if id := rec.moduleID; id != "" {
+			_ = exec.Command("pactl", "unload-module", id).Run()
+		}
+	}()
+
+	if err := rec.LoadSink(); err != nil {
+		t.Fatalf("LoadSink: %v", err)
+	}
+	out := filepath.Join(t.TempDir(), "capture.wav")
+	if err := rec.Start(out); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Play a 2s 440 Hz tone INTO our sink (PULSE_SINK routes this player's output
+	// to the sink; its monitor then carries it to the recorder).
+	play := exec.Command("ffmpeg", "-hide_banner", "-loglevel", "error",
+		"-f", "lavfi", "-i", "sine=frequency=440:duration=2",
+		"-f", "pulse", "citadel_meeting_gotest_player")
+	play.Env = withPulseSink(os.Environ(), rec.SinkName())
+	if err := play.Run(); err != nil {
+		t.Fatalf("play tone into sink: %v", err)
+	}
+	// Small settle so the tail of the tone is flushed to the monitor before stop.
+	time.Sleep(300 * time.Millisecond)
+
+	path, err := rec.Stop()
+	if err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat recording: %v", err)
+	}
+	if fi.Size() < 1024 {
+		t.Fatalf("recording suspiciously small: %d bytes", fi.Size())
+	}
+
+	mean := meanVolumeDB(t, path)
+	// Silence reads ~ -91 dB; a captured tone is far louder. -80 is a generous
+	// floor that still rejects a silent (failed-routing) capture.
+	if mean <= -80.0 {
+		t.Fatalf("recording appears silent (mean_volume %.1f dB) — PULSE_SINK routing or monitor capture failed", mean)
+	}
+	t.Logf("captured %d bytes, mean_volume %.1f dB", fi.Size(), mean)
+}
+
+var meanVolRe = regexp.MustCompile(`mean_volume:\s*(-?[0-9.]+) dB`)
+
+// meanVolumeDB runs ffmpeg volumedetect on a file and returns the mean volume in
+// dB. Fails the test if ffmpeg output cannot be parsed.
+func meanVolumeDB(t *testing.T, path string) float64 {
+	t.Helper()
+	out, _ := exec.Command("ffmpeg", "-hide_banner", "-nostats",
+		"-i", path, "-af", "volumedetect", "-f", "null", "/dev/null").CombinedOutput()
+	m := meanVolRe.FindSubmatch(out)
+	if m == nil {
+		t.Fatalf("could not parse mean_volume from ffmpeg output:\n%s", out)
+	}
+	v, err := strconv.ParseFloat(string(m[1]), 64)
+	if err != nil {
+		t.Fatalf("parse mean_volume %q: %v", m[1], err)
+	}
+	return v
+}

--- a/internal/platform/meeting_browser.go
+++ b/internal/platform/meeting_browser.go
@@ -1,0 +1,394 @@
+// internal/platform/meeting_browser.go
+//
+// Meeting-bot browser: a headed Chromium the notetaker drives over CDP to join a
+// video call, launched so its audio routes into a per-meeting PulseAudio null
+// sink for capture (issue #5098, epic #5097 — the sovereign auto-join notetaker).
+//
+// This is a deliberate SIBLING of CobrowseManager, not a reuse of it. The
+// co-browse manager is a process-wide singleton owning ONE long-lived browser
+// that a human logs into and the AI keeps steering. A meeting bot needs the
+// opposite: a short-lived, disposable browser per meeting, isolated from the
+// co-browse session so the two never fight over one Chromium (Chrome locks a
+// --user-data-dir to a single process, so they cannot share a profile anyway).
+// MeetingBrowser therefore owns its OWN Xvfb display, CDP debug port, and
+// throwaway profile dir, and reuses only the package-level, side-effect-free
+// launch helpers (buildChromeArgs, startManagedXvfb, withDisplay, findChromium,
+// pickTarget, cdpCommand) so there is no duplicated browser-launch logic.
+package platform
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"sync"
+	"time"
+)
+
+// ChromiumAvailable reports whether a Chromium/Chrome binary is on PATH. Exported
+// so capability detection can gate the `meeting` tag on a launchable browser
+// without reaching into this package's unexported findChromium.
+func ChromiumAvailable() bool {
+	_, err := findChromium()
+	return err == nil
+}
+
+// XvfbAvailable reports whether the Xvfb binary is on PATH. The meeting browser
+// always runs on a dedicated virtual display (meeting nodes are typically
+// headless), so Xvfb is a hard dependency of the `meeting` capability.
+func XvfbAvailable() bool {
+	return isCommandAvailable("Xvfb")
+}
+
+// AudioStackAvailable is the exported form of audioStackAvailable so capability
+// detection (a different package) can gate the `meeting` tag on a working
+// PulseAudio + ffmpeg + pactl stack.
+func AudioStackAvailable() bool {
+	return audioStackAvailable()
+}
+
+// findFreeDebugPort asks the kernel for an unused loopback TCP port so a meeting
+// browser's CDP endpoint never collides with co-browse's fixed 9222 or with a
+// second concurrent meeting. There is a small window between closing the probe
+// listener and Chromium binding the port; acceptable because the launcher fails
+// loudly (waitForCDPReady times out) rather than silently attaching to a ghost.
+func findFreeDebugPort() (int, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, fmt.Errorf("reserve free CDP port: %w", err)
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port, nil
+}
+
+// waitForCDPReady polls the CDP HTTP endpoint until a page target appears or the
+// timeout elapses. Package-level (not a MeetingBrowser method) so it is reusable
+// and stays free of manager state.
+func waitForCDPReady(debugPort int, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		if _, err := pickTarget(debugPort); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	return fmt.Errorf("CDP endpoint not ready after %s: %v", timeout, lastErr)
+}
+
+// clickJS builds a JS expression that clicks the first element matching selector
+// and THROWS when nothing matches. The throw is load-bearing: cdpEvaluate turns a
+// JS exception into a Go error, so a stale selector fails loudly during live
+// tuning instead of silently reporting a successful click. selector is embedded
+// via json.Marshal so any quotes/backslashes are safely escaped.
+func clickJS(selector string) string {
+	sel, _ := json.Marshal(selector)
+	return fmt.Sprintf(
+		`(function(){var el=document.querySelector(%s);`+
+			`if(!el){throw new Error("selector not found: "+%s);}`+
+			`el.scrollIntoView();el.click();return true;})()`,
+		sel, sel)
+}
+
+// typeJS builds a JS expression that focuses the first element matching selector
+// and sets its value using the native value setter (so React/Angular-controlled
+// inputs, like Meet's name field, observe the change), then dispatches input and
+// change events. Throws when the selector matches nothing (see clickJS). Both
+// selector and text are json.Marshal-escaped.
+func typeJS(selector, text string) string {
+	sel, _ := json.Marshal(selector)
+	val, _ := json.Marshal(text)
+	return fmt.Sprintf(
+		`(function(){var el=document.querySelector(%s);`+
+			`if(!el){throw new Error("selector not found: "+%s);}`+
+			`el.focus();`+
+			`var proto=el instanceof HTMLTextAreaElement?HTMLTextAreaElement.prototype:HTMLInputElement.prototype;`+
+			`var setter=Object.getOwnPropertyDescriptor(proto,'value').set;`+
+			`setter.call(el,%s);`+
+			`el.dispatchEvent(new Event('input',{bubbles:true}));`+
+			`el.dispatchEvent(new Event('change',{bubbles:true}));return true;})()`,
+		sel, sel, val)
+}
+
+// cdpEvaluate runs a JS expression in the page and returns its by-value result.
+//
+// It hardens the raw cdpCommand in two ways that matter for the join flow:
+//   - returnByValue:true so the caller reads an actual JSON value (a bool, a
+//     number, a string) rather than an opaque RemoteObject handle.
+//   - It inspects result.exceptionDetails and returns a Go error on a JS throw.
+//     cdpCommand only surfaces PROTOCOL errors (msg["error"]); a JS runtime
+//     exception comes back as a normal result, so without this a throwing click
+//     on a missing selector would masquerade as success — the worst outcome for
+//     the human tuning selectors against a live Meet.
+func cdpEvaluate(debugPort int, expression string) (any, error) {
+	res, err := cdpCommand(debugPort, "Runtime.evaluate", map[string]any{
+		"expression":    expression,
+		"returnByValue": true,
+		"awaitPromise":  true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if exc, ok := res["exceptionDetails"]; ok && exc != nil {
+		return nil, fmt.Errorf("javascript exception: %s", describeCDPException(exc))
+	}
+	result, ok := res["result"].(map[string]any)
+	if !ok {
+		return nil, nil
+	}
+	return result["value"], nil
+}
+
+// describeCDPException pulls a human-readable message out of a CDP
+// exceptionDetails object, preferring the thrown exception's description.
+func describeCDPException(exc any) string {
+	m, ok := exc.(map[string]any)
+	if !ok {
+		return fmt.Sprint(exc)
+	}
+	if e, ok := m["exception"].(map[string]any); ok {
+		if d, ok := e["description"].(string); ok && d != "" {
+			return d
+		}
+		if v, ok := e["value"]; ok {
+			return fmt.Sprint(v)
+		}
+	}
+	if t, ok := m["text"].(string); ok && t != "" {
+		return t
+	}
+	return fmt.Sprint(m)
+}
+
+// MeetingBrowser owns one disposable headed Chromium for a single meeting, its
+// dedicated Xvfb display, and its throwaway profile. Safe for concurrent use; the
+// reaper goroutines own the single Wait() for each child process, mirroring
+// CobrowseManager's process handling.
+type MeetingBrowser struct {
+	mu         sync.Mutex
+	sinkName   string
+	debugPort  int
+	profileDir string
+	display    string
+	chromePath string
+	cmd        *exec.Cmd
+	exited     chan struct{}
+	xvfb       *exec.Cmd
+	xvfbExited chan struct{}
+}
+
+// NewMeetingBrowser creates a meeting browser whose audio will route into the
+// given PulseAudio sink (from a NullSinkRecorder). The sink must be loaded before
+// Start so the browser's PULSE_SINK target exists at launch.
+func NewMeetingBrowser(sinkName string) *MeetingBrowser {
+	return &MeetingBrowser{sinkName: sinkName}
+}
+
+// DebugPort returns the CDP port the browser listens on (0 before Start).
+func (b *MeetingBrowser) DebugPort() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.debugPort
+}
+
+// Display returns the X display the browser renders on ("" before Start).
+func (b *MeetingBrowser) Display() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.display
+}
+
+// Start launches the headed Chromium on a fresh Xvfb display with a throwaway
+// profile, routing its audio into the meeting's null sink. It blocks until the
+// CDP endpoint is ready so the first Navigate does not race the launch.
+func (b *MeetingBrowser) Start() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.cmd != nil {
+		return fmt.Errorf("meeting browser already started")
+	}
+	if b.sinkName == "" {
+		return fmt.Errorf("meeting browser has no audio sink; construct with NewMeetingBrowser(sinkName)")
+	}
+
+	chrome, err := findChromium()
+	if err != nil {
+		return err
+	}
+
+	// Fresh, unique profile per meeting: Chrome locks a --user-data-dir to one
+	// process, so a disposable dir both avoids colliding with the co-browse
+	// profile and lets parallel meetings run without stomping each other.
+	profileDir, err := os.MkdirTemp("", "citadel-meeting-profile-")
+	if err != nil {
+		return fmt.Errorf("create meeting profile dir: %w", err)
+	}
+
+	debugPort, err := findFreeDebugPort()
+	if err != nil {
+		_ = os.RemoveAll(profileDir)
+		return err
+	}
+
+	// Meeting nodes are typically headless, so always run on a dedicated Xvfb
+	// virtual display (no shared-desktop mode here, unlike co-browse). A managed
+	// Xvfb has no GPU, so force software rendering.
+	xvfb, display, err := startManagedXvfb(xvfbResolution())
+	if err != nil {
+		_ = os.RemoveAll(profileDir)
+		return err
+	}
+
+	args := buildChromeArgs(cobrowseLaunchOptions{
+		debugPort:  debugPort,
+		profileDir: profileDir,
+		stealth:    stealthEnabled(),
+		userAgent:  os.Getenv(EnvCobrowseUserAgent),
+		softwareGL: true,
+	})
+
+	cmd := exec.Command(chrome, args...)
+	// Compose BOTH env transforms: DISPLAY pins the virtual display, PULSE_SINK
+	// routes this browser's (and only this browser's) audio into the meeting sink
+	// so the recorder captures exactly the call.
+	cmd.Env = withPulseSink(withDisplay(os.Environ(), display), b.sinkName)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	if err := cmd.Start(); err != nil {
+		if xvfb.Process != nil {
+			_ = xvfb.Process.Kill()
+		}
+		_ = os.RemoveAll(profileDir)
+		return fmt.Errorf("launch meeting chromium: %w", err)
+	}
+
+	b.cmd = cmd
+	b.chromePath = chrome
+	b.debugPort = debugPort
+	b.profileDir = profileDir
+	b.display = display
+	b.xvfb = xvfb
+
+	// Reap each child so a crash is observable and no zombie is left. Stop/Close
+	// signal the kill and wait on these channels; they never call Wait directly.
+	exited := make(chan struct{})
+	b.exited = exited
+	go func() {
+		_ = cmd.Wait()
+		close(exited)
+	}()
+	xvfbExited := make(chan struct{})
+	b.xvfbExited = xvfbExited
+	go func() {
+		_ = xvfb.Wait()
+		close(xvfbExited)
+	}()
+
+	if err := waitForCDPReady(debugPort, 20*time.Second); err != nil {
+		// Best-effort teardown so a browser that launched but never exposed CDP
+		// does not leak a process, display, or profile dir.
+		b.closeLocked()
+		return fmt.Errorf("meeting browser launched but CDP not ready: %w", err)
+	}
+	return nil
+}
+
+// Navigate drives the browser to a URL over CDP.
+func (b *MeetingBrowser) Navigate(url string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.cmd == nil {
+		return fmt.Errorf("meeting browser not started")
+	}
+	_, err := cdpCommand(b.debugPort, "Page.navigate", map[string]any{"url": url})
+	return err
+}
+
+// Click clicks the first element matching selector, erroring if none matches.
+func (b *MeetingBrowser) Click(selector string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.cmd == nil {
+		return fmt.Errorf("meeting browser not started")
+	}
+	_, err := cdpEvaluate(b.debugPort, clickJS(selector))
+	return err
+}
+
+// Type sets the value of the first element matching selector, erroring if none
+// matches.
+func (b *MeetingBrowser) Type(selector, text string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.cmd == nil {
+		return fmt.Errorf("meeting browser not started")
+	}
+	_, err := cdpEvaluate(b.debugPort, typeJS(selector, text))
+	return err
+}
+
+// Evaluate runs a JS expression and returns its by-value result. A JS throw is
+// returned as a Go error (see cdpEvaluate).
+func (b *MeetingBrowser) Evaluate(expression string) (any, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.cmd == nil {
+		return nil, fmt.Errorf("meeting browser not started")
+	}
+	return cdpEvaluate(b.debugPort, expression)
+}
+
+// Close tears down the browser, its Xvfb, and its throwaway profile. Safe to call
+// once; safe when never fully started.
+func (b *MeetingBrowser) Close() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.closeLocked()
+}
+
+// closeLocked performs teardown; caller holds b.mu. Kills the browser first, then
+// the Xvfb (so the browser is never left without a display mid-shutdown), then
+// removes the profile dir. Bounded waits avoid a hung child wedging shutdown.
+func (b *MeetingBrowser) closeLocked() error {
+	var firstErr error
+	if b.cmd != nil && b.cmd.Process != nil {
+		if err := b.cmd.Process.Kill(); err != nil && !isProcessGoneErr(err) {
+			firstErr = fmt.Errorf("kill meeting browser: %w", err)
+		}
+		if b.exited != nil {
+			select {
+			case <-b.exited:
+			case <-time.After(5 * time.Second):
+			}
+		}
+	}
+	b.cmd = nil
+	b.exited = nil
+
+	if b.xvfb != nil && b.xvfb.Process != nil {
+		if err := b.xvfb.Process.Kill(); err != nil && !isProcessGoneErr(err) && firstErr == nil {
+			firstErr = fmt.Errorf("kill meeting Xvfb: %w", err)
+		}
+		if b.xvfbExited != nil {
+			select {
+			case <-b.xvfbExited:
+			case <-time.After(5 * time.Second):
+			}
+		}
+	}
+	b.xvfb = nil
+	b.xvfbExited = nil
+	b.display = ""
+
+	if b.profileDir != "" {
+		if err := os.RemoveAll(b.profileDir); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("remove meeting profile dir: %w", err)
+		}
+		b.profileDir = ""
+	}
+	return firstErr
+}

--- a/internal/platform/meeting_browser_test.go
+++ b/internal/platform/meeting_browser_test.go
@@ -1,0 +1,125 @@
+package platform
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestClickJS_EscapesSelectorAndThrows(t *testing.T) {
+	// A selector containing a quote must be safely embedded (not break the JS)
+	// and the snippet must throw when the element is missing so a stale selector
+	// surfaces as an error rather than a false success.
+	sel := `button[aria-label="Leave call"]`
+	js := clickJS(sel)
+	marshaled, _ := json.Marshal(sel)
+	if !strings.Contains(js, string(marshaled)) {
+		t.Errorf("clickJS did not embed json-escaped selector; got: %s", js)
+	}
+	if !strings.Contains(js, "throw new Error") {
+		t.Errorf("clickJS must throw on missing selector; got: %s", js)
+	}
+	if !strings.Contains(js, ".click()") {
+		t.Errorf("clickJS must click the element; got: %s", js)
+	}
+}
+
+func TestTypeJS_EscapesSelectorAndText(t *testing.T) {
+	sel := `input[aria-label="Your name"]`
+	text := `O'Brien "Bot" \ x`
+	js := typeJS(sel, text)
+	for _, want := range []string{string(mustJSON(t, sel)), string(mustJSON(t, text))} {
+		if !strings.Contains(js, want) {
+			t.Errorf("typeJS missing escaped %q; got: %s", want, js)
+		}
+	}
+	if !strings.Contains(js, "throw new Error") {
+		t.Errorf("typeJS must throw on missing selector; got: %s", js)
+	}
+	// Uses the native setter path so controlled (React) inputs observe the change.
+	if !strings.Contains(js, "getOwnPropertyDescriptor") || !strings.Contains(js, "dispatchEvent") {
+		t.Errorf("typeJS must set value via native setter + dispatch events; got: %s", js)
+	}
+}
+
+func TestDescribeCDPException(t *testing.T) {
+	cases := []struct {
+		name string
+		exc  any
+		want string
+	}{
+		{
+			name: "exception description",
+			exc:  map[string]any{"exception": map[string]any{"description": "Error: selector not found"}},
+			want: "Error: selector not found",
+		},
+		{
+			name: "exception value fallback",
+			exc:  map[string]any{"exception": map[string]any{"value": "boom"}},
+			want: "boom",
+		},
+		{
+			name: "text fallback",
+			exc:  map[string]any{"text": "Uncaught"},
+			want: "Uncaught",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := describeCDPException(tc.exc); got != tc.want {
+				t.Errorf("describeCDPException = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFindFreeDebugPort(t *testing.T) {
+	p, err := findFreeDebugPort()
+	if err != nil {
+		t.Fatalf("findFreeDebugPort: %v", err)
+	}
+	if p <= 0 || p > 65535 {
+		t.Fatalf("findFreeDebugPort returned out-of-range port %d", p)
+	}
+}
+
+// TestMeetingBrowser_Launch is an integration test: it launches a real Chromium
+// on a real Xvfb display and drives one CDP round-trip. It skips under -short and
+// wherever the browser/display deps are missing, mirroring audio_test.go's
+// hardware-gated convention.
+func TestMeetingBrowser_Launch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping meeting-browser launch test in -short mode")
+	}
+	if !ChromiumAvailable() || !XvfbAvailable() {
+		t.Skip("no Chromium or Xvfb on this host; skipping meeting-browser launch test")
+	}
+	br := NewMeetingBrowser("citadel_meeting_gotest")
+	if err := br.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer br.Close()
+	if br.DebugPort() <= 0 {
+		t.Fatalf("expected a CDP debug port after Start, got %d", br.DebugPort())
+	}
+	v, err := br.Evaluate("1+1")
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if n, ok := v.(float64); !ok || n != 2 {
+		t.Fatalf("Evaluate(1+1) = %v (%T), want 2", v, v)
+	}
+	// A throwing expression must surface as a Go error, not a silent success.
+	if _, err := br.Evaluate(`throw new Error("nope")`); err == nil {
+		t.Fatal("expected error from throwing JS expression, got nil")
+	}
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("json.Marshal(%v): %v", v, err)
+	}
+	return b
+}

--- a/internal/tui/controlcenter/settings_page.go
+++ b/internal/tui/controlcenter/settings_page.go
@@ -40,6 +40,11 @@ type SettingsCallbacks struct {
 	LoadRendering func() *config.Rendering
 	// SaveRendering persists an updated fullscreen-rendering setting.
 	SaveRendering func(*config.Rendering) error
+
+	// LoadMeeting returns the current persisted meeting-capability setting.
+	LoadMeeting func() *config.Meeting
+	// SaveMeeting persists an updated meeting-capability setting.
+	SaveMeeting func(*config.Meeting) error
 	// SetFullscreenEnabled is the injection seam for applying the fullscreen
 	// preference on the running app. Unlike mouse capture, tview cannot swap the
 	// terminal's alternate-screen mode mid-run, so today this is a no-op seam that
@@ -70,6 +75,7 @@ type SettingsPage struct {
 	keepAwake *config.KeepAwake
 	mouse     *config.Mouse
 	rendering *config.Rendering
+	meeting   *config.Meeting
 
 	// UI
 	root *tview.Flex
@@ -115,6 +121,7 @@ func (p *SettingsPage) OnActivate() {
 	p.reloadKeepAwake()
 	p.reloadMouse()
 	p.reloadRendering()
+	p.reloadMeeting()
 	p.render()
 	if p.app != nil && p.view != nil {
 		p.app.SetFocus(p.view)
@@ -126,7 +133,8 @@ func (p *SettingsPage) OnDeactivate() {}
 
 // HandleInput implements Page. Numbered toggles (numbers + arrows convention, no
 // letter shortcuts): 1=mouse control, 2=fullscreen rendering, 3=anonymous
-// telemetry opt-out, 4=keep-awake-on-AC. Space/Enter also toggle telemetry.
+// telemetry opt-out, 4=keep-awake-on-AC, 5=meeting capability opt-out.
+// Space/Enter also toggle telemetry.
 func (p *SettingsPage) HandleInput(event *tcell.EventKey) *tcell.EventKey {
 	switch {
 	case event.Key() == tcell.KeyRune && event.Rune() == '1':
@@ -140,6 +148,9 @@ func (p *SettingsPage) HandleInput(event *tcell.EventKey) *tcell.EventKey {
 		return nil
 	case event.Key() == tcell.KeyRune && event.Rune() == '4':
 		p.toggleKeepAwake()
+		return nil
+	case event.Key() == tcell.KeyRune && event.Rune() == '5':
+		p.toggleMeeting()
 		return nil
 	case event.Key() == tcell.KeyRune && event.Rune() == ' ':
 		p.toggleTelemetry()
@@ -206,6 +217,37 @@ func (p *SettingsPage) toggleKeepAwake() {
 		}
 	}
 	p.keepAwake = next
+	p.render()
+}
+
+// reloadMeeting refreshes the in-memory meeting setting from disk.
+func (p *SettingsPage) reloadMeeting() {
+	if p.cb.LoadMeeting != nil {
+		p.meeting = p.cb.LoadMeeting()
+	}
+	if p.meeting == nil {
+		p.meeting = config.DefaultMeeting()
+	}
+}
+
+// toggleMeeting flips the meeting-capability opt-out and persists it. The change
+// takes effect on the next capability detection / worker start (the node
+// re-advertises the `meeting` tag or drops it); the inline hint says so.
+func (p *SettingsPage) toggleMeeting() {
+	if p.meeting == nil {
+		p.reloadMeeting()
+	}
+
+	next := &config.Meeting{MeetingEnabled: !p.meeting.MeetingEnabled}
+
+	if p.cb.SaveMeeting != nil {
+		if err := p.cb.SaveMeeting(next); err != nil {
+			p.meeting = next
+			p.renderWithError(fmt.Sprintf("Failed to save: %v", err))
+			return
+		}
+	}
+	p.meeting = next
 	p.render()
 }
 
@@ -355,6 +397,20 @@ func (p *SettingsPage) renderWithError(errMsg string) {
 	sb.WriteString("   this node is plugged in, so the laptop stays reachable on the\n")
 	sb.WriteString("   mesh. Released on battery and on exit. Display may still sleep.\n\n")
 	sb.WriteString("   [yellow::b]4[-:-:-] toggle keep-awake\n")
+
+	// -- Meeting capability --
+	meetingEnabled := p.meeting == nil || p.meeting.MeetingEnabled
+	sb.WriteString("\n [yellow::b]Meeting Notetaker[-:-:-]\n\n")
+	if meetingEnabled {
+		sb.WriteString("   Status:  [green::b]ON[-:-:-]  [gray](default)[-]\n")
+	} else {
+		sb.WriteString("   Status:  [red::b]OFF[-:-:-]  [gray](opted out)[-]\n")
+	}
+	sb.WriteString("\n   [white]What it does:[-] lets this node auto-join meetings to record\n")
+	sb.WriteString("   and transcribe them. Advertises the [white]meeting[-] capability when\n")
+	sb.WriteString("   the audio + browser deps are present. Opting out drops the tag so\n")
+	sb.WriteString("   the node stops receiving meeting jobs.\n\n")
+	sb.WriteString("   [yellow::b]5[-:-:-] [gray]toggle meeting capability (applies on next worker start)[-]\n")
 
 	// -- Connection status (read-only) --
 	sb.WriteString("\n [yellow::b]Connection[-:-:-]\n\n")

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -4,21 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"time"
 
+	"github.com/aceteam-ai/citadel-cli/internal/config"
 	"github.com/aceteam-ai/citadel-cli/internal/jobs"
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
-	"github.com/aceteam-ai/citadel-cli/internal/update"
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
 )
-
-// meetingEnabled reports whether the operator has opted into the meeting-join
-// capability via CITADEL_MEETING_ENABLED (truthy: 1/true/yes/on, case-insensitive).
-// Defaults to disabled when unset. Gates handler registration to match the
-// `meeting` capability advertisement gate in internal/capabilities.
-func meetingEnabled() bool {
-	return update.IsTruthy(os.Getenv("CITADEL_MEETING_ENABLED"))
-}
 
 // LegacyHandlerAdapter wraps a jobs.JobHandler to implement worker.JobHandler.
 // This allows existing handlers to work with the new worker abstraction.
@@ -240,11 +232,12 @@ func CreateLegacyHandlersWithOpts(opts LegacyHandlerOpts) []JobHandler {
 		// Auto-join meeting notetaker (aceteam#5098): records the call into a
 		// per-meeting null sink, then transcribes it via the handler above. Needs
 		// the workspace both to write the recording and to validate the audio path
-		// for transcription, so it lives inside this workspace gate. The join flow
-		// is unverified, so the handler only registers when an operator opts in via
-		// CITADEL_MEETING_ENABLED (matching the `meeting` capability gate); the PR
-		// merges dormant until then.
-		if meetingEnabled() {
+		// for transcription, so it lives inside this workspace gate. Gated on the
+		// persisted meeting toggle (default-on, the house opt-out convention) so
+		// the handler registers unless the operator has explicitly opted out —
+		// matching the `meeting` capability advertisement gate in
+		// internal/capabilities.
+		if config.LoadMeeting(platform.ConfigDir()).MeetingEnabled {
 			handlers = append(handlers,
 				NewLegacyHandlerAdapter(JobTypeMeetingJoin, jobs.NewMeetingJoinHandler(opts.WorkspaceDir)),
 			)

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -225,6 +225,11 @@ func CreateLegacyHandlersWithOpts(opts LegacyHandlerOpts) []JobHandler {
 			// with the workspace so it can validate audio paths the same way the
 			// file handlers do.
 			NewLegacyHandlerAdapter(JobTypeTranscribeAudio, jobs.NewTranscribeAudioHandler(opts.WorkspaceDir)),
+			// Auto-join meeting notetaker (aceteam#5098): records the call into a
+			// per-meeting null sink, then transcribes it via the handler above.
+			// Needs the workspace both to write the recording and to validate the
+			// audio path for transcription, so it lives inside this gate.
+			NewLegacyHandlerAdapter(JobTypeMeetingJoin, jobs.NewMeetingJoinHandler(opts.WorkspaceDir)),
 		)
 	}
 

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -4,11 +4,21 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/jobs"
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+	"github.com/aceteam-ai/citadel-cli/internal/update"
 )
+
+// meetingEnabled reports whether the operator has opted into the meeting-join
+// capability via CITADEL_MEETING_ENABLED (truthy: 1/true/yes/on, case-insensitive).
+// Defaults to disabled when unset. Gates handler registration to match the
+// `meeting` capability advertisement gate in internal/capabilities.
+func meetingEnabled() bool {
+	return update.IsTruthy(os.Getenv("CITADEL_MEETING_ENABLED"))
+}
 
 // LegacyHandlerAdapter wraps a jobs.JobHandler to implement worker.JobHandler.
 // This allows existing handlers to work with the new worker abstraction.
@@ -225,12 +235,20 @@ func CreateLegacyHandlersWithOpts(opts LegacyHandlerOpts) []JobHandler {
 			// with the workspace so it can validate audio paths the same way the
 			// file handlers do.
 			NewLegacyHandlerAdapter(JobTypeTranscribeAudio, jobs.NewTranscribeAudioHandler(opts.WorkspaceDir)),
-			// Auto-join meeting notetaker (aceteam#5098): records the call into a
-			// per-meeting null sink, then transcribes it via the handler above.
-			// Needs the workspace both to write the recording and to validate the
-			// audio path for transcription, so it lives inside this gate.
-			NewLegacyHandlerAdapter(JobTypeMeetingJoin, jobs.NewMeetingJoinHandler(opts.WorkspaceDir)),
 		)
+
+		// Auto-join meeting notetaker (aceteam#5098): records the call into a
+		// per-meeting null sink, then transcribes it via the handler above. Needs
+		// the workspace both to write the recording and to validate the audio path
+		// for transcription, so it lives inside this workspace gate. The join flow
+		// is unverified, so the handler only registers when an operator opts in via
+		// CITADEL_MEETING_ENABLED (matching the `meeting` capability gate); the PR
+		// merges dormant until then.
+		if meetingEnabled() {
+			handlers = append(handlers,
+				NewLegacyHandlerAdapter(JobTypeMeetingJoin, jobs.NewMeetingJoinHandler(opts.WorkspaceDir)),
+			)
+		}
 	}
 
 	// Register service-management handlers when a config directory is available.

--- a/internal/worker/job.go
+++ b/internal/worker/job.go
@@ -139,6 +139,7 @@ const (
 	JobTypeWhatsAppProvision = "WHATSAPP_PROVISION"  // Remotely deploy + provision the WhatsApp bridge on this node (aceteam#4454)
 	JobTypeInstanceMessage   = "INSTANCE_MESSAGE"    // Deliver a turn to a BYOC instance's loopback container (aceteam#5241)
 	JobTypeModuleSet         = "MODULE_SET"          // Set the desired state of a single module on this node (interim, aceteam#5280)
+	JobTypeMeetingJoin       = "MEETING_JOIN"        // Auto-join a video call, record + transcribe it node-locally (aceteam#5098)
 )
 
 // allKnownJobTypes enumerates every job type this citadel build knows about.
@@ -187,4 +188,5 @@ var allKnownJobTypes = []string{
 	JobTypeWhatsAppProvision,
 	JobTypeInstanceMessage,
 	JobTypeModuleSet,
+	JobTypeMeetingJoin,
 }


### PR DESCRIPTION
## Context

Sub-issue #5098 of the sovereign meeting-notetaker epic (#5097 / parent #3911) — the node-side crux. Goal: a Citadel node can be dispatched a `MEETING_JOIN` job, join a Google Meet as "AceTeam Notetaker", capture the call audio locally, and hand it to the existing `TRANSCRIBE_AUDIO` faster-whisper path. No Recall.ai, no per-meeting SaaS spend — audio never leaves the user's own node. This is the flagship dogfood of the sovereign-compute thesis.

## Summary

- **`internal/platform/audio.go`** — `NullSinkRecorder`: loads a PulseAudio null-sink, records its `.monitor` with ffmpeg, SIGINT-finalizes and unloads on stop. Proven on-node capturing real audio (−32 dB vs −91 silence). `audioStackAvailable` / `withPulseSink` / `buildAudioFFmpegArgs` helpers.
- **`internal/platform/meeting_browser.go`** — `MeetingBrowser`, a sibling of `CobrowseManager` (own Xvfb + CDP port + profile), reusing `buildChromeArgs`/`startManagedXvfb`/`withDisplay`+`withPulseSink`. Adds `Click`/`Type`/`Evaluate` over raw CDP (`Runtime.evaluate`) on top of the existing Navigate/Screenshot.
- **`internal/jobs/meeting_join.go`** — `MeetingJoinHandler`: orchestrates load-sink → launch headed Chrome on Xvfb routed to the sink → join flow → record → poll for end → stop → write `workspace/meetings/<id>.wav` → `TranscribeAudioHandler`. Contains a clearly-marked LIVE-TUNING selector block.
- **Registration** — `JobTypeMeetingJoin = "MEETING_JOIN"` in `worker/job.go` (const + allKnownJobTypes pin test), gated under the WorkspaceDir requirement in `handler_adapter.go`; `detectMeetingCapability()` in `capabilities/detector.go` so a node advertises `meeting` only when Xvfb+pulse+ffmpeg+chrome are all present.
- Tests green: `go build ./... && go vet ./... && go test -short ./...`. The on-node audio integration test skips in CI.

## ⚠️ Not ready to release — draft

The join flow is **blocked on identity (#5122)** and this is deliberately a draft:

1. **Anonymous join is falsified.** Live-tested against a real org Meet: the aceteam/adanomad Google Workspace rejects anonymous participants *before the knock reaches the host* ("You can't join this video call"). Every mechanic works (launch, name fill, cam/mic off, click "Ask to join", audio routing) — the join itself is policy-bounced. So the node needs a **signed-in bot Google account + persistent pre-authed Chrome profile** (#5122). Until that lands, a released `meeting` capability would fail 100% of dispatches.
2. **Selectors need live tuning** — the LIVE-TUNING block in `meeting_join.go` was written against Meet's current DOM but not yet verified end-to-end through admit→audio→transcript (needs a live Meet + the signed-in profile).
3. **Landmines flagged for follow-up:** no orphan-reaper for meeting profile dirs + null-sinks on hard-kill (mirror `cobrowse_orphan.go`, aceteam #396); display/port TOCTOU if concurrent meetings.

**Merge/release sequencing:** land #5122 (signed-in identity + persistent profile) and tune selectors against a live Meet first, then flip this to ready and cut a citadel release so nodes advertise `meeting`. Merging the code to `main` early is safe (dormant — nothing dispatches `MEETING_JOIN` yet, and the capability only advertises when the full audio stack is present).

Closes #5098 (code). Blocked-by #5122. Part of epic #5097.
