### PR TITLE
fix(terminal): make tmux session opt-in, off by default (#511)

### DIFF
--- a/internal/terminal/config.go
+++ b/internal/terminal/config.go
@@ -9,10 +9,12 @@ import (
 )
 
 // DefaultSessionName is the base tmux session name used when
-// CITADEL_TERMINAL_SESSION is not set. Its presence is what makes terminals
-// tmux-backed (and therefore reconnect-resilient) by default. It is a valid
-// tmux session name per tmux.ValidateSessionName.
-const DefaultSessionName = "citadel"
+// CITADEL_TERMINAL_SESSION is not set. It defaults to empty, which turns tmux
+// backing OFF so terminals run a fresh bare shell. Operators opt in to
+// persistent tmux by setting CITADEL_TERMINAL_SESSION to a session name (e.g.
+// "citadel"), which must be a valid tmux session name per
+// tmux.ValidateSessionName.
+const DefaultSessionName = ""
 
 // Config holds the terminal server configuration
 type Config struct {
@@ -49,10 +51,16 @@ type Config struct {
 	// SessionName is treated as a base name. The server derives a stable,
 	// per-user session name from it (base + sanitized user ID) so each user
 	// re-attaches to their own persistent terminal across reconnects while
-	// staying isolated from other users. It defaults to DefaultSessionName so
-	// terminals are tmux-backed (and reconnect-resilient) out of the box. Set
-	// CITADEL_TERMINAL_SESSION to the disable sentinel ("none"/"off"/
-	// "disabled") to force a bare, non-persistent shell.
+	// staying isolated from other users.
+	//
+	// It defaults to DefaultSessionName (empty), so tmux backing is OFF by
+	// default and terminals run a fresh, non-persistent bare shell. This keeps
+	// scripted/automated terminal use predictable (no state bleed across
+	// connections, consistent PTY/terminfo). To opt in to the persistent,
+	// reconnect-resilient tmux behavior, set CITADEL_TERMINAL_SESSION to a
+	// session name (e.g. "citadel"). The disable sentinels ("none"/"off"/
+	// "disabled"/"false"/"0") also force a bare shell and remain supported for
+	// explicit opt-out.
 	SessionName string
 
 	// AuthServiceURL is the URL of the AceTeam auth service for token validation

--- a/internal/terminal/config_test.go
+++ b/internal/terminal/config_test.go
@@ -3,6 +3,7 @@ package terminal
 
 import (
 	"os"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -64,6 +65,48 @@ func TestConfigFromEnv(t *testing.T) {
 
 	if config.MaxConnections != 20 {
 		t.Errorf("expected max connections 20 from env, got %d", config.MaxConnections)
+	}
+}
+
+// TestDefaultConfig_TmuxOffByDefault pins the off-by-default contract: with no
+// CITADEL_TERMINAL_SESSION set, no tmux session is configured, so the server
+// runs a bare shell (sessionCommand returns nil and sessionDisabled is true).
+func TestDefaultConfig_TmuxOffByDefault(t *testing.T) {
+	// Empty simulates "unset": getEnvOrDefault treats "" as absent and falls
+	// back to DefaultSessionName, which is now empty.
+	t.Setenv("CITADEL_TERMINAL_SESSION", "")
+
+	config := DefaultConfig()
+	if config.SessionName != "" {
+		t.Errorf("expected empty SessionName by default, got %q", config.SessionName)
+	}
+	if !sessionDisabled(config.SessionName) {
+		t.Error("expected tmux backing to be disabled by default")
+	}
+	// Even with a real tmux binary available, no command is produced.
+	makeFakeTmux(t)
+	if got := sessionCommand(config.SessionName, config.Shell); got != nil {
+		t.Errorf("expected nil session command by default, got %v", got)
+	}
+}
+
+// TestDefaultConfig_TmuxOptIn verifies operators restore persistent tmux by
+// setting CITADEL_TERMINAL_SESSION to a session name.
+func TestDefaultConfig_TmuxOptIn(t *testing.T) {
+	t.Setenv("CITADEL_TERMINAL_SESSION", "citadel")
+	bin := makeFakeTmux(t)
+
+	config := DefaultConfig()
+	if config.SessionName != "citadel" {
+		t.Errorf("expected SessionName %q from env, got %q", "citadel", config.SessionName)
+	}
+	if sessionDisabled(config.SessionName) {
+		t.Error("expected tmux backing to be enabled when opted in")
+	}
+	got := sessionCommand(config.SessionName, "/bin/bash")
+	want := []string{bin, "new-session", "-A", "-s", "citadel", "/bin/bash"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("sessionCommand = %v, want %v", got, want)
 	}
 }
 

--- a/internal/terminal/tmux.go
+++ b/internal/terminal/tmux.go
@@ -21,9 +21,13 @@ var disableSentinels = map[string]bool{
 }
 
 // sessionDisabled reports whether the configured session base name asks for
-// tmux backing to be turned off.
+// tmux backing to be turned off. An empty (or whitespace-only) name means no
+// session was configured, which is the off-by-default case, so it is treated as
+// disabled. The explicit sentinels ("none"/"off"/...) remain supported for
+// operators who opt out after setting a name.
 func sessionDisabled(sessionName string) bool {
-	return disableSentinels[strings.ToLower(strings.TrimSpace(sessionName))]
+	trimmed := strings.ToLower(strings.TrimSpace(sessionName))
+	return trimmed == "" || disableSentinels[trimmed]
 }
 
 // sessionNameForUser derives a stable, validated tmux session name from a base

--- a/internal/terminal/tmux_test.go
+++ b/internal/terminal/tmux_test.go
@@ -62,8 +62,9 @@ func TestSessionCommand_DisableSentinel(t *testing.T) {
 }
 
 func TestSessionDisabled(t *testing.T) {
-	on := []string{"", "citadel", "agent", "my-session", "nonexistent"}
-	off := []string{"none", "off", "OFF", "Disabled", "false", "0", "  off  "}
+	on := []string{"citadel", "agent", "my-session", "nonexistent"}
+	// Empty/whitespace-only means no session configured -> off by default.
+	off := []string{"", "  ", "none", "off", "OFF", "Disabled", "false", "0", "  off  "}
 	for _, s := range on {
 		if sessionDisabled(s) {
 			t.Errorf("sessionDisabled(%q) = true, want false", s)


### PR DESCRIPTION
## Context

Citadel's interactive terminal server wrapped **every** connection in a persistent, per-user tmux session by default. The default was baked in at `internal/terminal/config.go:15` (`const DefaultSessionName = "citadel"`), and neither call site that builds the config — the node terminal server (`cmd/work.go:1541`) nor the control-center console (`cmd/controlcenter.go:564`) — overrode it. So every connect ran a shell *inside* tmux instead of a bare shell.

That default gets in the way of scripted/automated terminal use:

- **State bleeds across connections** by design — a hung command, altered environment, or changed cwd carries into the next connect instead of resetting.
- **Different PTY/terminfo** — the shell runs under tmux's PTY with `TERM=tmux`/`screen`, altering escape/output handling versus a direct shell.
- **Node-dependent divergence** — when tmux can't be resolved the server silently falls back to a bare shell, so the same session behaves differently on nodes that have vs. lack tmux.

The persistent-session convenience should be opt-in, not the default. Requested by Jason.

## Summary

Flip tmux to **off by default** while keeping the opt-in path fully backwards compatible.

**`internal/terminal/config.go`**
- `DefaultSessionName` changed from `"citadel"` to `""` (line 15). With the env unset, `getEnvOrDefault("CITADEL_TERMINAL_SESSION", DefaultSessionName)` at line ~87 now yields empty, so no tmux wrapper is created. Doc comments (lines 11-16, 41-63) rewritten to state off-by-default and how to opt in.

**`internal/terminal/tmux.go`**
- `sessionDisabled` now treats an empty/whitespace-only name as **disabled** (in addition to the existing `none`/`off`/`disabled`/`false`/`0` sentinels). This is the load-bearing fix: `internal/terminal/server.go:394` guards with `!sessionDisabled(SessionName)` and *then* derives a per-user name via `sessionNameForUser("", userID)`, which returns `"-<userid>"` (non-empty) — so an empty base alone would still have reached `sessionCommand` and could spawn tmux. Making empty ⇒ disabled short-circuits the block to a bare shell. `sessionCommand` already returned `nil` for empty, so both paths now agree.

**Opt-in / backwards compat:** operators restore the old persistent-tmux behavior by setting `CITADEL_TERMINAL_SESSION=citadel` (or any valid session name). The explicit disable sentinels keep working. The managed-tmux auto-install (`cmd/work.go:1551`, `ensureManagedTmux`) is left as-is — it's best-effort and harmless; it now provisions a tmux binary that is simply unused unless an operator opts in.

## Test plan

All in `internal/terminal`, run with `go build ./...`, `go vet ./internal/terminal/...`, `gofmt -l`, and `go test ./...` (full repo) — all green.

| Test | Covers |
| --- | --- |
| `TestSessionDisabled` (updated) | Empty and whitespace-only names now assert **disabled**; named sessions stay enabled; explicit sentinels still disable. |
| `TestDefaultConfig_TmuxOffByDefault` (new) | With `CITADEL_TERMINAL_SESSION` unset, `DefaultConfig().SessionName == ""`, `sessionDisabled` is true, and `sessionCommand` returns `nil` even with a resolvable tmux binary present. |
| `TestDefaultConfig_TmuxOptIn` (new) | With `CITADEL_TERMINAL_SESSION=citadel`, config picks it up, `sessionDisabled` is false, and `sessionCommand` builds `tmux new-session -A -s citadel <shell>`. |
| Existing `TestSessionCommand_*` | Unchanged and still passing (no-name, invalid-name, tmux-unavailable, attach-or-create, disable sentinel). |

Verified via `grep -rn "\.SessionName" cmd/` that neither `work.go` nor `controlcenter.go` overrides the default — both inherit the new off-by-default value, so no consumer code needed changes.

## Related

Closes #511
