### PR TITLE
feat(meeting-bot): persistent signed-in Chrome profile for the meeting bot (#5122)

### DIFF
--- a/docs/meeting-bot-profile-seeding.md
+++ b/docs/meeting-bot-profile-seeding.md
@@ -1,0 +1,91 @@
+# Meeting Bot: Seeding the Persistent Chrome Profile
+
+**Issue:** [#5122](https://github.com/aceteam-ai/citadel-cli/issues/5122) (epic [#5097](https://github.com/aceteam-ai/citadel-cli/issues/5097))
+
+## Overview
+
+The `MEETING_JOIN` handler (`internal/jobs/meeting_join.go`, [#5098](https://github.com/aceteam-ai/citadel-cli/issues/5098)) drives a headed Chromium (`internal/platform/meeting_browser.go`) into a Google Meet call. Early testing showed Google policy-rejects **anonymous** participants in many orgs — the bot needs a real, signed-in Google identity to be let in at all.
+
+So the meeting browser's `--user-data-dir` is no longer a throwaway `os.MkdirTemp` profile: it is a **persistent** directory that a human signs into **once, by hand**, and every subsequent `MEETING_JOIN` job reuses the same cookies/session. This document covers the one-time (and periodic re-seed) manual steps. Everything else — resolving the profile path, creating it with locked-down permissions, reusing it across runs, and detecting when it has gone stale — is handled by the code; see `internal/platform/meeting_browser.go`.
+
+**Why this can't be automated:** Google actively detects and blocks scripted/automated sign-in (CAPTCHA challenges, "this browser may not be secure" blocks, account lockouts). Do not attempt to script the login form. The seed step below is a real human, with a real mouse and keyboard, typing into a real browser window.
+
+## What's code vs. what's manual
+
+| Step | Owner |
+|---|---|
+| Create the `notetaker@aceteam.ai` Google account | Human (one-time, org admin) |
+| Resolve/create the profile directory, lock permissions, reuse across runs | Code (`preparePersistentProfileDir` in `meeting_browser.go`) |
+| Manual sign-in into that profile directory | Human (one-time, and periodically on cookie expiry) |
+| Detect a signed-out profile and fail loudly instead of joining anonymously | Code (`IsGoogleSignInURL` + the check in `runJoinFlow`) |
+| Live join verification against a real Meet call | Human |
+
+## Where the profile lives
+
+By default the profile directory is `<citadel ConfigDir>/meeting-profile` — the same node-local persistent-state root that already holds `tls/`, `logs/`, and `gateway/` (see `platform.ConfigDir()`; typically `~/.citadel-cli/meeting-profile`, or `/etc/citadel/meeting-profile` when citadel runs as root/system service).
+
+Override it with the `CITADEL_MEETING_PROFILE_DIR` environment variable if the node's persistent state should live elsewhere (e.g. a dedicated data volume). The handler also exposes a `MeetingJoinHandler.ProfileDir` field for the worker's startup config to pin the same thing programmatically.
+
+The directory is created (if missing) and `chmod 0700`'d on every `MeetingBrowser.Start()` — it holds real Google session cookies for the bot account, so it must never be group- or world-readable.
+
+## One-time seeding procedure
+
+1. **Create the bot account** (human, once): a dedicated Google account for the notetaker, e.g. `notetaker@aceteam.ai`. Use a strong, unique password and enroll it in 2FA per your org's policy — but see the note on 2FA below.
+
+2. **Stop any running citadel worker on the target node** so nothing else launches Chrome against the same `--user-data-dir` while you're seeding it (Chrome locks a profile dir to one process; a concurrent launch will either fail to start or open a second, un-seeded window).
+
+3. **Resolve the profile path** for the node you're seeding:
+
+   ```bash
+   # Matches platform.ConfigDir(); check CITADEL_MEETING_PROFILE_DIR first if the
+   # node overrides it.
+   echo "${CITADEL_MEETING_PROFILE_DIR:-$HOME/.citadel-cli/meeting-profile}"
+   ```
+
+   Create it if it doesn't exist yet, locked to owner-only:
+
+   ```bash
+   mkdir -p ~/.citadel-cli/meeting-profile
+   chmod 700 ~/.citadel-cli/meeting-profile
+   ```
+
+4. **Launch a real, headed Chrome with that exact `--user-data-dir`** on the node (over VNC/physical display/remote desktop — this must be a real interactive session, not a job dispatch):
+
+   ```bash
+   google-chrome \
+     --user-data-dir="$HOME/.citadel-cli/meeting-profile" \
+     --no-first-run --no-default-browser-check \
+     https://accounts.google.com/
+   ```
+
+5. **Sign in by hand** as `notetaker@aceteam.ai`. Complete any 2FA challenge manually.
+   - If your org requires 2FA on this account, prefer a method that doesn't require a re-prompt on every session (e.g. "trust this device" / a long-lived device cookie) — Chrome persists that trust in the same profile directory, so a re-seed carries it forward. An OTP-app-only account with no trusted-device option will force a human back into this procedure far more often than intended.
+   - Dismiss "Chrome sync" / "make Chrome your default browser" prompts; they don't matter for this profile.
+
+6. **Verify the session sticks**: navigate to `https://meet.google.com/`. You should land signed in as the notetaker account (avatar/initial visible top-right), not on a sign-in page.
+
+7. **Close Chrome normally** (not `kill -9`) so its session/cookie DB flushes cleanly to disk.
+
+8. **Restart the citadel worker.** The next `MEETING_JOIN` job will launch Chromium against this same, now-seeded, profile directory and reuse the signed-in session.
+
+## Cookie expiry and periodic re-seeding
+
+Google session cookies are not permanent. Expect to redo steps 2–8 periodically (frequency depends on your org's session-length policy and whether 2FA trust was established) — or immediately if:
+
+- The join flow starts failing with a **signed-out** error (see below) rather than a generic join-flow error.
+- The account's password was rotated, or 2FA/device-trust was reset.
+- The profile directory was deleted or moved (it is intentionally **never** auto-deleted by citadel — see "Why the profile survives" below).
+
+## Signed-out detection
+
+`internal/platform/meeting_browser.go` exports `IsGoogleSignInURL(url string) bool`, a deterministic check for whether the browser's current page is a Google sign-in redirect (`accounts.google.com`). `MeetingJoinHandler.runJoinFlow` (`internal/jobs/meeting_join.go`) calls this immediately after navigating to the meeting URL: if the persistent profile's session has expired, Meet redirects to sign-in, and the job fails **loudly** with a clear "profile is signed out, re-seed docs/meeting-bot-profile-seeding.md" error rather than silently limping on and joining anonymously (which is likely to be policy-rejected anyway, defeating the entire point of this profile).
+
+A secondary, best-effort DOM signal (`meetAccountChipPresentJS` in `meeting_join.go`) checks for the signed-in account chip on the pre-join page; it is logged as a warning only (its selector is unverified against a live Meet call — see the file's `LIVE-TUNING REQUIRED` block) and does not fail the job on its own.
+
+## Why the profile survives `Close()`
+
+Prior to #5122, `MeetingBrowser` used `os.MkdirTemp` for its `--user-data-dir` and deleted it in `closeLocked()` after every meeting — appropriate for a throwaway automation profile, but it would have destroyed the seeded session after the very first meeting. `closeLocked()` now leaves the profile directory on disk untouched (only the in-memory handle is cleared); only the browser process and its dedicated Xvfb display are torn down per run.
+
+## Concurrency note
+
+Because the profile is shared and persistent, the bot account can be in **at most one meeting at a time per node** — Chrome refuses to open a second process against a locked `--user-data-dir`. This is an intentional constraint, not a bug: it mirrors the account itself (one Google session, one active call).

--- a/internal/jobs/meeting_join.go
+++ b/internal/jobs/meeting_join.go
@@ -95,13 +95,13 @@ const (
 		`})()`
 )
 
-// errMeetingBotSignedOut is a sentinel wrapped into the runJoinFlow error when
+// ErrMeetingBotSignedOut is a sentinel wrapped into the runJoinFlow error when
 // the persistent bot profile's Google session has expired (issue #5122). A
 // distinct sentinel (rather than a bare fmt.Errorf) lets a caller
 // errors.Is-detect "needs re-seed" specifically, e.g. to raise a
 // higher-urgency alert than a generic join failure (stale selector, host never
 // admitted the bot, etc.).
-var errMeetingBotSignedOut = fmt.Errorf("meeting bot Chrome profile is signed out of its Google account")
+var ErrMeetingBotSignedOut = fmt.Errorf("meeting bot Chrome profile is signed out of its Google account")
 
 // meetJoinButtonLabels are the visible button texts Meet uses for the join
 // action, in priority order. "Ask to join" appears when the bot needs host
@@ -366,7 +366,7 @@ func (h *MeetingJoinHandler) runJoinFlow(ctx JobContext, br *platform.MeetingBro
 	if curURL, err := br.CurrentURL(); err != nil {
 		ctx.Log("warn", "     - could not read current URL for signed-out check (non-fatal): %v", err)
 	} else if platform.IsGoogleSignInURL(curURL) {
-		return fmt.Errorf("%w: redirected to %s — re-seed docs/meeting-bot-profile-seeding.md", errMeetingBotSignedOut, curURL)
+		return fmt.Errorf("%w: redirected to %s — re-seed docs/meeting-bot-profile-seeding.md", ErrMeetingBotSignedOut, curURL)
 	}
 	// Secondary, best-effort corroborating signal (see meetAccountChipPresentJS
 	// doc comment); logged only, not fatal.

--- a/internal/jobs/meeting_join.go
+++ b/internal/jobs/meeting_join.go
@@ -82,7 +82,26 @@ const (
 		`var el=document.querySelector('[aria-label*="participant" i] , [data-participant-count]');` +
 		`if(!el)return -1;var m=(el.getAttribute('data-participant-count')||el.innerText||"").match(/\d+/);` +
 		`return m?parseInt(m[0],10):-1;})()`
+	// meetAccountChipPresentJS returns true if a signed-in Google account chip
+	// (the avatar/initial in the top-right corner) is present on the pre-join
+	// page. Secondary, best-effort signed-out signal alongside the deterministic
+	// accounts.google.com URL redirect (platform.IsGoogleSignInURL) — the URL
+	// check is what actually fails the join; this is logged only, since a
+	// missing chip while ON the correct meet.google.com URL could just mean the
+	// selector is stale. TODO(live-tuning): confirm selector against a real,
+	// signed-in Meet pre-join page and consider promoting to fatal once trusted.
+	meetAccountChipPresentJS = `(function(){` +
+		`return !!document.querySelector('[aria-label*="Google Account" i],a[aria-label*="account" i] img,header img[alt*="account" i]');` +
+		`})()`
 )
+
+// errMeetingBotSignedOut is a sentinel wrapped into the runJoinFlow error when
+// the persistent bot profile's Google session has expired (issue #5122). A
+// distinct sentinel (rather than a bare fmt.Errorf) lets a caller
+// errors.Is-detect "needs re-seed" specifically, e.g. to raise a
+// higher-urgency alert than a generic join failure (stale selector, host never
+// admitted the bot, etc.).
+var errMeetingBotSignedOut = fmt.Errorf("meeting bot Chrome profile is signed out of its Google account")
 
 // meetJoinButtonLabels are the visible button texts Meet uses for the join
 // action, in priority order. "Ask to join" appears when the bot needs host
@@ -224,7 +243,13 @@ func meetingWavPath(workspaceDir, meetingID string) string {
 // (same workspace) to turn the recording into a transcript node-locally.
 type MeetingJoinHandler struct {
 	WorkspaceDir string
-	transcriber  *TranscribeAudioHandler
+	// ProfileDir overrides the persistent, signed-in bot Chrome profile
+	// directory (issue #5122). Empty means "use platform's default
+	// resolution" — EnvMeetingProfileDir, then ConfigDir()/meeting-profile.
+	// Exposed here (rather than only via the env var) so the worker's
+	// startup config can pin it explicitly, e.g. to a dedicated data volume.
+	ProfileDir  string
+	transcriber *TranscribeAudioHandler
 }
 
 // NewMeetingJoinHandler constructs a handler rooted at the node workspace.
@@ -257,8 +282,10 @@ func (h *MeetingJoinHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, er
 	}
 	defer func() { _, _ = rec.Stop() }()
 
-	// Launch the sibling meeting browser routed into the sink.
-	br := platform.NewMeetingBrowser(rec.SinkName())
+	// Launch the sibling meeting browser routed into the sink, reusing the
+	// persistent, signed-in bot Chrome profile (issue #5122) rather than a
+	// throwaway one.
+	br := platform.NewMeetingBrowser(rec.SinkName(), h.ProfileDir)
 	if err := br.Start(); err != nil {
 		return nil, fmt.Errorf("start meeting browser: %w", err)
 	}
@@ -328,6 +355,26 @@ func (h *MeetingJoinHandler) runJoinFlow(ctx JobContext, br *platform.MeetingBro
 		return fmt.Errorf("navigate to meeting url: %w", err)
 	}
 	time.Sleep(meetPageSettle)
+
+	// Fatal: the persistent bot profile's Google session may have expired
+	// (cookie expiry, revoked session, forced re-auth). Rather than silently
+	// falling back to an anonymous join — which many orgs policy-reject anyway,
+	// the whole reason this profile exists — detect the accounts.google.com
+	// sign-in redirect and fail with a clear, actionable error pointing at the
+	// re-seed doc instead of limping on and failing confusingly at the join
+	// button or admission step.
+	if curURL, err := br.CurrentURL(); err != nil {
+		ctx.Log("warn", "     - could not read current URL for signed-out check (non-fatal): %v", err)
+	} else if platform.IsGoogleSignInURL(curURL) {
+		return fmt.Errorf("%w: redirected to %s — re-seed docs/meeting-bot-profile-seeding.md", errMeetingBotSignedOut, curURL)
+	}
+	// Secondary, best-effort corroborating signal (see meetAccountChipPresentJS
+	// doc comment); logged only, not fatal.
+	if v, err := br.Evaluate(meetAccountChipPresentJS); err == nil {
+		if present, ok := v.(bool); ok && !present {
+			ctx.Log("warn", "     - no signed-in account chip detected on pre-join page (non-fatal secondary signal; profile may need re-seeding)")
+		}
+	}
 
 	// Best-effort: dismiss any camera/mic permission or "continue without …"
 	// prompts. A missing prompt is normal, so this never fails the flow.

--- a/internal/jobs/meeting_join_test.go
+++ b/internal/jobs/meeting_join_test.go
@@ -2,6 +2,8 @@ package jobs
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -180,6 +182,23 @@ func TestToInt(t *testing.T) {
 		if ok != c.ok || got != c.want {
 			t.Errorf("toInt(%v) = (%d,%v), want (%d,%v)", c.in, got, ok, c.want, c.ok)
 		}
+	}
+}
+
+// TestErrMeetingBotSignedOut_ErrorsIsDetectable exercises the whole point of
+// exporting a sentinel (issue #5122): a caller several layers up (the worker
+// adapter, an alerting hook) must be able to errors.Is-detect "the bot needs
+// re-seeding" specifically, distinct from a generic join-flow failure like a
+// stale selector or an admission timeout.
+func TestErrMeetingBotSignedOut_ErrorsIsDetectable(t *testing.T) {
+	wrapped := fmt.Errorf("%w: redirected to %s — re-seed docs/meeting-bot-profile-seeding.md",
+		ErrMeetingBotSignedOut, "https://accounts.google.com/signin")
+	if !errors.Is(wrapped, ErrMeetingBotSignedOut) {
+		t.Fatalf("errors.Is(wrapped, ErrMeetingBotSignedOut) = false, want true; wrapped=%v", wrapped)
+	}
+	genericErr := fmt.Errorf("click join button: selector not found")
+	if errors.Is(genericErr, ErrMeetingBotSignedOut) {
+		t.Fatalf("a generic join-flow error must NOT match ErrMeetingBotSignedOut")
 	}
 }
 

--- a/internal/platform/meeting_browser.go
+++ b/internal/platform/meeting_browser.go
@@ -6,25 +6,111 @@
 //
 // This is a deliberate SIBLING of CobrowseManager, not a reuse of it. The
 // co-browse manager is a process-wide singleton owning ONE long-lived browser
-// that a human logs into and the AI keeps steering. A meeting bot needs the
-// opposite: a short-lived, disposable browser per meeting, isolated from the
-// co-browse session so the two never fight over one Chromium (Chrome locks a
-// --user-data-dir to a single process, so they cannot share a profile anyway).
-// MeetingBrowser therefore owns its OWN Xvfb display, CDP debug port, and
-// throwaway profile dir, and reuses only the package-level, side-effect-free
-// launch helpers (buildChromeArgs, startManagedXvfb, withDisplay, findChromium,
-// pickTarget, cdpCommand) so there is no duplicated browser-launch logic.
+// that a human logs into and the AI keeps steering. A meeting bot needs a
+// short-lived browser PROCESS per meeting, isolated from the co-browse session
+// so the two never fight over one Chromium — but (issue #5122) it now shares
+// co-browse's other trait: a PERSISTENT profile, not a throwaway one. Google
+// policy-rejects anonymous meeting participants in many orgs, so the bot needs
+// a real, signed-in Google identity (notetaker@aceteam.ai) whose session
+// cookies survive across meetings; a human seeds that session once by hand
+// (docs/meeting-bot-profile-seeding.md — Google blocks automated login) and
+// every MEETING_JOIN thereafter reuses it. Chrome still locks a
+// --user-data-dir to one process, so co-browse and the meeting bot still
+// cannot share a profile with EACH OTHER, and only one meeting can use the bot
+// profile at a time. MeetingBrowser therefore owns its OWN Xvfb display, CDP
+// debug port, and persistent profile dir, and reuses only the package-level,
+// side-effect-free launch helpers (buildChromeArgs, startManagedXvfb,
+// withDisplay, findChromium, pickTarget, cdpCommand) so there is no duplicated
+// browser-launch logic.
 package platform
 
 import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 )
+
+// EnvMeetingProfileDir overrides the default persistent Chrome profile
+// directory for the meeting bot's signed-in Google account (issue #5122).
+// Unlike co-browse's throwaway-friendly profile, this one is deliberately
+// reused across every meeting: a human seeds it ONCE with a manual, real
+// sign-in to the bot's Google account (see docs/meeting-bot-profile-seeding.md
+// — automated Google login is detection-blocked, so this cannot be scripted),
+// and every subsequent MEETING_JOIN reuses the same cookies/session rather
+// than joining as an anonymous, easily-rejected participant. Set this when a
+// node's persistent state should live somewhere other than the default
+// (e.g. a dedicated data volume).
+const EnvMeetingProfileDir = "CITADEL_MEETING_PROFILE_DIR"
+
+// defaultMeetingProfileDirName is the directory name under ConfigDir() that
+// holds the persistent meeting-bot Chrome profile when EnvMeetingProfileDir is
+// unset.
+const defaultMeetingProfileDirName = "meeting-profile"
+
+// defaultMeetingProfileDir resolves the default persistent profile path,
+// following the same node-local persistent-state convention as the rest of
+// citadel (ConfigDir() also backs ~/.citadel-cli/tls, /logs, /gateway).
+func defaultMeetingProfileDir() string {
+	return filepath.Join(ConfigDir(), defaultMeetingProfileDirName)
+}
+
+// resolveMeetingProfileDir picks the effective profile directory: an explicit
+// per-browser override wins (set via NewMeetingBrowser), then
+// EnvMeetingProfileDir, then the default under ConfigDir(). Pure aside from
+// reading the environment, so precedence is unit-testable without touching
+// the filesystem.
+func resolveMeetingProfileDir(override string) string {
+	if override != "" {
+		return override
+	}
+	if v := strings.TrimSpace(os.Getenv(EnvMeetingProfileDir)); v != "" {
+		return v
+	}
+	return defaultMeetingProfileDir()
+}
+
+// preparePersistentProfileDir resolves the effective meeting-bot profile
+// directory and ensures it exists, locked down to owner-only permissions —
+// it holds real Google session cookies for the bot account (issue #5122).
+// Idempotent and safe to call every Start(): an already-seeded profile is
+// reused as-is (its contents are untouched), and a pre-existing directory
+// with looser permissions (e.g. created by an older citadel-cli build, or by
+// hand during seeding with a stray umask) is tightened rather than trusted.
+// Extracted from Start so the resolution + permission-lock logic is testable
+// without launching a real browser.
+func preparePersistentProfileDir(override string) (string, error) {
+	dir := resolveMeetingProfileDir(override)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("create meeting profile dir: %w", err)
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		return "", fmt.Errorf("lock down meeting profile dir permissions: %w", err)
+	}
+	return dir, nil
+}
+
+// IsGoogleSignInURL reports whether rawURL is a Google account authentication
+// page (accounts.google.com), the reliable, deterministic signal that the
+// meeting bot's persistent Chrome profile has lost its signed-in session and
+// Meet has redirected it to log in. Used by the join flow to fail loudly with
+// an actionable "re-seed the profile" error instead of continuing the join as
+// an unauthenticated (and often policy-rejected) anonymous participant. A
+// malformed URL is treated as "not a sign-in page" (returns false) so a
+// transient CDP read glitch never masquerades as a signed-out profile.
+func IsGoogleSignInURL(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(u.Hostname(), "accounts.google.com")
+}
 
 // ChromiumAvailable reports whether a Chromium/Chrome binary is on PATH. Exported
 // so capability detection can gate the `meeting` tag on a launchable browser
@@ -164,27 +250,41 @@ func describeCDPException(exc any) string {
 }
 
 // MeetingBrowser owns one disposable headed Chromium for a single meeting, its
-// dedicated Xvfb display, and its throwaway profile. Safe for concurrent use; the
-// reaper goroutines own the single Wait() for each child process, mirroring
-// CobrowseManager's process handling.
+// dedicated Xvfb display, and the notetaker's PERSISTENT, signed-in Chrome
+// profile (issue #5122). Only the browser process and its Xvfb display are
+// disposable now — the profile directory deliberately survives Close() so the
+// bot's Google session (seeded once, by hand; see
+// docs/meeting-bot-profile-seeding.md) carries over to the next meeting. Chrome
+// locks a --user-data-dir to one process, so two MeetingBrowsers sharing the
+// same profile cannot run concurrently: the bot account can be in at most one
+// meeting at a time. Safe for concurrent use; the reaper goroutines own the
+// single Wait() for each child process, mirroring CobrowseManager's process
+// handling.
 type MeetingBrowser struct {
-	mu         sync.Mutex
-	sinkName   string
-	debugPort  int
-	profileDir string
-	display    string
-	chromePath string
-	cmd        *exec.Cmd
-	exited     chan struct{}
-	xvfb       *exec.Cmd
-	xvfbExited chan struct{}
+	mu                 sync.Mutex
+	sinkName           string
+	profileDirOverride string
+	debugPort          int
+	profileDir         string
+	display            string
+	chromePath         string
+	cmd                *exec.Cmd
+	exited             chan struct{}
+	xvfb               *exec.Cmd
+	xvfbExited         chan struct{}
 }
 
 // NewMeetingBrowser creates a meeting browser whose audio will route into the
 // given PulseAudio sink (from a NullSinkRecorder). The sink must be loaded before
 // Start so the browser's PULSE_SINK target exists at launch.
-func NewMeetingBrowser(sinkName string) *MeetingBrowser {
-	return &MeetingBrowser{sinkName: sinkName}
+//
+// profileDirOverride pins the persistent Chrome profile directory for this
+// browser, taking precedence over EnvMeetingProfileDir and the ConfigDir()
+// default (see resolveMeetingProfileDir). Pass "" to use the default
+// resolution — the normal case; a caller only needs this for tests or to
+// point at a non-default data volume.
+func NewMeetingBrowser(sinkName, profileDirOverride string) *MeetingBrowser {
+	return &MeetingBrowser{sinkName: sinkName, profileDirOverride: profileDirOverride}
 }
 
 // DebugPort returns the CDP port the browser listens on (0 before Start).
@@ -199,6 +299,31 @@ func (b *MeetingBrowser) Display() string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.display
+}
+
+// ProfileDir returns the resolved persistent Chrome profile directory ("" before
+// Start).
+func (b *MeetingBrowser) ProfileDir() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.profileDir
+}
+
+// CurrentURL returns the browser's current page URL over CDP. Used by the join
+// flow's signed-out detection (see IsGoogleSignInURL): a persistent profile
+// whose Google session expired gets redirected to accounts.google.com instead
+// of landing on the Meet pre-join page.
+func (b *MeetingBrowser) CurrentURL() (string, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.cmd == nil {
+		return "", fmt.Errorf("meeting browser not started")
+	}
+	t, err := pickTarget(b.debugPort)
+	if err != nil {
+		return "", err
+	}
+	return t.URL, nil
 }
 
 // Start launches the headed Chromium on a fresh Xvfb display with a throwaway
@@ -220,17 +345,18 @@ func (b *MeetingBrowser) Start() error {
 		return err
 	}
 
-	// Fresh, unique profile per meeting: Chrome locks a --user-data-dir to one
-	// process, so a disposable dir both avoids colliding with the co-browse
-	// profile and lets parallel meetings run without stomping each other.
-	profileDir, err := os.MkdirTemp("", "citadel-meeting-profile-")
+	// Persistent, signed-in profile (issue #5122): resolve the same directory
+	// every run — override, then EnvMeetingProfileDir, then the ConfigDir()
+	// default — so a human's one-time manual Google sign-in (see
+	// docs/meeting-bot-profile-seeding.md) survives across meetings instead of
+	// being thrown away with the old MkdirTemp profile.
+	profileDir, err := preparePersistentProfileDir(b.profileDirOverride)
 	if err != nil {
-		return fmt.Errorf("create meeting profile dir: %w", err)
+		return err
 	}
 
 	debugPort, err := findFreeDebugPort()
 	if err != nil {
-		_ = os.RemoveAll(profileDir)
 		return err
 	}
 
@@ -239,7 +365,6 @@ func (b *MeetingBrowser) Start() error {
 	// Xvfb has no GPU, so force software rendering.
 	xvfb, display, err := startManagedXvfb(xvfbResolution())
 	if err != nil {
-		_ = os.RemoveAll(profileDir)
 		return err
 	}
 
@@ -262,7 +387,8 @@ func (b *MeetingBrowser) Start() error {
 		if xvfb.Process != nil {
 			_ = xvfb.Process.Kill()
 		}
-		_ = os.RemoveAll(profileDir)
+		// profileDir is intentionally left in place: it is the persistent,
+		// signed-in bot profile, not a throwaway launch artifact.
 		return fmt.Errorf("launch meeting chromium: %w", err)
 	}
 
@@ -384,11 +510,11 @@ func (b *MeetingBrowser) closeLocked() error {
 	b.xvfbExited = nil
 	b.display = ""
 
-	if b.profileDir != "" {
-		if err := os.RemoveAll(b.profileDir); err != nil && firstErr == nil {
-			firstErr = fmt.Errorf("remove meeting profile dir: %w", err)
-		}
-		b.profileDir = ""
-	}
+	// Deliberately NOT removed (issue #5122): b.profileDir is the persistent,
+	// signed-in bot profile, not a throwaway per-run artifact. Deleting it here
+	// would silently wipe the human's one-time manual Google sign-in on every
+	// meeting teardown, forcing a re-seed before the bot could ever join again.
+	// Only clear the in-memory field; the directory on disk stays.
+	b.profileDir = ""
 	return firstErr
 }

--- a/internal/platform/meeting_browser_test.go
+++ b/internal/platform/meeting_browser_test.go
@@ -2,6 +2,9 @@ package platform
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -94,7 +97,9 @@ func TestMeetingBrowser_Launch(t *testing.T) {
 	if !ChromiumAvailable() || !XvfbAvailable() {
 		t.Skip("no Chromium or Xvfb on this host; skipping meeting-browser launch test")
 	}
-	br := NewMeetingBrowser("citadel_meeting_gotest")
+	// Isolate this run to a throwaway profile dir so the integration test never
+	// touches (or depends on) a real seeded bot profile under ConfigDir().
+	br := NewMeetingBrowser("citadel_meeting_gotest", filepath.Join(t.TempDir(), "meeting-profile"))
 	if err := br.Start(); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -112,6 +117,148 @@ func TestMeetingBrowser_Launch(t *testing.T) {
 	// A throwing expression must surface as a Go error, not a silent success.
 	if _, err := br.Evaluate(`throw new Error("nope")`); err == nil {
 		t.Fatal("expected error from throwing JS expression, got nil")
+	}
+}
+
+// TestResolveMeetingProfileDir_Precedence checks the persistent-profile-dir
+// override chain (issue #5122): an explicit per-browser override beats
+// EnvMeetingProfileDir, which beats the ConfigDir()-rooted default. Pure
+// (no filesystem I/O), so it does not need t.TempDir().
+func TestResolveMeetingProfileDir_Precedence(t *testing.T) {
+	t.Setenv(EnvMeetingProfileDir, "/env/profile")
+
+	if got := resolveMeetingProfileDir("/override/profile"); got != "/override/profile" {
+		t.Errorf("override should win over env var; got %q", got)
+	}
+	if got := resolveMeetingProfileDir(""); got != "/env/profile" {
+		t.Errorf("env var should win over default when override is unset; got %q", got)
+	}
+
+	t.Setenv(EnvMeetingProfileDir, "")
+	if got := resolveMeetingProfileDir(""); got != defaultMeetingProfileDir() {
+		t.Errorf("expected ConfigDir()-rooted default when override and env are both unset; got %q, want %q",
+			got, defaultMeetingProfileDir())
+	}
+}
+
+// TestMeetingBrowser_IsGoogleSignInURL checks the deterministic signed-out signal: any URL
+// hosted on accounts.google.com is a sign-in redirect, everything else
+// (including a real Meet URL, and unparseable input) is not.
+func TestMeetingBrowser_IsGoogleSignInURL(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{"signin identifier page", "https://accounts.google.com/signin/v2/identifier?service=meet", true},
+		{"bare accounts host", "https://accounts.google.com/", true},
+		{"case-insensitive host", "https://ACCOUNTS.GOOGLE.COM/signin", true},
+		{"real meet url", "https://meet.google.com/abc-defg-hij", false},
+		{"unrelated google host", "https://mail.google.com/mail/u/0/", false},
+		{"empty string", "", false},
+		{"unparseable url", "http://[::1", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsGoogleSignInURL(tc.url); got != tc.want {
+				t.Errorf("IsGoogleSignInURL(%q) = %v, want %v", tc.url, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMeetingProfileDir_CreatesWithOwnerOnlyPerms verifies a
+// freshly-created meeting profile dir is locked to 0700 — it will hold real
+// Google session cookies for the bot account (issue #5122).
+func TestMeetingProfileDir_CreatesWithOwnerOnlyPerms(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix permission bits not meaningful on windows")
+	}
+	target := filepath.Join(t.TempDir(), "nested", "meeting-profile")
+
+	got, err := preparePersistentProfileDir(target)
+	if err != nil {
+		t.Fatalf("preparePersistentProfileDir: %v", err)
+	}
+	if got != target {
+		t.Fatalf("preparePersistentProfileDir returned %q, want %q", got, target)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat profile dir: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o700 {
+		t.Errorf("expected owner-only 0700 perms, got %o", perm)
+	}
+}
+
+// TestMeetingProfileDir_ReusesExistingDirAndTightensLoosePerms
+// covers the "reuse across runs" contract: a pre-existing, already-seeded
+// profile directory keeps its contents (the seeded Google session), and
+// looser-than-0700 permissions on an existing dir (e.g. left over from manual
+// seeding under a permissive umask) are tightened rather than trusted.
+func TestMeetingProfileDir_ReusesExistingDirAndTightensLoosePerms(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix permission bits not meaningful on windows")
+	}
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o755); err != nil {
+		t.Fatalf("chmod setup: %v", err)
+	}
+	// Simulate seeded profile content (Chrome's cookie DB lives under Default/).
+	seeded := filepath.Join(dir, "Default", "Cookies")
+	if err := os.MkdirAll(filepath.Dir(seeded), 0o700); err != nil {
+		t.Fatalf("seed setup: %v", err)
+	}
+	if err := os.WriteFile(seeded, []byte("fake-session-cookie"), 0o600); err != nil {
+		t.Fatalf("seed setup: %v", err)
+	}
+
+	got, err := preparePersistentProfileDir(dir)
+	if err != nil {
+		t.Fatalf("preparePersistentProfileDir: %v", err)
+	}
+	if got != dir {
+		t.Fatalf("preparePersistentProfileDir returned %q, want %q (existing dir must be reused, not replaced)", got, dir)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat profile dir: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o700 {
+		t.Errorf("expected loose 0755 perms tightened to 0700, got %o", perm)
+	}
+	if _, err := os.Stat(seeded); err != nil {
+		t.Fatalf("expected pre-seeded profile content to survive reuse, got: %v", err)
+	}
+}
+
+// TestMeetingBrowser_CloseDoesNotRemoveProfileDir is the regression test for
+// the orphan-profile leak fix (issue #5122): the old MkdirTemp-based
+// closeLocked unconditionally os.RemoveAll'd the profile. Now that the
+// profile is the persistent, human-seeded bot session, Close() must leave it
+// on disk untouched — only the in-memory handle is cleared.
+func TestMeetingBrowser_CloseDoesNotRemoveProfileDir(t *testing.T) {
+	dir := t.TempDir()
+	seeded := filepath.Join(dir, "Default", "Cookies")
+	if err := os.MkdirAll(filepath.Dir(seeded), 0o700); err != nil {
+		t.Fatalf("seed setup: %v", err)
+	}
+	if err := os.WriteFile(seeded, []byte("fake-session-cookie"), 0o600); err != nil {
+		t.Fatalf("seed setup: %v", err)
+	}
+
+	// Construct directly (no real Start()) so this stays a pure filesystem
+	// test; closeLocked's process/Xvfb teardown paths are all nil-safe.
+	br := &MeetingBrowser{profileDir: dir}
+	if err := br.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := os.Stat(seeded); err != nil {
+		t.Fatalf("expected persistent profile content to survive Close(), got: %v", err)
+	}
+	if got := br.ProfileDir(); got != "" {
+		t.Errorf("expected in-memory ProfileDir cleared after Close, got %q", got)
 	}
 }
 

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -128,6 +128,12 @@ type LegacyHandlerOpts struct {
 	// "disabled" error rather than "unsupported job type"), but every command
 	// is rejected. Wired from the persisted `shell` node permission.
 	ShellDisabled bool
+	// MeetingProfileDir overrides the persistent, signed-in bot Chrome profile
+	// directory used by MEETING_JOIN (issue #5122). If empty, the handler falls
+	// back to platform.EnvMeetingProfileDir, then platform's ConfigDir()-rooted
+	// default — see jobs.MeetingJoinHandler.ProfileDir and
+	// docs/meeting-bot-profile-seeding.md.
+	MeetingProfileDir string
 }
 
 // CreateLegacyHandlers creates JobHandler adapters for all existing Nexus job handlers.
@@ -239,7 +245,7 @@ func CreateLegacyHandlersWithOpts(opts LegacyHandlerOpts) []JobHandler {
 		// internal/capabilities.
 		if config.LoadMeeting(platform.ConfigDir()).MeetingEnabled {
 			handlers = append(handlers,
-				NewLegacyHandlerAdapter(JobTypeMeetingJoin, jobs.NewMeetingJoinHandler(opts.WorkspaceDir)),
+				NewLegacyHandlerAdapter(JobTypeMeetingJoin, newMeetingJoinHandler(opts)),
 			)
 		}
 	}
@@ -267,4 +273,15 @@ func CreateLegacyHandlersWithOpts(opts LegacyHandlerOpts) []JobHandler {
 		result[i] = h
 	}
 	return result
+}
+
+// newMeetingJoinHandler wires opts.MeetingProfileDir into the handler so a
+// node's startup config can pin the persistent, signed-in bot Chrome profile
+// (issue #5122) without relying solely on the platform.EnvMeetingProfileDir
+// env var. Leaving it unset (the common case) preserves the handler's own
+// env-var-then-ConfigDir()-default resolution.
+func newMeetingJoinHandler(opts LegacyHandlerOpts) *jobs.MeetingJoinHandler {
+	h := jobs.NewMeetingJoinHandler(opts.WorkspaceDir)
+	h.ProfileDir = opts.MeetingProfileDir
+	return h
 }

--- a/internal/worker/handler_adapter_test.go
+++ b/internal/worker/handler_adapter_test.go
@@ -393,6 +393,32 @@ func TestCreateLegacyHandlersWithOpts_FileHandlers(t *testing.T) {
 	}
 }
 
+// TestNewMeetingJoinHandler_ThreadsProfileDirOverride covers the worker-config
+// half of the persistent bot profile plumbing (issue #5122): a node operator
+// pinning LegacyHandlerOpts.MeetingProfileDir (e.g. to a dedicated data
+// volume) must reach jobs.MeetingJoinHandler.ProfileDir, not just the
+// platform.EnvMeetingProfileDir env var.
+func TestNewMeetingJoinHandler_ThreadsProfileDirOverride(t *testing.T) {
+	h := newMeetingJoinHandler(LegacyHandlerOpts{
+		WorkspaceDir:      t.TempDir(),
+		MeetingProfileDir: "/custom/meeting-profile",
+	})
+	if h.ProfileDir != "/custom/meeting-profile" {
+		t.Errorf("ProfileDir = %q, want %q", h.ProfileDir, "/custom/meeting-profile")
+	}
+}
+
+// TestNewMeetingJoinHandler_DefaultsProfileDirEmpty checks the common case: an
+// unset MeetingProfileDir leaves ProfileDir empty so the handler falls back to
+// its own env-var-then-ConfigDir()-default resolution, rather than the worker
+// wiring accidentally forcing an empty-but-non-empty override.
+func TestNewMeetingJoinHandler_DefaultsProfileDirEmpty(t *testing.T) {
+	h := newMeetingJoinHandler(LegacyHandlerOpts{WorkspaceDir: t.TempDir()})
+	if h.ProfileDir != "" {
+		t.Errorf("expected empty ProfileDir when MeetingProfileDir is unset, got %q", h.ProfileDir)
+	}
+}
+
 // TestAllKnownJobTypesCoversRegisteredHandlers guards the allKnownJobTypes slice
 // (probed to report a node's supported job-type set in the unsupported-type
 // failure, issue #382) against drift. Handlers only expose CanHandle(type), so a


### PR DESCRIPTION
## Context

Stacked on #464 (#5098, epic #5097 — the sovereign auto-join notetaker). Early testing of the anonymous-join flow surfaced a blocker: many Google Workspace orgs policy-reject unauthenticated meeting participants outright, so an anonymous bot never even gets a lobby to wait in. The fix is identity, not selectors — the notetaker needs to join as a real, signed-in Google account (`notetaker@aceteam.ai`) whose session survives across meetings.

This PR is the **code half** of #5122. It also resolves the orphan-profile-dir landmine flagged during #5098 review: the old `os.MkdirTemp` profile was deleted on every `Close()`, which is correct for a throwaway automation profile but would have destroyed a seeded session after the very first meeting.

## What's code (this PR) vs. what stays human

| | |
|---|---|
| Creating the `notetaker@aceteam.ai` Google account | **Human** |
| Resolving/creating the profile dir, locking permissions, reuse across runs | **Code** ✅ |
| One-time manual sign-in into that profile (Google blocks scripted login) | **Human** — see `docs/meeting-bot-profile-seeding.md` |
| Not deleting the profile on browser teardown | **Code** ✅ |
| Detecting a signed-out/expired profile and failing loudly | **Code** ✅ (helper + join-flow wiring) |
| Live join verification against a real Meet call with a seeded account | **Human** — remains open, hence draft |

## Summary

**`internal/platform/meeting_browser.go`**
- Replaced the throwaway `os.MkdirTemp` `--user-data-dir` with a persistent profile directory, resolved via `preparePersistentProfileDir`: per-browser override (`NewMeetingBrowser(sinkName, profileDirOverride)`) → `CITADEL_MEETING_PROFILE_DIR` env var → default `<ConfigDir()>/meeting-profile` — the same node-local persistent-state root that already backs `tls/`, `logs/`, `gateway/`.
- The dir is `MkdirAll` + `chmod 0700`'d on **every** `Start()`, not just on first creation, so a pre-existing dir with looser permissions (e.g. from manual seeding under a permissive umask) gets tightened rather than trusted. It holds real Google session cookies.
- Killed the orphan-profile leak: `closeLocked()` no longer `os.RemoveAll`s the profile dir on any exit path (normal close, or an early failure during `Start()`). Only the in-memory handle is cleared — the seeded session survives every browser lifecycle.
- Added `IsGoogleSignInURL(url string) bool` — a deterministic, pure check for whether a URL is a Google sign-in redirect (`accounts.google.com`) — and `MeetingBrowser.CurrentURL()` to read the live page URL over CDP.

**`internal/jobs/meeting_join.go`**
- `MeetingJoinHandler.ProfileDir` lets the worker's startup config pin the profile path explicitly (in addition to the env var).
- `runJoinFlow` now checks `CurrentURL()` against `IsGoogleSignInURL` right after navigating to the meeting URL. A signed-out profile fails **loudly** with an actionable error pointing at the re-seed doc, instead of continuing on to a confusing join-button/admission-timeout failure or (worse) a silent anonymous join.
- Added `meetAccountChipPresentJS` as a secondary, best-effort DOM signal (account chip presence) in the existing `LIVE-TUNING REQUIRED` block — logged only, marked `TODO(live-tuning)` since its selector is unverified against a real signed-in Meet session, same caveat as the rest of that block.

**`docs/meeting-bot-profile-seeding.md`** (new)
- The exact one-time manual steps: stop the worker, launch headed Chrome on the node with the same `--user-data-dir`, sign into the bot account by hand (2FA note on device-trust to reduce re-seed frequency), verify on `meet.google.com`, close cleanly, restart the worker.
- Notes on cookie expiry / periodic re-seeding, the signed-out detection this PR wires up, why the profile survives `Close()`, and the one-meeting-at-a-time constraint (Chrome locks `--user-data-dir` to one process).

## Test plan

| Group | Coverage |
|---|---|
| `TestResolveMeetingProfileDir_Precedence` | override > env var > `ConfigDir()` default |
| `TestMeetingBrowser_IsGoogleSignInURL` | 7 cases: real sign-in URLs (incl. case-insensitivity), a real Meet URL, unrelated Google host, empty string, unparseable URL |
| `TestMeetingProfileDir_CreatesWithOwnerOnlyPerms` | fresh dir created at 0700 |
| `TestMeetingProfileDir_ReusesExistingDirAndTightensLoosePerms` | pre-existing 0755 dir with seeded content → reused (content untouched), perms tightened to 0700 |
| `TestMeetingBrowser_CloseDoesNotRemoveProfileDir` | regression test for the orphan-profile fix — `Close()` leaves seeded content on disk |
| Existing `TestMeetingBrowser_Launch` (integration, real Chromium+Xvfb, `-short`-skipped) | updated call site, isolated to a throwaway `t.TempDir()` profile so it never touches a real seeded profile |

```
go build ./... && go vet ./... && go test ./internal/platform/ -run Meeting -count=1
```
All pass except the pre-existing `TestMeetingBrowser_Launch` failure in this sandbox (no real Xvfb available — confirmed identical failure on unmodified `feat/5098-meeting-join-bot`, unrelated to this change). Full repo `go test ./... -short` is green except one pre-existing, unrelated failure in `internal/worklock` (also reproduces on the base branch).

## Related

- Epic #5097 (sovereign auto-join notetaker)
- #5098 / PR #464 (MEETING_JOIN handler this stacks on)
- #5122 (this issue — code half; human parts: account creation, manual seed, live join verification)