### PR TITLE
feat(jobs): INSTANCE_MESSAGE handler — deliver BYOC turns to loopback container (#5241)

### DIFF
--- a/internal/jobs/instance_message_handler.go
+++ b/internal/jobs/instance_message_handler.go
@@ -1,0 +1,205 @@
+// internal/jobs/instance_message_handler.go
+//
+// Delivers a turn (a user/kickoff message) to a payload-launched BYOC agent
+// instance running on THIS node (citadel-cli#462 / aceteam#5241).
+//
+// The instance's container is published on node-loopback only
+// (127.0.0.1:<host_port>, by the #463 design) and is NOT reachable over the
+// tailnet, so the backend cannot POST the turn to it directly. Instead the
+// backend enqueues an INSTANCE_MESSAGE job on this node's per-node Redis stream
+// (fail-closed, aceteam#4426) and this handler does the trivial loopback POST to
+// the container's /hooks/agent ingress. This reuses the proven Redis dispatch
+// path (same transport as SERVICE_START / SHELL_COMMAND) and avoids the
+// mesh-HTTP/cert/SOCKS class of bugs entirely.
+//
+// The container's OUTBOUND reply (container -> POST /api/instances/{id}/reply)
+// already works over normal egress and is unaffected by this handler; only the
+// inbound hop is delivered here.
+package jobs
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"syscall"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+// InstanceMessageHandler resolves a running BYOC instance's published loopback
+// port from the instance store and POSTs a turn to its /hooks/agent endpoint.
+type InstanceMessageHandler struct {
+	// instances is the registry of payload-launched instances (shared on-disk
+	// state with the ServiceHandler). Lazily initialized; overridable in tests.
+	instances *instanceStore
+	// client is the HTTP client used for the loopback POST. Lazily initialized;
+	// overridable in tests.
+	client *http.Client
+	// loopbackBaseURL builds the base URL (scheme://host:port) for a resolved
+	// host port. Defaults to http://127.0.0.1:<port>; overridable in tests so
+	// the POST can target an httptest.Server.
+	loopbackBaseURL func(hostPort int) string
+}
+
+// NewInstanceMessageHandler creates a handler with production defaults.
+func NewInstanceMessageHandler() *InstanceMessageHandler {
+	return &InstanceMessageHandler{}
+}
+
+// hooksAgentURL builds the /hooks/agent turn-ingress URL for a published host
+// port. Kept as a pure function so URL construction is unit-testable.
+func hooksAgentURL(base string) string {
+	return base + "/hooks/agent"
+}
+
+func defaultLoopbackBaseURL(hostPort int) string {
+	return fmt.Sprintf("http://127.0.0.1:%d", hostPort)
+}
+
+func (h *InstanceMessageHandler) store() *instanceStore {
+	if h.instances == nil {
+		s, err := newInstanceStore()
+		if err != nil {
+			// Mirror ServiceHandler.instanceStore(): a store we cannot open
+			// degrades to one rooted at an empty path; Get() returns not-found,
+			// which fails closed (unknown instance) rather than mis-delivering.
+			h.instances = &instanceStore{}
+		} else {
+			h.instances = s
+		}
+	}
+	return h.instances
+}
+
+func (h *InstanceMessageHandler) httpClient() *http.Client {
+	if h.client == nil {
+		h.client = &http.Client{Timeout: 15 * time.Second}
+	}
+	return h.client
+}
+
+func (h *InstanceMessageHandler) baseURL(hostPort int) string {
+	if h.loopbackBaseURL != nil {
+		return h.loopbackBaseURL(hostPort)
+	}
+	return defaultLoopbackBaseURL(hostPort)
+}
+
+// instanceMessageResult is the JSON returned to the platform on success.
+type instanceMessageResult struct {
+	Delivered bool   `json:"delivered"`
+	Service   string `json:"service"`
+	Status    int    `json:"status"`
+}
+
+// Execute delivers a turn to a running BYOC instance on this node.
+//
+// Payload fields (the wire contract shared with the aceteam backend):
+//   - service : the platform service name (instance store key, "ac-<shortcode>")
+//   - message : the turn text to deliver
+//   - name    : the message name/label (e.g. "Kickoff" / "Coordination")
+//   - bearer  : the fully-derived /hooks/agent bearer ("hooks_<gateway_key>")
+//
+// Fail-closed: if the service is not a known running instance in THIS node's
+// store, the turn is rejected rather than delivered to some other container.
+func (h *InstanceMessageHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	service := job.Payload["service"]
+	if service == "" {
+		return nil, errors.New("job payload missing 'service' field")
+	}
+	message := job.Payload["message"]
+	if message == "" {
+		return nil, errors.New("job payload missing 'message' field")
+	}
+	bearer := job.Payload["bearer"]
+	if bearer == "" {
+		return nil, errors.New("job payload missing 'bearer' field")
+	}
+	name := job.Payload["name"]
+	if name == "" {
+		name = "Coordination"
+	}
+
+	// Resolve the instance's published loopback port from the local store. A
+	// record exists only for instances this node launched and has not stopped,
+	// so a hit is proof the target belongs here (fail-closed node scoping).
+	rec, ok, err := h.store().Get(service)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read instance store for %q: %w", service, err)
+	}
+	if !ok {
+		return nil, fmt.Errorf("instance %q is not a known running instance on this node", service)
+	}
+	if rec.HostPort <= 0 {
+		return nil, fmt.Errorf("instance %q has no published host port on record", service)
+	}
+
+	url := hooksAgentURL(h.baseURL(rec.HostPort))
+	ctx.Log("info", "     - [Job %s] Delivering turn to instance %s at %s", job.ID, service, url)
+
+	body, err := json.Marshal(map[string]string{"message": message, "name": name})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal turn body: %w", err)
+	}
+
+	status, err := h.postWithRetry(url, bearer, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deliver turn to instance %q: %w", service, err)
+	}
+	if status >= 400 {
+		return nil, fmt.Errorf("instance %q /hooks/agent returned status %d", service, status)
+	}
+
+	return json.Marshal(instanceMessageResult{Delivered: true, Service: service, Status: status})
+}
+
+// postWithRetry POSTs the turn, retrying a few times on connection-refused. The
+// SERVICE_START that launched the container confirms docker "running" before
+// this job is dispatched, but uvicorn inside the container may not have bound
+// the port yet on a fast kickoff -- a bounded retry absorbs that race cheaply.
+func (h *InstanceMessageHandler) postWithRetry(url, bearer string, body []byte) (int, error) {
+	const attempts = 4
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		if i > 0 {
+			time.Sleep(500 * time.Millisecond)
+		}
+		status, err := h.post(url, bearer, body)
+		if err == nil {
+			return status, nil
+		}
+		lastErr = err
+		if !isConnRefused(err) {
+			return 0, err
+		}
+	}
+	return 0, lastErr
+}
+
+func (h *InstanceMessageHandler) post(url, bearer string, body []byte) (int, error) {
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := h.httpClient().Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	// Drain the body so the connection can be reused / closed cleanly.
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return resp.StatusCode, nil
+}
+
+// isConnRefused reports whether err is a connection-refused dial error, the
+// signature of a container whose HTTP server has not bound its port yet.
+func isConnRefused(err error) bool {
+	return errors.Is(err, syscall.ECONNREFUSED)
+}

--- a/internal/jobs/instance_message_handler_test.go
+++ b/internal/jobs/instance_message_handler_test.go
@@ -1,0 +1,194 @@
+// internal/jobs/instance_message_handler_test.go
+package jobs
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+func newMessageTestStore(t *testing.T) *instanceStore {
+	t.Helper()
+	return &instanceStore{path: filepath.Join(t.TempDir(), "instances", "state.json")}
+}
+
+func newMessageJob(payload map[string]string) *nexus.Job {
+	return &nexus.Job{ID: "test-job", Type: "INSTANCE_MESSAGE", Payload: payload}
+}
+
+// TestInstanceMessage_DeliversToResolvedPort verifies the handler resolves the
+// host port from the store and POSTs {message,name} with the bearer to
+// <base>/hooks/agent.
+func TestInstanceMessage_DeliversToResolvedPort(t *testing.T) {
+	var gotPath, gotAuth, gotContentType string
+	var gotBody map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotContentType = r.Header.Get("Content-Type")
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	store := newMessageTestStore(t)
+	if err := store.Put(InstanceRecord{ServiceName: "ac-abc", HostPort: 18800, ContainerName: "citadel-ac-abc"}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	var gotPort int
+	h := &InstanceMessageHandler{
+		instances: store,
+		loopbackBaseURL: func(port int) string {
+			gotPort = port
+			return srv.URL
+		},
+	}
+
+	out, err := h.Execute(JobContext{}, newMessageJob(map[string]string{
+		"service": "ac-abc",
+		"message": "hello there",
+		"name":    "Kickoff",
+		"bearer":  "hooks_gw_key_123",
+	}))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if gotPort != 18800 {
+		t.Errorf("resolved port = %d, want 18800", gotPort)
+	}
+	if gotPath != "/hooks/agent" {
+		t.Errorf("path = %q, want /hooks/agent", gotPath)
+	}
+	if gotAuth != "Bearer hooks_gw_key_123" {
+		t.Errorf("auth = %q, want Bearer hooks_gw_key_123", gotAuth)
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("content-type = %q, want application/json", gotContentType)
+	}
+	if gotBody["message"] != "hello there" || gotBody["name"] != "Kickoff" {
+		t.Errorf("body = %+v, want message=hello there name=Kickoff", gotBody)
+	}
+
+	var res instanceMessageResult
+	if err := json.Unmarshal(out, &res); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if !res.Delivered || res.Service != "ac-abc" || res.Status != http.StatusOK {
+		t.Errorf("result = %+v, want delivered=true service=ac-abc status=200", res)
+	}
+}
+
+// TestInstanceMessage_DefaultsName verifies the name defaults to Coordination.
+func TestInstanceMessage_DefaultsName(t *testing.T) {
+	var gotName string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]string
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		gotName = body["name"]
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	store := newMessageTestStore(t)
+	_ = store.Put(InstanceRecord{ServiceName: "ac-abc", HostPort: 20000})
+	h := &InstanceMessageHandler{instances: store, loopbackBaseURL: func(int) string { return srv.URL }}
+
+	if _, err := h.Execute(JobContext{}, newMessageJob(map[string]string{
+		"service": "ac-abc", "message": "hi", "bearer": "hooks_x",
+	})); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotName != "Coordination" {
+		t.Errorf("default name = %q, want Coordination", gotName)
+	}
+}
+
+// TestInstanceMessage_FailsClosedOnUnknownInstance verifies that a service not
+// present in the store is rejected WITHOUT any HTTP call (no mis-delivery).
+func TestInstanceMessage_FailsClosedOnUnknownInstance(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	store := newMessageTestStore(t) // empty
+	h := &InstanceMessageHandler{instances: store, loopbackBaseURL: func(int) string { return srv.URL }}
+
+	_, err := h.Execute(JobContext{}, newMessageJob(map[string]string{
+		"service": "ac-missing", "message": "hi", "bearer": "hooks_x",
+	}))
+	if err == nil {
+		t.Fatal("expected error for unknown instance, got nil")
+	}
+	if !strings.Contains(err.Error(), "not a known running instance") {
+		t.Errorf("error = %v, want fail-closed unknown-instance error", err)
+	}
+	if called {
+		t.Error("handler POSTed for an unknown instance; must fail closed without delivery")
+	}
+}
+
+// TestInstanceMessage_MissingFields verifies payload validation.
+func TestInstanceMessage_MissingFields(t *testing.T) {
+	h := &InstanceMessageHandler{instances: newMessageTestStore(t)}
+	cases := []struct {
+		name    string
+		payload map[string]string
+		want    string
+	}{
+		{"no service", map[string]string{"message": "m", "bearer": "b"}, "service"},
+		{"no message", map[string]string{"service": "ac-x", "bearer": "b"}, "message"},
+		{"no bearer", map[string]string{"service": "ac-x", "message": "m"}, "bearer"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := h.Execute(JobContext{}, newMessageJob(tc.payload))
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("err = %v, want mention of %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestInstanceMessage_PropagatesHooks4xx verifies a 4xx from the container is
+// surfaced as a delivery error (so the platform learns the turn was rejected).
+func TestInstanceMessage_PropagatesHooks4xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	store := newMessageTestStore(t)
+	_ = store.Put(InstanceRecord{ServiceName: "ac-abc", HostPort: 20001})
+	h := &InstanceMessageHandler{instances: store, loopbackBaseURL: func(int) string { return srv.URL }}
+
+	_, err := h.Execute(JobContext{}, newMessageJob(map[string]string{
+		"service": "ac-abc", "message": "hi", "bearer": "hooks_x",
+	}))
+	if err == nil || !strings.Contains(err.Error(), "401") {
+		t.Errorf("err = %v, want status 401 surfaced", err)
+	}
+}
+
+// TestHooksAgentURL verifies pure URL construction.
+func TestHooksAgentURL(t *testing.T) {
+	if got := hooksAgentURL(defaultLoopbackBaseURL(18800)); got != "http://127.0.0.1:18800/hooks/agent" {
+		t.Errorf("hooksAgentURL = %q", got)
+	}
+	if got := defaultLoopbackBaseURL(9999); got != fmt.Sprintf("http://127.0.0.1:%d", 9999) {
+		t.Errorf("defaultLoopbackBaseURL = %q", got)
+	}
+}

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -187,6 +187,14 @@ func CreateLegacyHandlersWithOpts(opts LegacyHandlerOpts) []JobHandler {
 		// registration rationale as the screenshot/type/keys handlers above.
 		NewLegacyHandlerAdapter(JobTypeVNCActions, &jobs.ActionsHandler{}),
 		NewLegacyHandlerAdapter(JobTypeCobrowse, jobs.NewCobrowseHandler()),
+		// Turn delivery to a payload-launched BYOC instance (aceteam#5241).
+		// Registered unconditionally: it resolves the target from its own
+		// on-disk instance store (~/.citadel/instances/state.json, shared with
+		// the service handler) rather than the citadel.yaml manifest, so it
+		// needs neither a workspace nor a config dir. On a node that never
+		// launched an instance the store lookup misses and the handler fails
+		// closed rather than mis-delivering.
+		NewLegacyHandlerAdapter(JobTypeInstanceMessage, jobs.NewInstanceMessageHandler()),
 	}
 
 	// Register file-operation handlers when a workspace is configured.

--- a/internal/worker/job.go
+++ b/internal/worker/job.go
@@ -137,6 +137,7 @@ const (
 	JobTypeTranscribeAudio   = "TRANSCRIBE_AUDIO"    // Transcribe workspace audio node-locally via the faster-whisper sidecar
 	JobTypeAgentUpdate       = "AGENT_UPDATE"        // Remotely update + restart this node's own citadel agent (aceteam#4427)
 	JobTypeWhatsAppProvision = "WHATSAPP_PROVISION"  // Remotely deploy + provision the WhatsApp bridge on this node (aceteam#4454)
+	JobTypeInstanceMessage   = "INSTANCE_MESSAGE"    // Deliver a turn to a BYOC instance's loopback container (aceteam#5241)
 )
 
 // allKnownJobTypes enumerates every job type this citadel build knows about.
@@ -183,4 +184,5 @@ var allKnownJobTypes = []string{
 	JobTypeTranscribeAudio,
 	JobTypeAgentUpdate,
 	JobTypeWhatsAppProvision,
+	JobTypeInstanceMessage,
 }


### PR DESCRIPTION
## Context

BYOC provisioning works end-to-end on prod (`spawn_instance` launches a `claudecode-service` container on the node), but **turns never reach the container**. The container is published on node-loopback only (`127.0.0.1:<host_port>`, by the #463 design) and is not reachable over the tailnet, and the instance's `internal_url` is null. So `send_message_to_instance` and the kickoff both had nowhere to deliver to.

This is the citadel half of the fix. It adds a job handler that receives the turn over the node's per-node Redis stream and does the trivial loopback POST to the container's `/hooks/agent` ingress.

## Approach — Option C: Redis-mediated inbound delivery

Rather than making the container mesh-reachable (tailnet bind / gateway HTTP / SOCKS / self-signed cert — the whole bug class that's been biting BYOC), the backend enqueues a turn job on the node's **per-node** Redis stream and this handler forwards it to loopback. This reuses the proven Redis dispatch transport (identical to SERVICE_START / SHELL_COMMAND, which work reliably) and keeps the mesh out of the inbound turn path entirely. The container's **outbound** reply (`container → POST /api/instances/{id}/reply`) already works over normal egress and is untouched.

## The job-type contract (both sides must agree)

- **Type string:** `INSTANCE_MESSAGE` (defined here as `JobTypeInstanceMessage` in `internal/worker/job.go`; the aceteam backend enqueues this exact string as `INSTANCE_MESSAGE_JOB_TYPE`).
- **Payload** (Redis stream field `payload`, a JSON string; arrives as `map[string]string` after the legacy adapter coerces it):

  | field | meaning |
  |-------|---------|
  | `service` | platform service name = instance-store key (`ac-<shortcode>`) |
  | `message` | the turn text |
  | `name`    | message label (`Kickoff` / `Coordination`) |
  | `bearer`  | fully-derived `/hooks/agent` bearer (`hooks_<gateway_key>`), derived backend-side |

The handler POSTs `{message, name}` with `Authorization: Bearer <bearer>` to `http://127.0.0.1:<host_port>/hooks/agent`.

## Summary

- **`internal/jobs/instance_message_handler.go`** — new legacy handler. Resolves the instance's published host port from the on-disk instance store (`~/.citadel/instances/state.json`, shared with the service handler), then POSTs the turn to loopback `/hooks/agent`.
  - **Fails closed:** if `service` is not a known running instance in *this* node's store, the turn is rejected with an error and **no HTTP call is made** — a turn can never be mis-delivered to another container.
  - **Bounded retry on connection-refused:** SERVICE_START confirms docker `running`, not that uvicorn has bound the port; a couple of retries absorb that race on a fast kickoff. Non-refused errors return immediately.
- **`internal/worker/job.go`** — `JobTypeInstanceMessage = "INSTANCE_MESSAGE"`, added to the const block and `allKnownJobTypes` (#382 supported-type reporting).
- **`internal/worker/handler_adapter.go`** — registered unconditionally (it uses its own instance store, so it needs neither a workspace nor a config dir).

## Test plan

`go build ./... && go vet ./... && gofmt -l . && go test ./...` — all green.

| Test | Covers |
|------|--------|
| `TestInstanceMessage_DeliversToResolvedPort` | port resolved from store; POST hits `/hooks/agent` with `Bearer hooks_…` and `{message,name}` body |
| `TestInstanceMessage_DefaultsName` | `name` defaults to `Coordination` |
| `TestInstanceMessage_FailsClosedOnUnknownInstance` | unknown service → error, **zero** HTTP calls |
| `TestInstanceMessage_MissingFields` | validation of `service` / `message` / `bearer` |
| `TestInstanceMessage_PropagatesHooks4xx` | container 4xx surfaced as delivery error |
| `TestHooksAgentURL` | pure URL construction |

## Live verification (backend + node, reserved to Jason)

1. Release citadel to the fleet, then `dispatch_node_update` node `1084`.
2. Deploy the aceteam backend PR.
3. `spawn_instance(node_id=1084, template_id="claude-code")` → container running.
4. `send_message_to_instance(<id>, "hello")` → expect a real reply back on the transcript (receipt, not assertion).

## Related

- Backend half (enqueues `INSTANCE_MESSAGE`, delivery branch + env-durability fix): aceteam#5241 PR — https://github.com/aceteam-ai/aceteam/pull/5261
- Refs aceteam#5241 · #463 (instance store) · #5147 (per-node host-port allocation)
