### PR TITLE
fix(work): move mTLS control listener off mesh :8443; fail loud on gateway mesh-bind loss (#504)

### DIFF
--- a/cmd/gateway_bind_error.go
+++ b/cmd/gateway_bind_error.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aceteam-ai/citadel-cli/services"
+)
+
+// gatewayVPNBindErrorMessage renders the startup error shown when the HTTPS
+// gateway cannot bind its mesh (tsnet) listener.
+//
+// This must be LOUD (#504): the gateway is the ONLY mesh entry point for
+// /vnc, /terminal, and /modules/*, so losing the bind means those routes are
+// unreachable over the mesh while the node still reports healthy in every
+// heartbeat. The old one-line "LAN-only" warning hid exactly that on every
+// node in the fleet after the mTLS control listener (#5028) started claiming
+// the same mesh :8443 first.
+//
+// tsnet reports a same-process double-bind as "listener already open" — that
+// is a collision between two citadel-owned listeners (a config/regression
+// bug, not an environment flake), so the message names the port and the
+// known culprit knobs instead of leaving the operator to guess.
+func gatewayVPNBindErrorMessage(port int, err error) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "❌ GATEWAY MESH LISTENER FAILED: could not bind mesh port %d: %v\n", port, err)
+	b.WriteString("   Mesh routes /vnc, /terminal, and /modules/* are UNREACHABLE over the VPN.\n")
+	b.WriteString("   The gateway continues on LAN only; platform features that dial this node over the mesh (desktop, WhatsApp bridge, provisioned modules) will fail.\n")
+	if strings.Contains(err.Error(), "listener already open") {
+		fmt.Fprintf(&b, "   Another citadel listener already owns mesh port %d.", port)
+		fmt.Fprintf(&b, " Check --gateway-port against the mTLS control listener (CITADEL_CONTROL_PORT, default %d) and restart with distinct ports.", services.ControlMTLSPort)
+	}
+	return b.String()
+}

--- a/cmd/gateway_bind_error_test.go
+++ b/cmd/gateway_bind_error_test.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/services"
+)
+
+func TestGatewayVPNBindErrorMessageNamesPortAndRoutes(t *testing.T) {
+	msg := gatewayVPNBindErrorMessage(8443, errors.New("listen on 100.64.0.21:8443: connection refused"))
+
+	for _, want := range []string{"8443", "/vnc", "/terminal", "/modules/*", "LAN"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message missing %q:\n%s", want, msg)
+		}
+	}
+	// Not a same-process double bind: no collision hint pointing at the control
+	// listener.
+	if strings.Contains(msg, "CITADEL_CONTROL_PORT") {
+		t.Errorf("collision hint should only appear for \"listener already open\" errors:\n%s", msg)
+	}
+}
+
+func TestGatewayVPNBindErrorMessageCollisionHint(t *testing.T) {
+	err := fmt.Errorf("listen on 100.64.0.21:8443: tsnet: listener already open for tcp, 100.64.0.21:8443")
+	msg := gatewayVPNBindErrorMessage(8443, err)
+
+	// A same-process collision must name the culprit knob and the control
+	// listener's current default so the operator can fix the config without
+	// spelunking (#504).
+	for _, want := range []string{
+		"CITADEL_CONTROL_PORT",
+		strconv.Itoa(services.ControlMTLSPort),
+		"--gateway-port",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("collision message missing %q:\n%s", want, msg)
+		}
+	}
+}

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1753,8 +1753,15 @@ func runWork(cmd *cobra.Command, args []string) {
 			vpnPort := fmt.Sprintf("%d", workGatewayPort)
 			rawLn, vpnIP, err := network.ListenVPN("tcp", vpnPort)
 			if err != nil {
-				Log("gateway VPN listener failed (LAN-only): %v", err)
-				fmt.Fprintf(os.Stderr, "   - ⚠️ Gateway VPN listener failed (LAN-only): %v\n", err)
+				// A lost mesh bind takes /vnc, /terminal, and /modules/* off the
+				// mesh while the node keeps heartbeating healthy — the silent
+				// degradation that hid the control-listener port collision on
+				// every node in the fleet (#504). Escalate to an unmissable
+				// startup error; keep booting because the LAN listener still
+				// works.
+				bindErr := gatewayVPNBindErrorMessage(workGatewayPort, err)
+				Log("%s", bindErr)
+				fmt.Fprintln(os.Stderr, bindErr)
 			} else {
 				var vpnGwLn net.Listener
 				if gwTLSConfig != nil {

--- a/internal/platform/meeting_browser.go
+++ b/internal/platform/meeting_browser.go
@@ -341,10 +341,10 @@ func (b *MeetingBrowser) CurrentURL() (string, error) {
 // set — especially the password-store choice — is unit-testable without launching.
 func buildMeetingChromeArgs(debugPort int, profileDir string) []string {
 	return buildChromeArgs(cobrowseLaunchOptions{
-		debugPort:          debugPort,
-		profileDir:         profileDir,
-		stealth:            stealthEnabled(),
-		userAgent:          os.Getenv(EnvCobrowseUserAgent),
+		debugPort:             debugPort,
+		profileDir:            profileDir,
+		stealth:               stealthEnabled(),
+		userAgent:             os.Getenv(EnvCobrowseUserAgent),
 		softwareGL:            true,
 		passwordStoreBasic:    true,
 		autoplayNoUserGesture: true,

--- a/internal/status/ca_bundle.go
+++ b/internal/status/ca_bundle.go
@@ -10,7 +10,7 @@
 // CRITICAL zero-break property (advisor / #5028): the fetch must NOT be a hard
 // dependency for an already-provisioned node. #461 turns the plaintext
 // /ssh/authorized-keys path into a 403 stub, so if a transient backend blip made
-// startup unable to bring up the :8443 listener, SSH-deploy would be dead until
+// startup unable to bring up the control listener, SSH-deploy would be dead until
 // the backend recovered AND the node restarted. To avoid that, a fetch failure
 // falls back to any previously-cached bundle on disk; only a first-ever cold
 // start with no cache leaves the node without a trust root (and it fails closed:

--- a/internal/status/server.go
+++ b/internal/status/server.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/aceteam-ai/citadel-cli/internal/desktop"
 	"github.com/aceteam-ai/citadel-cli/internal/terminal"
+	"github.com/aceteam-ai/citadel-cli/services"
 )
 
 // RouteRegistrar is a callback that registers HTTP routes on the status server's
@@ -110,16 +111,23 @@ type ServerConfig struct {
 	// fabric-CA-signed coordinator client certificate (issue #5028). When nil,
 	// those endpoints are refused everywhere (fail closed).
 	CAVerifier *FabricCAVerifier
-	// ControlPort is the port for the mTLS control listener (default: 8443). Only
-	// used when CAVerifier and ControlServerCert are both set.
+	// ControlPort is the port for the mTLS control listener (default:
+	// DefaultControlPort). Only used when CAVerifier and ControlServerCert are
+	// both set.
 	ControlPort int
 	// ControlServerCert is the TLS server certificate the control listener
 	// presents. Required (together with CAVerifier) to start the control listener.
 	ControlServerCert *tls.Certificate
 }
 
-// DefaultControlPort is the default port for the mTLS control listener.
-const DefaultControlPort = 8443
+// DefaultControlPort is the default port for the mTLS control listener. It is
+// defined in the services port registry (a port owned by a citadel-internal
+// process must never be hardcoded here) and deliberately distinct from the
+// HTTPS gateway's 8443: both listeners bind the same mesh IP, and when they
+// shared 8443 the control listener won the bind and the gateway silently
+// degraded to LAN-only, taking /vnc, /terminal, and /modules/* off the mesh
+// fleet-wide (#504).
+const DefaultControlPort = services.ControlMTLSPort
 
 // NewServer creates a new status HTTP server.
 func NewServer(cfg ServerConfig, collector *Collector) *Server {

--- a/internal/status/server_test.go
+++ b/internal/status/server_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/terminal"
+	"github.com/aceteam-ai/citadel-cli/services"
 )
 
 // mockTokenValidator is a test double for terminal.TokenValidator.
@@ -60,6 +61,28 @@ func TestNewServer(t *testing.T) {
 				t.Errorf("Port() = %v, want %v", server.Port(), tt.wantPort)
 			}
 		})
+	}
+}
+
+// TestControlPortDefaultsOffGatewayHTTPS is the #504 regression guard: the
+// mTLS control listener and the HTTPS gateway both bind the mesh IP, so their
+// defaults must never coincide. When both sat on 8443 the control listener won
+// the bind and the gateway silently dropped to LAN-only, taking /vnc,
+// /terminal, and /modules/* off the mesh fleet-wide.
+func TestControlPortDefaultsOffGatewayHTTPS(t *testing.T) {
+	collector := NewCollector(CollectorConfig{NodeName: "test-node"})
+
+	server := NewServer(ServerConfig{}, collector)
+	if server.controlPort != DefaultControlPort {
+		t.Errorf("default controlPort = %d, want DefaultControlPort (%d)", server.controlPort, DefaultControlPort)
+	}
+	if server.controlPort == services.GatewayHTTPSPort {
+		t.Errorf("default control port %d collides with the HTTPS gateway default (services.GatewayHTTPSPort); see #504", server.controlPort)
+	}
+
+	custom := NewServer(ServerConfig{ControlPort: 9443}, collector)
+	if custom.controlPort != 9443 {
+		t.Errorf("explicit ControlPort not respected: got %d, want 9443", custom.controlPort)
 	}
 }
 

--- a/services/ports.go
+++ b/services/ports.go
@@ -135,6 +135,15 @@ const (
 	GatewayPort = 8080
 	// GatewayHTTPSPort is the default HTTPS gateway port (cmd/serve.go).
 	GatewayHTTPSPort = 8443
+	// ControlMTLSPort is the coordinator mTLS control listener
+	// (internal/status.DefaultControlPort, overridable via CITADEL_CONTROL_PORT).
+	// It originally defaulted to 8443 and collided with GatewayHTTPSPort on the
+	// mesh IP (#504): the control listener bound first, the gateway's tsnet bind
+	// failed ("listener already open"), and every mesh gateway route (/vnc,
+	// /terminal, /modules/*) silently went dark fleet-wide. The coordinator
+	// (aceteam python-backend routes/fabric_relay.py) dials this port first and
+	// falls back to legacy 8443 for nodes that predate the move.
+	ControlMTLSPort = 8444
 	// TEIEmbeddingPort is the local TEI embedding service, wired as the
 	// gateway's /v1/embeddings upstream (cmd/serve.go --embedding-port,
 	// internal/jobs/embedding_handler.go). It sits INSIDE the apps
@@ -176,6 +185,7 @@ const (
 var ReservedCitadelPorts = map[int]string{
 	GatewayPort:       "gateway/status-server",
 	GatewayHTTPSPort:  "gateway-https",
+	ControlMTLSPort:   "control-mtls",
 	TEIEmbeddingPort:  "tei-embeddings",
 	VNCWebsockifyPort: "vnc-websockify",
 	VNCPort:           "vnc-rfb",

--- a/services/ports_test.go
+++ b/services/ports_test.go
@@ -1,0 +1,59 @@
+package services
+
+import "testing"
+
+// TestReservedCitadelPortsPairwiseDistinct asserts that no two DISTINCT
+// citadel-owned listeners are registered on the same port. Reserved ports are
+// a set-to-avoid for modules/apps (covered by the apps collision guard), but
+// nothing else proved citadel's own listeners avoid EACH OTHER — which is
+// exactly how #504 happened: the mTLS control listener and the HTTPS gateway
+// both defaulted to mesh :8443, the control listener won the bind, and the
+// gateway silently degraded to LAN-only. The map keying by port already makes
+// duplicates impossible to EXPRESS, so the load-bearing assertions here are
+// membership: every citadel-owned listener port must be present as its own
+// entry (an accidental re-merge onto an existing port would silently collapse
+// two entries into one).
+func TestReservedCitadelPortsPairwiseDistinct(t *testing.T) {
+	wantEntries := map[int]string{
+		GatewayPort:       "gateway/status-server",
+		GatewayHTTPSPort:  "gateway-https",
+		ControlMTLSPort:   "control-mtls",
+		TEIEmbeddingPort:  "tei-embeddings",
+		VNCWebsockifyPort: "vnc-websockify",
+		VNCPort:           "vnc-rfb",
+		DeskstreamPort:    "deskstream-h264",
+		TerminalPort:      "terminal-server",
+		LiveKitWSPort:     "livekit-signaling",
+		LiveKitICETCPPort: "livekit-ice-tcp",
+		LiveKitUDPMuxPort: "livekit-udp-mux",
+	}
+	if len(ReservedCitadelPorts) != len(wantEntries) {
+		t.Errorf("ReservedCitadelPorts has %d entries, want %d — a port constant collision collapses two listeners onto one port (see #504)",
+			len(ReservedCitadelPorts), len(wantEntries))
+	}
+	for port, name := range wantEntries {
+		if got, ok := ReservedCitadelPorts[port]; !ok || got != name {
+			t.Errorf("ReservedCitadelPorts[%d] = %q (present=%v), want %q", port, got, ok, name)
+		}
+	}
+}
+
+// TestControlMTLSPortAvoidsKnownSurfaces pins the #504 fix: the control
+// listener default must not sit on the HTTPS gateway port (both bind the mesh
+// IP), and must stay clear of the apps auto-allocation range and the module
+// registry so nothing else can be handed it.
+func TestControlMTLSPortAvoidsKnownSurfaces(t *testing.T) {
+	if ControlMTLSPort == GatewayHTTPSPort {
+		t.Fatalf("ControlMTLSPort (%d) must differ from GatewayHTTPSPort (%d); sharing it silently kills mesh /vnc, /terminal, /modules/* (#504)",
+			ControlMTLSPort, GatewayHTTPSPort)
+	}
+	if ControlMTLSPort >= AppsPortRangeStart && ControlMTLSPort <= AppsPortRangeEnd {
+		t.Errorf("ControlMTLSPort (%d) sits inside the apps auto-allocation range %d-%d",
+			ControlMTLSPort, AppsPortRangeStart, AppsPortRangeEnd)
+	}
+	for svc, port := range ServiceHostPorts {
+		if port == ControlMTLSPort {
+			t.Errorf("ControlMTLSPort (%d) collides with managed service %q", ControlMTLSPort, svc)
+		}
+	}
+}


### PR DESCRIPTION
## Context

Fixes #504. Every node in the fleet is currently serving the wrong thing on mesh `:8443`: `cmd/work.go` starts the mTLS control listener (`internal/status`, added for SSH-key injection in aceteam#5028) and the HTTPS gateway (`internal/gateway`, serving `/vnc`, `/terminal`, `/modules/*`) with the **same default mesh port 8443**. The control listener binds the mesh IP first, the gateway's tsnet bind fails with `tsnet: listener already open`, and the gateway silently degrades to LAN-only while the node keeps heartbeating healthy.

Confirmed blast radius (see #504): the desktop relay re-point (aceteam#5419) is gated, and WhatsApp bridge mesh calls (`whatsapp_health` etc., which dial `https://mesh:8443/modules/whatsapp/...` per aceteam#4709) fail TLS against the mTLS listener — "certificate still failed verification after refreshing it" — fleet-wide. Related: #501 (work-mode desktop parity, option (a) is gated behind this).

This PR implements options **1 + 3** from the issue: separate the default ports, and make the gateway's mesh-bind loss unmissable.

## Summary

**1. Control listener moves to mesh `:8444`, registered in the port registry** (`services/ports.go`)

- New `services.ControlMTLSPort = 8444`, added to `ReservedCitadelPorts` (`"control-mtls"`), so the existing apps/module host-port collision guard (`internal/apps/hostport_collision_test.go`) now covers it and no module/app can ever be allocated it.
- `internal/status.DefaultControlPort` now *derives from the registry* instead of hardcoding a literal — the registry is the single source of truth for citadel-owned ports, which is exactly the discipline whose absence caused this collision. `CITADEL_CONTROL_PORT` env override is unchanged.
- Gateway stays on `:8443` — that URL shape is baked into the coordinator's module/VNC/terminal dial paths and the gateway-cert trust flow; moving the *internal-only* control listener is the far smaller blast radius.

**2. Loud failure on gateway mesh-bind loss** (`cmd/work.go`, `cmd/gateway_bind_error.go`)

- The gateway's `ListenVPN` failure escalates from a one-line `LAN-only` warning to a multi-line startup **error** on stderr + log: it names the port, spells out what is now unreachable (`/vnc`, `/terminal`, `/modules/*` over the mesh; desktop/WhatsApp/modules platform features), and — when the error is tsnet's same-process `listener already open` — names the culprit knobs (`--gateway-port` vs `CITADEL_CONTROL_PORT`, default 8444). A collision between two of our own listeners must never be silent again.
- The process **keeps booting**: LAN service is intact, and killing the node over a mesh bind would be a worse failure mode. The escalation is about visibility, not fatality.

## Rollout compatibility

The coordinator (aceteam python-backend, `routes/fabric_relay.py`) dials node control at mesh `:8443` today. Companion PR aceteam-ai/aceteam#5450 changes the dial to **try `:8444`, then legacy `:8443`, then the existing flag-gated plaintext `:8080`**. A heartbeat-advertised control port was considered and rejected: it needs node → heartbeat → node-status-worker → persistence → relay plumbing (including a DB column) for a value with exactly two possible states, while try-with-fallback is self-healing across every skew case.

Version-skew matrix (SSH-key relay, the only control-port consumer):

| Coordinator | Node | `:8444` dial | `:8443` dial | Outcome |
| --- | --- | --- | --- | --- |
| old (8443 only) | old (control on 8443) | — | control listener answers | **works** (status quo) |
| old (8443 only) | **new** (control on 8444, gateway on 8443) | — | hits the **gateway**; its self-signed cert fails fabric-CA verification → transport error → plaintext `:8080` fallback → 403 stub | **fails closed** with a clear 403 until the coordinator updates → deploy aceteam#5450 **before** releasing this |
| **new** (8444→8443) | old (control on 8443) | connection refused (nothing there) → next | control listener answers | **works** |
| **new** (8444→8443) | **new** | control listener answers | not attempted | **works** |
| **new** (8444→8443) | pre-#5028 (no control listener at all) | refused | refused / TLS error | plaintext `:8080` fallback (flag-gated, unchanged) — **works** |

Key safety property: a control dial can never get a *false positive* from the gateway — the coordinator's mTLS client verifies the server cert against the fabric CA, and the gateway presents a self-signed leaf, so the wrong-listener case always fails as a clean transport error.

**Deploy order:** merge + deploy aceteam#5450 (coordinator dial, backward + forward compatible) first, then release this. In that order there is no window where SSH-deploy breaks. The gateway routes themselves (`/vnc`, `/modules/*`) need no coordinator change — this PR *restores* their intended `:8443` behavior.

## Test plan

| Group | Tests | Coverage |
| --- | --- | --- |
| `services/ports_test.go` (new) | 2 | registry membership + pairwise-distinct guard for every citadel-owned listener; control port ≠ gateway HTTPS port, clear of apps range + managed services |
| `internal/status/server_test.go` | +1 | `DefaultControlPort` regression guard (defaults off `services.GatewayHTTPSPort`, explicit override respected) |
| `cmd/gateway_bind_error_test.go` (new) | 2 | error message names port + dark routes; collision hint (control-port knobs) appears only for `listener already open` |
| existing | all | `go build ./...` clean; full `go test ./...` green, including the apps host-port collision guard now covering `ControlMTLSPort` |

Manual verification still worth doing on a canary node after release: `citadel work --gateway` on a mesh-connected node, confirm startup prints both `Gateway VPN: https://<mesh-ip>:8443` and `Control server VPN (mTLS): https://<mesh-ip>:8444`, and that `https://<mesh-ip>:8443/ping` (gateway) answers without a client cert.

## Related

- #504 (this fix), #501 (work-mode desktop parity, gated on this)
- aceteam-ai/aceteam#5419 (desktop relay re-point, gated on this), aceteam-ai/aceteam#5028 (control listener origin), aceteam-ai/aceteam#4709 (WhatsApp mesh dial broken by the collision)
- Companion coordinator PR: aceteam-ai/aceteam#5450

---
*Generated by Claude Fable 5*
