### PR TITLE
fix(meeting): subscribe nodes to org-scoped meeting queue (#5098)

### DIFF
--- a/cmd/work.go
+++ b/cmd/work.go
@@ -999,6 +999,47 @@ func runWork(cmd *cobra.Command, args []string) {
 		Debug("per-node shell stream skipped: Headscale node ID unavailable")
 	}
 
+	// Subscribe to the org-scoped meeting-notetaker queue when this node can
+	// actually run a meeting bot. The backend routes MEETING_JOIN jobs to the
+	// per-org tag queue jobs:v1:tag:meeting:org_{org_id} (a security fix rejected
+	// the bare cross-org queue), so a node has to consume that exact stream for
+	// auto-join dispatch to reach it (aceteam-ai/aceteam#5098).
+	//
+	// Gated on the node advertising the "meeting" capability tag rather than
+	// subscribed unconditionally like the shell stream: a node lacking the
+	// audio-capture stack, Chromium, or Xvfb cannot run a meeting bot, so
+	// claiming the job would only fail it. The capability detector adds this tag
+	// only when that stack is present, and the MEETING_JOIN handler ships behind
+	// the same gate, so subscription, capability, and handler activate together.
+	if nodeCaps != nil && hasCapabilityTag(nodeCaps.Tags, "meeting") {
+		meetingOrgID := ""
+		if deviceConfig != nil {
+			meetingOrgID = deviceConfig.OrgID
+		}
+		if meetingOrgID == "" {
+			if manifest, _, mErr := findAndReadManifest(); mErr == nil && manifest != nil {
+				meetingOrgID = manifest.Node.OrgID
+			}
+		}
+		if meetingOrgID != "" {
+			meetingQueue := meetingQueueName(meetingOrgID)
+			switch src := source.(type) {
+			case *worker.APISource:
+				src.AddQueue(meetingQueue)
+			case *worker.RedisSource:
+				if err := src.AddQueue(ctx, meetingQueue); err != nil {
+					fmt.Fprintf(os.Stderr, "   - Warning: meeting queue subscribe failed: %v\n", err)
+				}
+			}
+			fmt.Printf("   - Meeting notetaker queue: %s\n", meetingQueue)
+			Debug("meeting queue: %s", meetingQueue)
+		} else {
+			fmt.Fprintln(os.Stderr, "   - Warning: meeting queue skipped (org id unknown); "+
+				"meeting auto-join dispatch will not reach this node")
+			Debug("meeting queue skipped: org id unknown")
+		}
+	}
+
 	// Populate the worker introspection state with the resolved identity and
 	// the full subscribed queue list (issue #236). This drives /agent/worker-status
 	// and the doctor diagnosis below.
@@ -2059,6 +2100,27 @@ func stopManagedServices(started []startedService) {
 // Every online worker in the org consumes it, so any of them may claim a job.
 func shellQueueName(orgID string) string {
 	return fmt.Sprintf("jobs:v1:shell:org_%s", orgID)
+}
+
+// meetingQueueName returns the org-scoped meeting-notetaker tag queue name.
+// The backend dispatches MEETING_JOIN jobs to this per-org tag queue; the bare
+// jobs:v1:tag:meeting queue is rejected server-side to prevent cross-org meeting
+// dispatch (aceteam-ai/aceteam#5098). The string MUST stay byte-for-byte
+// identical to the Python dispatch helper.
+func meetingQueueName(orgID string) string {
+	return fmt.Sprintf("jobs:v1:tag:meeting:org_%s", orgID)
+}
+
+// hasCapabilityTag reports whether the resolved capability tags contain the
+// given tag. Used to gate optional queue subscriptions on the node actually
+// advertising the matching capability.
+func hasCapabilityTag(tags []string, tag string) bool {
+	for _, t := range tags {
+		if t == tag {
+			return true
+		}
+	}
+	return false
 }
 
 // nodeQueueName returns the per-node shell stream name for node-targeted jobs.

--- a/cmd/work_test.go
+++ b/cmd/work_test.go
@@ -147,6 +147,60 @@ func TestResolveConsumerGroup(t *testing.T) {
 	}
 }
 
+// TestMeetingQueueName guards the org-scoped meeting-notetaker tag queue naming
+// convention. This string MUST match the Python dispatch helper byte-for-byte,
+// otherwise MEETING_JOIN auto-join dispatch (aceteam-ai/aceteam#5098) never
+// reaches the node. The bare jobs:v1:tag:meeting queue is rejected server-side.
+func TestMeetingQueueName(t *testing.T) {
+	tests := []struct {
+		orgID string
+		want  string
+	}{
+		{
+			orgID: "550e8400-e29b-41d4-a716-446655440000",
+			want:  "jobs:v1:tag:meeting:org_550e8400-e29b-41d4-a716-446655440000",
+		},
+		{
+			orgID: "test-org-id",
+			want:  "jobs:v1:tag:meeting:org_test-org-id",
+		},
+	}
+
+	for _, tt := range tests {
+		got := meetingQueueName(tt.orgID)
+		if got != tt.want {
+			t.Errorf("meetingQueueName(%q) = %q, want %q", tt.orgID, got, tt.want)
+		}
+	}
+}
+
+// TestHasCapabilityTag verifies the gate that decides whether a node subscribes
+// to the meeting queue: only nodes advertising the "meeting" capability tag do,
+// so a node without the audio/Chromium/Xvfb stack never claims a job it cannot
+// run.
+func TestHasCapabilityTag(t *testing.T) {
+	tests := []struct {
+		name string
+		tags []string
+		tag  string
+		want bool
+	}{
+		{"present", []string{"cpu:general", "meeting", "os:linux"}, "meeting", true},
+		{"absent", []string{"cpu:general", "os:linux"}, "meeting", false},
+		{"nil tags", nil, "meeting", false},
+		{"empty tags", []string{}, "meeting", false},
+		{"no partial match", []string{"meeting:room"}, "meeting", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasCapabilityTag(tt.tags, tt.tag); got != tt.want {
+				t.Errorf("hasCapabilityTag(%v, %q) = %v, want %v", tt.tags, tt.tag, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestNodeQueueName guards the per-node shell stream naming convention. This
 // string MUST match the Python build_node_queue helper byte-for-byte, otherwise
 // node-targeted jobs (issue #3914) silently fall back to the shared stream and


### PR DESCRIPTION
## Context

Part of the meeting-notetaker bot epic (aceteam-ai/aceteam#5097, crux aceteam-ai/aceteam#5098). The backend (aceteam PR #5288 / issue #5238) now dispatches `MEETING_JOIN` jobs to the **org-scoped** tag queue `jobs:v1:tag:meeting:org_{organization_id}`. This was a security fix: the bare, cross-org `jobs:v1:tag:meeting` queue is now rejected server-side so one org can't sniff another's meeting jobs.

The problem: Citadel nodes never subscribed to that org-scoped queue. So meeting auto-join dispatch was **fail-closed** — the backend enqueued jobs that nothing consumed. This PR makes the node subscribe to its own org's meeting queue.

## Summary

**`cmd/work.go`**
- New `meetingQueueName(orgID)` helper → `jobs:v1:tag:meeting:org_{org_id}`. Kept byte-for-byte aligned with the Python dispatch helper, same as the existing `shellQueueName` / `nodeQueueName` guards.
- New `hasCapabilityTag(tags, tag)` helper for gating optional subscriptions on an advertised capability.
- In `runWork`, after the per-node shell-stream subscription and before the worker-status snapshot, subscribe to the meeting queue via the live source's `AddQueue` (handles both `APISource` and `RedisSource`). Org id resolves from `deviceConfig.OrgID` with a manifest fallback, mirroring the per-node block. Subscribing here means the queue shows up in `/agent/worker-status`.

**Why capability-gated, not unconditional like the shell stream**

A node without the audio-capture stack (PulseAudio + ffmpeg + pactl), a launchable Chromium, or Xvfb physically cannot run a meeting bot. If it subscribed anyway and claimed a `MEETING_JOIN` job, it would only fail it — and because capability-based routing treats "a consumer is listening" as "don't fall back," a broken consumer is worse than no consumer. So the subscription is gated on the node advertising the `"meeting"` capability tag. This is also the same gate the capability detector and the `MEETING_JOIN` handler use, so subscription + capability + handler all activate together.

## Deploy note (important)

The `"meeting"` capability detector and the `MEETING_JOIN` handler currently live on the **unmerged** `feat/5098-meeting-join-bot` branch, which is stale (cut from an old `main`; its diff deletes current files and needs a real rebase before it can land). So:

- This PR has **zero compile dependency** on that branch — it only reads `nodeCaps.Tags` for the literal `"meeting"`. `go build ./...` is green on `main`.
- On `main` today it is a **dormant no-op**: no node advertises `"meeting"`, so nothing subscribes.
- Deploy is unblocked only once the capability detection **and** the handler are reworked off the stale branch and merged. This PR is one of three coupled legs, not the whole fix.

## Test plan

| Test | Coverage |
|------|----------|
| `TestMeetingQueueName` | Queue string matches `jobs:v1:tag:meeting:org_{org}` byte-for-byte |
| `TestHasCapabilityTag` | present / absent / nil / empty / no-partial-match |

`go build ./...` green. `go test ./...` green except a pre-existing flaky `internal/worklock.TestIsHeldLiveWorker` (spawns a live worker binary; passes in isolation and on pristine `main`, fails only under full-suite parallel load — unrelated to this change).

True end-to-end (a real node claiming a `MEETING_JOIN` job) can't be exercised on `main` since the path is dormant until the capability+handler land.

## Related

- Epic aceteam-ai/aceteam#5097, crux aceteam-ai/aceteam#5098
- Backend org-scoping fix: aceteam PR #5288 (issue #5238)
- Capability + handler: `feat/5098-meeting-join-bot` (needs rebase before merge)