### PR TITLE
feat(windows): citadel-start.exe launcher, replace citadel.bat (#508)

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1091,3 +1091,23 @@ Auto-generated log of every release.
   - feat(node): node identity store — keypair + CSR + leaf storage (#4583 P2 PR-0) (#441)
 
 
+---
+
+## v2.72.0 — 2026-07-11
+
+| Metric | Value |
+|--------|-------|
+| Commits | 6 |
+| Files changed | 44 |
+| Lines added | +5096 |
+
+**Changes:**
+
+  - chore(release): v2.72.0
+  - fix(work): move mTLS control listener off mesh :8443; fail loud on gateway mesh-bind loss (#504) (#505)
+  - feat(resmon): track ALL GPU/host resource consumers, not just managed (#427) (#431)
+  - feat(meeting): live interactive layer for the Meet notetaker (#5435) (#506)
+  - feat: service idle detection auto-stop + operator view (#416) (#425)
+  - feat(node): node identity store — keypair + CSR + leaf storage (#4583 P2 PR-0) (#441)
+
+

--- a/cmd/citadel-start/main.go
+++ b/cmd/citadel-start/main.go
@@ -1,0 +1,167 @@
+// cmd/citadel-start/main.go
+/*
+Copyright © 2025 AceTeam <dev@aceteam.ai>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+// Command citadel-start is a tiny double-click launcher for Windows.
+//
+// The Windows release zip ships two files: citadel.exe (the raw CLI) and this
+// launcher. Double-clicking citadel.exe from Explorer flashes a console that
+// prints --help and vanishes, which confused first-run users. citadel-start.exe
+// is the obvious clickable "start the node" wrapper: it locates citadel.exe
+// sitting next to it, runs "citadel.exe work", streams its output, and — the
+// whole point — keeps the console window open on exit so the user actually sees
+// what happened (including the "run citadel init first" error on a fresh node)
+// instead of watching a window flash and disappear.
+//
+// The package is intentionally pure stdlib and OS-agnostic so it builds and its
+// tests run on any platform (CI is linux); the release only ships the
+// GOOS=windows binary.
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// childName is the CLI binary the launcher execs, expected to sit in the same
+// directory as the launcher itself.
+const childName = "citadel.exe"
+
+// startArg is the citadel subcommand that brings a node online.
+const startArg = "work"
+
+// noPauseEnv, when set to any non-empty value, disables the "Press Enter to
+// close" pause. Useful for scripted/terminal launches and for tests.
+const noPauseEnv = "CITADEL_START_NO_PAUSE"
+
+// siblingPath returns the path to a file sitting next to the launcher
+// executable, given the launcher's own resolved executable path. It never
+// consults PATH or the current working directory, which are unreliable when the
+// process is spawned by an Explorer double-click.
+func siblingPath(selfExe, name string) string {
+	return filepath.Join(filepath.Dir(selfExe), name)
+}
+
+// exitCodeFromErr maps the error returned by exec.Cmd.Run to a process exit
+// code: nil -> 0, an *exec.ExitError -> the child's own code, and any other
+// error (e.g. the binary could not be started) -> 1.
+func exitCodeFromErr(err error) int {
+	if err == nil {
+		return 0
+	}
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		return ee.ExitCode()
+	}
+	return 1
+}
+
+// shouldPause reports whether the launcher should wait for a keypress before
+// exiting. Pausing keeps the console window visible for a double-click user;
+// setting noPauseEnv skips it.
+func shouldPause(getenv func(string) string) bool {
+	return getenv(noPauseEnv) == ""
+}
+
+// exitHint returns a human-readable next-step message for a non-zero child exit
+// code, or "" when the child exited cleanly. The most common first-run failure
+// is an uninitialized node, so the hint points the user at "citadel init".
+func exitHint(code int) string {
+	if code == 0 {
+		return ""
+	}
+	return fmt.Sprintf("Citadel exited with code %d.\n"+
+		"If this node has not been set up yet, open a terminal in this folder and run:\n"+
+		"    %s init\n"+
+		"then double-click this launcher again.", code, childName)
+}
+
+// run executes the launcher logic and returns the exit code to propagate. It is
+// parameterized on its dependencies so the orchestration can be unit-tested
+// without spawning a real process or touching os.Stdin/Stdout.
+func run(
+	selfExe string,
+	statImpl func(string) (os.FileInfo, error),
+	execImpl func(childPath string) int,
+	out io.Writer,
+) int {
+	child := siblingPath(selfExe, childName)
+
+	if _, err := statImpl(child); err != nil {
+		fmt.Fprintf(out, "Cannot find %s next to this launcher.\n", childName)
+		fmt.Fprintf(out, "Expected it at: %s\n", child)
+		fmt.Fprintf(out, "Make sure you unzipped the whole archive and kept the files together.\n")
+		return 2
+	}
+
+	fmt.Fprintf(out, "Starting Citadel node (%s %s)...\n\n", childName, startArg)
+	code := execImpl(child)
+
+	fmt.Fprintln(out)
+	if hint := exitHint(code); hint != "" {
+		fmt.Fprintln(out, hint)
+	} else {
+		fmt.Fprintln(out, "Citadel stopped.")
+	}
+	return code
+}
+
+// execChild runs "<childPath> work", wiring the child's stdio straight through
+// to this process and setting its working directory to the launcher's own
+// directory (mirroring the old citadel.bat's `cd /d "%~dp0"`). It returns the
+// child's exit code.
+func execChild(childPath string) int {
+	cmd := exec.Command(childPath, startArg)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Dir = filepath.Dir(childPath)
+	return exitCodeFromErr(cmd.Run())
+}
+
+// pause blocks until the user presses Enter, keeping the console window open so
+// a double-click user can read the output. It is a no-op when noPauseEnv is set.
+func pause(getenv func(string) string, out io.Writer, in io.Reader) {
+	if !shouldPause(getenv) {
+		return
+	}
+	fmt.Fprint(out, "\nPress Enter to close this window...")
+	_, _ = bufio.NewReader(in).ReadString('\n')
+}
+
+func main() {
+	selfExe, err := os.Executable()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not determine launcher location: %v\n", err)
+		pause(os.Getenv, os.Stdout, os.Stdin)
+		os.Exit(1)
+	}
+
+	code := run(selfExe, os.Stat, execChild, os.Stdout)
+	pause(os.Getenv, os.Stdout, os.Stdin)
+	os.Exit(code)
+}

--- a/cmd/citadel-start/main_test.go
+++ b/cmd/citadel-start/main_test.go
@@ -1,0 +1,203 @@
+// cmd/citadel-start/main_test.go
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSiblingPath(t *testing.T) {
+	// The child must be resolved next to the launcher, never via PATH/CWD.
+	dir := filepath.FromSlash("/opt/citadel")
+	self := filepath.Join(dir, "citadel-start.exe")
+	got := siblingPath(self, childName)
+	want := filepath.Join(dir, childName)
+	if got != want {
+		t.Fatalf("siblingPath(%q, %q) = %q, want %q", self, childName, got, want)
+	}
+}
+
+func TestExitCodeFromErr(t *testing.T) {
+	if got := exitCodeFromErr(nil); got != 0 {
+		t.Fatalf("nil err: got %d, want 0", got)
+	}
+
+	// Non-ExitError (e.g. binary could not be launched) -> 1.
+	if got := exitCodeFromErr(errors.New("boom")); got != 1 {
+		t.Fatalf("generic err: got %d, want 1", got)
+	}
+
+	// A real *exec.ExitError should surface the child's own code.
+	// `exit 3` via the platform shell gives us a deterministic non-zero code.
+	var shell, flag string
+	if runtime.GOOS == "windows" {
+		shell, flag = "cmd", "/c"
+	} else {
+		shell, flag = "sh", "-c"
+	}
+	err := exec.Command(shell, flag, "exit 3").Run()
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("expected *exec.ExitError, got %T (%v)", err, err)
+	}
+	if got := exitCodeFromErr(err); got != 3 {
+		t.Fatalf("exit-3 child: got %d, want 3", got)
+	}
+}
+
+func TestShouldPause(t *testing.T) {
+	unset := func(string) string { return "" }
+	if !shouldPause(unset) {
+		t.Fatal("expected pause when env var unset")
+	}
+
+	set := func(k string) string {
+		if k == noPauseEnv {
+			return "1"
+		}
+		return ""
+	}
+	if shouldPause(set) {
+		t.Fatalf("expected no pause when %s is set", noPauseEnv)
+	}
+}
+
+func TestExitHint(t *testing.T) {
+	if got := exitHint(0); got != "" {
+		t.Fatalf("clean exit should produce no hint, got %q", got)
+	}
+
+	hint := exitHint(1)
+	if hint == "" {
+		t.Fatal("non-zero exit should produce a hint")
+	}
+	// The hint must guide the user toward initialization, the dominant
+	// first-run failure mode.
+	for _, want := range []string{"code 1", childName + " init"} {
+		if !strings.Contains(hint, want) {
+			t.Fatalf("hint %q missing %q", hint, want)
+		}
+	}
+}
+
+func TestRunMissingChild(t *testing.T) {
+	// When citadel.exe is absent next to the launcher, run must not exec
+	// anything, must explain the problem, and must return code 2.
+	self := filepath.Join(t.TempDir(), "citadel-start.exe")
+	statMissing := func(string) (os.FileInfo, error) {
+		return nil, fs.ErrNotExist
+	}
+	execCalled := false
+	execImpl := func(string) int {
+		execCalled = true
+		return 0
+	}
+
+	var out bytes.Buffer
+	code := run(self, statMissing, execImpl, &out)
+
+	if code != 2 {
+		t.Fatalf("missing child: got code %d, want 2", code)
+	}
+	if execCalled {
+		t.Fatal("must not exec the child when it is missing")
+	}
+	if !strings.Contains(out.String(), childName) {
+		t.Fatalf("output should name the missing binary, got %q", out.String())
+	}
+}
+
+func TestRunForwardsExitCode(t *testing.T) {
+	// A present child whose "work" run fails must have its exit code
+	// forwarded, and the uninitialized-node hint shown.
+	self := filepath.Join(t.TempDir(), "citadel-start.exe")
+	statOK := func(string) (os.FileInfo, error) {
+		return fakeFileInfo{}, nil
+	}
+	var gotChildPath string
+	execImpl := func(childPath string) int {
+		gotChildPath = childPath
+		return 1
+	}
+
+	var out bytes.Buffer
+	code := run(self, statOK, execImpl, &out)
+
+	if code != 1 {
+		t.Fatalf("got code %d, want 1 (forwarded)", code)
+	}
+	if want := siblingPath(self, childName); gotChildPath != want {
+		t.Fatalf("exec'd %q, want sibling %q", gotChildPath, want)
+	}
+	if !strings.Contains(out.String(), childName+" init") {
+		t.Fatalf("failed run should show init hint, got %q", out.String())
+	}
+}
+
+func TestRunCleanExit(t *testing.T) {
+	self := filepath.Join(t.TempDir(), "citadel-start.exe")
+	statOK := func(string) (os.FileInfo, error) { return fakeFileInfo{}, nil }
+	execImpl := func(string) int { return 0 }
+
+	var out bytes.Buffer
+	code := run(self, statOK, execImpl, &out)
+
+	if code != 0 {
+		t.Fatalf("got code %d, want 0", code)
+	}
+	if !strings.Contains(out.String(), "Citadel stopped") {
+		t.Fatalf("clean exit should report a stop, got %q", out.String())
+	}
+	if strings.Contains(out.String(), "init") {
+		t.Fatalf("clean exit should not show the init hint, got %q", out.String())
+	}
+}
+
+func TestPauseNoOpWhenDisabled(t *testing.T) {
+	// With the pause disabled, pause must not consume stdin or print a prompt.
+	disabled := func(k string) string {
+		if k == noPauseEnv {
+			return "1"
+		}
+		return ""
+	}
+	in := strings.NewReader("should-not-be-read\n")
+	var out bytes.Buffer
+	pause(disabled, &out, in)
+
+	if out.Len() != 0 {
+		t.Fatalf("disabled pause should print nothing, got %q", out.String())
+	}
+	rest, _ := in.ReadByte()
+	if rest != 's' {
+		t.Fatalf("disabled pause consumed stdin (next byte %q), want untouched", rest)
+	}
+}
+
+func TestPauseWaitsForEnter(t *testing.T) {
+	enabled := func(string) string { return "" }
+	in := strings.NewReader("\n")
+	var out bytes.Buffer
+	pause(enabled, &out, in)
+
+	if !strings.Contains(out.String(), "Press Enter") {
+		t.Fatalf("enabled pause should prompt, got %q", out.String())
+	}
+}
+
+type fakeFileInfo struct{}
+
+func (fakeFileInfo) Name() string       { return childName }
+func (fakeFileInfo) Size() int64        { return 0 }
+func (fakeFileInfo) Mode() os.FileMode  { return 0 }
+func (fakeFileInfo) ModTime() time.Time { return time.Time{} }
+func (fakeFileInfo) IsDir() bool        { return false }
+func (fakeFileInfo) Sys() any           { return nil }

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -501,7 +501,18 @@ func (c *Client) extractZip(archivePath, destPath string) error {
 				return err
 			}
 			foundExe = true
+		} else if baseName == "citadel-start.exe" {
+			// The double-click launcher ships next to citadel.exe (#508).
+			// Keep it in sync on update; best-effort so a missing/locked
+			// launcher never fails the update of the CLI itself.
+			startPath := filepath.Join(destDir, "citadel-start.exe")
+			_ = extractZipFile(f, startPath)
 		} else if baseName == "citadel.bat" {
+			// Backward compatibility: pre-#508 archives shipped a citadel.bat
+			// wrapper. Newer archives no longer contain it, but keep extracting
+			// it when present so a mixed-version update still lands a working
+			// file. Existing installs may retain a stale citadel.bat on disk;
+			// it is harmless and intentionally left in place.
 			batPath := filepath.Join(destDir, "citadel.bat")
 			_ = extractZipFile(f, batPath)
 		}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -106,8 +106,14 @@ hook_build() {
 
     local archive_name="citadel_v${version}_${os}_${arch}"
     if [[ "$os" == "windows" ]]; then
-      cp "$REPO_ROOT/scripts/windows/citadel.bat" "$build_dir/"
-      (cd "$build_dir" && zip -q "$release_dir/${archive_name}.zip" "citadel${ext}" "citadel.bat")
+      # Ship the double-click launcher (citadel-start.exe) alongside the CLI
+      # (citadel.exe). The launcher is the obvious clickable "start the node"
+      # entrypoint; citadel.exe remains the CLI for terminal use. This replaces
+      # the old citadel.bat wrapper (#508).
+      CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" go build \
+        -o "$build_dir/citadel-start${ext}" \
+        ./cmd/citadel-start
+      (cd "$build_dir" && zip -q "$release_dir/${archive_name}.zip" "citadel${ext}" "citadel-start${ext}")
     else
       tar -czf "$release_dir/${archive_name}.tar.gz" -C "$build_dir" "citadel${ext}"
     fi

--- a/scripts/windows/citadel.bat
+++ b/scripts/windows/citadel.bat
@@ -1,3 +1,0 @@
-@echo off
-cd /d "%~dp0"
-citadel.exe %*


### PR DESCRIPTION
## Context

The Windows release zip has a wrong-file trap. It ships **two** files and the
first-run user has to know which one to click:

- `citadel.exe` — the raw CLI. Double-click it from Explorer and a console
  flashes `--help` and vanishes. Does nothing useful.
- `citadel.bat` — a thin `@echo off / cd /d "%~dp0" / citadel.exe %*` wrapper
  that's the file you're *actually* supposed to click.

So the experience is: unzip → see two files → click the obvious one
(`citadel.exe`) → watch a window flash and disappear → confusion. Per the
founder: *"can we package the windows exe into a proper windows exe not a bat
script? it was confusing to click the citadel-start.bat and avoid the citadel
itself."*

This is **Option B** from #508: replace the `.bat` with a real, obvious,
icon-capable `citadel-start.exe` launcher.

## Summary

**New launcher — `cmd/citadel-start/main.go`**
A tiny, pure-stdlib program (built `GOOS=windows`) that:
- Resolves `citadel.exe` sitting **next to the launcher** via `os.Executable()`
  — never PATH/CWD, since Explorer double-click gives an unpredictable CWD.
- Runs `citadel.exe work` (the primary node-start command), with the child's
  working dir set to the launcher's folder (faithfully replicating the old
  bat's `cd /d "%~dp0"`).
- Streams the child's stdin/stdout/stderr straight through and **forwards the
  child's exit code**.
- **Keeps the console open on exit** (success or failure) with a "Press Enter to
  close" prompt — the whole point, so a double-click user actually sees output
  instead of a flash-and-vanish. On a non-zero exit it prints a next-step hint
  pointing at `citadel.exe init` (the dominant first-run failure: an
  uninitialized node, where `citadel work` exits 1). Pause is skippable via
  `CITADEL_START_NO_PAUSE` for scripted/terminal launches and tests.

The package carries **no `//go:build windows` constraint** — it's portable
stdlib, so linux CI compiles it and runs its unit tests; the release only ships
the windows binary. Cross-compiles clean for both `windows/amd64` and
`windows/arm64`.

**Release packaging — `scripts/release.sh`**
For windows targets, cross-compile `citadel-start.exe` and zip
`citadel.exe` + `citadel-start.exe`. **Dropped `citadel.bat`** from the zip
(the whole point). `citadel.exe` stays — it's still the CLI for terminal use.

**Self-update — `internal/update/update.go`**
`extractZip` now also lays down `citadel-start.exe` from the archive alongside
`citadel.exe` (best-effort, so a missing/locked launcher never fails the CLI
update). The old `citadel.bat` extraction branch is **kept for backward
compat** with pre-#508 archives; stale on-disk bats are harmless and
intentionally left in place (no removal migration — per the issue).

**Cleanup**
Removed `scripts/windows/citadel.bat` (no remaining references — grepped).
`install.ps1` needs no change: it only ever `Copy-Item`s `citadel.exe` to the
install dir + PATH (it never installed the clickable wrapper), so its
artifact contract is unchanged.

## Test plan

Unit-tested (linux CI, `go test ./cmd/citadel-start`):

| Test | Covers |
|------|--------|
| `TestSiblingPath` | child resolved next to launcher, not via PATH/CWD |
| `TestExitCodeFromErr` | nil→0, generic err→1, real `*exec.ExitError`→child's code |
| `TestShouldPause` | pause gating on `CITADEL_START_NO_PAUSE` |
| `TestExitHint` | non-zero exit produces an `init` next-step hint; clean exit doesn't |
| `TestRunMissingChild` | missing `citadel.exe` → code 2, no exec, clear message |
| `TestRunForwardsExitCode` | failed run forwards code + shows init hint |
| `TestRunCleanExit` | clean run → code 0, "Citadel stopped", no spurious hint |
| `TestPauseNoOpWhenDisabled` / `TestPauseWaitsForEnter` | pause behavior |

Also verified: `gofmt -l .` empty, `go build ./...`, `go vet ./...`,
`go test ./cmd/... ./internal/update/...` all green; `citadel-start`
cross-compiles for `windows/amd64` **and** `windows/arm64`.

### Live verification needed before un-drafting

The actual Explorer double-click UX can't be unit-tested. Someone must, on a
**real Windows box** (Jason has a Windows node), unzip a build and double-click
`citadel-start.exe`, confirming **both**:

- **(a) Uninitialized node** → the error is visible and the **console window
  stays open** (not flash-and-vanish). This is the core UX we're fixing.
- **(b) Initialized node** → the node actually comes online (`citadel work`
  runs) and the window stays open streaming logs.

Note: on a graceful Ctrl+C stop, Windows delivers `CTRL_C_EVENT` to the whole
console group, so the launcher may be signalled too and the "Press Enter" pause
may not fire — acceptable for Option B (the win we're shipping is the
immediate-error case). We deliberately did not add a `SetConsoleCtrlHandler`.

## Known limitations

- **Self-update one-version bootstrap lag:** the binary performing an update is
  the *currently installed* one. An existing install updating **to** the first
  release that contains this change runs the OLD `update.go`, which only knows
  `citadel.exe` + `citadel.bat` — so it won't lay down `citadel-start.exe` on
  that first hop. The launcher lands from the *second* update onward. This is
  unavoidable (the old code already shipped) and low-impact: zip downloaders
  (the people who actually double-click) get it immediately; self-updaters are
  terminal users. No migration built.
- **App icon:** skipped for now to avoid adding a `rsrc`/`goversioninfo` (+
  `.ico`, per-arch `.syso`) toolchain to the release pipeline. A working
  iconless launcher is the priority; icon is a cheap follow-up (commit a
  `.syso`, no `release.sh` change needed). `TODO` left for it.

## Related

Closes aceteam-ai/citadel-cli#508
