### PR TITLE
fix(meeting): treat host auto-admit (in-call toolbar) as join success

### DIFF
--- a/internal/jobs/meeting_join.go
+++ b/internal/jobs/meeting_join.go
@@ -70,13 +70,22 @@ const (
 //   - The "Join now"/"Ask to join" pre-join page renders only AFTER that
 //     interstitial is dismissed (plus a few more seconds) — hence the
 //     joinButtonTimeout poll loop in runJoinFlow.
+//   - HOST AUTO-ADMIT: when the bot creates its OWN meeting via
+//     meet.google.com/new (signed in), Google redirects to meet.google.com/<code>
+//     and drops it straight into the call ~8s after navigation — the in-call
+//     toolbar is present (buttons "Leave call", "Chat with everyone", "Meeting
+//     details", "Host controls", participant count 1) and NO "Join now"/"Ask to
+//     join"/"Join" button EVER renders. meetIsAdmittedJS's "Leave call" selector
+//     is therefore CONFIRMED for the host path, and pollForJoinClick treats
+//     admission as join success.
 //
-// Everything else (join-button labels, name input, admission/end heuristics)
-// remains UNVERIFIED — the live session never got past the interstitial. A human
-// must confirm/replace those during the next live-Meet session. Kept together so
-// that tuning is a one-place edit.
+// Everything else (guest-join button labels, name input, end heuristics)
+// remains UNVERIFIED — we've only exercised the host/auto-admit path live. A
+// human must confirm/replace those during the next live-Meet guest session.
+// Kept together so that tuning is a one-place edit.
 //
-//	verified against real Google Meet on: 2026-07-11 (interstitial only)
+//	verified against real Google Meet on: 2026-07-11 (interstitial + host
+//	auto-admit / in-call toolbar)
 //
 // ---------------------------------------------------------------------------
 const (
@@ -84,7 +93,8 @@ const (
 	// not-signed-in participants. Best-guess aria-label match.
 	meetNameInputSelector = `input[type="text"][aria-label*="name" i]`
 	// meetIsAdmittedJS returns true once the in-call toolbar is present and the
-	// pre-join / lobby UI is gone. Best-guess: presence of the leave-call button.
+	// pre-join / lobby UI is gone. The "Leave call" aria-label selector is
+	// CONFIRMED live 2026-07-11 on the host (auto-admit) path.
 	meetIsAdmittedJS = `(function(){` +
 		`return !!document.querySelector('button[aria-label*="Leave call" i],button[aria-label*="Leave" i][data-tooltip*="Leave" i]');` +
 		`})()`
@@ -385,10 +395,11 @@ func (h *MeetingJoinHandler) runJoinFlow(ctx JobContext, br *platform.MeetingBro
 		}
 	}
 
-	// Fatal: poll dismiss-interstitial → name → join until the join button is
-	// clicked or joinButtonTimeout elapses. A single-shot sequence races the
-	// page load (observed live 2026-07-11: the mic/camera interstitial renders
-	// ~9s after navigation, and the pre-join page a few seconds after that).
+	// Fatal: poll admitted-check → dismiss-interstitial → name → join until the
+	// bot is in-call (host auto-admit) or the join button is clicked, or
+	// joinButtonTimeout elapses. A single-shot sequence races the page load
+	// (observed live 2026-07-11: the mic/camera interstitial renders ~9s after
+	// navigation, and the pre-join page a few seconds after that).
 	if err := pollForJoinClick(ctx, br, p.BotDisplayName, joinButtonTimeout, meetingPollInterval); err != nil {
 		return err
 	}
@@ -404,15 +415,31 @@ type joinPage interface {
 	Type(selector, text string) error
 }
 
-// pollForJoinClick repeatedly (1) best-effort dismisses the mic/camera
-// interstitial, (2) best-effort types the bot display name, and (3) tries the
-// join/ask-to-join button, until the join button is clicked or timeout elapses.
-// Steps 1 and 2 are non-fatal on every pass; only never finding the join button
-// is fatal. Production callers pass joinButtonTimeout/meetingPollInterval; they
-// are parameters so tests can run the loop in milliseconds.
+// pollForJoinClick repeatedly (1) checks whether the bot is already in-call,
+// (2) best-effort dismisses the mic/camera interstitial, (3) best-effort types
+// the bot display name, and (4) tries the join/ask-to-join button, until the
+// bot is admitted or the join button is clicked, or timeout elapses. When the
+// bot hosts its own meeting (meet.google.com/new), Google auto-admits it
+// straight into the call and NO join button ever renders (confirmed live
+// 2026-07-11) — the admitted check is what lets that path succeed instead of
+// false-timing-out. Steps 2 and 3 are non-fatal on every pass; only reaching
+// the timeout with neither admission nor a join click is fatal. Production
+// callers pass joinButtonTimeout/meetingPollInterval; they are parameters so
+// tests can run the loop in milliseconds.
 func pollForJoinClick(ctx JobContext, page joinPage, botDisplayName string, timeout, interval time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
+		// Already in the call (host auto-admit path): success, no join button
+		// needed. runJoinFlow's waitUntilAdmitted re-checks this idempotently.
+		if v, err := page.Evaluate(meetIsAdmittedJS); err == nil {
+			if b, ok := v.(bool); ok && b {
+				ctx.Log("info", "     - already in call (host auto-admit), no join button needed")
+				return nil
+			}
+		} else {
+			ctx.Log("warn", "     - already-admitted probe errored (non-fatal): %v", err)
+		}
+
 		// Best-effort: dismiss the camera/mic interstitial or any "continue
 		// without …" prompt. A missing prompt is normal on any given pass.
 		if _, err := page.Evaluate(clickButtonByTextOptionalJS(meetDismissButtonLabels)); err != nil {

--- a/internal/jobs/meeting_join_test.go
+++ b/internal/jobs/meeting_join_test.go
@@ -195,10 +195,14 @@ type fakeJoinPage struct {
 	joinResults []any
 	// dismissResults likewise for dismiss-label probes.
 	dismissResults []any
-	typeErr        error
+	// admitResults likewise for meetIsAdmittedJS probes; when exhausted, false
+	// (not yet in-call) is returned.
+	admitResults []any
+	typeErr      error
 
 	joinProbes    int
 	dismissProbes int
+	admitProbes   int
 	typedNames    []string
 }
 
@@ -206,6 +210,17 @@ func (f *fakeJoinPage) Evaluate(expression string) (any, error) {
 	joinArr, _ := json.Marshal(meetJoinButtonLabels)
 	dismissArr, _ := json.Marshal(meetDismissButtonLabels)
 	switch {
+	case expression == meetIsAdmittedJS:
+		f.admitProbes++
+		if len(f.admitResults) > 0 {
+			v := f.admitResults[0]
+			f.admitResults = f.admitResults[1:]
+			if err, ok := v.(error); ok {
+				return nil, err
+			}
+			return v, nil
+		}
+		return false, nil
 	case strings.Contains(expression, string(joinArr)):
 		f.joinProbes++
 		if len(f.joinResults) > 0 {
@@ -267,6 +282,36 @@ func TestPollForJoinClick_InterstitialThenJoin(t *testing.T) {
 	}
 	if page.joinProbes != 2 {
 		t.Errorf("joinProbes = %d, want 2", page.joinProbes)
+	}
+}
+
+func TestPollForJoinClick_HostAutoAdmit(t *testing.T) {
+	// Host path (meet.google.com/new): Google drops the bot straight into the
+	// call — the in-call toolbar is present and NO join button ever renders.
+	// The loop must return success on the admitted check alone.
+	page := &fakeJoinPage{admitResults: []any{true}}
+	if err := pollForJoinClick(JobContext{}, page, "Bot", 200*time.Millisecond, time.Millisecond); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if page.admitProbes != 1 {
+		t.Errorf("admitProbes = %d, want 1 (return on first admitted pass)", page.admitProbes)
+	}
+	if page.joinProbes != 0 {
+		t.Errorf("joinProbes = %d, want 0 (no join-button probe once admitted)", page.joinProbes)
+	}
+}
+
+func TestPollForJoinClick_AdmitAfterRetries(t *testing.T) {
+	// Admission renders a couple of polls after navigation (observed ~8s live);
+	// an errored admitted probe on one pass must be retried, not fatal.
+	page := &fakeJoinPage{
+		admitResults: []any{false, fmt.Errorf("javascript exception"), true},
+	}
+	if err := pollForJoinClick(JobContext{}, page, "Bot", 200*time.Millisecond, time.Millisecond); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if page.admitProbes != 3 {
+		t.Errorf("admitProbes = %d, want 3", page.admitProbes)
 	}
 }
 


### PR DESCRIPTION
## Context

Diagnosed live against a real Google Meet (2026-07-11, v2.71.2): when the bot creates its **own** meeting via `meet.google.com/new` (signed in), Google redirects to `meet.google.com/<code>` and auto-admits it straight into the call ~8s after navigation — the in-call toolbar is already present (`Leave call`, `Chat with everyone`, `Meeting details`, `Host controls`, participant count 1) and **no "Join now"/"Ask to join"/"Join" button ever renders**.

`pollForJoinClick` in `internal/jobs/meeting_join.go` treated a join-button click as the only success condition, so the host path false-timed-out after 45s with `click join button: no button matched labels [...]` even though the bot was already in the call — blocking the entire E2E (record/transcribe never ran). The `meetIsAdmittedJS` heuristic already in the file would have detected the toolbar; the flow just never reached it because the join-click was fatal first.

## Summary

- `pollForJoinClick` now evaluates `meetIsAdmittedJS` at the top of each poll pass; if the in-call toolbar is present it logs `already in call (host auto-admit), no join button needed` and returns success. "Get into the call" now succeeds on **either** admission or a join-button click.
- The guest path is unchanged: best-effort interstitial dismissal, name typing, and the join-button probe run exactly as before, and a clicked button still returns success. Reaching the timeout with neither admission nor a click stays fatal with the same `click join button:` prefix (the backend greps that string).
- `runJoinFlow`'s subsequent `waitUntilAdmitted` is left as-is — it re-checks the same heuristic idempotently and returns immediately on the host path.
- LIVE-TUNING block updated: `meetIsAdmittedJS`'s "Leave call" selector is now **confirmed live** on the host/auto-admit path; guest join-button labels remain marked UNVERIFIED (only the host path has been exercised).

## Test plan

| Test | Covers |
|---|---|
| `TestPollForJoinClick_HostAutoAdmit` (new) | admitted=true, no join button → returns nil on first pass, zero join probes |
| `TestPollForJoinClick_AdmitAfterRetries` (new) | admitted false → JS error → true across passes; errored probe is retried, not fatal |
| `TestPollForJoinClick_FirstPassSuccess` / `_InterstitialThenJoin` / `_EvaluateErrorRetries` | existing guest join-click paths stay green |
| `TestPollForJoinClick_TimeoutError` | neither admitted nor clicked → fatal with `click join button:` prefix preserved |

`go build ./...`, `go test ./...` (full suite green, incl. worklock), `gofmt -l` clean.

## Related

- Meeting notetaker bot epic #5098 / aceteam#5097 — this unblocks the bot-hosted `/new` E2E (join → record → transcribe).