### PR TITLE
feat(worker): MODULE_SET handler + live ModuleOps adapter (interim, Option A)

### DIFF
--- a/cmd/manifest.go
+++ b/cmd/manifest.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
 	"github.com/aceteam-ai/citadel-cli/services"
@@ -17,6 +18,22 @@ type Service struct {
 	Type        string `yaml:"type,omitempty"`         // "native" or "docker" (default: auto-detect)
 	ComposeFile string `yaml:"compose_file,omitempty"` // For docker services
 	Port        int    `yaml:"port,omitempty"`         // For native services
+	// DesiredStatus is the operator-assigned run-state for boot. Empty means the
+	// service is started on boot (the historical behavior). "stopped" makes a
+	// remote MODULE_SET "stopped" DURABLE: the service stays installed but the
+	// boot paths (citadel run / citadel work) SKIP composing it up, so a stop
+	// survives a reboot instead of silently coming back. This is a per-service
+	// marker; it is NOT the same as uninstalling (which removes the service).
+	DesiredStatus string `yaml:"desired_status,omitempty"`
+}
+
+// serviceStartDisabled reports whether a service is marked "stopped" and must be
+// SKIPPED by the boot-time service-start paths (runAllServices in cmd/run.go and
+// startManagedServices in cmd/work.go). This is the single predicate both boot
+// paths consult so a remote-assigned "stopped" state is honored consistently and
+// does not restart on reboot.
+func serviceStartDisabled(s Service) bool {
+	return strings.EqualFold(strings.TrimSpace(s.DesiredStatus), "stopped")
 }
 
 // ManifestCapabilities defines the optional capabilities section in citadel.yaml.
@@ -267,6 +284,53 @@ func addServiceToManifestWithTags(configDir, serviceName string, nodeTags []stri
 	}
 
 	// Write back
+	return writeManifest(manifestPath, manifest)
+}
+
+// removeServiceFromManifest removes a service from the node manifest by name and
+// writes it back. It is the de-registration half of an uninstall (the compose
+// teardown + lockfile/lock-file cleanup are the caller's responsibility). It is
+// idempotent: removing a service that is not present rewrites the manifest
+// unchanged and returns nil, so a re-run of an uninstall converges cleanly.
+func removeServiceFromManifest(configDir, serviceName string) error {
+	manifestPath := filepath.Join(configDir, "citadel.yaml")
+	manifest, _, err := findAndReadManifest()
+	if err != nil {
+		return fmt.Errorf("failed to read manifest: %w", err)
+	}
+	kept := make([]Service, 0, len(manifest.Services))
+	for _, s := range manifest.Services {
+		if s.Name == serviceName {
+			continue
+		}
+		kept = append(kept, s)
+	}
+	manifest.Services = kept
+	return writeManifest(manifestPath, manifest)
+}
+
+// setServiceDesiredStatus sets (or clears, when status is "") the per-service
+// boot marker used to make a remote "stopped" durable. Setting "stopped" makes
+// the boot-time service-start paths skip the service (serviceStartDisabled);
+// clearing it (status == "") restores start-on-boot. Returns an error if the
+// service is not present so a caller does not silently no-op on a typo'd name.
+func setServiceDesiredStatus(configDir, serviceName, status string) error {
+	manifestPath := filepath.Join(configDir, "citadel.yaml")
+	manifest, _, err := findAndReadManifest()
+	if err != nil {
+		return fmt.Errorf("failed to read manifest: %w", err)
+	}
+	found := false
+	for i := range manifest.Services {
+		if manifest.Services[i].Name == serviceName {
+			manifest.Services[i].DesiredStatus = status
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("service %q not found in manifest", serviceName)
+	}
 	return writeManifest(manifestPath, manifest)
 }
 

--- a/cmd/module_ops.go
+++ b/cmd/module_ops.go
@@ -62,25 +62,19 @@ func (o *liveModuleOps) Install(ctx context.Context, m reconcile.ModuleAssignmen
 		return fmt.Errorf("parse source %q: %w", m.Source, err)
 	}
 
-	// Update-in-place: if this source is already installed, uninstall it first so
-	// the fresh install does not trip the port-conflict / already-in-manifest
-	// guards. Reconcile drives ActionUpdate through Install for source/config
-	// drift; this makes that a clean down+up.
-	if existing := o.installedNameForSource(m.Source); existing != "" {
-		o.log("MODULE_SET: %q already installed; updating in place", existing)
-		if err := o.Uninstall(ctx, existing); err != nil {
-			return fmt.Errorf("update %q: uninstall existing: %w", existing, err)
-		}
-	}
-
-	// Resolve the module (catalog name or external git source) into a manifest +
-	// compose path (+ provenance for external sources).
+	// Resolve + verify BEFORE any teardown. The network-dependent work (git clone
+	// / cosign verify) is exactly what can fail transiently, so it must happen
+	// while any existing module is still installed and running -- otherwise a
+	// transient failure during a routine config update would delete a running
+	// module and (on retry) leave it uninstalled. See the update-in-place teardown
+	// below, which is keyed on the RESOLVED manifest.Name (stable across
+	// source-ref/basename differences) and runs only after resolve+verify succeed.
 	manifest, composeSrc, resolved, err := resolveModuleForTUI(src)
 	if err != nil {
 		return fmt.Errorf("resolve %q: %w", m.Source, err)
 	}
 
-	_, configDir, err := findOrCreateManifest()
+	nodeManifest, configDir, err := findOrCreateManifest()
 	if err != nil {
 		return fmt.Errorf("initialize node config: %w", err)
 	}
@@ -108,6 +102,22 @@ func (o *liveModuleOps) Install(ctx context.Context, m reconcile.ModuleAssignmen
 	}
 	if verifyResult.Verified {
 		lockImages = markLockImagesVerified(lockImages)
+	}
+
+	// Update-in-place: reconcile drives ActionUpdate (source/config drift) through
+	// Install. If the RESOLVED module name is already installed, uninstall it now
+	// -- AFTER the fallible resolve+verify -- so the fresh install does not trip
+	// the port-conflict / already-in-manifest guards. Keying on the resolved
+	// manifest.Name (not a source basename) makes this correct even when the
+	// service name differs from the source basename or changes across refs.
+	// Residual (interim, acceptable): if this Uninstall succeeds but the
+	// InstallFromManifest below then fails, the module is left down until the
+	// job retries and reinstalls it.
+	if hasService(nodeManifest, manifest.Name) {
+		o.log("MODULE_SET: %q already installed; updating in place", manifest.Name)
+		if err := o.Uninstall(ctx, manifest.Name); err != nil {
+			return fmt.Errorf("update %q: uninstall existing: %w", manifest.Name, err)
+		}
 	}
 
 	// Non-interactive install: m.Config supplies the overrides; a missing REQUIRED
@@ -277,30 +287,6 @@ func (o *liveModuleOps) ListInstalled(ctx context.Context) ([]reconcile.Installe
 		out = append(out, im)
 	}
 	return out, nil
-}
-
-// installedNameForSource returns the manifest service name currently installed
-// from the given (canonical, requested-form) source, or "" if none. It matches
-// on the lockfile Source first (external modules), then falls back to a catalog/
-// basename match (NameFromSource) for services without a lockfile entry.
-func (o *liveModuleOps) installedNameForSource(source string) string {
-	manifest, _, err := findAndReadManifest()
-	if err != nil {
-		return ""
-	}
-	lf, _ := catalog.LoadLockfile()
-	basename := reconcile.NameFromSource(source)
-	for _, s := range manifest.Services {
-		if lf != nil {
-			if e, ok := lf.LookupLock(s.Name); ok && e.Source == source {
-				return s.Name
-			}
-		}
-		if s.Name == basename {
-			return s.Name
-		}
-	}
-	return ""
 }
 
 // recordLock upserts provenance for a freshly installed/updated module, carrying

--- a/cmd/module_ops.go
+++ b/cmd/module_ops.go
@@ -45,9 +45,9 @@ func newLiveModuleOps(log func(format string, args ...any)) *liveModuleOps {
 	}
 	return &liveModuleOps{
 		log:         log,
-		startFn:     startService,          // cmd/service.go: docker compose up -d
-		composeDown: stopServiceByCompose,  // cmd/stop.go: docker compose down
-		isRunning:   containerIsRunning,    // docker inspect state
+		startFn:     startService,         // cmd/service.go: docker compose up -d
+		composeDown: stopServiceByCompose, // cmd/stop.go: docker compose down
+		isRunning:   containerIsRunning,   // docker inspect state
 	}
 }
 

--- a/cmd/module_ops.go
+++ b/cmd/module_ops.go
@@ -1,0 +1,371 @@
+// cmd/module_ops.go
+//
+// liveModuleOps is the LIVE reconcile.ModuleOps adapter for the MODULE_SET
+// handler (aceteam-ai/aceteam#5280). It maps the reconcile engine's narrow
+// side-effect surface (install / uninstall / start / stop / list) onto the
+// EXISTING catalog + compose + lockfile + manifest machinery this repo already
+// uses for `citadel module install` / `citadel run` / `citadel stop`.
+//
+// It lives in the cmd package (not internal/worker) because it depends on the
+// cmd-level manifest edges (findOrCreateManifest, addServiceToManifestWithTags,
+// startService, stopServiceByCompose) that the worker package cannot import
+// without a cycle. The worker handler stays decoupled and testable via the
+// injected reconcile.ModuleOps interface; cmd wires this concrete adapter in
+// registerPrivilegedNodeJobHandlers.
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/catalog"
+	"github.com/aceteam-ai/citadel-cli/internal/reconcile"
+)
+
+// liveModuleOps implements reconcile.ModuleOps against the real node.
+type liveModuleOps struct {
+	log func(format string, args ...any)
+
+	// Injectable seams so the container-touching operations can be stubbed in
+	// tests (the pure manifest/lockfile logic is exercised through them).
+	startFn     func(name, composePath string) error
+	composeDown func(composePath string, remove bool) error
+	isRunning   func(name string) bool
+}
+
+// newLiveModuleOps builds the live adapter wired to this node's real edges.
+func newLiveModuleOps(log func(format string, args ...any)) *liveModuleOps {
+	if log == nil {
+		log = func(string, ...any) {}
+	}
+	return &liveModuleOps{
+		log:         log,
+		startFn:     startService,          // cmd/service.go: docker compose up -d
+		composeDown: stopServiceByCompose,  // cmd/stop.go: docker compose down
+		isRunning:   containerIsRunning,    // docker inspect state
+	}
+}
+
+// Install installs (or updates) a module from the assignment's Source with its
+// Config overrides, then starts it. After a successful Install the module is
+// RUNNING (the engine issues a follow-up Stop when the desired status is
+// stopped). An already-installed module is updated in place via uninstall-then-
+// install so its host ports free and its compose is replaced cleanly.
+func (o *liveModuleOps) Install(ctx context.Context, m reconcile.ModuleAssignment) error {
+	src, err := catalog.ParseSource(m.Source)
+	if err != nil {
+		return fmt.Errorf("parse source %q: %w", m.Source, err)
+	}
+
+	// Update-in-place: if this source is already installed, uninstall it first so
+	// the fresh install does not trip the port-conflict / already-in-manifest
+	// guards. Reconcile drives ActionUpdate through Install for source/config
+	// drift; this makes that a clean down+up.
+	if existing := o.installedNameForSource(m.Source); existing != "" {
+		o.log("MODULE_SET: %q already installed; updating in place", existing)
+		if err := o.Uninstall(ctx, existing); err != nil {
+			return fmt.Errorf("update %q: uninstall existing: %w", existing, err)
+		}
+	}
+
+	// Resolve the module (catalog name or external git source) into a manifest +
+	// compose path (+ provenance for external sources).
+	manifest, composeSrc, resolved, err := resolveModuleForTUI(src)
+	if err != nil {
+		return fmt.Errorf("resolve %q: %w", m.Source, err)
+	}
+
+	_, configDir, err := findOrCreateManifest()
+	if err != nil {
+		return fmt.Errorf("initialize node config: %w", err)
+	}
+	servicesDir := filepath.Join(configDir, "services")
+
+	trusted := catalog.IsTrusted(src)
+	untrusted := !trusted
+	// Catalog (Tier-0) sources are first-party and exempt from the privilege gate
+	// (they have no --allow-privileged flag), matching the CLI/TUI catalog path.
+	// External sources keep the hard gate: a Critical compose is REFUSED here
+	// (this is a remote, non-interactive apply -- there is no operator to
+	// --allow-privileged, so a privileged external module fails with a clear
+	// error rather than silently running with host-root access).
+	allowPrivileged := src.Kind == catalog.KindCatalog
+
+	// Signature gate (shared core): verify a verified-publisher signature by
+	// digest before install; a no-op for sources with no signature requirement.
+	var lockImages []catalog.LockImage
+	if resolved != nil {
+		lockImages = catalog.BuildLockImages(resolved.Images)
+	}
+	verifyResult, err := catalog.VerifyModule(src, lockImages)
+	if err != nil {
+		return fmt.Errorf("verify %q: %w", manifest.Name, err)
+	}
+	if verifyResult.Verified {
+		lockImages = markLockImagesVerified(lockImages)
+	}
+
+	// Non-interactive install: m.Config supplies the overrides; a missing REQUIRED
+	// config var is a returned error (never a stdin prompt on a headless node).
+	result, err := catalog.InstallFromManifest(manifest, composeSrc, servicesDir, m.Config, false, allowPrivileged, untrusted, false)
+	if err != nil {
+		return fmt.Errorf("install %q: %w", manifest.Name, err)
+	}
+
+	// Register in the manifest (merging the module's declared routing tags).
+	if err := addServiceToManifestWithTags(configDir, result.Name, manifest.NodeTags); err != nil {
+		return fmt.Errorf("register %q in manifest: %w", result.Name, err)
+	}
+
+	// Record provenance so a re-run does not see spurious drift. CRITICAL: store
+	// the REQUESTED source form (src.Raw) and the config, so ListInstalled reports
+	// the same canonical Source + Config the desired assignment carries and the
+	// engine converges to a no-op on the next pass.
+	o.recordLock(src, resolved, result, lockImages, m.Config)
+
+	// A fresh install/update is RUNNING: clear any stale stopped marker, then
+	// compose up. (The engine will follow with Stop if desired is stopped.)
+	if err := setServiceDesiredStatus(configDir, result.Name, ""); err != nil {
+		o.log("MODULE_SET: could not clear stopped marker for %q: %v", result.Name, err)
+	}
+	composePath := filepath.Join(servicesDir, result.Name+".yml")
+	if err := o.startFn(result.Name, composePath); err != nil {
+		return fmt.Errorf("start %q: %w", result.Name, err)
+	}
+	return nil
+}
+
+// Uninstall removes an installed module by name: compose down + drop it from the
+// node manifest + delete its lockfile entry + remove its materialized files. It
+// is the NET-NEW uninstall primitive (no imperative uninstall existed before).
+// Idempotent: uninstalling a module that is not installed is a no-op success.
+func (o *liveModuleOps) Uninstall(ctx context.Context, name string) error {
+	manifest, configDir, err := findAndReadManifest()
+	if err != nil {
+		// No manifest => nothing is installed => idempotent no-op.
+		o.log("MODULE_SET: uninstall %q: no manifest, treating as no-op", name)
+		return nil
+	}
+
+	var composeRel string
+	found := false
+	for _, s := range manifest.Services {
+		if s.Name == name {
+			composeRel = s.ComposeFile
+			found = true
+			break
+		}
+	}
+	if !found {
+		o.log("MODULE_SET: uninstall %q: not installed, no-op", name)
+		return nil
+	}
+
+	// Compose down (stop + remove containers, keep named volumes). A missing
+	// compose file means the stack is already gone -> proceed to de-register. A
+	// real `docker compose down` failure (e.g. docker daemon down) is TRANSIENT:
+	// return it so the job retries and we do not de-register a still-running
+	// stack.
+	if composeRel != "" {
+		composePath := filepath.Join(configDir, composeRel)
+		if _, statErr := os.Stat(composePath); statErr == nil {
+			if err := o.composeDown(composePath, false); err != nil {
+				return fmt.Errorf("compose down %q: %w", name, err)
+			}
+		}
+	}
+
+	// De-register from the manifest.
+	if err := removeServiceFromManifest(configDir, name); err != nil {
+		return fmt.Errorf("remove %q from manifest: %w", name, err)
+	}
+	// Delete the lockfile provenance entry (idempotent, best-effort).
+	if err := catalog.DeleteLockEntry(name); err != nil {
+		o.log("MODULE_SET: could not delete lock entry for %q: %v", name, err)
+	}
+	// Remove the materialized compose / sandbox / env files (best-effort).
+	o.removeServiceFiles(configDir, name)
+	return nil
+}
+
+// Start brings an already-installed module up and clears its durable stopped
+// marker so it also starts on the next boot.
+func (o *liveModuleOps) Start(ctx context.Context, name string) error {
+	_, configDir, err := findAndReadManifest()
+	if err != nil {
+		return fmt.Errorf("read manifest: %w", err)
+	}
+	if err := setServiceDesiredStatus(configDir, name, ""); err != nil {
+		return err
+	}
+	composePath := o.composePathFor(configDir, name)
+	if composePath == "" {
+		return fmt.Errorf("start %q: no compose file in manifest", name)
+	}
+	return o.startFn(name, composePath)
+}
+
+// Stop brings an already-installed module down WITHOUT uninstalling it, and marks
+// it durably stopped so the boot-time service-start paths skip it (the stop
+// survives a reboot -- the sharp risk this handler must not silently regress).
+func (o *liveModuleOps) Stop(ctx context.Context, name string) error {
+	_, configDir, err := findAndReadManifest()
+	if err != nil {
+		return fmt.Errorf("read manifest: %w", err)
+	}
+	// Mark durable-stopped FIRST so that even if the compose-down below is
+	// interrupted, a reboot will not resurrect the service.
+	if err := setServiceDesiredStatus(configDir, name, "stopped"); err != nil {
+		return err
+	}
+	composePath := o.composePathFor(configDir, name)
+	if composePath == "" {
+		// Installed but no compose file recorded: the marker alone makes it durable.
+		return nil
+	}
+	if _, statErr := os.Stat(composePath); statErr != nil {
+		return nil
+	}
+	return o.composeDown(composePath, false)
+}
+
+// ListInstalled reports the actual on-node state of every installed module,
+// joining the manifest (source of truth for what is installed) with the lockfile
+// (canonical Source / Ref / Config provenance). CANONICAL-FORM CONTRACT: Source
+// is the REQUESTED source string the module was installed from (lockfile Source,
+// i.e. src.Raw), so it diffs equal against a desired assignment expressed in the
+// same requested form. Health reflects the durable stopped marker first, then the
+// live container run-state.
+func (o *liveModuleOps) ListInstalled(ctx context.Context) ([]reconcile.InstalledModule, error) {
+	manifest, _, err := findAndReadManifest()
+	if err != nil {
+		// No manifest => nothing installed. Not an error for the reconciler.
+		return nil, nil
+	}
+	lf, _ := catalog.LoadLockfile() // best-effort; nil-safe below
+
+	out := make([]reconcile.InstalledModule, 0, len(manifest.Services))
+	for _, s := range manifest.Services {
+		im := reconcile.InstalledModule{Name: s.Name}
+		if lf != nil {
+			if e, ok := lf.LookupLock(s.Name); ok {
+				im.Source = e.Source
+				im.Ref = e.Ref
+				im.Commit = e.Commit
+				im.Config = e.Config
+			}
+		}
+		// Catalog / embedded services carry no lockfile entry: their source IS the
+		// service name (a bare catalog name), which is also what NameFromSource
+		// derives, so a desired assignment with source == name diffs equal.
+		if im.Source == "" {
+			im.Source = s.Name
+		}
+		// Health: a durable stopped marker wins; otherwise reflect the container.
+		if serviceStartDisabled(s) {
+			im.Health = reconcile.HealthStopped
+		} else if o.isRunning(s.Name) {
+			im.Health = reconcile.HealthRunning
+		} else {
+			im.Health = reconcile.HealthStopped
+		}
+		out = append(out, im)
+	}
+	return out, nil
+}
+
+// installedNameForSource returns the manifest service name currently installed
+// from the given (canonical, requested-form) source, or "" if none. It matches
+// on the lockfile Source first (external modules), then falls back to a catalog/
+// basename match (NameFromSource) for services without a lockfile entry.
+func (o *liveModuleOps) installedNameForSource(source string) string {
+	manifest, _, err := findAndReadManifest()
+	if err != nil {
+		return ""
+	}
+	lf, _ := catalog.LoadLockfile()
+	basename := reconcile.NameFromSource(source)
+	for _, s := range manifest.Services {
+		if lf != nil {
+			if e, ok := lf.LookupLock(s.Name); ok && e.Source == source {
+				return s.Name
+			}
+		}
+		if s.Name == basename {
+			return s.Name
+		}
+	}
+	return ""
+}
+
+// recordLock upserts provenance for a freshly installed/updated module, carrying
+// the REQUESTED source form + config so the reconciler sees no spurious drift.
+// Best-effort: a lockfile write failure is logged, not fatal to the install.
+func (o *liveModuleOps) recordLock(src catalog.Source, resolved *catalog.ResolvedModule, result *catalog.InstallResult, images []catalog.LockImage, config map[string]string) {
+	entry := catalog.LockEntry{
+		Name:      result.Name,
+		Source:    src.Raw,
+		Ref:       src.Ref,
+		Config:    config,
+		Sandboxed: result.Sandboxed,
+	}
+	if resolved != nil {
+		entry.ResolvedRef = resolved.ResolvedRef
+		entry.Commit = resolved.Commit
+		if images == nil {
+			images = catalog.BuildLockImages(resolved.Images)
+		}
+		entry.Images = images
+	}
+	if err := catalog.UpsertLockEntry(entry); err != nil {
+		o.log("MODULE_SET: could not record provenance for %q: %v", result.Name, err)
+	}
+}
+
+// removeServiceFiles removes a module's materialized compose, sandbox override,
+// and env files from the services directory. Best-effort: missing files are fine.
+func (o *liveModuleOps) removeServiceFiles(configDir, name string) {
+	servicesDir := filepath.Join(configDir, "services")
+	for _, suffix := range []string{".yml", ".sandbox.yml", ".env"} {
+		path := filepath.Join(servicesDir, name+suffix)
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			o.log("MODULE_SET: could not remove %s: %v", path, err)
+		}
+	}
+}
+
+// composePathFor returns the absolute compose path for a manifest service, or ""
+// if the service is not in the manifest or has no compose file.
+func (o *liveModuleOps) composePathFor(configDir, name string) string {
+	manifest, _, err := findAndReadManifest()
+	if err != nil {
+		return ""
+	}
+	for _, s := range manifest.Services {
+		if s.Name == name && s.ComposeFile != "" {
+			return filepath.Join(configDir, s.ComposeFile)
+		}
+	}
+	return ""
+}
+
+// containerIsRunning reports whether the module's citadel-<name> container is up.
+// Best-effort: returns false if the engine is unavailable or the query fails.
+func containerIsRunning(name string) bool {
+	rt := catalog.SelectContainerRuntime()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, rt.EngineBin, "inspect", "--format", "{{.State.Running}}", "citadel-"+name).Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) == "true"
+}
+
+// Ensure liveModuleOps implements reconcile.ModuleOps.
+var _ reconcile.ModuleOps = (*liveModuleOps)(nil)

--- a/cmd/nodejobs.go
+++ b/cmd/nodejobs.go
@@ -80,4 +80,13 @@ func registerPrivilegedNodeJobHandlers(runner *worker.Runner, opts nodeJobHandle
 		},
 		Log: opts.HandlerLog,
 	}))
+
+	// MODULE_SET (aceteam#5280, interim): imperatively apply a single module's
+	// desired state (running/stopped/absent) on this node, reusing the tested
+	// reconcile engine scoped to one module and the live catalog/compose/lockfile
+	// adapter. Converges into the durable pull-based desired-state loop (#4273).
+	runner.RegisterHandler(worker.NewModuleSetHandler(worker.ModuleSetConfig{
+		Ops: newLiveModuleOps(opts.HandlerLog),
+		Log: opts.HandlerLog,
+	}))
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -86,6 +86,14 @@ func runAllServices() {
 	fmt.Printf("--- 🚀 Starting %d service(s) ---\n", len(manifest.Services))
 
 	for _, service := range manifest.Services {
+		// Honor a durable "stopped" marker: a service a remote MODULE_SET set to
+		// stopped stays installed but must NOT be composed up on boot, or the stop
+		// would silently come back on the next restart (aceteam#5280).
+		if serviceStartDisabled(service) {
+			fmt.Printf("⏸️  Skipping stopped service: %s (desired_status: stopped)\n", service.Name)
+			continue
+		}
+
 		serviceType := determineServiceType(service)
 
 		if serviceType == internalServices.ServiceTypeNative {

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1955,6 +1955,14 @@ func startManagedServices(ctx context.Context) []startedService {
 			break
 		}
 
+		// Honor a durable "stopped" marker: a service a remote MODULE_SET set to
+		// stopped stays installed but must NOT be composed up on boot, or the stop
+		// would silently come back on the next `citadel work` restart (aceteam#5280).
+		if serviceStartDisabled(service) {
+			fmt.Printf("   - Skipping stopped service: %s (desired_status: stopped)\n", service.Name)
+			continue
+		}
+
 		serviceType := determineServiceType(service)
 
 		if serviceType == internalServices.ServiceTypeNative {

--- a/internal/catalog/lockfile.go
+++ b/internal/catalog/lockfile.go
@@ -23,6 +23,12 @@ type LockEntry struct {
 	ResolvedRef string      `yaml:"resolved_ref,omitempty"` // concrete tag a constraint/channel resolved to (e.g. "^1.2" -> "v1.4.0")
 	Commit      string      `yaml:"commit,omitempty"`       // resolved git HEAD commit
 	Images      []LockImage `yaml:"images,omitempty"`
+	// Config records the config-var overrides the module was installed with. It
+	// lets the desired-state reconciler detect config drift without re-resolving
+	// the source (an installed module with no recorded config diffs as "no config"
+	// against a desired assignment with no config, so a converged node does not
+	// churn re-updates every pass). Absent for pre-config-tracking installs.
+	Config map[string]string `yaml:"config,omitempty"`
 	// Sandboxed records that a least-privilege hardening override was generated
 	// for this (untrusted/Tier-2) module at install time. Absent/false means the
 	// module runs without an override (trusted/curated, or pre-sandbox installs).
@@ -101,6 +107,43 @@ func UpsertLockEntry(entry LockEntry) error {
 	if !replaced {
 		lf.Modules = append(lf.Modules, entry)
 	}
+
+	path := LockfilePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("failed to create lockfile directory: %w", err)
+	}
+	data, err := yaml.Marshal(lf)
+	if err != nil {
+		return fmt.Errorf("failed to marshal lockfile: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("failed to write lockfile %s: %w", path, err)
+	}
+	return nil
+}
+
+// DeleteLockEntry removes a module's provenance entry from the lockfile by name
+// and writes it back. It is the uninstall counterpart to UpsertLockEntry, and is
+// idempotent: deleting an entry that is not present (or a lockfile that does not
+// yet exist) is a no-op success. Other entries are preserved.
+func DeleteLockEntry(name string) error {
+	lf, err := LoadLockfile()
+	if err != nil {
+		return err
+	}
+	kept := lf.Modules[:0]
+	removed := false
+	for _, e := range lf.Modules {
+		if e.Name == name {
+			removed = true
+			continue
+		}
+		kept = append(kept, e)
+	}
+	if !removed {
+		return nil // idempotent: nothing to delete
+	}
+	lf.Modules = kept
 
 	path := LockfilePath()
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {

--- a/internal/worker/job.go
+++ b/internal/worker/job.go
@@ -138,6 +138,7 @@ const (
 	JobTypeAgentUpdate       = "AGENT_UPDATE"        // Remotely update + restart this node's own citadel agent (aceteam#4427)
 	JobTypeWhatsAppProvision = "WHATSAPP_PROVISION"  // Remotely deploy + provision the WhatsApp bridge on this node (aceteam#4454)
 	JobTypeInstanceMessage   = "INSTANCE_MESSAGE"    // Deliver a turn to a BYOC instance's loopback container (aceteam#5241)
+	JobTypeModuleSet         = "MODULE_SET"          // Set the desired state of a single module on this node (interim, aceteam#5280)
 )
 
 // allKnownJobTypes enumerates every job type this citadel build knows about.
@@ -185,4 +186,5 @@ var allKnownJobTypes = []string{
 	JobTypeAgentUpdate,
 	JobTypeWhatsAppProvision,
 	JobTypeInstanceMessage,
+	JobTypeModuleSet,
 }

--- a/internal/worker/module_set.go
+++ b/internal/worker/module_set.go
@@ -1,0 +1,281 @@
+// internal/worker/module_set.go
+//
+// MODULE_SET job handler (interim, aceteam-ai/aceteam#5280). Lets the
+// `node_module_set` MCP tool remote-control which service modules run on a
+// user's OWN Citadel node by assigning a SINGLE module a desired state:
+//
+//   - running -- the module must be installed and running (install if missing)
+//   - stopped -- the module must be installed but NOT running (durably)
+//   - absent  -- the module must be uninstalled (removed from the node)
+//
+// # Why this handler exists (interim vs. the durable design)
+//
+// The full design (aceteam#4273) is a DECLARATIVE pull loop: the node fetches
+// its whole desired module set from a control-plane serve endpoint and converges
+// via the internal/reconcile engine. That serve endpoint + durable server-side
+// desired-state storage do not exist yet. Meanwhile `node_module_set` already
+// QUEUES a MODULE_SET job carrying ONE ModuleAssignment on the node's per-node
+// stream, and today NO citadel handler consumes it (it nacks + dead-letters).
+// This handler closes that gap by applying that single assignment IMPERATIVELY,
+// reusing the SAME tested reconcile engine but scoped to one module. It converges
+// into #4273 when the pull loop lands.
+//
+// # The single-module-scoped-actual trick
+//
+// The reconcile engine treats `desired` as AUTHORITATIVE for the whole node:
+// anything in `actual` but not in `desired` is uninstalled. If we passed the
+// node's FULL installed set as `actual` with a one-entry `desired`, the engine
+// would uninstall EVERY OTHER module. So we scope BOTH sides to just the target
+// module (matched by canonical Source), and align the desired assignment's key
+// to the installed module's real service name to avoid the name-gap churn (see
+// scopeToSingleModule). The engine then emits exactly the install/update/start/
+// stop/uninstall step for this one module and touches nothing else.
+//
+// # Privilege gating
+//
+// MODULE_SET installs/uninstalls a compose stack + mutates the node manifest, so
+// it is honored ONLY when the job arrives on the per-node stream
+// (jobs:v1:shell:org_<id>:node:<nodeid>), never the shared org pool -- exactly
+// like AGENT_UPDATE and WHATSAPP_PROVISION (isPerNodeStream). It fails closed.
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/aceteam-ai/citadel-cli/internal/reconcile"
+)
+
+// statusAbsent is the desired_status value that means "uninstall". It is NOT a
+// reconcile.DesiredStatus (which only models running/stopped); absent is realized
+// as an EMPTY desired set for the scoped module, which the engine converges by
+// uninstalling the module if it is installed (and is a no-op if it is not).
+const statusAbsent = "absent"
+
+// ModuleSetConfig configures a ModuleSetHandler. The Ops dependency is injectable
+// so the handler's routing (single-module scope, absent-uninstall, idempotency)
+// is unit-testable with a fake ModuleOps -- without touching docker, git, the
+// catalog, or the node manifest.
+type ModuleSetConfig struct {
+	// Ops is the live side-effect surface (install/uninstall/start/stop/list).
+	// The live adapter is wired in cmd (it needs cmd-level catalog/manifest edges
+	// the worker package cannot import); a nil Ops makes Execute fail with a clear
+	// error rather than panic.
+	Ops reconcile.ModuleOps
+
+	// Log reports progress. Nil is a no-op.
+	Log func(format string, args ...any)
+}
+
+// ModuleSetHandler processes MODULE_SET jobs.
+type ModuleSetHandler struct {
+	cfg ModuleSetConfig
+}
+
+// NewModuleSetHandler constructs a MODULE_SET handler.
+func NewModuleSetHandler(cfg ModuleSetConfig) *ModuleSetHandler {
+	if cfg.Log == nil {
+		cfg.Log = func(string, ...any) {}
+	}
+	return &ModuleSetHandler{cfg: cfg}
+}
+
+// CanHandle reports whether this handler processes the given job type.
+func (h *ModuleSetHandler) CanHandle(jobType string) bool {
+	return jobType == JobTypeModuleSet
+}
+
+// Execute applies a single module assignment to this node via the scoped
+// reconcile engine. See the package doc for the privilege gate and the
+// single-module-scoped-actual trick.
+func (h *ModuleSetHandler) Execute(ctx context.Context, job *Job, stream StreamWriter) (*JobResult, error) {
+	// Privilege gate: MODULE_SET must arrive on the per-node stream, not the
+	// shared org pool -- installing/uninstalling a compose stack on the user's
+	// node is privileged and node-targeted. Fail closed.
+	if !isPerNodeStream(job.SourceQueue) {
+		return h.failure(fmt.Errorf(
+			"MODULE_SET refused: must be dispatched to the per-node stream, got source queue %q", job.SourceQueue)), nil
+	}
+
+	if h.cfg.Ops == nil {
+		return h.failure(fmt.Errorf("MODULE_SET handler is misconfigured: no module ops")), nil
+	}
+
+	m, err := parseModuleAssignment(job.Payload)
+	if err != nil {
+		// A malformed assignment is a permanent (terminal) failure: retrying the
+		// same bad payload cannot help.
+		return h.failure(fmt.Errorf("MODULE_SET: %w", err)), nil
+	}
+
+	statusRaw := strings.ToLower(strings.TrimSpace(string(m.DesiredStatus)))
+	absent := statusRaw == statusAbsent
+	// Reject an unknown status up front (running/stopped/absent are the contract;
+	// empty defaults to running). An unknown value is a terminal bad request.
+	switch statusRaw {
+	case "", string(reconcile.StatusRunning), string(reconcile.StatusStopped), statusAbsent:
+	default:
+		return h.failure(fmt.Errorf("MODULE_SET: unknown desired_status %q (want running|stopped|absent)", m.DesiredStatus)), nil
+	}
+
+	h.cfg.Log("MODULE_SET: source=%q desired_status=%q", m.Source, statusRaw)
+
+	// Scope BOTH desired and actual to just this module. This is the crux: it
+	// prevents the whole-node-authoritative engine from uninstalling every other
+	// installed module.
+	desired, actual, key, err := scopeToSingleModule(ctx, h.cfg.Ops, m, absent)
+	if err != nil {
+		// Listing installed state failed -- a transient node/docker problem worth a
+		// retry rather than a terminal failure.
+		return h.retry(fmt.Errorf("MODULE_SET: inspect installed modules: %w", err)), nil
+	}
+
+	plan, err := reconcile.Reconcile(ctx, desired, actual)
+	if err != nil {
+		return h.retry(fmt.Errorf("MODULE_SET: plan: %w", err)), nil
+	}
+
+	applyRes, err := reconcile.Apply(ctx, h.cfg.Ops, plan)
+	if err != nil {
+		// Context cancellation / caller-level problem -- retry.
+		return h.retry(fmt.Errorf("MODULE_SET: apply: %w", err)), nil
+	}
+
+	steps := describeSteps(plan)
+	if applyRes.Failed() {
+		// Per-module failure isolation means, for our single scoped module, the
+		// error is the one that matters. Treat it as transient (Nack -> retry,
+		// DLQ-bounded by the runner's MaxAttempts) so a flaky clone/pull recovers.
+		failErr := firstApplyError(applyRes)
+		return h.retryOutput(
+			fmt.Errorf("MODULE_SET: converge %q failed: %w", key, failErr),
+			map[string]any{
+				"module":         key,
+				"source":         m.Source,
+				"desired_status": statusRaw,
+				"steps":          steps,
+			}), nil
+	}
+
+	h.cfg.Log("MODULE_SET: converged %q (%d step(s))", key, len(plan.Steps))
+	return &JobResult{
+		Status: JobStatusSuccess,
+		Output: map[string]any{
+			"module":         key,
+			"source":         m.Source,
+			"desired_status": statusRaw,
+			"steps":          steps,
+			"converged":      true,
+		},
+	}, nil
+}
+
+// scopeToSingleModule builds the desired/actual pair for a ONE-module reconcile.
+//
+// It lists the node's installed modules, finds the one whose canonical Source
+// equals the assignment's Source, and:
+//
+//   - aligns the desired assignment's Name (reconcile key) to the installed
+//     module's REAL service name, so start/stop/uninstall steps carry the name
+//     the ops adapter can map back to a manifest service -- this sidesteps the
+//     "payload has no name, basename != service name" gap (see the PR note).
+//   - scopes `actual` to just that module (or empty when not installed), so the
+//     whole-node-authoritative engine cannot uninstall the node's other modules.
+//
+// For absent, `desired` is empty (the engine uninstalls the scoped module if it
+// is installed; a no-op if not).
+func scopeToSingleModule(ctx context.Context, ops reconcile.ModuleOps, m reconcile.ModuleAssignment, absent bool) (reconcile.DesiredState, []reconcile.InstalledModule, string, error) {
+	installed, err := ops.ListInstalled(ctx)
+	if err != nil {
+		return reconcile.DesiredState{}, nil, "", err
+	}
+
+	var actual []reconcile.InstalledModule
+	for i := range installed {
+		if installed[i].Source == m.Source {
+			// Align the desired key to the installed module's real name.
+			m.Name = installed[i].Name
+			actual = []reconcile.InstalledModule{installed[i]}
+			break
+		}
+	}
+
+	key := m.Key() // aligned name if installed, else NameFromSource(source)
+
+	if absent {
+		// Empty desired for the scoped module => uninstall it if installed.
+		return reconcile.DesiredState{}, actual, key, nil
+	}
+	return reconcile.DesiredState{Modules: []reconcile.ModuleAssignment{m}}, actual, key, nil
+}
+
+// parseModuleAssignment reconstructs a ModuleAssignment from the flattened job
+// payload. `node_module_set` xadds `payload = json(assignment)` and the redis
+// source unmarshals that JSON directly into Job.Payload, so the assignment fields
+// (source, desired_status, config) sit at the TOP LEVEL of Job.Payload. We
+// re-marshal and decode into the typed assignment so the json tags do the field
+// mapping (extra keys such as target_node are ignored).
+func parseModuleAssignment(payload map[string]any) (reconcile.ModuleAssignment, error) {
+	var m reconcile.ModuleAssignment
+	if payload == nil {
+		return m, fmt.Errorf("empty payload")
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return m, fmt.Errorf("marshal payload: %w", err)
+	}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return m, fmt.Errorf("decode assignment: %w", err)
+	}
+	if strings.TrimSpace(m.Source) == "" {
+		return m, fmt.Errorf("assignment is missing a source")
+	}
+	return m, nil
+}
+
+// describeSteps renders a plan's steps for the job output (observability).
+func describeSteps(plan reconcile.Plan) []map[string]any {
+	out := make([]map[string]any, 0, len(plan.Steps))
+	for _, s := range plan.Steps {
+		out = append(out, map[string]any{
+			"action": string(s.Action),
+			"name":   s.Name,
+			"reason": s.Reason,
+		})
+	}
+	return out
+}
+
+// firstApplyError returns any one per-module error from an ApplyResult (for a
+// single-module plan there is at most one).
+func firstApplyError(res reconcile.ApplyResult) error {
+	for _, e := range res.Errors {
+		return e
+	}
+	return fmt.Errorf("unknown convergence error")
+}
+
+func (h *ModuleSetHandler) failure(err error) *JobResult {
+	return &JobResult{
+		Status: JobStatusFailure,
+		Error:  err,
+		Output: map[string]any{"error": err.Error()},
+	}
+}
+
+func (h *ModuleSetHandler) retry(err error) *JobResult {
+	return h.retryOutput(err, map[string]any{"error": err.Error()})
+}
+
+func (h *ModuleSetHandler) retryOutput(err error, output map[string]any) *JobResult {
+	if output == nil {
+		output = map[string]any{}
+	}
+	output["error"] = err.Error()
+	return &JobResult{Status: JobStatusRetry, Error: err, Output: output}
+}
+
+// Ensure ModuleSetHandler implements JobHandler.
+var _ JobHandler = (*ModuleSetHandler)(nil)

--- a/internal/worker/module_set_test.go
+++ b/internal/worker/module_set_test.go
@@ -1,0 +1,322 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/reconcile"
+)
+
+// fakeModuleOps is a STATEFUL in-memory reconcile.ModuleOps for handler tests.
+// It is keyed by the module's real service name (which may differ from the
+// source basename, so the name-gap / source-scoping behavior can be asserted).
+// Every op is logged so tests can prove the handler routed a single assignment
+// through the scoped engine WITHOUT touching the node's other modules.
+type fakeModuleOps struct {
+	byName  map[string]reconcile.InstalledModule
+	calls   []string
+	failOps map[string]error // "install"/"uninstall"/"start"/"stop"/"list" -> err
+}
+
+func newFakeModuleOps(seed ...reconcile.InstalledModule) *fakeModuleOps {
+	f := &fakeModuleOps{byName: map[string]reconcile.InstalledModule{}, failOps: map[string]error{}}
+	for _, im := range seed {
+		f.byName[im.Name] = im
+	}
+	return f
+}
+
+func (f *fakeModuleOps) Install(ctx context.Context, m reconcile.ModuleAssignment) error {
+	f.calls = append(f.calls, "install:"+m.Key())
+	if err := f.failOps["install"]; err != nil {
+		return err
+	}
+	// Fresh install => running, recording the requested source + config so a
+	// re-list diffs equal against the same assignment (no churn).
+	f.byName[m.Key()] = reconcile.InstalledModule{
+		Name:   m.Key(),
+		Source: m.Source,
+		Config: m.Config,
+		Health: reconcile.HealthRunning,
+	}
+	return nil
+}
+
+func (f *fakeModuleOps) Uninstall(ctx context.Context, name string) error {
+	f.calls = append(f.calls, "uninstall:"+name)
+	if err := f.failOps["uninstall"]; err != nil {
+		return err
+	}
+	delete(f.byName, name)
+	return nil
+}
+
+func (f *fakeModuleOps) Start(ctx context.Context, name string) error {
+	f.calls = append(f.calls, "start:"+name)
+	if err := f.failOps["start"]; err != nil {
+		return err
+	}
+	if im, ok := f.byName[name]; ok {
+		im.Health = reconcile.HealthRunning
+		f.byName[name] = im
+	}
+	return nil
+}
+
+func (f *fakeModuleOps) Stop(ctx context.Context, name string) error {
+	f.calls = append(f.calls, "stop:"+name)
+	if err := f.failOps["stop"]; err != nil {
+		return err
+	}
+	if im, ok := f.byName[name]; ok {
+		im.Health = reconcile.HealthStopped
+		f.byName[name] = im
+	}
+	return nil
+}
+
+func (f *fakeModuleOps) ListInstalled(ctx context.Context) ([]reconcile.InstalledModule, error) {
+	if err := f.failOps["list"]; err != nil {
+		return nil, err
+	}
+	out := make([]reconcile.InstalledModule, 0, len(f.byName))
+	for _, im := range f.byName {
+		out = append(out, im)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+func (f *fakeModuleOps) names() []string {
+	out := make([]string, 0, len(f.byName))
+	for n := range f.byName {
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func moduleSetJob(sourceQueue string, assignment map[string]any) *Job {
+	return &Job{ID: "ms-1", Type: JobTypeModuleSet, SourceQueue: sourceQueue, Payload: assignment}
+}
+
+func hasCall(calls []string, want string) bool {
+	for _, c := range calls {
+		if c == want {
+			return true
+		}
+	}
+	return false
+}
+
+// The shared org pool (no ":node:" segment) must be refused fail-closed.
+const sharedPoolQueue = "jobs:v1:shell:org_test"
+
+func TestModuleSetRefusesSharedPool(t *testing.T) {
+	f := newFakeModuleOps()
+	h := NewModuleSetHandler(ModuleSetConfig{Ops: f})
+	res, err := h.Execute(context.Background(), moduleSetJob(sharedPoolQueue, map[string]any{
+		"source": "owner/repo@v1", "desired_status": "running",
+	}), &NoOpStreamWriter{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Status != JobStatusFailure {
+		t.Fatalf("status = %v, want failure (fail-closed)", res.Status)
+	}
+	if len(f.calls) != 0 {
+		t.Fatalf("shared-pool job must not touch ops; got calls %v", f.calls)
+	}
+}
+
+func TestModuleSetInstallsMissingModule(t *testing.T) {
+	f := newFakeModuleOps()
+	h := NewModuleSetHandler(ModuleSetConfig{Ops: f})
+	res, err := h.Execute(context.Background(), moduleSetJob(perNodeQueue, map[string]any{
+		"source": "owner/repo@v1", "desired_status": "running",
+	}), &NoOpStreamWriter{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Status != JobStatusSuccess {
+		t.Fatalf("status = %v, want success", res.Status)
+	}
+	if !hasCall(f.calls, "install:repo") {
+		t.Fatalf("expected install:repo, got %v", f.calls)
+	}
+}
+
+// The single-module scope must NOT uninstall the node's other modules.
+func TestModuleSetDoesNotTouchOtherModules(t *testing.T) {
+	f := newFakeModuleOps(
+		reconcile.InstalledModule{Name: "alpha", Source: "owner/alpha@v1", Health: reconcile.HealthRunning},
+		reconcile.InstalledModule{Name: "beta", Source: "owner/beta@v1", Health: reconcile.HealthRunning},
+		reconcile.InstalledModule{Name: "target", Source: "owner/target@v1", Health: reconcile.HealthRunning},
+	)
+	h := NewModuleSetHandler(ModuleSetConfig{Ops: f})
+	// Uninstall ONLY target.
+	res, err := h.Execute(context.Background(), moduleSetJob(perNodeQueue, map[string]any{
+		"source": "owner/target@v1", "desired_status": "absent",
+	}), &NoOpStreamWriter{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Status != JobStatusSuccess {
+		t.Fatalf("status = %v, want success", res.Status)
+	}
+	if !hasCall(f.calls, "uninstall:target") {
+		t.Fatalf("expected uninstall:target, got %v", f.calls)
+	}
+	got := f.names()
+	if len(got) != 2 || got[0] != "alpha" || got[1] != "beta" {
+		t.Fatalf("other modules must survive; remaining = %v", got)
+	}
+	// Nothing else should have been uninstalled.
+	if hasCall(f.calls, "uninstall:alpha") || hasCall(f.calls, "uninstall:beta") {
+		t.Fatalf("scoped uninstall leaked to other modules: %v", f.calls)
+	}
+}
+
+// absent uninstalls when installed, and is a no-op when already absent.
+func TestModuleSetAbsentIsIdempotent(t *testing.T) {
+	f := newFakeModuleOps(
+		reconcile.InstalledModule{Name: "target", Source: "owner/target@v1", Health: reconcile.HealthRunning},
+	)
+	h := NewModuleSetHandler(ModuleSetConfig{Ops: f})
+
+	// First absent: uninstalls.
+	if _, err := h.Execute(context.Background(), moduleSetJob(perNodeQueue, map[string]any{
+		"source": "owner/target@v1", "desired_status": "absent",
+	}), &NoOpStreamWriter{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !hasCall(f.calls, "uninstall:target") {
+		t.Fatalf("expected uninstall:target, got %v", f.calls)
+	}
+
+	// Second absent: no-op success, NO further uninstall.
+	f.calls = nil
+	res, err := h.Execute(context.Background(), moduleSetJob(perNodeQueue, map[string]any{
+		"source": "owner/target@v1", "desired_status": "absent",
+	}), &NoOpStreamWriter{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Status != JobStatusSuccess {
+		t.Fatalf("status = %v, want success", res.Status)
+	}
+	for _, c := range f.calls {
+		if c == "uninstall:target" {
+			t.Fatalf("re-absent must be a no-op, but uninstalled again: %v", f.calls)
+		}
+	}
+}
+
+// stopped stops (does NOT uninstall) and keeps the module installed -- the
+// durable stopped state, distinct from absent. The name-gap is also covered
+// here: the installed service name ("svc") differs from the source basename
+// ("repo"), and the handler must align to "svc" so it stops (not churn-install).
+func TestModuleSetStoppedStopsNotUninstalls(t *testing.T) {
+	f := newFakeModuleOps(
+		reconcile.InstalledModule{Name: "svc", Source: "owner/repo@v1", Health: reconcile.HealthRunning},
+	)
+	h := NewModuleSetHandler(ModuleSetConfig{Ops: f})
+	res, err := h.Execute(context.Background(), moduleSetJob(perNodeQueue, map[string]any{
+		"source": "owner/repo@v1", "desired_status": "stopped",
+	}), &NoOpStreamWriter{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Status != JobStatusSuccess {
+		t.Fatalf("status = %v, want success", res.Status)
+	}
+	if !hasCall(f.calls, "stop:svc") {
+		t.Fatalf("expected stop:svc (name aligned past the source basename), got %v", f.calls)
+	}
+	if hasCall(f.calls, "uninstall:svc") {
+		t.Fatalf("stopped must NOT uninstall: %v", f.calls)
+	}
+	if hasCall(f.calls, "install:repo") || hasCall(f.calls, "install:svc") {
+		t.Fatalf("stopped on a matching install must not churn-install: %v", f.calls)
+	}
+	im, ok := f.byName["svc"]
+	if !ok {
+		t.Fatalf("module must stay installed after stop")
+	}
+	if im.Health != reconcile.HealthStopped {
+		t.Fatalf("health = %v, want stopped", im.Health)
+	}
+}
+
+// A converged node (desired == actual) yields NO steps: proof of idempotency and
+// no source-basename churn when the installed name differs from the basename.
+func TestModuleSetRunningConvergedIsNoOp(t *testing.T) {
+	f := newFakeModuleOps(
+		reconcile.InstalledModule{Name: "svc", Source: "owner/repo@v1", Health: reconcile.HealthRunning},
+	)
+	h := NewModuleSetHandler(ModuleSetConfig{Ops: f})
+	res, err := h.Execute(context.Background(), moduleSetJob(perNodeQueue, map[string]any{
+		"source": "owner/repo@v1", "desired_status": "running",
+	}), &NoOpStreamWriter{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Status != JobStatusSuccess {
+		t.Fatalf("status = %v, want success", res.Status)
+	}
+	for _, c := range f.calls {
+		switch {
+		case len(c) >= 8 && c[:8] == "install:",
+			len(c) >= 10 && c[:10] == "uninstall:",
+			len(c) >= 6 && c[:6] == "start:",
+			len(c) >= 5 && c[:5] == "stop:":
+			t.Fatalf("converged running module must produce no side effects, got %v", f.calls)
+		}
+	}
+}
+
+func TestModuleSetMissingSourceIsTerminal(t *testing.T) {
+	f := newFakeModuleOps()
+	h := NewModuleSetHandler(ModuleSetConfig{Ops: f})
+	res, err := h.Execute(context.Background(), moduleSetJob(perNodeQueue, map[string]any{
+		"desired_status": "running",
+	}), &NoOpStreamWriter{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Status != JobStatusFailure {
+		t.Fatalf("status = %v, want failure (terminal) for missing source", res.Status)
+	}
+}
+
+func TestModuleSetListFailureRetries(t *testing.T) {
+	f := newFakeModuleOps()
+	f.failOps["list"] = fmt.Errorf("docker down")
+	h := NewModuleSetHandler(ModuleSetConfig{Ops: f})
+	res, err := h.Execute(context.Background(), moduleSetJob(perNodeQueue, map[string]any{
+		"source": "owner/repo@v1", "desired_status": "running",
+	}), &NoOpStreamWriter{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Status != JobStatusRetry {
+		t.Fatalf("status = %v, want retry on transient list failure", res.Status)
+	}
+}
+
+func TestModuleSetInstallFailureRetries(t *testing.T) {
+	f := newFakeModuleOps()
+	f.failOps["install"] = fmt.Errorf("clone failed")
+	h := NewModuleSetHandler(ModuleSetConfig{Ops: f})
+	res, err := h.Execute(context.Background(), moduleSetJob(perNodeQueue, map[string]any{
+		"source": "owner/repo@v1", "desired_status": "running",
+	}), &NoOpStreamWriter{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Status != JobStatusRetry {
+		t.Fatalf("status = %v, want retry on transient install failure", res.Status)
+	}
+}


### PR DESCRIPTION
## Context

The `node_module_set` MCP tool (aceteam-ai/aceteam#5280) already lets an operator
assign a single module a desired state on a specific node. It xadds a `MODULE_SET`
job to the node's per-node stream carrying one `ModuleAssignment`
(`{source, desired_status: running|stopped|absent, config}`), but **no citadel
handler consumed it** — the job nacked and dead-lettered. This PR closes that gap
with an interim, imperative handler that reuses the existing (tested-but-dormant)
`internal/reconcile` engine.

The full design (#4273) is a declarative pull loop where the node fetches its
whole desired set from a control-plane serve endpoint that does not exist yet.
This is **Option A**: apply the one assignment now, converging into #4273 later.

## What it does

- **`internal/worker/module_set.go`** — a privileged, per-node `MODULE_SET`
  handler. It fails closed unless the job arrives on the per-node stream
  (`isPerNodeStream`), parses the single `ModuleAssignment` from the flattened
  payload, runs the scoped reconcile + apply, and returns success / retry.
- **`cmd/module_ops.go`** — the live `reconcile.ModuleOps` adapter (the bulk of
  the work), mapping install/uninstall/start/stop/list onto the existing
  catalog + compose + lockfile + manifest machinery.

### The single-module-scoped-actual trick

The reconcile engine treats `desired` as authoritative for the **whole node** —
anything in `actual` but not in `desired` is uninstalled. Passing the node's full
installed set as `actual` with a one-entry `desired` would uninstall every other
module. So the handler scopes **both** sides to just the target module: it lists
installed modules, finds the one whose canonical `Source` equals the assignment's
`Source`, and passes only that as `actual` (empty when not installed). `absent` is
realized as an **empty desired set** for the scoped module, which the engine
converges by uninstalling it (a no-op if not installed). The engine then emits
exactly the one step for this module and touches nothing else.

### The net-new uninstall primitive

No imperative uninstall existed before. `liveModuleOps.Uninstall` is per-module and
idempotent: `docker compose down` → drop the service from `citadel.yaml` →
`catalog.DeleteLockEntry` (new) → remove the materialized compose/sandbox/env
files. Uninstalling a module that is not installed is a no-op success. A real
`compose down` failure (docker daemon down) returns a transient error so the job
retries rather than de-registering a still-running stack.

### How `stopped` is made durable

`cmd/run.go` (`runAllServices`) and `cmd/work.go` (`startManagedServices`) compose
up every manifest service on boot, so a naive imperative stop comes back on the
next `citadel work` restart. This adds a per-service `desired_status` marker to the
manifest `Service`; `Stop` sets it to `stopped` (marker first, then compose down),
and both boot paths **skip** services where `serviceStartDisabled(s)` is true. The
module stays installed but is not started — `stopped` is distinct from `absent`,
and it survives a reboot. `Start`/`Install` clear the marker.

### The `name`-gap note (aceteam-side fix warranted)

The payload has **no `name`**, so the reconcile key falls back to the source
basename (`NameFromSource`), which need not equal the module's declared service
name in `citadel.yaml`. Keying naively on the basename would churn (re-install
every pass) and orphan the real service. The handler avoids this by **matching on
canonical `Source`** and aligning the desired assignment's `Name` to the installed
service's real name before reconciling, so start/stop/uninstall carry a name the
adapter maps back to a manifest service. `ListInstalled` reports `Source` in the
requested canonical form (lockfile `src.Raw`), and `LockEntry.Config` (new) is
recorded/reported so a converged node does not see spurious config drift.

This is a workaround. `internal/reconcile/types.go` itself says the control plane
**SHOULD** send `Name` for stable keying. An aceteam-side fix — having
`node_module_set` include the resolved module name in the assignment — is
**warranted** and would remove the one remaining fragile case (a source-ref change
where the repo's `service.yaml` name also changes across refs → orphan). Not fixed
here (this PR does not touch the aceteam repo).

## Test plan

Scoped tests only (never `go test ./...`, which crashes this env):

| Area | Coverage |
|------|----------|
| `internal/worker` (`TestModuleSet*`, 9 tests) | fail-closed on shared pool; install missing; **does not touch other installed modules**; absent uninstalls + idempotent; **stopped stops (not uninstall) and stays installed**; converged running = no-op (no churn, incl. name != basename); missing source terminal; list/install failure → retry |
| `internal/reconcile/...` | existing suite still green |
| Build | `go build ./cmd ./internal/worker ./internal/reconcile ./internal/catalog` + full `./cmd/citadel` binary links |

The live adapter (`cmd/module_ops.go`) is build-verified: its container-touching
ops are injectable seams, but unit-testing it directly would read/write the host's
real config dir, and running `./cmd` tests risks the crash-prone tree. Its core
routing/scoping/idempotency/absent/stopped semantics are fully exercised through
the handler tests against a stateful fake `reconcile.ModuleOps`. The `run.go` /
`work.go` boot-skip is build-verified and driven by the single shared predicate
`serviceStartDisabled`.

## Related

- Interim per aceteam-ai/aceteam#5280; converges into #4273 durable desired-state.
- Mirrors the AGENT_UPDATE (#4427) / WHATSAPP_PROVISION (#4454) per-node privileged
  handler pattern.

---
*Generated by Claude Opus 4.8*
