### PR TITLE
feat(meeting): /ace control verbs, sync vLLM summary, windowed transcription (#5435)

### DIFF
--- a/internal/jobs/meeting_command.go
+++ b/internal/jobs/meeting_command.go
@@ -52,8 +52,22 @@ var aceSpokenCommandPrefixes = []string{"slash ace", "slash-ace"}
 type CommandKind string
 
 const (
-	// CommandLeave is the one auto-executed action: end the bot's participation.
+	// CommandLeave is an auto-executed action: end the bot's participation. It is
+	// the one DESTRUCTIVE registry command (it ends the recording), which is why
+	// the safety property still requires the literal `/ace ` token for it.
 	CommandLeave CommandKind = "leave"
+	// CommandHelp posts the list of available `/ace` commands to the Meet chat.
+	CommandHelp CommandKind = "help"
+	// CommandStatus posts recording state, elapsed duration, and live-transcript
+	// health (segment count) to the Meet chat.
+	CommandStatus CommandKind = "status"
+	// CommandNote appends a timestamped NOTE to the meeting output buffer.
+	CommandNote CommandKind = "note"
+	// CommandAction appends a timestamped ACTION ITEM to the meeting output buffer.
+	CommandAction CommandKind = "action"
+	// CommandSummary summarizes the live transcript via the node-local vLLM and
+	// posts the result to the Meet chat.
+	CommandSummary CommandKind = "summary"
 	// CommandGeneric is a `/ace <command>` whose command word is not in the
 	// registry. It is captured and surfaced for the agent layer, not executed.
 	CommandGeneric CommandKind = "generic"
@@ -87,11 +101,22 @@ type RecognizedCommand struct {
 }
 
 // commandRegistry maps a `/ace <word>` command keyword to its kind. It is the
-// small, extensible surface for adding node-executed commands: today only
-// "leave" is auto-executed; a new entry here (plus wiring in meeting_join.go)
-// adds another. A word absent from the registry parses as CommandGeneric.
+// small, extensible surface for node-executed commands: a new entry here (plus a
+// case in the interactive dispatcher, meeting_commands_exec.go) adds another. A
+// word absent from the registry parses as CommandGeneric (captured, not executed).
+//
+// Every registered command EXCEPT leave is non-destructive (it only reads state
+// or appends to an in-memory buffer / posts chat), so the interactive layer
+// auto-executes them the same way it auto-executes leave. Only leave ends the
+// recording, so the safety property (literal `/ace ` token required) exists for
+// its sake; a stray auto-executed `/ace summary` from ambient speech is harmless.
 var commandRegistry = map[string]CommandKind{
-	"leave": CommandLeave,
+	"leave":   CommandLeave,
+	"help":    CommandHelp,
+	"status":  CommandStatus,
+	"note":    CommandNote,
+	"action":  CommandAction,
+	"summary": CommandSummary,
 }
 
 // ParseCommand scans one line of text (a transcript segment or a chat line) for

--- a/internal/jobs/meeting_command_test.go
+++ b/internal/jobs/meeting_command_test.go
@@ -139,13 +139,25 @@ func TestParseCommand_PickFirst(t *testing.T) {
 }
 
 func TestParseCommand_RegistryExtensible(t *testing.T) {
-	// Guard the registry contract: "leave" is the only auto-executed command
-	// today. If this changes, the wiring in meeting_join.go must be reviewed for
-	// what new destructive actions become auto-executable.
-	if len(commandRegistry) != 1 {
-		t.Fatalf("commandRegistry has %d entries; adding auto-executed commands requires reviewing meeting_join.go wiring", len(commandRegistry))
+	// Guard the registry contract: this is the exact reviewed set of auto-executed
+	// commands. "leave" is the only DESTRUCTIVE one (it ends the recording); the
+	// rest are non-destructive (read state / append a buffer / post chat). Adding
+	// an entry here requires wiring a dispatch case (meeting_commands_exec.go or
+	// the interactive loop for leave) and re-reviewing the safety property.
+	want := map[string]CommandKind{
+		"leave":   CommandLeave,
+		"help":    CommandHelp,
+		"status":  CommandStatus,
+		"note":    CommandNote,
+		"action":  CommandAction,
+		"summary": CommandSummary,
 	}
-	if commandRegistry["leave"] != CommandLeave {
-		t.Errorf("registry[leave] = %q, want %q", commandRegistry["leave"], CommandLeave)
+	if len(commandRegistry) != len(want) {
+		t.Fatalf("commandRegistry has %d entries, want %d; adding auto-executed commands requires reviewing the dispatch wiring", len(commandRegistry), len(want))
+	}
+	for word, kind := range want {
+		if commandRegistry[word] != kind {
+			t.Errorf("registry[%q] = %q, want %q", word, commandRegistry[word], kind)
+		}
 	}
 }

--- a/internal/jobs/meeting_commands_exec.go
+++ b/internal/jobs/meeting_commands_exec.go
@@ -1,0 +1,164 @@
+// internal/jobs/meeting_commands_exec.go
+//
+// In-call `/ace` command execution (issue #5435, epic #5097). The parser
+// (meeting_command.go) recognizes a command; this file ACTS on the
+// non-destructive verbs — help, status, note, action, summary — while leave is
+// handled inline by the interactive loop (it must break the loop, not just post
+// chat). Execution is deliberately kept OUT of the parser and OUT of package
+// globals: the executor is constructed with its exact dependencies (chat poster,
+// recording start time, live transcript buffer, summarizer, clock) so it is
+// unit-testable with fakes and never reaches into shared state.
+//
+// SELF-ECHO SAFETY (the #1 bug risk): every chat line the bot posts is seeded
+// into botMessages BEFORE the post (unconditionally, like announceOnAdmission)
+// so the interactive loop never re-parses the bot's own output as a command. All
+// bot output is a SINGLE line — multi-line output could be split by Meet into
+// separate chat rows, none of which would match the seeded full string, so a row
+// carrying "/ace ..." would be parsed and re-executed in a loop.
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// meetingTranscriptBuffer accumulates stabilized transcript segments during the
+// call so `/ace status` can report how much has been captured and `/ace summary`
+// can build a prompt. It is written and read only on the interactive loop's
+// single goroutine, so it needs no locking.
+type meetingTranscriptBuffer struct {
+	segments []TranscriptSegment
+}
+
+// add appends one stabilized segment.
+func (b *meetingTranscriptBuffer) add(s TranscriptSegment) {
+	b.segments = append(b.segments, s)
+}
+
+// count returns how many segments have been captured (transcript health signal).
+func (b *meetingTranscriptBuffer) count() int {
+	return len(b.segments)
+}
+
+// text joins the captured segment texts into one whitespace-collapsed string for
+// the summary prompt. Empty when nothing has streamed yet.
+func (b *meetingTranscriptBuffer) text() string {
+	parts := make([]string, 0, len(b.segments))
+	for _, s := range b.segments {
+		if t := strings.TrimSpace(s.Text); t != "" {
+			parts = append(parts, t)
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+// meetingCommandExecutor holds everything the non-destructive `/ace` verbs need,
+// injected rather than reached for. postChat seeds botMessages and posts to Meet
+// chat; startTime + now yield elapsed duration; transcript is the live buffer;
+// summarize is the (injectable) node-local vLLM call; out receives appended
+// notes/action items for the MEETING_JOIN result.
+type meetingCommandExecutor struct {
+	log        func(level, format string, args ...any)
+	postChat   func(text string)
+	startTime  time.Time
+	now        func() time.Time
+	transcript *meetingTranscriptBuffer
+	summarize  meetingSummarizer
+	out        *interactiveOutcome
+}
+
+// dispatch executes one recognized non-destructive command. Unknown/destructive
+// kinds are ignored here (leave is handled by the loop; generic/instruction are
+// captured only), so dispatch is a no-op for anything it does not own.
+func (e *meetingCommandExecutor) dispatch(cmd RecognizedCommand) {
+	switch cmd.Kind {
+	case CommandHelp:
+		e.postChat(meetingHelpText)
+	case CommandStatus:
+		e.postChat(e.statusText())
+	case CommandNote:
+		e.appendEntry("NOTE", cmd.Instruction, "noted")
+	case CommandAction:
+		e.appendEntry("ACTION", cmd.Instruction, "action item recorded")
+	case CommandSummary:
+		e.postSummary()
+	}
+}
+
+// meetingHelpText is the single-line command list posted for `/ace help`. Single
+// line by design (see the SELF-ECHO SAFETY note); the seed suppresses re-parsing
+// the "/ace ..." tokens it contains.
+const meetingHelpText = "AceTeam commands: /ace help · /ace status · /ace note <text> · " +
+	"/ace action <text> · /ace summary · /ace leave"
+
+// statusText reports recording state, elapsed duration, and transcript health.
+func (e *meetingCommandExecutor) statusText() string {
+	return fmt.Sprintf("Status: recording · %s elapsed · %d transcript segments captured",
+		formatElapsed(e.elapsed()), e.transcript.count())
+}
+
+// appendEntry records a timestamped NOTE/ACTION in the outcome buffer and
+// confirms in chat. Empty text is not recorded — the bot posts a usage hint
+// instead so a stray "/ace note" does not litter the buffer with blanks.
+func (e *meetingCommandExecutor) appendEntry(label, text, confirmation string) {
+	text = strings.TrimSpace(collapseToSingleLine(text))
+	if text == "" {
+		e.postChat(fmt.Sprintf("Nothing to record — usage: /ace %s <text>", strings.ToLower(label)))
+		return
+	}
+	entry := fmt.Sprintf("[%s] %s: %s", formatElapsed(e.elapsed()), label, text)
+	e.out.notes = append(e.out.notes, entry)
+	e.postChat(fmt.Sprintf("%s: %s", confirmation, text))
+}
+
+// postSummary builds a prompt from the live transcript, calls the summarizer
+// synchronously, and posts the result. It NEVER lets a summarizer failure crash
+// the loop: an empty buffer or an unreachable model yields a clear fallback chat
+// message. Runs on the loop goroutine so it shares the transcript buffer with no
+// race; the summarizer's own tight timeout bounds the pause.
+func (e *meetingCommandExecutor) postSummary() {
+	transcript := e.transcript.text()
+	if strings.TrimSpace(transcript) == "" {
+		e.postChat("No transcript captured yet — nothing to summarize.")
+		return
+	}
+	summary, err := e.summarize(context.Background(), transcript)
+	if err != nil || strings.TrimSpace(summary) == "" {
+		if err != nil {
+			e.log("warn", "     - /ace summary: local model unavailable (non-fatal): %v", err)
+		}
+		e.postChat("Summary unavailable right now — the local model is unreachable.")
+		return
+	}
+	e.postChat("Summary: " + collapseToSingleLine(summary))
+}
+
+// elapsed is the wall time since recording started.
+func (e *meetingCommandExecutor) elapsed() time.Duration {
+	return e.now().Sub(e.startTime)
+}
+
+// formatElapsed renders a duration as H:MM:SS (or MM:SS under an hour) for the
+// meeting-relative timestamps on notes and the status line.
+func formatElapsed(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	total := int(d.Seconds())
+	h := total / 3600
+	m := (total % 3600) / 60
+	s := total % 60
+	if h > 0 {
+		return fmt.Sprintf("%d:%02d:%02d", h, m, s)
+	}
+	return fmt.Sprintf("%02d:%02d", m, s)
+}
+
+// collapseToSingleLine flattens any newlines/runs of whitespace in a string to
+// single spaces so every bot chat post stays on ONE line (see the SELF-ECHO
+// SAFETY note). Model summaries and pasted note text can arrive multi-line.
+func collapseToSingleLine(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}

--- a/internal/jobs/meeting_commands_exec_test.go
+++ b/internal/jobs/meeting_commands_exec_test.go
@@ -1,0 +1,195 @@
+package jobs
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newTestExecutor builds a meetingCommandExecutor with a capturing chat poster, a
+// fixed clock (elapsed = 125s), an empty transcript, and an injected summarizer.
+// posted collects every chat line the executor emits.
+func newTestExecutor(summarize meetingSummarizer) (*meetingCommandExecutor, *[]string, *interactiveOutcome, *meetingTranscriptBuffer) {
+	var posted []string
+	out := &interactiveOutcome{}
+	buf := &meetingTranscriptBuffer{}
+	start := time.Unix(1_700_000_000, 0)
+	e := &meetingCommandExecutor{
+		log:        func(string, string, ...any) {},
+		postChat:   func(text string) { posted = append(posted, text) },
+		startTime:  start,
+		now:        func() time.Time { return start.Add(125 * time.Second) },
+		transcript: buf,
+		summarize:  summarize,
+		out:        out,
+	}
+	return e, &posted, out, buf
+}
+
+func dispatchWord(e *meetingCommandExecutor, kind CommandKind, word, instruction string) {
+	e.dispatch(RecognizedCommand{Kind: kind, Command: word, Instruction: instruction})
+}
+
+func TestExecutor_Help(t *testing.T) {
+	e, posted, _, _ := newTestExecutor(nil)
+	dispatchWord(e, CommandHelp, "help", "")
+	if len(*posted) != 1 || (*posted)[0] != meetingHelpText {
+		t.Fatalf("help posted %v, want the help text", *posted)
+	}
+	// The help text must be a single line so Meet cannot split it into rows that
+	// evade the self-echo seed (each row would re-parse the "/ace ..." tokens).
+	if strings.ContainsAny(meetingHelpText, "\n\r") {
+		t.Error("help text must be a single line")
+	}
+}
+
+func TestExecutor_Status(t *testing.T) {
+	e, posted, _, buf := newTestExecutor(nil)
+	buf.add(TranscriptSegment{Start: 0, End: 2, Text: "hello"})
+	buf.add(TranscriptSegment{Start: 2, End: 4, Text: "world"})
+	dispatchWord(e, CommandStatus, "status", "")
+	if len(*posted) != 1 {
+		t.Fatalf("status posted %d messages, want 1", len(*posted))
+	}
+	got := (*posted)[0]
+	for _, want := range []string{"recording", "02:05", "2 transcript segments"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("status %q missing %q", got, want)
+		}
+	}
+}
+
+func TestExecutor_NoteWithText(t *testing.T) {
+	e, posted, out, _ := newTestExecutor(nil)
+	dispatchWord(e, CommandNote, "note", "buy more GPUs")
+	if len(out.notes) != 1 {
+		t.Fatalf("notes = %v, want one entry", out.notes)
+	}
+	if !strings.Contains(out.notes[0], "NOTE:") || !strings.Contains(out.notes[0], "buy more GPUs") || !strings.Contains(out.notes[0], "02:05") {
+		t.Errorf("note entry %q missing label/timestamp/text", out.notes[0])
+	}
+	if len(*posted) != 1 || !strings.Contains((*posted)[0], "noted") {
+		t.Errorf("note confirmation = %v, want a 'noted' confirmation", *posted)
+	}
+}
+
+func TestExecutor_NoteWithoutText(t *testing.T) {
+	e, posted, out, _ := newTestExecutor(nil)
+	dispatchWord(e, CommandNote, "note", "   ")
+	if len(out.notes) != 0 {
+		t.Errorf("empty note must not append an entry; got %v", out.notes)
+	}
+	if len(*posted) != 1 || !strings.Contains((*posted)[0], "usage") {
+		t.Errorf("empty note should post a usage hint; got %v", *posted)
+	}
+}
+
+func TestExecutor_Action(t *testing.T) {
+	e, posted, out, _ := newTestExecutor(nil)
+	dispatchWord(e, CommandAction, "action", "Alice to send the deck")
+	if len(out.notes) != 1 || !strings.Contains(out.notes[0], "ACTION:") || !strings.Contains(out.notes[0], "Alice to send the deck") {
+		t.Fatalf("action entry = %v, want an ACTION entry", out.notes)
+	}
+	if len(*posted) != 1 || !strings.Contains((*posted)[0], "action item") {
+		t.Errorf("action confirmation = %v", *posted)
+	}
+}
+
+func TestExecutor_SummaryEmptyBuffer(t *testing.T) {
+	called := false
+	e, posted, _, _ := newTestExecutor(func(context.Context, string) (string, error) {
+		called = true
+		return "should not run", nil
+	})
+	dispatchWord(e, CommandSummary, "summary", "")
+	if called {
+		t.Error("summarizer must NOT be called on an empty transcript")
+	}
+	if len(*posted) != 1 || !strings.Contains(strings.ToLower((*posted)[0]), "nothing to summarize") {
+		t.Errorf("empty-buffer summary = %v, want a 'nothing to summarize' message", *posted)
+	}
+}
+
+func TestExecutor_SummaryModelDown(t *testing.T) {
+	e, posted, _, buf := newTestExecutor(func(context.Context, string) (string, error) {
+		return "", errors.New("connection refused")
+	})
+	buf.add(TranscriptSegment{Start: 0, End: 3, Text: "we discussed the roadmap"})
+	dispatchWord(e, CommandSummary, "summary", "")
+	if len(*posted) != 1 || !strings.Contains(strings.ToLower((*posted)[0]), "unavailable") {
+		t.Errorf("vLLM-down summary = %v, want a graceful fallback message", *posted)
+	}
+}
+
+func TestExecutor_SummarySuccessIsSingleLine(t *testing.T) {
+	e, posted, _, buf := newTestExecutor(func(_ context.Context, transcript string) (string, error) {
+		if !strings.Contains(transcript, "roadmap") {
+			t.Errorf("summarizer got transcript %q, want it to include the buffer text", transcript)
+		}
+		return "Line one.\nLine two.\n\nLine three.", nil
+	})
+	buf.add(TranscriptSegment{Start: 0, End: 3, Text: "we discussed the roadmap"})
+	dispatchWord(e, CommandSummary, "summary", "")
+	if len(*posted) != 1 {
+		t.Fatalf("summary posted %d, want 1", len(*posted))
+	}
+	got := (*posted)[0]
+	if strings.ContainsAny(got, "\n\r") {
+		t.Errorf("summary post %q must be a single line (self-echo safety)", got)
+	}
+	if !strings.Contains(got, "Line one. Line two. Line three.") {
+		t.Errorf("summary %q did not collapse newlines to spaces", got)
+	}
+}
+
+func TestExecutor_GenericKindIsNoOp(t *testing.T) {
+	e, posted, out, _ := newTestExecutor(nil)
+	// A captured-but-not-executed kind must produce no chat and no notes.
+	e.dispatch(RecognizedCommand{Kind: CommandGeneric, Command: "frobnicate"})
+	if len(*posted) != 0 || len(out.notes) != 0 {
+		t.Errorf("generic dispatch had side effects: posted=%v notes=%v", *posted, out.notes)
+	}
+}
+
+func TestFormatElapsed(t *testing.T) {
+	cases := map[time.Duration]string{
+		0:                  "00:00",
+		65 * time.Second:   "01:05",
+		125 * time.Second:  "02:05",
+		3661 * time.Second: "1:01:01",
+		-5 * time.Second:   "00:00",
+	}
+	for d, want := range cases {
+		if got := formatElapsed(d); got != want {
+			t.Errorf("formatElapsed(%v) = %q, want %q", d, got, want)
+		}
+	}
+}
+
+func TestParseCommand_NewVerbs(t *testing.T) {
+	cases := []struct {
+		line  string
+		kind  CommandKind
+		cmd   string
+		instr string
+	}{
+		{"/ace help", CommandHelp, "help", ""},
+		{"/ace status", CommandStatus, "status", ""},
+		{"/ace note buy more GPUs", CommandNote, "note", "buy more GPUs"},
+		{"/ace action Alice to send the deck", CommandAction, "action", "Alice to send the deck"},
+		{"/ace summary", CommandSummary, "summary", ""},
+	}
+	for _, c := range cases {
+		got, ok := ParseCommand(c.line, SourceChat)
+		if !ok {
+			t.Errorf("ParseCommand(%q) not recognized", c.line)
+			continue
+		}
+		if got.Kind != c.kind || got.Command != c.cmd || got.Instruction != c.instr {
+			t.Errorf("ParseCommand(%q) = {kind:%q cmd:%q instr:%q}, want {kind:%q cmd:%q instr:%q}",
+				c.line, got.Kind, got.Command, got.Instruction, c.kind, c.cmd, c.instr)
+		}
+	}
+}

--- a/internal/jobs/meeting_interactive.go
+++ b/internal/jobs/meeting_interactive.go
@@ -295,6 +295,14 @@ func checkMeetingEnded(page meetPage) (string, bool) {
 // a segment always stabilizes and is emitted before it slides out of the window.
 // If clipping fails (e.g. the header is not fully written yet early in a call),
 // it falls back to whole-file transcription: correctness over latency.
+//
+// Known quality wrinkle (live-verification item): each clip's LEADING edge
+// starts mid-utterance ~window seconds back, so whisper may occasionally emit a
+// short garbled fragment there. Absolute-start bucket dedup drops the common case
+// (that audio was already emitted with full context in a prior pass), but a
+// fragment landing in a never-before-started bucket can slip into the streamed
+// buffer. This is cosmetic — the STORED transcript is the untouched end-of-call
+// batch pass, and garbled text won't match an `/ace` token.
 func (h *MeetingJoinHandler) transcribeSegments(ctx JobContext, meetingID, wavPath string) ([]TranscriptSegment, error) {
 	h.transcribeMu.Lock()
 	defer h.transcribeMu.Unlock()

--- a/internal/jobs/meeting_interactive.go
+++ b/internal/jobs/meeting_interactive.go
@@ -34,6 +34,11 @@ import (
 const (
 	defaultStreamingInterval = 15 * time.Second
 	defaultStreamingWindow   = 10 * time.Second
+	// defaultStreamingMaxWindow caps the trailing audio each rolling pass
+	// re-transcribes (see meeting_transcribe_window.go). Far larger than
+	// defaultStreamingWindow + defaultStreamingInterval so a segment always
+	// stabilizes and is emitted before it slides out of the re-fed window.
+	defaultStreamingMaxWindow = 90 * time.Second
 )
 
 // meetPage is the browser surface the interactive session drives via page JS:
@@ -54,6 +59,9 @@ type interactiveOutcome struct {
 	chat             []MeetChatMessage
 	streamedSegments int
 	recognized       []RecognizedCommand
+	// notes are timestamped NOTE/ACTION entries appended by the in-call `/ace
+	// note` and `/ace action` commands, surfaced in the MEETING_JOIN result.
+	notes []string
 }
 
 func (h *MeetingJoinHandler) streamingInterval() time.Duration {
@@ -143,9 +151,34 @@ func (h *MeetingJoinHandler) waitForMeetingEndInteractive(
 	seenChat := make(map[int]struct{})
 	var leaveRequested bool
 
+	// transcript accumulates stabilized segments so `/ace status` and `/ace
+	// summary` can read the live conversation. Written only in drainSegments.
+	transcript := &meetingTranscriptBuffer{}
+
+	// exec runs the non-destructive `/ace` verbs (help/status/note/action/
+	// summary). postChat SEEDS botMessages before every post so the loop never
+	// re-parses the bot's own output (the #1 self-echo bug). startTime is the loop
+	// entry, i.e. the moment recording is under way.
+	exec := &meetingCommandExecutor{
+		log: ctx.Log,
+		postChat: func(text string) {
+			botMessages[normalizeChatText(text)] = struct{}{}
+			if err := postMeetChat(page, text); err != nil {
+				ctx.Log("warn", "     - could not post `/ace` reply to chat (non-fatal, selector may be stale): %v", err)
+			}
+		},
+		startTime:  time.Now(),
+		now:        time.Now,
+		transcript: transcript,
+		summarize:  localVLLMSummarize,
+		out:        &out,
+	}
+
 	// handleLine parses one transcript/chat line for an invocation and records
-	// it. Only a literal `/ace leave` is auto-executed (below); generic commands
-	// and wake-phrase instructions are captured/surfaced for the agent layer.
+	// it. `/ace leave` is auto-executed by the loop below (it must break the
+	// loop); the other registered verbs are executed here (non-destructive: they
+	// only read state, append to a buffer, or post chat). Generic commands and
+	// wake-phrase instructions are captured/surfaced for the agent layer.
 	handleLine := func(line string, source CommandSource) {
 		cmd, ok := ParseCommand(line, source)
 		if !ok {
@@ -155,13 +188,15 @@ func (h *MeetingJoinHandler) waitForMeetingEndInteractive(
 		out.recognized = append(out.recognized, cmd)
 		if cmd.Kind == CommandLeave {
 			leaveRequested = true
+			return
 		}
+		exec.dispatch(cmd)
 	}
 
 	deadline := time.Now().Add(p.maxDuration())
 	for time.Now().Before(deadline) {
 		// 1. Drain newly-stabilized transcript segments (non-blocking).
-		h.drainSegments(segCh, &out, handleLine)
+		h.drainSegments(segCh, &out, transcript, handleLine)
 
 		// 2. Read chat; feed new lines (dedup by append-only index).
 		if msgs, err := readMeetChat(page); err != nil {
@@ -206,13 +241,15 @@ func (h *MeetingJoinHandler) waitForMeetingEndInteractive(
 }
 
 // drainSegments pulls all currently-buffered transcript segments without
-// blocking, updating the outcome's streamed count and feeding each to
+// blocking, updating the outcome's streamed count, accumulating each into the
+// live transcript buffer (for `/ace status`/`/ace summary`), and feeding each to
 // handleLine. Extracted so the non-blocking drain is readable and reusable.
-func (h *MeetingJoinHandler) drainSegments(segCh <-chan TranscriptSegment, out *interactiveOutcome, handleLine func(string, CommandSource)) {
+func (h *MeetingJoinHandler) drainSegments(segCh <-chan TranscriptSegment, out *interactiveOutcome, transcript *meetingTranscriptBuffer, handleLine func(string, CommandSource)) {
 	for {
 		select {
 		case s := <-segCh:
 			out.streamedSegments++
+			transcript.add(s)
 			handleLine(s.Text, SourceTranscript)
 		default:
 			return
@@ -239,17 +276,40 @@ func checkMeetingEnded(page meetPage) (string, bool) {
 	return "", false
 }
 
-// transcribeSegments re-transcribes the growing recording and returns its
-// segments, for one rolling pass. It serializes sidecar access via
-// h.transcribeMu so a rolling pass never overlaps the final batch transcribe (or
-// another pass) — they would otherwise hit the whisper sidecar and read the
-// in-progress WAV concurrently. An error is returned (not fatal) so the rolling
-// driver logs and retries on the next tick.
+// transcribeSegments transcribes the recent TAIL of the growing recording and
+// returns its segments (on the ABSOLUTE recording timeline) for one rolling pass.
+// It serializes sidecar access via h.transcribeMu so a rolling pass never
+// overlaps the final batch transcribe (or another pass) — they would otherwise
+// hit the whisper sidecar and read the in-progress WAV concurrently. An error is
+// returned (not fatal) so the rolling driver logs and retries on the next tick.
+//
+// WINDOWING (the latency fix): the whisper sidecar transcribes a whole file with
+// no offset/streaming API, so re-transcribing the entire wav-so-far every pass
+// makes each pass slower as the call grows. Instead this clips only the trailing
+// h.streamingMaxWindow() of audio into a workspace-local scratch WAV
+// (meeting_transcribe_window.go) and transcribes THAT, then shifts the returned
+// segment times by the clip's start offset back onto the absolute timeline so the
+// rolling driver's absolute-start dedup/stabilization contract is preserved. The
+// tradeoff — segments older than the window are never re-fed — is safe because
+// the window (default 90s) is far larger than the stability margin + cadence, so
+// a segment always stabilizes and is emitted before it slides out of the window.
+// If clipping fails (e.g. the header is not fully written yet early in a call),
+// it falls back to whole-file transcription: correctness over latency.
 func (h *MeetingJoinHandler) transcribeSegments(ctx JobContext, meetingID, wavPath string) ([]TranscriptSegment, error) {
 	h.transcribeMu.Lock()
 	defer h.transcribeMu.Unlock()
 
-	synthetic := syntheticTranscribeJob(meetingID+"-rolling", wavPath)
+	transcribePath := wavPath
+	var offset float64
+	clipPath := meetingWindowWavPath(h.WorkspaceDir, meetingID)
+	if off, err := clipWavTail(wavPath, clipPath, h.streamingMaxWindow()); err != nil {
+		ctx.Log("warn", "     - rolling window clip failed, falling back to whole-file transcribe (non-fatal): %v", err)
+	} else {
+		transcribePath = clipPath
+		offset = off
+	}
+
+	synthetic := syntheticTranscribeJob(meetingID+"-rolling", transcribePath)
 	raw, err := h.transcriber.Execute(ctx, synthetic)
 	if err != nil {
 		return nil, err
@@ -260,5 +320,20 @@ func (h *MeetingJoinHandler) transcribeSegments(ctx JobContext, meetingID, wavPa
 	if err := json.Unmarshal(raw, &decoded); err != nil {
 		return nil, fmt.Errorf("decode rolling transcript segments: %w", err)
 	}
+	if offset > 0 {
+		for i := range decoded.Segments {
+			decoded.Segments[i].Start += offset
+			decoded.Segments[i].End += offset
+		}
+	}
 	return decoded.Segments, nil
+}
+
+// streamingMaxWindow resolves the trailing-audio cap for a rolling pass, falling
+// back to the package default when unset.
+func (h *MeetingJoinHandler) streamingMaxWindow() time.Duration {
+	if h.StreamingMaxWindow > 0 {
+		return h.StreamingMaxWindow
+	}
+	return defaultStreamingMaxWindow
 }

--- a/internal/jobs/meeting_interactive_test.go
+++ b/internal/jobs/meeting_interactive_test.go
@@ -231,6 +231,79 @@ func TestAnnounceOnAdmission_SeedsOwnMessageGuard(t *testing.T) {
 	}
 }
 
+// TestInteractive_HelpCommandDoesNotSelfLeaveOnEcho is the self-echo regression
+// guard for the new verbs. A participant types `/ace help`; the bot posts the
+// help text, which literally contains "/ace leave". Meet echoes the bot's own
+// message back into the chat panel. If the loop scanned that echo it would parse
+// the embedded "/ace leave" and end the call. The post-time seed of botMessages
+// (done by the loop's postChat wrapper) must suppress command parsing for the
+// echoed line while still capturing it for the audit trail.
+func TestInteractive_HelpCommandDoesNotSelfLeaveOnEcho(t *testing.T) {
+	h := newTestInteractiveHandler()
+
+	helpJSON, _ := json.Marshal(meetingHelpText)
+	page := &fakeMeetPage{chatReads: []string{
+		// Poll 1: a participant asks for help (triggers the bot's help post).
+		`[{"index":0,"sender":"Bob","text":"/ace help"}]`,
+		// Poll 2: the bot's own help output is echoed back by Meet.
+		`[{"index":0,"sender":"Bob","text":"/ace help"},{"index":1,"sender":"You","text":` + string(helpJSON) + `}]`,
+	}}
+	go func() {
+		time.Sleep(25 * time.Millisecond)
+		page.mu.Lock()
+		page.ended = true
+		page.mu.Unlock()
+	}()
+	noSegments := func() ([]TranscriptSegment, error) { return nil, nil }
+
+	out := h.waitForMeetingEndInteractive(JobContext{}, page, testParams(), noSegments, time.Millisecond, map[string]struct{}{})
+
+	if out.endReason == "ace_command_leave" || page.leaveHit {
+		t.Fatal("bot self-triggered a leave from its own /ace help echo")
+	}
+	// Exactly one command recognized: Bob's /ace help. The echoed help line
+	// (which contains "/ace leave") must be suppressed by the own-message guard.
+	if len(out.recognized) != 1 || out.recognized[0].Kind != CommandHelp {
+		t.Errorf("recognized = %+v, want exactly one help command", out.recognized)
+	}
+	// The bot must have actually posted the help text (recorded by the fake).
+	var postedHelp bool
+	for _, js := range page.posted {
+		if strings.Contains(js, "AceTeam commands") {
+			postedHelp = true
+		}
+	}
+	if !postedHelp {
+		t.Error("expected the bot to post the help text to chat")
+	}
+}
+
+// TestInteractive_NoteCommandRecordsToOutcome verifies an in-call `/ace note`
+// flows through the loop into the outcome's notes buffer (surfaced in the
+// MEETING_JOIN result) and does not trigger a leave.
+func TestInteractive_NoteCommandRecordsToOutcome(t *testing.T) {
+	h := newTestInteractiveHandler()
+	page := &fakeMeetPage{chatReads: []string{
+		`[{"index":0,"sender":"Ann","text":"/ace note ship the release"}]`,
+	}}
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		page.mu.Lock()
+		page.ended = true
+		page.mu.Unlock()
+	}()
+	noSegments := func() ([]TranscriptSegment, error) { return nil, nil }
+
+	out := h.waitForMeetingEndInteractive(JobContext{}, page, testParams(), noSegments, time.Millisecond, map[string]struct{}{})
+
+	if page.leaveHit {
+		t.Error("/ace note must not trigger a leave")
+	}
+	if len(out.notes) != 1 || !strings.Contains(out.notes[0], "ship the release") {
+		t.Errorf("outcome notes = %v, want the noted text", out.notes)
+	}
+}
+
 // TestInteractive_DoesNotSelfTriggerOnAnnouncementEcho is the regression guard
 // for the self-echo landmine: the bot posts an announcement that literally
 // contains "/ace leave", and Meet renders the bot's own message back in the chat

--- a/internal/jobs/meeting_join.go
+++ b/internal/jobs/meeting_join.go
@@ -296,6 +296,10 @@ type MeetingJoinHandler struct {
 	// values fall back to the package defaults at use.
 	StreamingInterval time.Duration
 	StreamingWindow   time.Duration
+	// StreamingMaxWindow caps how much trailing audio each rolling pass
+	// re-transcribes (see meeting_transcribe_window.go), keeping per-pass cost
+	// bounded regardless of call length. Zero falls back to the package default.
+	StreamingMaxWindow time.Duration
 
 	// transcribeMu serializes whisper-sidecar access so a during-call rolling
 	// pass (meeting_interactive.go) never overlaps the end-of-call batch
@@ -354,6 +358,9 @@ func (h *MeetingJoinHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, er
 	if err := os.MkdirAll(filepath.Dir(wavPath), 0o700); err != nil {
 		return nil, fmt.Errorf("create meetings dir: %w", err)
 	}
+	// The rolling-window transcription scratch clip (meeting_transcribe_window.go)
+	// is a per-pass temp; remove it on exit so it does not linger in the workspace.
+	defer func() { _ = os.Remove(meetingWindowWavPath(h.WorkspaceDir, p.MeetingID)) }()
 	if err := rec.Start(wavPath); err != nil {
 		return nil, fmt.Errorf("start recording: %w", err)
 	}
@@ -395,6 +402,7 @@ func (h *MeetingJoinHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, er
 			"chat":                chatForResult(outcome.chat),
 			"recognized_commands": commandsForResult(outcome.recognized),
 			"streamed_segments":   outcome.streamedSegments,
+			"notes":               notesForResult(outcome.notes),
 		})
 		return out, nil
 	}
@@ -408,6 +416,7 @@ func (h *MeetingJoinHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, er
 		"chat":                chatForResult(outcome.chat),
 		"recognized_commands": commandsForResult(outcome.recognized),
 		"streamed_segments":   outcome.streamedSegments,
+		"notes":               notesForResult(outcome.notes),
 	})
 	return out, nil
 }
@@ -609,6 +618,15 @@ func commandsForResult(cmds []RecognizedCommand) []RecognizedCommand {
 		return []RecognizedCommand{}
 	}
 	return cmds
+}
+
+// notesForResult normalizes the in-call NOTE/ACTION entries to an empty array so
+// the additive `notes` field serializes as [] rather than null.
+func notesForResult(notes []string) []string {
+	if notes == nil {
+		return []string{}
+	}
+	return notes
 }
 
 // JobTypeTranscribeAudioType is the wire type string for the transcription job,

--- a/internal/jobs/meeting_summary.go
+++ b/internal/jobs/meeting_summary.go
@@ -1,0 +1,158 @@
+// internal/jobs/meeting_summary.go
+//
+// Synchronous, node-local vLLM summarization for the in-call `/ace summary`
+// command (issue #5435, epic #5097). Unlike the Redis-job inference handlers
+// (llm_inference.go / vllm_inference.go), this is a SMALL in-process helper
+// called on the interactive meeting loop's own goroutine: a participant types
+// `/ace summary`, the bot summarizes the live transcript buffer and posts the
+// result back to Meet chat, all within one poll tick.
+//
+// DESIGN — why this does NOT reuse waitForVLLMReady:
+//   - The Redis inference handlers poll vLLM's /health for up to 60s before
+//     giving up. Doing that here would freeze the meeting loop (chat/leave/end
+//     checks all pause) for a full minute whenever the model is cold or absent.
+//     Instead this makes a SINGLE attempt under a tight context deadline
+//     (localVLLMTimeout): any failure — unreachable, no served model, non-200,
+//     empty completion, or timeout — returns an error so the caller posts a
+//     graceful fallback message and the meeting continues untouched.
+package jobs
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// localVLLMBaseURL is the node-local vLLM OpenAI-compatible endpoint. It mirrors
+// VLLMInferenceHandler (vllm_inference.go), which targets localhost:8000 for the
+// meeting/inference node's vLLM. Kept as a single const so a port change is a
+// one-place edit.
+const localVLLMBaseURL = "http://localhost:8000"
+
+// localVLLMTimeout bounds the WHOLE summary round-trip (model discovery + the
+// completion). It is deliberately tight: the call runs on the meeting loop
+// goroutine, so a long deadline would stall in-call chat/leave/end handling.
+const localVLLMTimeout = 8 * time.Second
+
+// meetingSummaryMaxTranscriptChars caps how much of the live transcript is fed
+// to the model so a long call cannot blow the prompt (or the tight deadline).
+// The TAIL is kept (recent discussion is the most summary-relevant) when the
+// buffer exceeds the cap.
+const meetingSummaryMaxTranscriptChars = 6000
+
+// meetingSummarizer summarizes a transcript and returns a single-paragraph
+// summary. It is injected into the command executor so tests can supply a fake
+// (or a failing) implementation without a real vLLM. An error means "summary
+// unavailable"; the caller posts a fallback message rather than propagating it.
+type meetingSummarizer func(ctx context.Context, transcript string) (string, error)
+
+// localVLLMSummarize is the production meetingSummarizer: it discovers the served
+// model, then requests a short summary from the node-local vLLM. It never blocks
+// longer than localVLLMTimeout and returns a plain error on any failure path so
+// the meeting loop degrades to a fallback chat message.
+func localVLLMSummarize(ctx context.Context, transcript string) (string, error) {
+	transcript = strings.TrimSpace(transcript)
+	if transcript == "" {
+		return "", fmt.Errorf("empty transcript")
+	}
+	if len(transcript) > meetingSummaryMaxTranscriptChars {
+		transcript = transcript[len(transcript)-meetingSummaryMaxTranscriptChars:]
+	}
+
+	cctx, cancel := context.WithTimeout(ctx, localVLLMTimeout)
+	defer cancel()
+
+	model, err := discoverLocalVLLMModel(cctx)
+	if err != nil {
+		return "", fmt.Errorf("discover vLLM model: %w", err)
+	}
+
+	prompt := buildMeetingSummaryPrompt(transcript)
+	reqBody, _ := json.Marshal(map[string]any{
+		"model":       model,
+		"prompt":      prompt,
+		"max_tokens":  256,
+		"temperature": 0.3,
+		"stop":        []string{"\n\n"},
+	})
+
+	req, err := http.NewRequestWithContext(cctx, http.MethodPost, localVLLMBaseURL+"/v1/completions", bytes.NewBuffer(reqBody))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("connect to vLLM: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("vLLM returned status %d", resp.StatusCode)
+	}
+
+	var decoded struct {
+		Choices []struct {
+			Text string `json:"text"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return "", fmt.Errorf("parse vLLM response: %w", err)
+	}
+	if len(decoded.Choices) == 0 {
+		return "", fmt.Errorf("vLLM returned no choices")
+	}
+	summary := strings.TrimSpace(decoded.Choices[0].Text)
+	if summary == "" {
+		return "", fmt.Errorf("vLLM returned an empty summary")
+	}
+	return summary, nil
+}
+
+// discoverLocalVLLMModel asks vLLM which model is served and returns the first
+// id. vLLM validates the completion request's "model" against its served models,
+// so the summary cannot hardcode a name — it must ask. Any failure (unreachable
+// or no models) is an error that aborts the summary.
+func discoverLocalVLLMModel(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, localVLLMBaseURL+"/v1/models", nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("connect to vLLM: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("vLLM /v1/models returned status %d", resp.StatusCode)
+	}
+	var decoded struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		return "", fmt.Errorf("parse vLLM models: %w", err)
+	}
+	if len(decoded.Data) == 0 || strings.TrimSpace(decoded.Data[0].ID) == "" {
+		return "", fmt.Errorf("vLLM reports no served models")
+	}
+	return decoded.Data[0].ID, nil
+}
+
+// buildMeetingSummaryPrompt frames the transcript for a completion model. The
+// closing "Summary:" cue plus the "\n\n" stop keeps the output to one compact
+// paragraph, which the caller collapses to a single chat line.
+func buildMeetingSummaryPrompt(transcript string) string {
+	return "You are a meeting notetaker. Summarize the meeting so far in 2-3 concise " +
+		"sentences, capturing decisions and action items. Do not add anything not in the transcript.\n\n" +
+		"Transcript:\n" + transcript + "\n\nSummary:"
+}

--- a/internal/jobs/meeting_summary.go
+++ b/internal/jobs/meeting_summary.go
@@ -28,11 +28,16 @@ import (
 	"time"
 )
 
-// localVLLMBaseURL is the node-local vLLM OpenAI-compatible endpoint. It mirrors
-// VLLMInferenceHandler (vllm_inference.go), which targets localhost:8000 for the
-// meeting/inference node's vLLM. Kept as a single const so a port change is a
-// one-place edit.
-const localVLLMBaseURL = "http://localhost:8000"
+// localVLLMBaseURL returns the node-local vLLM OpenAI-compatible base URL. It
+// uses the shared vllmBaseURL() helper (llm_inference.go) rather than a literal
+// so the port comes from the citadel port registry (services.VLLMHostPort) AND
+// honors the CITADEL_VLLM_HOST_PORT override — the same source the newer
+// LLMInferenceHandler resolves. (The legacy VLLMInferenceHandler still hardcodes
+// :8000, a pre-registry literal; a per-node port change belongs in the registry/
+// env, not here.)
+func localVLLMBaseURL() string {
+	return vllmBaseURL()
+}
 
 // localVLLMTimeout bounds the WHOLE summary round-trip (model discovery + the
 // completion). It is deliberately tight: the call runs on the meeting loop
@@ -81,7 +86,7 @@ func localVLLMSummarize(ctx context.Context, transcript string) (string, error) 
 		"stop":        []string{"\n\n"},
 	})
 
-	req, err := http.NewRequestWithContext(cctx, http.MethodPost, localVLLMBaseURL+"/v1/completions", bytes.NewBuffer(reqBody))
+	req, err := http.NewRequestWithContext(cctx, http.MethodPost, localVLLMBaseURL()+"/v1/completions", bytes.NewBuffer(reqBody))
 	if err != nil {
 		return "", err
 	}
@@ -121,7 +126,7 @@ func localVLLMSummarize(ctx context.Context, transcript string) (string, error) 
 // so the summary cannot hardcode a name — it must ask. Any failure (unreachable
 // or no models) is an error that aborts the summary.
 func discoverLocalVLLMModel(ctx context.Context) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, localVLLMBaseURL+"/v1/models", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, localVLLMBaseURL()+"/v1/models", nil)
 	if err != nil {
 		return "", err
 	}

--- a/internal/jobs/meeting_transcribe_window.go
+++ b/internal/jobs/meeting_transcribe_window.go
@@ -1,0 +1,195 @@
+// internal/jobs/meeting_transcribe_window.go
+//
+// Bounded rolling-window WAV clipping for during-call transcription (issue
+// #5435, epic #5097). The whisper sidecar transcribes a WHOLE file (no
+// offset/streaming API), so re-transcribing the entire wav-so-far every rolling
+// pass makes each pass slower as the call grows — the latency wall. This clips
+// only the trailing window of audio into a scratch WAV so per-pass cost is
+// bounded by the window length, not the call length.
+//
+// WHY MANUAL BYTE-RANGE CLIP (not `ffmpeg -ss`):
+//   - The recording is STILL BEING WRITTEN. ffmpeg only finalizes the RIFF/data
+//     chunk sizes in the WAV header on SIGINT (end of call); mid-recording those
+//     size fields hold a placeholder (0 or 0xFFFFFFFF). So the header's data size
+//     is unreliable — we take the TRUE data length from os.Stat (file size minus
+//     the PCM start offset) and read the fixed audio format (byte rate, frame
+//     size) from the fmt chunk, which is valid from t=0.
+//   - A pure byte-range copy is dependency-free and unit-testable, and cannot be
+//     tripped up by ffmpeg refusing to seek a file with a placeholder header.
+//
+// The clip start is aligned DOWN to a whole audio frame so we never cut a sample
+// in half; the returned offset (clip-start seconds) is added back to each
+// segment's times by the caller to restore the absolute recording timeline,
+// preserving the rolling driver's absolute-start dedup/stabilization contract.
+package jobs
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// meetingWindowWavPath is the workspace-local scratch file each rolling pass
+// clips the trailing window into. It sits beside the recording under meetings/
+// (so it passes the transcribe handler's workspace ValidatePath) and is
+// overwritten every pass (passes are serialized under transcribeMu), keyed by
+// the sanitized meeting id.
+func meetingWindowWavPath(workspaceDir, meetingID string) string {
+	return filepath.Join(workspaceDir, "meetings", sanitizeMeetingFilename(meetingID)+"-window.wav")
+}
+
+// wavFormat holds the parsed, size-independent fields of a WAV's fmt chunk plus
+// the byte offset where PCM samples begin.
+type wavFormat struct {
+	channels      int
+	bitsPerSample int
+	byteRate      int   // bytes per second of audio (sampleRate*channels*bits/8)
+	dataOffset    int64 // file offset of the first PCM sample byte
+}
+
+// frameSize is the size in bytes of one audio frame (all channels, one sample).
+// Clip boundaries are aligned to it so a sample is never split.
+func (f wavFormat) frameSize() int64 {
+	fs := int64(f.channels) * int64(f.bitsPerSample) / 8
+	if fs <= 0 {
+		return 1
+	}
+	return fs
+}
+
+// clipWavTail writes the trailing `window` of audio from srcPath into dstPath as
+// a standalone WAV (reusing src's header, patched to the clip's sizes) and
+// returns the clip-start offset in SECONDS on the source timeline. When the
+// recording is shorter than the window the whole file is copied and the offset is
+// 0 (identical to whole-file transcription). It reads the true audio length from
+// the file size, never the (mid-recording, placeholder) header size.
+func clipWavTail(srcPath, dstPath string, window time.Duration) (float64, error) {
+	src, err := os.Open(srcPath)
+	if err != nil {
+		return 0, err
+	}
+	defer src.Close()
+
+	info, err := src.Stat()
+	if err != nil {
+		return 0, err
+	}
+	fileSize := info.Size()
+
+	format, header, err := readWavHeader(src)
+	if err != nil {
+		return 0, err
+	}
+
+	dataBytes := fileSize - format.dataOffset
+	if dataBytes < 0 {
+		return 0, fmt.Errorf("wav data offset %d exceeds file size %d", format.dataOffset, fileSize)
+	}
+
+	frame := format.frameSize()
+	// True audio length, aligned down to a whole frame (a partially-written final
+	// frame is dropped so we never feed the sidecar a split sample).
+	dataBytes -= dataBytes % frame
+
+	windowBytes := int64(window.Seconds() * float64(format.byteRate))
+	windowBytes -= windowBytes % frame
+	if windowBytes < frame {
+		windowBytes = frame
+	}
+
+	clipBytes := dataBytes
+	if clipBytes > windowBytes {
+		clipBytes = windowBytes
+	}
+	clipStart := dataBytes - clipBytes // already frame-aligned (both operands are)
+	offsetSeconds := float64(clipStart) / float64(format.byteRate)
+
+	pcm := make([]byte, clipBytes)
+	if _, err := src.ReadAt(pcm, format.dataOffset+clipStart); err != nil && err != io.EOF {
+		return 0, fmt.Errorf("read wav tail: %w", err)
+	}
+
+	out := patchWavHeaderSizes(header, format, clipBytes)
+	out = append(out, pcm...)
+	if err := os.WriteFile(dstPath, out, 0o600); err != nil {
+		return 0, err
+	}
+	return offsetSeconds, nil
+}
+
+// readWavHeader parses a canonical RIFF/WAVE header off r, returning the fmt
+// fields, the PCM start offset, and the raw header bytes (everything before the
+// first sample) so the clip can reuse the source's exact fmt chunk. It walks the
+// chunk list rather than assuming a fixed 44-byte layout, so extra chunks (e.g.
+// a LIST/INFO chunk) before "data" are tolerated.
+func readWavHeader(r io.ReaderAt) (wavFormat, []byte, error) {
+	var riff [12]byte
+	if _, err := r.ReadAt(riff[:], 0); err != nil {
+		return wavFormat{}, nil, fmt.Errorf("read RIFF header: %w", err)
+	}
+	if string(riff[0:4]) != "RIFF" || string(riff[8:12]) != "WAVE" {
+		return wavFormat{}, nil, fmt.Errorf("not a RIFF/WAVE file")
+	}
+
+	var format wavFormat
+	haveFmt := false
+	offset := int64(12)
+	var chunkHdr [8]byte
+	for {
+		if _, err := r.ReadAt(chunkHdr[:], offset); err != nil {
+			return wavFormat{}, nil, fmt.Errorf("read chunk header at %d: %w", offset, err)
+		}
+		id := string(chunkHdr[0:4])
+		size := int64(binary.LittleEndian.Uint32(chunkHdr[4:8]))
+		body := offset + 8
+
+		switch id {
+		case "fmt ":
+			fmtBody := make([]byte, 16)
+			if _, err := r.ReadAt(fmtBody, body); err != nil {
+				return wavFormat{}, nil, fmt.Errorf("read fmt chunk: %w", err)
+			}
+			format.channels = int(binary.LittleEndian.Uint16(fmtBody[2:4]))
+			format.byteRate = int(binary.LittleEndian.Uint32(fmtBody[8:12]))
+			format.bitsPerSample = int(binary.LittleEndian.Uint16(fmtBody[14:16]))
+			if format.channels <= 0 || format.byteRate <= 0 || format.bitsPerSample <= 0 {
+				return wavFormat{}, nil, fmt.Errorf("invalid fmt chunk (channels=%d byteRate=%d bits=%d)", format.channels, format.byteRate, format.bitsPerSample)
+			}
+			haveFmt = true
+		case "data":
+			if !haveFmt {
+				return wavFormat{}, nil, fmt.Errorf("data chunk precedes fmt chunk")
+			}
+			format.dataOffset = body
+			header := make([]byte, body)
+			if _, err := r.ReadAt(header, 0); err != nil {
+				return wavFormat{}, nil, fmt.Errorf("read header prefix: %w", err)
+			}
+			return format, header, nil
+		}
+
+		// Advance to the next chunk (chunks are word-aligned: odd sizes pad by 1).
+		offset = body + size
+		if size%2 == 1 {
+			offset++
+		}
+	}
+}
+
+// patchWavHeaderSizes returns a copy of the source header with the RIFF chunk
+// size and the data chunk size rewritten to match a clip carrying clipBytes of
+// PCM, so the scratch WAV is self-consistent and finite (the source header's
+// sizes are the mid-recording placeholders we must not copy).
+func patchWavHeaderSizes(header []byte, format wavFormat, clipBytes int64) []byte {
+	out := make([]byte, len(header))
+	copy(out, header)
+	// RIFF chunk size lives at bytes 4:8 and covers everything after it:
+	// (headerLen - 8) + clipBytes.
+	binary.LittleEndian.PutUint32(out[4:8], uint32(int64(len(header))-8+clipBytes))
+	// The data chunk size is the 4 bytes immediately preceding the PCM start.
+	binary.LittleEndian.PutUint32(out[format.dataOffset-4:format.dataOffset], uint32(clipBytes))
+	return out
+}

--- a/internal/jobs/meeting_transcribe_window_test.go
+++ b/internal/jobs/meeting_transcribe_window_test.go
@@ -1,0 +1,159 @@
+package jobs
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeTestWav writes a canonical 44-byte-header mono 16 kHz s16 WAV carrying
+// `seconds` of PCM. Byte i of the PCM is set to byte(i) so a clip's contents can
+// be checked against the expected source offset. If placeholderSizes is true the
+// RIFF/data size fields are written as 0xFFFFFFFF, emulating a recording that
+// ffmpeg has not yet finalized — clipWavTail must ignore those and use the file
+// size instead.
+func writeTestWav(t *testing.T, path string, seconds int, placeholderSizes bool) (byteRate int, dataBytes int) {
+	t.Helper()
+	const sampleRate = 16000
+	const channels = 1
+	const bits = 16
+	byteRate = sampleRate * channels * bits / 8 // 32000
+	dataBytes = byteRate * seconds
+
+	buf := make([]byte, 44+dataBytes)
+	copy(buf[0:4], "RIFF")
+	copy(buf[8:12], "WAVE")
+	copy(buf[12:16], "fmt ")
+	binary.LittleEndian.PutUint32(buf[16:20], 16) // PCM fmt chunk size
+	binary.LittleEndian.PutUint16(buf[20:22], 1)  // audio format PCM
+	binary.LittleEndian.PutUint16(buf[22:24], channels)
+	binary.LittleEndian.PutUint32(buf[24:28], sampleRate)
+	binary.LittleEndian.PutUint32(buf[28:32], uint32(byteRate))
+	binary.LittleEndian.PutUint16(buf[32:34], channels*bits/8) // block align
+	binary.LittleEndian.PutUint16(buf[34:36], bits)
+	copy(buf[36:40], "data")
+	if placeholderSizes {
+		binary.LittleEndian.PutUint32(buf[4:8], 0xFFFFFFFF)
+		binary.LittleEndian.PutUint32(buf[40:44], 0xFFFFFFFF)
+	} else {
+		binary.LittleEndian.PutUint32(buf[4:8], uint32(36+dataBytes))
+		binary.LittleEndian.PutUint32(buf[40:44], uint32(dataBytes))
+	}
+	for i := 0; i < dataBytes; i++ {
+		buf[44+i] = byte(i)
+	}
+	if err := os.WriteFile(path, buf, 0o600); err != nil {
+		t.Fatalf("write test wav: %v", err)
+	}
+	return byteRate, dataBytes
+}
+
+func TestClipWavTail_ClipsTrailingWindow(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "rec.wav")
+	dst := filepath.Join(dir, "clip.wav")
+	// 100s recording, placeholder header sizes (mid-recording), clip last 30s.
+	byteRate, _ := writeTestWav(t, src, 100, true)
+
+	offset, err := clipWavTail(src, dst, 30*time.Second)
+	if err != nil {
+		t.Fatalf("clipWavTail: %v", err)
+	}
+	// Clip start = (100 - 30)s = 70s.
+	if offset < 69.99 || offset > 70.01 {
+		t.Errorf("offset = %v, want ~70", offset)
+	}
+
+	format, _, err := readWavHeaderPath(t, dst)
+	if err != nil {
+		t.Fatalf("read clip header: %v", err)
+	}
+	info, _ := os.Stat(dst)
+	clipData := info.Size() - format.dataOffset
+	if clipData != int64(30*byteRate) {
+		t.Errorf("clip data bytes = %d, want %d (30s)", clipData, 30*byteRate)
+	}
+	// The clip's data size field must be self-consistent (not the placeholder).
+	if sz := dataSizeField(t, dst, format.dataOffset); sz != uint32(clipData) {
+		t.Errorf("clip data-size field = %d, want %d", sz, clipData)
+	}
+	// The first clip sample must equal source byte at offset 70s (byte value wraps
+	// mod 256): source PCM index = 70*32000 = 2_240_000.
+	first := firstPCMByte(t, dst, format.dataOffset)
+	if want := byte(70 * byteRate); first != want {
+		t.Errorf("first clip byte = %d, want %d (source offset preserved)", first, want)
+	}
+}
+
+func TestClipWavTail_ShorterThanWindowCopiesWhole(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "rec.wav")
+	dst := filepath.Join(dir, "clip.wav")
+	byteRate, dataBytes := writeTestWav(t, src, 10, false)
+
+	offset, err := clipWavTail(src, dst, 90*time.Second)
+	if err != nil {
+		t.Fatalf("clipWavTail: %v", err)
+	}
+	if offset != 0 {
+		t.Errorf("offset = %v, want 0 when recording is shorter than the window", offset)
+	}
+	format, _, _ := readWavHeaderPath(t, dst)
+	info, _ := os.Stat(dst)
+	if got := info.Size() - format.dataOffset; got != int64(dataBytes) {
+		t.Errorf("clip data bytes = %d, want the whole %d", got, dataBytes)
+	}
+	_ = byteRate
+}
+
+func TestClipWavTail_RejectsNonWav(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "bad.wav")
+	if err := os.WriteFile(src, []byte("not a wav file at all"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := clipWavTail(src, filepath.Join(dir, "clip.wav"), 30*time.Second); err == nil {
+		t.Error("expected an error clipping a non-WAV file")
+	}
+}
+
+// readWavHeaderPath is a test helper that opens a file and parses its WAV header.
+func readWavHeaderPath(t *testing.T, path string) (wavFormat, []byte, error) {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		return wavFormat{}, nil, err
+	}
+	defer f.Close()
+	return readWavHeader(f)
+}
+
+func dataSizeField(t *testing.T, path string, dataOffset int64) uint32 {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	var b [4]byte
+	if _, err := f.ReadAt(b[:], dataOffset-4); err != nil {
+		t.Fatal(err)
+	}
+	return binary.LittleEndian.Uint32(b[:])
+}
+
+func firstPCMByte(t *testing.T, path string, dataOffset int64) byte {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	var b [1]byte
+	if _, err := f.ReadAt(b[:], dataOffset); err != nil {
+		t.Fatal(err)
+	}
+	return b[0]
+}


### PR DESCRIPTION
## Context

Continues the interactive Meet-notetaker work on aceteam#5435 (epic #5097 — turning the passive notetaker into a controllable in-call agent). The interactive layer landed in `67ec447` (self-announce, rolling transcription, chat capture, and the one auto-executed `/ace leave`). This PR builds on top of it: it makes the bot *useful* mid-call (ask it for help/status/a summary, drop notes and action items) and fixes the rolling-transcription latency wall so streaming stays responsive on long calls.

`StreamingEnabled` stays default-off — the whole layer is still additive and degrades to the batch record→transcribe path.

## Summary

**In-call `/ace` verbs** (all non-destructive, so auto-executed like `leave`):

| Verb | Effect |
|------|--------|
| `/ace help` | Posts the command list to Meet chat |
| `/ace status` | Posts recording state + elapsed duration + transcript segment count |
| `/ace note <text>` | Appends a timestamped `NOTE` to the result buffer; confirms in chat |
| `/ace action <text>` | Appends a timestamped `ACTION` item; confirms in chat |
| `/ace summary` | Summarizes the live transcript via node-local vLLM; posts to chat |

Execution lives in a dependency-injected `meetingCommandExecutor` (chat poster, clock, live transcript buffer, summarizer, outcome) — no package globals, fully unit-testable with fakes. `leave` stays handled inline in the loop because it must *break* the loop, not just post chat. `note`/`action` entries surface in a new `notes` field on the `MEETING_JOIN` result (added to both the `completed` and `recorded_transcription_failed` blocks).

**Synchronous local-vLLM summarizer** (`meeting_summary.go`): discovers the served model via `/v1/models`, then requests a short completion — a *single* attempt under a tight `context` deadline (does **not** reuse the 60s `waitForVLLMReady` poll, which would freeze the meeting loop). Any failure path (unreachable / no model / non-200 / empty / timeout) returns an error so the caller posts a graceful fallback message and the call continues. Runs on the loop goroutine so it shares the single-threaded transcript buffer with no race. The vLLM base URL resolves through the in-package `vllmBaseURL()` (citadel port registry + `CITADEL_VLLM_HOST_PORT` override), not a hardcoded literal.

**Windowed rolling transcription** (`meeting_transcribe_window.go`): the whisper sidecar transcribes a whole file with no offset API, so re-transcribing the entire wav-so-far every pass got slower as the call grew. Now each pass clips only the trailing window (default 90s) into a workspace-local scratch WAV and shifts the returned segment times back onto the absolute timeline, so the rolling driver's absolute-start dedup/stabilization contract is untouched. Per-pass cost is bounded by window length, not call length.

- Manual byte-range clip (no `ffmpeg -ss`): the recording is still being written, so ffmpeg's RIFF/data size fields hold a placeholder until SIGINT. True data length comes from `os.Stat`; the fixed audio format (byte rate, frame size) comes from the `fmt` chunk, valid from t=0. Clip start is aligned to a whole audio frame.
- Falls back to whole-file transcription if clipping fails (e.g. header not fully written early in a call): correctness over latency.
- Tradeoff: segments older than the window are never re-fed (safe: window ≫ stability margin + cadence). Cosmetic wrinkle — each clip's leading edge starts mid-utterance, so whisper may occasionally emit a garbled fragment there; the *stored* transcript is the untouched end-of-call batch pass.

**Self-echo safety** (the #1 bug risk): every bot chat post is seeded into `botMessages` *before* the post and kept to a single line, so the loop never re-parses its own output — the help text literally contains `/ace leave`, and a multi-line post could be split into rows that evade an exact-match seed.

## Test plan

| Group | Coverage |
|-------|----------|
| Verb parsing | `help`/`status`/`note`/`action`/`summary` classify + capture instruction; registry contract guard updated for the reviewed set |
| Executor dispatch | help/status output; note with/without text; action; summary empty-buffer (summarizer not called), model-down (fallback), success (single-line collapse); generic kind is a no-op; elapsed formatting |
| Loop integration | `/ace help` echo does **not** self-leave (self-echo guard); `/ace note` records to outcome; existing leave/generic/dedup/panic tests still green |
| WAV windowing | clips trailing window with correct offset + byte length + preserved source bytes; whole-file copy when shorter than window; rejects non-WAV; ignores placeholder header sizes |

`go build ./...` and `go test ./...` are green.

### Deferred (manual, pending — why this is a draft)

- **Meet chat DOM selectors** remain **unverified against a live call** (carried over from the merged layer's `LIVE-TUNING` blocks). Reading/posting chat — and therefore every verb's round trip — needs a human on a real Meet call to confirm or replace the selectors. The self-echo seed is already in place so it's safe when the selectors go live.
- **vLLM port dependency:** `/ace summary` resolves the endpoint via `vllmBaseURL()` (default `services.VLLMHostPort` = 8201, overridable by `CITADEL_VLLM_HOST_PORT`). Confirm the notetaker node's vLLM actually listens there; the codebase has historically disagreed (legacy `VLLMInferenceHandler` hardcodes :8000). Wrong port ⇒ graceful "unavailable" fallback, no crash.
- **Streamed-segment quality** on a live call (leading-edge re-segmentation from windowing) — cosmetic, worth an eyeball once selectors work.
- Run `/security-review` at the ready-for-review transition (touches `meetingID`→path handling; already mitigated via `sanitizeMeetingFilename` + `ValidatePath`).

## Related

- aceteam#5435 (interactive in-call agent)
- Epic #5097 (meeting notetaker bot)
- Builds on `67ec447` (interactive Meet-notetaker layer)