### PR TITLE
feat(jobs): optional runtime field in inline SERVICE_START spec (#470)

### DIFF
--- a/internal/jobs/instance_store.go
+++ b/internal/jobs/instance_store.go
@@ -45,6 +45,10 @@ type InstanceRecord struct {
 	StateVolumePath string `json:"state_volume_path"`
 	// StateMountPath is the container path StateVolumePath is mounted at.
 	StateMountPath string `json:"state_mount_path"`
+	// Runtime is the allowlist-validated docker runtime the instance runs under
+	// (e.g. "kata", "runsc"). Empty means the daemon default (runc). Recorded so
+	// SERVICE_STATUS can report the runtime a BYOC instance is isolated by.
+	Runtime string `json:"runtime,omitempty"`
 }
 
 // instanceStore persists the set of payload-launched instances to a JSON file.

--- a/internal/jobs/service_handler.go
+++ b/internal/jobs/service_handler.go
@@ -74,6 +74,10 @@ type serviceResult struct {
 	// provisioned service. Empty for native services or when no host port is
 	// published. See citadel-cli#415.
 	Endpoint string `json:"endpoint,omitempty"`
+	// Runtime is the docker container runtime a payload-launched instance runs
+	// under (e.g. "kata", "runsc"). Empty for the daemon default (runc) and for
+	// manifest/native services. See citadel-cli#470.
+	Runtime string `json:"runtime,omitempty"`
 }
 
 func (h *ServiceHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {

--- a/internal/jobs/service_payload.go
+++ b/internal/jobs/service_payload.go
@@ -79,7 +79,19 @@ type instanceSpec struct {
 	// StateVolumePath is the absolute, ~-expanded, validated host path.
 	StateVolumePath string
 	StateMountPath  string
+	// Runtime is the optional, allowlist-validated docker container runtime the
+	// instance runs under (e.g. "kata", "runsc"). Empty means the daemon default
+	// (runc). Set so an untrusted BYOC workload can run under a stronger runtime
+	// (aceteam#5028 / substrate spike #468).
+	Runtime string
 }
+
+// allowedRuntimes is the strict allowlist of docker `--runtime` values a payload
+// may request. The value is passed to `docker run --runtime=<value>`, so it is a
+// code-execution surface: an unvalidated string would let a payload select an
+// arbitrary runtime binary. Only these exact spellings are accepted; the daemon
+// preflight (preflightRuntime) then confirms the requested one is registered.
+var allowedRuntimes = []string{"kata", "kata-runtime", "runsc"}
 
 // payloadHasInlineSpec reports whether a job payload is the extended,
 // self-contained launch form (carries an "image") rather than the legacy
@@ -137,6 +149,11 @@ func parseInstanceSpec(payload map[string]string, homeDir string) (*instanceSpec
 		return nil, err
 	}
 
+	runtime := strings.TrimSpace(payload["runtime"])
+	if err := validateRuntime(runtime); err != nil {
+		return nil, err
+	}
+
 	// Container port: honor an explicit PORT in the payload env, else the
 	// wrapper's default. The host port is published to this in-container port.
 	containerPort := defaultContainerPort
@@ -158,7 +175,25 @@ func parseInstanceSpec(payload map[string]string, homeDir string) (*instanceSpec
 		ContainerPort:   containerPort,
 		StateVolumePath: volPath,
 		StateMountPath:  mountPath,
+		Runtime:         runtime,
 	}, nil
+}
+
+// validateRuntime enforces the strict runtime allowlist. An empty value is
+// valid (the daemon default runtime is used and no `--runtime` flag is passed).
+// Any other value must match an allowed spelling exactly; this is what keeps an
+// arbitrary string from reaching `docker run --runtime=`.
+func validateRuntime(runtime string) error {
+	if runtime == "" {
+		return nil
+	}
+	for _, allowed := range allowedRuntimes {
+		if runtime == allowed {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid runtime %q: allowed runtimes are %s",
+		runtime, strings.Join(allowedRuntimes, ", "))
 }
 
 // validateServiceName rejects names that could break out of the "citadel-<name>"
@@ -308,6 +343,14 @@ func buildDockerRunArgs(spec *instanceSpec) []string {
 		"-v", fmt.Sprintf("%s:%s", spec.StateVolumePath, spec.StateMountPath),
 	}
 
+	// Run under an alternative container runtime when one is requested (Kata,
+	// gVisor). Omitted entirely when empty so the daemon default (runc) is used.
+	// The value is allowlist-validated at parse time (validateRuntime), so it is
+	// never an arbitrary `--runtime` argument.
+	if spec.Runtime != "" {
+		args = append(args, "--runtime="+spec.Runtime)
+	}
+
 	// Inject the durability + port env unless the payload already set them, so
 	// the runtime writes into the mounted volume and listens on the published
 	// port. Explicit payload values win.
@@ -375,6 +418,13 @@ func (h *ServiceHandler) serviceStartPayload(ctx JobContext, job *nexus.Job) ([]
 		return h.instanceResult(spec, "start", true, "")
 	}
 
+	// Preflight the requested runtime against the local Docker daemon so a node
+	// without Kata/gVisor installed fails the job with an actionable message
+	// rather than letting `docker run --runtime=...` fail cryptically.
+	if err := preflightRuntime(spec.Runtime); err != nil {
+		return nil, err
+	}
+
 	// Ensure the state volume dir exists on the host before mounting. The
 	// container entrypoint chowns it to the runtime user, so host ownership is
 	// fine; it just has to exist.
@@ -413,6 +463,7 @@ func (h *ServiceHandler) serviceStatusPayload(rec InstanceRecord) ([]byte, error
 		Running: running,
 		Kind:    "docker",
 		Action:  "status",
+		Runtime: rec.Runtime,
 		Message: fmt.Sprintf("%s is %s (docker)", rec.ServiceName, boolToStatus(running)),
 	})
 }
@@ -445,7 +496,7 @@ func (h *ServiceHandler) serviceStopPayload(ctx JobContext, rec InstanceRecord) 
 func (h *ServiceHandler) instanceResult(spec *instanceSpec, action string, running bool, errMsg string) ([]byte, error) {
 	res := serviceResult{
 		Name: spec.ServiceName, Running: running, Kind: "docker",
-		Action: action, Error: errMsg,
+		Action: action, Error: errMsg, Runtime: spec.Runtime,
 	}
 	endpoint := fmt.Sprintf("127.0.0.1:%d", spec.HostPort)
 	res.Endpoint = endpoint
@@ -468,6 +519,7 @@ func (h *ServiceHandler) recordInstance(spec *instanceSpec) error {
 		ContainerPort:   spec.ContainerPort,
 		StateVolumePath: spec.StateVolumePath,
 		StateMountPath:  spec.StateMountPath,
+		Runtime:         spec.Runtime,
 	})
 }
 
@@ -493,4 +545,66 @@ func (h *ServiceHandler) instanceStore() *instanceStore {
 func (h *ServiceHandler) dockerContainerExists(containerName string) bool {
 	cmd := exec.Command("docker", "inspect", "--format", "{{.Name}}", containerName)
 	return cmd.Run() == nil
+}
+
+// dockerRuntimesFunc returns the set of container runtimes registered with the
+// local Docker daemon (the keys of `docker info`'s .Runtimes map). It is a
+// package var so the preflight is testable without a running daemon.
+var dockerRuntimesFunc = defaultDockerRuntimes
+
+// defaultDockerRuntimes queries the local Docker daemon for its configured
+// runtimes. `docker info --format '{{json .Runtimes}}'` prints a JSON object
+// keyed by runtime name (runc plus any operator-registered runtime such as
+// kata-runtime or runsc).
+func defaultDockerRuntimes() (map[string]bool, error) {
+	cmd := exec.Command("docker", "info", "--format", "{{json .Runtimes}}")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to query docker runtimes: %w", err)
+	}
+	var runtimes map[string]json.RawMessage
+	if err := json.Unmarshal(out, &runtimes); err != nil {
+		return nil, fmt.Errorf("failed to parse docker runtimes: %w", err)
+	}
+	set := make(map[string]bool, len(runtimes))
+	for name := range runtimes {
+		set[name] = true
+	}
+	return set, nil
+}
+
+// preflightRuntime verifies the requested runtime is actually registered with
+// the local Docker daemon before launch, so a node missing Kata/gVisor fails
+// with an actionable message instead of a cryptic `docker run` error. An empty
+// runtime (the daemon default) needs no daemon round-trip. The requested value
+// is checked verbatim -- a "kata" request is NOT satisfied by a daemon that
+// registered the runtime as "kata-runtime"; that mismatch must surface here.
+func preflightRuntime(runtime string) error {
+	if runtime == "" {
+		return nil
+	}
+	runtimes, err := dockerRuntimesFunc()
+	if err != nil {
+		return fmt.Errorf("cannot verify runtime %s: %w", runtime, err)
+	}
+	if !runtimes[runtime] {
+		return fmt.Errorf("runtime %s requested but not installed on this node (registered runtimes: %s)",
+			runtime, strings.Join(sortedBoolKeys(runtimes), ", "))
+	}
+	return nil
+}
+
+// sortedBoolKeys returns the keys of a set in ascending order for a stable
+// error message.
+func sortedBoolKeys(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	for i := 1; i < len(keys); i++ {
+		for j := i; j > 0 && keys[j-1] > keys[j]; j-- {
+			keys[j-1], keys[j] = keys[j], keys[j-1]
+		}
+	}
+	return keys
 }

--- a/internal/jobs/service_payload_test.go
+++ b/internal/jobs/service_payload_test.go
@@ -119,6 +119,9 @@ func TestParseInstanceSpec_Rejects(t *testing.T) {
 		{"volume outside data dir", func(p map[string]string) { p["state_volume_path"] = "/etc" }, "outside the citadel data dir"},
 		{"volume traversal via ~", func(p map[string]string) { p["state_volume_path"] = "~/../../etc/passwd" }, "outside the citadel data dir"},
 		{"relative mount path", func(p map[string]string) { p["state_mount_path"] = "state" }, "must be an absolute container path"},
+		{"runtime not allowed", func(p map[string]string) { p["runtime"] = "runsc-evil" }, "invalid runtime"},
+		{"runtime shell injection", func(p map[string]string) { p["runtime"] = "kata; rm -rf /" }, "invalid runtime"},
+		{"runtime flag injection", func(p map[string]string) { p["runtime"] = "--privileged" }, "invalid runtime"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -250,6 +253,142 @@ func TestBuildDockerRunArgs_PayloadEnvWins(t *testing.T) {
 		t.Errorf("expected exactly one CLAUDE_CONFIG_DIR env, got %d", n)
 	}
 }
+
+func TestValidateRuntime(t *testing.T) {
+	tests := []struct {
+		runtime string
+		wantErr bool
+	}{
+		{"", false},             // empty -> daemon default, no flag
+		{"kata", false},         // allowed
+		{"kata-runtime", false}, // allowed
+		{"runsc", false},        // allowed
+		{"runc", true},          // not on the allowlist (default is the empty string, not "runc")
+		{"nvidia", true},        // not on the allowlist
+		{"runsc-evil", true},    // near-miss must not pass
+		{"kata; rm -rf /", true},
+		{"--privileged", true},
+		{"kata runsc", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.runtime, func(t *testing.T) {
+			err := validateRuntime(tt.runtime)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateRuntime(%q) err = %v, wantErr %v", tt.runtime, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseInstanceSpec_Runtime(t *testing.T) {
+	p := basePayload()
+	p["runtime"] = "kata"
+	spec, err := parseInstanceSpec(p, testHome)
+	if err != nil {
+		t.Fatalf("parseInstanceSpec: %v", err)
+	}
+	if spec.Runtime != "kata" {
+		t.Errorf("Runtime = %q, want kata", spec.Runtime)
+	}
+
+	// Omitted runtime -> empty (daemon default).
+	spec2, err := parseInstanceSpec(basePayload(), testHome)
+	if err != nil {
+		t.Fatalf("parseInstanceSpec: %v", err)
+	}
+	if spec2.Runtime != "" {
+		t.Errorf("Runtime = %q, want empty", spec2.Runtime)
+	}
+}
+
+func TestBuildDockerRunArgs_Runtime(t *testing.T) {
+	base := func() *instanceSpec {
+		return &instanceSpec{
+			ServiceName:     "ac-x",
+			ContainerName:   "citadel-ac-x",
+			Image:           "ghcr.io/aceteam-ai/claudecode-service:latest",
+			Env:             map[string]string{},
+			HostPort:        18789,
+			ContainerPort:   8787,
+			StateVolumePath: "/home/citadel/citadel-cache/instances/i-1",
+			StateMountPath:  "/state",
+		}
+	}
+
+	// With runtime: exactly one --runtime=<value> flag, image still last.
+	withRT := base()
+	withRT.Runtime = "runsc"
+	args := buildDockerRunArgs(withRT)
+	if args[len(args)-1] != withRT.Image {
+		t.Errorf("image is not the last arg: %v", args)
+	}
+	n := 0
+	for _, a := range args {
+		if a == "--runtime=runsc" {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Errorf("expected exactly one --runtime=runsc arg, got %d in %v", n, args)
+	}
+
+	// Without runtime: no --runtime flag at all.
+	noRT := base()
+	got := strings.Join(buildDockerRunArgs(noRT), " ")
+	if strings.Contains(got, "--runtime") {
+		t.Errorf("did not expect a --runtime flag, got: %s", got)
+	}
+}
+
+func TestPreflightRuntime(t *testing.T) {
+	// Empty runtime never touches the daemon and always passes.
+	orig := dockerRuntimesFunc
+	defer func() { dockerRuntimesFunc = orig }()
+
+	dockerRuntimesFunc = func() (map[string]bool, error) {
+		t.Fatal("preflightRuntime queried the daemon for an empty runtime")
+		return nil, nil
+	}
+	if err := preflightRuntime(""); err != nil {
+		t.Errorf("preflightRuntime(\"\") = %v, want nil", err)
+	}
+
+	// Requested runtime registered with the daemon -> pass.
+	dockerRuntimesFunc = func() (map[string]bool, error) {
+		return map[string]bool{"runc": true, "kata-runtime": true}, nil
+	}
+	if err := preflightRuntime("kata-runtime"); err != nil {
+		t.Errorf("preflightRuntime(kata-runtime) = %v, want nil", err)
+	}
+
+	// Requested runtime absent -> actionable failure. A "kata" request is NOT
+	// satisfied by a daemon that only registered "kata-runtime" (verbatim check).
+	dockerRuntimesFunc = func() (map[string]bool, error) {
+		return map[string]bool{"runc": true, "kata-runtime": true}, nil
+	}
+	err := preflightRuntime("kata")
+	if err == nil {
+		t.Fatal("expected preflight failure for absent runtime, got nil")
+	}
+	if !strings.Contains(err.Error(), "not installed on this node") {
+		t.Errorf("error = %q, want 'not installed on this node'", err.Error())
+	}
+
+	// Daemon query error propagates.
+	dockerRuntimesFunc = func() (map[string]bool, error) {
+		return nil, errStub
+	}
+	if err := preflightRuntime("runsc"); err == nil {
+		t.Error("expected preflight to propagate daemon query error, got nil")
+	}
+}
+
+// errStub is a sentinel error for the daemon-query failure path.
+var errStub = stubErr("docker daemon unreachable")
+
+type stubErr string
+
+func (e stubErr) Error() string { return string(e) }
 
 // itoa avoids importing strconv just for the reserved-port table above.
 func itoa(n int) string {


### PR DESCRIPTION
Closes #470

## Context
First concrete step of the substrate spike (#468) and the mechanism gap behind aceteam#5028: make the container runtime pluggable so a node with Kata Containers or gVisor installed can run untrusted BYOC instances under a stronger runtime. No platform change required — the platform sends the field when it decides to.

## Changes
- `internal/jobs/service_payload.go`
  - `instanceSpec` gains a `Runtime` field; `parseInstanceSpec` reads the optional `runtime` payload field.
  - `validateRuntime`: strict allowlist (`kata`, `kata-runtime`, `runsc`). Empty = daemon default. Any other non-empty value rejects the job. Unvalidated input never reaches `docker --runtime`.
  - `buildDockerRunArgs`: injects `--runtime=<value>` when set, omits entirely when empty.
  - `preflightRuntime` + `dockerRuntimesFunc` (func-var seam): before launch, parses `docker info --format '{{json .Runtimes}}'` and confirms the requested runtime is registered. Requested value is checked **verbatim** (a `kata` request is not satisfied by a daemon that registered `kata-runtime`). Absent runtime fails the job with an actionable message ("runtime kata requested but not installed on this node") instead of a cryptic `docker run` error. Empty runtime takes no daemon round-trip.
- `internal/jobs/instance_store.go`: `InstanceRecord.Runtime` persisted.
- `internal/jobs/service_handler.go`: `serviceResult.Runtime`; `serviceStatusPayload` reports the runtime an instance runs under.

## Validation approach
Two layers, defense in depth:
1. **Allowlist at parse** — exact-match against `{kata, kata-runtime, runsc}`; injection-shaped values (`kata; rm -rf /`, `--privileged`) and near-misses (`runsc-evil`) are rejected before any docker call.
2. **Daemon preflight before launch** — the requested runtime must actually be registered with the local Docker daemon, so a mis-provisioned node fails fast and clearly.

## Out of scope (stays in #468)
Installing Kata, trust-tier→runtime policy (platform decides and sends the field), GPU-passthrough-under-kata validation.

## Testing
`go build ./... && go vet ./... && gofmt -l . && go test ./...` — all green (`gofmt -l .` prints nothing).

New/updated unit tests in `service_payload_test.go`:
- `TestValidateRuntime` — allowlist accept/reject incl. shell/flag injection and near-miss.
- `TestParseInstanceSpec_Rejects` — added runtime not-allowed / shell-injection / flag-injection cases.
- `TestParseInstanceSpec_Runtime` — set vs omitted.
- `TestBuildDockerRunArgs_Runtime` — exactly one `--runtime=` flag when set, image still last; no flag when empty.
- `TestPreflightRuntime` — empty (no daemon round-trip), present, absent (actionable message), daemon-query-error propagation; func-var stub restored via `defer`.