### PR TITLE
fix: auto-update opt-out + dev binary no longer self-installs (#473)

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -1928,6 +1928,14 @@ func runTUIWorker(ctx context.Context, activityFn func(level, msg string)) error
 // ccAutoUpdate checks for updates and auto-updates if available.
 // Returns true if the binary was updated (caller should restart).
 func ccAutoUpdate() bool {
+	// Never auto-install when the user opted out (--no-auto-update /
+	// CITADEL_NO_AUTO_UPDATE) or when this is a locally-built dev binary: a
+	// hand-copied dev/test binary must not silently replace itself with a
+	// release before it can be exercised. Explicit `citadel update` still works.
+	if !autoUpdateAllowed() {
+		return false
+	}
+
 	// Check for updates
 	spinner := whimsy.NewSimpleSpinner([]string{"Checking for updates..."})
 	spinner.Start()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,6 +33,13 @@ var debugMode bool
 var daemonMode bool
 var noColorGlobal bool
 
+// noAutoUpdate, when set via the --no-auto-update persistent flag (or the
+// CITADEL_NO_AUTO_UPDATE env var), opts this invocation out of every automatic
+// update check and install. It exists so a hand-copied dev/test binary is not
+// silently replaced by a release before it can be exercised. Explicit
+// `citadel update` is unaffected.
+var noAutoUpdate bool
+
 // noMouse, when set, disables terminal mouse reporting in the control center for
 // the current session, overriding the persisted preference. Users set it to keep
 // their terminal's native drag-to-copy working.
@@ -134,7 +141,8 @@ control center. All other subcommands are for scripting and advanced use.`,
 			parentName = cmd.Parent().Name()
 		}
 		skipUpdateCheck := cmdName == "update" || parentName == "update" ||
-			cmdName == "version" || cmdName == "help"
+			cmdName == "version" || cmdName == "help" ||
+			autoUpdateOptedOut()
 
 		// Detect if we're about to launch TUI control center
 		// In this case, suppress stdout printing and defer to TUI activity log
@@ -149,6 +157,22 @@ control center. All other subcommands are for scripting and advanced use.`,
 			checkForUpdateOnStartup(isTUIContext)
 		}
 	},
+}
+
+// autoUpdateOptedOut reports whether the user has opted out of automatic update
+// checks/installs for this invocation, via the --no-auto-update persistent flag
+// or a truthy CITADEL_NO_AUTO_UPDATE env var. It gates the notify-only startup
+// check (skipUpdateCheck) as well as the auto-install paths.
+func autoUpdateOptedOut() bool {
+	return noAutoUpdate || update.IsTruthy(os.Getenv("CITADEL_NO_AUTO_UPDATE"))
+}
+
+// autoUpdateAllowed reports whether an automatic update *install* should run for
+// this process: false when the user opted out (--no-auto-update /
+// CITADEL_NO_AUTO_UPDATE) or when the running binary is a locally-built dev
+// build rather than a real release tag. Explicit `citadel update` bypasses this.
+func autoUpdateAllowed() bool {
+	return update.ShouldAutoInstall(Version, noAutoUpdate, os.Getenv("CITADEL_NO_AUTO_UPDATE"))
 }
 
 // checkForUpdateOnStartup shows cached update notification and triggers background check.
@@ -218,6 +242,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&authServiceURL, "auth-service", getEnvOrDefault("CITADEL_AUTH_HOST", "https://aceteam.ai"), "The URL of the authentication service")
 	rootCmd.PersistentFlags().BoolVar(&debugMode, "debug", false, "Enable debug output")
 	rootCmd.PersistentFlags().BoolVar(&noColorGlobal, "no-color", false, "Disable colorized output")
+	rootCmd.PersistentFlags().BoolVar(&noAutoUpdate, "no-auto-update", false, "Disable automatic update checks and installs for this run (or set CITADEL_NO_AUTO_UPDATE=1)")
 	rootCmd.Flags().BoolVar(&daemonMode, "daemon", false, "Run in background daemon mode (no TUI)")
 	rootCmd.Flags().BoolVar(&noMouse, "no-mouse", false, "Disable control-center mouse control (keeps terminal drag-to-copy)")
 

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -2140,6 +2140,13 @@ func resolveConsumerGroup(explicit, headscaleNodeID, hostname string) string {
 // Disabled by default. Evaluated every tick so the web UI (which dispatches
 // `citadel update enable/disable` to the node) can toggle a running agent.
 func resolveAutoUpdateEnabled() bool {
+	// The opt-out (--no-auto-update / CITADEL_NO_AUTO_UPDATE) and a dev build
+	// both veto auto-INSTALL, ahead of any enable signal: a safety/"don't touch
+	// my binary" signal must win over --auto-update / CITADEL_AUTO_UPDATE.
+	// Explicit `citadel update` remains the escape hatch for a dev binary.
+	if !autoUpdateAllowed() {
+		return false
+	}
 	if workAutoUpdate {
 		return true
 	}

--- a/cmd/work_test.go
+++ b/cmd/work_test.go
@@ -22,6 +22,9 @@ func TestResolveAutoUpdateEnabled(t *testing.T) {
 		flag     bool
 		env      string // "" means unset
 		state    *bool  // nil means no state file
+		version  string // "" means a real release tag (v2.45.0)
+		noAuto   bool   // --no-auto-update flag
+		noAutoEn string // CITADEL_NO_AUTO_UPDATE env
 		expected bool
 	}{
 		{name: "default off when nothing set", expected: false},
@@ -30,15 +33,26 @@ func TestResolveAutoUpdateEnabled(t *testing.T) {
 		{name: "env true overrides disabled state", env: "true", state: boolPtr(false), expected: true},
 		{name: "env off overrides enabled state", env: "off", state: boolPtr(true), expected: false},
 		{name: "flag wins over env and state", flag: true, env: "off", state: boolPtr(false), expected: true},
+		// #473: a dev binary never auto-installs, even with an enable signal.
+		{name: "dev binary vetoes auto-update flag", flag: true, version: "dev", expected: false},
+		{name: "dev binary vetoes enabled state", state: boolPtr(true), version: "dev", expected: false},
+		// #473: opt-out (flag / env) wins over every enable signal.
+		{name: "no-auto-update flag vetoes auto-update flag", flag: true, noAuto: true, expected: false},
+		{name: "CITADEL_NO_AUTO_UPDATE env vetoes enabled state", state: boolPtr(true), noAutoEn: "1", expected: false},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("HOME", t.TempDir()) // isolate the on-disk update state
 			t.Setenv("CITADEL_AUTO_UPDATE", tc.env)
-			orig := workAutoUpdate
-			workAutoUpdate = tc.flag
-			t.Cleanup(func() { workAutoUpdate = orig })
+			t.Setenv("CITADEL_NO_AUTO_UPDATE", tc.noAutoEn)
+			ver := tc.version
+			if ver == "" {
+				ver = "v2.45.0"
+			}
+			origVer, origFlag, origNoAuto := Version, workAutoUpdate, noAutoUpdate
+			Version, workAutoUpdate, noAutoUpdate = ver, tc.flag, tc.noAuto
+			t.Cleanup(func() { Version, workAutoUpdate, noAutoUpdate = origVer, origFlag, origNoAuto })
 			if tc.state != nil {
 				writeState(t, *tc.state)
 			}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -363,6 +363,48 @@ func (c *Client) isNewerVersion(newVersion string) (bool, error) {
 	return IsNewerVersion(c.CurrentVersion, newVersion)
 }
 
+// IsTruthy reports whether an environment-variable value should be treated as
+// "on". It mirrors the truthy set already used by resolveAutoUpdateEnabled
+// ("1"/"true"/"yes"/"on") and is case- and whitespace-insensitive. Used by the
+// CITADEL_NO_AUTO_UPDATE opt-out.
+func IsTruthy(s string) bool {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
+}
+
+// IsReleaseVersion reports whether v is a real, installable release version
+// (a parseable semver, with or without a leading "v"), as opposed to a
+// locally-built "dev" binary or an unset/empty version. The automatic update
+// *install* paths use this to avoid clobbering a hand-copied dev binary that a
+// developer is actively testing. It deliberately does NOT gate the explicit
+// `citadel update` command, which is an intentional user action and must be
+// able to update any binary.
+func IsReleaseVersion(v string) bool {
+	s := strings.TrimPrefix(strings.TrimSpace(v), "v")
+	if s == "" || s == "dev" {
+		return false
+	}
+	_, err := version.NewVersion(s)
+	return err == nil
+}
+
+// ShouldAutoInstall reports whether an automatic update *install* should
+// proceed for a process running currentVersion, given the --no-auto-update
+// flag state and the raw CITADEL_NO_AUTO_UPDATE environment value. It returns
+// false when the user has opted out (flag set or truthy env) OR when
+// currentVersion is not a real release tag (e.g. a locally-built "dev"
+// binary). This is the single decision the startup and periodic auto-update
+// paths share; the explicit `citadel update` command does not consult it.
+func ShouldAutoInstall(currentVersion string, noAutoUpdateFlag bool, noAutoUpdateEnv string) bool {
+	if noAutoUpdateFlag || IsTruthy(noAutoUpdateEnv) {
+		return false
+	}
+	return IsReleaseVersion(currentVersion)
+}
+
 // getDownloadURL constructs the download URL for the current platform
 func (c *Client) getDownloadURL(release *Release) string {
 	binaryName := c.getBinaryArchiveName(release)

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -141,6 +141,83 @@ func TestIsNewerVersionExported(t *testing.T) {
 	}
 }
 
+func TestIsTruthy(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"1", true},
+		{"true", true},
+		{"yes", true},
+		{"on", true},
+		{"TRUE", true},
+		{"  Yes  ", true},
+		{"0", false},
+		{"false", false},
+		{"no", false},
+		{"", false},
+		{"maybe", false},
+	}
+	for _, tt := range tests {
+		if got := IsTruthy(tt.in); got != tt.want {
+			t.Errorf("IsTruthy(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestIsReleaseVersion(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"v2.45.0", true},
+		{"2.45.0", true},
+		{"v1.0.0", true},
+		{"dev", false},
+		{"", false},
+		{"  ", false},
+		{"garbage", false},
+	}
+	for _, tt := range tests {
+		if got := IsReleaseVersion(tt.in); got != tt.want {
+			t.Errorf("IsReleaseVersion(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
+// TestShouldAutoInstall covers the single decision shared by the startup and
+// periodic auto-update paths (#473): a dev binary must not auto-install a
+// release over itself, and either opt-out (flag or truthy env) suppresses the
+// install for a real release. The explicit `citadel update` command does not
+// call this and is verified separately by TestIsNewerVersion ("dev" -> release
+// still returns true).
+func TestShouldAutoInstall(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		flag    bool
+		env     string
+		want    bool
+	}{
+		{"real release, not opted out, installs", "v2.45.0", false, "", true},
+		{"dev never auto-installs", "dev", false, "", false},
+		{"empty version never auto-installs", "", false, "", false},
+		{"env opt-out suppresses install", "v2.45.0", false, "1", false},
+		{"env opt-out (true) suppresses install", "v2.45.0", false, "true", false},
+		{"env opt-out (yes) suppresses install", "v2.45.0", false, "yes", false},
+		{"flag opt-out suppresses install", "v2.45.0", true, "", false},
+		{"opt-out wins over release", "v2.45.0", true, "", false},
+		{"falsey env does not opt out", "v2.45.0", false, "0", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ShouldAutoInstall(tt.version, tt.flag, tt.env); got != tt.want {
+				t.Errorf("ShouldAutoInstall(%q, %v, %q) = %v, want %v", tt.version, tt.flag, tt.env, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetBinaryArchiveName(t *testing.T) {
 	client := NewClient("v1.0.0")
 	release := &Release{TagName: "v1.2.3"}


### PR DESCRIPTION
Closes #473

## Context
A hand-copied `dev` binary self-updates to the latest release before it can be tested, and there is no env var or flag to suppress it. The observed clobber (`✓ Update available: dev → v2.45.0 … ⠹ Installing update...`) comes from the control center's `ccAutoUpdate` (its spinner strings match the transcript); `IsNewerVersion` treats `current == "dev"` as always-has-update, so the check always finds a "newer" release.

## Root cause
Two gaps:
1. No opt-out. The only auto-update gates were the notify-only startup check (`cmd/root.go` `skipUpdateCheck`) and the periodic worker updater — neither had a user-facing off switch.
2. `dev`-always-updates. `update.IsNewerVersion("dev", …)` returns true, and the auto-install paths acted on it, so a dev binary installed a release over itself.

## Changes
- `internal/update/update.go` — new pure, testable helpers:
  - `IsTruthy(s)` — env truthiness, matching the existing `resolveAutoUpdateEnabled` set (`1`/`true`/`yes`/`on`).
  - `IsReleaseVersion(v)` — true only for a parseable semver tag; `dev`/empty/non-semver → false.
  - `ShouldAutoInstall(version, flag, env)` — the single decision shared by the auto-install paths: false when opted out (flag or truthy env) or when the running binary is not a real release.
- `cmd/root.go` — `--no-auto-update` persistent flag + `noAutoUpdate` var; `autoUpdateOptedOut()` extends `skipUpdateCheck` (suppresses the startup notify/background check); `autoUpdateAllowed()` gates installs.
- `cmd/controlcenter.go` — `ccAutoUpdate` early-returns when `!autoUpdateAllowed()` (the observed clobber path). This is the chosen dev-default: **option (b) — auto-update only fires for a real release tag** (cleaner single choke point via `IsReleaseVersion`, and it avoids touching the shared `IsNewerVersion`/`CheckForUpdate` that explicit `citadel update` relies on).
- `cmd/work.go` — `resolveAutoUpdateEnabled` vetoes via `!autoUpdateAllowed()` **before** the enable signals, so opt-out and dev builds beat `--auto-update` / `CITADEL_AUTO_UPDATE` / persisted state.

### Preserved
- Explicit `citadel update` / `citadel update install` update any binary, including `dev` (they do not consult the gate; `IsNewerVersion` unchanged).
- Real release binaries still auto-update unless opted out.

### Deliberately not gated
- `internal/worker/agent_update.go` (AGENT_UPDATE job handler) is a control-plane-dispatched explicit update — closer to `citadel update` than to startup/periodic auto-update — so it is intentionally left ungated, consistent with the "explicit update always works" rule.

## Testing
`go build ./... && go vet ./... && gofmt -l . && go test ./...` — all green.

New/updated tests:
- `internal/update/update_test.go`: `TestIsTruthy`, `TestIsReleaseVersion`, `TestShouldAutoInstall` (env opt-out, flag opt-out, dev-not-installing, real-release-fires, opt-out-wins).
- `cmd/work_test.go`: extended `TestResolveAutoUpdateEnabled` with dev-veto and opt-out-veto cases (opt-out/dev beat every enable signal).

### Manual verification
- Release binary, no opt-out → auto-update fires (unchanged).
- `--no-auto-update` or `CITADEL_NO_AUTO_UPDATE=1` → startup check and periodic re-check both skip.
- `dev` binary on startup → no auto-install; `citadel update install` still updates it.