### PR TITLE
feat(release): auto-update Homebrew tap on release

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,8 +559,11 @@ The script will:
    - Display the release URL
 
 5. **Update Homebrew Tap**
-   - Automatically updates the `aceteam-ai/homebrew-tap` formula
-   - Commits new version and SHA256 checksums
+   - Automatically updates the `aceteam-ai/homebrew-tap` formula via
+     `scripts/update-homebrew-tap.sh` (bumps the version + the four per-platform
+     SHA256s, then commits and pushes)
+   - Failures here are non-fatal: the release still completes and prints the
+     manual `update-homebrew-tap.sh` fallback
 
 ### Version Numbering
 
@@ -572,7 +575,10 @@ Follow semantic versioning (semver):
 
 ### Manual Release Process
 
-> **Note:** Manual releases will NOT update the Homebrew tap. Always prefer `release.sh`.
+> **Note:** Prefer `release.sh` — it updates the Homebrew tap for you. If you
+> release by hand, sync the tap yourself afterward with
+> `./scripts/update-homebrew-tap.sh <version>` (it fetches the release's
+> checksums from GitHub and pushes the formula bump).
 
 If you absolutely must release manually:
 
@@ -592,5 +598,6 @@ gh release create v1.2.0 \
   release/citadel_v1.2.0_*.zip \
   release/checksums.txt
 
-# 4. Manually update Homebrew tap (aceteam-ai/homebrew-tap)
+# 4. Sync the Homebrew tap (aceteam-ai/homebrew-tap)
+./scripts/update-homebrew-tap.sh 1.2.0
 ```

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -135,9 +135,22 @@ hook_artifact() {
 }
 
 hook_post_release() {
-  info "Next steps:"
-  echo "  1. Update Homebrew tap with new version + checksums"
-  echo "  2. Citadel OS will pick up the new CLI version on next ISO build"
+  local version
+  version=$(read_state "target_version")
+  [[ -z "$version" ]] && version=$(hook_get_version)
+
+  info "Updating Homebrew tap (aceteam-ai/homebrew-tap)..."
+  # Feed the freshly built checksums.txt so the tap update doesn't have to wait
+  # for GitHub to finish processing the just-created release assets.
+  if CHECKSUMS_FILE="$REPO_ROOT/release/checksums.txt" \
+       bash "$SCRIPT_DIR/update-homebrew-tap.sh" "$version"; then
+    ok "Homebrew tap updated to ${version}."
+  else
+    warn "Homebrew tap update failed — run it manually once the release is up:"
+    warn "  ./scripts/update-homebrew-tap.sh ${version}"
+  fi
+
+  info "Citadel OS will pick up the new CLI version on next ISO build."
 }
 
 # ── Load engine and run ────────────────────────────────────────────────────

--- a/scripts/update-homebrew-tap.sh
+++ b/scripts/update-homebrew-tap.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# update-homebrew-tap.sh — Sync the aceteam-ai/homebrew-tap Citadel formula to a
+# published release: rewrites the formula version and the four per-platform
+# SHA256s, then commits and pushes.
+#
+# Invoked automatically by release.sh (hook_post_release). Can also be run
+# standalone to (re)sync the tap to any already-published GitHub release — handy
+# for backfilling a version the tap missed.
+#
+# Usage:
+#   ./scripts/update-homebrew-tap.sh            # version = latest vX.Y.Z git tag
+#   ./scripts/update-homebrew-tap.sh 2.73.0     # explicit version (no leading v)
+#
+# Env:
+#   CHECKSUMS_FILE  If set, read checksums from this file instead of downloading
+#                   them from the GitHub release (release.sh passes its freshly
+#                   built release/checksums.txt).
+#
+# Requires: gh (authenticated with push access to the tap), git.
+
+set -euo pipefail
+
+SOURCE_REPO="aceteam-ai/citadel-cli"
+TAP_REPO="aceteam-ai/homebrew-tap"
+FORMULA_PATH="Formula/citadel.rb"
+TAG_PREFIX="v"
+
+# Homebrew ships macOS + Linux only; the formula has no Windows bottles.
+PLATFORMS=(darwin_arm64 darwin_amd64 linux_arm64 linux_amd64)
+
+info()  { echo "[tap] $*"; }
+fatal() { echo "[tap] ERROR: $*" >&2; exit 1; }
+
+command -v gh  >/dev/null || fatal "gh is required (authenticated with tap push access)."
+command -v git >/dev/null || fatal "git is required."
+
+# ── Resolve version ─────────────────────────────────────────────────────────
+VERSION="${1:-}"
+if [[ -z "$VERSION" ]]; then
+  VERSION=$(git tag --list "${TAG_PREFIX}*" --sort=-version:refname 2>/dev/null | head -1)
+  VERSION="${VERSION#"$TAG_PREFIX"}"
+fi
+[[ -n "$VERSION" ]] || fatal "Could not determine version (pass it explicitly, e.g. 2.73.0)."
+TAG="${TAG_PREFIX}${VERSION}"
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+# ── Obtain checksums ────────────────────────────────────────────────────────
+CHECKSUMS="${CHECKSUMS_FILE:-}"
+if [[ -n "$CHECKSUMS" ]]; then
+  [[ -f "$CHECKSUMS" ]] || fatal "CHECKSUMS_FILE=$CHECKSUMS does not exist."
+  info "Using local checksums: $CHECKSUMS"
+else
+  info "Downloading checksums.txt from $SOURCE_REPO release $TAG..."
+  gh release download "$TAG" --repo "$SOURCE_REPO" --pattern checksums.txt --dir "$WORK" \
+    || fatal "Could not download checksums.txt for $TAG (is the release published?)."
+  CHECKSUMS="$WORK/checksums.txt"
+fi
+
+# ── Extract per-platform SHA256s ────────────────────────────────────────────
+declare -A SHA
+for plat in "${PLATFORMS[@]}"; do
+  archive="citadel_v${VERSION}_${plat}.tar.gz"
+  sum=$(awk -v a="$archive" '$2==a {print $1}' "$CHECKSUMS")
+  [[ -n "$sum" ]] || fatal "No checksum for $archive in $CHECKSUMS."
+  SHA[$plat]="$sum"
+done
+
+# ── Clone tap and rewrite the formula ───────────────────────────────────────
+info "Cloning $TAP_REPO..."
+gh repo clone "$TAP_REPO" "$WORK/tap" -- --depth 1 --quiet \
+  || fatal "Could not clone $TAP_REPO."
+cd "$WORK/tap"
+[[ -f "$FORMULA_PATH" ]] || fatal "$FORMULA_PATH not found in tap."
+
+# awk keys each sha256 line off the platform token in the url line above it, so
+# the four bottles are matched positionally-independent and never mixed up. The
+# url lines interpolate #{version}, so only the version line + sha256s change.
+awk \
+  -v ver="$VERSION" \
+  -v da="${SHA[darwin_arm64]}" -v di="${SHA[darwin_amd64]}" \
+  -v la="${SHA[linux_arm64]}"  -v li="${SHA[linux_amd64]}" '
+  /^[[:space:]]*version "/            { sub(/version "[^"]*"/, "version \"" ver "\""); print; next }
+  /url ".*_darwin_arm64\./           { plat="da"; print; next }
+  /url ".*_darwin_amd64\./           { plat="di"; print; next }
+  /url ".*_linux_arm64\./            { plat="la"; print; next }
+  /url ".*_linux_amd64\./            { plat="li"; print; next }
+  /^[[:space:]]*sha256 "/ {
+    if      (plat=="da") sub(/sha256 "[^"]*"/, "sha256 \"" da "\"")
+    else if (plat=="di") sub(/sha256 "[^"]*"/, "sha256 \"" di "\"")
+    else if (plat=="la") sub(/sha256 "[^"]*"/, "sha256 \"" la "\"")
+    else if (plat=="li") sub(/sha256 "[^"]*"/, "sha256 \"" li "\"")
+    plat=""; print; next
+  }
+  { print }
+' "$FORMULA_PATH" > "$FORMULA_PATH.tmp"
+mv "$FORMULA_PATH.tmp" "$FORMULA_PATH"
+
+if git diff --quiet -- "$FORMULA_PATH"; then
+  info "Formula already at $VERSION with matching checksums — nothing to push."
+  exit 0
+fi
+
+info "Formula updated to $VERSION:"
+git --no-pager diff -- "$FORMULA_PATH"
+
+git add "$FORMULA_PATH"
+git commit -m "citadel ${VERSION}" --quiet
+git push origin HEAD --quiet
+info "Pushed formula update to $TAP_REPO (citadel ${VERSION})."


### PR DESCRIPTION
## Context

Cutting v2.73.0 surfaced that the Homebrew tap (`aceteam-ai/homebrew-tap`) was stuck at **2.70.0** — two releases stale. Root cause: `release.sh`'s `hook_post_release` only ever *printed a reminder* to "update the Homebrew tap with new version + checksums" by hand, while the README and `docs-site/.../releasing.md` both claimed the tap was updated **automatically**. Doc said automated; code said "good luck". So it drifted, and `brew install aceteam-ai/tap/citadel` shipped an old binary.

This makes the docs true: the tap now updates itself as part of every `release.sh` run.

## Summary

**`scripts/update-homebrew-tap.sh` (new)** — the actual tap sync, usable both from the release flow and standalone:
- Rewrites `Formula/citadel.rb`: the `version` line + the four macOS/Linux `sha256`s (Homebrew has no Windows bottles). The rewrite keys each `sha256` off the platform token in the `url` line above it (`_darwin_arm64.`, `_linux_amd64.`, …), so the four bottles can't get mismatched — the failure mode that makes a hand-edited formula install the wrong binary.
- Checksums come from `CHECKSUMS_FILE` (release.sh feeds its freshly built `release/checksums.txt`) **or** are downloaded from the published GitHub release via `gh release download`. The download path means it also works standalone to backfill a version the tap missed: `./scripts/update-homebrew-tap.sh 2.71.4`.
- **Idempotent**: if the formula already matches, it prints "nothing to push" and exits 0 — no empty commits.

**`scripts/release.sh`** — `hook_post_release` now calls the script with the release version (from `target_version` state, falling back to the latest tag). **Non-fatal**: a tap failure warns and prints the manual fallback, but the release itself still succeeds (the release is already pushed by that point; the tap is downstream).

**`README.md`** — the "Update Homebrew Tap" step and the manual-release note now describe the real mechanism and point at `update-homebrew-tap.sh`.

## Test plan

| Check | Result |
|-------|--------|
| `bash -n` on both scripts | pass |
| awk rewrite vs. real formula + real v2.73.0 checksums | all 4 SHAs mapped to correct platforms, only 5 lines changed |
| Run against tap (v2.73.0 bump) | pushed `citadel 2.73.0` to homebrew-tap (`e3d3d3f`); tap now at 2.73.0 |
| Idempotent re-run (GitHub-download path) | cloned, detected no diff, exited 0 without pushing |

Already dogfooded: this script performed the v2.73.0 tap bump that had been the outstanding manual step, so the tap is current as of this PR.

## Related

- Follows the v2.73.0 release (#512, tmux opt-in) whose manual tap step motivated this.