### PR TITLE
feat(tui): Team Chat tab — real AceTeam org channels in the Control Center

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -31,6 +31,7 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
 	pmx "github.com/aceteam-ai/citadel-cli/internal/proxmox"
 	"github.com/aceteam-ai/citadel-cli/internal/status"
+	"github.com/aceteam-ai/citadel-cli/internal/teamchat"
 	"github.com/aceteam-ai/citadel-cli/internal/telemetry"
 	"github.com/aceteam-ai/citadel-cli/internal/terminal"
 	"github.com/aceteam-ai/citadel-cli/internal/tui"
@@ -243,7 +244,10 @@ func runControlCenter() {
 		// longer shows a permanent "device authorization required" status.
 		Chat:               buildChatConfig(),
 		ChatConfigProvider: buildChatConfig,
-		Proxmox:            buildProxmoxConfig(),
+
+		TeamChat:               buildTeamChatConfig(),
+		TeamChatConfigProvider: buildTeamChatConfig,
+		Proxmox:                buildProxmoxConfig(),
 		Settings: controlcenter.SettingsCallbacks{
 			LoadTelemetry: func() *config.Telemetry {
 				return config.LoadTelemetry(platform.ConfigDir())
@@ -1057,6 +1061,30 @@ func buildChatConfig() controlcenter.ChatPageConfig {
 		OrgID:      orgID,
 		NodeID:     nodeID,
 		NodeName:   nodeName,
+	}
+}
+
+// buildTeamChatConfig constructs TeamChatPageConfig for the Team Chat page.
+// The credential chain mirrors `citadel mcp`: ACETEAM_API_KEY env var, then
+// the aceteam_api_key config.yaml field, then the device token. The device
+// token is currently scope-denied on Team Chat routes (the page renders
+// setup guidance in that case) — see aceteam-ai/citadel-cli#495.
+func buildTeamChatConfig() controlcenter.TeamChatPageConfig {
+	apiBaseURL := authServiceURL
+	var configKey, deviceToken string
+	if deviceConfig := getDeviceConfigFromFile(); deviceConfig != nil {
+		if deviceConfig.APIBaseURL != "" {
+			apiBaseURL = deviceConfig.APIBaseURL
+		}
+		configKey = deviceConfig.AceteamAPIKey
+		deviceToken = deviceConfig.DeviceAPIToken
+	}
+
+	token, source := teamchat.ResolveToken(os.Getenv("ACETEAM_API_KEY"), configKey, deviceToken)
+	return controlcenter.TeamChatPageConfig{
+		APIBaseURL:  apiBaseURL,
+		Token:       token,
+		TokenSource: source,
 	}
 }
 

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -2258,6 +2258,10 @@ type DeviceConfig struct {
 	RedisURL       string `yaml:"redis_url"`
 	UserEmail      string `yaml:"user_email"`
 	UserName       string `yaml:"user_name"`
+	// AceteamAPIKey is an optional user act_ API key for surfaces the
+	// device token cannot reach (Team Chat, MCP). Set manually by the user;
+	// device auth never writes it. See aceteam-ai/citadel-cli#495.
+	AceteamAPIKey string `yaml:"aceteam_api_key"`
 }
 
 // getDeviceConfigFromFile reads device authentication config from global config file.

--- a/internal/teamchat/client.go
+++ b/internal/teamchat/client.go
@@ -1,0 +1,268 @@
+package teamchat
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// APIError is a non-2xx response from the Team Chat API. It preserves the
+// HTTP status so callers can branch on auth failures (401/403) versus
+// transient server errors.
+type APIError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("team chat API error (status %d): %s", e.StatusCode, e.Message)
+}
+
+// IsAuthError reports whether err is an APIError with a 401 or 403 status —
+// i.e. the credential is missing, invalid, or lacks the scope for Team Chat.
+// A device API token currently always yields 403 here because its endpoint
+// whitelist excludes /api/channels/** (see aceteam-ai/citadel-cli#495); the
+// TUI turns this into an actionable "configure an API key" message.
+func IsAuthError(err error) bool {
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.StatusCode == http.StatusUnauthorized || apiErr.StatusCode == http.StatusForbidden
+	}
+	return false
+}
+
+// Client is a typed HTTP client for the AceTeam Team Chat REST API.
+type Client struct {
+	baseURL    string
+	token      string
+	httpClient *http.Client
+}
+
+// ClientConfig configures a Client.
+type ClientConfig struct {
+	// BaseURL is the AceTeam API base URL (e.g. "https://aceteam.ai").
+	BaseURL string
+	// Token is the Bearer credential: a user act_ API key or a Supabase JWT.
+	// A device_api_token authenticates but is scope-denied on these routes
+	// today (see IsAuthError).
+	Token string
+	// Timeout is the per-request HTTP timeout (default 15s).
+	Timeout time.Duration
+}
+
+// NewClient creates a Team Chat API client.
+func NewClient(cfg ClientConfig) *Client {
+	if cfg.Timeout == 0 {
+		cfg.Timeout = 15 * time.Second
+	}
+	return &Client{
+		baseURL:    strings.TrimRight(cfg.BaseURL, "/"),
+		token:      cfg.Token,
+		httpClient: &http.Client{Timeout: cfg.Timeout},
+	}
+}
+
+// BaseURL returns the configured API base URL.
+func (c *Client) BaseURL() string { return c.baseURL }
+
+// HasToken reports whether a credential is configured.
+func (c *Client) HasToken() bool { return c.token != "" }
+
+// MessagesOptions bounds a Messages call. Zero values use server defaults
+// (limit 50, direction "before" = newest page, chronological order).
+type MessagesOptions struct {
+	// Limit is the page size (1-100; server default 50).
+	Limit int
+	// Cursor is a message ID to page from, per Direction.
+	Cursor string
+	// Direction is "before" (older than cursor; default) or "after".
+	Direction string
+}
+
+// ListChannels returns the channels visible to the authenticated user's org.
+// GET /api/channels — the server auto-seeds #general for empty orgs.
+func (c *Client) ListChannels(ctx context.Context) ([]Channel, error) {
+	var out struct {
+		Channels []Channel `json:"channels"`
+	}
+	if err := c.doJSON(ctx, http.MethodGet, "/api/channels", nil, &out); err != nil {
+		return nil, err
+	}
+	return out.Channels, nil
+}
+
+// Messages returns a page of messages for a channel.
+// GET /api/channels/{id}/messages
+func (c *Client) Messages(ctx context.Context, channelID string, opts MessagesOptions) (MessagesPage, error) {
+	q := url.Values{}
+	if opts.Limit > 0 {
+		q.Set("limit", strconv.Itoa(opts.Limit))
+	}
+	if opts.Cursor != "" {
+		q.Set("cursor", opts.Cursor)
+	}
+	if opts.Direction != "" {
+		q.Set("direction", opts.Direction)
+	}
+	path := "/api/channels/" + url.PathEscape(channelID) + "/messages"
+	if len(q) > 0 {
+		path += "?" + q.Encode()
+	}
+
+	var out MessagesPage
+	if err := c.doJSON(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return MessagesPage{}, err
+	}
+	return out, nil
+}
+
+// SendMessage posts a message to a channel as the authenticated user.
+// POST /api/channels/{id}/messages. parentMessageID, when non-empty, makes
+// the message a threaded reply.
+func (c *Client) SendMessage(ctx context.Context, channelID, content, parentMessageID string) (Message, error) {
+	body := map[string]any{"content": content}
+	if parentMessageID != "" {
+		body["parent_message_id"] = parentMessageID
+	}
+
+	var out struct {
+		Message Message `json:"message"`
+	}
+	path := "/api/channels/" + url.PathEscape(channelID) + "/messages"
+	if err := c.doJSON(ctx, http.MethodPost, path, body, &out); err != nil {
+		return Message{}, err
+	}
+	return out.Message, nil
+}
+
+// ListMembers returns the members of a channel (direct + team-derived).
+// GET /api/channels/{id}/members
+func (c *Client) ListMembers(ctx context.Context, channelID string) ([]Member, error) {
+	var out struct {
+		Members []Member `json:"members"`
+	}
+	path := "/api/channels/" + url.PathEscape(channelID) + "/members"
+	if err := c.doJSON(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return out.Members, nil
+}
+
+// SearchMessages searches message content within a channel.
+// GET /api/channels/{id}/messages/search
+func (c *Client) SearchMessages(ctx context.Context, channelID, query string, limit int) ([]Message, error) {
+	q := url.Values{}
+	q.Set("q", query)
+	if limit > 0 {
+		q.Set("limit", strconv.Itoa(limit))
+	}
+	path := "/api/channels/" + url.PathEscape(channelID) + "/messages/search?" + q.Encode()
+
+	var out struct {
+		Messages []Message `json:"messages"`
+	}
+	if err := c.doJSON(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return out.Messages, nil
+}
+
+// MarkRead advances the caller's read cursor for a channel to a message.
+// POST /api/channels/{id}/mark-read
+func (c *Client) MarkRead(ctx context.Context, channelID, messageID string) error {
+	path := "/api/channels/" + url.PathEscape(channelID) + "/mark-read"
+	return c.doJSON(ctx, http.MethodPost, path, map[string]any{"messageId": messageID}, nil)
+}
+
+// UnreadCounts returns per-channel unread message counts for the caller.
+// GET /api/channels/unread-counts
+func (c *Client) UnreadCounts(ctx context.Context) (map[string]int, error) {
+	var out struct {
+		Counts map[string]int `json:"counts"`
+	}
+	if err := c.doJSON(ctx, http.MethodGet, "/api/channels/unread-counts", nil, &out); err != nil {
+		return nil, err
+	}
+	return out.Counts, nil
+}
+
+// doJSON performs an authenticated JSON request. A nil body sends no payload;
+// a nil out discards the response body. Non-2xx responses are returned as
+// *APIError with the server's error message when parseable.
+func (c *Client) doJSON(ctx context.Context, method, path string, body any, out any) error {
+	var reqBody io.Reader
+	if body != nil {
+		payload, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshal request: %w", err)
+		}
+		reqBody = bytes.NewReader(payload)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reqBody)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("%s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	// Bound reads so a misbehaving server can't exhaust memory.
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return &APIError{StatusCode: resp.StatusCode, Message: parseErrorMessage(data)}
+	}
+
+	if out != nil {
+		if err := json.Unmarshal(data, out); err != nil {
+			return fmt.Errorf("decode response: %w", err)
+		}
+	}
+	return nil
+}
+
+// parseErrorMessage extracts a human-readable message from an error response
+// body. The Next.js routes return {"error": "..."}; scope denials may also
+// carry {"message": "..."}. Falls back to a body snippet.
+func parseErrorMessage(data []byte) string {
+	var parsed struct {
+		Error   string `json:"error"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(data, &parsed); err == nil {
+		if parsed.Error != "" {
+			return parsed.Error
+		}
+		if parsed.Message != "" {
+			return parsed.Message
+		}
+	}
+	snippet := strings.TrimSpace(string(data))
+	if len(snippet) > 200 {
+		snippet = snippet[:200]
+	}
+	if snippet == "" {
+		return "request failed"
+	}
+	return snippet
+}

--- a/internal/teamchat/client_test.go
+++ b/internal/teamchat/client_test.go
@@ -1,0 +1,335 @@
+package teamchat
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// newTestClient spins up an httptest server with the given handler and
+// returns a Client pointed at it.
+func newTestClient(t *testing.T, handler http.HandlerFunc) *Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return NewClient(ClientConfig{BaseURL: srv.URL, Token: "act_test123"})
+}
+
+func TestListChannels(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/channels" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer act_test123" {
+			t.Errorf("Authorization = %q, want Bearer act_test123", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"channels":[
+			{"id":"ch-1","name":"general","visibility":"organization","organization_id":"org-1","created_by":"u-1"},
+			{"id":"ch-2","name":"eng","description":"engineering","visibility":"public","organization_id":"org-1","created_by":"u-1"}
+		]}`))
+	})
+
+	channels, err := client.ListChannels(context.Background())
+	if err != nil {
+		t.Fatalf("ListChannels: %v", err)
+	}
+	if len(channels) != 2 {
+		t.Fatalf("got %d channels, want 2", len(channels))
+	}
+	if channels[0].Name != "general" || channels[1].Name != "eng" {
+		t.Errorf("unexpected channel names: %q, %q", channels[0].Name, channels[1].Name)
+	}
+	if channels[1].Description == nil || *channels[1].Description != "engineering" {
+		t.Errorf("channel 2 description not decoded: %v", channels[1].Description)
+	}
+}
+
+func TestMessagesPagination(t *testing.T) {
+	var gotQuery string
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/channels/ch-1/messages" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{
+			"messages":[
+				{"id":"m-1","channel_id":"ch-1","content":"hello","created_at":"2026-07-01T12:00:00+00:00","message_type":"user","reply_count":0,
+				 "sender":{"id":"u-1","email":"jason@example.com","full_name":"Jason Sun"}},
+				{"id":"m-2","channel_id":"ch-1","content":"hi from an agent","created_at":"2026-07-01T12:00:05.123456+00:00","message_type":"agent","reply_count":2,
+				 "agent":{"id":"a-1","title":"Ace"},"sender":null}
+			],
+			"hasMore":true,"nextCursor":"m-1"
+		}`))
+	})
+
+	page, err := client.Messages(context.Background(), "ch-1", MessagesOptions{Limit: 50, Cursor: "m-9", Direction: "before"})
+	if err != nil {
+		t.Fatalf("Messages: %v", err)
+	}
+	if gotQuery != "cursor=m-9&direction=before&limit=50" {
+		t.Errorf("query = %q", gotQuery)
+	}
+	if len(page.Messages) != 2 || !page.HasMore || page.NextCursor == nil || *page.NextCursor != "m-1" {
+		t.Fatalf("unexpected page: %+v", page)
+	}
+
+	human, agent := page.Messages[0], page.Messages[1]
+	if human.SenderLabel() != "Jason Sun" {
+		t.Errorf("human SenderLabel = %q, want Jason Sun", human.SenderLabel())
+	}
+	if agent.SenderLabel() != "Ace" {
+		t.Errorf("agent SenderLabel = %q, want Ace", agent.SenderLabel())
+	}
+	want := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	if !human.CreatedAt.Equal(want) {
+		t.Errorf("CreatedAt = %v, want %v", human.CreatedAt.Time, want)
+	}
+}
+
+func TestSendMessage(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/channels/ch-1/messages" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body["content"] != "ship it" {
+			t.Errorf("content = %v", body["content"])
+		}
+		if body["parent_message_id"] != "m-7" {
+			t.Errorf("parent_message_id = %v", body["parent_message_id"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"message":{"id":"m-10","channel_id":"ch-1","content":"ship it","created_at":"2026-07-01T12:01:00+00:00","message_type":"user","reply_count":0}}`))
+	})
+
+	msg, err := client.SendMessage(context.Background(), "ch-1", "ship it", "m-7")
+	if err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+	if msg.ID != "m-10" || msg.Content != "ship it" {
+		t.Errorf("unexpected message: %+v", msg)
+	}
+}
+
+func TestSendMessageOmitsEmptyParent(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if _, present := body["parent_message_id"]; present {
+			t.Error("parent_message_id should be omitted when empty")
+		}
+		w.Write([]byte(`{"message":{"id":"m-11","channel_id":"ch-1","content":"x","message_type":"user","reply_count":0}}`))
+	})
+
+	if _, err := client.SendMessage(context.Background(), "ch-1", "x", ""); err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+}
+
+func TestListMembers(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/channels/ch-1/members" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Write([]byte(`{"members":[
+			{"id":"cm-1","user_id":"u-1","role":"admin","source":"direct","user":{"id":"u-1","email":"jason@example.com","full_name":"Jason Sun"}},
+			{"id":"team:t-1:u-2","user_id":"u-2","role":"member","source":"team","user":{"id":"u-2","email":"justin@example.com"}}
+		]}`))
+	})
+
+	members, err := client.ListMembers(context.Background(), "ch-1")
+	if err != nil {
+		t.Fatalf("ListMembers: %v", err)
+	}
+	if len(members) != 2 {
+		t.Fatalf("got %d members, want 2", len(members))
+	}
+	if members[0].Label() != "Jason Sun" {
+		t.Errorf("member 0 label = %q", members[0].Label())
+	}
+	if members[1].Label() != "justin@example.com" {
+		t.Errorf("member 1 label = %q", members[1].Label())
+	}
+}
+
+func TestSearchMessages(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/channels/ch-1/messages/search" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("q"); got != "deploy plan" {
+			t.Errorf("q = %q", got)
+		}
+		if got := r.URL.Query().Get("limit"); got != "25" {
+			t.Errorf("limit = %q", got)
+		}
+		w.Write([]byte(`{"messages":[{"id":"m-3","channel_id":"ch-1","content":"the deploy plan is ready","message_type":"user","reply_count":0}]}`))
+	})
+
+	results, err := client.SearchMessages(context.Background(), "ch-1", "deploy plan", 25)
+	if err != nil {
+		t.Fatalf("SearchMessages: %v", err)
+	}
+	if len(results) != 1 || results[0].ID != "m-3" {
+		t.Fatalf("unexpected results: %+v", results)
+	}
+}
+
+func TestMarkRead(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/channels/ch-1/mark-read" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body["messageId"] != "m-10" {
+			t.Errorf("messageId = %v", body["messageId"])
+		}
+		w.Write([]byte(`{"success":true}`))
+	})
+
+	if err := client.MarkRead(context.Background(), "ch-1", "m-10"); err != nil {
+		t.Fatalf("MarkRead: %v", err)
+	}
+}
+
+func TestUnreadCounts(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/channels/unread-counts" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Write([]byte(`{"counts":{"ch-1":3,"ch-2":0}}`))
+	})
+
+	counts, err := client.UnreadCounts(context.Background())
+	if err != nil {
+		t.Fatalf("UnreadCounts: %v", err)
+	}
+	if counts["ch-1"] != 3 || counts["ch-2"] != 0 {
+		t.Errorf("unexpected counts: %v", counts)
+	}
+}
+
+func TestScopeDeniedIsAuthError(t *testing.T) {
+	// A device API token hitting /api/channels/** gets 403 SCOPE_DENIED from
+	// the platform's endpoint whitelist. The client must surface this as an
+	// auth error so the TUI can render setup guidance instead of a raw 403.
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`{"error":"Endpoint '/api/channels' is not in allowed endpoints list"}`))
+	})
+
+	_, err := client.ListChannels(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !IsAuthError(err) {
+		t.Errorf("IsAuthError = false for 403, err = %v", err)
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error is not *APIError: %v", err)
+	}
+	if apiErr.Message != "Endpoint '/api/channels' is not in allowed endpoints list" {
+		t.Errorf("message = %q", apiErr.Message)
+	}
+}
+
+func TestUnauthorizedIsAuthError(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":"Invalid API key"}`))
+	})
+
+	_, err := client.ListChannels(context.Background())
+	if !IsAuthError(err) {
+		t.Errorf("IsAuthError = false for 401, err = %v", err)
+	}
+}
+
+func TestServerErrorIsNotAuthError(t *testing.T) {
+	client := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`oops`))
+	})
+
+	_, err := client.ListChannels(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if IsAuthError(err) {
+		t.Error("IsAuthError = true for 500")
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusInternalServerError {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if apiErr.Message != "oops" {
+		t.Errorf("message = %q, want body snippet", apiErr.Message)
+	}
+}
+
+func TestTimestampFormats(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  time.Time
+	}{
+		{"rfc3339 offset", `"2026-07-01T12:00:00+00:00"`, time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)},
+		{"rfc3339 z", `"2026-07-01T12:00:00Z"`, time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)},
+		{"fractional", `"2026-07-01T12:00:00.123456+00:00"`, time.Date(2026, 7, 1, 12, 0, 0, 123456000, time.UTC)},
+		{"no offset", `"2026-07-01T12:00:00"`, time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)},
+		{"empty", `""`, time.Time{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var ts Timestamp
+			if err := json.Unmarshal([]byte(tc.input), &ts); err != nil {
+				t.Fatalf("unmarshal %s: %v", tc.input, err)
+			}
+			if !ts.Equal(tc.want) {
+				t.Errorf("got %v, want %v", ts.Time, tc.want)
+			}
+		})
+	}
+
+	var ts Timestamp
+	if err := json.Unmarshal([]byte(`"not-a-time"`), &ts); err == nil {
+		t.Error("expected error for garbage timestamp")
+	}
+}
+
+func TestSenderLabelFallbacks(t *testing.T) {
+	empty := ""
+	cases := []struct {
+		name string
+		msg  Message
+		want string
+	}{
+		{"agent no join", Message{MessageType: "agent"}, "agent"},
+		{"user email only", Message{MessageType: "user", Sender: &Sender{Email: "a@b.c"}}, "a@b.c"},
+		{"user blank name", Message{MessageType: "user", Sender: &Sender{Email: "a@b.c", FullName: &empty}}, "a@b.c"},
+		{"no sender", Message{MessageType: "user"}, "unknown"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.msg.SenderLabel(); got != tc.want {
+				t.Errorf("SenderLabel = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/teamchat/token.go
+++ b/internal/teamchat/token.go
@@ -1,0 +1,32 @@
+package teamchat
+
+// Token sources, in resolution priority order. Mirrors the `citadel mcp`
+// credential chain (flag/env > config > device token) so Team Chat and the
+// MCP bridge behave consistently.
+const (
+	// TokenSourceEnv is the ACETEAM_API_KEY environment variable.
+	TokenSourceEnv = "env"
+	// TokenSourceConfig is the aceteam_api_key field in config.yaml.
+	TokenSourceConfig = "config"
+	// TokenSourceDevice is the node's device_api_token. It authenticates but
+	// is scope-denied on /api/channels/** today (see citadel-cli#495), so the
+	// UI warns when this is the only credential available.
+	TokenSourceDevice = "device"
+)
+
+// ResolveToken picks the Team Chat credential from the available sources:
+// the ACETEAM_API_KEY environment variable, then the aceteam_api_key config
+// field, then the device token. Returns the token and its source label, or
+// ("", "") when nothing is configured.
+func ResolveToken(envKey, configKey, deviceToken string) (token, source string) {
+	switch {
+	case envKey != "":
+		return envKey, TokenSourceEnv
+	case configKey != "":
+		return configKey, TokenSourceConfig
+	case deviceToken != "":
+		return deviceToken, TokenSourceDevice
+	default:
+		return "", ""
+	}
+}

--- a/internal/teamchat/token_test.go
+++ b/internal/teamchat/token_test.go
@@ -1,0 +1,28 @@
+package teamchat
+
+import "testing"
+
+func TestResolveToken(t *testing.T) {
+	cases := []struct {
+		name       string
+		env        string
+		config     string
+		device     string
+		wantToken  string
+		wantSource string
+	}{
+		{"env wins", "act_env", "act_cfg", "act_dev", "act_env", TokenSourceEnv},
+		{"config over device", "", "act_cfg", "act_dev", "act_cfg", TokenSourceConfig},
+		{"device fallback", "", "", "act_dev", "act_dev", TokenSourceDevice},
+		{"nothing", "", "", "", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			token, source := ResolveToken(tc.env, tc.config, tc.device)
+			if token != tc.wantToken || source != tc.wantSource {
+				t.Errorf("ResolveToken = (%q, %q), want (%q, %q)",
+					token, source, tc.wantToken, tc.wantSource)
+			}
+		})
+	}
+}

--- a/internal/teamchat/types.go
+++ b/internal/teamchat/types.go
@@ -1,0 +1,164 @@
+// Package teamchat provides a typed HTTP client for the AceTeam Team Chat
+// REST API — the v1 `/api/channels/**` surface backed by the `channels`,
+// `channel_messages`, and `channel_members` tables. This is the same contract
+// the iOS and Android apps consume (see aceteam `types/channels.ts`), so the
+// TUI renders the same org conversation users see on every other platform.
+//
+// Live updates use light polling, matching the mobile clients: the platform's
+// v1 chat WebSocket has been removed pending the v2 chat cutover, so polling
+// is the current cross-client parity mechanism (aceteam-ai/citadel-cli#495).
+package teamchat
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Timestamp wraps time.Time with tolerant JSON parsing. Supabase serializes
+// TIMESTAMPTZ with an offset (e.g. "2026-07-01T12:00:00+00:00"), sometimes
+// with fractional seconds, and the contract also admits offset-less local
+// timestamps. A strict time.RFC3339 parse would reject some of these shapes.
+type Timestamp struct {
+	time.Time
+}
+
+// timestampLayouts are tried in order when parsing a Timestamp. Offset-less
+// values are interpreted as UTC (Supabase stores TIMESTAMPTZ in UTC).
+var timestampLayouts = []string{
+	time.RFC3339Nano,
+	time.RFC3339,
+	"2006-01-02T15:04:05.999999999",
+	"2006-01-02T15:04:05",
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (t *Timestamp) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("timestamp: %w", err)
+	}
+	if s == "" {
+		t.Time = time.Time{}
+		return nil
+	}
+	for _, layout := range timestampLayouts {
+		if parsed, err := time.Parse(layout, s); err == nil {
+			// Offset-less layouts parse into time.UTC already; keep as-is.
+			t.Time = parsed
+			return nil
+		}
+	}
+	return fmt.Errorf("timestamp: unrecognized format %q", s)
+}
+
+// MarshalJSON implements json.Marshaler.
+func (t Timestamp) MarshalJSON() ([]byte, error) {
+	if t.IsZero() {
+		return []byte(`""`), nil
+	}
+	return json.Marshal(t.Format(time.RFC3339))
+}
+
+// Channel is a team-chat channel row (aceteam zChannelSchema subset).
+type Channel struct {
+	ID             string  `json:"id"`
+	Name           string  `json:"name"`
+	Description    *string `json:"description,omitempty"`
+	Visibility     string  `json:"visibility"`
+	OrganizationID string  `json:"organization_id"`
+	CreatedBy      string  `json:"created_by"`
+	CreatedAt      *string `json:"created_at,omitempty"`
+	ArchivedAt     *string `json:"archived_at,omitempty"`
+}
+
+// Sender is the hydrated user join on a message (null for agent messages).
+type Sender struct {
+	ID       string  `json:"id"`
+	Email    string  `json:"email"`
+	FullName *string `json:"full_name,omitempty"`
+}
+
+// AgentSummary is the hydrated agent join on a message (null for human messages).
+type AgentSummary struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+}
+
+// Attachment is a file attached to a message.
+type Attachment struct {
+	ID       string `json:"id"`
+	FileName string `json:"file_name"`
+	MimeType string `json:"mime_type"`
+	ByteSize int64  `json:"byte_size"`
+}
+
+// Message is a team-chat message (aceteam zChannelMessageWithSenderSchema
+// subset — only the fields the TUI renders).
+type Message struct {
+	ID              string        `json:"id"`
+	ChannelID       string        `json:"channel_id"`
+	Content         string        `json:"content"`
+	CreatedAt       Timestamp     `json:"created_at"`
+	MessageType     string        `json:"message_type"`
+	AgentID         *string       `json:"agent_id,omitempty"`
+	ParentMessageID *string       `json:"parent_message_id,omitempty"`
+	ReplyCount      int           `json:"reply_count"`
+	Sender          *Sender       `json:"sender,omitempty"`
+	Agent           *AgentSummary `json:"agent,omitempty"`
+	Attachments     []Attachment  `json:"attachments,omitempty"`
+}
+
+// SenderLabel returns the best human-readable label for the message author:
+// agent title for agent messages, then the sender's full name, then email,
+// then a generic fallback.
+func (m Message) SenderLabel() string {
+	if m.MessageType == "agent" {
+		if m.Agent != nil && m.Agent.Title != "" {
+			return m.Agent.Title
+		}
+		return "agent"
+	}
+	if m.Sender != nil {
+		if m.Sender.FullName != nil && strings.TrimSpace(*m.Sender.FullName) != "" {
+			return strings.TrimSpace(*m.Sender.FullName)
+		}
+		if m.Sender.Email != "" {
+			return m.Sender.Email
+		}
+	}
+	return "unknown"
+}
+
+// MessagesPage is the paginated response from GET .../messages
+// (aceteam zPaginatedMessagesResponseSchema). Messages are in chronological
+// (oldest-first) order for the default "before" direction.
+type MessagesPage struct {
+	Messages   []Message `json:"messages"`
+	HasMore    bool      `json:"hasMore"`
+	NextCursor *string   `json:"nextCursor,omitempty"`
+}
+
+// Member is a channel member with the hydrated user join
+// (aceteam zChannelMemberWithUserSchema subset).
+type Member struct {
+	ID     string  `json:"id"`
+	UserID string  `json:"user_id"`
+	Role   string  `json:"role"`
+	Source string  `json:"source,omitempty"`
+	User   *Sender `json:"user,omitempty"`
+}
+
+// Label returns the member's display label (name, then email, then user id).
+func (m Member) Label() string {
+	if m.User != nil {
+		if m.User.FullName != nil && strings.TrimSpace(*m.User.FullName) != "" {
+			return strings.TrimSpace(*m.User.FullName)
+		}
+		if m.User.Email != "" {
+			return m.User.Email
+		}
+	}
+	return m.UserID
+}

--- a/internal/tui/controlcenter/chat_page.go
+++ b/internal/tui/controlcenter/chat_page.go
@@ -176,8 +176,10 @@ func (p *ChatPage) currentAPIBaseURL() string {
 // Name implements Page.
 func (p *ChatPage) Name() string { return "chat" }
 
-// Title implements Page.
-func (p *ChatPage) Title() string { return "Chat" }
+// Title implements Page. "Node Chat" distinguishes this ephemeral
+// node-to-node pub/sub chat from the TeamChatPage, which mirrors the AceTeam
+// Team Chat product surface (issue #495).
+func (p *ChatPage) Title() string { return "Node Chat" }
 
 // Build implements Page. Constructs the split-pane chat layout.
 func (p *ChatPage) Build(app *tview.Application) tview.Primitive {

--- a/internal/tui/controlcenter/controlcenter.go
+++ b/internal/tui/controlcenter/controlcenter.go
@@ -573,6 +573,11 @@ type ControlCenter struct {
 	chatPage       *ChatPage             // nil until registered in Run
 	proxmoxConfig  ProxmoxConfig         // Proxmox page config (zero = disabled)
 
+	// Team Chat (AceTeam org channels — distinct from the node-to-node chatPage)
+	teamChatConfig     TeamChatPageConfig        // stored from Config; used to lazily create TeamChatPage
+	teamChatConfigProv func() TeamChatPageConfig // lazy re-resolver for Team Chat credentials
+	teamChatPage       *TeamChatPage             // nil until registered in Run
+
 	// Settings
 	settingsConfig SettingsCallbacks // Settings page hooks (telemetry load/save)
 
@@ -658,10 +663,16 @@ type Config struct {
 	OnConnect          func(activityFn func(level, msg string)) // Called after VPN connects (starts terminal/VNC servers)
 	Chat               ChatPageConfig                           // Chat page configuration (initial snapshot; may be empty pre-auth)
 	ChatConfigProvider func() ChatPageConfig                    // Lazy re-resolver for chat credentials (picks up post-startup device auth)
-	Proxmox            ProxmoxConfig                            // Proxmox page configuration (empty = disabled)
-	Settings           SettingsCallbacks                        // Settings page hooks (telemetry load/save)
-	WhatsApp           WhatsAppCallbacks                        // WhatsApp bridge page hooks (deploy/stop/status/QR)
-	ModuleInstall      ModuleInstallCallbacks                   // Install-module page hooks (resolve source + install)
+
+	// Team Chat page configuration (AceTeam org channels; initial snapshot may
+	// be empty pre-auth) and its lazy credential re-resolver.
+	TeamChat               TeamChatPageConfig
+	TeamChatConfigProvider func() TeamChatPageConfig
+
+	Proxmox       ProxmoxConfig          // Proxmox page configuration (empty = disabled)
+	Settings      SettingsCallbacks      // Settings page hooks (telemetry load/save)
+	WhatsApp      WhatsAppCallbacks      // WhatsApp bridge page hooks (deploy/stop/status/QR)
+	ModuleInstall ModuleInstallCallbacks // Install-module page hooks (resolve source + install)
 
 	// MouseEnabled is the resolved initial mouse state (persisted preference with
 	// the --no-mouse flag applied). When true, the control center opts into
@@ -720,6 +731,8 @@ func New(cfg Config) *ControlCenter {
 		nexusURL:            cfg.NexusURL,
 		chatConfig:          cfg.Chat,
 		chatConfigProv:      cfg.ChatConfigProvider,
+		teamChatConfig:      cfg.TeamChat,
+		teamChatConfigProv:  cfg.TeamChatConfigProvider,
 		proxmoxConfig:       cfg.Proxmox,
 		settingsConfig:      cfg.Settings,
 		whatsappConfig:      cfg.WhatsApp,
@@ -824,6 +837,13 @@ func (cc *ControlCenter) Run() error {
 	cc.chatConfig.Provider = cc.chatConfigProv
 	cc.chatPage = NewChatPage(cc.chatConfig)
 	cc.pmgr.Register(cc.chatPage, false)
+
+	// Team Chat page (hidden until network is connected): the AceTeam org
+	// channels surface (parity with web/iOS/Android), distinct from the
+	// node-to-node Node Chat above. Same lazy-provider pattern.
+	cc.teamChatConfig.Provider = cc.teamChatConfigProv
+	cc.teamChatPage = NewTeamChatPage(cc.teamChatConfig)
+	cc.pmgr.Register(cc.teamChatPage, false)
 
 	// Alt+4: Gateway page (hidden until gateway ledger appears on disk)
 	gatewayBaseDir := filepath.Join(os.Getenv("HOME"), ".citadel-cli")
@@ -949,6 +969,7 @@ func (cc *ControlCenter) Run() error {
 func (cc *ControlCenter) ShowChat() {
 	if cc.pmgr != nil {
 		cc.pmgr.Show("chat")
+		cc.pmgr.Show("teamchat")
 	}
 }
 
@@ -992,6 +1013,9 @@ func (cc *ControlCenter) Cleanup() {
 	}
 	if cc.chatPage != nil {
 		cc.chatPage.Close()
+	}
+	if cc.teamChatPage != nil {
+		cc.teamChatPage.Close()
 	}
 }
 

--- a/internal/tui/controlcenter/teamchat_page.go
+++ b/internal/tui/controlcenter/teamchat_page.go
@@ -55,6 +55,7 @@ type TeamChatPage struct {
 	messages      []teamchat.Message
 	lastMessageID string // newest rendered message; drives re-render + mark-read
 	loadedOnce    bool   // first successful channel-list load happened
+	authGuidance  bool   // credential guidance is on screen (avoid 5s re-render flicker)
 
 	// Poll lifecycle. pollCancel is non-nil while the page is active.
 	pollMu     sync.Mutex
@@ -364,6 +365,7 @@ func (p *TeamChatPage) loadChannels(ctx context.Context, client *teamchat.Client
 	p.dataMu.Lock()
 	p.channels = channels
 	p.loadedOnce = true
+	p.authGuidance = false // credentials work; clear the sticky guidance state
 	active := p.activeChannel
 	if active == "" && len(channels) > 0 {
 		active = channels[0].ID
@@ -608,7 +610,16 @@ func (p *TeamChatPage) runSearch(query string) {
 // for auth errors, a transient status-bar error otherwise.
 func (p *TeamChatPage) handleFetchError(err error) {
 	if teamchat.IsAuthError(err) {
-		p.showAuthGuidance(err.Error())
+		// Render the guidance once, not on every 5s poll tick — a device-token-
+		// only node hits this on every fetch until the #495 backend lands, and
+		// re-clearing the view each tick would flicker while the user reads.
+		p.dataMu.Lock()
+		alreadyShown := p.authGuidance
+		p.authGuidance = true
+		p.dataMu.Unlock()
+		if !alreadyShown {
+			p.showAuthGuidance(err.Error())
+		}
 		return
 	}
 	errMsg := err.Error()

--- a/internal/tui/controlcenter/teamchat_page.go
+++ b/internal/tui/controlcenter/teamchat_page.go
@@ -1,0 +1,819 @@
+package controlcenter
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/teamchat"
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+// teamChatPollInterval is how often the active channel is re-fetched while the
+// Team Chat tab is open. Matches the iOS/Android light-polling cadence — the
+// platform's v1 chat WebSocket is gone pending the v2 cutover, so polling is
+// the cross-client parity mechanism (issue #495).
+const teamChatPollInterval = 5 * time.Second
+
+// teamChatPageSize is the message page size fetched per poll/load.
+const teamChatPageSize = 50
+
+// TeamChatPage implements the Page interface for the Team Chat tab. It mirrors
+// the AceTeam Team Chat product surface (web /team-chat, iOS, Android): org
+// channels backed by the channels/channel_messages tables, read and written
+// through the v1 REST API via the teamchat client.
+//
+// This is distinct from the ChatPage ("Node Chat"), which is an ephemeral
+// node-to-node pub/sub chat over the Redis proxy. Team Chat requires a user
+// act_ API key until device tokens are allowed onto /api/channels/** (#495).
+type TeamChatPage struct {
+	app *tview.Application
+
+	// Config, resolved lazily like ChatPage: a node that completes device
+	// authorization (or exports ACETEAM_API_KEY) after startup should pick up
+	// credentials at connect time rather than freezing the startup snapshot.
+	configMu sync.Mutex
+	cfg      TeamChatPageConfig
+
+	// UI components
+	root        *tview.Flex
+	channelList *tview.List
+	membersBox  *tview.TextView
+	msgView     *tview.TextView
+	statusBar   *tview.TextView
+	input       *tview.InputField
+	sendButton  *tview.Button
+
+	// Client + data. dataMu guards everything below.
+	dataMu        sync.Mutex
+	client        *teamchat.Client
+	channels      []teamchat.Channel
+	activeChannel string // channel ID; empty until channels load
+	messages      []teamchat.Message
+	lastMessageID string // newest rendered message; drives re-render + mark-read
+	loadedOnce    bool   // first successful channel-list load happened
+
+	// Poll lifecycle. pollCancel is non-nil while the page is active.
+	pollMu     sync.Mutex
+	pollCancel context.CancelFunc
+}
+
+// TeamChatPageConfig holds the configuration for the Team Chat page.
+type TeamChatPageConfig struct {
+	// APIBaseURL is the AceTeam API base URL (e.g. "https://aceteam.ai").
+	APIBaseURL string
+	// Token is the Bearer credential (user act_ key preferred; the device
+	// token is scope-denied on Team Chat routes today, see #495).
+	Token string
+	// TokenSource labels where Token came from ("env", "config", "device"),
+	// so the UI can warn when only the device token is available.
+	TokenSource string
+	// Provider, when set, lazily re-resolves the fields above at connect time
+	// (same pattern as ChatPageConfig.Provider).
+	Provider func() TeamChatPageConfig
+}
+
+// NewTeamChatPage creates the Team Chat page. Data loads lazily on first
+// activation.
+func NewTeamChatPage(cfg TeamChatPageConfig) *TeamChatPage {
+	return &TeamChatPage{cfg: cfg}
+}
+
+// Name implements Page.
+func (p *TeamChatPage) Name() string { return "teamchat" }
+
+// Title implements Page.
+func (p *TeamChatPage) Title() string { return "Team Chat" }
+
+// Build implements Page.
+func (p *TeamChatPage) Build(app *tview.Application) tview.Primitive {
+	p.app = app
+
+	// -- Left sidebar: channel list + members --
+
+	p.channelList = tview.NewList()
+	p.channelList.ShowSecondaryText(false)
+	p.channelList.SetBorder(true)
+	p.channelList.SetTitle(" Channels ")
+	p.channelList.SetTitleAlign(tview.AlignLeft)
+	p.channelList.SetSelectedFunc(func(index int, mainText, secondaryText string, shortcut rune) {
+		p.onChannelSelected(index)
+	})
+
+	p.membersBox = tview.NewTextView()
+	p.membersBox.SetDynamicColors(true)
+	p.membersBox.SetBorder(true)
+	p.membersBox.SetTitle(" Members ")
+	p.membersBox.SetTitleAlign(tview.AlignLeft)
+
+	sidebar := tview.NewFlex().SetDirection(tview.FlexRow).
+		AddItem(p.channelList, 0, 2, false).
+		AddItem(p.membersBox, 0, 1, false)
+
+	// -- Right panel: messages + status + input --
+
+	p.msgView = tview.NewTextView()
+	p.msgView.SetDynamicColors(true)
+	p.msgView.SetScrollable(true)
+	p.msgView.SetBorder(true)
+	p.msgView.SetTitle(" Team Chat ")
+	p.msgView.SetTitleAlign(tview.AlignLeft)
+	p.msgView.SetText(" [gray]Loading Team Chat...[white]\n")
+
+	p.statusBar = tview.NewTextView()
+	p.statusBar.SetDynamicColors(true)
+	p.statusBar.SetTextAlign(tview.AlignLeft)
+
+	p.input = tview.NewInputField()
+	p.input.SetLabel("> ")
+	p.input.SetFieldBackgroundColor(tcell.ColorDarkSlateGray)
+	p.input.SetLabelColor(tcell.ColorGreen)
+	p.input.SetPlaceholder("Message — Enter to send, /search <text> to search")
+	p.input.SetPlaceholderTextColor(tcell.ColorDimGray)
+	p.input.SetDoneFunc(func(key tcell.Key) {
+		if key == tcell.KeyEnter {
+			p.submitInput()
+		}
+	})
+
+	p.sendButton = tview.NewButton("Send")
+	p.sendButton.SetSelectedFunc(func() {
+		p.submitInput()
+		if p.app != nil && p.input != nil {
+			p.app.SetFocus(p.input)
+		}
+	})
+
+	inputRow := tview.NewFlex().
+		AddItem(p.input, 0, 1, true).
+		AddItem(p.sendButton, 8, 0, false)
+
+	rightPanel := tview.NewFlex().SetDirection(tview.FlexRow).
+		AddItem(p.msgView, 0, 1, false).
+		AddItem(p.statusBar, 1, 0, false).
+		AddItem(inputRow, 1, 0, true)
+
+	p.renderStatus(connConnecting, "")
+
+	p.root = tview.NewFlex().
+		AddItem(sidebar, 28, 0, false).
+		AddItem(rightPanel, 0, 1, true)
+
+	// Clicking the message history or members focuses the input (same
+	// mouse-only hook as ChatPage); the channel list keeps real clicks so
+	// mouse users can switch channels.
+	focusInputOnClick := func(action tview.MouseAction, event *tcell.EventMouse) (tview.MouseAction, *tcell.EventMouse) {
+		switch action {
+		case tview.MouseLeftClick, tview.MouseLeftDown:
+			if p.app != nil && p.input != nil {
+				p.app.SetFocus(p.input)
+			}
+			return tview.MouseConsumed, nil
+		default:
+			return action, event
+		}
+	}
+	p.msgView.SetMouseCapture(focusInputOnClick)
+	p.membersBox.SetMouseCapture(focusInputOnClick)
+
+	return p.root
+}
+
+// OnActivate implements Page. Starts (or restarts) the poll loop and performs
+// the initial channel load.
+func (p *TeamChatPage) OnActivate() {
+	if p.app != nil && p.input != nil {
+		p.app.SetFocus(p.input)
+	}
+
+	p.pollMu.Lock()
+	if p.pollCancel != nil {
+		p.pollMu.Unlock()
+		return // already polling
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	p.pollCancel = cancel
+	p.pollMu.Unlock()
+
+	go p.run(ctx)
+}
+
+// OnDeactivate implements Page. Stops polling — mobile parity: no background
+// fetching while the tab is not visible.
+func (p *TeamChatPage) OnDeactivate() {
+	p.stopPolling()
+}
+
+// Close shuts down the page.
+func (p *TeamChatPage) Close() {
+	p.stopPolling()
+}
+
+func (p *TeamChatPage) stopPolling() {
+	p.pollMu.Lock()
+	if p.pollCancel != nil {
+		p.pollCancel()
+		p.pollCancel = nil
+	}
+	p.pollMu.Unlock()
+}
+
+// HandleInput implements Page. Same navigation contract as ChatPage: the
+// input consumes text + Enter; PgUp/PgDn scroll; Escape defocuses; Tab cycles
+// panes and bubbles at the edges so the user can always leave the tab.
+func (p *TeamChatPage) HandleInput(event *tcell.EventKey) *tcell.EventKey {
+	switch classifyChatKey(event) {
+	case chatKeyScrollUp:
+		row, col := p.msgView.GetScrollOffset()
+		p.msgView.ScrollTo(row-10, col)
+		return nil
+	case chatKeyScrollDown:
+		row, col := p.msgView.GetScrollOffset()
+		p.msgView.ScrollTo(row+10, col)
+		return nil
+	case chatKeyDefocus:
+		if p.app != nil && p.msgView != nil {
+			p.app.SetFocus(p.msgView)
+		}
+		return nil
+	case chatKeyNextPane:
+		if p.cyclePane(1) {
+			return nil
+		}
+		return event
+	case chatKeyPrevPane:
+		if p.cyclePane(-1) {
+			return nil
+		}
+		return event
+	default:
+		return event
+	}
+}
+
+// panes returns the focusable panes in tab order.
+func (p *TeamChatPage) panes() []tview.Primitive {
+	return []tview.Primitive{p.input, p.msgView, p.channelList, p.membersBox}
+}
+
+func (p *TeamChatPage) currentPaneIndex() int {
+	if p.app == nil {
+		return -1
+	}
+	focused := p.app.GetFocus()
+	for i, pane := range p.panes() {
+		if pane == focused {
+			return i
+		}
+	}
+	return -1
+}
+
+// cyclePane moves focus to the next/previous pane, reporting false when the
+// cycle bubbles past an edge (caller lets the tab switch). Reuses the shared
+// nextChatPaneIndex edge-bubbling helper.
+func (p *TeamChatPage) cyclePane(delta int) bool {
+	panes := p.panes()
+	idx := nextChatPaneIndex(p.currentPaneIndex(), len(panes), delta)
+	if idx < 0 || idx >= len(panes) {
+		return false
+	}
+	if p.app != nil {
+		p.app.SetFocus(panes[idx])
+	}
+	return true
+}
+
+// resolveClient returns the teamchat client, creating it from the freshest
+// credentials when needed. Returns nil (with guidance already rendered) when
+// no token is available at all.
+func (p *TeamChatPage) resolveClient() *teamchat.Client {
+	p.dataMu.Lock()
+	if p.client != nil {
+		client := p.client
+		p.dataMu.Unlock()
+		return client
+	}
+	p.dataMu.Unlock()
+
+	p.configMu.Lock()
+	if (p.cfg.Token == "" || p.cfg.APIBaseURL == "") && p.cfg.Provider != nil {
+		fresh := p.cfg.Provider()
+		if fresh.APIBaseURL != "" {
+			p.cfg.APIBaseURL = fresh.APIBaseURL
+		}
+		if fresh.Token != "" {
+			p.cfg.Token = fresh.Token
+			p.cfg.TokenSource = fresh.TokenSource
+		}
+	}
+	cfg := p.cfg
+	p.configMu.Unlock()
+
+	if cfg.APIBaseURL == "" || cfg.Token == "" {
+		p.showAuthGuidance("no credentials configured")
+		return nil
+	}
+
+	client := teamchat.NewClient(teamchat.ClientConfig{
+		BaseURL: cfg.APIBaseURL,
+		Token:   cfg.Token,
+	})
+	p.dataMu.Lock()
+	p.client = client
+	p.dataMu.Unlock()
+	return client
+}
+
+// run is the page's background loop: initial load, then poll ticks until ctx
+// is cancelled.
+func (p *TeamChatPage) run(ctx context.Context) {
+	client := p.resolveClient()
+	if client == nil {
+		return
+	}
+
+	p.loadChannels(ctx, client)
+
+	ticker := time.NewTicker(teamChatPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.pollActiveChannel(ctx, client)
+		}
+	}
+}
+
+// loadChannels fetches the channel list, renders it, and selects the first
+// channel when nothing is selected yet.
+func (p *TeamChatPage) loadChannels(ctx context.Context, client *teamchat.Client) {
+	reqCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	channels, err := client.ListChannels(reqCtx)
+	cancel()
+	if err != nil {
+		p.handleFetchError(err)
+		return
+	}
+
+	p.dataMu.Lock()
+	p.channels = channels
+	p.loadedOnce = true
+	active := p.activeChannel
+	if active == "" && len(channels) > 0 {
+		active = channels[0].ID
+		p.activeChannel = active
+	}
+	p.dataMu.Unlock()
+
+	p.app.QueueUpdateDraw(func() {
+		p.renderChannelList()
+		p.renderStatus(connConnected, "")
+	})
+
+	if active != "" {
+		p.loadChannel(ctx, client, active)
+	} else {
+		p.setMsgText(" [gray]No channels visible to your organization.[white]\n")
+	}
+}
+
+// loadChannel fetches history + members for a channel and renders both.
+func (p *TeamChatPage) loadChannel(ctx context.Context, client *teamchat.Client, channelID string) {
+	reqCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	page, err := client.Messages(reqCtx, channelID, teamchat.MessagesOptions{Limit: teamChatPageSize})
+	cancel()
+	if err != nil {
+		p.handleFetchError(err)
+		return
+	}
+
+	p.dataMu.Lock()
+	if p.activeChannel != channelID {
+		p.dataMu.Unlock()
+		return // user switched away while we were loading
+	}
+	p.messages = page.Messages
+	newest := newestMessageID(page.Messages)
+	changed := newest != p.lastMessageID
+	p.lastMessageID = newest
+	p.dataMu.Unlock()
+
+	p.app.QueueUpdateDraw(func() {
+		p.renderMessages()
+		p.renderStatus(connConnected, "")
+	})
+
+	if changed && newest != "" {
+		p.markRead(ctx, client, channelID, newest)
+	}
+
+	// Members are secondary; fetch after messages render.
+	reqCtx, cancel = context.WithTimeout(ctx, 15*time.Second)
+	members, err := client.ListMembers(reqCtx, channelID)
+	cancel()
+	if err == nil {
+		p.app.QueueUpdateDraw(func() {
+			p.renderMembers(members)
+		})
+	}
+}
+
+// pollActiveChannel re-fetches the newest page for the active channel and
+// re-renders only when the newest message changed.
+func (p *TeamChatPage) pollActiveChannel(ctx context.Context, client *teamchat.Client) {
+	p.dataMu.Lock()
+	channelID := p.activeChannel
+	loaded := p.loadedOnce
+	p.dataMu.Unlock()
+
+	if !loaded {
+		p.loadChannels(ctx, client)
+		return
+	}
+	if channelID == "" {
+		return
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	page, err := client.Messages(reqCtx, channelID, teamchat.MessagesOptions{Limit: teamChatPageSize})
+	cancel()
+	if err != nil {
+		p.handleFetchError(err)
+		return
+	}
+
+	newest := newestMessageID(page.Messages)
+
+	p.dataMu.Lock()
+	if p.activeChannel != channelID {
+		p.dataMu.Unlock()
+		return
+	}
+	changed := newest != p.lastMessageID || len(page.Messages) != len(p.messages)
+	p.messages = page.Messages
+	p.lastMessageID = newest
+	p.dataMu.Unlock()
+
+	if changed {
+		p.app.QueueUpdateDraw(func() {
+			p.renderMessages()
+			p.renderStatus(connConnected, "")
+		})
+		if newest != "" {
+			p.markRead(ctx, client, channelID, newest)
+		}
+	}
+}
+
+// markRead advances the read cursor, best-effort.
+func (p *TeamChatPage) markRead(ctx context.Context, client *teamchat.Client, channelID, messageID string) {
+	reqCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	_ = client.MarkRead(reqCtx, channelID, messageID)
+}
+
+// onChannelSelected handles a channel list selection (keyboard or mouse).
+func (p *TeamChatPage) onChannelSelected(index int) {
+	p.dataMu.Lock()
+	if index < 0 || index >= len(p.channels) {
+		p.dataMu.Unlock()
+		return
+	}
+	channelID := p.channels[index].ID
+	if channelID == p.activeChannel {
+		p.dataMu.Unlock()
+		if p.app != nil && p.input != nil {
+			p.app.SetFocus(p.input)
+		}
+		return
+	}
+	p.activeChannel = channelID
+	p.messages = nil
+	p.lastMessageID = ""
+	client := p.client
+	p.dataMu.Unlock()
+
+	p.msgView.Clear()
+	fmt.Fprint(p.msgView, " [gray]Loading messages...[white]\n")
+	p.renderChannelTitle()
+	if p.app != nil && p.input != nil {
+		p.app.SetFocus(p.input)
+	}
+
+	if client != nil {
+		go p.loadChannel(context.Background(), client, channelID)
+	}
+}
+
+// submitInput sends the input field's content: either a /search command or a
+// chat message to the active channel.
+func (p *TeamChatPage) submitInput() {
+	text := strings.TrimSpace(p.input.GetText())
+	if text == "" {
+		return
+	}
+
+	if query, ok := parseSearchCommand(text); ok {
+		p.input.SetText("")
+		go p.runSearch(query)
+		return
+	}
+
+	p.dataMu.Lock()
+	client := p.client
+	channelID := p.activeChannel
+	p.dataMu.Unlock()
+	if client == nil || channelID == "" {
+		return
+	}
+
+	p.input.SetText("")
+
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+
+		msg, err := client.SendMessage(ctx, channelID, text, "")
+		if err != nil {
+			errMsg := err.Error()
+			p.app.QueueUpdateDraw(func() {
+				fmt.Fprintf(p.msgView, " [red]Send failed: %s[white]\n", tview.Escape(errMsg))
+				p.msgView.ScrollToEnd()
+			})
+			return
+		}
+
+		// Append the server-confirmed message immediately; the next poll
+		// replaces the buffer wholesale, and ID-based state means no echo
+		// dedup is needed (unlike the pub/sub Node Chat).
+		p.dataMu.Lock()
+		if p.activeChannel == channelID {
+			p.messages = append(p.messages, msg)
+			p.lastMessageID = msg.ID
+		}
+		p.dataMu.Unlock()
+
+		p.app.QueueUpdateDraw(func() {
+			p.appendMessage(msg)
+		})
+	}()
+}
+
+// runSearch executes a /search command against the active channel and renders
+// the results in the message view. The next poll re-render returns to the
+// live channel view.
+func (p *TeamChatPage) runSearch(query string) {
+	p.dataMu.Lock()
+	client := p.client
+	channelID := p.activeChannel
+	p.dataMu.Unlock()
+	if client == nil || channelID == "" {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	results, err := client.SearchMessages(ctx, channelID, query, 20)
+	if err != nil {
+		errMsg := err.Error()
+		p.app.QueueUpdateDraw(func() {
+			fmt.Fprintf(p.msgView, " [red]Search failed: %s[white]\n", tview.Escape(errMsg))
+			p.msgView.ScrollToEnd()
+		})
+		return
+	}
+
+	p.app.QueueUpdateDraw(func() {
+		p.msgView.Clear()
+		fmt.Fprintf(p.msgView, " [yellow]Search results for %q[white] (%d)\n\n", query, len(results))
+		if len(results) == 0 {
+			fmt.Fprint(p.msgView, " [gray]No matches in this channel.[white]\n")
+		}
+		for _, msg := range results {
+			p.writeMessageLine(msg)
+		}
+		fmt.Fprint(p.msgView, "\n [gray]Live view resumes on the next update.[white]\n")
+		p.msgView.ScrollToEnd()
+	})
+}
+
+// handleFetchError routes an API failure to the right UI: credential guidance
+// for auth errors, a transient status-bar error otherwise.
+func (p *TeamChatPage) handleFetchError(err error) {
+	if teamchat.IsAuthError(err) {
+		p.showAuthGuidance(err.Error())
+		return
+	}
+	errMsg := err.Error()
+	p.app.QueueUpdateDraw(func() {
+		p.renderStatus(connError, errMsg)
+	})
+}
+
+// showAuthGuidance renders actionable credential setup instructions. This is
+// the expected state on a node that only has its device token: device keys
+// are endpoint-whitelisted away from /api/channels/** until the #495 backend
+// follow-up lands.
+func (p *TeamChatPage) showAuthGuidance(detail string) {
+	p.configMu.Lock()
+	base := p.cfg.APIBaseURL
+	source := p.cfg.TokenSource
+	p.configMu.Unlock()
+	if base == "" {
+		base = "https://aceteam.ai"
+	}
+
+	var b strings.Builder
+	b.WriteString(" [yellow]Team Chat needs an AceTeam API key.[white]\n\n")
+	if source == "device" {
+		b.WriteString(" This node's device token cannot access Team Chat yet\n")
+		b.WriteString(" (its API scope is limited to fabric endpoints — see\n")
+		b.WriteString(" citadel-cli#495 for the backend follow-up).\n\n")
+	}
+	b.WriteString(" To connect:\n")
+	fmt.Fprintf(&b, "   1. Generate a key at [green]%s/settings/api-keys[white]\n", tview.Escape(base))
+	b.WriteString("   2. Provide it via [green]ACETEAM_API_KEY[white] env var, or add\n")
+	b.WriteString("      [green]aceteam_api_key: act_...[white] to your citadel config.yaml\n")
+	b.WriteString("   3. Restart the control center\n")
+
+	text := b.String()
+	p.app.QueueUpdateDraw(func() {
+		p.msgView.Clear()
+		fmt.Fprint(p.msgView, text)
+		p.renderStatus(connError, detail)
+	})
+}
+
+// setMsgText replaces the message view content from a background goroutine.
+func (p *TeamChatPage) setMsgText(text string) {
+	p.app.QueueUpdateDraw(func() {
+		p.msgView.Clear()
+		fmt.Fprint(p.msgView, text)
+	})
+}
+
+// renderChannelList redraws the sidebar channel list. Must run on the main
+// goroutine.
+func (p *TeamChatPage) renderChannelList() {
+	p.dataMu.Lock()
+	channels := make([]teamchat.Channel, len(p.channels))
+	copy(channels, p.channels)
+	active := p.activeChannel
+	p.dataMu.Unlock()
+
+	p.channelList.Clear()
+	currentIdx := 0
+	for i, ch := range channels {
+		p.channelList.AddItem("# "+ch.Name, "", 0, nil)
+		if ch.ID == active {
+			currentIdx = i
+		}
+	}
+	if len(channels) > 0 {
+		p.channelList.SetCurrentItem(currentIdx)
+	}
+	p.renderChannelTitle()
+}
+
+// renderChannelTitle sets the message view title to the active channel name.
+func (p *TeamChatPage) renderChannelTitle() {
+	p.dataMu.Lock()
+	name := ""
+	for _, ch := range p.channels {
+		if ch.ID == p.activeChannel {
+			name = ch.Name
+			break
+		}
+	}
+	p.dataMu.Unlock()
+	if name == "" {
+		p.msgView.SetTitle(" Team Chat ")
+		return
+	}
+	p.msgView.SetTitle(" #" + tview.Escape(name) + " ")
+}
+
+// renderMessages redraws the full message buffer. Must run on the main
+// goroutine.
+func (p *TeamChatPage) renderMessages() {
+	p.dataMu.Lock()
+	messages := make([]teamchat.Message, len(p.messages))
+	copy(messages, p.messages)
+	p.dataMu.Unlock()
+
+	p.msgView.Clear()
+	if len(messages) == 0 {
+		fmt.Fprint(p.msgView, " [gray]No messages yet — say hi![white]\n")
+		return
+	}
+	for _, msg := range messages {
+		p.writeMessageLine(msg)
+	}
+	p.msgView.ScrollToEnd()
+}
+
+// appendMessage renders a single message at the end of the view. Must run on
+// the main goroutine.
+func (p *TeamChatPage) appendMessage(msg teamchat.Message) {
+	p.writeMessageLine(msg)
+	p.msgView.ScrollToEnd()
+}
+
+// writeMessageLine renders one message into the view.
+func (p *TeamChatPage) writeMessageLine(msg teamchat.Message) {
+	fmt.Fprintf(p.msgView, " %s\n", formatTeamChatMessage(msg))
+}
+
+// renderMembers redraws the members sidebar. Must run on the main goroutine.
+func (p *TeamChatPage) renderMembers(members []teamchat.Member) {
+	if len(members) == 0 {
+		p.membersBox.SetText(" [gray]no members[white]")
+		return
+	}
+	var sb strings.Builder
+	for _, m := range members {
+		marker := "[white]"
+		if m.Role == "admin" {
+			marker = "[yellow]"
+		}
+		fmt.Fprintf(&sb, " %s%s[white]\n", marker, tview.Escape(m.Label()))
+	}
+	p.membersBox.SetText(sb.String())
+}
+
+// renderStatus updates the one-line status bar. Must run on the main
+// goroutine (Build seeds it before the app runs, which is also safe).
+func (p *TeamChatPage) renderStatus(state connState, detail string) {
+	if p.statusBar == nil {
+		return
+	}
+	p.configMu.Lock()
+	base := p.cfg.APIBaseURL
+	p.configMu.Unlock()
+	p.statusBar.SetText(formatChatStatusBar(state, base, detail))
+}
+
+// formatTeamChatMessage renders a message as a single tview-markup line:
+// timestamp, sender (agents in magenta, humans in cyan), thread marker, body.
+// Pure and unit-testable.
+func formatTeamChatMessage(msg teamchat.Message) string {
+	ts := msg.CreatedAt.Local().Format("Jan 02 15:04")
+	name := msg.SenderLabel()
+
+	nameColor := "cyan"
+	if msg.MessageType == "agent" {
+		nameColor = "magenta"
+	}
+
+	thread := ""
+	if msg.ParentMessageID != nil && *msg.ParentMessageID != "" {
+		thread = "↳ "
+	}
+
+	body := strings.TrimSpace(msg.Content)
+	if body == "" && len(msg.Attachments) > 0 {
+		body = fmt.Sprintf("(%d attachment(s))", len(msg.Attachments))
+	}
+
+	line := fmt.Sprintf("[gray]%s[white] %s[%s]%s[white]: %s",
+		ts, thread, nameColor, tview.Escape(name), tview.Escape(body))
+
+	if msg.ReplyCount > 0 {
+		line += fmt.Sprintf(" [gray](%d replies)[white]", msg.ReplyCount)
+	}
+	for _, att := range msg.Attachments {
+		line += fmt.Sprintf("\n   [gray]+ attachment: %s[white]", tview.Escape(att.FileName))
+	}
+	return line
+}
+
+// parseSearchCommand recognizes "/search <query>" input. Pure and
+// unit-testable. Returns the query and true when the input is a search
+// command with a non-empty query.
+func parseSearchCommand(text string) (string, bool) {
+	const prefix = "/search"
+	if !strings.HasPrefix(text, prefix) {
+		return "", false
+	}
+	rest := strings.TrimSpace(strings.TrimPrefix(text, prefix))
+	if rest == "" {
+		return "", false
+	}
+	return rest, true
+}
+
+// newestMessageID returns the ID of the last (newest) message, or "".
+// Messages arrive oldest-first from the API.
+func newestMessageID(messages []teamchat.Message) string {
+	if len(messages) == 0 {
+		return ""
+	}
+	return messages[len(messages)-1].ID
+}

--- a/internal/tui/controlcenter/teamchat_page_test.go
+++ b/internal/tui/controlcenter/teamchat_page_test.go
@@ -1,0 +1,151 @@
+package controlcenter
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/teamchat"
+)
+
+func tsAt(t time.Time) teamchat.Timestamp {
+	return teamchat.Timestamp{Time: t}
+}
+
+func TestFormatTeamChatMessage(t *testing.T) {
+	name := "Jason Sun"
+	parent := "m-1"
+	created := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name     string
+		msg      teamchat.Message
+		contains []string
+		excludes []string
+	}{
+		{
+			name: "human message",
+			msg: teamchat.Message{
+				ID: "m-2", Content: "hello team", MessageType: "user",
+				CreatedAt: tsAt(created),
+				Sender:    &teamchat.Sender{ID: "u-1", Email: "j@x.c", FullName: &name},
+			},
+			contains: []string{"[cyan]Jason Sun[white]", "hello team"},
+			excludes: []string{"replies", "↳"},
+		},
+		{
+			name: "agent message",
+			msg: teamchat.Message{
+				ID: "m-3", Content: "on it", MessageType: "agent",
+				CreatedAt: tsAt(created),
+				Agent:     &teamchat.AgentSummary{ID: "a-1", Title: "Ace"},
+			},
+			contains: []string{"[magenta]Ace[white]", "on it"},
+		},
+		{
+			name: "threaded reply with reply count",
+			msg: teamchat.Message{
+				ID: "m-4", Content: "reply", MessageType: "user",
+				CreatedAt:       tsAt(created),
+				ParentMessageID: &parent,
+				ReplyCount:      3,
+			},
+			contains: []string{"↳", "(3 replies)"},
+		},
+		{
+			name: "attachment-only message",
+			msg: teamchat.Message{
+				ID: "m-5", Content: "", MessageType: "user",
+				CreatedAt:   tsAt(created),
+				Attachments: []teamchat.Attachment{{ID: "att-1", FileName: "report.pdf"}},
+			},
+			contains: []string{"(1 attachment(s))", "+ attachment: report.pdf"},
+		},
+		{
+			name: "markup in content is escaped",
+			msg: teamchat.Message{
+				ID: "m-6", Content: "danger [red]text[white]", MessageType: "user",
+				CreatedAt: tsAt(created),
+			},
+			// tview.Escape turns [red] into [red[] so user content can't
+			// inject color codes.
+			contains: []string{"[red[]"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatTeamChatMessage(tc.msg)
+			for _, want := range tc.contains {
+				if !strings.Contains(got, want) {
+					t.Errorf("formatTeamChatMessage = %q, missing %q", got, want)
+				}
+			}
+			for _, not := range tc.excludes {
+				if strings.Contains(got, not) {
+					t.Errorf("formatTeamChatMessage = %q, should not contain %q", got, not)
+				}
+			}
+		})
+	}
+}
+
+func TestParseSearchCommand(t *testing.T) {
+	cases := []struct {
+		input     string
+		wantQuery string
+		wantOK    bool
+	}{
+		{"/search deploy plan", "deploy plan", true},
+		{"/search   spaced   ", "spaced", true},
+		{"/search", "", false},
+		{"/search   ", "", false},
+		{"hello /search foo", "", false},
+		{"regular message", "", false},
+		{"", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			query, ok := parseSearchCommand(tc.input)
+			if query != tc.wantQuery || ok != tc.wantOK {
+				t.Errorf("parseSearchCommand(%q) = (%q, %v), want (%q, %v)",
+					tc.input, query, ok, tc.wantQuery, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestNewestMessageID(t *testing.T) {
+	if got := newestMessageID(nil); got != "" {
+		t.Errorf("newestMessageID(nil) = %q, want empty", got)
+	}
+	msgs := []teamchat.Message{{ID: "m-1"}, {ID: "m-2"}, {ID: "m-3"}}
+	if got := newestMessageID(msgs); got != "m-3" {
+		t.Errorf("newestMessageID = %q, want m-3 (messages are oldest-first)", got)
+	}
+}
+
+func TestTeamChatPageInterface(t *testing.T) {
+	// TeamChatPage must satisfy the Page interface and carry stable
+	// name/title used by PageManager.Show("teamchat") in ShowChat.
+	var page Page = NewTeamChatPage(TeamChatPageConfig{})
+	if page.Name() != "teamchat" {
+		t.Errorf("Name = %q, want teamchat", page.Name())
+	}
+	if page.Title() != "Team Chat" {
+		t.Errorf("Title = %q, want Team Chat", page.Title())
+	}
+}
+
+func TestNodeChatPageRetitled(t *testing.T) {
+	// The legacy node-to-node pub/sub chat keeps its registered name "chat"
+	// (ShowChat depends on it) but is retitled to distinguish it from the
+	// Team Chat tab.
+	page := NewChatPage(ChatPageConfig{})
+	if page.Name() != "chat" {
+		t.Errorf("Name = %q, want chat", page.Name())
+	}
+	if page.Title() != "Node Chat" {
+		t.Errorf("Title = %q, want Node Chat", page.Title())
+	}
+}


### PR DESCRIPTION
## Context

The Control Center's "Chat" tab has been a node-to-node toy: ephemeral pub/sub over the Redis proxy, one hardcoded `#general`, no history, zero connection to the Team Chat users actually live in on web/iOS/Android. This PR makes the TUI a real Team Chat client — the same org channels, messages, members, and agents everyone else sees — rendered in the terminal.

Contract verified against the aceteam repo before writing any code: both mobile apps consume the v1 REST surface (`/api/channels/**`, shapes in `types/channels.ts`) with a Bearer token and do ~5s light polling for live updates (the v1 chat WebSocket is deleted server-side and the v2 socket serves the separate `chat_*` conversations model — polling **is** the current cross-client parity mechanism). Full investigation in #495.

## Summary

**`internal/teamchat` — typed REST client** (commit 1)
- `ListChannels`, `Messages` (cursor paging), `SendMessage` (incl. threaded replies), `ListMembers`, `SearchMessages`, `MarkRead`, `UnreadCounts` against `/api/channels/**`
- Tolerant `Timestamp` parsing (Supabase `+00:00` offsets, fractional seconds, offset-less)
- `*APIError` preserves HTTP status; `IsAuthError` distinguishes 401/403 so the UI can render setup guidance instead of a raw scope-denial — this matters because a node's **device token is endpoint-whitelisted away from `/api/channels/**`** (403 SCOPE_DENIED) until the #495 backend follow-up lands
- `ResolveToken` mirrors the `citadel mcp` credential chain: `ACETEAM_API_KEY` env > new `aceteam_api_key` config.yaml field > device token

**Team Chat TUI page** (commit 2)
- Channel list (keyboard + mouse selection), message history, send-as-user, member sidebar (admins highlighted), `/search <text>` command, automatic mark-read on newest message
- 5s polling while the tab is active, stopped on deactivate (mobile parity; ID-based state means no echo-dedup hacks like the pub/sub page needs)
- Same keyboard contract as the existing chat page (reuses `classifyChatKey` / `nextChatPaneIndex`): Tab cycles panes and bubbles at the edges, Escape releases the input, PgUp/PgDn scroll
- On auth failure the page renders actionable setup steps (generate key at Settings → API Keys, set `ACETEAM_API_KEY` or `aceteam_api_key`), rendered once rather than per poll tick (commit 3)
- Existing node-to-node tab preserved, retitled **"Node Chat"** (registered name `chat` unchanged, so `ShowChat()` and settings wiring are untouched)

## What works end-to-end vs. gated

| Path | Status |
| --- | --- |
| User `act_` API key (env or config.yaml) | Works today — default keys have `scopes: ["*"]`, `allowedEndpoints: ["*"]` |
| Node's device token | Blocked by design: 403 from the device-key endpoint whitelist → page shows setup guidance. Backend follow-up (extend device-key `allowedEndpoints` + `team_chat` scopes) tracked in #495 Phase 2 |

## Test plan

| Group | Coverage |
| --- | --- |
| `internal/teamchat` client (12 tests) | every endpoint against `httptest` fakes: auth header, query/body encoding, pagination cursors, parent-message omission, 401/403→`IsAuthError`, 500 is not auth, timestamp format matrix, sender-label fallbacks |
| `internal/teamchat` token (4 cases) | credential chain priority: env > config > device > none |
| TUI page pure functions | message formatting (human/agent colors, thread marker, reply count, attachments, tview-markup escaping), `/search` parsing, newest-ID selection, Page interface identity, Node Chat retitle |
| Manual (needs a real key) | run `ACETEAM_API_KEY=act_... citadel` on an enrolled node → Team Chat tab: channels load, history renders, send appears on web `/team-chat`, poll picks up messages sent from web, guidance page on a device-token-only node |

`go build ./...` and the full `go test ./...` suite are green.

## Related

- Closes nothing yet — initial implementation for #495 (Phase 1 of 3)
- #495 Phase 2: aceteam backend — allow device tokens onto `/api/channels/**` so Team Chat works with zero configuration
- #495 Phase 3: fold Node Chat into the Team Chat page as a local channel; adopt the v2 WebSocket when the platform's chat migration lands
