### PR TITLE
fix(meeting): pin meeting browser to --password-store=basic for stable cookie crypto

### DIFF
--- a/docs/meeting-bot-profile-seeding.md
+++ b/docs/meeting-bot-profile-seeding.md
@@ -8,6 +8,8 @@ The `MEETING_JOIN` handler (`internal/jobs/meeting_join.go`, [#5098](https://git
 
 So the meeting browser's `--user-data-dir` is no longer a throwaway `os.MkdirTemp` profile: it is a **persistent** directory that a human signs into **once, by hand**, and every subsequent `MEETING_JOIN` job reuses the same cookies/session. This document covers the one-time (and periodic re-seed) manual steps. Everything else — resolving the profile path, creating it with locked-down permissions, reusing it across runs, and detecting when it has gone stale — is handled by the code; see `internal/platform/meeting_browser.go`.
 
+The meeting browser launches Chromium with **`--password-store=basic`**, which pins how the profile's cookies are encrypted. **Any seed of this profile — the manual `google-chrome` step below, or any automated tool — MUST also launch Chrome with `--password-store=basic`**, or the seeded cookies will be encrypted with a key the bot can't read, and every join will fail as "signed out". See the "os_crypt / `--password-store=basic`" section for why.
+
 **Why this can't be automated:** Google actively detects and blocks scripted/automated sign-in (CAPTCHA challenges, "this browser may not be secure" blocks, account lockouts). Do not attempt to script the login form. The seed step below is a real human, with a real mouse and keyboard, typing into a real browser window.
 
 ## What's code vs. what's manual
@@ -49,10 +51,11 @@ The directory is created (if missing) and `chmod 0700`'d on every `MeetingBrowse
    chmod 700 ~/.citadel-cli/meeting-profile
    ```
 
-4. **Launch a real, headed Chrome with that exact `--user-data-dir`** on the node (over VNC/physical display/remote desktop — this must be a real interactive session, not a job dispatch):
+4. **Launch a real, headed Chrome with that exact `--user-data-dir`** on the node (over VNC/physical display/remote desktop — this must be a real interactive session, not a job dispatch). **You MUST pass `--password-store=basic`** so the cookies are encrypted with the same key the meeting bot uses (see "os_crypt / `--password-store=basic`" below — without it the seed silently won't be readable by the bot):
 
    ```bash
    google-chrome \
+     --password-store=basic \
      --user-data-dir="$HOME/.citadel-cli/meeting-profile" \
      --no-first-run --no-default-browser-check \
      https://accounts.google.com/
@@ -67,6 +70,19 @@ The directory is created (if missing) and `chmod 0700`'d on every `MeetingBrowse
 7. **Close Chrome normally** (not `kill -9`) so its session/cookie DB flushes cleanly to disk.
 
 8. **Restart the citadel worker.** The next `MEETING_JOIN` job will launch Chromium against this same, now-seeded, profile directory and reuse the signed-in session.
+
+## os_crypt / `--password-store=basic`
+
+Chrome encrypts its cookie store (and saved passwords) with an "os_crypt" key. On Linux, the default backend derives that key from a **"Safe Storage" secret held in the OS keyring** (gnome-keyring / kwallet), reachable only when a desktop session + keyring + dbus are present (`DBUS_SESSION_BUS_ADDRESS` set). That keyring secret is tied to the specific Chrome/Chromium **binary and keyring label**. Consequences for a persistent, out-of-band-seeded profile:
+
+- A profile seeded by **a different browser build** (or on a box where the keyring was reachable) produces cookies that **another binary cannot decrypt**. Chrome then sees *no* valid auth cookies, and Google redirects to the account chooser — which the join flow correctly reports as **"signed out"**, even though the Google session was never actually revoked.
+- Headless / server nodes often have **no keyring or dbus at all**, so keyring-backed encryption is unreliable to reproduce during automated seeding.
+
+`--password-store=basic` sidesteps all of this: Chromium's "basic" backend encrypts with a **hardcoded, build-independent key** (internally the passphrase is literally `"peanuts"`) — no keyring, no dbus, no desktop session. Every Chrome/Chromium build, on any box, derives the *same* os_crypt key, so a profile seeded with `--password-store=basic` is readable by the meeting bot (which also launches with `--password-store=basic`) regardless of which binary seeded it or whether a keyring was present.
+
+The trade-off — weaker at-rest cookie encryption (a fixed key vs. an OS-guarded secret) — is acceptable here: the profile dir is already `chmod 0700` and holds a single dedicated bot identity on a server, not a human's personal browser. This is why the change is scoped to the **meeting browser only**; co-browse keeps the keyring-backed default for its human-facing persistent logins.
+
+**The one rule to remember:** the encryption key must match between seed and use. The bot always uses `--password-store=basic`, so **the seed must too**. If you seed WITHOUT it (keyring key) and then let the bot read it (basic key), or vice-versa, the cookies won't decrypt and the bot will look signed out. Switching an already-seeded profile onto `--password-store=basic` therefore requires a **re-seed** (steps 2–8) under the flag.
 
 ## Cookie expiry and periodic re-seeding
 

--- a/internal/platform/cobrowse.go
+++ b/internal/platform/cobrowse.go
@@ -104,6 +104,12 @@ type cobrowseLaunchOptions struct {
 	// headed Chromium spawns a GPU process that fails to initialize on Xvfb and
 	// logs churn. Left false when sharing a real display that may have a GPU.
 	softwareGL bool
+	// passwordStoreBasic forces Chromium's built-in "basic" os_crypt backend
+	// (--password-store=basic) instead of the OS keyring. See buildChromeArgs for
+	// the full rationale: it makes cookie encryption binary- and
+	// environment-independent, which a persistent, externally-seeded profile
+	// requires. Left false for co-browse (keeps keyring-backed persistent logins).
+	passwordStoreBasic bool
 }
 
 // stealthEnabled resolves whether stealth launch flags should be applied,
@@ -183,6 +189,25 @@ func buildChromeArgs(opts cobrowseLaunchOptions) []string {
 		// process does not fail to initialize. Page.captureScreenshot still works
 		// via the software compositor.
 		args = append(args, "--disable-gpu")
+	}
+
+	if opts.passwordStoreBasic {
+		// Force Chromium's built-in "basic" os_crypt backend instead of the OS
+		// keyring (gnome-keyring / kwallet). Chrome encrypts its cookie store with
+		// an "os_crypt" key; with the keyring backend that key is derived from a
+		// "Safe Storage" secret tied to the specific Chrome/Chromium BINARY and
+		// keyring LABEL, and it only exists when a desktop session + keyring +
+		// dbus are reachable. That makes a persistent profile non-portable: a
+		// profile seeded by any other browser build (or with the keyring
+		// unavailable) yields cookies THIS binary cannot decrypt, so it sees no
+		// auth cookies and the site treats the profile as signed out. The "basic"
+		// backend uses Chromium's hardcoded, build-independent key ("peanuts") with
+		// no keyring/dbus/desktop-session dependency, so cookie crypto is identical
+		// across every Chrome/Chromium build and environment. This is the right
+		// choice for a headless, server-side bot whose profile is seeded out-of-band
+		// -- but it REQUIRES that whoever seeds the profile also launches Chrome
+		// with --password-store=basic, or the seeded cookies won't decrypt here.
+		args = append(args, "--password-store=basic")
 	}
 
 	if opts.startURL != "" {

--- a/internal/platform/cobrowse_test.go
+++ b/internal/platform/cobrowse_test.go
@@ -174,6 +174,27 @@ func TestBuildChromeArgs_SoftwareGL(t *testing.T) {
 	}
 }
 
+// TestBuildChromeArgs_PasswordStoreBasic checks --password-store=basic is emitted
+// only when passwordStoreBasic is set. The meeting bot sets it so its persistent,
+// externally-seeded profile uses Chromium's build-independent os_crypt key
+// instead of a keyring secret; co-browse leaves it off to keep keyring-backed
+// persistent logins.
+func TestBuildChromeArgs_PasswordStoreBasic(t *testing.T) {
+	on := buildChromeArgs(cobrowseLaunchOptions{debugPort: 9222, profileDir: "/p", stealth: true, passwordStoreBasic: true})
+	if !containsArg(on, "--password-store=basic") {
+		t.Errorf("passwordStoreBasic on: missing --password-store=basic in %v", on)
+	}
+	off := buildChromeArgs(cobrowseLaunchOptions{debugPort: 9222, profileDir: "/p", stealth: true})
+	if containsArg(off, "--password-store=basic") {
+		t.Errorf("passwordStoreBasic off: --password-store=basic must be absent in %v", off)
+	}
+	// Default co-browse launch options (as constructed in Start) must NOT enable it.
+	cobrowseLike := buildChromeArgs(cobrowseLaunchOptions{debugPort: 9222, profileDir: "/p", stealth: true, softwareGL: true})
+	if containsArg(cobrowseLike, "--password-store=basic") {
+		t.Errorf("co-browse default: --password-store=basic must be absent in %v", cobrowseLike)
+	}
+}
+
 // TestResolveCobrowseDisplay checks the display-mode precedence: a dedicated
 // managed Xvfb by default, an operator-pinned display when EnvCobrowseDisplay is
 // set (trimmed).

--- a/internal/platform/meeting_browser.go
+++ b/internal/platform/meeting_browser.go
@@ -326,6 +326,30 @@ func (b *MeetingBrowser) CurrentURL() (string, error) {
 	return t.URL, nil
 }
 
+// buildMeetingChromeArgs constructs the Chromium command line for a meeting-bot
+// launch: the shared co-browse launch flags PLUS the meeting-only choices —
+// software rendering (managed Xvfb has no GPU) and, load-bearingly,
+// --password-store=basic. The basic os_crypt backend uses Chromium's fixed,
+// build-independent key instead of a keyring secret tied to a specific binary
+// and desktop session, so the persistent profile's cookies stay decryptable no
+// matter which Chrome build seeded it or whether a keyring/dbus is present
+// (issue #5122). Without it the bot reads no auth cookies and Google redirects
+// to the account chooser, which the join flow correctly reports as "signed out".
+// The seed procedure MUST match this flag (see docs/meeting-bot-profile-seeding.md).
+//
+// Split out from Start (which needs a real browser + display) so the exact flag
+// set — especially the password-store choice — is unit-testable without launching.
+func buildMeetingChromeArgs(debugPort int, profileDir string) []string {
+	return buildChromeArgs(cobrowseLaunchOptions{
+		debugPort:          debugPort,
+		profileDir:         profileDir,
+		stealth:            stealthEnabled(),
+		userAgent:          os.Getenv(EnvCobrowseUserAgent),
+		softwareGL:         true,
+		passwordStoreBasic: true,
+	})
+}
+
 // Start launches the headed Chromium on a fresh Xvfb display with a throwaway
 // profile, routing its audio into the meeting's null sink. It blocks until the
 // CDP endpoint is ready so the first Navigate does not race the launch.
@@ -368,13 +392,7 @@ func (b *MeetingBrowser) Start() error {
 		return err
 	}
 
-	args := buildChromeArgs(cobrowseLaunchOptions{
-		debugPort:  debugPort,
-		profileDir: profileDir,
-		stealth:    stealthEnabled(),
-		userAgent:  os.Getenv(EnvCobrowseUserAgent),
-		softwareGL: true,
-	})
+	args := buildMeetingChromeArgs(debugPort, profileDir)
 
 	cmd := exec.Command(chrome, args...)
 	// Compose BOTH env transforms: DISPLAY pins the virtual display, PULSE_SINK

--- a/internal/platform/meeting_browser_test.go
+++ b/internal/platform/meeting_browser_test.go
@@ -90,6 +90,23 @@ func TestFindFreeDebugPort(t *testing.T) {
 // on a real Xvfb display and drives one CDP round-trip. It skips under -short and
 // wherever the browser/display deps are missing, mirroring audio_test.go's
 // hardware-gated convention.
+// TestBuildMeetingChromeArgs_PasswordStoreBasic locks in the actual fix (issue
+// #5122 os_crypt mismatch): the meeting bot's launch MUST pass
+// --password-store=basic so its persistent, externally-seeded profile uses
+// Chromium's build-independent cookie-encryption key instead of a keyring secret.
+// This covers the load-bearing Start() choice, which the buildChromeArgs-level
+// test cannot (that only proves the flag is emitted WHEN the option is set).
+func TestBuildMeetingChromeArgs_PasswordStoreBasic(t *testing.T) {
+	args := buildMeetingChromeArgs(9222, "/tmp/meeting-profile")
+	if !containsArg(args, "--password-store=basic") {
+		t.Errorf("meeting launch must include --password-store=basic, got %v", args)
+	}
+	// The persistent profile dir must still be wired through.
+	if !containsArg(args, "--user-data-dir=/tmp/meeting-profile") {
+		t.Errorf("meeting launch missing --user-data-dir, got %v", args)
+	}
+}
+
 func TestMeetingBrowser_Launch(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping meeting-browser launch test in -short mode")


### PR DESCRIPTION
## Context

The meeting bot's persistent Chrome profile is seeded once by hand, then reused by every `MEETING_JOIN`. On a live prod node, every join was failing ~7s in with *"meeting bot Chrome profile is signed out … redirected to accountchooser"* — even right after a fresh, confirmed-working manual sign-in.

Root cause is **not** Google session revocation. It's an **os_crypt cookie-encryption key mismatch**:

- citadel launched the meeting browser via `buildChromeArgs` with `--user-data-dir` but **no `--password-store`**.
- On a node with a desktop session + reachable gnome-keyring (`DBUS_SESSION_BUS_ADDRESS` set), Chrome derives its cookie-encryption key from the **keyring** ("Safe Storage" entry).
- That keyring key is tied to the specific Chrome/Chromium **binary + keyring label**. A profile seeded by any other browser build (or with the keyring unavailable) yields cookies citadel's `google-chrome` **cannot decrypt** → it sees no auth cookies → Google redirects to the account chooser → the handler correctly reports "signed out".

This makes headless/externally-seeded profiles fundamentally unreliable across binaries and environments — exactly the meeting-bot use case.

## Summary

Launch the meeting browser with **`--password-store=basic`** — Chromium's hardcoded, build-independent os_crypt key (internally the `"peanuts"` passphrase). No keyring, no dbus, no desktop-session dependence, and identical across every Chrome/Chromium build. This is the correct choice for a headless, server-side bot whose profile is seeded out-of-band, and it lets **any** tool seed the profile as long as it also uses `--password-store=basic`.

- **`internal/platform/cobrowse.go`** — new `passwordStoreBasic bool` on `cobrowseLaunchOptions`; `buildChromeArgs` appends `--password-store=basic` when set, with a comment explaining the os_crypt rationale. Cobrowse callers leave it **false** → cobrowse behavior unchanged (it relies on keyring-backed human logins).
- **`internal/platform/meeting_browser.go`** — extracted `buildMeetingChromeArgs(debugPort, profileDir)` that sets `passwordStoreBasic: true`, so the load-bearing flag choice is unit-testable without launching a real browser.
- **`docs/meeting-bot-profile-seeding.md`** — added the manual-seed `--password-store=basic` flag, and a new "os_crypt / `--password-store=basic`" section explaining why the seed's encryption key must match the bot's.

Scope is intentionally the **meeting browser only** — cobrowse keeps its keyring default.

## ⚠️ Deployment consequence (re-seed required)

Switching to `--password-store=basic` changes the encryption key, so it **invalidates every profile currently seeded under the keyring key**. Every already-seeded node must be **re-seeded under `--password-store=basic`** (docs steps 2–8) or it will keep failing in exactly the "signed out" way this PR fixes. This is expected, not a regression — the old keyring-seeded cookies were the problem.

## Test plan

| Test | Covers |
|---|---|
| `TestBuildChromeArgs_PasswordStoreBasic` | flag emitted iff `passwordStoreBasic` true; absent for default co-browse options |
| `TestBuildMeetingChromeArgs_PasswordStoreBasic` | the actual fix — meeting launch always includes `--password-store=basic` + persistent `--user-data-dir` |
| existing cobrowse/meeting suite | unchanged behavior (co-browse args, stealth, display, reaper) |

`go build ./...`, `gofmt -l`, and `go test ./internal/platform/` are clean. Full E2E requires re-seeding a real node under `--password-store=basic` then running a live `MEETING_JOIN` (can't be automated — Google blocks scripted sign-in).

## Related

- Meeting-bot persistent profile: #5122 (epic #5097 sovereign auto-join notetaker)
- Join handler + signed-out detection: #5098