### PR TITLE
chore(release): remind to bump CITADEL_LATEST_VERSION after release

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -420,4 +420,9 @@ else
     echo "Next steps:"
     echo "  1. Review the release notes and edit if needed"
     echo "  2. Announce the release to your team"
+    echo "  3. ACTION REQUIRED - bump the fleet 'latest' marker or fleet_node_versions"
+    echo "     'outdated' detection goes stale. CITADEL_LATEST_VERSION is an env var on"
+    echo "     the aceteam.ai 'python-mcp' Railway service (NOT auto-derived). Until you"
+    echo "     bump it, nodes behind $VERSION are not flagged. From the aceteam repo:"
+    echo "       railway variables --service python-mcp --set \"CITADEL_LATEST_VERSION=$VERSION\""
 fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -129,9 +129,17 @@ hook_artifact() {
 }
 
 hook_post_release() {
+  local new_version
+  new_version="$(read_state "target_version" 2>/dev/null || true)"
   info "Next steps:"
   echo "  1. Update Homebrew tap with new version + checksums"
   echo "  2. Citadel OS will pick up the new CLI version on next ISO build"
+  echo "  3. ACTION REQUIRED - bump the fleet 'latest' marker or 'outdated'"
+  echo "     detection goes stale. fleet_node_versions compares each node against"
+  echo "     CITADEL_LATEST_VERSION, an env var on the aceteam.ai 'python-mcp'"
+  echo "     Railway service (NOT auto-derived). Until you bump it, nodes behind"
+  echo "     ${RELEASE_TAG_PREFIX}${new_version} are not flagged. From the aceteam repo (railway-linked):"
+  echo "       railway variables --service python-mcp --set \"CITADEL_LATEST_VERSION=${RELEASE_TAG_PREFIX}${new_version}\""
 }
 
 # ── Load engine and run ────────────────────────────────────────────────────


### PR DESCRIPTION
## Context

The fleet-version view (`fleet_node_versions`, aceteam #4427) flags nodes running behind the latest Citadel release. "Latest" is read from the env var `CITADEL_LATEST_VERSION` on the aceteam.ai **python-mcp** Railway service. It is NOT auto-derived from releases, so it silently goes stale after every citadel release, its "outdated" column stops flagging newly-behind nodes, and the only safeguard was a human remembering.

## Change

Both release scripts (`scripts/release.sh` canonical auto-bump, and the version-explicit `release.sh`) now print an **ACTION REQUIRED** line in their post-release "Next steps", with the exact copy-paste command and the just-released tag baked in:

```
railway variables --service python-mcp --set "CITADEL_LATEST_VERSION=vX.Y.Z"
```

Purely additive echo output, no change to release behavior. Syntax-checked with `bash -n`; `read_state` (used to pull the target version in the hook) is defined in `release-engine.sh`, which is sourced before hooks run.

## Follow-up (not in this PR)

The real elimination of this manual step is to make `get_latest_version()` fall back to a **cached GitHub Releases fetch** when `CITADEL_LATEST_VERSION` is unset - the `utils/citadel_version.py` docstring already notes this as "a reasonable follow-up". That would make the env var optional and self-updating. Flagging for a decision; this PR is the cheap interim guard.

---
*Generated by Claude Opus 4.8*