### PR TITLE
feat(catalog): self-healing resolution auto-refreshes a cold cache

### DIFF
--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -316,7 +316,7 @@ func runCatalogInstall(cmd *cobra.Command, args []string) error {
 	// atomically. This is a security invariant: the trust decision must key the
 	// exact compose that gets installed, so a community source cannot shadow a
 	// default service's name to install its own compose under default privileges.
-	resolved, err := catalog.ResolveCatalogService(name)
+	resolved, err := catalog.ResolveCatalogServiceSelfHealing(name)
 	if err != nil {
 		return err
 	}

--- a/cmd/module.go
+++ b/cmd/module.go
@@ -799,7 +799,10 @@ func buildModuleInstallCallbacks() controlcenter.ModuleInstallCallbacks {
 // external source it clones/updates the repo and returns the full ResolvedModule.
 func resolveModuleForTUI(src catalog.Source) (manifest *catalog.ServiceManifest, composeSrc string, resolved *catalog.ResolvedModule, err error) {
 	if src.Kind == catalog.KindCatalog {
-		manifest, err = catalog.LoadServiceManifest(src.Name)
+		// Self-healing: on a cold catalog cache this refreshes the configured
+		// source(s) once and retries, so a remote MODULE_SET / reconcile install
+		// (and the TUI install) succeeds on a node that never ran `catalog update`.
+		manifest, err = catalog.LoadServiceManifestSelfHealing(src.Name)
 		if err != nil {
 			return nil, "", nil, err
 		}

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -405,7 +405,7 @@ func LoadServiceManifest(name string) (*ServiceManifest, error) {
 			return nil, err
 		}
 	}
-	return nil, fmt.Errorf("service '%s' not found in catalog", name)
+	return nil, fmt.Errorf("service '%s' not found in catalog: %w", name, ErrServiceNotFound)
 }
 
 // loadManifestFromPath reads a service's service.yaml from a single source's

--- a/internal/catalog/selfheal.go
+++ b/internal/catalog/selfheal.go
@@ -1,0 +1,87 @@
+// internal/catalog/selfheal.go
+//
+// Self-healing catalog resolution (aceteam-ai/aceteam#518).
+//
+// The install path resolves a module from the node's LOCAL catalog cache. On a
+// COLD cache (a fresh node that never ran `citadel service catalog update`) that
+// resolution fails with "service '<name>' not found in catalog" -- exactly what
+// bit the meeting-module (#514) prod canary. Over the remote MODULE_SET /
+// reconcile-pull converge path there is no operator to run `catalog update`
+// manually, so a desired-state assignment could never install on a cold node.
+//
+// These wrappers make resolution self-healing: when a service is absent from the
+// local cache, refresh the configured catalog source(s) ONCE, then retry before
+// failing. Bounded to a single refresh per resolution (no retry storm); a service
+// still absent after the refresh returns the same clear error.
+package catalog
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrServiceNotFound is the sentinel wrapped by the catalog resolvers when a
+// service name is absent from every configured source's LOCAL cache. The
+// self-healing wrappers key their single catalog refresh on this sentinel: a
+// not-found triggers exactly one refresh-and-retry, while any OTHER resolution
+// error (unparseable manifest, stat failure) is returned immediately without a
+// refresh.
+var ErrServiceNotFound = errors.New("service not found in catalog")
+
+// catalogRefresh is the refresh the self-healing resolvers run when a service is
+// missing from the local cache. It is a package var so tests can substitute a
+// fake refresh (seeding a temp cache) instead of a real git clone/pull. In
+// production it is Update -- clone/pull of every configured source.
+var catalogRefresh = Update
+
+// ResolveCatalogServiceSelfHealing resolves a catalog service name atomically
+// (see ResolveCatalogService for the single-source shadow-safety invariant) and,
+// when the service is absent from the local cache, refreshes the configured
+// catalog source(s) exactly ONCE and retries before failing.
+//
+// The refresh error is deliberately NOT treated as fatal on its own: Update() is
+// partial-failure-tolerant (it refreshes every source and returns the first error
+// even if the rest, including the built-in default, succeeded). So a node with a
+// broken community source added must still be able to install a default-catalog
+// module (e.g. `meeting`). We retry resolution first and only surface the refresh
+// error if the service is STILL absent afterward.
+func ResolveCatalogServiceSelfHealing(name string) (*ResolvedCatalogService, error) {
+	resolved, err := ResolveCatalogService(name)
+	if err == nil || !errors.Is(err, ErrServiceNotFound) {
+		return resolved, err
+	}
+
+	refreshErr := catalogRefresh()
+
+	resolved, err = ResolveCatalogService(name)
+	if err == nil {
+		return resolved, nil
+	}
+	if refreshErr != nil {
+		return nil, fmt.Errorf("%w; catalog refresh also failed: %v", err, refreshErr)
+	}
+	return nil, err
+}
+
+// LoadServiceManifestSelfHealing is LoadServiceManifest with the same
+// refresh-once-on-cold-cache behavior, for the reconcile / MODULE_SET catalog
+// path (resolveModuleForTUI). After a successful refresh the cache is warm, so
+// the caller's follow-up GetComposeFile read also succeeds -- one refresh covers
+// both manifest and compose.
+func LoadServiceManifestSelfHealing(name string) (*ServiceManifest, error) {
+	manifest, err := LoadServiceManifest(name)
+	if err == nil || !errors.Is(err, ErrServiceNotFound) {
+		return manifest, err
+	}
+
+	refreshErr := catalogRefresh()
+
+	manifest, err = LoadServiceManifest(name)
+	if err == nil {
+		return manifest, nil
+	}
+	if refreshErr != nil {
+		return nil, fmt.Errorf("%w; catalog refresh also failed: %v", err, refreshErr)
+	}
+	return nil, err
+}

--- a/internal/catalog/selfheal_test.go
+++ b/internal/catalog/selfheal_test.go
@@ -1,0 +1,139 @@
+package catalog
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// stubRefresh swaps the package-level catalogRefresh for the duration of a test,
+// returning a pointer to a call counter so a test can assert the refresh ran the
+// expected number of times (bounded == exactly once). It restores the real
+// Update on cleanup.
+func stubRefresh(t *testing.T, fn func() error) *int {
+	t.Helper()
+	var calls int
+	prev := catalogRefresh
+	catalogRefresh = func() error {
+		calls++
+		return fn()
+	}
+	t.Cleanup(func() { catalogRefresh = prev })
+	return &calls
+}
+
+// TestResolveSelfHealingColdCacheRefreshesOnce verifies the core self-heal: a
+// module absent from a cold cache resolves after exactly one automatic refresh
+// (the refresh seeds the cache), and the refresh is not called a second time.
+func TestResolveSelfHealingColdCacheRefreshesOnce(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	calls := stubRefresh(t, func() error {
+		// The "refresh" seeds the default catalog cache, as `catalog update` would.
+		seedService(t, GetCatalogPath(), "meeting", "name: meeting\nversion: 1.0.0\n")
+		return nil
+	})
+
+	resolved, err := ResolveCatalogServiceSelfHealing("meeting")
+	if err != nil {
+		t.Fatalf("ResolveCatalogServiceSelfHealing: %v", err)
+	}
+	if resolved.SourceName != DefaultSourceName {
+		t.Errorf("resolved source = %q, want %q", resolved.SourceName, DefaultSourceName)
+	}
+	if *calls != 1 {
+		t.Errorf("catalog refresh called %d times, want exactly 1 (bounded, no retry storm)", *calls)
+	}
+}
+
+// TestResolveSelfHealingStillAbsentAfterRefresh verifies that a module still
+// missing after the single refresh returns the clear not-found error, and the
+// refresh ran exactly once (no storm).
+func TestResolveSelfHealingStillAbsentAfterRefresh(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	calls := stubRefresh(t, func() error { return nil }) // refresh seeds nothing
+
+	_, err := ResolveCatalogServiceSelfHealing("nonexistent")
+	if err == nil {
+		t.Fatal("expected an error for a module absent after refresh")
+	}
+	if !errors.Is(err, ErrServiceNotFound) {
+		t.Errorf("error = %v, want it to wrap ErrServiceNotFound", err)
+	}
+	if !strings.Contains(err.Error(), "not found in catalog") {
+		t.Errorf("error = %q, want the clear 'not found in catalog' message", err.Error())
+	}
+	if *calls != 1 {
+		t.Errorf("catalog refresh called %d times, want exactly 1", *calls)
+	}
+}
+
+// TestResolveSelfHealingRefreshPartialErrorButResolves is the landmine guard: a
+// node with a broken community source makes Update() return a non-nil (partial)
+// error even though the DEFAULT catalog refreshed fine. The wrapper must retry
+// resolution first and succeed -- it must not refuse the install just because the
+// refresh returned an error. This mirrors #514 (meeting is a default module).
+func TestResolveSelfHealingRefreshPartialErrorButResolves(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	calls := stubRefresh(t, func() error {
+		// The default catalog refreshed fine (module now present)...
+		seedService(t, GetCatalogPath(), "meeting", "name: meeting\nversion: 1.0.0\n")
+		// ...but a broken community source made Update() return a partial error.
+		return errors.New("catalog source \"evilcat\": git clone failed")
+	})
+
+	resolved, err := ResolveCatalogServiceSelfHealing("meeting")
+	if err != nil {
+		t.Fatalf("expected success despite partial refresh error, got: %v", err)
+	}
+	if resolved.SourceName != DefaultSourceName {
+		t.Errorf("resolved source = %q, want %q", resolved.SourceName, DefaultSourceName)
+	}
+	if *calls != 1 {
+		t.Errorf("catalog refresh called %d times, want exactly 1", *calls)
+	}
+}
+
+// TestResolveSelfHealingWarmCacheNoRefresh verifies the common case: a module
+// already present in the cache resolves WITHOUT any refresh (zero network cost).
+func TestResolveSelfHealingWarmCacheNoRefresh(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	seedService(t, GetCatalogPath(), "meeting", "name: meeting\nversion: 1.0.0\n")
+
+	calls := stubRefresh(t, func() error {
+		t.Error("refresh must not run when the module is already in the cache")
+		return nil
+	})
+
+	if _, err := ResolveCatalogServiceSelfHealing("meeting"); err != nil {
+		t.Fatalf("ResolveCatalogServiceSelfHealing: %v", err)
+	}
+	if *calls != 0 {
+		t.Errorf("catalog refresh called %d times, want 0 on a warm cache", *calls)
+	}
+}
+
+// TestLoadServiceManifestSelfHealingColdCache verifies the reconcile / MODULE_SET
+// catalog path (resolveModuleForTUI -> LoadServiceManifestSelfHealing) also
+// self-heals a cold cache with exactly one refresh.
+func TestLoadServiceManifestSelfHealingColdCache(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	calls := stubRefresh(t, func() error {
+		seedService(t, GetCatalogPath(), "meeting", "name: meeting\nversion: 1.0.0\n")
+		return nil
+	})
+
+	manifest, err := LoadServiceManifestSelfHealing("meeting")
+	if err != nil {
+		t.Fatalf("LoadServiceManifestSelfHealing: %v", err)
+	}
+	if manifest.Name != "meeting" {
+		t.Errorf("manifest name = %q, want meeting", manifest.Name)
+	}
+	if *calls != 1 {
+		t.Errorf("catalog refresh called %d times, want exactly 1", *calls)
+	}
+}

--- a/internal/catalog/sources.go
+++ b/internal/catalog/sources.go
@@ -351,7 +351,7 @@ func ResolveCatalogService(name string) (*ResolvedCatalogService, error) {
 			SourceName:  src.Name,
 		}, nil
 	}
-	return nil, fmt.Errorf("service '%s' not found in catalog", name)
+	return nil, fmt.Errorf("service '%s' not found in catalog: %w", name, ErrServiceNotFound)
 }
 
 // SourceOf returns the name of the catalog source that owns service `name`,


### PR DESCRIPTION
## Context

Installing a catalog module on a node — `citadel module install <name>`, and the remote `MODULE_SET` / desired-state reconcile-pull converge path — resolves the module from the node's **local catalog cache**. On a fresh node that cache is empty until someone runs `citadel service catalog update`, so the install fails with `service '<name>' not found in catalog`.

This isn't theoretical: it bit the meeting-module (#514) prod canary — the first `citadel module install meeting` failed until a manual `catalog update`. And over MCP / remote desired-state there's **no operator** to run `catalog update`, so an agent-driven assignment could never converge on a cold node.

Closes #518.

## Summary

Make catalog resolution **self-healing** in the install path: when a requested module is absent from the local cache, automatically refresh the configured source(s) **once**, then retry before failing.

- **`ResolveCatalogServiceSelfHealing`** (`internal/catalog/selfheal.go`) wraps the atomic single-source resolver used by `runCatalogInstall` (interactive install). The atomic resolution stays intact — this is the shadow-safety invariant (a community source can't shadow a default service's name to install its own compose under default privileges), so the wrapper sits *around* it, not through `LoadServiceManifest`.
- **`LoadServiceManifestSelfHealing`** wraps the catalog branch of `resolveModuleForTUI`, which covers the `MODULE_SET` handler, the reconcile-pull converge path (`liveModuleOps.Install`), **and** the TUI install callbacks in one edit. The follow-up `GetComposeFile` reads the now-warm cache, so a single refresh covers both manifest and compose.
- **Bounded**: exactly one refresh per resolution attempt — no retry storm.
- **Partial-refresh-tolerant** (the subtle part): `Update()` refreshes every source and returns the *first* error even when the rest — including the built-in default — succeeded. So a node with a broken community source added must still install a default-catalog module like `meeting`. The wrapper retries resolution first and only surfaces the refresh error if the module is *still* absent. This mirrors `Update()`'s own "one broken repo never blocks the rest" contract.
- A new `ErrServiceNotFound` sentinel (wrapped at both not-found sites) scopes the refresh to genuine cache misses; other resolution errors (unparseable manifest, stat failure) return immediately without a refresh. The existing clear `not found in catalog` message is preserved.

## Test plan

New `internal/catalog/selfheal_test.go` (mocks the refresh via an injectable package var — no git/network), mirroring the package's `seedService` / `t.Setenv("HOME", …)` patterns:

| Test | Covers |
|------|--------|
| cold cache → refresh seeds cache → resolves | happy path; asserts refresh ran **exactly once** (bounded) |
| still absent after refresh | returns the clear `not found in catalog` error; refresh ran once |
| refresh returns a partial error but module resolves anyway | the landmine guard — install must not be refused on a partial `Update()` error |
| warm cache | resolves with **zero** refreshes (no needless network cost) |
| `LoadServiceManifestSelfHealing` cold cache | the reconcile / MODULE_SET path self-heals with one refresh |

`go build ./...`, `go vet`, and `go test ./...` all green.

## Needs live-node verification

- On a genuinely cold node, `citadel module install meeting` should now succeed without a prior `catalog update` (the #514 repro).
- A remote `node_module_set` → `MODULE_SET` assignment for a default-catalog module on a never-updated node should converge cleanly.

Opening as draft pending that on-node check.

## Related

- #518 (this) · #514 (meeting-module canary that surfaced it)