### PR TITLE
fix(whisper-service): add missing requests dependency

### DIFF
--- a/services/whisper-service/requirements.txt
+++ b/services/whisper-service/requirements.txt
@@ -1,4 +1,9 @@
 faster-whisper==1.0.3
+# faster-whisper 1.0.3 imports `requests` at module load (faster_whisper/utils.py)
+# but does not declare it, and recent huggingface_hub no longer pulls it in
+# transitively -- so it must be pinned explicitly or the first /transcribe call
+# 500s with ModuleNotFoundError while /health still passes (model is lazy-loaded).
+requests==2.32.3
 fastapi==0.115.6
 uvicorn==0.34.0
 pydantic==2.10.4


### PR DESCRIPTION
## Context

Node-local ("sovereign") transcription was just unblocked by publishing the `whisper-service` image (#465 / #467). But E2E-testing an actual capture on node `1084` surfaced a second, sneakier bug: **the image starts healthy but the first real transcription 500s.**

`faster-whisper==1.0.3` imports `requests` at module load (`faster_whisper/utils.py`), but `requirements.txt` never listed it — and recent `huggingface_hub` no longer pulls `requests` in transitively. So:

- `docker build` succeeds
- the container starts, `GET /health` returns `{"status":"ok"}` (the model is **lazy-loaded** on first request)
- the first `POST /transcribe` throws `ModuleNotFoundError: No module named 'requests'` → HTTP 500

A health check alone never catches this — you have to run a real transcription.

## Fix

Add `requests==2.32.3` to `services/whisper-service/requirements.txt`.

## Verification

- **On-node (prod, node 1084):** `docker exec citadel-transcribe pip install requests` then re-POST → the sidecar transcribed a real espeak clip correctly (`"This is an end-to-end test ... quick brown fox ..."`, lang=en, p=0.938). Confirms `requests` was the only missing dep.
- **Local rebuild:** `docker build` + `python -c "import faster_whisper, requests"` → `imports_ok 1.0.3`.

## Post-merge

The `build-whisper-service` workflow republishes `:latest` on merge (source under `services/whisper-service/**` changed). Nodes running the old image need to re-pull + restart the sidecar (`service_start transcribe` after `docker pull`) to pick it up. The prod node 1084 sidecar is currently patched in-memory (`pip install requests`); that's lost on container restart, so the republished image is the durable fix.

Related: #465 (publish the image). Found while driving the meeting-capture E2E (#5097 / extension #5119).
