### PR TITLE
fix(meeting): gate browser-launch integration test behind opt-in env

### DIFF
--- a/internal/platform/meeting_browser_test.go
+++ b/internal/platform/meeting_browser_test.go
@@ -94,6 +94,15 @@ func TestMeetingBrowser_Launch(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping meeting-browser launch test in -short mode")
 	}
+	// Launching a real headed browser under Xvfb is unreliable in CI containers
+	// even when the chrome/Xvfb *binaries* are present: the DinD runners have no
+	// working display/sandbox, so Start() fails rather than the binary-presence
+	// guard below skipping. Binary presence is therefore not a safe trigger.
+	// Require an explicit opt-in so `go test ./...` in CI always skips this; run
+	// it deliberately on a real node with CITADEL_BROWSER_INTEGRATION=1.
+	if os.Getenv("CITADEL_BROWSER_INTEGRATION") == "" {
+		t.Skip("set CITADEL_BROWSER_INTEGRATION=1 to run the meeting-browser launch integration test")
+	}
 	if !ChromiumAvailable() || !XvfbAvailable() {
 		t.Skip("no Chromium or Xvfb on this host; skipping meeting-browser launch test")
 	}


### PR DESCRIPTION
## Context
Main CI went red on the #485 merge commit — `TestMeetingBrowser_Launch` (`internal/platform`) FAILED. It's the meeting-bot browser integration test added in #464.

## Root cause
The test launches a real headed Chrome under Xvfb whenever the chrome/Xvfb **binaries** are present. But the self-hosted ARC DinD runners have the binaries without a launchable display/sandbox, so `br.Start()` fails instead of the binary-presence guard skipping. Runners in the pool are inconsistent, so main CI is red *intermittently* — it passed on the #464 PR run (runner lacked the binaries → skipped) and failed on the #485 merge run (runner had them → launched → failed). This would block every `release.sh` cut.

## Fix
Presence != launchability. Gate the real-launch portion behind `CITADEL_BROWSER_INTEGRATION=1` so `go test ./...` in CI always skips it (mirroring the audio integration test's skip-in-CI convention via `audioStackAvailable()`). The test still runs deliberately on a real node when the env is set. The pure-unit tests in the same file (clickJS/typeJS escaping, CDP exception parsing, free-port) are unaffected.

## Test plan
- `go test ./internal/platform/` → green; `TestMeetingBrowser_Launch` now SKIPs with a clear message instead of failing.
- Unblocks main CI and future citadel releases.