### PR TITLE
fix(meeting): play remote call audio by relaxing Chrome autoplay policy (#5098)

### DIFF
--- a/internal/platform/cobrowse.go
+++ b/internal/platform/cobrowse.go
@@ -110,6 +110,15 @@ type cobrowseLaunchOptions struct {
 	// environment-independent, which a persistent, externally-seeded profile
 	// requires. Left false for co-browse (keeps keyring-backed persistent logins).
 	passwordStoreBasic bool
+	// autoplayNoUserGesture relaxes Chrome's autoplay policy
+	// (--autoplay-policy=no-user-gesture-required). An automated browser has no
+	// user gesture, so by default Chrome refuses to start an AudioContext / play
+	// incoming <audio> (remote WebRTC) audio — a meeting bot then joins the call
+	// but renders SILENCE, and the null-sink recorder captures a flat -91 dB
+	// track (issue #5098). Set for the meeting bot, whose whole job is to hear
+	// and record the other participants. Left false for co-browse (a human drives
+	// it and supplies the gesture).
+	autoplayNoUserGesture bool
 }
 
 // stealthEnabled resolves whether stealth launch flags should be applied,
@@ -208,6 +217,15 @@ func buildChromeArgs(opts cobrowseLaunchOptions) []string {
 		// -- but it REQUIRES that whoever seeds the profile also launches Chrome
 		// with --password-store=basic, or the seeded cookies won't decrypt here.
 		args = append(args, "--password-store=basic")
+	}
+
+	if opts.autoplayNoUserGesture {
+		// An automated browser never produces a user gesture, so Chrome's default
+		// autoplay policy leaves the AudioContext suspended and blocks remote
+		// (WebRTC) audio playback — the meeting bot joins but hears nothing and
+		// records pure silence. Relax the policy so incoming call audio plays and
+		// reaches the PULSE_SINK the recorder captures (issue #5098).
+		args = append(args, "--autoplay-policy=no-user-gesture-required")
 	}
 
 	if opts.startURL != "" {

--- a/internal/platform/cobrowse_test.go
+++ b/internal/platform/cobrowse_test.go
@@ -195,6 +195,27 @@ func TestBuildChromeArgs_PasswordStoreBasic(t *testing.T) {
 	}
 }
 
+// TestBuildChromeArgs_AutoplayNoUserGesture checks
+// --autoplay-policy=no-user-gesture-required is emitted only when the option is
+// set. The meeting bot sets it so Chrome plays incoming (WebRTC) call audio into
+// the recorder's sink instead of recording silence (issue #5098); co-browse
+// leaves it off since a human drives it and supplies the gesture.
+func TestBuildChromeArgs_AutoplayNoUserGesture(t *testing.T) {
+	on := buildChromeArgs(cobrowseLaunchOptions{debugPort: 9222, profileDir: "/p", stealth: true, autoplayNoUserGesture: true})
+	if !containsArg(on, "--autoplay-policy=no-user-gesture-required") {
+		t.Errorf("autoplayNoUserGesture on: missing --autoplay-policy=no-user-gesture-required in %v", on)
+	}
+	off := buildChromeArgs(cobrowseLaunchOptions{debugPort: 9222, profileDir: "/p", stealth: true})
+	if containsArg(off, "--autoplay-policy=no-user-gesture-required") {
+		t.Errorf("autoplayNoUserGesture off: --autoplay-policy must be absent in %v", off)
+	}
+	// Default co-browse launch options must NOT enable it.
+	cobrowseLike := buildChromeArgs(cobrowseLaunchOptions{debugPort: 9222, profileDir: "/p", stealth: true, softwareGL: true})
+	if containsArg(cobrowseLike, "--autoplay-policy=no-user-gesture-required") {
+		t.Errorf("co-browse default: --autoplay-policy must be absent in %v", cobrowseLike)
+	}
+}
+
 // TestResolveCobrowseDisplay checks the display-mode precedence: a dedicated
 // managed Xvfb by default, an operator-pinned display when EnvCobrowseDisplay is
 // set (trimmed).

--- a/internal/platform/meeting_browser.go
+++ b/internal/platform/meeting_browser.go
@@ -345,8 +345,9 @@ func buildMeetingChromeArgs(debugPort int, profileDir string) []string {
 		profileDir:         profileDir,
 		stealth:            stealthEnabled(),
 		userAgent:          os.Getenv(EnvCobrowseUserAgent),
-		softwareGL:         true,
-		passwordStoreBasic: true,
+		softwareGL:            true,
+		passwordStoreBasic:    true,
+		autoplayNoUserGesture: true,
 	})
 }
 

--- a/internal/platform/meeting_browser_test.go
+++ b/internal/platform/meeting_browser_test.go
@@ -107,6 +107,17 @@ func TestBuildMeetingChromeArgs_PasswordStoreBasic(t *testing.T) {
 	}
 }
 
+// TestBuildMeetingChromeArgs_AutoplayNoUserGesture locks in the audio-capture fix
+// (issue #5098): an automated browser has no user gesture, so without this flag
+// Chrome keeps the AudioContext suspended and blocks remote (WebRTC) audio, and
+// the bot records pure silence. The meeting launch MUST relax the autoplay policy.
+func TestBuildMeetingChromeArgs_AutoplayNoUserGesture(t *testing.T) {
+	args := buildMeetingChromeArgs(9222, "/tmp/meeting-profile")
+	if !containsArg(args, "--autoplay-policy=no-user-gesture-required") {
+		t.Errorf("meeting launch must include --autoplay-policy=no-user-gesture-required, got %v", args)
+	}
+}
+
 func TestMeetingBrowser_Launch(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping meeting-browser launch test in -short mode")


### PR DESCRIPTION
## Context

The sovereign meeting notetaker (epic #5097, issue #5098) could join a Google Meet, record, transcribe, and store a transcript — the entire pipeline was green — but every stored transcript was garbage: `[Speaker 1]: You` repeated, Whisper's classic hallucination on **silence**. Live debugging on a meeting node showed the captured wav was a flat **-91.0 dB** (digital noise floor): the bot joined the call and heard nothing.

## Root cause

The meeting bot's Chrome is an automated browser with no user gesture. Chrome's default autoplay policy therefore keeps the `AudioContext` suspended and blocks incoming (WebRTC) call audio from ever playing. The per-meeting `PULSE_SINK` routing was correct — during the call the null sink showed `RUNNING` with Chrome's playback stream connected — Chrome was simply feeding it silence.

## Summary

- **`buildChromeArgs`**: new `autoplayNoUserGesture` option that emits `--autoplay-policy=no-user-gesture-required`.
- **`buildMeetingChromeArgs`**: sets it. Co-browse leaves it off (a human drives it and supplies the gesture).

## Test plan

| Check | Result |
|---|---|
| Unit: flag present for meeting args, present when option set, absent for co-browse defaults | pass (`TestBuildMeetingChromeArgs_AutoplayNoUserGesture`, `TestBuildChromeArgs_AutoplayNoUserGesture`) |
| Isolation A/B on the exact `PULSE_SINK` capture path (real `<audio autoplay>`) | with flag **-21.1 dB** (real) / without **-91.0 dB** (silence) — reproduces the bug and the fix |
| Live E2E on node 1084: join → record → transcribe → store | full-file capture **mean -27.2 dB, max -0.2 dB** over 1:46 — real speech, no silence |
| `go vet` / full `internal/platform` package | pass |

## Related

- Epic #5097 (sovereign auto-join notetaker), issue #5098.
- Follow-up #5424 (fabric job-polling burns ~43k/day of rate budget) — surfaced while debugging this.