### PR TITLE
feat(transcribe): real speaker diarization via whisperx + pyannote (epic #5821 Slice B)

### DIFF
--- a/internal/jobs/transcribe_audio.go
+++ b/internal/jobs/transcribe_audio.go
@@ -86,14 +86,15 @@ func (h *TranscribeAudioHandler) client() *http.Client {
 //   - audio_path: workspace-relative or absolute path to the recorded audio.
 //   - language:   optional ISO language hint (e.g. "en"); empty = auto-detect.
 //   - diarize:    optional speaker-labelling mode. "speaker" = real pyannote
-//                 diarization (reprocess path); "true" = basic silence-gap
-//                 labelling (quick path); anything else = no labels.
+//     diarization (reprocess path); "true" = basic silence-gap
+//     labelling (quick path); anything else = no labels.
 //
 // Response JSON (relayed verbatim from the sidecar). Fields are additive: old
 // callers reading text/language/segments still work. When diarize is set, each
-// segment carries a raw speaker label and a speakers[] roster is included; with
-// a HuggingFace token the labels are real pyannote identities ("SPEAKER_NN"),
-// otherwise a silence-gap fallback ("Speaker N"). speakers[].id equals the
+// segment carries a raw speaker label and a speakers[] roster is included. The
+// `diarization` field reports the tier that actually ran: "speaker" (real
+// pyannote identities "SPEAKER_NN"; needs a HuggingFace token), "basic"
+// (silence-gap fallback "Speaker N"), or "none". speakers[].id equals the
 // segment's speaker label verbatim (the join key between a segment and the
 // roster); speakers[].label is a human-friendly name. start/end are seconds.
 //
@@ -106,7 +107,7 @@ func (h *TranscribeAudioHandler) client() *http.Client {
 //	  "speakers": [
 //	    {"id": "SPEAKER_00", "label": "Speaker 1", "talkTimePct": 62.5}
 //	  ],
-//	  "diarization": "pyannote"
+//	  "diarization": "speaker"
 //	}
 func (h *TranscribeAudioHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
 	audioPath, ok := job.Payload["audio_path"]

--- a/internal/jobs/transcribe_audio.go
+++ b/internal/jobs/transcribe_audio.go
@@ -87,15 +87,24 @@ func (h *TranscribeAudioHandler) client() *http.Client {
 //   - language:   optional ISO language hint (e.g. "en"); empty = auto-detect.
 //   - diarize:    optional "true"/"false"; basic per-segment speaker labels.
 //
-// Response JSON (relayed verbatim from the sidecar):
+// Response JSON (relayed verbatim from the sidecar). Fields are additive: old
+// callers reading text/language/segments still work. When diarize is set, each
+// segment carries a raw speaker label and a speakers[] roster is included; with
+// a HuggingFace token the labels are real pyannote identities ("SPEAKER_NN"),
+// otherwise a silence-gap fallback ("Speaker N"). speakers[].id equals the
+// segment's speaker label verbatim (the join key between a segment and the
+// roster); speakers[].label is a human-friendly name. start/end are seconds.
 //
 //	{
 //	  "text": "full transcript",
 //	  "language": "en",
-//	  "language_probability": 0.98,
 //	  "segments": [
-//	    {"start": 0.0, "end": 3.2, "text": "...", "speaker": "Speaker 1"}
-//	  ]
+//	    {"start": 0.0, "end": 3.2, "text": "...", "speaker": "SPEAKER_00"}
+//	  ],
+//	  "speakers": [
+//	    {"id": "SPEAKER_00", "label": "Speaker 1", "talkTimePct": 62.5}
+//	  ],
+//	  "diarization": "pyannote"
 //	}
 func (h *TranscribeAudioHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
 	audioPath, ok := job.Payload["audio_path"]

--- a/internal/jobs/transcribe_audio.go
+++ b/internal/jobs/transcribe_audio.go
@@ -85,7 +85,9 @@ func (h *TranscribeAudioHandler) client() *http.Client {
 // Payload fields (all strings via nexus.Job):
 //   - audio_path: workspace-relative or absolute path to the recorded audio.
 //   - language:   optional ISO language hint (e.g. "en"); empty = auto-detect.
-//   - diarize:    optional "true"/"false"; basic per-segment speaker labels.
+//   - diarize:    optional speaker-labelling mode. "speaker" = real pyannote
+//                 diarization (reprocess path); "true" = basic silence-gap
+//                 labelling (quick path); anything else = no labels.
 //
 // Response JSON (relayed verbatim from the sidecar). Fields are additive: old
 // callers reading text/language/segments still work. When diarize is set, each
@@ -149,7 +151,16 @@ func (h *TranscribeAudioHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte
 	if lang, ok := job.Payload["language"]; ok && lang != "" {
 		requestPayload["language"] = lang
 	}
-	if diarize, ok := job.Payload["diarize"]; ok && diarize == "true" {
+	// diarize modes: "speaker" requests REAL pyannote diarization (reprocess
+	// path); "true" requests BASIC silence-gap labelling (quick path). The
+	// sidecar reports which tier actually ran in its `diarization` response
+	// field ("speaker"/"basic"/"none") so the backend can decide whether to
+	// replace the stored transcript or keep retrying.
+	switch job.Payload["diarize"] {
+	case "speaker":
+		requestPayload["diarize"] = true
+		requestPayload["speaker"] = true
+	case "true":
 		requestPayload["diarize"] = true
 	}
 

--- a/internal/jobs/transcribe_audio_test.go
+++ b/internal/jobs/transcribe_audio_test.go
@@ -103,6 +103,69 @@ func TestTranscribeAudio_Success(t *testing.T) {
 	}
 }
 
+// TestTranscribeAudio_DiarizeModes covers the diarize payload mapping: the
+// "speaker" mode (reprocess path) must request REAL pyannote diarization
+// (diarize + speaker), "true" (quick path) must request BASIC labelling only,
+// and any other value must request no speaker labels at all.
+func TestTranscribeAudio_DiarizeModes(t *testing.T) {
+	cases := []struct {
+		name        string
+		diarize     string
+		wantDiarize bool
+		wantSpeaker bool
+	}{
+		{"speaker mode", "speaker", true, true},
+		{"basic mode", "true", true, false},
+		{"off", "false", false, false},
+		{"absent", "", false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "a.webm"), []byte("x"), 0o644); err != nil {
+				t.Fatalf("setup: %v", err)
+			}
+
+			var body map[string]any
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/health" {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				b, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(b, &body)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"text":"ok","language":"en","segments":[],"speakers":[],"diarization":"none"}`))
+			}))
+			defer srv.Close()
+
+			h := NewTranscribeAudioHandler(dir)
+			h.ServiceURL = srv.URL
+
+			payload := map[string]string{"audio_path": "a.webm"}
+			if tc.diarize != "" {
+				payload["diarize"] = tc.diarize
+			}
+			if _, err := h.Execute(JobContext{}, &nexus.Job{
+				ID:      "dm",
+				Type:    "TRANSCRIBE_AUDIO",
+				Payload: payload,
+			}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			gotDiarize, _ := body["diarize"].(bool)
+			gotSpeaker, _ := body["speaker"].(bool)
+			if gotDiarize != tc.wantDiarize {
+				t.Errorf("diarize forwarded = %v, want %v (body=%v)", gotDiarize, tc.wantDiarize, body)
+			}
+			if gotSpeaker != tc.wantSpeaker {
+				t.Errorf("speaker forwarded = %v, want %v (body=%v)", gotSpeaker, tc.wantSpeaker, body)
+			}
+		})
+	}
+}
+
 func TestTranscribeAudio_ServiceError(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "a.webm"), []byte("x"), 0o644); err != nil {

--- a/services/compose/transcribe.yml
+++ b/services/compose/transcribe.yml
@@ -5,7 +5,8 @@ services:
     ports:
       - "8101:8101"
     volumes:
-      # faster-whisper model cache (shared with other HF-based services).
+      # HF model cache: faster-whisper + wav2vec2 alignment + pyannote models.
+      # Shared with other HF-based services so downloads are paid once.
       - ~/citadel-cache/huggingface:/root/.cache/huggingface
       # Mount the node workspace read-only so the service can read audio files
       # that FILE_WRITE_BYTES placed there.
@@ -18,9 +19,38 @@ services:
       #   CITADEL_WORKSPACE=/home/<user>/citadel-node/workspace
       - ${CITADEL_WORKSPACE:?set CITADEL_WORKSPACE to an absolute workspace path}:/workspace:ro
     environment:
-      # faster-whisper model size: base = good CPU speed/accuracy tradeoff.
-      - WHISPER_MODEL=base
-      - WHISPER_DEVICE=cpu
-      - WHISPER_COMPUTE_TYPE=int8
+      # faster-whisper model size. "base" is the CPU-friendly default; bump to
+      # "large-v3" (fits a 24GB GPU) or "medium" for higher accuracy when a GPU
+      # is available and free.
+      - WHISPER_MODEL=${WHISPER_MODEL:-base}
+      # Device: "auto" uses CUDA when visible, else CPU. The published image is
+      # a CPU build, so this resolves to cpu until a CUDA image + GPU
+      # reservation are added (see the deploy.resources block below).
+      - WHISPER_DEVICE=${WHISPER_DEVICE:-auto}
+      # HuggingFace token for pyannote speaker diarization. pyannote's model is
+      # GATED: without a token the service falls back to silence-gap labelling
+      # ("basic" tier) and never breaks. To enable REAL diarization:
+      #   1. Create a token at https://hf.co/settings/tokens
+      #   2. Accept the terms on
+      #      https://hf.co/pyannote/speaker-diarization-community-1
+      #      (whisperx's default model). To use the classic 3.1 pipeline
+      #      instead, set DIARIZE_MODEL=pyannote/speaker-diarization-3.1 and
+      #      accept that model plus https://hf.co/pyannote/segmentation-3.0.
+      #   3. Export HF_TOKEN in the node environment before SERVICE_START.
+      - HF_TOKEN=${HF_TOKEN:-}
+      # Optional: pin a specific pyannote diarization model (see above).
+      - DIARIZE_MODEL=${DIARIZE_MODEL:-}
       - PORT=8101
     restart: unless-stopped
+    # GPU enablement (commented until a CUDA image is published): uncomment to
+    # run large-v3 + pyannote on the GPU. Requires the nvidia container runtime
+    # (default on fabric GPU nodes) and enough free VRAM (~5GB for large-v3
+    # float16 + wav2vec2 + pyannote). Note: a busy GPU (e.g. vLLM holding most
+    # of the card) will OOM the model load, so keep WHISPER_DEVICE=cpu there.
+    # deploy:
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - driver: nvidia
+    #           count: 1
+    #           capabilities: [gpu]

--- a/services/whisper-service/Dockerfile
+++ b/services/whisper-service/Dockerfile
@@ -1,13 +1,26 @@
-# Node-local faster-whisper STT sidecar for Citadel.
+# Node-local whisperx STT + speaker-diarization sidecar for Citadel.
 # Built and published as ghcr.io/aceteam-ai/whisper-service (see transcribe.yml).
+#
+# CPU image: torch/torchaudio are installed from the CPU wheel index to keep the
+# image lean and dodge CUDA (cuDNN/ctranslate2) version drift. The service
+# auto-detects device at runtime, so a future CUDA base image needs no code
+# change -- only a GPU torch build and `deploy.resources` GPU reservation.
 FROM python:3.12-slim
 
-# ffmpeg is required by faster-whisper to decode webm/mp3/wav inputs.
+# ffmpeg is required to decode webm/mp3/wav inputs (whisperx.load_audio).
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
+
+# Install CPU torch first so whisperx's transitive torch requirement resolves
+# to the lean CPU wheel instead of the multi-GB CUDA default. Versions match
+# whisperx 3.8.6's pins (torch~=2.8.0, torchvision~=0.23.0) so pip does not
+# re-resolve them to the CUDA build when whisperx is installed next.
+RUN pip install --no-cache-dir \
+    torch==2.8.0 torchaudio==2.8.0 torchvision==0.23.0 \
+    --index-url https://download.pytorch.org/whl/cpu
 
 COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt

--- a/services/whisper-service/app.py
+++ b/services/whisper-service/app.py
@@ -14,12 +14,20 @@ via whisperx = faster-whisper transcription + wav2vec2 forced alignment (tight
 word/segment timestamps) + pyannote speaker diarization (true voice identities,
 labelled "SPEAKER_00", "SPEAKER_01", ...).
 
-Fail-soft tiers, so TRANSCRIBE_AUDIO never breaks:
-  1. pyannote  -- real diarization. Requires HF_TOKEN (pyannote's model is
-     gated). Segments carry true "SPEAKER_NN" identities.
-  2. basic     -- silence-gap heuristic ("Speaker 1/2..."). Used when the
-     HF token or the pyannote model is unavailable. It can't actually tell
-     voices apart; it just beats a single unlabelled speaker.
+Fail-soft tiers, reported in the response `diarization` field so an
+orchestrator can tell a genuine result from a fallback (never breaks
+TRANSCRIBE_AUDIO):
+  - "speaker" -- real pyannote diarization. Requires HF_TOKEN (pyannote's
+     model is gated) and a `speaker` request. Segments carry true
+     "SPEAKER_NN" identities.
+  - "basic"   -- silence-gap heuristic ("Speaker 1/2..."). Used for the quick
+     path, or when a `speaker` request can't reach pyannote (no token/model).
+     It can't actually tell voices apart; it just beats a single unlabelled
+     speaker.
+  - "none"    -- plain transcription, no speaker labels requested.
+
+Request modes: `diarize` = basic labelling (quick path); `speaker` = attempt
+real pyannote (reprocess path), falling back to basic and reporting it.
 
 Alignment (wav2vec2) is ungated and runs whenever the align model is available;
 it only tightens timestamps and is skipped silently if it can't load.
@@ -195,8 +203,13 @@ class TranscribeRequest(BaseModel):
     audio_path: str
     # Optional ISO language hint (e.g. "en"); None = auto-detect.
     language: str | None = None
-    # Enable speaker labelling (real pyannote when available, else basic).
+    # Produce speaker labels at all. The quick path sets this for BASIC
+    # (silence-gap) labelling.
     diarize: bool = False
+    # Request REAL pyannote diarization (implies diarize). The reprocess path
+    # sets this. Falls back to basic labelling when the token/model is
+    # unavailable, which the response reports so callers can stay retryable.
+    speaker: bool = False
 
 
 def _resolve_audio_path(audio_path: str) -> str:
@@ -319,7 +332,8 @@ def health():
         "status": "ok",
         "model": WHISPER_MODEL,
         "device": WHISPER_DEVICE,
-        "diarization": "pyannote" if HF_TOKEN else "basic",
+        # Best tier a "speaker" request could achieve given current config.
+        "diarization": "speaker" if HF_TOKEN else "basic",
     }
 
 
@@ -353,10 +367,17 @@ def transcribe(req: TranscribeRequest):
         except Exception as exc:  # noqa: BLE001 - alignment is best-effort.
             logger.warning("alignment failed (%s); using unaligned timestamps", exc)
 
+    # Diarization tier reported to callers so an orchestrator can distinguish a
+    # genuine diarized result (safe to REPLACE the quick transcript) from a
+    # fallback (keep the quick transcript, stay retryable):
+    #   "speaker" - real pyannote ran, segments carry true SPEAKER_NN ids.
+    #   "basic"   - silence-gap fallback (no token/model, or basic requested).
+    #   "none"    - plain transcription, no speaker labels.
+    want_labels = req.diarize or req.speaker
     diarization_tier = "none"
-    if req.diarize:
-        if _diarize_pyannote(audio, result):
-            diarization_tier = "pyannote"
+    if want_labels:
+        if req.speaker and _diarize_pyannote(audio, result):
+            diarization_tier = "speaker"
         else:
             _label_speakers_basic(result["segments"])
             diarization_tier = "basic"
@@ -373,7 +394,7 @@ def transcribe(req: TranscribeRequest):
         segments.append(seg)
 
     text = " ".join(s["text"] for s in segments).strip()
-    speakers = _summarize_speakers(segments) if req.diarize else []
+    speakers = _summarize_speakers(segments) if want_labels else []
 
     return {
         "text": text,

--- a/services/whisper-service/app.py
+++ b/services/whisper-service/app.py
@@ -1,55 +1,192 @@
-"""Node-local speech-to-text sidecar for Citadel.
+"""Node-local speech-to-text + speaker-diarization sidecar for Citadel.
 
-A tiny FastAPI service (faster-whisper on CPU) that loads a model once and
-transcribes audio files placed in the node workspace, reusing the proven
-node-local faster-whisper STT pattern already shipped elsewhere in Citadel.
-Used by the citadel-cli TRANSCRIBE_AUDIO job handler, which POSTs a
-workspace-relative audio path here.
+A small FastAPI service that loads its models once and transcribes audio files
+placed in the node workspace, keeping audio on the user's own machine. Used by
+the citadel-cli TRANSCRIBE_AUDIO job handler, which POSTs a workspace-relative
+audio path here.
 
 Audio never leaves the node: the workspace is mounted read-only at /workspace
 and the resulting transcript is returned to the local Go worker, which relays
 it back over the VPN mesh to the user's own AceTeam org.
 
-Diarization (Phase 1): BASIC. faster-whisper produces timestamped segments but
-no speaker identities. We label segments heuristically (a new speaker after a
-silence gap) so distinct speakers read better than unlabelled imports. Full
-diarization (pyannote/whisperx) is deferred to a later phase.
+Diarization (Slice B, epic aceteam-ai/aceteam#5821): REAL speaker diarization
+via whisperx = faster-whisper transcription + wav2vec2 forced alignment (tight
+word/segment timestamps) + pyannote speaker diarization (true voice identities,
+labelled "SPEAKER_00", "SPEAKER_01", ...).
+
+Fail-soft tiers, so TRANSCRIBE_AUDIO never breaks:
+  1. pyannote  -- real diarization. Requires HF_TOKEN (pyannote's model is
+     gated). Segments carry true "SPEAKER_NN" identities.
+  2. basic     -- silence-gap heuristic ("Speaker 1/2..."). Used when the
+     HF token or the pyannote model is unavailable. It can't actually tell
+     voices apart; it just beats a single unlabelled speaker.
+
+Alignment (wav2vec2) is ungated and runs whenever the align model is available;
+it only tightens timestamps and is skipped silently if it can't load.
 """
 
+import logging
 import os
 
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
+logger = logging.getLogger("citadel-whisper-service")
+
 # Workspace mount inside the container (see services/compose/transcribe.yml).
 WORKSPACE_ROOT = os.environ.get("WORKSPACE_ROOT", "/workspace")
 
+# faster-whisper model size. "base" is the CPU-friendly default kept for
+# backward compatibility; set WHISPER_MODEL=large-v3 (fits a 24GB GPU) or
+# "medium" for higher accuracy when a GPU is available.
 WHISPER_MODEL = os.environ.get("WHISPER_MODEL", "base")
-WHISPER_DEVICE = os.environ.get("WHISPER_DEVICE", "cpu")
-WHISPER_COMPUTE_TYPE = os.environ.get("WHISPER_COMPUTE_TYPE", "int8")
+
+# Device selection. "auto" picks cuda when a CUDA device is visible, else cpu.
+WHISPER_DEVICE = os.environ.get("WHISPER_DEVICE", "auto")
+
+# Compute type. Empty => choose per device (float16 on cuda, int8 on cpu).
+WHISPER_COMPUTE_TYPE = os.environ.get("WHISPER_COMPUTE_TYPE", "")
+
+# Batch size for whisperx batched inference.
+WHISPER_BATCH_SIZE = int(os.environ.get("WHISPER_BATCH_SIZE", "8"))
+
+# HuggingFace token for the gated pyannote diarization model. Without it we
+# fall back to the silence-gap heuristic. Accept either common env name.
+HF_TOKEN = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+
+# Optional speaker-count hints for pyannote (tighten clustering when known).
+DIARIZE_MIN_SPEAKERS = os.environ.get("DIARIZE_MIN_SPEAKERS")
+DIARIZE_MAX_SPEAKERS = os.environ.get("DIARIZE_MAX_SPEAKERS")
+
+# Pyannote diarization model. Empty => whisperx's default
+# (pyannote/speaker-diarization-community-1). Override to pin a specific gated
+# model, e.g. "pyannote/speaker-diarization-3.1". All are gated and require the
+# HF token above plus accepting the model's terms on HuggingFace.
+DIARIZE_MODEL = os.environ.get("DIARIZE_MODEL") or None
 
 # A pause longer than this (seconds) between segments is treated as a likely
-# speaker change for BASIC diarization. Tuned conservatively; better than
-# tagging every line the same.
+# speaker change for the BASIC (fail-soft) heuristic.
 SPEAKER_GAP_SECONDS = float(os.environ.get("WHISPER_SPEAKER_GAP_SECONDS", "2.0"))
 
 app = FastAPI(title="citadel-whisper-service")
 
-_model = None
+# Lazily-initialised, process-global model handles.
+_whisper_model = None
+_align_cache: dict[str, tuple] = {}
+_diarize_pipeline = None
+_diarize_unavailable = False  # sticky: don't retry a known-missing pipeline.
 
 
-def _get_model():
-    """Lazy-load the faster-whisper model once on first transcription."""
-    global _model
-    if _model is None:
-        from faster_whisper import WhisperModel
+def _resolve_device() -> str:
+    if WHISPER_DEVICE != "auto":
+        return WHISPER_DEVICE
+    try:
+        import torch
 
-        _model = WhisperModel(
+        return "cuda" if torch.cuda.is_available() else "cpu"
+    except Exception:
+        return "cpu"
+
+
+def _resolve_compute_type(device: str) -> str:
+    if WHISPER_COMPUTE_TYPE:
+        return WHISPER_COMPUTE_TYPE
+    return "float16" if device == "cuda" else "int8"
+
+
+def _get_whisper_model():
+    """Lazy-load the whisperx (faster-whisper) model once."""
+    global _whisper_model
+    if _whisper_model is None:
+        import whisperx
+
+        device = _resolve_device()
+        compute_type = _resolve_compute_type(device)
+        logger.info(
+            "loading whisper model=%s device=%s compute_type=%s",
             WHISPER_MODEL,
-            device=WHISPER_DEVICE,
-            compute_type=WHISPER_COMPUTE_TYPE,
+            device,
+            compute_type,
         )
-    return _model
+        _whisper_model = whisperx.load_model(
+            WHISPER_MODEL, device, compute_type=compute_type
+        )
+    return _whisper_model
+
+
+def _get_align_model(language_code: str):
+    """Lazy-load (and cache per language) the wav2vec2 alignment model.
+
+    Returns (model, metadata) or None if the align model can't be loaded for
+    this language -- alignment is a timestamp refinement, never required.
+    """
+    if language_code in _align_cache:
+        return _align_cache[language_code]
+    try:
+        import whisperx
+
+        device = _resolve_device()
+        model, metadata = whisperx.load_align_model(
+            language_code=language_code, device=device
+        )
+        _align_cache[language_code] = (model, metadata)
+        return _align_cache[language_code]
+    except Exception as exc:  # noqa: BLE001 - alignment is best-effort.
+        logger.warning("alignment model unavailable for %s: %s", language_code, exc)
+        _align_cache[language_code] = None
+        return None
+
+
+def _get_diarize_pipeline():
+    """Lazy-load the pyannote diarization pipeline once.
+
+    Returns the pipeline, or None when it is unavailable (no HF token, gated
+    model not accepted, or import/runtime failure). The None result is cached
+    so we don't repeatedly pay a failing load on every request.
+    """
+    global _diarize_pipeline, _diarize_unavailable
+    if _diarize_pipeline is not None:
+        return _diarize_pipeline
+    if _diarize_unavailable:
+        return None
+    if not HF_TOKEN:
+        logger.warning(
+            "diarization disabled: no HF_TOKEN/HUGGING_FACE_HUB_TOKEN set; "
+            "pyannote's model is gated. Falling back to silence-gap labelling."
+        )
+        _diarize_unavailable = True
+        return None
+    try:
+        # whisperx moved DiarizationPipeline between minor versions; support both.
+        try:
+            from whisperx.diarize import DiarizationPipeline
+        except ImportError:
+            from whisperx import DiarizationPipeline  # type: ignore[attr-defined]
+
+        device = _resolve_device()
+        logger.info("loading pyannote diarization pipeline on %s", device)
+        # whisperx >=3.8 renamed the auth kwarg to `token` and takes an optional
+        # `model_name`. Older releases used `use_auth_token`; support both.
+        try:
+            _diarize_pipeline = DiarizationPipeline(
+                model_name=DIARIZE_MODEL, token=HF_TOKEN, device=device
+            )
+        except TypeError:
+            _diarize_pipeline = DiarizationPipeline(
+                use_auth_token=HF_TOKEN, device=device
+            )
+        return _diarize_pipeline
+    except Exception as exc:  # noqa: BLE001 - fail-soft to basic labelling.
+        logger.warning(
+            "pyannote diarization unavailable (%s); falling back to silence-gap "
+            "labelling. With HF_TOKEN set, accept the model terms at "
+            "hf.co/pyannote/speaker-diarization-community-1 (whisperx's default "
+            "model), or set DIARIZE_MODEL=pyannote/speaker-diarization-3.1 and "
+            "accept that model plus hf.co/pyannote/segmentation-3.0.",
+            exc,
+        )
+        _diarize_unavailable = True
+        return None
 
 
 class TranscribeRequest(BaseModel):
@@ -58,7 +195,7 @@ class TranscribeRequest(BaseModel):
     audio_path: str
     # Optional ISO language hint (e.g. "en"); None = auto-detect.
     language: str | None = None
-    # BASIC speaker labelling when True.
+    # Enable speaker labelling (real pyannote when available, else basic).
     diarize: bool = False
 
 
@@ -77,12 +214,12 @@ def _resolve_audio_path(audio_path: str) -> str:
     return candidate
 
 
-def _label_speakers(segments: list[dict]) -> list[dict]:
-    """Assign BASIC speaker labels by silence-gap heuristic.
+def _label_speakers_basic(segments: list[dict]) -> list[dict]:
+    """Assign BASIC speaker labels by silence-gap heuristic (fail-soft tier).
 
     Increments the speaker number whenever the gap since the previous segment
-    exceeds SPEAKER_GAP_SECONDS. This is intentionally simple; it just beats a
-    single `[None]` label. Full diarization is deferred.
+    exceeds SPEAKER_GAP_SECONDS. Intentionally simple; it cannot actually tell
+    voices apart, it just beats a single unlabelled speaker.
     """
     speaker_idx = 1
     prev_end: float | None = None
@@ -94,41 +231,155 @@ def _label_speakers(segments: list[dict]) -> list[dict]:
     return segments
 
 
+def _summarize_speakers(segments: list[dict]) -> list[dict]:
+    """Build the speakers[] roster with per-speaker talk-time percentages.
+
+    talkTimePct is the share of total spoken segment duration attributable to
+    each speaker. Emitted for BOTH diarization tiers so callers never hit a
+    missing field. `label` is a human-friendly name derived from the id.
+    """
+    totals: dict[str, float] = {}
+    order: list[str] = []
+    for seg in segments:
+        spk = seg.get("speaker")
+        if spk is None:
+            continue
+        if spk not in totals:
+            totals[spk] = 0.0
+            order.append(spk)
+        totals[spk] += max(0.0, float(seg["end"]) - float(seg["start"]))
+
+    total = sum(totals.values())
+    speakers = []
+    for spk in order:
+        pct = round((totals[spk] / total) * 100, 1) if total > 0 else 0.0
+        speakers.append({"id": spk, "label": _speaker_label(spk), "talkTimePct": pct})
+    return speakers
+
+
+def _speaker_label(speaker_id: str) -> str:
+    """Human-friendly label from a speaker id.
+
+    "SPEAKER_00" -> "Speaker 1"; a basic "Speaker 2" label passes through.
+    """
+    if speaker_id.startswith("SPEAKER_"):
+        try:
+            return f"Speaker {int(speaker_id.rsplit('_', 1)[1]) + 1}"
+        except (ValueError, IndexError):
+            return speaker_id
+    return speaker_id
+
+
+def _diarize_pyannote(audio, aligned_result: dict) -> bool:
+    """Run real pyannote diarization and assign speakers onto segments in place.
+
+    Returns True if diarization ran and labelled segments, False otherwise so
+    the caller can fall back to the basic heuristic.
+    """
+    pipeline = _get_diarize_pipeline()
+    if pipeline is None:
+        return False
+    try:
+        import whisperx
+
+        kwargs = {}
+        if DIARIZE_MIN_SPEAKERS:
+            kwargs["min_speakers"] = int(DIARIZE_MIN_SPEAKERS)
+        if DIARIZE_MAX_SPEAKERS:
+            kwargs["max_speakers"] = int(DIARIZE_MAX_SPEAKERS)
+        diarize_segments = pipeline(audio, **kwargs)
+        assigned = whisperx.assign_word_speakers(diarize_segments, aligned_result)
+        # assign_word_speakers returns the mutated result in recent versions.
+        result = assigned if isinstance(assigned, dict) else aligned_result
+
+        # Ensure every segment carries a speaker (assign leaves silences blank).
+        last = "SPEAKER_00"
+        for seg in result["segments"]:
+            spk = seg.get("speaker")
+            if spk is None:
+                seg["speaker"] = last
+            else:
+                last = spk
+        aligned_result["segments"] = result["segments"]
+        return True
+    except Exception as exc:  # noqa: BLE001 - fail-soft to basic labelling.
+        logger.warning("pyannote diarization run failed (%s); using basic", exc)
+        return False
+
+
 @app.get("/health")
 def health():
-    return {"status": "ok", "model": WHISPER_MODEL}
+    """Fast, dependency-free readiness probe.
+
+    Never loads a model, so it answers immediately and keeps the Go handler's
+    health poll from tripping its 120s model-load budget. Reports whether a
+    diarization token is configured so callers can predict the tier.
+    """
+    return {
+        "status": "ok",
+        "model": WHISPER_MODEL,
+        "device": WHISPER_DEVICE,
+        "diarization": "pyannote" if HF_TOKEN else "basic",
+    }
 
 
 @app.post("/transcribe")
 def transcribe(req: TranscribeRequest):
+    import whisperx
+
     path = _resolve_audio_path(req.audio_path)
-    model = _get_model()
+    model = _get_whisper_model()
+    device = _resolve_device()
 
-    segments_iter, info = model.transcribe(
-        path,
-        beam_size=5,
-        language=req.language,
+    audio = whisperx.load_audio(path)
+    result = model.transcribe(
+        audio, batch_size=WHISPER_BATCH_SIZE, language=req.language
     )
+    language = result.get("language") or (req.language or "en")
 
-    segments = [
-        {
-            "start": round(s.start, 3),
-            "end": round(s.end, 3),
-            "text": s.text.strip(),
-        }
-        for s in segments_iter
-    ]
+    # Forced alignment (ungated wav2vec2): tightens word/segment timestamps.
+    align = _get_align_model(language)
+    if align is not None:
+        try:
+            align_model, metadata = align
+            result = whisperx.align(
+                result["segments"],
+                align_model,
+                metadata,
+                audio,
+                device,
+                return_char_alignments=False,
+            )
+        except Exception as exc:  # noqa: BLE001 - alignment is best-effort.
+            logger.warning("alignment failed (%s); using unaligned timestamps", exc)
 
+    diarization_tier = "none"
     if req.diarize:
-        segments = _label_speakers(segments)
+        if _diarize_pyannote(audio, result):
+            diarization_tier = "pyannote"
+        else:
+            _label_speakers_basic(result["segments"])
+            diarization_tier = "basic"
+
+    segments = []
+    for s in result["segments"]:
+        seg = {
+            "start": round(float(s["start"]), 3),
+            "end": round(float(s["end"]), 3),
+            "text": s["text"].strip(),
+        }
+        if "speaker" in s:
+            seg["speaker"] = s["speaker"]
+        segments.append(seg)
 
     text = " ".join(s["text"] for s in segments).strip()
+    speakers = _summarize_speakers(segments) if req.diarize else []
 
     return {
         "text": text,
-        "language": info.language,
-        "language_probability": round(info.language_probability, 3),
+        "language": language,
         "segments": segments,
-        # Surface diarization status so callers know what they got.
-        "diarization": "basic" if req.diarize else "none",
+        "speakers": speakers,
+        # Surface which fail-soft tier produced the labels.
+        "diarization": diarization_tier,
     }

--- a/services/whisper-service/requirements.txt
+++ b/services/whisper-service/requirements.txt
@@ -1,9 +1,14 @@
-faster-whisper==1.0.3
-# faster-whisper 1.0.3 imports `requests` at module load (faster_whisper/utils.py)
-# but does not declare it, and recent huggingface_hub no longer pulls it in
-# transitively -- so it must be pinned explicitly or the first /transcribe call
-# 500s with ModuleNotFoundError while /health still passes (model is lazy-loaded).
-requests==2.32.3
+# Node-local whisperx STT + speaker-diarization sidecar.
+#
+# whisperx bundles the full pipeline: faster-whisper transcription, wav2vec2
+# forced alignment, and pyannote speaker diarization. It pulls transformers,
+# ctranslate2, faster-whisper and pyannote.audio transitively. torch,
+# torchaudio and torchvision are installed separately in the Dockerfile from
+# the CPU wheel index (whisperx 3.8.x pins ~=2.8.0) to keep the image lean and
+# avoid CUDA (cuDNN/ctranslate2) version drift; the service auto-detects device
+# at runtime.
+whisperx==3.8.6
+
 fastapi==0.115.6
 uvicorn==0.34.0
 pydantic==2.10.4

--- a/services/whisper-service/test_app.py
+++ b/services/whisper-service/test_app.py
@@ -1,0 +1,75 @@
+"""Unit tests for the whisper-service diarization helpers.
+
+Covers the pure post-processing logic (speaker labelling, roster summarization,
+label derivation) without loading any ML model. Run with:
+
+    cd services/whisper-service && pip install pytest && pytest
+"""
+
+import app
+
+
+def test_speaker_label_pyannote_ids_are_one_indexed():
+    assert app._speaker_label("SPEAKER_00") == "Speaker 1"
+    assert app._speaker_label("SPEAKER_01") == "Speaker 2"
+    assert app._speaker_label("SPEAKER_12") == "Speaker 13"
+
+
+def test_speaker_label_passthrough_for_basic_labels():
+    # Basic-tier labels ("Speaker N") and anything unrecognised pass through.
+    assert app._speaker_label("Speaker 2") == "Speaker 2"
+    assert app._speaker_label("weird") == "weird"
+
+
+def test_label_speakers_basic_increments_on_gap():
+    segments = [
+        {"start": 0.0, "end": 2.0, "text": "a"},
+        {"start": 2.5, "end": 4.0, "text": "b"},  # gap 0.5 < 2.0 -> same
+        {"start": 7.0, "end": 8.0, "text": "c"},  # gap 3.0 > 2.0 -> new
+    ]
+    out = app._label_speakers_basic(segments)
+    assert [s["speaker"] for s in out] == ["Speaker 1", "Speaker 1", "Speaker 2"]
+
+
+def test_summarize_speakers_join_key_and_talktime():
+    # id MUST equal the raw segment.speaker label (the roster join key), with a
+    # human-friendly name in `label`. talkTimePct is duration-weighted.
+    segments = [
+        {"start": 0.0, "end": 3.0, "text": "x", "speaker": "SPEAKER_00"},
+        {"start": 3.0, "end": 4.0, "text": "y", "speaker": "SPEAKER_01"},
+        {"start": 4.0, "end": 6.0, "text": "z", "speaker": "SPEAKER_00"},
+    ]
+    roster = app._summarize_speakers(segments)
+    by_id = {s["id"]: s for s in roster}
+    assert set(by_id) == {"SPEAKER_00", "SPEAKER_01"}
+    # SPEAKER_00 spoke 5s of 6s total, SPEAKER_01 spoke 1s.
+    assert by_id["SPEAKER_00"]["talkTimePct"] == round(5 / 6 * 100, 1)
+    assert by_id["SPEAKER_01"]["talkTimePct"] == round(1 / 6 * 100, 1)
+    # Human-friendly label is derived, id stays the raw join key.
+    assert by_id["SPEAKER_00"]["label"] == "Speaker 1"
+    assert by_id["SPEAKER_01"]["label"] == "Speaker 2"
+
+
+def test_summarize_speakers_preserves_first_seen_order():
+    segments = [
+        {"start": 0.0, "end": 1.0, "text": "a", "speaker": "SPEAKER_01"},
+        {"start": 1.0, "end": 2.0, "text": "b", "speaker": "SPEAKER_00"},
+    ]
+    roster = app._summarize_speakers(segments)
+    assert [s["id"] for s in roster] == ["SPEAKER_01", "SPEAKER_00"]
+
+
+def test_summarize_speakers_ignores_unlabelled_segments():
+    segments = [
+        {"start": 0.0, "end": 1.0, "text": "a"},
+        {"start": 1.0, "end": 2.0, "text": "b", "speaker": "SPEAKER_00"},
+    ]
+    roster = app._summarize_speakers(segments)
+    assert len(roster) == 1
+    assert roster[0]["id"] == "SPEAKER_00"
+    assert roster[0]["talkTimePct"] == 100.0
+
+
+def test_resolve_compute_type_defaults_by_device():
+    assert app._resolve_compute_type("cuda") == "float16"
+    assert app._resolve_compute_type("cpu") == "int8"


### PR DESCRIPTION
## Context

Slice B of the speaker-diarization epic (aceteam-ai/aceteam#5821). The node-local transcribe sidecar was fast and accurate but **couldn't tell who said what** — it faked speaker labels with a silence-gap heuristic ("Speaker 1/2") that can't actually distinguish voices. This PR upgrades it to **real speaker diarization** via [whisperx](https://github.com/m-bain/whisperX): faster-whisper transcription + wav2vec2 forced alignment (tight word/segment timestamps) + **pyannote** speaker diarization (true voice identities).

This is the contract the rest of the epic consumes — Slice A's web transcript view and Slice C's reprocess/storage join on `speakers[].id == segment.speaker`.

## Summary

**`services/whisper-service/app.py`** — rewritten around whisperx with explicit fail-soft tiers so `TRANSCRIBE_AUDIO` never breaks:
- **`speaker`** — real pyannote diarization. Requires `HF_TOKEN` (pyannote's model is gated) and a `speaker` request. Segments carry true `SPEAKER_NN` identities.
- **`basic`** — the existing silence-gap heuristic. Quick path, or fallback when a `speaker` request can't reach pyannote (no token/model). Never crashes.
- **`none`** — plain transcription, no labels.
- Alignment (wav2vec2, ungated) runs whenever available and only tightens timestamps; skipped silently on failure.
- Device auto-detects (`cuda` when free, else `cpu`), model size via `WHISPER_MODEL`.

**Request modes** (set by the Go handler from the job's `diarize` param):
- `diarize="speaker"` → attempt real pyannote (reprocess path).
- `diarize="true"` → basic silence-gap labelling (quick path, back-compat).
- anything else → no labels.

**Response contract** (additive — old callers reading `text`/`language`/`segments` still work):
```json
{
  "text": "…",
  "language": "en",
  "segments": [{"start": 0.05, "end": 5.47, "speaker": "SPEAKER_00", "text": "…"}],
  "speakers": [{"id": "SPEAKER_00", "label": "Speaker 1", "talkTimePct": 62.5}],
  "diarization": "speaker"
}
```
- `speakers[].id` equals the raw `segment.speaker` label verbatim (the roster **join key**); `speakers[].label` is the human-friendly name; `talkTimePct` is duration-weighted; timestamps in seconds.
- **`diarization` field** signals real-vs-fallback for the reprocess orchestrator: `"speaker"` = real pyannote ran (safe to replace the stored transcript), `"basic"` = fell back to silence-gap (keep the quick transcript, stay retryable), `"none"` = no labels requested.

**`Dockerfile` / `requirements.txt`** — whisperx 3.8.6; torch/torchaudio/torchvision installed from the CPU wheel index (matching whisperx's `~=2.8.0` pins) to keep the image lean and dodge the cuDNN/ctranslate2 version hell that plagues GPU whisperx images. The service auto-detects device, so a future CUDA image needs no code change.

**`services/compose/transcribe.yml`** — `HF_TOKEN` + `DIARIZE_MODEL` env passthrough with setup instructions, plus a commented-out GPU reservation block for future CUDA images.

**`internal/jobs/transcribe_audio.go`** — maps the `diarize` job param to the sidecar request (`speaker` vs basic vs off) and relays the JSON verbatim; doc updated for the additive `speakers[]` roster.

## One thing the founder must supply: `HF_TOKEN`

pyannote's diarization model is **gated** — it's the single missing piece for real diarization. No token is configured on the test node or in the repos. To enable it:

1. Create a token at https://hf.co/settings/tokens
2. Accept the terms on https://hf.co/pyannote/speaker-diarization-community-1 (whisperx's default model). Or set `DIARIZE_MODEL=pyannote/speaker-diarization-3.1` and accept that model + https://hf.co/pyannote/segmentation-3.0.
3. Set `HF_TOKEN=hf_…` in the node environment before `SERVICE_START` (compose reads `${HF_TOKEN:-}`).

Without it, `speaker` requests fall back to the `basic` tier and report it — no breakage, just no real voice separation.

## Proof on the GPU node

Validated the full whisperx pipeline on the RTX-class GPU node against a synthesized two-voice conversation clip (33s, two distinct espeak voices).

**Note on device:** a co-resident GPU workload currently occupies most of the card's VRAM, so I proved on CPU (diarization correctness is device-independent; loading a GPU model there would OOM the live workload). The image is GPU-capable via `WHISPER_DEVICE=auto` for when the card frees.

**Fail-soft path (no token) — real transcription + tight aligned timestamps + contract shape:**
```json
{"text":"Hey Sarah, did you get a chance to review the quarterly budget report…",
 "segments":[{"start":0.051,"end":5.474,"speaker":"Speaker 1","text":"Hey Sarah, did you get a chance to review the quarterly budget report I sent over yesterday?"}, …],
 "speakers":[{"id":"Speaker 1","label":"Speaker 1","talkTimePct":100.0}],
 "diarization":"basic"}
```
The basic heuristic collapsed both speakers into one — a vivid demonstration of why real diarization is needed.

**`speaker` request reaches the pyannote auth gate** (proving the code correctly invokes pyannote and only the token is missing — this also caught a real bug: whisperx 3.8.6 renamed the auth kwarg `use_auth_token` → `token`, now fixed):
```
whisperx.diarize - Loading diarization model: pyannote/speaker-diarization-community-1
GatedRepoError: 401 … Access to model pyannote/speaker-diarization-community-1 is restricted
pyannote diarization unavailable (…); falling back to silence-gap labelling  → diarization: "basic"
```
Once `HF_TOKEN` is set + terms accepted, this same path produces real `SPEAKER_NN` segments and `diarization: "speaker"`.

**Real `assign_word_speakers` assembly (token-free proxy for the diarized output).** The pyannote *voice clustering* needs a token, but the post-diarization assembly — `whisperx.assign_word_speakers` + segment-speaker fill + roster with talk-time % — was exercised end-to-end by feeding a synthetic pyannote-shaped diarization DataFrame through the real whisperx 3.8.6 call on a real aligned transcript:
```json
"segments": [{"start":0.05,"end":5.47,"text":"…","speaker":"SPEAKER_00"}, …,
             {"start":20.26,"end":21.83,"text":"The payment for timing spend.","speaker":"SPEAKER_01"}, …],
"speakers": [{"id":"SPEAKER_00","label":"Speaker 1","talkTimePct":59.5},
             {"id":"SPEAKER_01","label":"Speaker 2","talkTimePct":40.5}]
```
This validates the exact 3.8.6 API surface my code depends on (column names, return type, fill-missing loop, roster) — it's how the API-break `use_auth_token`→`token` was caught. The remaining unexecuted piece is pyannote's actual clustering, gated solely on the token.

> **Assumption to verify when the token lands:** whisperx 3.8.6 defaults to `pyannote/speaker-diarization-community-1` (pyannote 4.x). The contract promises `"SPEAKER_NN"`-style labels; pyannote pipelines emit that format, but I couldn't confirm community-1's exact strings without a token. The roster join key (`id == segment.speaker`) holds regardless. To guarantee the classic format, set `DIARIZE_MODEL=pyannote/speaker-diarization-3.1`.

## Deploy

Built the CPU image on the GPU node from this branch (CI only builds GHCR on merge-to-main) and swapped the live `citadel-transcribe` sidecar on `:8101` — verified healthy and serving the new contract end-to-end (basic tier, no token). Rollback: the previous image is preserved locally as `ghcr.io/aceteam-ai/whisper-service:rollback-v272`; re-tag it to `:latest` and recreate. The permanent GHCR image publishes automatically on merge (`build-whisper-service.yml`).

## Test plan

| Group | Coverage |
|---|---|
| Python `test_app.py` (7) | roster join-key + talk-time %, first-seen order, unlabelled segments ignored, label derivation, silence-gap increment, compute-type-by-device |
| Go `transcribe_audio_test.go` | diarize mode mapping (speaker/basic/off/absent), path validation, verbatim relay, fast-fail on unreachable sidecar, patient-while-loading, symlinked workspace |
| On-node | `/health` fast, transcribe+align+contract on real 2-voice audio, all three request modes, pyannote path reaches auth gate, fail-soft to basic, deployed `:8101` end-to-end |

## Related

- Epic: aceteam-ai/aceteam#5821
- Contract consumed by Slice A (web view) and Slice C (reprocess orchestration)

---
*Generated by Claude Opus 4.8*
