### PR TITLE
feat(storage): citadel storage start|status|stop backed by VersityGW (#469)

### DIFF
--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -1,0 +1,120 @@
+// cmd/storage.go
+// On-node S3-compatible object storage (VersityGW), M1 of the object-storage
+// epic (#466 / #469).
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/aceteam-ai/citadel-cli/internal/storage"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+var storageCmd = &cobra.Command{
+	Use:   "storage",
+	Short: "Manage on-node S3-compatible object storage",
+	Long: `Run an S3-compatible object store on this node, backed by VersityGW.
+
+Objects are stored under ~/.citadel/storage/data and survive restarts. The
+gateway is published on 127.0.0.1 only (never 0.0.0.0). Root credentials are
+minted once on first start and reused on every restart, so stored objects and
+presigned URLs remain valid.`,
+}
+
+var storageStartCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Start the object storage gateway",
+	RunE:  runStorageStart,
+}
+
+var storageStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show the object storage gateway status",
+	RunE:  runStorageStatus,
+}
+
+var storageStopCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "Stop the object storage gateway",
+	RunE:  runStorageStop,
+}
+
+func init() {
+	rootCmd.AddCommand(storageCmd)
+	storageCmd.AddCommand(storageStartCmd)
+	storageCmd.AddCommand(storageStatusCmd)
+	storageCmd.AddCommand(storageStopCmd)
+}
+
+func runStorageStart(cmd *cobra.Command, args []string) error {
+	fmt.Println("Starting object storage gateway...")
+	if err := storage.Start(); err != nil {
+		return err
+	}
+	st, err := storage.GetStatus()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Storage gateway is running.\n")
+	fmt.Printf("  Endpoint:   %s\n", st.Endpoint)
+	fmt.Printf("  Access key: %s\n", st.AccessKey)
+	fmt.Printf("  Data:       ~/.citadel/storage/data\n")
+	fmt.Printf("\nRoot credentials are stored in ~/.citadel/storage/state.json.\n")
+	fmt.Printf("Reach it with: aws --endpoint-url %s s3 ls\n", st.Endpoint)
+	return nil
+}
+
+func runStorageStatus(cmd *cobra.Command, args []string) error {
+	st, err := storage.GetStatus()
+	if err != nil {
+		return err
+	}
+
+	stateStr := color.New(color.FgRed).Sprint("stopped")
+	if st.Running {
+		if st.Healthy {
+			stateStr = color.New(color.FgGreen).Sprint("running (healthy)")
+		} else {
+			stateStr = color.New(color.FgYellow).Sprint("running (unhealthy)")
+		}
+	}
+
+	meshStr := st.MeshIP
+	if meshStr == "" {
+		meshStr = "unavailable (node not connected in this process)"
+	}
+
+	fmt.Printf("Object storage gateway\n")
+	fmt.Printf("  Status:   %s\n", stateStr)
+	fmt.Printf("  Endpoint: %s\n", st.Endpoint)
+	fmt.Printf("  Mesh IP:  %s\n", meshStr)
+	fmt.Printf("  Port:     %d\n", st.Port)
+	fmt.Printf("  Buckets:  %d\n", st.BucketCount)
+	fmt.Printf("  Used:     %s (approx)\n", humanBytes(st.BytesUsed))
+	return nil
+}
+
+// humanBytes renders a byte count in a compact human-readable form (e.g.
+// "1.5 MiB"). Kept local to avoid promoting the go-humanize indirect dependency.
+func humanBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for x := n / unit; x >= unit; x /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(n)/float64(div), "KMGTPE"[exp])
+}
+
+func runStorageStop(cmd *cobra.Command, args []string) error {
+	fmt.Println("Stopping object storage gateway...")
+	if err := storage.Stop(); err != nil {
+		return err
+	}
+	fmt.Println("Storage gateway stopped. Objects and credentials are preserved.")
+	return nil
+}

--- a/internal/storage/gateway.go
+++ b/internal/storage/gateway.go
@@ -1,0 +1,267 @@
+package storage
+
+import (
+	"fmt"
+	"io/fs"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/network"
+	"github.com/aceteam-ai/citadel-cli/services"
+)
+
+// Image is the pinned VersityGW image. It is a BUILT-IN, operator-vetted
+// reference baked into the binary, NOT a remotely-supplied one, so it is
+// deliberately exempt from the internal/jobs SERVICE_START registry allowlist
+// (which constrains untrusted inline payload images to ghcr.io/aceteam-ai/).
+// VersityGW's official image lives on Docker Hub; pinning an exact tag here is
+// the trust boundary. Bump this constant to upgrade.
+const Image = "versity/versitygw:v1.6.0"
+
+// ContainerName is the docker container name for the storage gateway. The
+// "citadel-" prefix matches the manifest/payload service convention.
+const ContainerName = "citadel-storage"
+
+// containerPort is VersityGW's in-container S3 listen port. The host publish
+// (services.StorageHostPort) maps to this.
+const containerPort = 7070
+
+// containerDataDir / containerIAMDir are the in-container mount targets for the
+// posix backing dir and the gateway's IAM state.
+const (
+	containerDataDir = "/data"
+	containerIAMDir  = "/iam"
+)
+
+// HostPort is the fixed host port the gateway publishes on.
+func HostPort() int { return services.StorageHostPort }
+
+// dockerRunArgs assembles the `docker run` arguments for the gateway. Pure
+// (inputs in, args out) so the port/bind/volume/env/command wiring is testable
+// without Docker.
+//
+// Binding: the container is published on 127.0.0.1 ONLY. It is never bound to
+// 0.0.0.0, so it is not exposed on the LAN or publicly. It is also not bound to
+// the node's mesh IP: that address is a userspace-tsnet virtual IP with no
+// kernel interface, so `docker -p <mesh-ip>:...` cannot bind it. Mesh
+// reachability for S3 needs a TCP-preserving relay (a path-rewriting gateway
+// route would break SigV4, which signs host+path); that is deferred past M1.
+//
+// Credentials are passed as environment (ROOT_ACCESS_KEY/ROOT_SECRET_KEY), not
+// on the command line, so the secret never appears in the container's argv.
+// VersityGW args are passed explicitly (the image entrypoint execs the binary
+// with "$@"), which is stable across image versions.
+func dockerRunArgs(creds Credentials, hostPort int, dataDir, iamDir string) []string {
+	args := []string{
+		"run", "-d",
+		"--name", ContainerName,
+		// Survive node reboot with no citadel loop (nothing else auto-starts
+		// this). STOP does an explicit `docker rm`, so this never resurrects a
+		// deliberately stopped gateway.
+		"--restart", "unless-stopped",
+		// Loopback publish only. Never 0.0.0.0.
+		"-p", fmt.Sprintf("127.0.0.1:%d:%d", hostPort, containerPort),
+		"-v", fmt.Sprintf("%s:%s", dataDir, containerDataDir),
+		"-v", fmt.Sprintf("%s:%s", iamDir, containerIAMDir),
+		"-e", "ROOT_ACCESS_KEY=" + creds.AccessKey,
+		"-e", "ROOT_SECRET_KEY=" + creds.SecretKey,
+		Image,
+		// Global flags precede the posix subcommand; posix takes the backing dir.
+		"--port", fmt.Sprintf(":%d", containerPort),
+		"--iam-dir", containerIAMDir,
+		"posix", containerDataDir,
+	}
+	return args
+}
+
+// Status is the reported state of the storage gateway.
+type Status struct {
+	Running     bool   `json:"running"`
+	Healthy     bool   `json:"healthy"`
+	Endpoint    string `json:"endpoint"`
+	MeshIP      string `json:"mesh_ip"`
+	Port        int    `json:"port"`
+	BucketCount int    `json:"bucket_count"`
+	BytesUsed   int64  `json:"bytes_used"`
+	AccessKey   string `json:"access_key"`
+}
+
+// Start launches the gateway container. It is idempotent: if the container is
+// already running it returns without error. Credentials are create-once (loaded
+// or minted by LoadOrCreateState); the backing dir is bounded to the storage
+// data dir.
+func Start() error {
+	if err := dockerAvailable(); err != nil {
+		return err
+	}
+	state, err := LoadOrCreateState()
+	if err != nil {
+		return fmt.Errorf("failed to load storage state: %w", err)
+	}
+
+	if containerRunning() {
+		return nil
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("cannot resolve home directory: %w", err)
+	}
+	dataDir, err := resolveBackingDir("", homeDir)
+	if err != nil {
+		return err
+	}
+	iamDir, err := IAMDir()
+	if err != nil {
+		return err
+	}
+	// 0700: the backing dirs hold object data and IAM state.
+	if err := os.MkdirAll(dataDir, 0700); err != nil {
+		return fmt.Errorf("failed to create backing dir %s: %w", dataDir, err)
+	}
+	if err := os.MkdirAll(iamDir, 0700); err != nil {
+		return fmt.Errorf("failed to create iam dir %s: %w", iamDir, err)
+	}
+
+	// A stale stopped container with the same name blocks `docker run --name`;
+	// remove it first (best-effort). The backing dirs on disk are untouched, so a
+	// relaunch reattaches the same durable state and credentials.
+	_ = exec.Command("docker", "rm", "-f", ContainerName).Run()
+
+	args := dockerRunArgs(state.Credentials, HostPort(), dataDir, iamDir)
+	if out, runErr := exec.Command("docker", args...).CombinedOutput(); runErr != nil {
+		return fmt.Errorf("failed to launch storage gateway: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// Stop stops and removes the gateway container. The backing dirs (objects, IAM,
+// credentials) are left intact so a later Start reattaches them.
+func Stop() error {
+	if !containerRunning() && !containerExists() {
+		return nil
+	}
+	if out, err := exec.Command("docker", "rm", "-f", ContainerName).CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to stop storage gateway: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// GetStatus reports the gateway's current state: endpoint, mesh IP, port, bucket
+// count, bytes used, and health.
+func GetStatus() (*Status, error) {
+	state, err := loadState()
+	if err != nil {
+		return nil, err
+	}
+	running := containerRunning()
+	port := HostPort()
+
+	st := &Status{
+		Running:   running,
+		Endpoint:  fmt.Sprintf("http://127.0.0.1:%d", port),
+		MeshIP:    meshIP(),
+		Port:      port,
+		AccessKey: state.Credentials.AccessKey,
+	}
+
+	dataDir, derr := DataDir()
+	if derr == nil {
+		if count, bytes, aerr := usage(dataDir); aerr == nil {
+			st.BucketCount = count
+			st.BytesUsed = bytes
+		}
+	}
+
+	if running {
+		st.Healthy = healthy(st.Endpoint)
+	}
+	return st, nil
+}
+
+// usage reports the bucket count and bytes used under the posix backing dir. In
+// the posix backend each bucket is a top-level directory and each object is a
+// regular file, so buckets are the non-dotfile immediate subdirectories and
+// bytes-used is the sum of regular-file sizes. These are filesystem-level
+// approximations (no S3 auth needed) and are documented as such in status.
+func usage(dataDir string) (int, int64, error) {
+	entries, err := os.ReadDir(dataDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, 0, nil
+		}
+		return 0, 0, err
+	}
+	buckets := 0
+	for _, e := range entries {
+		if e.IsDir() && !strings.HasPrefix(e.Name(), ".") {
+			buckets++
+		}
+	}
+
+	var total int64
+	_ = filepath.WalkDir(dataDir, func(_ string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil // best-effort: skip unreadable entries
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if info, ierr := d.Info(); ierr == nil {
+			total += info.Size()
+		}
+		return nil
+	})
+	return buckets, total, nil
+}
+
+// healthy reports whether the gateway answers HTTP. VersityGW returns an S3 XML
+// error (e.g. 403 AccessDenied) to an anonymous request, which is still a valid
+// HTTP response and proves the listener is up. A connection refused/timeout is
+// unhealthy.
+func healthy(endpoint string) bool {
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Get(endpoint)
+	if err != nil {
+		return false
+	}
+	_ = resp.Body.Close()
+	return true
+}
+
+// meshIP returns the node's AceTeam Network IPv4 best-effort. In a one-shot CLI
+// invocation the embedded tsnet server is not running, so this is typically ""
+// unless the command runs inside a connected process; it is informational only.
+func meshIP() string {
+	ip, err := network.GetGlobalIPv4()
+	if err != nil {
+		return ""
+	}
+	return ip
+}
+
+// dockerAvailable checks that the docker daemon is responsive.
+func dockerAvailable() error {
+	if err := exec.Command("docker", "info").Run(); err != nil {
+		return fmt.Errorf("Docker is not available (is Docker installed and running?): %w", err)
+	}
+	return nil
+}
+
+// containerRunning reports whether the gateway container is running.
+func containerRunning() bool {
+	out, err := exec.Command("docker", "inspect", "--format", "{{.State.Status}}", ContainerName).Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) == "running"
+}
+
+// containerExists reports whether the gateway container exists in any state.
+func containerExists() bool {
+	return exec.Command("docker", "inspect", "--format", "{{.Name}}", ContainerName).Run() == nil
+}

--- a/internal/storage/gateway_test.go
+++ b/internal/storage/gateway_test.go
@@ -1,0 +1,114 @@
+package storage
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/services"
+)
+
+// TestDockerRunArgs asserts the container is published on loopback only (never
+// 0.0.0.0 and never the mesh IP), credentials go via env not argv, and the
+// VersityGW posix command is assembled correctly against the pinned image.
+func TestDockerRunArgs(t *testing.T) {
+	creds := Credentials{AccessKey: "AKIAEXAMPLE", SecretKey: "s3cr3t/secret+key"}
+	args := dockerRunArgs(creds, services.StorageHostPort, "/home/x/.citadel/storage/data", "/home/x/.citadel/storage/iam")
+	joined := strings.Join(args, " ")
+
+	wantPublish := fmt.Sprintf("127.0.0.1:%d:%d", services.StorageHostPort, containerPort)
+	if !containsPair(args, "-p", wantPublish) {
+		t.Fatalf("expected loopback publish %q, got: %s", wantPublish, joined)
+	}
+	// Must never bind all interfaces.
+	if strings.Contains(joined, "0.0.0.0") {
+		t.Fatalf("args must not bind 0.0.0.0: %s", joined)
+	}
+
+	// Restart policy for reboot survival.
+	if !containsPair(args, "--restart", "unless-stopped") {
+		t.Fatalf("expected --restart unless-stopped: %s", joined)
+	}
+
+	// Credentials via env, not on the command line.
+	if !containsPair(args, "-e", "ROOT_ACCESS_KEY="+creds.AccessKey) ||
+		!containsPair(args, "-e", "ROOT_SECRET_KEY="+creds.SecretKey) {
+		t.Fatalf("expected creds passed via -e env: %s", joined)
+	}
+
+	// Both mounts present.
+	if !containsPair(args, "-v", "/home/x/.citadel/storage/data:"+containerDataDir) {
+		t.Fatalf("expected data volume mount: %s", joined)
+	}
+	if !containsPair(args, "-v", "/home/x/.citadel/storage/iam:"+containerIAMDir) {
+		t.Fatalf("expected iam volume mount: %s", joined)
+	}
+
+	// Pinned image, then the posix command with the backing dir last.
+	if !strings.Contains(joined, Image) {
+		t.Fatalf("expected pinned image %q: %s", Image, joined)
+	}
+	if !strings.HasSuffix(joined, "posix "+containerDataDir) {
+		t.Fatalf("expected posix backing dir as final arg: %s", joined)
+	}
+	// The image must appear before the versitygw flags (so they are not read as
+	// docker flags).
+	imgIdx := indexOf(args, Image)
+	posixIdx := indexOf(args, "posix")
+	if imgIdx < 0 || posixIdx < 0 || imgIdx > posixIdx {
+		t.Fatalf("image must precede the posix subcommand: %s", joined)
+	}
+}
+
+// TestStorageHostPort_Allocation asserts the fixed host port is a well-behaved
+// registry slot: outside citadel's reserved listeners, outside the apps
+// auto-allocation range, and unique among the managed service host ports. This
+// is the "port allocation" guarantee for the storage service.
+func TestStorageHostPort_Allocation(t *testing.T) {
+	port := HostPort()
+	if port != services.StorageHostPort {
+		t.Fatalf("HostPort() = %d, want registry slot %d", port, services.StorageHostPort)
+	}
+
+	// Not a citadel-reserved listener (gateway, status, VNC, terminal, ...).
+	if name, reserved := services.ReservedCitadelPorts[port]; reserved {
+		t.Fatalf("storage port %d collides with reserved citadel port %q", port, name)
+	}
+
+	// Outside the apps auto-allocation range so a dynamically allocated app can
+	// never land on it.
+	if port >= services.AppsPortRangeStart && port <= services.AppsPortRangeEnd {
+		t.Fatalf("storage port %d falls inside the apps range %d-%d",
+			port, services.AppsPortRangeStart, services.AppsPortRangeEnd)
+	}
+
+	// Unique among managed service host ports.
+	for svc, p := range services.ServiceHostPorts {
+		if svc == "storage" {
+			continue
+		}
+		if p == port {
+			t.Fatalf("storage port %d collides with managed service %q", port, svc)
+		}
+	}
+}
+
+// containsPair reports whether args contains flag immediately followed by value.
+func containsPair(args []string, flag, value string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+// indexOf returns the index of the first occurrence of v in args, or -1.
+func indexOf(args []string, v string) int {
+	for i, a := range args {
+		if a == v {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/storage/state.go
+++ b/internal/storage/state.go
@@ -1,0 +1,252 @@
+// Package storage manages an on-node, S3-compatible object store backed by
+// VersityGW (Apache-2.0). It is the node-side half of the object-storage epic
+// (aceteam-ai/citadel-cli#466); this M1 slice provides the
+// `citadel storage start|status|stop` command group.
+//
+// The gateway runs as a managed docker container (like the apps catalog in
+// internal/apps and the payload instances in internal/jobs): a pinned image,
+// `--restart unless-stopped` so it survives a node reboot, and a persistent
+// state file under ~/.citadel so start/status/stop share one source of truth.
+//
+// Two invariants make this store safe to depend on:
+//
+//   - Create-once credentials. The root access/secret are minted on the FIRST
+//     start and persisted; a restart reuses them verbatim. Regenerating them
+//     would orphan every stored object (their on-disk owner would no longer
+//     match) and invalidate every outstanding presigned URL (the secret signs
+//     them). See Credentials / LoadOrCreateState.
+//   - A fixed host port (services.StorageHostPort). S3 presigned URLs sign the
+//     endpoint host+port, so the publish must be stable across restarts. A
+//     registry slot is stable by construction; a dynamically probed port could
+//     land elsewhere after reboot and silently break signed URLs.
+package storage
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// Credentials is the create-once S3 root key pair minted on first start.
+type Credentials struct {
+	// AccessKey is the S3 root access key id (ROOT_ACCESS_KEY).
+	AccessKey string `json:"access_key"`
+	// SecretKey is the S3 root secret access key (ROOT_SECRET_KEY). It signs
+	// presigned URLs, so it must never change once objects exist.
+	SecretKey string `json:"secret_key"`
+}
+
+// State is the persisted storage-service state. It currently holds only the
+// create-once credentials; the port is a fixed registry slot and the backing
+// dirs are derived from the base dir, so neither is persisted here.
+type State struct {
+	Credentials Credentials `json:"credentials"`
+
+	mu   sync.Mutex
+	path string
+}
+
+// accessKeyLen / secretKeyLen size the minted credentials. 20/40 alphanumeric
+// chars mirror the shape of AWS-style keys, which keeps them compatible with S3
+// clients that validate key length.
+const (
+	accessKeyLen = 20
+	secretKeyLen = 40
+)
+
+// credCharset is the alphabet for minted credentials: URL/HTTP-header safe so a
+// key never needs escaping in a docker -e value or an S3 Authorization header.
+const credCharset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+// BaseDir returns ~/.citadel/storage, the root of the storage service's data
+// and state. Bounded there for the same reason as the payload state volume in
+// internal/jobs: everything the container mounts stays inside a citadel data
+// dir.
+func BaseDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+	return filepath.Join(home, ".citadel", "storage"), nil
+}
+
+// DataDir returns the posix backing directory the S3 buckets/objects live in.
+// It is deliberately separate from IAMDir so the bucket/bytes accounting in
+// status only ever sees real S3 data, not gateway metadata.
+func DataDir() (string, error) {
+	base, err := BaseDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "data"), nil
+}
+
+// IAMDir returns the directory VersityGW stores its internal IAM state in. Kept
+// OUT of DataDir so it never inflates the bucket count or bytes-used report.
+func IAMDir() (string, error) {
+	base, err := BaseDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "iam"), nil
+}
+
+// statePath returns ~/.citadel/storage/state.json.
+func statePath() (string, error) {
+	base, err := BaseDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "state.json"), nil
+}
+
+// resolveBackingDir bounds a requested backing directory to <home>/.citadel/
+// storage, mirroring internal/jobs.resolveStateVolumePath. A leading "~" is
+// expanded to homeDir; the result must resolve to the storage base dir or a path
+// beneath it, else it is rejected. This is what stops a caller from pointing the
+// S3 backing store at, say, ~/.ssh or /etc. Pure (no I/O) apart from the passed
+// homeDir, so it is table-testable.
+func resolveBackingDir(raw, homeDir string) (string, error) {
+	if homeDir == "" {
+		return "", fmt.Errorf("cannot resolve backing dir: home directory unknown")
+	}
+	base := filepath.Join(homeDir, ".citadel", "storage")
+
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		// Default: the standard data dir under the storage base.
+		return filepath.Join(base, "data"), nil
+	}
+
+	expanded := raw
+	switch {
+	case raw == "~":
+		expanded = homeDir
+	case strings.HasPrefix(raw, "~/"):
+		expanded = filepath.Join(homeDir, raw[2:])
+	}
+
+	abs, err := filepath.Abs(expanded)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve backing dir %q: %w", raw, err)
+	}
+	abs = filepath.Clean(abs)
+
+	if abs == base || strings.HasPrefix(abs, base+string(filepath.Separator)) {
+		return abs, nil
+	}
+	return "", fmt.Errorf(
+		"backing dir %q resolves to %q, which is outside the storage data dir (allowed: %s)",
+		raw, abs, base)
+}
+
+// LoadOrCreateState loads the persisted state, minting and persisting fresh
+// credentials on first use. It is the create-once entry point: a second call
+// always returns the SAME credentials, so a restart never regenerates them.
+func LoadOrCreateState() (*State, error) {
+	s, err := loadState()
+	if err != nil {
+		return nil, err
+	}
+	if s.Credentials.AccessKey != "" && s.Credentials.SecretKey != "" {
+		return s, nil
+	}
+	// First start (or a state file predating credentials): mint once and persist
+	// before returning so a crash between here and container launch still leaves
+	// the same keys on disk for the next attempt.
+	creds, err := generateCredentials()
+	if err != nil {
+		return nil, err
+	}
+	s.Credentials = creds
+	if err := s.Save(); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// loadState reads the default state.json. A missing file yields an empty
+// (uninitialised) state, not an error, so the first start works on a fresh node.
+func loadState() (*State, error) {
+	p, err := statePath()
+	if err != nil {
+		return nil, err
+	}
+	return loadStateFromPath(p)
+}
+
+// loadStateFromPath reads a state file from an explicit path (injectable for
+// tests). A missing file yields an empty state.
+func loadStateFromPath(p string) (*State, error) {
+	s := &State{path: p}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return s, nil
+		}
+		return nil, fmt.Errorf("failed to read storage state %s: %w", p, err)
+	}
+	if len(data) == 0 {
+		return s, nil
+	}
+	if err := json.Unmarshal(data, s); err != nil {
+		return nil, fmt.Errorf("failed to parse storage state %s: %w", p, err)
+	}
+	return s, nil
+}
+
+// Save writes the state atomically (temp file + rename) with 0600 perms, since
+// it holds the S3 secret key.
+func (s *State) Save() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := os.MkdirAll(filepath.Dir(s.path), 0700); err != nil {
+		return fmt.Errorf("failed to create storage state dir: %w", err)
+	}
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal storage state: %w", err)
+	}
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return fmt.Errorf("failed to write storage state: %w", err)
+	}
+	if err := os.Rename(tmp, s.path); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("failed to persist storage state: %w", err)
+	}
+	return nil
+}
+
+// generateCredentials mints a random access/secret key pair using crypto/rand.
+func generateCredentials() (Credentials, error) {
+	access, err := randomString(accessKeyLen)
+	if err != nil {
+		return Credentials{}, fmt.Errorf("failed to generate access key: %w", err)
+	}
+	secret, err := randomString(secretKeyLen)
+	if err != nil {
+		return Credentials{}, fmt.Errorf("failed to generate secret key: %w", err)
+	}
+	return Credentials{AccessKey: access, SecretKey: secret}, nil
+}
+
+// randomString returns a cryptographically random string of n chars over
+// credCharset.
+func randomString(n int) (string, error) {
+	out := make([]byte, n)
+	limit := big.NewInt(int64(len(credCharset)))
+	for i := range out {
+		idx, err := rand.Int(rand.Reader, limit)
+		if err != nil {
+			return "", err
+		}
+		out[i] = credCharset[idx.Int64()]
+	}
+	return string(out), nil
+}

--- a/internal/storage/state_test.go
+++ b/internal/storage/state_test.go
@@ -1,0 +1,120 @@
+package storage
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestLoadOrCreateState_CreateOnce is the load-bearing guarantee: credentials
+// are minted once and persisted, then NEVER regenerated on a subsequent load.
+// Regeneration would orphan stored objects and break presigned URLs.
+func TestLoadOrCreateState_CreateOnce(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+
+	// First start: mint and persist.
+	first := &State{path: path}
+	creds, err := generateCredentials()
+	if err != nil {
+		t.Fatalf("generateCredentials: %v", err)
+	}
+	first.Credentials = creds
+	if err := first.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	// Every subsequent reload must return the SAME credentials.
+	for i := 0; i < 3; i++ {
+		got, err := loadStateFromPath(path)
+		if err != nil {
+			t.Fatalf("reload %d: %v", i, err)
+		}
+		if got.Credentials != creds {
+			t.Fatalf("reload %d: credentials changed: got %+v want %+v", i, got.Credentials, creds)
+		}
+	}
+}
+
+// TestLoadStateFromPath_MissingIsEmpty asserts a fresh node (no state file) is
+// an empty state, not an error, so the first start can proceed to mint.
+func TestLoadStateFromPath_MissingIsEmpty(t *testing.T) {
+	got, err := loadStateFromPath(filepath.Join(t.TempDir(), "state.json"))
+	if err != nil {
+		t.Fatalf("missing file should not error: %v", err)
+	}
+	if got.Credentials.AccessKey != "" || got.Credentials.SecretKey != "" {
+		t.Fatalf("expected empty credentials, got %+v", got.Credentials)
+	}
+}
+
+// TestGenerateCredentials_Random asserts minted credentials are well-formed and
+// non-repeating.
+func TestGenerateCredentials_Random(t *testing.T) {
+	a, err := generateCredentials()
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	b, err := generateCredentials()
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if len(a.AccessKey) != accessKeyLen || len(a.SecretKey) != secretKeyLen {
+		t.Fatalf("unexpected key lengths: access=%d secret=%d", len(a.AccessKey), len(a.SecretKey))
+	}
+	if a.AccessKey == b.AccessKey || a.SecretKey == b.SecretKey {
+		t.Fatalf("credentials are not random: two mints collided")
+	}
+	for _, c := range a.AccessKey + a.SecretKey {
+		if !strings.ContainsRune(credCharset, c) {
+			t.Fatalf("credential contains char %q outside charset", c)
+		}
+	}
+}
+
+// TestResolveBackingDir_Bounding asserts the backing dir is bounded to
+// <home>/.citadel/storage and anything outside is rejected.
+func TestResolveBackingDir_Bounding(t *testing.T) {
+	home := "/home/tester"
+	base := filepath.Join(home, ".citadel", "storage")
+
+	tests := []struct {
+		name    string
+		raw     string
+		want    string
+		wantErr bool
+	}{
+		{"empty defaults to data dir", "", filepath.Join(base, "data"), false},
+		{"base itself", base, base, false},
+		{"subdir of base", filepath.Join(base, "data"), filepath.Join(base, "data"), false},
+		{"tilde-expanded inside base", "~/.citadel/storage/objects", filepath.Join(base, "objects"), false},
+		{"outside: home ssh", "~/.ssh", "", true},
+		{"outside: etc", "/etc", "", true},
+		{"escape via ..", filepath.Join(base, "..", "..", "etc"), "", true},
+		{"sibling prefix trick", base + "-evil", "", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveBackingDir(tc.raw, home)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got %q", tc.raw, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tc.raw, err)
+			}
+			if got != tc.want {
+				t.Fatalf("resolveBackingDir(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveBackingDir_NoHome asserts a missing home dir is a hard error.
+func TestResolveBackingDir_NoHome(t *testing.T) {
+	if _, err := resolveBackingDir("", ""); err == nil {
+		t.Fatal("expected error when home dir is unknown")
+	}
+}

--- a/services/ports.go
+++ b/services/ports.go
@@ -66,18 +66,29 @@ const (
 	// agent-runtime module (Hermes/OpenClaw) is allocated 8205 rather than
 	// re-hardcoding 8204.
 	ClaudecodeHostPort = 8204
+	// storage: the on-node S3-compatible object store (VersityGW, #469). It is
+	// NOT a compose service and has no ${CITADEL_*_HOST_PORT} env var -- the
+	// `citadel storage` command constructs its `docker run` publish directly from
+	// this constant (internal/storage). It sits above the earmarked 8205
+	// Hermes/OpenClaw slot so a fixed, reboot-stable port is signed into S3
+	// presigned URLs without a persisted-port crash-loop risk. Kept in the
+	// registry so future allocations skip it and the collision guard covers it.
+	StorageHostPort = 8206
 )
 
-// ServiceHostPorts maps service name -> citadel-assigned host port for every
-// service whose host publish citadel owns via env-var substitution. The
-// collision guard test unions this with the apps catalog and the parsed compose
-// files to prove no two host ports clash.
+// ServiceHostPorts maps service name -> citadel-assigned host port. Most entries
+// are compose services whose host publish citadel owns via env-var substitution;
+// "storage" is the exception -- it has no compose file and is consumed directly
+// by the storage command's `docker run` construction. The collision guard test
+// unions this with the apps catalog and the parsed compose files to prove no two
+// host ports clash.
 var ServiceHostPorts = map[string]int{
 	"llamacpp":   LlamacppHostPort,
 	"vllm":       VLLMHostPort,
 	"extraction": ExtractionHostPort,
 	"diffusers":  DiffusersHostPort,
 	"claudecode": ClaudecodeHostPort,
+	"storage":    StorageHostPort,
 }
 
 // serviceHostPortEnv maps each managed service to the compose env-var that


### PR DESCRIPTION
Closes #469

M1 of the object-storage epic (#466). Node-side only. Adds a `citadel storage start|status|stop` command group that runs an on-node, S3-compatible object store backed by VersityGW (Apache-2.0), reusing the managed-container patterns from #463 (`internal/jobs`) and the app catalog (`internal/apps`).

## Design decisions

**Image (pinned, built-in).** `versity/versitygw:v1.6.0`, hardcoded in `internal/storage`. This is deliberately NOT routed through the #463 SERVICE_START registry allowlist (`ghcr.io/aceteam-ai/`): that allowlist constrains *remotely-supplied, untrusted* inline payload image refs. This image is an operator-vetted constant baked into the binary at build time, so the pinned tag itself is the trust boundary. VersityGW's official image lives on Docker Hub. Bump the constant to upgrade.

**Create-once credentials.** Root access/secret are minted with `crypto/rand` on the first `start` and persisted to `~/.citadel/storage/state.json` (0600). Every subsequent start loads and reuses them verbatim; they are never regenerated. Regenerating would orphan stored objects (their on-disk owner would no longer match) and invalidate every outstanding presigned URL (the secret signs them). Verified: two `stop`/`start` cycles keep the same access key.

**Binding: loopback only (never 0.0.0.0), never the mesh IP directly.** The container is published on `127.0.0.1:<port>:7070` only. It is deliberately NOT bound to the node's mesh/tailnet IP: citadel's mesh IP is a userspace-tsnet virtual address with no kernel interface, so `docker -p <mesh-ip>:...` cannot bind it (a `net.Listen` probe on that IP fails on every real node). Mesh reachability for S3 needs a TCP-preserving relay on the tsnet listener — a path-rewriting gateway route (the WhatsApp-bridge pattern) would break SigV4, which signs the host header and path. That relay lives in the long-running `citadel work` process, not a one-shot CLI command, and is deferred past M1. Loopback is sufficient for M1's real consumers (local `aws --endpoint-url`, on-node Litestream #4968). `status` still reports the mesh IP as informational (best-effort; typically empty in a one-shot CLI invocation where the tsnet server isn't running).

**Fixed host port (registry slot), not dynamic.** `services.StorageHostPort = 8206`, the next free slot in the existing 8200 block after claudecode (8204) and the earmarked Hermes/OpenClaw (8205). A static slot is reboot-stable by construction and covered by the existing `internal/apps` collision-guard test — no persisted-port crash-loop risk (a dynamically probed-then-persisted port could be held by a foreign process after reboot and crash-loop the `--restart unless-stopped` container). This matters because S3 presigned URLs sign the endpoint port.

**Reboot survival.** `--restart unless-stopped`, matching the app catalog and #463 payload instances. `stop` does an explicit `docker rm -f`, so it never resurrects a deliberately stopped gateway. Verified the policy is set on the launched container.

**Backing dir bounding.** `resolveBackingDir` mirrors `internal/jobs.resolveStateVolumePath`: bounded under `<home>/.citadel/storage`, rejecting `~/.ssh`, `/etc`, `..` escapes, and sibling-prefix tricks. IAM state lives in a separate `~/.citadel/storage/iam` dir so it never inflates the bucket/bytes accounting.

**Status accounting.** Bucket count = non-dotfile immediate subdirectories of the posix backing dir; bytes used = sum of regular-file sizes (filesystem-level, no S3 auth needed; reported as approximate). Health = container running AND an HTTP GET to the endpoint returns any response (VersityGW answers anonymous requests with `403 AccessDenied` XML, which proves the listener is up).

## Out of scope (later slices of #466)
Fabric capacity advertising, platform registration channel, billing, Litestream consumer wiring (#4968), and S3-over-mesh relay.

## Files
- `services/ports.go` — add `StorageHostPort = 8206` registry slot + `ServiceHostPorts["storage"]`.
- `internal/storage/state.go` — create-once credentials, atomic 0600 persistence, path bounding.
- `internal/storage/gateway.go` — pinned image, `docker run` arg construction, start/stop/status, health, usage accounting.
- `cmd/storage.go` — Cobra `storage start|status|stop`.
- `internal/storage/{state,gateway}_test.go` — creds create-once, path bounding, docker-args (loopback-only, creds-via-env, posix command), port allocation.

## Test evidence
`go build ./... && go vet ./... && gofmt -l . && go test ./...` — all green (full suite passes).

Manual end-to-end (Docker available):
- `storage start` pulled `versity/versitygw:v1.6.0`, launched `citadel-storage`, published `127.0.0.1:8206->7070/tcp` (verified via `docker inspect` — no 0.0.0.0, no mesh IP), restart policy `unless-stopped`.
- `state.json` written `0600`, access key len 20 / secret len 40.
- `status` → `running (healthy)`; anonymous `GET :8206/` returns VersityGW `<Error><Code>AccessDenied>` XML.
- Created a bucket dir + 2 KiB object under the backing dir → `status` reported `Buckets: 1`, `Used: 2.0 KiB`.
- `stop` then `start` → access key unchanged (create-once verified); objects survived.
