### PR TITLE
fix(meeting): poll for interstitial dismissal + join button instead of single-shot click

### DIFF
--- a/internal/jobs/meeting_join.go
+++ b/internal/jobs/meeting_join.go
@@ -8,11 +8,13 @@
 // the end, transcribe node-locally, and return a structured result. Every byte
 // (audio + transcript) stays on the user's machine.
 //
-// IMPORTANT (unverified): the Google Meet join flow and end-detection below are
-// BEST-GUESS DOM interactions. They are NOT verified end-to-end — a human must
-// run this against a live meet.google.com call and confirm/swap the selectors and
-// heuristics in the LIVE-TUNING block before this can be trusted. Everything is
-// isolated so tuning is a single-file edit.
+// IMPORTANT (partially verified): the Google Meet join flow and end-detection
+// below are mostly BEST-GUESS DOM interactions. The mic/camera interstitial and
+// its dismiss-button text were confirmed against a live signed-in session on
+// 2026-07-11; the join-button labels and everything downstream are NOT verified
+// end-to-end — a human must run this against a live meet.google.com call and
+// confirm/swap the selectors and heuristics in the LIVE-TUNING block before this
+// can be trusted. Everything is isolated so tuning is a single-file edit.
 package jobs
 
 import (
@@ -41,6 +43,12 @@ const (
 	// admitTimeout bounds how long we wait in the "asking to join" lobby for a
 	// host to admit the bot before giving up.
 	admitTimeout = 3 * time.Minute
+	// joinButtonTimeout bounds the dismiss-interstitial → join-button poll loop.
+	// Observed live (2026-07-11): the mic/camera interstitial renders ~9s after
+	// navigation, and the "Join now"/"Ask to join" pre-join page only appears a
+	// few seconds after the interstitial is dismissed — a single-shot click
+	// races the page load, so we poll well past both renders.
+	joinButtonTimeout = 45 * time.Second
 	// meetingPollInterval is how often we re-check admission / meeting-end state.
 	meetingPollInterval = 5 * time.Second
 	// defaultMeetingMaxDuration is the absolute safety cap when a job omits
@@ -49,14 +57,26 @@ const (
 )
 
 // ---------------------------------------------------------------------------
-// LIVE-TUNING REQUIRED
+// LIVE-TUNING REQUIRED (partially verified)
 //
-// Everything in this block is a best-guess against Google Meet's DOM and has NOT
-// been verified against a live call. A human must confirm/replace each selector,
-// button label, and heuristic during the live-Meet session. Kept together so
+// Most of this block is a best-guess against Google Meet's DOM. Confirmed live
+// on 2026-07-11 (signed-in session at meet.google.com/new):
+//
+//   - ~9s after navigation Meet shows a mic/camera interstitial ("Do you want
+//     people to see and hear you in the meeting?") with exactly two visible
+//     buttons: "Continue without microphone and camera" (no aria-label) and an
+//     expand_more "More options" button. meetDismissButtonLabels substring-matches
+//     it via "Continue without microphone".
+//   - The "Join now"/"Ask to join" pre-join page renders only AFTER that
+//     interstitial is dismissed (plus a few more seconds) — hence the
+//     joinButtonTimeout poll loop in runJoinFlow.
+//
+// Everything else (join-button labels, name input, admission/end heuristics)
+// remains UNVERIFIED — the live session never got past the interstitial. A human
+// must confirm/replace those during the next live-Meet session. Kept together so
 // that tuning is a one-place edit.
 //
-//	verified against real Google Meet on: <NOT YET VERIFIED>
+//	verified against real Google Meet on: 2026-07-11 (interstitial only)
 //
 // ---------------------------------------------------------------------------
 const (
@@ -109,9 +129,11 @@ var ErrMeetingBotSignedOut = fmt.Errorf("meeting bot Chrome profile is signed ou
 // exact casing/locale against a real call.
 var meetJoinButtonLabels = []string{"Ask to join", "Join now", "Join"}
 
-// meetDismissButtonLabels are best-guess labels for the permission / "continue
-// without microphone|camera" prompts Meet shows before the join button. Clicking
-// them is best-effort (non-fatal). LIVE-TUNING: confirm against a real call.
+// meetDismissButtonLabels are labels for the permission / "continue without
+// microphone|camera" prompts Meet shows before the join button. Clicking them is
+// best-effort (non-fatal). CONFIRMED live 2026-07-11: the interstitial's button
+// text is "Continue without microphone and camera", which "Continue without
+// microphone" substring-matches (the matcher uses indexOf).
 var meetDismissButtonLabels = []string{
 	"Continue without microphone",
 	"Continue without camera",
@@ -120,25 +142,12 @@ var meetDismissButtonLabels = []string{
 	"Dismiss",
 }
 
-// clickButtonByTextJS builds a JS expression that clicks the FIRST visible
-// button/[role=button] whose trimmed text matches (case-insensitively) any of the
-// given labels, returning the matched label or throwing when none is found. The
-// throw lets the caller distinguish "clicked" from "no such button" (cdpEvaluate
-// maps a JS throw to a Go error). labels are json.Marshal-escaped.
-func clickButtonByTextJS(labels []string) string {
-	arr, _ := json.Marshal(labels)
-	return `(function(){var labels=` + string(arr) + `.map(function(s){return s.toLowerCase();});` +
-		`var btns=Array.prototype.slice.call(document.querySelectorAll('button,[role="button"]'));` +
-		`for(var i=0;i<btns.length;i++){var b=btns[i];` +
-		`var txt=(b.innerText||b.textContent||"").trim().toLowerCase();` +
-		`if(!txt)continue;` +
-		`for(var j=0;j<labels.length;j++){if(txt===labels[j]||txt.indexOf(labels[j])!==-1){b.click();return labels[j];}}}` +
-		`throw new Error("no button matched labels");})()`
-}
-
-// clickButtonByTextOptionalJS is like clickButtonByTextJS but returns "" instead
-// of throwing when nothing matches — for best-effort dismissals where a missing
-// prompt is normal.
+// clickButtonByTextOptionalJS builds a JS expression that clicks the FIRST
+// visible button/[role=button] whose trimmed text matches (case-insensitively,
+// substring via indexOf) any of the given labels, returning the matched label or
+// "" when nothing matches. The empty-string miss (instead of a throw) lets the
+// poll loop in runJoinFlow retry without treating "not rendered yet" as an
+// error. labels are json.Marshal-escaped.
 func clickButtonByTextOptionalJS(labels []string) string {
 	arr, _ := json.Marshal(labels)
 	return `(function(){var labels=` + string(arr) + `.map(function(s){return s.toLowerCase();});` +
@@ -347,8 +356,8 @@ func (h *MeetingJoinHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, er
 	return out, nil
 }
 
-// runJoinFlow drives the best-guess Google Meet pre-join sequence. UNVERIFIED —
-// see the LIVE-TUNING block. Non-fatal steps (permission dismissals, name entry
+// runJoinFlow drives the Google Meet pre-join sequence (partially verified —
+// see the LIVE-TUNING block). Non-fatal steps (permission dismissals, name entry
 // when signed in) log and continue; the join click and admission are fatal.
 func (h *MeetingJoinHandler) runJoinFlow(ctx JobContext, br *platform.MeetingBrowser, p meetingJoinParams) error {
 	if err := br.Navigate(p.MeetingURL); err != nil {
@@ -376,25 +385,58 @@ func (h *MeetingJoinHandler) runJoinFlow(ctx JobContext, br *platform.MeetingBro
 		}
 	}
 
-	// Best-effort: dismiss any camera/mic permission or "continue without …"
-	// prompts. A missing prompt is normal, so this never fails the flow.
-	if _, err := br.Evaluate(clickButtonByTextOptionalJS(meetDismissButtonLabels)); err != nil {
-		ctx.Log("warn", "     - permission-prompt dismissal errored (non-fatal): %v", err)
-	}
-
-	// Best-effort: type the bot's display name into the pre-join name field. A
-	// signed-in session has no name field, so a miss here is non-fatal.
-	if err := br.Type(meetNameInputSelector, p.BotDisplayName); err != nil {
-		ctx.Log("warn", "     - could not set bot name (non-fatal, may be signed in): %v", err)
-	}
-
-	// Fatal: click the join/ask-to-join button.
-	if _, err := br.Evaluate(clickButtonByTextJS(meetJoinButtonLabels)); err != nil {
-		return fmt.Errorf("click join button: %w", err)
+	// Fatal: poll dismiss-interstitial → name → join until the join button is
+	// clicked or joinButtonTimeout elapses. A single-shot sequence races the
+	// page load (observed live 2026-07-11: the mic/camera interstitial renders
+	// ~9s after navigation, and the pre-join page a few seconds after that).
+	if err := pollForJoinClick(ctx, br, p.BotDisplayName, joinButtonTimeout, meetingPollInterval); err != nil {
+		return err
 	}
 
 	// Fatal: wait until admitted (in-call toolbar appears) or timeout.
 	return h.waitUntilAdmitted(ctx, br, p)
+}
+
+// joinPage is the slice of platform.MeetingBrowser that pollForJoinClick needs,
+// so the loop is unit-testable without a real browser.
+type joinPage interface {
+	Evaluate(expression string) (any, error)
+	Type(selector, text string) error
+}
+
+// pollForJoinClick repeatedly (1) best-effort dismisses the mic/camera
+// interstitial, (2) best-effort types the bot display name, and (3) tries the
+// join/ask-to-join button, until the join button is clicked or timeout elapses.
+// Steps 1 and 2 are non-fatal on every pass; only never finding the join button
+// is fatal. Production callers pass joinButtonTimeout/meetingPollInterval; they
+// are parameters so tests can run the loop in milliseconds.
+func pollForJoinClick(ctx JobContext, page joinPage, botDisplayName string, timeout, interval time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		// Best-effort: dismiss the camera/mic interstitial or any "continue
+		// without …" prompt. A missing prompt is normal on any given pass.
+		if _, err := page.Evaluate(clickButtonByTextOptionalJS(meetDismissButtonLabels)); err != nil {
+			ctx.Log("warn", "     - permission-prompt dismissal errored (non-fatal): %v", err)
+		}
+
+		// Best-effort: type the bot's display name into the pre-join name
+		// field. A signed-in session has no name field, so a miss is non-fatal.
+		if err := page.Type(meetNameInputSelector, botDisplayName); err != nil {
+			ctx.Log("warn", "     - could not set bot name (non-fatal, may be signed in): %v", err)
+		}
+
+		// Try the join/ask-to-join button; a non-empty return means it was
+		// clicked.
+		if v, err := page.Evaluate(clickButtonByTextOptionalJS(meetJoinButtonLabels)); err != nil {
+			ctx.Log("warn", "     - join-button probe errored (retrying): %v", err)
+		} else if label, ok := v.(string); ok && label != "" {
+			ctx.Log("info", "     - clicked join button (matched label %q)", label)
+			return nil
+		}
+
+		time.Sleep(interval)
+	}
+	return fmt.Errorf("click join button: no button matched labels %v within %s (interstitial/pre-join page may have changed — re-tune meeting_join.go labels)", meetJoinButtonLabels, timeout)
 }
 
 // waitUntilAdmitted polls the admission heuristic until the bot is in-call or the

--- a/internal/jobs/meeting_join_test.go
+++ b/internal/jobs/meeting_join_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
 )
@@ -145,23 +146,156 @@ func TestParsePositiveSeconds(t *testing.T) {
 	}
 }
 
-func TestClickButtonByTextJS(t *testing.T) {
-	labels := []string{"Ask to join", "Join now"}
-	js := clickButtonByTextJS(labels)
-	arr, _ := json.Marshal(labels)
-	if !strings.Contains(js, string(arr)) {
-		t.Errorf("clickButtonByTextJS did not embed labels array; got: %s", js)
+func TestClickButtonByTextOptionalJS(t *testing.T) {
+	// Both label sets used by the poll loop must be embedded correctly.
+	for name, labels := range map[string][]string{
+		"join":    meetJoinButtonLabels,
+		"dismiss": meetDismissButtonLabels,
+	} {
+		t.Run(name, func(t *testing.T) {
+			js := clickButtonByTextOptionalJS(labels)
+			arr, _ := json.Marshal(labels)
+			if !strings.Contains(js, string(arr)) {
+				t.Errorf("clickButtonByTextOptionalJS did not embed labels array; got: %s", js)
+			}
+			// The optional variant returns "" instead of throwing, so the poll
+			// loop can retry a not-yet-rendered button without an error.
+			if strings.Contains(js, "throw new Error") {
+				t.Errorf("optional variant must not throw; got: %s", js)
+			}
+			if !strings.Contains(js, `return "";`) {
+				t.Errorf("optional variant must return empty string on no match; got: %s", js)
+			}
+		})
 	}
-	if !strings.Contains(js, "throw new Error") {
-		t.Errorf("clickButtonByTextJS must throw when no button matches; got: %s", js)
+}
+
+func TestJoinButtonTimeout_Sane(t *testing.T) {
+	// The interstitial renders ~9s after navigation (observed live 2026-07-11)
+	// and the pre-join page a few seconds after dismissal, so the poll window
+	// must comfortably exceed that; it must also stay well under admitTimeout
+	// so a stale-label failure surfaces before a lobby-length wait.
+	if joinButtonTimeout < 20*time.Second {
+		t.Errorf("joinButtonTimeout = %v, too short to outlast the ~9s interstitial + pre-join render", joinButtonTimeout)
 	}
-	// Optional variant returns "" instead of throwing.
-	opt := clickButtonByTextOptionalJS(labels)
-	if strings.Contains(opt, "throw new Error") {
-		t.Errorf("optional variant must not throw; got: %s", opt)
+	if joinButtonTimeout >= admitTimeout {
+		t.Errorf("joinButtonTimeout = %v must be shorter than admitTimeout %v", joinButtonTimeout, admitTimeout)
 	}
-	if !strings.Contains(opt, `return "";`) {
-		t.Errorf("optional variant must return empty string on no match; got: %s", opt)
+	if meetingPollInterval >= joinButtonTimeout {
+		t.Errorf("meetingPollInterval %v must be shorter than joinButtonTimeout %v", meetingPollInterval, joinButtonTimeout)
+	}
+}
+
+// fakeJoinPage simulates the Meet pre-join DOM for pollForJoinClick: Evaluate
+// answers each clickButtonByTextOptionalJS probe from a scripted queue keyed by
+// which label set the JS embeds.
+type fakeJoinPage struct {
+	// joinResults are returned (then consumed) for successive join-label
+	// probes; when exhausted, "" (no match) is returned.
+	joinResults []any
+	// dismissResults likewise for dismiss-label probes.
+	dismissResults []any
+	typeErr        error
+
+	joinProbes    int
+	dismissProbes int
+	typedNames    []string
+}
+
+func (f *fakeJoinPage) Evaluate(expression string) (any, error) {
+	joinArr, _ := json.Marshal(meetJoinButtonLabels)
+	dismissArr, _ := json.Marshal(meetDismissButtonLabels)
+	switch {
+	case strings.Contains(expression, string(joinArr)):
+		f.joinProbes++
+		if len(f.joinResults) > 0 {
+			v := f.joinResults[0]
+			f.joinResults = f.joinResults[1:]
+			if err, ok := v.(error); ok {
+				return nil, err
+			}
+			return v, nil
+		}
+		return "", nil
+	case strings.Contains(expression, string(dismissArr)):
+		f.dismissProbes++
+		if len(f.dismissResults) > 0 {
+			v := f.dismissResults[0]
+			f.dismissResults = f.dismissResults[1:]
+			if err, ok := v.(error); ok {
+				return nil, err
+			}
+			return v, nil
+		}
+		return "", nil
+	}
+	return nil, fmt.Errorf("fakeJoinPage: unexpected expression: %s", expression)
+}
+
+func (f *fakeJoinPage) Type(selector, text string) error {
+	f.typedNames = append(f.typedNames, text)
+	return f.typeErr
+}
+
+func TestPollForJoinClick_FirstPassSuccess(t *testing.T) {
+	page := &fakeJoinPage{joinResults: []any{"ask to join"}}
+	if err := pollForJoinClick(JobContext{}, page, "Bot", 200*time.Millisecond, time.Millisecond); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if page.joinProbes != 1 {
+		t.Errorf("joinProbes = %d, want 1", page.joinProbes)
+	}
+	if page.dismissProbes != 1 {
+		t.Errorf("dismissProbes = %d, want 1 (dismiss must run before the join probe)", page.dismissProbes)
+	}
+	if len(page.typedNames) != 1 || page.typedNames[0] != "Bot" {
+		t.Errorf("typedNames = %v, want [Bot]", page.typedNames)
+	}
+}
+
+func TestPollForJoinClick_InterstitialThenJoin(t *testing.T) {
+	// Pass 1: interstitial dismissed, join button not rendered yet.
+	// Pass 2: join button appears. Non-fatal dismiss misses and a Type error
+	// must not abort the loop.
+	page := &fakeJoinPage{
+		dismissResults: []any{"continue without microphone", ""},
+		joinResults:    []any{"", "join now"},
+		typeErr:        fmt.Errorf("no name field (signed in)"),
+	}
+	if err := pollForJoinClick(JobContext{}, page, "Bot", 200*time.Millisecond, time.Millisecond); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if page.joinProbes != 2 {
+		t.Errorf("joinProbes = %d, want 2", page.joinProbes)
+	}
+}
+
+func TestPollForJoinClick_EvaluateErrorRetries(t *testing.T) {
+	// A JS exception on one pass (page mid-render) is retried, not fatal.
+	page := &fakeJoinPage{
+		joinResults: []any{fmt.Errorf("javascript exception"), "join now"},
+	}
+	if err := pollForJoinClick(JobContext{}, page, "Bot", 200*time.Millisecond, time.Millisecond); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if page.joinProbes != 2 {
+		t.Errorf("joinProbes = %d, want 2", page.joinProbes)
+	}
+}
+
+func TestPollForJoinClick_TimeoutError(t *testing.T) {
+	page := &fakeJoinPage{} // join button never appears
+	err := pollForJoinClick(JobContext{}, page, "Bot", 200*time.Millisecond, time.Millisecond)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	// The backend (routes/meeting_bot.py) greps error strings; the prefix must
+	// be preserved.
+	if !strings.HasPrefix(err.Error(), "click join button:") {
+		t.Errorf("error must keep the 'click join button:' prefix for backend error mapping; got: %v", err)
+	}
+	if page.joinProbes < 2 {
+		t.Errorf("joinProbes = %d, want multiple passes before timing out", page.joinProbes)
 	}
 }
 


### PR DESCRIPTION
## Context

First live E2E of the MEETING_JOIN bot (2026-07-11, real Google Meet in prod) got further than ever before — the persistent profile's Google auth passed for the first time — and then died at the join click, 6.5s total including Chrome launch:

```
click join button: javascript exception: Error: no button matched labels
```

Ground truth captured from a signed-in session at `meet.google.com/new`: ~9 seconds after navigation, Meet shows a mic/camera interstitial — body text "Do you want people to see and hear you in the meeting?" with exactly two visible buttons: `"Continue without microphone and camera"` (no aria-label) and an `expand_more` "More options" button. The "Join now"/"Ask to join" pre-join page only renders AFTER that interstitial is dismissed, plus a few more seconds.

The old flow was single-shot: `Navigate` → 5s settle → signed-out check → ONE best-effort dismiss → ONE best-effort name-type → ONE FATAL join click. At the 5s mark the interstitial hasn't even rendered, so the dismiss is a no-op and the fatal join click throws. The labels were never the problem — `meetDismissButtonLabels` already substring-matches the interstitial button and the join labels are plausible. The timing was the bug.

## Summary

- **Poll loop replaces the single-shot sequence** (`pollForJoinClick`, extracted behind a tiny `joinPage` interface so it's unit-testable without a browser; loop structure mirrors `waitUntilAdmitted`). Each pass: best-effort interstitial dismiss → best-effort bot-name type → join-button probe with the *optional* (non-throwing) click JS; a non-empty match logs the label and breaks out.
- **New tunable `joinButtonTimeout = 45s`** next to the other meeting consts — interstitial ~9s + pre-join render observed live, with headroom; kept well under `admitTimeout` so a stale-label failure surfaces before a lobby-length wait. Poll cadence reuses `meetingPollInterval`.
- **Label lists unchanged** — dismiss labels already match the live interstitial (the matcher uses `indexOf`), and join labels remain best-guess since the live session never got past the interstitial. LIVE-TUNING block updated: interstitial CONFIRMED 2026-07-11, join labels still carry the caveat.
- **Error mapping preserved**: the timeout error keeps the `click join button:` prefix that `routes/meeting_bot.py` greps on.
- **Dead code removed**: the throwing `clickButtonByTextJS` variant had no remaining callers, so it's deleted; its test was repurposed to cover the optional variant for both label sets.

## Test plan

| Test | Covers |
|------|--------|
| `TestClickButtonByTextOptionalJS` (join + dismiss subtests) | JS builder embeds both label sets, no throw, `return "";` miss |
| `TestJoinButtonTimeout_Sane` | const exists, > interstitial window, < `admitTimeout`, > poll interval |
| `TestPollForJoinClick_FirstPassSuccess` | happy path: dismiss + name + join all on pass 1 |
| `TestPollForJoinClick_InterstitialThenJoin` | live-observed sequence: interstitial dismissed pass 1, join appears pass 2; `Type` error non-fatal |
| `TestPollForJoinClick_EvaluateErrorRetries` | mid-render JS exception retried, not fatal |
| `TestPollForJoinClick_TimeoutError` | timeout error shape + `click join button:` prefix, multiple passes |

`go build ./...`, `go test ./...` (full suite green, including `worklock`), `gofmt -l` clean.

**Manual step — live E2E:** seed the bot profile, then dispatch a `meeting_join` within the session window against a real Meet call; confirm the interstitial gets dismissed on a later pass and the join labels match (they're the remaining LIVE-TUNING unknown).

## Related

- Epic #5097 (sovereign meeting notetaker), issue #5098 (Meet v1 join flow)
- #5122 (persistent signed-in bot profile — the auth that finally passed on this run)