### PR TITLE
fix(transcribe): fail fast when whisper sidecar is unreachable

### DIFF
--- a/internal/jobs/transcribe_audio.go
+++ b/internal/jobs/transcribe_audio.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
@@ -20,8 +21,21 @@ const defaultTranscribeServiceURL = "http://localhost:8101"
 
 // transcribeReadyTimeout bounds how long we wait for the whisper sidecar to
 // load its model and report healthy. Model load (faster-whisper "base", int8)
-// is a one-time cost on first job; subsequent jobs hit a warm service.
+// is a one-time cost on first job; subsequent jobs hit a warm service. This
+// budget only applies once the sidecar is actually answering connections —
+// see transcribeUnreachableTimeout for the case where nothing is listening.
 const transcribeReadyTimeout = 120 * time.Second
+
+// transcribeUnreachableTimeout bounds how long waitForReady tolerates a
+// connection-refused health check, i.e. nothing listening on the sidecar's
+// port at all. A refused connection means the sidecar container was never
+// started (or crashed before it could bind its port) — not that it is warming
+// up — so there is nothing worth waiting the full transcribeReadyTimeout for.
+// Keeping this short ensures the handler fails well under the backend's
+// ~100s request-gateway budget, so the backend can fall back to cloud
+// transcription instead of the client eventually seeing a bare "Failed to
+// fetch" once the gateway times out first.
+const transcribeUnreachableTimeout = 8 * time.Second
 
 // transcribeRequestTimeout bounds a single transcription. Whisper on CPU is
 // roughly real-time-ish for the "base" model, so a long meeting needs headroom.
@@ -158,18 +172,36 @@ func (h *TranscribeAudioHandler) waitForReady() error {
 	pollInterval := 1 * time.Second
 	startTime := time.Now()
 
-	for time.Since(startTime) < transcribeReadyTimeout {
-		resp, err := http.Get(healthURL)
-		if err == nil && resp.StatusCode == http.StatusOK {
+	for {
+		resp, err := h.client().Get(healthURL)
+		if err == nil {
+			ready := resp.StatusCode == http.StatusOK
 			resp.Body.Close()
-			return nil
+			if ready {
+				return nil
+			}
+			// Reachable, just not ready yet (e.g. model still loading) —
+			// fall through to the patient transcribeReadyTimeout budget below.
+		} else if isConnectionRefused(err) && time.Since(startTime) >= transcribeUnreachableTimeout {
+			// Nothing has ever answered on this port within the fast-fail
+			// budget: treat the sidecar as absent rather than warming up, and
+			// give up now instead of burning the full model-load timeout.
+			return fmt.Errorf("transcription service unreachable at %s: %w", h.serviceURL(), err)
 		}
-		if resp != nil {
-			resp.Body.Close()
+
+		if time.Since(startTime) >= transcribeReadyTimeout {
+			break
 		}
 		time.Sleep(pollInterval)
 	}
 	return fmt.Errorf("transcription service did not become ready within %v", transcribeReadyTimeout)
+}
+
+// isConnectionRefused reports whether err indicates nothing is listening on
+// the target port at all, as distinct from a service that answered but isn't
+// ready yet (e.g. still loading its model).
+func isConnectionRefused(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "connection refused")
 }
 
 // Ensure TranscribeAudioHandler implements JobHandler.

--- a/internal/jobs/transcribe_audio_test.go
+++ b/internal/jobs/transcribe_audio_test.go
@@ -3,11 +3,14 @@ package jobs
 import (
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
 )
@@ -125,6 +128,96 @@ func TestTranscribeAudio_ServiceError(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for non-200 service response")
+	}
+}
+
+// TestTranscribeAudio_WaitForReady_UnreachableFailsFast covers the cold-start
+// hang: a sidecar that was never started (nothing listening on its port) must
+// not make waitForReady block anywhere near the full 120s model-load budget.
+// It should give up within the short transcribeUnreachableTimeout window so
+// the backend's node-local request fails well inside its own ~100s gateway
+// timeout, allowing a fall back to cloud transcription.
+func TestTranscribeAudio_WaitForReady_UnreachableFailsFast(t *testing.T) {
+	// Bind an ephemeral port, then release it immediately: nothing is
+	// listening on the resulting address, so dials to it get an immediate
+	// connection-refused, mirroring an absent whisper sidecar.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	h := NewTranscribeAudioHandler(t.TempDir())
+	h.ServiceURL = "http://" + addr
+
+	start := time.Now()
+	err = h.waitForReady()
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error for an unreachable sidecar")
+	}
+	// Generous slack over the fast-fail budget for scheduler jitter, but this
+	// must land nowhere near the 120s patient timeout — that's the bug.
+	if elapsed > transcribeUnreachableTimeout+10*time.Second {
+		t.Fatalf("waitForReady took %v, want close to the %v fast-fail budget (not the %v patient budget)", elapsed, transcribeUnreachableTimeout, transcribeReadyTimeout)
+	}
+}
+
+// TestTranscribeAudio_WaitForReady_PatientWhileLoading proves the fast-fail
+// path for unreachable sidecars does not regress the legitimate warm-up case:
+// a sidecar that answers health checks (just not with 200 yet, because its
+// model is still loading) must be given the full patient budget, even past
+// the point where an unreachable sidecar would have already failed fast.
+func TestTranscribeAudio_WaitForReady_PatientWhileLoading(t *testing.T) {
+	var mu sync.Mutex
+	ready := false
+	calls := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		calls++
+		isReady := ready
+		mu.Unlock()
+		if isReady {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	h := NewTranscribeAudioHandler(t.TempDir())
+	h.ServiceURL = srv.URL
+
+	// Flip to ready after longer than transcribeUnreachableTimeout, so a pass
+	// here proves the "reachable but loading" path survives past the window
+	// that would have killed an actually-unreachable sidecar.
+	loadDelay := transcribeUnreachableTimeout + 1*time.Second
+	go func() {
+		time.Sleep(loadDelay)
+		mu.Lock()
+		ready = true
+		mu.Unlock()
+	}()
+
+	start := time.Now()
+	if err := h.waitForReady(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed < loadDelay {
+		t.Fatalf("waitForReady returned after %v, want at least %v (it should have kept polling until ready)", elapsed, loadDelay)
+	}
+
+	mu.Lock()
+	n := calls
+	mu.Unlock()
+	if n < 2 {
+		t.Fatalf("expected multiple health polls while loading, got %d", n)
 	}
 }
 


### PR DESCRIPTION
## Context

`internal/jobs/transcribe_audio.go`'s `waitForReady()` polls the local faster-whisper sidecar's `/health` for up to `transcribeReadyTimeout` (120s) before running a `TRANSCRIBE_AUDIO` job. That budget is sized for a legitimately warming-up sidecar — model load (faster-whisper "base", int8) is a one-time ~9s cost on first job, verified via `{"status":"ok","model":"base"}` appearing ~9s after `service_start`.

The bug: the same 120s budget also applied when the sidecar is **absent** (never started — connection refused on every poll). 120s exceeds the backend's ~100s request-gateway budget, so a node without the whisper sidecar hung the node-local request past the gateway timeout, and the client saw a bare "Failed to fetch" instead of the intended fast error → cloud fallback.

## Fix

Distinguish the two cases inside `waitForReady()`:

- **Sidecar unreachable** (dial fails with `connection refused` — nothing listening): fail fast after a new `transcribeUnreachableTimeout` (8s) instead of the full 120s, so the caller can return an error the backend turns into a fallback well inside its own gateway budget.
- **Sidecar reachable but not ready** (health endpoint answers, just not with 200 yet — e.g. still loading): unchanged — keeps the existing patient `transcribeReadyTimeout` (120s), so a legitimately-warming sidecar is not killed prematurely.

Classification uses `strings.Contains(err.Error(), "connection refused")`, matching the existing error-classification convention in `internal/nexus/deviceauth.go`.

Also fixed `waitForReady()` to route health polls through `h.client()` instead of a bare `http.Get` — the handler's injectable `HTTPClient` seam previously only covered the transcription request, not the ready-wait loop, which made this path untestable without a real unreachable/loading sidecar.

**Verified the fast-fail is safe against a real cold start**: `services/whisper-service/app.py` binds and starts serving `/health` (unconditional `{"status": "ok"}`, no model dependency) as soon as the FastAPI process starts — the `faster_whisper.WhisperModel` is loaded lazily, only inside the `POST /transcribe` handler on first use. So model load can never make `/health` look like "connection refused"; a refused connection reliably means the sidecar container itself was never started, which also matches the dispatch path — `TRANSCRIBE_AUDIO` is dispatched directly with no `SERVICE_START` gate in front of it, so there's no race between "sidecar mid-boot" and "sidecar absent" for this fast-fail to misfire on.

`transcribeRequestTimeout` (30m, bounding the actual transcription call) is unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/jobs/ -run Transcribe -count=1` — all pass
- New: `TestTranscribeAudio_WaitForReady_UnreachableFailsFast` — binds then releases an ephemeral port (nothing listening → connection refused) and asserts `waitForReady()` returns an error within the fast-fail budget, nowhere near 120s.
- New: `TestTranscribeAudio_WaitForReady_PatientWhileLoading` — stub sidecar answers `/health` with 503 until a delay longer than `transcribeUnreachableTimeout`, then flips to 200; asserts `waitForReady()` still succeeds and polls multiple times, proving the patient warm-up path isn't regressed by the new fast-fail branch.
- Existing tests (`TestTranscribeAudio_Success`, `TestTranscribeAudio_ServiceError`, `TestTranscribeAudio_SymlinkedWorkspace`, path validation tests) unchanged and still pass.