### PR TITLE
feat: LiveKit huddle support — reserved ports, host-network payload launches, compose env-file fix

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -1179,7 +1179,8 @@ func gatherControlCenterData() (controlcenter.StatusData, error) {
 
 			fullComposePath := filepath.Join(configDir, service.ComposeFile)
 			if _, err := os.Stat(fullComposePath); err == nil {
-				psCmd := composeCommand("-f", fullComposePath, "ps", "--format", "json")
+				psArgs := append(composeFileArgs(fullComposePath, fullComposePath), "ps", "--format", "json")
+				psCmd := composeCommand(psArgs...)
 				if output, err := psCmd.Output(); err == nil {
 					var containers []struct {
 						State  string `json:"State"`
@@ -1366,7 +1367,8 @@ func ccStopService(name string) error {
 	for _, service := range manifest.Services {
 		if service.Name == name {
 			fullComposePath := filepath.Join(configDir, service.ComposeFile)
-			cmd := composeCommand("-f", fullComposePath, "-p", "citadel-"+name, "down")
+			downArgs := append(composeFileArgs(fullComposePath, fullComposePath), "-p", "citadel-"+name, "down")
+			cmd := composeCommand(downArgs...)
 			return cmd.Run()
 		}
 	}
@@ -1384,7 +1386,8 @@ func ccRestartService(name string) error {
 	for _, service := range manifest.Services {
 		if service.Name == name {
 			fullComposePath := filepath.Join(configDir, service.ComposeFile)
-			cmd := composeCommand("-f", fullComposePath, "-p", "citadel-"+name, "restart")
+			restartArgs := append(composeFileArgs(fullComposePath, fullComposePath), "-p", "citadel-"+name, "restart")
+			cmd := composeCommand(restartArgs...)
 			return cmd.Run()
 		}
 	}
@@ -1407,7 +1410,8 @@ func ccGetServiceDetail(name string) *controlcenter.ServiceDetailInfo {
 			}
 
 			// Get container info via docker compose ps
-			psCmd := composeCommand("-f", fullComposePath, "-p", "citadel-"+name, "ps", "--format", "json")
+			psArgs := append(composeFileArgs(fullComposePath, fullComposePath), "-p", "citadel-"+name, "ps", "--format", "json")
+			psCmd := composeCommand(psArgs...)
 			if output, err := psCmd.Output(); err == nil {
 				var container struct {
 					ID      string `json:"ID"`
@@ -1448,7 +1452,8 @@ func ccGetServiceLogs(name string) ([]string, error) {
 	for _, service := range manifest.Services {
 		if service.Name == name {
 			fullComposePath := filepath.Join(configDir, service.ComposeFile)
-			cmd := composeCommand("-f", fullComposePath, "-p", "citadel-"+name, "logs", "--tail", "50", "--no-color")
+			logArgs := append(composeFileArgs(fullComposePath, fullComposePath), "-p", "citadel-"+name, "logs", "--tail", "50", "--no-color")
+			cmd := composeCommand(logArgs...)
 			output, err := cmd.Output()
 			if err != nil {
 				return nil, err

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -231,7 +231,8 @@ func restartAllServices() {
 		}
 		fmt.Printf("🔄 Restarting service: %s\n", service.Name)
 
-		composeCmd := composeCommand("-f", fullComposePath, "restart")
+		restartArgs := append(composeFileArgs(fullComposePath, fullComposePath), "restart")
+		composeCmd := composeCommand(restartArgs...)
 		output, err := composeCmd.CombinedOutput()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "   ❌ Failed to restart service %s: %s\n", service.Name, string(output))

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -213,6 +213,11 @@ func composeFileArgs(origComposePath, actualComposePath string) []string {
 	if override := sandboxOverridePathFor(origComposePath); override != "" {
 		args = append(args, "-f", override)
 	}
+	// Pass the install-time config env (<name>.env) explicitly: docker compose
+	// only auto-loads a file literally named ".env", so without this every
+	// ${VAR:?...}-guarded catalog service (claudecode, livekit) fails compose
+	// interpolation despite its config sitting right next to the compose file.
+	args = append(args, compose.EnvFileArgs(origComposePath)...)
 	return args
 }
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -261,7 +261,8 @@ func gatherStatusData() (dashboard.StatusData, error) {
 			if configDir != "" {
 				fullComposePath := filepath.Join(configDir, service.ComposeFile)
 				if _, err := os.Stat(fullComposePath); err == nil {
-					psCmd := composeCommand("-f", fullComposePath, "ps", "--format", "json")
+					psArgs := append(composeFileArgs(fullComposePath, fullComposePath), "ps", "--format", "json")
+					psCmd := composeCommand(psArgs...)
 					if output, err := psCmd.Output(); err == nil {
 						var containers []struct {
 							State string `json:"State"`
@@ -787,7 +788,8 @@ func printServiceInfo(w *tabwriter.Writer) {
 			continue
 		}
 
-		psCmd := composeCommand("-f", fullComposePath, "ps", "--format", "json")
+		psArgs := append(composeFileArgs(fullComposePath, fullComposePath), "ps", "--format", "json")
+		psCmd := composeCommand(psArgs...)
 		output, err := psCmd.CombinedOutput() // Use CombinedOutput to get stderr
 		if err != nil {
 			errMsg := string(output)

--- a/internal/compose/envfile.go
+++ b/internal/compose/envfile.go
@@ -1,0 +1,40 @@
+// internal/compose/envfile.go
+//
+// Resolution of the install-time config env for service compose invocations.
+//
+// `citadel service catalog install <name>` writes resolved config values to
+// <servicesDir>/<name>.env, next to the installed <name>.yml compose file. But
+// docker compose only auto-loads a file literally named ".env" (in the project
+// directory), so that sibling is invisible unless passed explicitly with
+// --env-file. Any compose file that guards its config with ${VAR:?...}
+// interpolation (claudecode's ACETEAM_*/ANTHROPIC_*, livekit's LIVEKIT_*) then
+// fails EVERY compose invocation — up, ps, restart, logs — even though the
+// config exists on disk. The whatsapp command worked around this locally
+// (cmd/whatsapp.go); this helper is the shared fix for the catalog services.
+package compose
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// EnvFileArgs returns the "--env-file <path>" arguments for a compose
+// invocation against an installed service compose file, when the install-time
+// sibling env file (<name>.env next to <name>.yml) exists. Returns nil when
+// there is no sibling, so call sites can append unconditionally.
+//
+// Derive from the ORIGINAL installed compose path, not a platform-stripped
+// temp copy — the sibling lives next to the original (same rule as the
+// sandbox override).
+func EnvFileArgs(composePath string) []string {
+	if composePath == "" {
+		return nil
+	}
+	base := strings.TrimSuffix(composePath, filepath.Ext(composePath))
+	envPath := base + ".env"
+	if fi, err := os.Stat(envPath); err != nil || fi.IsDir() {
+		return nil
+	}
+	return []string{"--env-file", envPath}
+}

--- a/internal/compose/envfile_test.go
+++ b/internal/compose/envfile_test.go
@@ -1,0 +1,51 @@
+package compose
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEnvFileArgs(t *testing.T) {
+	dir := t.TempDir()
+
+	composePath := filepath.Join(dir, "livekit.yml")
+	envPath := filepath.Join(dir, "livekit.env")
+	if err := os.WriteFile(composePath, []byte("services: {}\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(envPath, []byte("LIVEKIT_API_KEY=k\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := EnvFileArgs(composePath)
+	want := []string{"--env-file", envPath}
+	if len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("EnvFileArgs = %v, want %v", got, want)
+	}
+
+	// No sibling -> nil, so call sites can append unconditionally.
+	bare := filepath.Join(dir, "ollama.yml")
+	if err := os.WriteFile(bare, []byte("services: {}\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if got := EnvFileArgs(bare); got != nil {
+		t.Errorf("EnvFileArgs without sibling = %v, want nil", got)
+	}
+
+	if got := EnvFileArgs(""); got != nil {
+		t.Errorf("EnvFileArgs(\"\") = %v, want nil", got)
+	}
+
+	// A directory named like the env sibling must not be passed as --env-file.
+	dirCompose := filepath.Join(dir, "weird.yml")
+	if err := os.WriteFile(dirCompose, []byte("services: {}\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "weird.env"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if got := EnvFileArgs(dirCompose); got != nil {
+		t.Errorf("EnvFileArgs with dir sibling = %v, want nil", got)
+	}
+}

--- a/internal/jobs/service_payload.go
+++ b/internal/jobs/service_payload.go
@@ -16,8 +16,18 @@
 //	  "env":               {"ANTHROPIC_BASE_URL": "...", ...},  // JSON object
 //	  "host_port":         18789,                        // constant today (NOT per-instance)
 //	  "state_volume_path": "~/citadel-cache/instances/<id>",   // literal ~, node-expanded
-//	  "state_mount_path":  "/state"
+//	  "state_mount_path":  "/state",
+//	  "host_network":      "true"                        // optional; omit for the default port publish
 //	}
+//
+// host_network launches the container with `--network host` instead of a
+// `-p 127.0.0.1:<host_port>:<ctr_port>` publish — required for services whose
+// media plane needs real host sockets (the livekit SFU's UDP mux). The
+// container then binds whatever its own config binds; host_port remains
+// required and is used for endpoint reporting/health, so the platform should
+// set env PORT to the same value (e.g. 7880 for livekit) to keep the recorded
+// container port truthful. The grant is gated by the image allowlist below,
+// same as every payload launch.
 //
 // The platform does NOT read back the launched endpoint; it reaches the
 // container at host_port over the mesh. So the host port is published VERBATIM,
@@ -84,6 +94,8 @@ type instanceSpec struct {
 	// (runc). Set so an untrusted BYOC workload can run under a stronger runtime
 	// (aceteam#5028 / substrate spike #468).
 	Runtime string
+	// HostNetwork launches with `--network host` instead of a -p publish.
+	HostNetwork bool
 }
 
 // allowedRuntimes is the strict allowlist of docker `--runtime` values a payload
@@ -128,11 +140,25 @@ func parseInstanceSpec(payload map[string]string, homeDir string) (*instanceSpec
 		return nil, err
 	}
 
+	hostNetwork := false
+	if raw := strings.TrimSpace(payload["host_network"]); raw != "" {
+		parsed, perr := strconv.ParseBool(raw)
+		if perr != nil {
+			return nil, fmt.Errorf("invalid host_network %q: expected a boolean", raw)
+		}
+		hostNetwork = parsed
+	}
+
 	hostPort, err := parsePort(payload["host_port"])
 	if err != nil {
 		return nil, fmt.Errorf("invalid host_port: %w", err)
 	}
-	if err := validateHostPort(hostPort); err != nil {
+	// Under host networking there is no -p publish: the container binds what
+	// its own config binds (for livekit, exactly the ports reserved for it in
+	// services/ports.go), and host_port is informational (endpoint reporting).
+	// The reserved-port guard exists to protect docker publishes, so it only
+	// applies to the publish path.
+	if err := validateHostPort(hostPort, !hostNetwork); err != nil {
 		return nil, err
 	}
 
@@ -176,6 +202,7 @@ func parseInstanceSpec(payload map[string]string, homeDir string) (*instanceSpec
 		StateVolumePath: volPath,
 		StateMountPath:  mountPath,
 		Runtime:         runtime,
+		HostNetwork:     hostNetwork,
 	}, nil
 }
 
@@ -236,10 +263,15 @@ func validateImageRef(image string) error {
 // listeners own (gateway, status server, VNC, terminal, ...). The host-port
 // registry (services/ports.go) is used here for VALIDATION only -- the port is
 // assigned by the platform, not re-allocated -- so a payload can never collide
-// with a citadel-internal listener.
-func validateHostPort(port int) error {
+// with a citadel-internal listener. publish=false (host networking) keeps only
+// the range check: there is no -p, so the reserved-port guard has nothing to
+// protect and would wrongly reject e.g. livekit's own reserved 7880.
+func validateHostPort(port int, publish bool) error {
 	if port < 1 || port > 65535 {
 		return fmt.Errorf("host_port %d out of range", port)
+	}
+	if !publish {
+		return nil
 	}
 	if name, reserved := embeddedservices.ReservedCitadelPorts[port]; reserved {
 		return fmt.Errorf("host_port %d is reserved for citadel's %s listener", port, name)
@@ -337,11 +369,20 @@ func buildDockerRunArgs(spec *instanceSpec) []string {
 		// auto-starts these). STOP does an explicit `docker rm`, so this does
 		// not resurrect a deliberately stopped instance.
 		"--restart", "unless-stopped",
+	}
+	if spec.HostNetwork {
+		// Real host sockets for services whose media plane can't live behind
+		// docker's userland proxy (livekit's UDP mux). The container binds per
+		// its own config; there is no publish.
+		args = append(args, "--network", "host")
+	} else {
 		// Publish on loopback only: the citadel gateway/mesh reaches services on
 		// 127.0.0.1, matching the manifest services' host publish.
-		"-p", fmt.Sprintf("127.0.0.1:%d:%d", spec.HostPort, spec.ContainerPort),
-		"-v", fmt.Sprintf("%s:%s", spec.StateVolumePath, spec.StateMountPath),
+		args = append(args, "-p", fmt.Sprintf("127.0.0.1:%d:%d", spec.HostPort, spec.ContainerPort))
 	}
+	args = append(args,
+		"-v", fmt.Sprintf("%s:%s", spec.StateVolumePath, spec.StateMountPath),
+	)
 
 	// Run under an alternative container runtime when one is requested (Kata,
 	// gVisor). Omitted entirely when empty so the daemon default (runc) is used.

--- a/internal/jobs/service_payload_test.go
+++ b/internal/jobs/service_payload_test.go
@@ -116,6 +116,11 @@ func TestParseInstanceSpec_Rejects(t *testing.T) {
 		{"empty env key", func(p map[string]string) { p["env"] = `{"":"v"}` }, "empty key"},
 		{"host_port not a number", func(p map[string]string) { p["host_port"] = "abc" }, "invalid host_port"},
 		{"host_port reserved", func(p map[string]string) { p["host_port"] = reservedPort }, "reserved for citadel"},
+		{"host_network not boolean", func(p map[string]string) { p["host_network"] = "maybe" }, "invalid host_network"},
+		{"host_network port out of range", func(p map[string]string) {
+			p["host_network"] = "true"
+			p["host_port"] = "70000"
+		}, "out of range"},
 		{"volume outside data dir", func(p map[string]string) { p["state_volume_path"] = "/etc" }, "outside the citadel data dir"},
 		{"volume traversal via ~", func(p map[string]string) { p["state_volume_path"] = "~/../../etc/passwd" }, "outside the citadel data dir"},
 		{"relative mount path", func(p map[string]string) { p["state_mount_path"] = "state" }, "must be an absolute container path"},
@@ -135,6 +140,45 @@ func TestParseInstanceSpec_Rejects(t *testing.T) {
 				t.Errorf("error = %q, want substring %q", err.Error(), tt.errSub)
 			}
 		})
+	}
+}
+
+func TestParseInstanceSpec_HostNetwork(t *testing.T) {
+	// The livekit shape: host networking, and a host_port that IS in the
+	// reserved set (7880 is reserved FOR livekit). Without a -p publish the
+	// reserved-port guard must not apply.
+	p := basePayload()
+	p["host_network"] = "true"
+	p["host_port"] = itoa(embeddedservices.LiveKitWSPort)
+	p["env"] = `{"PORT":"7880","LIVEKIT_CONFIG":"port: 7880"}`
+
+	spec, err := parseInstanceSpec(p, testHome)
+	if err != nil {
+		t.Fatalf("parseInstanceSpec: %v", err)
+	}
+	if !spec.HostNetwork {
+		t.Error("HostNetwork = false, want true")
+	}
+	if spec.HostPort != embeddedservices.LiveKitWSPort {
+		t.Errorf("HostPort = %d, want %d", spec.HostPort, embeddedservices.LiveKitWSPort)
+	}
+	if spec.ContainerPort != 7880 {
+		t.Errorf("ContainerPort = %d, want 7880 (from env PORT)", spec.ContainerPort)
+	}
+
+	// Omitted / explicit-false keeps the publish path and its reserved guard.
+	for _, raw := range []string{"", "false"} {
+		p := basePayload()
+		if raw != "" {
+			p["host_network"] = raw
+		}
+		spec, err := parseInstanceSpec(p, testHome)
+		if err != nil {
+			t.Fatalf("host_network=%q: %v", raw, err)
+		}
+		if spec.HostNetwork {
+			t.Errorf("host_network=%q: HostNetwork = true, want false", raw)
+		}
 	}
 }
 
@@ -224,6 +268,34 @@ func TestBuildDockerRunArgs(t *testing.T) {
 		if !strings.Contains(joined, want) {
 			t.Errorf("docker run args missing %q\n got: %s", want, joined)
 		}
+	}
+}
+
+func TestBuildDockerRunArgs_HostNetwork(t *testing.T) {
+	spec := &instanceSpec{
+		ServiceName:     "livekit",
+		ContainerName:   "citadel-livekit",
+		Image:           "ghcr.io/aceteam-ai/livekit-server:v1.13.3",
+		Env:             map[string]string{"LIVEKIT_CONFIG": "port: 7880", "PORT": "7880"},
+		HostPort:        7880,
+		ContainerPort:   7880,
+		StateVolumePath: "/home/citadel/citadel-cache/livekit",
+		StateMountPath:  "/state",
+		HostNetwork:     true,
+	}
+	args := buildDockerRunArgs(spec)
+	joined := strings.Join(args, " ")
+
+	if !strings.Contains(joined, "--network host") {
+		t.Errorf("docker run args missing --network host: %s", joined)
+	}
+	for i, a := range args {
+		if a == "-p" {
+			t.Errorf("host-network launch must not publish ports, found -p %s", args[i+1])
+		}
+	}
+	if args[len(args)-1] != spec.Image {
+		t.Errorf("image is not the last arg: %v", args)
 	}
 }
 

--- a/internal/status/collector.go
+++ b/internal/status/collector.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/apps"
+	"github.com/aceteam-ai/citadel-cli/internal/compose"
 	"github.com/aceteam-ai/citadel-cli/internal/desktop"
 	"github.com/aceteam-ai/citadel-cli/internal/network"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
@@ -346,7 +347,13 @@ func (c *Collector) detectLLMServiceType(serviceName string) string {
 
 // getDockerComposeStatus checks if a docker compose service is running.
 func (c *Collector) getDockerComposeStatus(composeFile string) string {
-	cmd := exec.Command("docker", "compose", "-f", composeFile, "ps", "--format", "json")
+	// Pass the install-time config env (<name>.env) explicitly: compose
+	// interpolates the file even for `ps`, so a ${VAR:?...}-guarded service
+	// (claudecode, livekit) would report a false ServiceStatusError on every
+	// heartbeat without it.
+	args := append([]string{"compose", "-f", composeFile}, compose.EnvFileArgs(composeFile)...)
+	args = append(args, "ps", "--format", "json")
+	cmd := exec.Command("docker", args...)
 	output, err := cmd.Output()
 	if err != nil {
 		return ServiceStatusError

--- a/services/ports.go
+++ b/services/ports.go
@@ -156,6 +156,17 @@ const (
 	// --terminal-port, internal/terminal/config.go). The platform relay dials
 	// ws://<vpn_ip>:7860, so this is a live mesh port a module must not take.
 	TerminalPort = 7860
+	// LiveKit SFU ports (voice huddles). The livekit catalog module
+	// (aceteam-ai/citadel-services services/livekit) runs with
+	// `network_mode: host`, so it binds these on the host directly — outside
+	// Docker's publish bookkeeping and outside this registry's env-var
+	// substitution. They are reserved here so no app allocation or module/
+	// payload publish can claim a port the SFU's own config will bind. The
+	// platform relay dials ws://<vpn_ip>:7880 for signaling, so 7880 is a live
+	// mesh port just like TerminalPort.
+	LiveKitWSPort     = 7880
+	LiveKitICETCPPort = 7881
+	LiveKitUDPMuxPort = 7882
 )
 
 // ReservedCitadelPorts is the set of host ports owned by citadel's own
@@ -170,6 +181,9 @@ var ReservedCitadelPorts = map[int]string{
 	VNCPort:           "vnc-rfb",
 	DeskstreamPort:    "deskstream-h264",
 	TerminalPort:      "terminal-server",
+	LiveKitWSPort:     "livekit-signaling",
+	LiveKitICETCPPort: "livekit-ice-tcp",
+	LiveKitUDPMuxPort: "livekit-udp-mux",
 }
 
 // AppsPortRange is the inclusive range apps auto-allocate host ports from


### PR DESCRIPTION
## Context

Node-side foundation for **AceTeam voice huddles** (team-chat calls at aceteam.ai/chat): a LiveKit WebRTC SFU runs as a Citadel service on the node a channel picks as its "call machine". The catalog module lives in aceteam-ai/citadel-services (`services/livekit`, companion branch `feat/livekit-service`); this PR is everything citadel-cli needs to host and launch it. Signaling reaches the node over the mesh (platform relay → `:7880`, same pattern as the terminal port), while WebRTC media flows browser↔node directly over a single-port UDP mux.

## Changes

**1. Reserve LiveKit ports (`services/ports.go`)** — 7880 (signaling WS), 7881 (ICE/TCP fallback), 7882 (UDP media mux) join `ReservedCitadelPorts`. The module runs with `network_mode: host`, so it binds these outside Docker's publish bookkeeping; reserving them keeps apps, modules, and payload publishes off them. The existing collision-guard test now enforces this for free.

**2. Host-network payload launches (`internal/jobs/service_payload.go`)** — the inline-spec `SERVICE_START` contract gains an optional `host_network: "true"` field: launches with `--network host` instead of `-p 127.0.0.1:<host_port>:<ctr_port>`. This is how the platform auto-provisions the SFU (generated key/secret injected via the payload `env`, no secrets in shell commands). Design notes:

- `host_port` stays required (endpoint reporting), but the reserved-port guard now only applies to the publish path — with no `-p` there is nothing to protect, and it would wrongly reject livekit's own reserved 7880. Range check retained.
- Trust gate unchanged: the `ghcr.io/aceteam-ai/` image allowlist still gates every payload launch, and host networking is a per-image grant under that same model.

**3. Fix: pass the install-time `<name>.env` to every service compose invocation** (`internal/compose/envfile.go` + call sites). Root cause: docker compose only auto-loads a file literally named `.env`, so the config that `citadel service catalog install` writes to `<servicesDir>/<name>.env` was invisible to every compose invocation. Impact today (pre-livekit): any `${VAR:?...}`-guarded catalog service — claudecode included — fails a manual `citadel run`, and the **heartbeat collector's `compose ps` reports a false error status on every beat** even while the container runs. The whatsapp command had already worked around exactly this locally (`cmd/whatsapp.go` `--env-file`). Now a shared `compose.EnvFileArgs` helper resolves the sibling env file and is wired through `composeFileArgs` (start paths), the bare `-f` sites in `status`, `run --restart`, controlcenter (ps/down/restart/logs), and the heartbeat collector.

## Testing

- Unit: host-network spec parsing (reserved port accepted under host networking, bad boolean / out-of-range port rejected, omitted/false keeps the publish path + guard), docker args (`--network host` present, no `-p`, image last), `EnvFileArgs` (sibling present/absent/empty/dir).
- `go test ./...` green apart from `TestEnsureStateDirCreatesDirectory`, which fails identically on `main` in this environment (writes to the real `$HOME`).
- **End-to-end on a Linux box with Docker**: `citadel service catalog install livekit --set LIVEKIT_API_KEY=... --set LIVEKIT_API_SECRET=...` → `citadel run livekit` brings the SFU up (previously died on the `:?` guard): STUN discovers the external IP, `GET :7880/ → 200`, `/rtc/validate` rejects bad tokens, UDP 7882 + TCP 7880/7881 bound on host interfaces including the mesh IP, and `citadel status` shows `livekit 🟢 RUNNING` (previously false error).

## Related

- Companion catalog module: aceteam-ai/citadel-services `feat/livekit-service` (blocked on repo write access)
- Platform side: voice-huddle Phase 2 in aceteam-ai/aceteam (calls API, token mint, signaling relay)
- Prior art for the env-file class of bug: #410 / #426 (CITADEL_*_HOST_PORT injection)

---
*Generated by Claude Fable 5*