### PR TITLE
ci: mirror livekit-server image into ghcr.io/aceteam-ai

### DIFF
--- a/.github/workflows/mirror-livekit-image.yml
+++ b/.github/workflows/mirror-livekit-image.yml
@@ -1,0 +1,64 @@
+name: Mirror livekit-server image
+
+# Mirrors the upstream LiveKit SFU image into the org registry as
+# ghcr.io/aceteam-ai/livekit-server, so Citadel nodes can pull it: the
+# payload-launch allowlist (internal/jobs/service_payload.go) only permits
+# ghcr.io/aceteam-ai/*, so the Docker Hub image (livekit/livekit-server)
+# cannot be launched directly. Auto-provisioning a channel's call machine
+# (aceteam-ai/aceteam#5299) references the mirrored tag.
+#
+# A pure manifest copy (no build): `imagetools create` preserves the upstream
+# multi-arch manifest list (amd64 + arm64) so nodes of either arch can pull.
+#
+# Manual, deliberate action — run once per LiveKit version bump. Uses the
+# workflow's ephemeral GITHUB_TOKEN with packages:write; no personal PAT and
+# nothing org-wide (this is the narrow alternative to a write:packages grant).
+#
+# NOTE: on first publish the new package is PRIVATE. Set its visibility to
+# Public in the org's package settings (Packages → livekit-server → Settings),
+# same as whisper-service — fabric nodes pull anonymously.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "LiveKit server version tag to mirror (e.g. v1.13.3)"
+        required: true
+        default: "v1.13.3"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.version }}
+  cancel-in-progress: false
+
+env:
+  SOURCE: livekit/livekit-server
+  DEST: ghcr.io/aceteam-ai/livekit-server
+
+jobs:
+  mirror:
+    name: Mirror ${{ inputs.version }}
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Mirror multi-arch image (manifest copy)
+        run: |
+          set -euo pipefail
+          echo "Mirroring ${SOURCE}:${{ inputs.version }} -> ${DEST}:${{ inputs.version }}"
+          docker buildx imagetools create \
+            -t "${DEST}:${{ inputs.version }}" \
+            "${SOURCE}:${{ inputs.version }}"
+
+      - name: Verify the mirrored manifest
+        run: |
+          docker buildx imagetools inspect "${DEST}:${{ inputs.version }}"


### PR DESCRIPTION
## Why

Voice huddles run the LiveKit **SFU** (self-hosted media server) on Citadel nodes. Citadel's payload-launch allowlist (`internal/jobs/service_payload.go`) only permits `ghcr.io/aceteam-ai/*` images, so the upstream `livekit/livekit-server` on Docker Hub can't be launched on a node directly. Auto-provisioning a channel's call machine (aceteam-ai/aceteam#5299) needs `ghcr.io/aceteam-ai/livekit-server:v1.13.3` to exist.

This is the **narrow, correct alternative to granting anyone `write:packages` on the org** — a CI workflow using the run's ephemeral `GITHUB_TOKEN` with `packages: write`, exactly like the existing `build-whisper-service.yml` / `build-diffusers-service.yml` publish jobs. No personal PAT, nothing org-wide, no long-lived credential.

## What it does

- `workflow_dispatch` with a `version` input (default `v1.13.3`) — a deliberate, once-per-LiveKit-bump action.
- Copies the upstream **multi-arch** manifest (amd64 + arm64) with `docker buildx imagetools create` — a manifest copy, not a rebuild — so nodes of either arch can pull.
- Verifies the mirrored manifest with `imagetools inspect`.

## One manual step after first run

GHCR packages start **private**. After the first mirror, set the package visibility to **Public** in the org's package settings (same as whisper-service) so fabric nodes pull anonymously. That's a one-time org setting a workflow can't flip.

## To use

Actions → *Mirror livekit-server image* → Run workflow → `v1.13.3`. Then flip the package public. That unblocks #5299.

## Related
- aceteam-ai/aceteam#5299 · precedent: `build-whisper-service.yml` (aceteam-ai/citadel-cli#465)

---
*Generated by Claude Fable 5*