### PR TITLE
feat(meeting): live interactive layer for the Meet notetaker (#5435)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ docs-site/build/
 docs-site/.docusaurus/
 .claude/
 .release/
+
+# git worktrees created for isolated feature work
+.worktrees/

--- a/internal/config/meeting.go
+++ b/internal/config/meeting.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -23,16 +24,73 @@ type Meeting struct {
 	// nodes work out of the box; the Control Center settings pane discloses the
 	// default-on behavior and offers the toggle.
 	MeetingEnabled bool `yaml:"meeting_enabled" json:"meeting_enabled"`
+
+	// StreamingEnabled gates the DURING-CALL rolling transcription + in-call
+	// command monitor (issue #5435). When false, the bot behaves exactly like
+	// the shipped batch notetaker: join, record, transcribe once at the end.
+	// When true, the recording is additionally transcribed in a rolling window
+	// as the call runs so the bot can react to spoken/typed `/ace` commands
+	// live. Default-on (opt-out), same house convention as MeetingEnabled; the
+	// interactive layer is built to degrade gracefully (log + continue) so a
+	// stale live selector can never regress the batch pipeline.
+	StreamingEnabled bool `yaml:"streaming_enabled" json:"streaming_enabled"`
+
+	// StreamingIntervalSeconds is how often (during the call) the growing
+	// recording is re-transcribed to surface new transcript segments. Smaller
+	// values lower command-detection latency at the cost of more whisper passes;
+	// the v1 strategy re-transcribes the whole wav-so-far, so passes get slower
+	// as a long call grows (see meeting_transcribe_rolling.go). Must be positive.
+	StreamingIntervalSeconds int `yaml:"streaming_interval_seconds" json:"streaming_interval_seconds"`
+
+	// StreamingWindowSeconds is the trailing "not yet stable" margin. Whole-file
+	// re-transcription revises the most recent audio (segment text and start
+	// times shift as more context arrives), so a segment is only emitted
+	// downstream once its end is older than (current tail - window). This holds
+	// back the churning tail to avoid emitting — and acting on — a partial or
+	// hallucinated segment that the next pass rewrites. Must be positive.
+	StreamingWindowSeconds int `yaml:"streaming_window_seconds" json:"streaming_window_seconds"`
+}
+
+// StreamingInterval returns the rolling-transcription cadence as a Duration,
+// falling back to the default when a persisted config carries a non-positive
+// value (e.g. a hand-edited or truncated meeting.yaml). Keeping the clamp here
+// means the consumer never has to defend against a zero ticker interval.
+func (m *Meeting) StreamingInterval() time.Duration {
+	if m.StreamingIntervalSeconds <= 0 {
+		return time.Duration(defaultStreamingIntervalSeconds) * time.Second
+	}
+	return time.Duration(m.StreamingIntervalSeconds) * time.Second
+}
+
+// StreamingWindow returns the trailing stability margin as a Duration, with the
+// same non-positive fallback rationale as StreamingInterval.
+func (m *Meeting) StreamingWindow() time.Duration {
+	if m.StreamingWindowSeconds <= 0 {
+		return time.Duration(defaultStreamingWindowSeconds) * time.Second
+	}
+	return time.Duration(m.StreamingWindowSeconds) * time.Second
 }
 
 const meetingFile = "meeting.yaml"
+
+// Streaming defaults. Interval trades command latency against whisper load;
+// 15s is a middle ground on CPU "base". Window must comfortably exceed a
+// typical whisper segment (~5-10s) so the churning tail stabilizes before we
+// emit it.
+const (
+	defaultStreamingIntervalSeconds = 15
+	defaultStreamingWindowSeconds   = 10
+)
 
 // DefaultMeeting returns a Meeting struct with the capability enabled.
 // Default-on is intentional: it matches the house convention that capabilities
 // are opt-out, so a dep-capable node joins meetings without extra setup.
 func DefaultMeeting() *Meeting {
 	return &Meeting{
-		MeetingEnabled: true,
+		MeetingEnabled:           true,
+		StreamingEnabled:         true,
+		StreamingIntervalSeconds: defaultStreamingIntervalSeconds,
+		StreamingWindowSeconds:   defaultStreamingWindowSeconds,
 	}
 }
 

--- a/internal/config/meeting_test.go
+++ b/internal/config/meeting_test.go
@@ -4,12 +4,59 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestDefaultMeeting(t *testing.T) {
 	m := DefaultMeeting()
 	if !m.MeetingEnabled {
 		t.Errorf("DefaultMeeting should be enabled (opt-out), got %+v", m)
+	}
+	// Streaming (issue #5435) is also opt-out with sane cadence defaults.
+	if !m.StreamingEnabled {
+		t.Errorf("DefaultMeeting should have streaming enabled (opt-out), got %+v", m)
+	}
+	if m.StreamingInterval() != defaultStreamingIntervalSeconds*time.Second {
+		t.Errorf("StreamingInterval = %v, want %v", m.StreamingInterval(), defaultStreamingIntervalSeconds*time.Second)
+	}
+	if m.StreamingWindow() != defaultStreamingWindowSeconds*time.Second {
+		t.Errorf("StreamingWindow = %v, want %v", m.StreamingWindow(), defaultStreamingWindowSeconds*time.Second)
+	}
+}
+
+func TestStreamingDurationFallbacks(t *testing.T) {
+	// A persisted config with non-positive values (hand-edited or truncated)
+	// must not yield a zero ticker interval; the accessor clamps to defaults.
+	m := &Meeting{StreamingIntervalSeconds: 0, StreamingWindowSeconds: -5}
+	if m.StreamingInterval() != defaultStreamingIntervalSeconds*time.Second {
+		t.Errorf("StreamingInterval fallback = %v, want default", m.StreamingInterval())
+	}
+	if m.StreamingWindow() != defaultStreamingWindowSeconds*time.Second {
+		t.Errorf("StreamingWindow fallback = %v, want default", m.StreamingWindow())
+	}
+	// Explicit positive values are honored.
+	m2 := &Meeting{StreamingIntervalSeconds: 5, StreamingWindowSeconds: 3}
+	if m2.StreamingInterval() != 5*time.Second {
+		t.Errorf("StreamingInterval = %v, want 5s", m2.StreamingInterval())
+	}
+	if m2.StreamingWindow() != 3*time.Second {
+		t.Errorf("StreamingWindow = %v, want 3s", m2.StreamingWindow())
+	}
+}
+
+func TestLoadMeeting_StreamingDefaultsPreservedOnPartialFile(t *testing.T) {
+	// A file that only sets meeting_enabled must keep the streaming defaults
+	// (absent keys preserve defaults via unmarshal-into-defaults).
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "meeting.yaml"), []byte("meeting_enabled: true\n"), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	m := LoadMeeting(dir)
+	if !m.StreamingEnabled {
+		t.Errorf("partial file should preserve StreamingEnabled default (true), got %+v", m)
+	}
+	if m.StreamingIntervalSeconds != defaultStreamingIntervalSeconds {
+		t.Errorf("partial file should preserve interval default, got %d", m.StreamingIntervalSeconds)
 	}
 }
 

--- a/internal/jobs/meeting_chat.go
+++ b/internal/jobs/meeting_chat.go
@@ -1,0 +1,244 @@
+// internal/jobs/meeting_chat.go
+//
+// Meet in-call text-chat capture + post (issue #5435, epic #5097). Provides the
+// CDP-driven helpers to (1) open the Meet chat panel, (2) READ the chat message
+// history, and (3) POST a chat message, plus the self-announcement the bot posts
+// on admittance. Chat lines are fed into the in-call command monitor
+// (meeting_command.go) alongside transcript segments, and captured chat is
+// persisted in the MEETING_JOIN result.
+//
+// All page interaction goes through the SAME CDP evaluate mechanism the join
+// flow uses (platform.MeetingBrowser.Evaluate -> cdpEvaluate -> Runtime.evaluate
+// with returnByValue). No new CDP library is introduced. The helpers here take a
+// minimal `chatEvaluator` interface so the JS-building and result-parsing logic
+// is unit-testable without a real browser; the LIVE selectors themselves can
+// only be confirmed by a human on a real call (see the LIVE-TUNING block below).
+package jobs
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// meetAnnouncementText is the consent/intro message the bot posts to Meet chat
+// once admitted (capability 4). Kept as a single const so the exact wording is
+// reviewed in one place and the tone stays consistent. TTS voice is out of scope
+// for this PR (chat only); speaking this aloud is a named follow-up.
+const meetAnnouncementText = "Hi, I'm AceTeam. I'm recording this call - audio, video, and text. " +
+	"To give me instructions, say /ace leave or /ace <command>, or just talk to me."
+
+// ---------------------------------------------------------------------------
+// LIVE-TUNING REQUIRED (best-guess, UNVERIFIED)
+//
+// Every selector in this block is a best guess at Google Meet's in-call chat
+// DOM. NONE has been confirmed against a live call — only a human signed into a
+// real meeting can open the chat panel, read the rendered markup, and confirm or
+// replace these. They are kept together so tuning is a one-place edit, mirroring
+// the discipline in meeting_join.go's LIVE-TUNING block.
+//
+// What a human must confirm on a live call before this is trusted:
+//
+//   - The "Chat with everyone" toolbar button's aria-label (to OPEN the panel).
+//     Note: meeting_join.go already observed a "Chat with everyone" button in the
+//     in-call toolbar on 2026-07-11, so meetChatOpenSelector is the LEAST
+//     uncertain piece here — but the exact aria-label casing is still unverified.
+//
+//   - The chat message row container + the sender-name and message-text sub
+//     elements (to READ history).
+//
+//   - The chat text input and the send button (to POST).
+//
+//     best-guess as of: 2026-07-11 (NOT verified on a live call)
+//
+// ---------------------------------------------------------------------------
+const (
+	// meetChatOpenSelector: the in-call toolbar button that opens the chat
+	// panel. "Chat with everyone" was seen in the toolbar on 2026-07-11.
+	meetChatOpenSelector = `button[aria-label*="Chat with everyone" i],button[aria-label*="chat" i]`
+	// meetChatMessageRowSelector: one rendered chat message row. Meet groups
+	// consecutive messages from one sender; this best-guess targets individual
+	// message text nodes.
+	meetChatMessageRowSelector = `div[data-message-id],div[jsname][data-sender-name],div[aria-label*="chat message" i]`
+	// meetChatSenderSelector: the sender-name element WITHIN a message row.
+	meetChatSenderSelector = `[data-sender-name],[data-self-name],.sender-name`
+	// meetChatTextSelector: the message-text element WITHIN a message row.
+	meetChatTextSelector = `[data-message-text],.message-text,div[jsname="dTKtvb"]`
+	// meetChatInputSelector: the chat text input (a textarea in current Meet).
+	meetChatInputSelector = `textarea[aria-label*="Send a message" i],textarea[placeholder*="Send a message" i],textarea[aria-label*="message" i]`
+	// meetChatSendSelector: the send button next to the chat input.
+	meetChatSendSelector = `button[aria-label*="Send a message" i],button[aria-label*="Send message" i],button[data-tooltip*="Send" i]`
+)
+
+// MeetChatMessage is one captured Meet chat line. Index is the message's position in
+// the rendered, append-only chat list, used to dedup across repeated reads (Meet
+// chat only grows, so a stable index distinguishes two identical texts). Sender
+// may be empty when the DOM does not expose a name for a grouped message.
+type MeetChatMessage struct {
+	Index  int    `json:"index"`
+	Sender string `json:"sender"`
+	Text   string `json:"text"`
+}
+
+// Line renders a chat message as a single line for the command monitor, which
+// scans "text" for invocations. The sender is prefixed for the audit trail but
+// the command monitor matches on substrings so the prefix does not interfere.
+func (m MeetChatMessage) Line() string {
+	if m.Sender == "" {
+		return m.Text
+	}
+	return m.Sender + ": " + m.Text
+}
+
+// normalizeChatText canonicalizes a chat line for own-message matching: trimmed,
+// lower-cased, with internal whitespace collapsed. Used so the bot does not scan
+// its OWN posted messages (notably the announcement, which literally contains
+// "/ace leave") for commands and self-trigger a leave — robust to minor Meet
+// re-rendering of the text it echoes back.
+func normalizeChatText(s string) string {
+	return strings.ToLower(strings.Join(strings.Fields(s), " "))
+}
+
+// chatEvaluator is the slice of platform.MeetingBrowser the chat helpers need,
+// so they are unit-testable without a real browser (mirrors joinPage).
+type chatEvaluator interface {
+	Evaluate(expression string) (any, error)
+}
+
+// meetChatOpenJS builds the JS that opens the chat panel by clicking the chat
+// toolbar button. It throws (via clickFirstBySelectorJS) when the selector
+// matches nothing so a stale selector fails loudly during live tuning rather
+// than silently leaving the panel closed and the readback empty.
+func meetChatOpenJS() string {
+	return clickFirstBySelectorJS(meetChatOpenSelector)
+}
+
+// meetChatReadJS builds the JS that scans rendered chat rows and returns a
+// JSON-serializable array of {index, sender, text}. It NEVER throws on an empty
+// chat (a call with no messages is normal); it returns []. Selectors are
+// embedded json-escaped. The panel must be open for rows to be in the DOM.
+func meetChatReadJS() string {
+	rowSel, _ := json.Marshal(meetChatMessageRowSelector)
+	senderSel, _ := json.Marshal(meetChatSenderSelector)
+	textSel, _ := json.Marshal(meetChatTextSelector)
+	return `(function(){` +
+		`var rows=Array.prototype.slice.call(document.querySelectorAll(` + string(rowSel) + `));` +
+		`var out=[];` +
+		`for(var i=0;i<rows.length;i++){var r=rows[i];` +
+		`var s=r.querySelector(` + string(senderSel) + `);` +
+		`var t=r.querySelector(` + string(textSel) + `);` +
+		`var text=(t?(t.innerText||t.textContent):(r.innerText||r.textContent))||"";` +
+		`text=text.trim();if(!text)continue;` +
+		`out.push({index:i,sender:s?((s.innerText||s.textContent)||"").trim():"",text:text});}` +
+		`return JSON.stringify(out);})()`
+}
+
+// meetChatSendJS builds the JS that types text into the chat input (via the
+// native value setter so Meet's controlled input observes the change, mirroring
+// platform.typeJS) and clicks send. Throws when the input or send button is
+// missing so a stale selector fails loudly. text is json-escaped.
+func meetChatSendJS(text string) string {
+	inputSel, _ := json.Marshal(meetChatInputSelector)
+	sendSel, _ := json.Marshal(meetChatSendSelector)
+	val, _ := json.Marshal(text)
+	return `(function(){` +
+		`var el=document.querySelector(` + string(inputSel) + `);` +
+		`if(!el){throw new Error("chat input not found: "+` + string(inputSel) + `);}` +
+		`el.focus();` +
+		`var proto=el instanceof HTMLTextAreaElement?HTMLTextAreaElement.prototype:HTMLInputElement.prototype;` +
+		`var setter=Object.getOwnPropertyDescriptor(proto,'value').set;` +
+		`setter.call(el,` + string(val) + `);` +
+		`el.dispatchEvent(new Event('input',{bubbles:true}));` +
+		`el.dispatchEvent(new Event('change',{bubbles:true}));` +
+		`var btn=document.querySelector(` + string(sendSel) + `);` +
+		`if(btn){btn.click();return true;}` +
+		// Fallback: some Meet builds send on Enter with no separate button.
+		`el.dispatchEvent(new KeyboardEvent('keydown',{key:'Enter',code:'Enter',keyCode:13,which:13,bubbles:true}));` +
+		`return true;})()`
+}
+
+// clickFirstBySelectorJS builds a JS expression that clicks the first element
+// matching selector and THROWS when nothing matches (so cdpEvaluate turns a
+// stale selector into a Go error). Mirrors platform.clickJS but is defined here
+// to keep the jobs package free of a platform dependency for JS building.
+func clickFirstBySelectorJS(selector string) string {
+	sel, _ := json.Marshal(selector)
+	return `(function(){var el=document.querySelector(` + string(sel) + `);` +
+		`if(!el){throw new Error("selector not found: "+` + string(sel) + `);}` +
+		`el.scrollIntoView();el.click();return true;})()`
+}
+
+// openMeetChat opens the chat panel. Best-effort: a stale selector returns an
+// error the caller logs and continues on (chat capture degrading must never
+// crash the recording).
+func openMeetChat(page chatEvaluator) error {
+	_, err := page.Evaluate(meetChatOpenJS())
+	return err
+}
+
+// readMeetChat reads the current chat history and parses it into ordered
+// ChatMessages. Returns a parse error only when the page returned something
+// unexpected; an empty chat yields (nil, nil).
+func readMeetChat(page chatEvaluator) ([]MeetChatMessage, error) {
+	v, err := page.Evaluate(meetChatReadJS())
+	if err != nil {
+		return nil, err
+	}
+	return parseChatMessages(v)
+}
+
+// postMeetChat posts text to the chat. Best-effort (see openMeetChat).
+func postMeetChat(page chatEvaluator, text string) error {
+	_, err := page.Evaluate(meetChatSendJS(text))
+	return err
+}
+
+// parseChatMessages decodes the readback value from meetChatReadJS. The JS
+// returns a JSON STRING (JSON.stringify) so the value crosses CDP as a string
+// regardless of returnByValue quirks; parseChatMessages tolerates either a
+// string payload or an already-decoded []any (defensive against a future change
+// to the readback shape). A nil/empty value yields no messages.
+func parseChatMessages(v any) ([]MeetChatMessage, error) {
+	switch payload := v.(type) {
+	case nil:
+		return nil, nil
+	case string:
+		s := strings.TrimSpace(payload)
+		if s == "" {
+			return nil, nil
+		}
+		var msgs []MeetChatMessage
+		if err := json.Unmarshal([]byte(s), &msgs); err != nil {
+			return nil, fmt.Errorf("parse chat readback JSON: %w", err)
+		}
+		return msgs, nil
+	case []any:
+		return coerceChatArray(payload)
+	default:
+		return nil, fmt.Errorf("unexpected chat readback type %T", v)
+	}
+}
+
+// coerceChatArray converts an already-decoded []any (each a map) into
+// ChatMessages, tolerating missing fields. Used only if the readback ever comes
+// back as a live array rather than a JSON string.
+func coerceChatArray(arr []any) ([]MeetChatMessage, error) {
+	out := make([]MeetChatMessage, 0, len(arr))
+	for i, item := range arr {
+		m, ok := item.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("chat item %d is not an object: %T", i, item)
+		}
+		text, _ := m["text"].(string)
+		if strings.TrimSpace(text) == "" {
+			continue
+		}
+		sender, _ := m["sender"].(string)
+		idx := i
+		if n, ok := toInt(m["index"]); ok {
+			idx = n
+		}
+		out = append(out, MeetChatMessage{Index: idx, Sender: sender, Text: text})
+	}
+	return out, nil
+}

--- a/internal/jobs/meeting_chat_test.go
+++ b/internal/jobs/meeting_chat_test.go
@@ -1,0 +1,173 @@
+package jobs
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestMeetChatSendJS_EmbedsEscapedText(t *testing.T) {
+	// A message with quotes/backslashes must be safely escaped into the JS.
+	js := meetChatSendJS(`hi "there" \o/`)
+	if !strings.Contains(js, `hi \"there\" \\o/`) {
+		t.Errorf("send JS did not json-escape the text; got: %s", js)
+	}
+	// The input selector must be embedded, and a missing input must throw so a
+	// stale selector fails loudly (not a silent no-op).
+	if !strings.Contains(js, "chat input not found") {
+		t.Errorf("send JS must throw on a missing chat input; got: %s", js)
+	}
+}
+
+func TestMeetChatOpenJS_ThrowsOnMissing(t *testing.T) {
+	js := meetChatOpenJS()
+	if !strings.Contains(js, "throw new Error") {
+		t.Errorf("open JS must throw on a missing chat button; got: %s", js)
+	}
+	escaped, _ := json.Marshal(meetChatOpenSelector)
+	if !strings.Contains(js, string(escaped)) {
+		t.Errorf("open JS must embed the chat-open selector; got: %s", js)
+	}
+}
+
+func TestMeetChatReadJS_NeverThrowsAndReturnsJSON(t *testing.T) {
+	js := meetChatReadJS()
+	// Empty chat is normal; the readback must not throw and must return a JSON
+	// string (JSON.stringify) so the value crosses CDP cleanly.
+	if strings.Contains(js, "throw new Error") {
+		t.Errorf("read JS must not throw on empty chat; got: %s", js)
+	}
+	if !strings.Contains(js, "JSON.stringify") {
+		t.Errorf("read JS must JSON.stringify its result; got: %s", js)
+	}
+}
+
+func TestParseChatMessages_JSONString(t *testing.T) {
+	v := `[{"index":0,"sender":"Alice","text":"hello"},{"index":1,"sender":"Bob","text":"/ace leave"}]`
+	msgs, err := parseChatMessages(v)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []MeetChatMessage{
+		{Index: 0, Sender: "Alice", Text: "hello"},
+		{Index: 1, Sender: "Bob", Text: "/ace leave"},
+	}
+	if !reflect.DeepEqual(msgs, want) {
+		t.Errorf("parsed = %+v, want %+v", msgs, want)
+	}
+}
+
+func TestParseChatMessages_EmptyAndNil(t *testing.T) {
+	for _, v := range []any{nil, "", "   ", "[]"} {
+		msgs, err := parseChatMessages(v)
+		if err != nil {
+			t.Errorf("parseChatMessages(%v) errored: %v", v, err)
+		}
+		if len(msgs) != 0 {
+			t.Errorf("parseChatMessages(%v) = %v, want empty", v, msgs)
+		}
+	}
+}
+
+func TestParseChatMessages_DecodedArrayFallback(t *testing.T) {
+	// Defensive path: an already-decoded []any (map items). Empty-text items are
+	// skipped; index falls back to position when absent.
+	v := []any{
+		map[string]any{"sender": "Alice", "text": "hi", "index": float64(2)},
+		map[string]any{"sender": "Bob", "text": "   "}, // skipped (blank)
+		map[string]any{"text": "no sender"},
+	}
+	msgs, err := parseChatMessages(v)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []MeetChatMessage{
+		{Index: 2, Sender: "Alice", Text: "hi"},
+		{Index: 2, Sender: "", Text: "no sender"},
+	}
+	if !reflect.DeepEqual(msgs, want) {
+		t.Errorf("parsed = %+v, want %+v", msgs, want)
+	}
+}
+
+func TestParseChatMessages_Malformed(t *testing.T) {
+	if _, err := parseChatMessages("{not json"); err == nil {
+		t.Error("expected error for malformed JSON string")
+	}
+	if _, err := parseChatMessages(42); err == nil {
+		t.Error("expected error for unexpected readback type")
+	}
+}
+
+func TestChatMessageLine(t *testing.T) {
+	if got := (MeetChatMessage{Sender: "Alice", Text: "hi"}).Line(); got != "Alice: hi" {
+		t.Errorf("Line() = %q, want 'Alice: hi'", got)
+	}
+	if got := (MeetChatMessage{Text: "hi"}).Line(); got != "hi" {
+		t.Errorf("Line() with no sender = %q, want 'hi'", got)
+	}
+}
+
+// fakeChatPage is a scripted chatEvaluator: it returns a queued value/error per
+// call and records the last expression it saw, so the helper wrappers can be
+// exercised (parse + error propagation) without a real browser.
+type fakeChatPage struct {
+	readValue any
+	readErr   error
+	postErr   error
+	openErr   error
+	lastExpr  string
+}
+
+func (f *fakeChatPage) Evaluate(expression string) (any, error) {
+	f.lastExpr = expression
+	switch {
+	case strings.Contains(expression, "JSON.stringify"):
+		return f.readValue, f.readErr
+	case strings.Contains(expression, "chat input not found"):
+		return true, f.postErr
+	default:
+		return true, f.openErr
+	}
+}
+
+func TestReadMeetChat_ParsesThroughEvaluator(t *testing.T) {
+	page := &fakeChatPage{readValue: `[{"index":0,"sender":"A","text":"/ace leave"}]`}
+	msgs, err := readMeetChat(page)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(msgs) != 1 || msgs[0].Text != "/ace leave" {
+		t.Errorf("readMeetChat = %+v, want one leave line", msgs)
+	}
+}
+
+func TestReadMeetChat_PropagatesEvaluateError(t *testing.T) {
+	page := &fakeChatPage{readErr: fmt.Errorf("cdp boom")}
+	if _, err := readMeetChat(page); err == nil {
+		t.Error("expected readMeetChat to propagate the evaluate error")
+	}
+}
+
+func TestPostAndOpenMeetChat_PropagateErrors(t *testing.T) {
+	page := &fakeChatPage{postErr: fmt.Errorf("no input")}
+	if err := postMeetChat(page, "hi"); err == nil {
+		t.Error("expected postMeetChat to propagate the evaluate error")
+	}
+	page2 := &fakeChatPage{openErr: fmt.Errorf("no button")}
+	if err := openMeetChat(page2); err == nil {
+		t.Error("expected openMeetChat to propagate the evaluate error")
+	}
+}
+
+func TestMeetAnnouncementText_MentionsCommands(t *testing.T) {
+	// The announcement is the consent + control surface; it must disclose
+	// recording and how to invoke the bot.
+	for _, want := range []string{"recording", "/ace leave", "/ace <command>"} {
+		if !strings.Contains(meetAnnouncementText, want) {
+			t.Errorf("announcement missing %q; got: %q", want, meetAnnouncementText)
+		}
+	}
+}

--- a/internal/jobs/meeting_command.go
+++ b/internal/jobs/meeting_command.go
@@ -1,0 +1,233 @@
+// internal/jobs/meeting_command.go
+//
+// In-call command monitor (issue #5435, epic #5097 — turning the passive Meet
+// notetaker into a controllable in-call agent). This file is a PURE, fully
+// unit-tested parser: it scans a single line of text (a transcript segment OR a
+// captured Meet chat line) for an invocation and returns a structured
+// RecognizedCommand, with NO side effects and NO DOM/browser knowledge. The
+// wiring that acts on the result lives in meeting_join.go; the recognition
+// logic lives here so it can be tested exhaustively without a browser.
+//
+// SAFETY PROPERTY (deliberate): the ONLY invocation this node auto-executes is a
+// literal `/ace leave`, which ends the bot's participation. Everything else —
+// a generic `/ace <command>` or a wake-phrase instruction — is CAPTURED and
+// surfaced (result + logs) for the cloud/agent layer to interpret; this node
+// never executes free-form instructions. Requiring the literal `/ace ` token
+// (not a fuzzy homophone) for the one destructive action means ambient speech
+// like "does the ace leave early?" can never end a meeting.
+package jobs
+
+import (
+	"strings"
+	"unicode"
+)
+
+// aceCommandToken is the literal invocation prefix for typed/spoken commands:
+// `/ace <command>`. Matched case-insensitively but NOT fuzzily — a real slash is
+// required, so ordinary speech transcribed without a slash cannot trigger a
+// command (see the SAFETY PROPERTY above).
+const aceCommandToken = "/ace"
+
+// aceWakePhrases are the spoken wake phrases that introduce a free-form
+// instruction: "hey aceteam, <instructions>". Multiple spellings are accepted
+// because whisper renders the brand inconsistently ("aceteam" / "ace team").
+// Matched case-insensitively as a substring so surrounding speech in the same
+// segment ("... so hey aceteam, summarize that") still matches.
+var aceWakePhrases = []string{"hey aceteam", "hey ace team"}
+
+// aceSpokenCommandPrefixes are best-guess spoken renderings of the `/ace` token
+// for when a participant SAYS the command out loud and whisper transcribes the
+// slash as a word ("slash ace leave"). This is a HEURISTIC, not a guarantee —
+// it is deliberately kept separate from the literal aceCommandToken path and is
+// only consulted for command recognition, never promoted to the auto-executed
+// leave path unless the parsed command is itself an explicit registry command.
+//
+// LIVE-TUNING REQUIRED (best-guess, unverified) — 2026-07-11: whether whisper
+// renders a spoken "/ace" as "slash ace", "slash-ace", or something else can
+// only be confirmed by a human speaking commands on a live call. Keep these
+// together for one-place tuning.
+var aceSpokenCommandPrefixes = []string{"slash ace", "slash-ace"}
+
+// CommandKind classifies a recognized invocation.
+type CommandKind string
+
+const (
+	// CommandLeave is the one auto-executed action: end the bot's participation.
+	CommandLeave CommandKind = "leave"
+	// CommandGeneric is a `/ace <command>` whose command word is not in the
+	// registry. It is captured and surfaced for the agent layer, not executed.
+	CommandGeneric CommandKind = "generic"
+	// CommandInstruction is a wake-phrase free-form instruction
+	// ("hey aceteam, <instructions>"). Captured and surfaced, not executed.
+	CommandInstruction CommandKind = "instruction"
+)
+
+// CommandSource records where a recognized command was observed, so a caller
+// (and the audit trail) can distinguish a spoken command from a typed one.
+type CommandSource string
+
+const (
+	// SourceTranscript means the command came from a rolling transcript segment.
+	SourceTranscript CommandSource = "transcript"
+	// SourceChat means the command came from a Meet in-call chat line.
+	SourceChat CommandSource = "chat"
+)
+
+// RecognizedCommand is the structured result of parsing one line. Command is the
+// registry keyword for CommandLeave/CommandGeneric (lower-cased, no arguments);
+// Instruction carries the free-form remainder for CommandGeneric (the args after
+// the command word) and CommandInstruction (everything after the wake phrase).
+// Raw is the original untrimmed line, preserved for the audit trail.
+type RecognizedCommand struct {
+	Kind        CommandKind   `json:"kind"`
+	Command     string        `json:"command,omitempty"`
+	Instruction string        `json:"instruction,omitempty"`
+	Source      CommandSource `json:"source"`
+	Raw         string        `json:"raw"`
+}
+
+// commandRegistry maps a `/ace <word>` command keyword to its kind. It is the
+// small, extensible surface for adding node-executed commands: today only
+// "leave" is auto-executed; a new entry here (plus wiring in meeting_join.go)
+// adds another. A word absent from the registry parses as CommandGeneric.
+var commandRegistry = map[string]CommandKind{
+	"leave": CommandLeave,
+}
+
+// ParseCommand scans one line of text (a transcript segment or a chat line) for
+// an in-call invocation and returns a RecognizedCommand plus ok=true when one is
+// found. It is pure and allocation-light; a non-match returns (zero, false)
+// rather than an error because "no command in this line" is the overwhelmingly
+// common case, not an exceptional one.
+//
+// Precedence: the literal `/ace` token wins over the spoken-command heuristic,
+// which wins over the wake phrase. Within a line the FIRST matching invocation
+// is used (pick-first) so a line mentioning several never ambiguously executes.
+func ParseCommand(line string, source CommandSource) (RecognizedCommand, bool) {
+	lower := strings.ToLower(line)
+
+	// 1. Literal `/ace <command>` — the authoritative path (only source of the
+	//    auto-executed leave). The token must sit on a boundary: not glued to a
+	//    preceding word (so "a/ace@host" is not a command) and followed by a
+	//    separator (so "/aceleave" is not a command).
+	if rest, ok := tokenRestWithBoundary(line, lower, aceCommandToken); ok {
+		if cmd, ok := parseAceCommandRest(rest, source, line); ok {
+			return cmd, true
+		}
+	}
+
+	// 2. Spoken-command heuristic ("slash ace leave"). Flagged, best-effort.
+	for _, prefix := range aceSpokenCommandPrefixes {
+		if rest, ok := tokenRestWithBoundary(line, lower, prefix); ok {
+			if cmd, ok := parseAceCommandRest(rest, source, line); ok {
+				return cmd, true
+			}
+		}
+	}
+
+	// 3. Wake phrase ("hey aceteam, <instructions>") — free-form capture only.
+	for _, phrase := range aceWakePhrases {
+		if idx := strings.Index(lower, phrase); idx >= 0 {
+			rest := strings.TrimSpace(trimLeadingPunct(line[idx+len(phrase):]))
+			if rest == "" {
+				// A bare wake phrase with no instruction is not actionable.
+				continue
+			}
+			return RecognizedCommand{
+				Kind:        CommandInstruction,
+				Instruction: rest,
+				Source:      source,
+				Raw:         line,
+			}, true
+		}
+	}
+
+	return RecognizedCommand{}, false
+}
+
+// parseAceCommandRest interprets the text after an `/ace` (or spoken-equivalent)
+// token: the first word is the command keyword (registry lookup decides leave vs
+// generic), and any remainder is captured as the instruction/arguments. Returns
+// ok=false when there is no command word at all (a bare `/ace`), so callers can
+// fall through to other invocation forms.
+func parseAceCommandRest(rest string, source CommandSource, raw string) (RecognizedCommand, bool) {
+	rest = trimLeadingPunct(rest)
+	fields := strings.Fields(rest)
+	if len(fields) == 0 {
+		return RecognizedCommand{}, false
+	}
+	word := strings.ToLower(trimSurroundingPunct(fields[0]))
+	if word == "" {
+		return RecognizedCommand{}, false
+	}
+	instruction := strings.TrimSpace(rest[strings.Index(rest, fields[0])+len(fields[0]):])
+	instruction = strings.TrimSpace(trimLeadingPunct(instruction))
+
+	kind, known := commandRegistry[word]
+	if !known {
+		kind = CommandGeneric
+	}
+	return RecognizedCommand{
+		Kind:        kind,
+		Command:     word,
+		Instruction: instruction,
+		Source:      source,
+		Raw:         raw,
+	}, true
+}
+
+// tokenRestWithBoundary finds the FIRST occurrence of an ASCII token in lower
+// (the lower-cased line) that sits on a word boundary, and returns the slice of
+// the ORIGINAL line following it. A valid boundary means: the char before the
+// token is the start of the line or a non-alphanumeric rune (so the token is not
+// the tail of a larger word like "a/ace"), and the char after the token is the
+// end of the line or a recognized separator (so "/aceleave" or "/ace@x" do not
+// match while "/ace leave" and "/ace: leave" do). token must be ASCII; both
+// invocation tokens are. Returns ok=false when no bounded occurrence exists.
+func tokenRestWithBoundary(line, lower, token string) (string, bool) {
+	search := 0
+	for {
+		rel := strings.Index(lower[search:], token)
+		if rel < 0 {
+			return "", false
+		}
+		idx := search + rel
+		after := idx + len(token)
+		beforeOK := idx == 0 || !isWordRune(rune(lower[idx-1]))
+		afterOK := after >= len(lower) || isCommandSeparator(rune(lower[after]))
+		if beforeOK && afterOK {
+			return line[after:], true
+		}
+		search = idx + len(token)
+	}
+}
+
+// isWordRune reports whether r is an alphanumeric character, i.e. part of a word.
+// Used to reject a token glued to a preceding word.
+func isWordRune(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r)
+}
+
+// isCommandSeparator reports whether r is whitespace or a punctuation separator
+// that may legitimately follow an invocation token ("/ace: leave", "/ace,leave").
+// Notably '@' and alphanumerics are NOT separators, so a token buried inside an
+// email or a longer word is not treated as a command.
+func isCommandSeparator(r rune) bool {
+	if unicode.IsSpace(r) {
+		return true
+	}
+	return strings.ContainsRune(",:;.-—–", r)
+}
+
+// trimLeadingPunct strips leading whitespace and common separator punctuation
+// (comma, colon, dash, period) that whisper or a typist may place right after
+// the token, e.g. "/ace: leave" or "hey aceteam, ...".
+func trimLeadingPunct(s string) string {
+	return strings.TrimLeft(s, " \t\r\n,:;.-—–")
+}
+
+// trimSurroundingPunct strips separator/terminator punctuation from both ends of
+// a single word so "leave." or "leave," matches the registry key "leave".
+func trimSurroundingPunct(s string) string {
+	return strings.Trim(s, " \t\r\n,.;:!?—–-\"'")
+}

--- a/internal/jobs/meeting_command_test.go
+++ b/internal/jobs/meeting_command_test.go
@@ -1,0 +1,151 @@
+package jobs
+
+import "testing"
+
+func TestParseCommand_LeaveVariants(t *testing.T) {
+	// The one auto-executed command must be recognized across casing,
+	// punctuation, and surrounding words — but only via the literal /ace token.
+	cases := []string{
+		"/ace leave",
+		"/ACE Leave",
+		"  /ace   leave  ",
+		"/ace: leave",
+		"/ace leave.",
+		"okay everyone, /ace leave now please",
+		"/Ace leave the call",
+	}
+	for _, in := range cases {
+		got, ok := ParseCommand(in, SourceTranscript)
+		if !ok {
+			t.Errorf("ParseCommand(%q) not recognized, want leave", in)
+			continue
+		}
+		if got.Kind != CommandLeave {
+			t.Errorf("ParseCommand(%q).Kind = %q, want %q", in, got.Kind, CommandLeave)
+		}
+		if got.Command != "leave" {
+			t.Errorf("ParseCommand(%q).Command = %q, want leave", in, got.Command)
+		}
+		if got.Raw != in {
+			t.Errorf("ParseCommand(%q).Raw = %q, want the original line", in, got.Raw)
+		}
+	}
+}
+
+func TestParseCommand_GenericCapture(t *testing.T) {
+	// A /ace command not in the registry is captured (not executed) with its
+	// arguments preserved as the instruction.
+	got, ok := ParseCommand("/ace summarize the last five minutes", SourceChat)
+	if !ok {
+		t.Fatal("expected generic command to be recognized")
+	}
+	if got.Kind != CommandGeneric {
+		t.Errorf("Kind = %q, want %q", got.Kind, CommandGeneric)
+	}
+	if got.Command != "summarize" {
+		t.Errorf("Command = %q, want summarize", got.Command)
+	}
+	if got.Instruction != "the last five minutes" {
+		t.Errorf("Instruction = %q, want 'the last five minutes'", got.Instruction)
+	}
+	if got.Source != SourceChat {
+		t.Errorf("Source = %q, want %q", got.Source, SourceChat)
+	}
+}
+
+func TestParseCommand_WakePhrase(t *testing.T) {
+	cases := map[string]string{
+		"hey aceteam, summarize that":         "summarize that",
+		"Hey AceTeam summarize that":          "summarize that",
+		"so hey ace team, what did John say?": "what did John say?",
+		"HEY ACETEAM: mute yourself":          "mute yourself",
+	}
+	for in, wantInstr := range cases {
+		got, ok := ParseCommand(in, SourceTranscript)
+		if !ok {
+			t.Errorf("ParseCommand(%q) not recognized, want instruction", in)
+			continue
+		}
+		if got.Kind != CommandInstruction {
+			t.Errorf("ParseCommand(%q).Kind = %q, want %q", in, got.Kind, CommandInstruction)
+		}
+		if got.Instruction != wantInstr {
+			t.Errorf("ParseCommand(%q).Instruction = %q, want %q", in, got.Instruction, wantInstr)
+		}
+	}
+}
+
+func TestParseCommand_SpokenSlashHeuristic(t *testing.T) {
+	// The spoken-command heuristic ("slash ace leave") is best-effort; when it
+	// resolves to a registry command it still classifies correctly.
+	got, ok := ParseCommand("slash ace leave", SourceTranscript)
+	if !ok {
+		t.Fatal("expected spoken slash-ace to be recognized")
+	}
+	if got.Kind != CommandLeave {
+		t.Errorf("Kind = %q, want %q", got.Kind, CommandLeave)
+	}
+}
+
+func TestParseCommand_NonMatches(t *testing.T) {
+	// Ambient speech and near-misses must NOT trigger a command — especially not
+	// the destructive leave. This is the safety property.
+	nonMatches := []string{
+		"",
+		"   ",
+		"does the ace leave early?",
+		"we should ace this presentation",
+		"the interface looks great",
+		"hey team, let's start",       // not the wake phrase
+		"hey aceteam",                 // bare wake phrase, no instruction
+		"hey aceteam,   ",             // wake phrase, empty instruction
+		"/ace",                        // bare token, no command word
+		"/ace   ",                     // token with only whitespace
+		"please leave the meeting",    // 'leave' without the /ace token
+		"my email is a/ace@thing.com", // no space-delimited command word
+	}
+	for _, in := range nonMatches {
+		if got, ok := ParseCommand(in, SourceTranscript); ok {
+			t.Errorf("ParseCommand(%q) = %+v, ok=true; want no match", in, got)
+		}
+	}
+}
+
+func TestParseCommand_HallucinatedPartialSegment(t *testing.T) {
+	// A garbled/partial transcript segment must not falsely match. Only a clean
+	// /ace token or wake phrase counts.
+	partials := []string{
+		"a-ace lea",
+		"...ace lev the ca",
+		"h y acetea",
+	}
+	for _, in := range partials {
+		if _, ok := ParseCommand(in, SourceTranscript); ok {
+			t.Errorf("ParseCommand(%q) matched a partial/hallucinated segment; want no match", in)
+		}
+	}
+}
+
+func TestParseCommand_PickFirst(t *testing.T) {
+	// A line containing more than one invocation resolves to the first (the
+	// literal /ace token, which outranks the wake phrase) — never ambiguous.
+	got, ok := ParseCommand("/ace leave and hey aceteam summarize", SourceTranscript)
+	if !ok {
+		t.Fatal("expected a match")
+	}
+	if got.Kind != CommandLeave {
+		t.Errorf("Kind = %q, want leave (literal token outranks wake phrase)", got.Kind)
+	}
+}
+
+func TestParseCommand_RegistryExtensible(t *testing.T) {
+	// Guard the registry contract: "leave" is the only auto-executed command
+	// today. If this changes, the wiring in meeting_join.go must be reviewed for
+	// what new destructive actions become auto-executable.
+	if len(commandRegistry) != 1 {
+		t.Fatalf("commandRegistry has %d entries; adding auto-executed commands requires reviewing meeting_join.go wiring", len(commandRegistry))
+	}
+	if commandRegistry["leave"] != CommandLeave {
+		t.Errorf("registry[leave] = %q, want %q", commandRegistry["leave"], CommandLeave)
+	}
+}

--- a/internal/jobs/meeting_interactive.go
+++ b/internal/jobs/meeting_interactive.go
@@ -1,0 +1,264 @@
+// internal/jobs/meeting_interactive.go
+//
+// In-call interactive session coordinator (issue #5435, epic #5097). This wires
+// the three additive capabilities — rolling transcription
+// (meeting_transcribe_rolling.go), the `/ace` command monitor
+// (meeting_command.go), and Meet chat capture (meeting_chat.go) — into the
+// during-call poll loop, plus the self-announcement on admittance. It is the
+// interactive replacement for meeting_join.go's plain waitForMeetingEnd, run
+// only when StreamingEnabled; the batch record→transcribe path is untouched.
+//
+// HARD CONSTRAINT (the reason for every guard here): the batch pipeline already
+// works in production. The interactive layer is STRICTLY ADDITIVE and must never
+// crash or stall the recording. Concretely:
+//   - Every DOM/CDP interaction (chat read, announcement, leave click, end
+//     heuristics) is best-effort: an error is logged and the loop continues.
+//   - Rolling transcription runs on its own goroutine wrapped in recover(), so a
+//     panic in whisper/decoding cannot take down the recording.
+//   - Sidecar access from rolling passes and the final batch transcribe is
+//     serialized (h.transcribeMu) so they never hit the whisper sidecar — or
+//     read the growing WAV — concurrently.
+//   - The ONLY auto-executed action is a parsed literal `/ace leave` (see the
+//     safety property in meeting_command.go).
+package jobs
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Fallback streaming cadence/margin when the handler's values are unset (zero).
+// The worker populates the handler from the persisted meeting config (which
+// clamps its own defaults), so these only apply to a hand-constructed handler.
+const (
+	defaultStreamingInterval = 15 * time.Second
+	defaultStreamingWindow   = 10 * time.Second
+)
+
+// meetPage is the browser surface the interactive session drives via page JS:
+// chat read/post, end heuristics, and the leave click. *platform.MeetingBrowser
+// satisfies it; a fake satisfies it in tests. Structurally identical to
+// chatEvaluator; named separately for the wider interactive use.
+type meetPage interface {
+	Evaluate(expression string) (any, error)
+}
+
+// interactiveOutcome is what the interactive session observed across the call:
+// why it ended, the captured chat, how many transcript segments streamed in, and
+// which in-call commands were recognized (leave plus captured/surfaced generics
+// and wake-phrase instructions). It feeds the additive fields of the MEETING_JOIN
+// result.
+type interactiveOutcome struct {
+	endReason        string
+	chat             []MeetChatMessage
+	streamedSegments int
+	recognized       []RecognizedCommand
+}
+
+func (h *MeetingJoinHandler) streamingInterval() time.Duration {
+	if h.StreamingInterval > 0 {
+		return h.StreamingInterval
+	}
+	return defaultStreamingInterval
+}
+
+func (h *MeetingJoinHandler) streamingWindow() time.Duration {
+	if h.StreamingWindow > 0 {
+		return h.StreamingWindow
+	}
+	return defaultStreamingWindow
+}
+
+// announceOnAdmission opens the chat panel and posts the consent/intro
+// announcement (capability 4). Best-effort at every step: a stale chat selector
+// logs and returns without disturbing the recording. Posting is attempted even
+// if opening errored, since the panel may already be open.
+//
+// It ALWAYS records the announcement's normalized text into botMessages —
+// regardless of whether the post succeeded — so the poll loop never scans the
+// bot's OWN echoed announcement for commands. This matters because the
+// announcement literally contains "/ace leave": without this guard, the bot
+// would read its own message back and immediately leave the call. Seeding
+// unconditionally means the guard is in place BEFORE the chat-post selectors are
+// live-tuned to actually work (when the echo first appears).
+func (h *MeetingJoinHandler) announceOnAdmission(ctx JobContext, page meetPage, botMessages map[string]struct{}) {
+	botMessages[normalizeChatText(meetAnnouncementText)] = struct{}{}
+
+	if err := openMeetChat(page); err != nil {
+		ctx.Log("warn", "     - could not open Meet chat to announce (non-fatal, selector may be stale): %v", err)
+	}
+	if err := postMeetChat(page, meetAnnouncementText); err != nil {
+		ctx.Log("warn", "     - could not post self-announcement to chat (non-fatal, selector may be stale): %v", err)
+		return
+	}
+	ctx.Log("info", "     - posted self-announcement to Meet chat")
+}
+
+// waitForMeetingEndInteractive runs the during-call interactive loop until the
+// call ends, an `/ace leave` is recognized, or the hard duration cap trips. It
+// never errors: any interactive failure degrades to the batch behavior (a valid
+// recording still gets transcribed at the end). transcribe is injected (built
+// from h.transcribeSegments in production, a fake in tests). pollInterval is the
+// loop cadence for chat/end/leave checks; the rolling transcriber ticks
+// independently at h.streamingInterval().
+func (h *MeetingJoinHandler) waitForMeetingEndInteractive(
+	ctx JobContext,
+	page meetPage,
+	p meetingJoinParams,
+	transcribe TranscribeFunc,
+	pollInterval time.Duration,
+	botMessages map[string]struct{},
+) interactiveOutcome {
+	segCh := make(chan TranscriptSegment, 64)
+	stop := make(chan struct{})
+	defer close(stop)
+
+	// Rolling transcription on its own goroutine. recover() is load-bearing: a
+	// panic in the injected transcribe (or decoding) must not crash the process
+	// and lose the recording. Emit races the loop's stop via a select so it never
+	// blocks after the loop has moved on.
+	rt := &RollingTranscriber{
+		Interval:   h.streamingInterval(),
+		Window:     h.streamingWindow(),
+		Transcribe: transcribe,
+		Emit: func(s TranscriptSegment) {
+			select {
+			case segCh <- s:
+			case <-stop:
+			}
+		},
+		Log: func(level, msg string) { ctx.Log(level, "%s", msg) },
+	}
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				ctx.Log("warn", "     - rolling transcription goroutine panicked (recovered, recording unaffected): %v", r)
+			}
+		}()
+		rt.Run(stop)
+	}()
+
+	out := interactiveOutcome{endReason: "max_duration_reached"}
+	seenChat := make(map[int]struct{})
+	var leaveRequested bool
+
+	// handleLine parses one transcript/chat line for an invocation and records
+	// it. Only a literal `/ace leave` is auto-executed (below); generic commands
+	// and wake-phrase instructions are captured/surfaced for the agent layer.
+	handleLine := func(line string, source CommandSource) {
+		cmd, ok := ParseCommand(line, source)
+		if !ok {
+			return
+		}
+		ctx.Log("info", "     - recognized in-call command (source=%s kind=%s cmd=%q)", source, cmd.Kind, cmd.Command)
+		out.recognized = append(out.recognized, cmd)
+		if cmd.Kind == CommandLeave {
+			leaveRequested = true
+		}
+	}
+
+	deadline := time.Now().Add(p.maxDuration())
+	for time.Now().Before(deadline) {
+		// 1. Drain newly-stabilized transcript segments (non-blocking).
+		h.drainSegments(segCh, &out, handleLine)
+
+		// 2. Read chat; feed new lines (dedup by append-only index).
+		if msgs, err := readMeetChat(page); err != nil {
+			ctx.Log("warn", "     - chat read failed (non-fatal, selector may be stale): %v", err)
+		} else {
+			for _, m := range msgs {
+				if _, seen := seenChat[m.Index]; seen {
+					continue
+				}
+				seenChat[m.Index] = struct{}{}
+				out.chat = append(out.chat, m)
+				// Never scan the bot's OWN echoed messages for commands (the
+				// announcement contains "/ace leave"). Still captured above for the
+				// audit trail; just not fed to the command monitor.
+				if _, own := botMessages[normalizeChatText(m.Text)]; own {
+					continue
+				}
+				handleLine(m.Line(), SourceChat)
+			}
+		}
+
+		// 3. Act on a recognized /ace leave (the only auto-executed command).
+		if leaveRequested {
+			ctx.Log("info", "     - /ace leave recognized; leaving the call gracefully")
+			if _, err := page.Evaluate(meetLeaveCallJS); err != nil {
+				ctx.Log("warn", "     - graceful leave click errored (non-fatal, teardown closes the browser): %v", err)
+			}
+			out.endReason = "ace_command_leave"
+			return out
+		}
+
+		// 4. Existing end heuristics (call ended / bot alone).
+		if reason, ended := checkMeetingEnded(page); ended {
+			out.endReason = reason
+			return out
+		}
+
+		time.Sleep(pollInterval)
+	}
+	ctx.Log("info", "     - max meeting duration (%s) reached; leaving", p.maxDuration())
+	return out
+}
+
+// drainSegments pulls all currently-buffered transcript segments without
+// blocking, updating the outcome's streamed count and feeding each to
+// handleLine. Extracted so the non-blocking drain is readable and reusable.
+func (h *MeetingJoinHandler) drainSegments(segCh <-chan TranscriptSegment, out *interactiveOutcome, handleLine func(string, CommandSource)) {
+	for {
+		select {
+		case s := <-segCh:
+			out.streamedSegments++
+			handleLine(s.Text, SourceTranscript)
+		default:
+			return
+		}
+	}
+}
+
+// checkMeetingEnded runs the two shared end heuristics: the "you left / call
+// ended" text scan and the bot-alone participant-count signal. Both are
+// best-guess (see meeting_join.go's LIVE-TUNING block); a read error is treated
+// as "not ended" so a transient DOM glitch never ends the call early. Shared by
+// the plain and interactive wait loops.
+func checkMeetingEnded(page meetPage) (string, bool) {
+	if v, err := page.Evaluate(meetIsEndedJS); err == nil {
+		if b, ok := v.(bool); ok && b {
+			return "call_ended", true
+		}
+	}
+	if v, err := page.Evaluate(meetParticipantCountJS); err == nil {
+		if n, ok := toInt(v); ok && n >= 0 && n <= 1 {
+			return "alone_in_call", true
+		}
+	}
+	return "", false
+}
+
+// transcribeSegments re-transcribes the growing recording and returns its
+// segments, for one rolling pass. It serializes sidecar access via
+// h.transcribeMu so a rolling pass never overlaps the final batch transcribe (or
+// another pass) — they would otherwise hit the whisper sidecar and read the
+// in-progress WAV concurrently. An error is returned (not fatal) so the rolling
+// driver logs and retries on the next tick.
+func (h *MeetingJoinHandler) transcribeSegments(ctx JobContext, meetingID, wavPath string) ([]TranscriptSegment, error) {
+	h.transcribeMu.Lock()
+	defer h.transcribeMu.Unlock()
+
+	synthetic := syntheticTranscribeJob(meetingID+"-rolling", wavPath)
+	raw, err := h.transcriber.Execute(ctx, synthetic)
+	if err != nil {
+		return nil, err
+	}
+	var decoded struct {
+		Segments []TranscriptSegment `json:"segments"`
+	}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return nil, fmt.Errorf("decode rolling transcript segments: %w", err)
+	}
+	return decoded.Segments, nil
+}

--- a/internal/jobs/meeting_interactive_test.go
+++ b/internal/jobs/meeting_interactive_test.go
@@ -1,0 +1,273 @@
+package jobs
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeMeetPage is a scripted meetPage for the interactive loop. It serves chat
+// reads from a queue (advancing one entry per read, then repeating the last),
+// answers the end heuristics from flags, and records whether the leave click ran.
+type fakeMeetPage struct {
+	mu sync.Mutex
+
+	chatReads   []string // JSON strings returned by successive chat reads
+	chatIdx     int
+	ended       bool // meetIsEndedJS result
+	participant any  // meetParticipantCountJS result (nil -> -1)
+
+	openErr  error
+	postErr  error
+	leaveHit bool
+	posted   []string
+}
+
+func (f *fakeMeetPage) Evaluate(expression string) (any, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	switch {
+	case expression == meetLeaveCallJS:
+		f.leaveHit = true
+		return true, nil
+	case expression == meetIsEndedJS:
+		return f.ended, nil
+	case expression == meetParticipantCountJS:
+		if f.participant == nil {
+			return float64(-1), nil
+		}
+		return f.participant, nil
+	case strings.Contains(expression, "JSON.stringify"): // chat read
+		var v string
+		if f.chatIdx < len(f.chatReads) {
+			v = f.chatReads[f.chatIdx]
+			f.chatIdx++
+		} else if len(f.chatReads) > 0 {
+			v = f.chatReads[len(f.chatReads)-1]
+		} else {
+			v = "[]"
+		}
+		return v, nil
+	case strings.Contains(expression, "chat input not found"): // post
+		f.posted = append(f.posted, expression)
+		return true, f.postErr
+	default: // open chat
+		return true, f.openErr
+	}
+}
+
+func newTestInteractiveHandler() *MeetingJoinHandler {
+	h := NewMeetingJoinHandler("/ws")
+	h.StreamingEnabled = true
+	h.StreamingInterval = time.Millisecond // fast rolling ticks
+	// A small positive window is honored (0 would fall back to the default). The
+	// stability margin always withholds the churning tail segment, so tests that
+	// exercise a streamed command supply a trailing segment past the margin.
+	h.StreamingWindow = time.Second
+	return h
+}
+
+func testParams() meetingJoinParams {
+	return meetingJoinParams{MeetingURL: "https://meet.google.com/x", MeetingID: "m1", MaxDurationSeconds: 3600}
+}
+
+func TestInteractive_LeaveViaChat(t *testing.T) {
+	h := newTestInteractiveHandler()
+	page := &fakeMeetPage{chatReads: []string{`[{"index":0,"sender":"Bob","text":"/ace leave"}]`}}
+	noSegments := func() ([]TranscriptSegment, error) { return nil, nil }
+
+	out := h.waitForMeetingEndInteractive(JobContext{}, page, testParams(), noSegments, time.Millisecond, map[string]struct{}{})
+
+	if out.endReason != "ace_command_leave" {
+		t.Errorf("endReason = %q, want ace_command_leave", out.endReason)
+	}
+	if !page.leaveHit {
+		t.Error("expected the graceful leave click to have run")
+	}
+	if len(out.chat) != 1 || out.chat[0].Text != "/ace leave" {
+		t.Errorf("captured chat = %+v, want the leave line", out.chat)
+	}
+	if len(out.recognized) != 1 || out.recognized[0].Kind != CommandLeave {
+		t.Errorf("recognized = %+v, want one leave command", out.recognized)
+	}
+}
+
+func TestInteractive_LeaveViaSpokenTranscript(t *testing.T) {
+	h := newTestInteractiveHandler()
+	page := &fakeMeetPage{} // empty chat, never ends on its own
+	// The rolling transcriber surfaces the command segment plus a later trailing
+	// segment, so the command is past the stability margin (the tail is withheld).
+	transcribe := func() ([]TranscriptSegment, error) {
+		return []TranscriptSegment{
+			{Start: 0, End: 2, Text: "okay, /ace leave everyone"},
+			{Start: 2, End: 20, Text: "bye now"},
+		}, nil
+	}
+
+	out := h.waitForMeetingEndInteractive(JobContext{}, page, testParams(), transcribe, time.Millisecond, map[string]struct{}{})
+
+	if out.endReason != "ace_command_leave" {
+		t.Errorf("endReason = %q, want ace_command_leave", out.endReason)
+	}
+	if out.streamedSegments == 0 {
+		t.Error("expected at least one streamed segment to have been processed")
+	}
+}
+
+func TestInteractive_EndsWhenCallEnds(t *testing.T) {
+	h := newTestInteractiveHandler()
+	page := &fakeMeetPage{ended: true}
+	noSegments := func() ([]TranscriptSegment, error) { return nil, nil }
+
+	out := h.waitForMeetingEndInteractive(JobContext{}, page, testParams(), noSegments, time.Millisecond, map[string]struct{}{})
+	if out.endReason != "call_ended" {
+		t.Errorf("endReason = %q, want call_ended", out.endReason)
+	}
+	if page.leaveHit {
+		t.Error("leave click must not run when the call ends on its own")
+	}
+}
+
+func TestInteractive_AloneInCall(t *testing.T) {
+	h := newTestInteractiveHandler()
+	page := &fakeMeetPage{participant: float64(1)}
+	noSegments := func() ([]TranscriptSegment, error) { return nil, nil }
+
+	out := h.waitForMeetingEndInteractive(JobContext{}, page, testParams(), noSegments, time.Millisecond, map[string]struct{}{})
+	if out.endReason != "alone_in_call" {
+		t.Errorf("endReason = %q, want alone_in_call", out.endReason)
+	}
+}
+
+func TestInteractive_CapturesGenericCommandsWithoutLeaving(t *testing.T) {
+	h := newTestInteractiveHandler()
+	// First read surfaces a generic command; the call then ends so the loop
+	// terminates without an /ace leave.
+	page := &fakeMeetPage{
+		chatReads: []string{
+			`[{"index":0,"sender":"Ann","text":"/ace summarize so far"}]`,
+			`[{"index":0,"sender":"Ann","text":"/ace summarize so far"}]`,
+		},
+	}
+	// End the call on the second poll.
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		page.mu.Lock()
+		page.ended = true
+		page.mu.Unlock()
+	}()
+	noSegments := func() ([]TranscriptSegment, error) { return nil, nil }
+
+	out := h.waitForMeetingEndInteractive(JobContext{}, page, testParams(), noSegments, time.Millisecond, map[string]struct{}{})
+
+	if page.leaveHit {
+		t.Error("a generic (non-leave) command must NOT trigger a leave")
+	}
+	if len(out.recognized) == 0 || out.recognized[0].Kind != CommandGeneric {
+		t.Errorf("recognized = %+v, want a captured generic command", out.recognized)
+	}
+	if out.endReason != "call_ended" {
+		t.Errorf("endReason = %q, want call_ended", out.endReason)
+	}
+}
+
+func TestInteractive_ChatDedupByIndex(t *testing.T) {
+	h := newTestInteractiveHandler()
+	// The same message is returned on every read; it must be captured once.
+	page := &fakeMeetPage{chatReads: []string{`[{"index":0,"sender":"Ann","text":"hello"}]`}}
+	go func() {
+		time.Sleep(15 * time.Millisecond)
+		page.mu.Lock()
+		page.ended = true
+		page.mu.Unlock()
+	}()
+	noSegments := func() ([]TranscriptSegment, error) { return nil, nil }
+
+	out := h.waitForMeetingEndInteractive(JobContext{}, page, testParams(), noSegments, time.Millisecond, map[string]struct{}{})
+	if len(out.chat) != 1 {
+		t.Errorf("captured chat = %d messages, want 1 (deduped by index across polls)", len(out.chat))
+	}
+}
+
+func TestInteractive_TranscribeErrorIsNonFatal(t *testing.T) {
+	h := newTestInteractiveHandler()
+	page := &fakeMeetPage{ended: true}
+	panicky := func() ([]TranscriptSegment, error) {
+		panic("whisper exploded")
+	}
+	// A panic in the rolling pass is recovered on its goroutine; the loop still
+	// ends the call normally.
+	out := h.waitForMeetingEndInteractive(JobContext{}, page, testParams(), panicky, time.Millisecond, map[string]struct{}{})
+	if out.endReason != "call_ended" {
+		t.Errorf("endReason = %q, want call_ended despite a panicking transcriber", out.endReason)
+	}
+}
+
+func TestAnnounceOnAdmission_PostsAnnouncement(t *testing.T) {
+	h := newTestInteractiveHandler()
+	page := &fakeMeetPage{}
+	h.announceOnAdmission(JobContext{}, page, map[string]struct{}{})
+	if len(page.posted) != 1 {
+		t.Fatalf("expected exactly one chat post (the announcement), got %d", len(page.posted))
+	}
+	// The announcement text must be embedded (json-escaped) in the send JS.
+	if !strings.Contains(page.posted[0], "recording this call") {
+		t.Errorf("posted JS did not carry the announcement text; got: %s", page.posted[0])
+	}
+}
+
+func TestAnnounceOnAdmission_SeedsOwnMessageGuard(t *testing.T) {
+	h := newTestInteractiveHandler()
+	botMessages := map[string]struct{}{}
+	// Even when posting throws (unverified selectors), the guard must be seeded so
+	// echo-suppression is in place BEFORE the post selectors are live-tuned.
+	page := &fakeMeetPage{postErr: errors.New("no chat input yet")}
+	h.announceOnAdmission(JobContext{}, page, botMessages)
+	if _, ok := botMessages[normalizeChatText(meetAnnouncementText)]; !ok {
+		t.Error("announceOnAdmission must seed the announcement into botMessages even when the post fails")
+	}
+}
+
+// TestInteractive_DoesNotSelfTriggerOnAnnouncementEcho is the regression guard
+// for the self-echo landmine: the bot posts an announcement that literally
+// contains "/ace leave", and Meet renders the bot's own message back in the chat
+// panel. If the loop scanned it, the bot would leave itself within one poll. The
+// own-message guard must suppress command parsing for that echoed line while
+// still capturing it for the audit trail.
+func TestInteractive_DoesNotSelfTriggerOnAnnouncementEcho(t *testing.T) {
+	h := newTestInteractiveHandler()
+
+	// The chat read echoes back the bot's own announcement (as Meet does), then
+	// the call ends so the loop terminates on its own.
+	textJSON, _ := json.Marshal(meetAnnouncementText)
+	echo := `[{"index":0,"sender":"You","text":` + string(textJSON) + `}]`
+	page := &fakeMeetPage{chatReads: []string{echo}}
+	go func() {
+		time.Sleep(15 * time.Millisecond)
+		page.mu.Lock()
+		page.ended = true
+		page.mu.Unlock()
+	}()
+
+	botMessages := map[string]struct{}{normalizeChatText(meetAnnouncementText): {}}
+	noSegments := func() ([]TranscriptSegment, error) { return nil, nil }
+
+	out := h.waitForMeetingEndInteractive(JobContext{}, page, testParams(), noSegments, time.Millisecond, botMessages)
+
+	if out.endReason == "ace_command_leave" {
+		t.Fatal("bot self-triggered a leave from its own announcement echo")
+	}
+	if page.leaveHit {
+		t.Error("leave click must not run from the bot's own announcement echo")
+	}
+	if len(out.recognized) != 0 {
+		t.Errorf("no command should be recognized from the bot's own echo; got %+v", out.recognized)
+	}
+	// The echoed message is still captured for the audit trail.
+	if len(out.chat) != 1 {
+		t.Errorf("captured chat = %d, want 1 (own echo still captured for audit)", len(out.chat))
+	}
+}

--- a/internal/jobs/meeting_join.go
+++ b/internal/jobs/meeting_join.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
@@ -123,6 +124,17 @@ const (
 	meetAccountChipPresentJS = `(function(){` +
 		`return !!document.querySelector('[aria-label*="Google Account" i],a[aria-label*="account" i] img,header img[alt*="account" i]');` +
 		`})()`
+	// meetLeaveCallJS clicks the in-call "Leave call" button so the bot exits the
+	// meeting gracefully in response to an `/ace leave` command (issue #5435). It
+	// reuses the SAME "Leave call" aria-label selector as meetIsAdmittedJS, which
+	// is CONFIRMED live 2026-07-11 (host auto-admit path) — so this is the LEAST
+	// uncertain interactive selector. Returns true if a button was clicked, false
+	// if none matched (best-effort: the browser Close() teardown is the backstop,
+	// so a missed click only means a slightly less graceful exit, never a stuck
+	// bot). Intentionally does NOT throw on no-match, unlike platform.clickJS.
+	meetLeaveCallJS = `(function(){` +
+		`var b=document.querySelector('button[aria-label*="Leave call" i],button[aria-label*="Leave" i][data-tooltip*="Leave" i]');` +
+		`if(!b)return false;b.click();return true;})()`
 )
 
 // ErrMeetingBotSignedOut is a sentinel wrapped into the runJoinFlow error when
@@ -269,6 +281,27 @@ type MeetingJoinHandler struct {
 	// startup config can pin it explicitly, e.g. to a dedicated data volume.
 	ProfileDir  string
 	transcriber *TranscribeAudioHandler
+
+	// StreamingEnabled turns on the DURING-call interactive layer (issue #5435):
+	// rolling transcription, the in-call `/ace` command monitor, chat capture,
+	// and the self-announcement. Default false (zero value) so the plain
+	// NewMeetingJoinHandler constructor and the existing batch pipeline are
+	// unchanged; the worker sets it from the persisted meeting config
+	// (config.Meeting.StreamingEnabled, default-on). The whole interactive layer
+	// degrades gracefully (log + continue), so a stale live selector can never
+	// regress the batch record→transcribe path.
+	StreamingEnabled bool
+	// StreamingInterval / StreamingWindow are the rolling-transcription cadence
+	// and trailing stability margin (see meeting_transcribe_rolling.go). Zero
+	// values fall back to the package defaults at use.
+	StreamingInterval time.Duration
+	StreamingWindow   time.Duration
+
+	// transcribeMu serializes whisper-sidecar access so a during-call rolling
+	// pass (meeting_interactive.go) never overlaps the end-of-call batch
+	// transcribe — they would otherwise hit the sidecar and read the growing WAV
+	// concurrently.
+	transcribeMu sync.Mutex
 }
 
 // NewMeetingJoinHandler constructs a handler rooted at the node workspace.
@@ -326,8 +359,13 @@ func (h *MeetingJoinHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, er
 	}
 	ctx.Log("info", "     - [Job %s] recording meeting to %s", job.ID, wavPath)
 
-	// Stay in the call until it ends or the hard cap trips.
-	endStatus := h.waitForMeetingEnd(ctx, br, p)
+	// Stay in the call until it ends or the hard cap trips. When the interactive
+	// layer is enabled (issue #5435) this additionally announces the bot, runs
+	// rolling transcription + the in-call `/ace` command monitor, and captures
+	// Meet chat — all best-effort, so a stale live selector degrades to the batch
+	// behavior rather than regressing the recording. Otherwise the plain
+	// record-until-end loop runs exactly as the shipped batch notetaker.
+	outcome := h.runMeetingLoop(ctx, br, p, wavPath)
 
 	// Finalize the recording (also unloads the sink; the deferred Stop is then a
 	// harmless no-op). Take the path from Stop so we transcribe exactly what was
@@ -340,30 +378,63 @@ func (h *MeetingJoinHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, er
 		recordedPath = wavPath
 	}
 
-	// Transcribe node-locally by reusing the transcribe handler in-process.
+	// Transcribe node-locally by reusing the transcribe handler in-process. This
+	// end-of-call batch pass remains the SOURCE OF TRUTH for the stored
+	// transcript; rolling transcription during the call was additive.
 	transcript, tErr := h.transcribe(ctx, job, recordedPath)
 	if tErr != nil {
 		// Return a structured partial result rather than failing outright: the
 		// recording succeeded and is on disk; transcription can be retried.
 		out, _ := json.Marshal(map[string]any{
-			"status":         "recorded_transcription_failed",
-			"meeting_id":     p.MeetingID,
-			"audio_path":     recordedPath,
-			"end_reason":     endStatus,
-			"transcript":     nil,
-			"transcript_err": tErr.Error(),
+			"status":              "recorded_transcription_failed",
+			"meeting_id":          p.MeetingID,
+			"audio_path":          recordedPath,
+			"end_reason":          outcome.endReason,
+			"transcript":          nil,
+			"transcript_err":      tErr.Error(),
+			"chat":                chatForResult(outcome.chat),
+			"recognized_commands": commandsForResult(outcome.recognized),
+			"streamed_segments":   outcome.streamedSegments,
 		})
 		return out, nil
 	}
 
 	out, _ := json.Marshal(map[string]any{
-		"status":     "completed",
-		"meeting_id": p.MeetingID,
-		"audio_path": recordedPath,
-		"end_reason": endStatus,
-		"transcript": json.RawMessage(transcript),
+		"status":              "completed",
+		"meeting_id":          p.MeetingID,
+		"audio_path":          recordedPath,
+		"end_reason":          outcome.endReason,
+		"transcript":          json.RawMessage(transcript),
+		"chat":                chatForResult(outcome.chat),
+		"recognized_commands": commandsForResult(outcome.recognized),
+		"streamed_segments":   outcome.streamedSegments,
 	})
 	return out, nil
+}
+
+// runMeetingLoop chooses the interactive during-call loop (issue #5435) when
+// streaming is enabled, else the plain record-until-end loop. In both cases it
+// returns an interactiveOutcome; the plain path fills only endReason so the
+// result shape is uniform (chat/recognized_commands come back empty). Splitting
+// here keeps Execute's happy path readable and the streaming gate in one place.
+func (h *MeetingJoinHandler) runMeetingLoop(ctx JobContext, br *platform.MeetingBrowser, p meetingJoinParams, wavPath string) interactiveOutcome {
+	if !h.StreamingEnabled {
+		return interactiveOutcome{endReason: h.waitForMeetingEnd(ctx, br, p)}
+	}
+
+	// botMessages tracks the normalized text of messages the bot itself posts, so
+	// the poll loop never scans its own echoed chat for commands (the
+	// announcement contains "/ace leave"). Seeded by announceOnAdmission.
+	botMessages := make(map[string]struct{})
+
+	// Capability 4: announce on admittance (best-effort, never fatal).
+	h.announceOnAdmission(ctx, br, botMessages)
+
+	// Build the production rolling-transcription pass over the growing wav.
+	transcribe := func() ([]TranscriptSegment, error) {
+		return h.transcribeSegments(ctx, p.MeetingID, wavPath)
+	}
+	return h.waitForMeetingEndInteractive(ctx, br, p, transcribe, meetingPollInterval, botMessages)
 }
 
 // runJoinFlow drives the Google Meet pre-join sequence (partially verified —
@@ -491,16 +562,8 @@ func (h *MeetingJoinHandler) waitUntilAdmitted(ctx JobContext, br *platform.Meet
 func (h *MeetingJoinHandler) waitForMeetingEnd(ctx JobContext, br *platform.MeetingBrowser, p meetingJoinParams) string {
 	deadline := time.Now().Add(p.maxDuration())
 	for time.Now().Before(deadline) {
-		if v, err := br.Evaluate(meetIsEndedJS); err == nil {
-			if b, ok := v.(bool); ok && b {
-				return "call_ended"
-			}
-		}
-		// Secondary signal: everyone else left and the bot is alone.
-		if v, err := br.Evaluate(meetParticipantCountJS); err == nil {
-			if n, ok := toInt(v); ok && n >= 0 && n <= 1 {
-				return "alone_in_call"
-			}
+		if reason, ended := checkMeetingEnded(br); ended {
+			return reason
 		}
 		time.Sleep(meetingPollInterval)
 	}
@@ -508,17 +571,44 @@ func (h *MeetingJoinHandler) waitForMeetingEnd(ctx JobContext, br *platform.Meet
 	return "max_duration_reached"
 }
 
-// transcribe reuses the TRANSCRIBE_AUDIO handler in-process by handing it a
-// synthetic job whose audio_path points at the recording under the workspace.
-func (h *MeetingJoinHandler) transcribe(ctx JobContext, job *nexus.Job, wavPath string) ([]byte, error) {
-	synthetic := &nexus.Job{
-		ID:   job.ID + "-transcribe",
+// syntheticTranscribeJob builds the in-process TRANSCRIBE_AUDIO job used to reuse
+// the transcribe handler for both the end-of-call batch pass and each rolling
+// pass, keyed by a caller-supplied id so the two are distinguishable in logs.
+func syntheticTranscribeJob(id, wavPath string) *nexus.Job {
+	return &nexus.Job{
+		ID:   id,
 		Type: JobTypeTranscribeAudioType,
 		Payload: map[string]string{
 			"audio_path": wavPath,
 		},
 	}
-	return h.transcriber.Execute(ctx, synthetic)
+}
+
+// transcribe reuses the TRANSCRIBE_AUDIO handler in-process for the end-of-call
+// batch pass (the stored transcript's source of truth). It serializes on
+// transcribeMu with any in-flight rolling pass so the two never hit the whisper
+// sidecar or read the recording concurrently.
+func (h *MeetingJoinHandler) transcribe(ctx JobContext, job *nexus.Job, wavPath string) ([]byte, error) {
+	h.transcribeMu.Lock()
+	defer h.transcribeMu.Unlock()
+	return h.transcriber.Execute(ctx, syntheticTranscribeJob(job.ID+"-transcribe", wavPath))
+}
+
+// chatForResult and commandsForResult normalize nil slices to empty arrays so
+// the additive MEETING_JOIN result fields serialize as [] rather than null,
+// keeping the schema stable for consumers whether or not streaming ran.
+func chatForResult(msgs []MeetChatMessage) []MeetChatMessage {
+	if msgs == nil {
+		return []MeetChatMessage{}
+	}
+	return msgs
+}
+
+func commandsForResult(cmds []RecognizedCommand) []RecognizedCommand {
+	if cmds == nil {
+		return []RecognizedCommand{}
+	}
+	return cmds
 }
 
 // JobTypeTranscribeAudioType is the wire type string for the transcription job,

--- a/internal/jobs/meeting_transcribe_rolling.go
+++ b/internal/jobs/meeting_transcribe_rolling.go
@@ -1,0 +1,192 @@
+// internal/jobs/meeting_transcribe_rolling.go
+//
+// Rolling (streaming) transcription driver (issue #5435, epic #5097). The
+// shipped notetaker transcribes the recording ONCE at end-of-call. This driver
+// adds an additive DURING-call pass: on a fixed cadence it re-transcribes the
+// growing recording and emits newly-stabilized transcript segments through a
+// callback, so the in-call command monitor (meeting_command.go) can react to
+// spoken `/ace` commands live. The end-of-call batch pass remains the source of
+// truth for the stored transcript; this is purely additive.
+//
+// DESIGN — why re-transcribe the whole wav-so-far (v1):
+//   - The whisper sidecar transcribes a whole file (no offset/streaming API), and
+//     this PR deliberately does not modify that separate Python service. So each
+//     pass re-transcribes the recording as it stands. This is correct but its
+//     cost grows with call length — late in a long call each pass is slower, so
+//     streaming cadence degrades. That is the honest v1 tradeoff; a windowed /
+//     offset-based transcription (extract only the trailing unfinished audio) is
+//     the named follow-up. The task explicitly endorsed "chunked faster-whisper
+//     over the wav-so-far", which this is.
+//
+// DESIGN — stability margin (why we hold back the tail):
+//   - Whole-file re-transcription REVISES the most recent audio: a segment's text
+//     and even its start time shift as more context arrives. Emitting the raw
+//     tail would surface — and potentially act on — partial or hallucinated
+//     text the next pass rewrites. So a segment is only emitted once its end is
+//     older than (latest segment end - window). Dedup keys on a coarse
+//     start-time bucket so a revised-then-stabilized segment is emitted exactly
+//     once.
+//
+// The driver is pure of whisper/browser specifics: it calls an injected
+// transcribeFn returning the CURRENT best full segment list, so it is fully
+// unit-testable with a fake (no real whisper in tests).
+package jobs
+
+import (
+	"fmt"
+	"time"
+)
+
+// TranscriptSegment is one whisper segment: a [Start,End] time span (seconds
+// from the recording start) carrying transcribed text and an optional speaker
+// label. Mirrors the sidecar's per-segment JSON shape (see
+// transcribe_audio.go's response doc) so a production transcribeFn can decode
+// straight into it.
+type TranscriptSegment struct {
+	Start   float64 `json:"start"`
+	End     float64 `json:"end"`
+	Text    string  `json:"text"`
+	Speaker string  `json:"speaker,omitempty"`
+}
+
+// TranscribeFunc returns the current best full list of segments for the growing
+// recording. Implementations re-transcribe the wav-so-far; tests inject a fake
+// that returns scripted, growing lists. An error means "this pass failed" — the
+// driver logs and continues (a transient whisper hiccup must never crash the
+// recording), so a TranscribeFunc should return its own error rather than
+// panicking.
+type TranscribeFunc func() ([]TranscriptSegment, error)
+
+// SegmentEmitFunc receives each newly-stabilized segment exactly once, in
+// increasing start-time order. It runs on the driver's goroutine; keep it fast
+// and non-blocking (the production wiring just hands the segment to the
+// single-threaded command monitor via a channel).
+type SegmentEmitFunc func(TranscriptSegment)
+
+// rollingBucketSeconds is the width of the start-time bucket used to dedup
+// segments across re-transcription passes. Whisper start times drift by a
+// fraction of a second between passes as context grows; a 1s bucket absorbs that
+// jitter without collapsing genuinely distinct adjacent segments (whisper
+// segments are multi-second).
+const rollingBucketSeconds = 1.0
+
+// RollingTranscriber drives repeated transcription passes and emits stabilized
+// segments. It is single-goroutine by construction (Run owns all state), so it
+// needs no locking; the caller communicates results out via the emit callback.
+type RollingTranscriber struct {
+	// Interval is the pass cadence. Must be positive.
+	Interval time.Duration
+	// Window is the trailing "not yet stable" margin. A segment is withheld
+	// until its end is older than (latest end - Window). Must be non-negative.
+	Window time.Duration
+	// Transcribe is the injected pass function (real whisper or a test fake).
+	Transcribe TranscribeFunc
+	// Emit receives each stabilized segment once. Required.
+	Emit SegmentEmitFunc
+	// Log is an optional structured logger for pass errors; nil discards.
+	Log func(level, msg string)
+
+	// emittedBuckets records which start-time buckets have already been emitted
+	// so a segment revised across passes is surfaced exactly once.
+	emittedBuckets map[int64]struct{}
+}
+
+// logf logs via the optional Log hook, swallowing output when unset.
+func (r *RollingTranscriber) logf(level, format string, args ...any) {
+	if r.Log != nil {
+		r.Log(level, fmt.Sprintf(format, args...))
+	}
+}
+
+// Run drives passes on Interval until stop is closed, then performs ONE final
+// pass so any segments that stabilized between the last tick and the stop are
+// still emitted. It is blocking and meant to run on its own goroutine. Passes
+// run SERIALLY (a ticker coalesces if a pass overruns), so two whole-file
+// transcriptions never overlap. Run never returns an error: a failed pass is
+// logged and skipped, because the recording (the actual deliverable) must
+// survive any streaming-layer failure. Note: Run itself does not recover() —
+// the production caller wraps the goroutine in a recover (see meeting_join.go)
+// so a panic in an injected TranscribeFunc cannot crash the recording.
+func (r *RollingTranscriber) Run(stop <-chan struct{}) {
+	if r.emittedBuckets == nil {
+		r.emittedBuckets = make(map[int64]struct{})
+	}
+	if r.Interval <= 0 {
+		r.logf("warn", "     - rolling transcriber: non-positive interval %v; streaming disabled", r.Interval)
+		return
+	}
+	if r.Transcribe == nil || r.Emit == nil {
+		r.logf("warn", "     - rolling transcriber: missing Transcribe or Emit; streaming disabled")
+		return
+	}
+
+	ticker := time.NewTicker(r.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-stop:
+			// Final pass to catch segments stabilized after the last tick.
+			r.runPass()
+			return
+		case <-ticker.C:
+			r.runPass()
+		}
+	}
+}
+
+// runPass performs a single transcription pass and emits any segments that have
+// newly stabilized (end older than the tail margin, not previously emitted).
+func (r *RollingTranscriber) runPass() {
+	segments, err := r.Transcribe()
+	if err != nil {
+		r.logf("warn", "     - rolling transcription pass failed (non-fatal, will retry): %v", err)
+		return
+	}
+	for _, seg := range stabilizedSegments(segments, r.Window, r.emittedBuckets) {
+		r.Emit(seg)
+	}
+}
+
+// stabilizedSegments returns, in start order, the segments that are (a) older
+// than the trailing stability margin and (b) not already emitted (tracked by
+// coarse start-time bucket in emitted, which this function MUTATES to record the
+// newly-emitted buckets). Extracted as a pure function so the emit/dedup/margin
+// logic is unit-testable independent of timers and goroutines.
+func stabilizedSegments(segments []TranscriptSegment, window time.Duration, emitted map[int64]struct{}) []TranscriptSegment {
+	if len(segments) == 0 {
+		return nil
+	}
+	// The tail is the latest segment end across the current pass; everything
+	// within `window` of it is still churning and withheld.
+	var tail float64
+	for _, s := range segments {
+		if s.End > tail {
+			tail = s.End
+		}
+	}
+	cutoff := tail - window.Seconds()
+
+	var out []TranscriptSegment
+	for _, s := range segments {
+		// Withhold the churning tail: a segment is stable only once its end is
+		// at/under the cutoff. A window of 0 makes every segment stable at once.
+		if s.End > cutoff {
+			continue
+		}
+		bucket := startBucket(s.Start)
+		if _, seen := emitted[bucket]; seen {
+			continue
+		}
+		emitted[bucket] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
+// startBucket maps a segment start time (seconds) to a coarse integer bucket for
+// cross-pass dedup, absorbing the sub-second start-time drift whole-file
+// re-transcription introduces.
+func startBucket(start float64) int64 {
+	return int64(start / rollingBucketSeconds)
+}

--- a/internal/jobs/meeting_transcribe_rolling_test.go
+++ b/internal/jobs/meeting_transcribe_rolling_test.go
@@ -1,0 +1,217 @@
+package jobs
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+)
+
+// seg is a terse constructor for test segments.
+func seg(start, end float64, text string) TranscriptSegment {
+	return TranscriptSegment{Start: start, End: end, Text: text}
+}
+
+func startsOf(segs []TranscriptSegment) []float64 {
+	out := make([]float64, len(segs))
+	for i, s := range segs {
+		out[i] = s.Start
+	}
+	return out
+}
+
+func TestStabilizedSegments_WindowHoldsBackTail(t *testing.T) {
+	// Latest end is 30s; with a 10s window, everything ending after 20s is the
+	// churning tail and must be withheld.
+	segs := []TranscriptSegment{
+		seg(0, 5, "a"),
+		seg(5, 12, "b"),
+		seg(12, 22, "c"), // ends at 22 > cutoff 20 -> withheld
+		seg(22, 30, "d"), // tail -> withheld
+	}
+	emitted := map[int64]struct{}{}
+	got := stabilizedSegments(segs, 10*time.Second, emitted)
+	if want := []float64{0, 5}; !reflect.DeepEqual(startsOf(got), want) {
+		t.Errorf("stabilized starts = %v, want %v", startsOf(got), want)
+	}
+}
+
+func TestStabilizedSegments_ZeroWindowEmitsAll(t *testing.T) {
+	segs := []TranscriptSegment{seg(0, 5, "a"), seg(5, 10, "b")}
+	emitted := map[int64]struct{}{}
+	got := stabilizedSegments(segs, 0, emitted)
+	if len(got) != 2 {
+		t.Errorf("zero window should emit all; got %d", len(got))
+	}
+}
+
+func TestStabilizedSegments_Empty(t *testing.T) {
+	if got := stabilizedSegments(nil, 0, map[int64]struct{}{}); got != nil {
+		t.Errorf("empty input should yield nil, got %v", got)
+	}
+}
+
+func TestStabilizedSegments_MonotonicGrowthNoDoubleEmit(t *testing.T) {
+	emitted := map[int64]struct{}{}
+	window := 10 * time.Second
+
+	// Pass 1: recording up to 20s. Cutoff = 10s. Emit segments ending <= 10.
+	p1 := []TranscriptSegment{seg(0, 5, "a"), seg(5, 10, "b"), seg(10, 20, "c")}
+	got1 := stabilizedSegments(p1, window, emitted)
+	if want := []float64{0, 5}; !reflect.DeepEqual(startsOf(got1), want) {
+		t.Fatalf("pass1 starts = %v, want %v", startsOf(got1), want)
+	}
+
+	// Pass 2: recording grew to 40s; earlier segments unchanged, "c" now stable.
+	p2 := []TranscriptSegment{seg(0, 5, "a"), seg(5, 10, "b"), seg(10, 20, "c"), seg(20, 32, "d"), seg(32, 40, "e")}
+	got2 := stabilizedSegments(p2, window, emitted)
+	// Cutoff = 30s: a,b already emitted; c (end 20) and d (end 32? >30 withheld).
+	// So only "c" (start 10) is newly stable.
+	if want := []float64{10}; !reflect.DeepEqual(startsOf(got2), want) {
+		t.Fatalf("pass2 starts = %v, want %v (no re-emit of a/b, c newly stable)", startsOf(got2), want)
+	}
+}
+
+func TestStabilizedSegments_RevisedTailEmittedOnceAfterStabilizing(t *testing.T) {
+	emitted := map[int64]struct{}{}
+	window := 5 * time.Second
+
+	// Pass 1: tail segment at start 10 is churning (text "helo"), withheld.
+	p1 := []TranscriptSegment{seg(0, 8, "hello there"), seg(10, 14, "helo")}
+	got1 := stabilizedSegments(p1, window, emitted)
+	if want := []float64{0}; !reflect.DeepEqual(startsOf(got1), want) {
+		t.Fatalf("pass1 starts = %v, want %v", startsOf(got1), want)
+	}
+
+	// Pass 2: the tail was REVISED (start drifted 10.0 -> 10.3, text fixed) and
+	// now more audio follows so it is stable. It must emit exactly once, keyed on
+	// its coarse start bucket despite the drift.
+	p2 := []TranscriptSegment{seg(0, 8, "hello there"), seg(10.3, 14.2, "hello"), seg(14.2, 25, "and more")}
+	got2 := stabilizedSegments(p2, window, emitted)
+	if want := []float64{10.3}; !reflect.DeepEqual(startsOf(got2), want) {
+		t.Fatalf("pass2 starts = %v, want %v (revised tail emitted once)", startsOf(got2), want)
+	}
+
+	// Pass 3: same content re-transcribed; nothing new should emit.
+	got3 := stabilizedSegments(p2, window, emitted)
+	if len(got3) != 0 {
+		t.Fatalf("pass3 should emit nothing; got %v", startsOf(got3))
+	}
+}
+
+func TestRollingTranscriber_Run_EmitsAcrossPassesAndFinalizes(t *testing.T) {
+	var mu sync.Mutex
+	var emitted []TranscriptSegment
+
+	// Fake transcriber: returns a growing segment list on each call.
+	var passes int
+	transcribe := func() ([]TranscriptSegment, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		passes++
+		switch {
+		case passes == 1:
+			return []TranscriptSegment{seg(0, 5, "a"), seg(5, 20, "b")}, nil // b is tail
+		case passes == 2:
+			// Recording grew; b now stable, c is the new tail.
+			return []TranscriptSegment{seg(0, 5, "a"), seg(5, 12, "b"), seg(12, 30, "c")}, nil
+		default:
+			// Grew again; c is now stable (a later segment d is the tail).
+			return []TranscriptSegment{seg(0, 5, "a"), seg(5, 12, "b"), seg(12, 30, "c"), seg(30, 50, "d")}, nil
+		}
+	}
+
+	rt := &RollingTranscriber{
+		Interval:   5 * time.Millisecond,
+		Window:     10 * time.Second,
+		Transcribe: transcribe,
+		Emit: func(s TranscriptSegment) {
+			mu.Lock()
+			emitted = append(emitted, s)
+			mu.Unlock()
+		},
+	}
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		rt.Run(stop)
+		close(done)
+	}()
+
+	// Let several passes run, then stop.
+	time.Sleep(60 * time.Millisecond)
+	close(stop)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after stop")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	// Across all passes we expect a (start 0), b (start 5), c (start 12) each
+	// exactly once, in order.
+	if want := []float64{0, 5, 12}; !reflect.DeepEqual(startsOf(emitted), want) {
+		t.Fatalf("emitted starts = %v, want %v", startsOf(emitted), want)
+	}
+}
+
+func TestRollingTranscriber_Run_PassErrorIsNonFatal(t *testing.T) {
+	var mu sync.Mutex
+	var emitted []TranscriptSegment
+	var calls int
+	transcribe := func() ([]TranscriptSegment, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+		if calls == 1 {
+			return nil, fmt.Errorf("whisper hiccup")
+		}
+		return []TranscriptSegment{seg(0, 5, "ok")}, nil
+	}
+	rt := &RollingTranscriber{
+		Interval:   5 * time.Millisecond,
+		Window:     0,
+		Transcribe: transcribe,
+		Emit: func(s TranscriptSegment) {
+			mu.Lock()
+			emitted = append(emitted, s)
+			mu.Unlock()
+		},
+	}
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() { rt.Run(stop); close(done) }()
+	time.Sleep(40 * time.Millisecond)
+	close(stop)
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
+	// The first pass errored (non-fatal); a later pass succeeded and emitted.
+	if len(emitted) == 0 {
+		t.Fatal("expected a segment emitted after the transient error")
+	}
+}
+
+func TestRollingTranscriber_Run_GuardsMisconfiguration(t *testing.T) {
+	// Non-positive interval or missing callbacks must return immediately, not
+	// spin or panic.
+	for name, rt := range map[string]*RollingTranscriber{
+		"zero interval":  {Interval: 0, Transcribe: func() ([]TranscriptSegment, error) { return nil, nil }, Emit: func(TranscriptSegment) {}},
+		"nil transcribe": {Interval: time.Millisecond, Emit: func(TranscriptSegment) {}},
+		"nil emit":       {Interval: time.Millisecond, Transcribe: func() ([]TranscriptSegment, error) { return nil, nil }},
+	} {
+		t.Run(name, func(t *testing.T) {
+			done := make(chan struct{})
+			go func() { rt.Run(make(chan struct{})); close(done) }()
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+				t.Fatal("Run did not return immediately on misconfiguration")
+			}
+		})
+	}
+}

--- a/internal/platform/meeting_browser.go
+++ b/internal/platform/meeting_browser.go
@@ -341,10 +341,10 @@ func (b *MeetingBrowser) CurrentURL() (string, error) {
 // set — especially the password-store choice — is unit-testable without launching.
 func buildMeetingChromeArgs(debugPort int, profileDir string) []string {
 	return buildChromeArgs(cobrowseLaunchOptions{
-		debugPort:          debugPort,
-		profileDir:         profileDir,
-		stealth:            stealthEnabled(),
-		userAgent:          os.Getenv(EnvCobrowseUserAgent),
+		debugPort:             debugPort,
+		profileDir:            profileDir,
+		stealth:               stealthEnabled(),
+		userAgent:             os.Getenv(EnvCobrowseUserAgent),
 		softwareGL:            true,
 		passwordStoreBasic:    true,
 		autoplayNoUserGesture: true,

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -283,5 +283,13 @@ func CreateLegacyHandlersWithOpts(opts LegacyHandlerOpts) []JobHandler {
 func newMeetingJoinHandler(opts LegacyHandlerOpts) *jobs.MeetingJoinHandler {
 	h := jobs.NewMeetingJoinHandler(opts.WorkspaceDir)
 	h.ProfileDir = opts.MeetingProfileDir
+	// Wire the during-call interactive layer (issue #5435) from the persisted
+	// meeting config (default-on, opt-out — same house convention as the meeting
+	// capability itself). The config accessors clamp non-positive cadence values
+	// to sane defaults.
+	m := config.LoadMeeting(platform.ConfigDir())
+	h.StreamingEnabled = m.StreamingEnabled
+	h.StreamingInterval = m.StreamingInterval()
+	h.StreamingWindow = m.StreamingWindow()
 	return h
 }


### PR DESCRIPTION
## Context

The sovereign Google Meet notetaker (epic aceteam-ai/aceteam#5097) already works end-to-end in production as of citadel v2.71.4: the bot joins a call, records audio into a per-meeting PulseAudio sink, detects the end, and transcribes node-locally at the end. It is a **passive recorder**.

This PR lays the **node-side foundation to turn it into a controllable in-call agent** (aceteam-ai/aceteam#5435): the bot can transcribe the call *as it happens*, watch for spoken/typed commands, read and post Meet chat, and announce itself on admittance. The headline experience: a participant types (or says) `/ace leave` and the bot leaves gracefully; says `hey aceteam, summarize the last point` and the instruction is captured for the agent layer.

The hard constraint shaping every design decision here: **the batch pipeline works — the interactive layer must be strictly additive and must never crash or stall the recording.** Everything is gated (`StreamingEnabled`, default-on/opt-out), every DOM/CDP touch is best-effort (log + continue), and all the Google-Meet-DOM guesswork is isolated in clearly-flagged `LIVE-TUNING REQUIRED` blocks — because, exactly like #5098, only a human on a real call can confirm those selectors. **This is why the PR is a draft.**

## Summary

| Capability | What + why |
|---|---|
| **1. Rolling transcription** (`meeting_transcribe_rolling.go`) | A `RollingTranscriber` re-transcribes the growing recording on a cadence and emits newly-**stabilized** segments through a callback. Whole-file-so-far strategy (v1; the whisper sidecar has no offset API and this PR doesn't touch that Python service — windowed/offset transcription is the named follow-up). A trailing **stability margin** withholds the churning tail (whole-file re-transcription revises recent segments as more audio arrives), and coarse start-time-bucket dedup emits a revised-then-stabilized segment exactly once. Pure of whisper specifics via an injected `TranscribeFunc`; runs on its own `recover()`-wrapped goroutine so a panic can't kill the recording. |
| **2. In-call command monitor** (`meeting_command.go`) | A **pure** parser scanning transcript segments + chat lines for `/ace <command>` (word-boundary matched, so ambient speech / emails can't match), a flagged spoken-slash heuristic, and the `hey aceteam, <instructions>` wake phrase. Small extensible registry; `leave` is the only auto-executed command. **Safety property:** only a literal `/ace leave` is auto-executed — generic `/ace` commands and wake-phrase instructions are *captured/surfaced* for the agent layer, never executed on the node. |
| **3. Meet chat capture** (`meeting_chat.go`) | CDP helpers (reusing the repo's existing `Runtime.evaluate` mechanism — no new CDP lib) to open the chat panel, READ history, and POST a message. All interpolated selectors/text are `json.Marshal`-escaped (no JS injection from untrusted chat/segment text). Captured chat is persisted in the result and fed to the command monitor. |
| **4. Self-announcement** (`meeting_chat.go` + wiring) | On admittance the bot posts a consent/intro message (a single const): recording disclosure + how to invoke `/ace`. TTS voice is out of scope (chat only) — a named follow-up. |
| **Lifecycle wiring** (`meeting_interactive.go`, `meeting_join.go`) | Ties 1–4 into join→record→transcribe, gated on `StreamingEnabled`. `/ace leave` clicks the **CONFIRMED** "Leave call" selector and ends the call (`ace_command_leave`). Sidecar access from rolling passes and the final batch transcribe is serialized (`transcribeMu`) so they never hit whisper / read the growing WAV concurrently. Result schema extended additively (`chat`, `recognized_commands`, `streamed_segments`); the stored transcript source of truth is unchanged. |

A self-echo landmine was caught and guarded in review: the announcement literally contains `/ace leave`, and Meet renders the bot's own messages back into the chat panel — without a guard the bot would read its own announcement and leave within one poll (masked today only because the post selectors throw; it would detonate the moment a human tunes them). The loop now tracks the bot's own posted texts and never scans them for commands (still captured for audit), with a dedicated regression test.

## Test plan

All unit tests; no live browser required. `go build ./...`, `go vet ./...`, `gofmt -l` (clean except the pre-existing `meeting_browser.go`), `go test ./...` all green (jobs suite also passes under `-race`).

| Area | Coverage |
|---|---|
| Command parser (`meeting_command_test.go`) | leave variants (casing/punctuation/surrounding words), generic capture, wake phrase, spoken-slash heuristic, **non-matches** (ambient speech, emails, bare token — the safety property), hallucinated/partial segments, pick-first, registry contract |
| Rolling transcriber (`meeting_transcribe_rolling_test.go`) | stability margin holds back tail, zero-window emits all, monotonic growth no double-emit, revised-tail-emitted-once, driver run across passes + finalize (injected fake transcriber), pass-error non-fatal, misconfiguration guards |
| Chat helpers (`meeting_chat_test.go`) | JS builder escaping + throw-on-missing semantics, readback parse (JSON string / decoded-array fallback / empty / malformed), `Line()`, evaluator error propagation, announcement content |
| Interactive loop (`meeting_interactive_test.go`) | leave via chat, leave via spoken transcript, ends-when-call-ends, alone-in-call, captures generic commands **without** leaving, chat dedup by index, panicking transcriber non-fatal, announcement post, own-message-guard seeding, **self-echo regression** (bot must not leave from its own announcement echo) |
| Config (`meeting_test.go`) | streaming defaults, duration fallbacks, partial-file preserves defaults |

## Live-tuning required before un-drafting

A human must run a **real** Google Meet call (needs Jason + the physical node — cannot be automated) to confirm/replace:

- **Chat panel selectors** (`meeting_chat.go` LIVE-TUNING block, all UNVERIFIED): "Chat with everyone" open button aria-label, chat message row + sender/text sub-selectors (READ), chat textarea + send button (POST). The open button was *seen* in the in-call toolbar on 2026-07-11 but its exact aria-label is unconfirmed.
- **Leave-call click** (`meetLeaveCallJS`): reuses the `meetIsAdmittedJS` "Leave call" selector, CONFIRMED live 2026-07-11 on the host path — lowest risk, but confirm it clicks (vs. a confirm dialog) on a guest call.
- **Spoken-slash heuristic** (`aceSpokenCommandPrefixes`): whether whisper renders a spoken "/ace" as "slash ace" — best-guess, unverified.
- **Rolling read of an in-progress WAV**: whether faster-whisper reads a growing WAV correctly mid-record needs live verification; if not, the follow-up snapshots the tail before each pass. (Degrades gracefully today — a failed pass is logged and retried.)
- **Spoken-leave-at-very-end edge**: a `/ace leave` spoken as the last utterance before silence stays in the withheld tail until more audio arrives; in practice the call's own end heuristics take over. Typed (chat) leave has no such delay.

## Related

- aceteam-ai/aceteam#5435 — interactive in-call agent (this work). Closes aceteam-ai/aceteam#5435.
- aceteam-ai/aceteam#5097 — sovereign notetaker epic.
- aceteam-ai/aceteam#5098 — batch join/record/transcribe (the foundation this builds on; same isolated + live-tuning-flagged bar).
- #503 — meeting-bot autoplay fix (prior citadel meeting work).
