### PR TITLE
fix(heartbeat): carry citadel binary version in status heartbeat (aceteam#5819)

### DIFF
--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1449,6 +1449,7 @@ func runWork(cmd *cobra.Command, args []string) {
 					NodeID:          nodeName,
 					HeadscaleNodeID: headscaleNodeID,
 					OrgID:           orgID,
+					AgentVersion:    Version,
 					DebugFunc:       Debug,
 				}, collector)
 				if err != nil {
@@ -1481,6 +1482,7 @@ func runWork(cmd *cobra.Command, args []string) {
 				NodeID:          nodeName,
 				HeadscaleNodeID: headscaleNodeID,
 				DeviceCode:      deviceCode,
+				AgentVersion:    Version,
 				ChannelOverride: workStatusChannel,
 				DebugFunc:       Debug,
 			}, collector)

--- a/internal/heartbeat/api.go
+++ b/internal/heartbeat/api.go
@@ -32,6 +32,7 @@ type APIPublisher struct {
 	nodeID          string
 	headscaleNodeID string // Headscale numeric node ID (e.g., "758")
 	orgID           string
+	agentVersion    string // citadel-cli binary version, reported as agent_version
 	interval        time.Duration
 	collector       *status.Collector
 
@@ -83,6 +84,12 @@ type APIPublisherConfig struct {
 	// OrgID is the organization ID for channel scoping (required for API mode)
 	OrgID string
 
+	// AgentVersion is the citadel-cli binary version (e.g. "v2.75.0"), included
+	// in every heartbeat so the backend can persist the node's agent_version.
+	// Optional: empty means "unknown" and the backend never overwrites a
+	// known-good value with it.
+	AgentVersion string
+
 	// Interval is the time between status publishes (default: 30s)
 	Interval time.Duration
 
@@ -119,6 +126,7 @@ func NewAPIPublisher(cfg APIPublisherConfig, collector *status.Collector) (*APIP
 		nodeID:          cfg.NodeID,
 		headscaleNodeID: cfg.HeadscaleNodeID,
 		orgID:           cfg.OrgID,
+		agentVersion:    cfg.AgentVersion,
 		interval:        cfg.Interval,
 		collector:       collector,
 		pubSubChannel:   pubSubChannel,
@@ -208,6 +216,7 @@ func (p *APIPublisher) publishStatus(ctx context.Context) error {
 		HeadscaleNodeID: p.headscaleNodeID,
 		Status:          nodeStatus,
 		Permissions:     p.permissions,
+		AgentVersion:    p.agentVersion,
 	}
 
 	p.debug("heartbeat: publishing to channel %s", p.pubSubChannel)

--- a/internal/heartbeat/api_test.go
+++ b/internal/heartbeat/api_test.go
@@ -1,0 +1,77 @@
+package heartbeat
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/redisapi"
+	"github.com/aceteam-ai/citadel-cli/internal/status"
+)
+
+// TestAPIPublisherWiresAgentVersion verifies the citadel-cli binary version
+// configured on APIPublisherConfig is carried through to the publisher, and
+// thus into every heartbeat StatusMessage. This is the wiring that was missing
+// (aceteam#5819): the heartbeat path never carried the agent version, so a
+// current node showed "unknown" in the fleet version view.
+func TestAPIPublisherWiresAgentVersion(t *testing.T) {
+	collector := status.NewCollector(status.CollectorConfig{NodeName: "test"})
+
+	pub, err := NewAPIPublisher(APIPublisherConfig{
+		Client:       &redisapi.Client{},
+		NodeID:       "ubuntu-gpu",
+		OrgID:        "org-123",
+		AgentVersion: "v2.75.0",
+	}, collector)
+	if err != nil {
+		t.Fatalf("NewAPIPublisher failed: %v", err)
+	}
+
+	if pub.agentVersion != "v2.75.0" {
+		t.Errorf("agentVersion = %q, want %q", pub.agentVersion, "v2.75.0")
+	}
+}
+
+// TestStatusMessageAgentVersionIncludedWhenSet verifies agentVersion is emitted
+// in the heartbeat JSON when set, so the backend can persist it.
+func TestStatusMessageAgentVersionIncludedWhenSet(t *testing.T) {
+	msg := StatusMessage{
+		Version:      "1.0",
+		Timestamp:    "2024-01-15T12:00:00Z",
+		NodeID:       "ubuntu-gpu",
+		AgentVersion: "v2.75.0",
+		Status:       &status.NodeStatus{Version: "1.0"},
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("Failed to marshal StatusMessage: %v", err)
+	}
+
+	if !strings.Contains(string(data), `"agentVersion":"v2.75.0"`) {
+		t.Errorf("JSON should include agentVersion when set, got: %s", string(data))
+	}
+}
+
+// TestStatusMessageAgentVersionOmittedWhenEmpty verifies agentVersion is
+// omitted from the heartbeat JSON when empty (omitempty). An older citadel that
+// does not wire the version must NOT send an empty string, so the backend can
+// leave a previously-recorded version untouched ("unknown never clobbers
+// known-good").
+func TestStatusMessageAgentVersionOmittedWhenEmpty(t *testing.T) {
+	msg := StatusMessage{
+		Version:   "1.0",
+		Timestamp: "2024-01-15T12:00:00Z",
+		NodeID:    "ubuntu-gpu",
+		Status:    &status.NodeStatus{Version: "1.0"},
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("Failed to marshal StatusMessage: %v", err)
+	}
+
+	if strings.Contains(string(data), "agentVersion") {
+		t.Errorf("JSON should omit agentVersion when empty, got: %s", string(data))
+	}
+}

--- a/internal/heartbeat/redis.go
+++ b/internal/heartbeat/redis.go
@@ -40,6 +40,17 @@ type StatusMessage struct {
 	DeviceCode      string             `json:"deviceCode,omitempty"`
 	Status          *status.NodeStatus `json:"status"`
 	Permissions     *PermissionState   `json:"permissions,omitempty"`
+
+	// AgentVersion is the citadel-cli binary version (e.g. "v2.75.0"), reported
+	// so the backend can persist fabric_node_status.agent_version on every
+	// heartbeat. This is the reliable version telemetry path: the separate
+	// node-state (ActualState) report also carries the version but lands
+	// unreliably (aceteam#5819), whereas the heartbeat writes the node status
+	// row unconditionally every 30s. Omitted (empty) on builds/paths that do
+	// not wire it, which the backend treats as "unknown" and never overwrites a
+	// known-good value with. Distinct from Version above, which is the wire
+	// protocol version ("1.0").
+	AgentVersion string `json:"agentVersion,omitempty"`
 }
 
 // PermissionState mirrors config.Permissions for the heartbeat payload.
@@ -59,6 +70,7 @@ type RedisPublisher struct {
 	redisURL        string // For debug logging
 	nodeID          string
 	headscaleNodeID string // Headscale numeric node ID (e.g., "758")
+	agentVersion    string // citadel-cli binary version, reported as agent_version
 	interval        time.Duration
 	collector       *status.Collector
 
@@ -114,6 +126,12 @@ type RedisPublisherConfig struct {
 	// DeviceCode is the device authorization code for config lookup (optional)
 	DeviceCode string
 
+	// AgentVersion is the citadel-cli binary version (e.g. "v2.75.0"), included
+	// in every heartbeat so the backend can persist the node's agent_version.
+	// Optional: empty means "unknown" and the backend never overwrites a
+	// known-good value with it.
+	AgentVersion string
+
 	// Interval is the time between status publishes (default: 30s)
 	Interval time.Duration
 
@@ -162,6 +180,7 @@ func NewRedisPublisher(cfg RedisPublisherConfig, collector *status.Collector) (*
 		redisURL:        cfg.RedisURL,
 		nodeID:          cfg.NodeID,
 		headscaleNodeID: cfg.HeadscaleNodeID,
+		agentVersion:    cfg.AgentVersion,
 		deviceCode:      cfg.DeviceCode,
 		interval:        cfg.Interval,
 		collector:       collector,
@@ -262,6 +281,7 @@ func (p *RedisPublisher) publishStatus(ctx context.Context) error {
 		DeviceCode:      deviceCode,
 		Status:          nodeStatus,
 		Permissions:     p.permissions,
+		AgentVersion:    p.agentVersion,
 	}
 
 	// Marshal to JSON


### PR DESCRIPTION
## Context

Backend companion: https://github.com/aceteam-ai/aceteam/pull/5826 (closes aceteam#5819).

The fleet version view (`fleet_node_versions`) shows nearly every online node — including current ones like **1084 on v2.75.0** — as version **`unknown`**, even while they heartbeat fresh. Root cause spans two repos; this is the node side.

A node reports to the backend over **two independent paths**:

- **Heartbeat** (`APIPublisher` → `node:status:stream`, every 30s) — the reliable path that keeps `reported_at`/`is_online` fresh. It **never carried the binary version**.
- **Node-state** (`ActualState` protobuf POST) — carries the version, but lands unreliably. It's the only thing that ever wrote `agent_version`, so when it doesn't land the fleet view shows `unknown` forever.

## Fix

Carry the citadel-cli binary version on the reliable heartbeat too.

- Add `AgentVersion` to `StatusMessage` (the shared heartbeat payload) with `omitempty`.
- Add `AgentVersion` to `APIPublisherConfig` and `RedisPublisherConfig`, thread it into the publishers, and set it on every emitted `StatusMessage`.
- Wire it in `cmd/work.go` from the existing `Version` var — the same value already fed to the node-state emitter, so no new plumbing.

`omitempty` means a build that doesn't set it sends nothing; the backend treats absent as "unknown" and never overwrites a known-good stored version. The legacy Redis publisher is wired too, so no node class is left permanently unversioned.

## Test plan

`internal/heartbeat/api_test.go` (new):

| Test | Covers |
|------|--------|
| `TestAPIPublisherWiresAgentVersion` | config `AgentVersion` → publisher (the wiring that was missing) |
| `TestStatusMessageAgentVersionIncludedWhenSet` | version emitted in heartbeat JSON when set |
| `TestStatusMessageAgentVersionOmittedWhenEmpty` | omitted when empty, so the backend never sees a clobbering empty string |

```
go build ./...        ok
go test ./internal/... ok
gofmt -l               clean
```

## Verification (forward-only)

Backend-alone and node-alone are both inert. To confirm end-to-end: ship the backend PR, cut a citadel release containing this change, upgrade node 1084, wait ~30s, then re-query `fabric_node_status.agent_version` for 1084 (or run `fleet_node_versions`) — it should read `v2.75.x` instead of `unknown`.

## Related

- aceteam#5819
- Backend PR: https://github.com/aceteam-ai/aceteam/pull/5826