### PR TITLE
ci(whisper-service): build + publish image to GHCR (#465)

### DIFF
--- a/.github/workflows/build-whisper-service.yml
+++ b/.github/workflows/build-whisper-service.yml
@@ -1,0 +1,60 @@
+name: Build whisper-service image
+
+# Builds and publishes the node-local faster-whisper STT sidecar to GHCR as
+# ghcr.io/aceteam-ai/whisper-service. The node compose file
+# (services/compose/transcribe.yml) pulls this image when a node provisions the
+# "transcribe" runtime via SERVICE_START, so the image MUST exist in the
+# registry (public) for every fabric node. Without it, node-local transcription
+# (POST /native/transcribe, the Chrome extension, and the meeting bot) fails
+# with a `denied` pull on every node. See aceteam-ai/citadel-cli#465.
+#
+# Triggers only when the service source changes on main (or manually), so
+# ordinary Go PRs don't rebuild the image. Tags: `latest` on main plus the
+# commit SHA for pinning/rollback.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "services/whisper-service/**"
+      - ".github/workflows/build-whisper-service.yml"
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE: ghcr.io/aceteam-ai/whisper-service
+
+jobs:
+  build:
+    name: Build + push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: services/whisper-service
+          file: services/whisper-service/Dockerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Context

Node-local ("sovereign") audio transcription is broken fleet-wide: the node compose file (`services/compose/transcribe.yml`) pulls `ghcr.io/aceteam-ai/whisper-service:latest` when a node provisions the "transcribe" runtime, but that image was never published. Source exists (`services/whisper-service/`) but no CI workflow builds and pushes it, so every node hits a `denied` pull and `POST /native/transcribe`, the Chrome extension, and the meeting bot all fail.

## What this does

Adds `.github/workflows/build-whisper-service.yml`, mirroring the existing `build-claudecode-service.yml` convention:

- Triggers on push to `main` when `services/whisper-service/**` changes (plus `workflow_dispatch` for manual runs), so ordinary Go PRs don't trigger a rebuild.
- Builds `services/whisper-service/Dockerfile` with Buildx + GHA layer caching.
- Pushes `ghcr.io/aceteam-ai/whisper-service:latest` and `:${{ github.sha }}` for pinning/rollback.

Verified the Dockerfile builds cleanly locally (`python:3.12-slim` + `ffmpeg` + `faster-whisper` 1.0.3 / `fastapi` / `uvicorn`, ~9s install, image exports fine).

## Post-merge human steps

1. After merge, the workflow runs automatically on the next push to `main` that touches `services/whisper-service/**` — or trigger it immediately via `workflow_dispatch` (Actions tab → "Build whisper-service image" → Run workflow).
2. Once the first build completes, a human must set the `whisper-service` GHCR package visibility to **Public**: Org → Packages → `whisper-service` → Package settings → Change visibility. Fabric nodes pull the image anonymously, so a private package will still return `denied` even after this workflow runs — same requirement as `claudecode-service`.

Closes #465