### PR TITLE
fix(huddles): expose LiveKit signaling (7880) over the tsnet mesh

### DIFF
--- a/cmd/work.go
+++ b/cmd/work.go
@@ -46,6 +46,7 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/worker"
 	"github.com/aceteam-ai/citadel-cli/internal/workflow"
 	"github.com/aceteam-ai/citadel-cli/internal/worklock"
+	"github.com/aceteam-ai/citadel-cli/services"
 	"github.com/google/uuid"
 	goredis "github.com/redis/go-redis/v9"
 	"github.com/spf13/cobra"
@@ -1252,6 +1253,28 @@ func runWork(cmd *cobra.Command, args []string) {
 					Log("control server VPN listener on %s:%s", ctrlIP, ctrlPort)
 					fmt.Printf("   - Control server VPN (mTLS): https://%s:%d\n", ctrlIP, controlPortForVPN)
 				}
+			}
+
+			// LiveKit signaling rides the mesh as a raw TCP pipe: the SFU
+			// container binds host port 7880 (docker host networking), which
+			// tsnet's userspace stack does NOT expose at the VPN IP on its
+			// own. The platform relay dials ws://<vpn_ip>:7880/rtc
+			// (services/ports.go LiveKitWSPort), so pipe that port to the
+			// host. Lazy per-connection dial: harmless when the livekit
+			// service isn't installed, picks it up the moment it starts.
+			lkPort := fmt.Sprintf("%d", services.LiveKitWSPort)
+			if lkLn, lkIP, err := network.ListenVPN("tcp", lkPort); err != nil {
+				Log("livekit signaling VPN listener failed: %v", err)
+				fmt.Fprintf(os.Stderr, "   - ⚠️ LiveKit signaling VPN listener failed: %v\n", err)
+			} else {
+				lkTarget := fmt.Sprintf("127.0.0.1:%d", services.LiveKitWSPort)
+				go func() {
+					if err := network.RunTCPProxy(ctx, lkLn, lkTarget); err != nil && err != context.Canceled {
+						Log("livekit signaling VPN proxy stopped: %v", err)
+					}
+				}()
+				Log("livekit signaling VPN proxy on %s:%s -> %s", lkIP, lkPort, lkTarget)
+				fmt.Printf("   - LiveKit signaling VPN: %s:%d -> %s\n", lkIP, services.LiveKitWSPort, lkTarget)
 			}
 		}
 

--- a/internal/network/tcpproxy.go
+++ b/internal/network/tcpproxy.go
@@ -1,0 +1,76 @@
+package network
+
+import (
+	"context"
+	"io"
+	"net"
+	"time"
+)
+
+// dialTimeout bounds the per-connection upstream dial. The target is always
+// loopback, so a healthy service answers instantly; the timeout only trims
+// how long a dead target holds the downstream open.
+const dialTimeout = 5 * time.Second
+
+// RunTCPProxy accepts connections on ln and pipes each to a fresh TCP
+// connection to targetAddr until ctx is cancelled. The dial is lazy and
+// per-connection, so a target that starts after the proxy (e.g. the livekit
+// container coming up on its host port) is picked up automatically — the
+// same posture as the websockify bridge's lazy VNC dial.
+//
+// This is what exposes a host-bound service port over the tsnet mesh: tsnet
+// is userspace networking, so a docker host-network port is NOT reachable at
+// the node's VPN IP unless the citadel process explicitly listens there and
+// pipes the bytes (see services/ports.go LiveKitWSPort).
+func RunTCPProxy(ctx context.Context, ln net.Listener, targetAddr string) error {
+	go func() {
+		<-ctx.Done()
+		_ = ln.Close()
+	}()
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return err
+		}
+		go proxyTCPConn(ctx, conn, targetAddr)
+	}
+}
+
+func proxyTCPConn(ctx context.Context, downstream net.Conn, targetAddr string) {
+	defer downstream.Close()
+
+	dialer := net.Dialer{Timeout: dialTimeout}
+	upstream, err := dialer.DialContext(ctx, "tcp", targetAddr)
+	if err != nil {
+		// Nothing listening on the target (service not installed/running).
+		// Closing the downstream is the whole error signal, matching what a
+		// direct connection refusal would look like to the dialer.
+		return
+	}
+	defer upstream.Close()
+
+	done := make(chan struct{}, 2)
+	pump := func(dst, src net.Conn) {
+		_, _ = io.Copy(dst, src)
+		// Half-close where the transport supports it so the peer sees EOF
+		// and can finish its own write side (WebSocket close handshake).
+		if cw, ok := dst.(interface{ CloseWrite() error }); ok {
+			_ = cw.CloseWrite()
+		}
+		done <- struct{}{}
+	}
+	go pump(upstream, downstream)
+	go pump(downstream, upstream)
+
+	// Wait for one direction to finish, then give the other a bounded drain
+	// before the deferred closes tear the pipe down.
+	<-done
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+	case <-ctx.Done():
+	}
+}

--- a/internal/network/tcpproxy_test.go
+++ b/internal/network/tcpproxy_test.go
@@ -1,0 +1,118 @@
+package network
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// echoServer accepts one connection and echoes everything back.
+func echoServer(t *testing.T) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("echo listen: %v", err)
+	}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer conn.Close()
+				_, _ = io.Copy(conn, conn)
+			}()
+		}
+	}()
+	return ln
+}
+
+func TestRunTCPProxyPipesBothDirections(t *testing.T) {
+	echo := echoServer(t)
+	defer echo.Close()
+
+	proxyLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("proxy listen: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = RunTCPProxy(ctx, proxyLn, echo.Addr().String()) }()
+
+	conn, err := net.Dial("tcp", proxyLn.Addr().String())
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer conn.Close()
+
+	payload := []byte("livekit-signaling-bytes")
+	if _, err := conn.Write(payload); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := make([]byte, len(payload))
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	if _, err := io.ReadFull(conn, got); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("echoed %q, want %q", got, payload)
+	}
+}
+
+// A dead target must close the downstream promptly — that closure IS the
+// error signal the platform relay classifies as "SFU not running".
+func TestRunTCPProxyDeadTargetClosesDownstream(t *testing.T) {
+	// Reserve an address with nothing listening.
+	dead, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	deadAddr := dead.Addr().String()
+	dead.Close()
+
+	proxyLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("proxy listen: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = RunTCPProxy(ctx, proxyLn, deadAddr) }()
+
+	conn, err := net.Dial("tcp", proxyLn.Addr().String())
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer conn.Close()
+
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	buf := make([]byte, 1)
+	if _, err := conn.Read(buf); err == nil {
+		t.Fatal("expected downstream close/EOF for dead target, got data")
+	}
+}
+
+func TestRunTCPProxyStopsOnContextCancel(t *testing.T) {
+	echo := echoServer(t)
+	defer echo.Close()
+
+	proxyLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("proxy listen: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- RunTCPProxy(ctx, proxyLn, echo.Addr().String()) }()
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != context.Canceled {
+			t.Fatalf("RunTCPProxy returned %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("RunTCPProxy did not stop on cancel")
+	}
+}


### PR DESCRIPTION
## Context

Found on the first live signaling attempt of the voice-huddles E2E (aceteam-ai/aceteam#5298). The platform relay dials `ws://<vpn_ip>:7880/rtc` to reach a call machine's SFU — #479 reserved 7880-7882 and documented 7880 as a live mesh port, but nothing ever listened there. Citadel's networking is embedded tsnet (userspace), so a docker host-network port like LiveKit's 7880 is **not** reachable at the node's VPN IP unless the citadel process explicitly listens and pipes the bytes. Every relay dial got connection-refused; huddle signaling was dead on arrival.

## Summary

- `internal/network/tcpproxy.go`: `RunTCPProxy` — accepts on a listener, pipes each connection to a fresh loopback dial. Lazy per-connection dial (the SFU container may start after `citadel work`, mirroring the websockify bridge's lazy VNC dial), TCP half-close forwarding so the WebSocket close handshake completes cleanly, shuts down with the work context.
- `cmd/work.go`: in the existing VPN-listener block (status server / mTLS control), add `ListenVPN(tcp, 7880)` → `RunTCPProxy` to `127.0.0.1:7880`. Unconditional: harmless when livekit isn't installed (a dead target closes the downstream, which the relay classifies as "SFU not running").

7881 (ICE/TCP) and 7882 (UDP mux) intentionally stay un-proxied — media flows browser↔node directly, not over the mesh.

## Test plan

- 3 unit tests: bidirectional piping, dead-target closes downstream promptly, context-cancel stops the accept loop.
- `go build ./...`, `go vet`, full `internal/network` suite green.
- Live verification happening in aceteam-ai/aceteam#5298 with a dev-built binary on a real node.

## Related

aceteam-ai/aceteam#5298 · aceteam-ai/aceteam#5290 · aceteam-ai/aceteam#5295 · #479

---
*Generated by Claude Fable 5*