### PR TITLE
Register gotenberg host port 8209

### DIFF
--- a/services/ports.go
+++ b/services/ports.go
@@ -51,6 +51,13 @@ const (
 	// the 8200 registry block below.
 	EnvMeetingdHostPort   = "CITADEL_MEETINGD_HOST_PORT"
 	EnvMeetingCDPHostPort = "CITADEL_MEETING_CDP_HOST_PORT"
+	// EnvGotenbergHostPort carries the host port for the gotenberg
+	// document-conversion module (aceteam-ai/citadel-services#10). Like
+	// claudecode and meeting, gotenberg's compose lives in
+	// aceteam-ai/citadel-services (not the embedded ServiceMap), but it is
+	// registered here so `citadel module install gotenberg` injects the port via
+	// the same HostPortEnv() mechanism.
+	EnvGotenbergHostPort = "CITADEL_GOTENBERG_HOST_PORT"
 )
 
 // Citadel-assigned host ports for the pre-packaged compose services. These are
@@ -93,6 +100,13 @@ const (
 	// process.
 	MeetingdHostPort   = 8207
 	MeetingCDPHostPort = 8208
+	// gotenberg: the document-conversion module (LibreOffice + Chromium -> PDF,
+	// citadel-services#10) that unblocks Sovereign Sign P2 (aceteam#5793) --
+	// sovereign DOCX->PDF conversion on the customer's own node. Next free slot
+	// in the 8200 block after meeting's 8207/8208. The container-internal port
+	// is 3000; this is the HOST publish, bound to 127.0.0.1 only (Gotenberg has
+	// no auth of its own).
+	GotenbergHostPort = 8209
 )
 
 // ServiceHostPorts maps service name -> citadel-assigned host port. Most entries
@@ -110,6 +124,7 @@ var ServiceHostPorts = map[string]int{
 	"storage":     StorageHostPort,
 	"meeting":     MeetingdHostPort,
 	"meeting-cdp": MeetingCDPHostPort,
+	"gotenberg":   GotenbergHostPort,
 }
 
 // serviceHostPortEnv maps each managed service to the compose env-var that
@@ -122,6 +137,7 @@ var serviceHostPortEnv = map[string]string{
 	"claudecode":  EnvClaudecodeHostPort,
 	"meeting":     EnvMeetingdHostPort,
 	"meeting-cdp": EnvMeetingCDPHostPort,
+	"gotenberg":   EnvGotenbergHostPort,
 }
 
 // HostPortEnv returns "KEY=value" entries for every citadel-managed host port,

--- a/services/ports_test.go
+++ b/services/ports_test.go
@@ -57,6 +57,55 @@ func TestMeetingHostPortsRegistered(t *testing.T) {
 	}
 }
 
+// TestGotenbergHostPortRegistered pins the gotenberg document-conversion
+// module's host port (aceteam-ai/citadel-services#10, unblocking Sovereign
+// Sign P2 / aceteam#5793): it must be registered, distinct from every other
+// managed/reserved port, and above the apps auto-allocation range. Like
+// claudecode and meeting, gotenberg's compose lives in citadel-services (not
+// the embedded ServiceMap), so this registry -- and this test -- is the only
+// thing that stops a future module from hardcoding over 8209. The union guard
+// in internal/apps/hostport_collision_test.go does NOT cover this port: it
+// only claims ports from the apps catalog and services.ServiceMap compose
+// files, neither of which gotenberg is part of.
+func TestGotenbergHostPortRegistered(t *testing.T) {
+	got, ok := ServiceHostPorts["gotenberg"]
+	if !ok || got != GotenbergHostPort {
+		t.Errorf("ServiceHostPorts[%q] = %d (present=%v), want %d", "gotenberg", got, ok, GotenbergHostPort)
+	}
+	if _, ok := serviceHostPortEnv["gotenberg"]; !ok {
+		t.Errorf("serviceHostPortEnv is missing %q; HostPortEnv() will not inject its host port", "gotenberg")
+	}
+	if GotenbergHostPort >= AppsPortRangeStart && GotenbergHostPort <= AppsPortRangeEnd {
+		t.Errorf("gotenberg host port %d sits inside the apps auto-allocation range %d-%d", GotenbergHostPort, AppsPortRangeStart, AppsPortRangeEnd)
+	}
+	if name, taken := ReservedCitadelPorts[GotenbergHostPort]; taken {
+		t.Errorf("gotenberg host port %d collides with reserved citadel port %q", GotenbergHostPort, name)
+	}
+	// Pairwise-unique against every other managed service.
+	for svc, port := range ServiceHostPorts {
+		if svc == "gotenberg" {
+			continue
+		}
+		if port == GotenbergHostPort {
+			t.Errorf("gotenberg host port collides with managed service %q (%d)", svc, port)
+		}
+	}
+	// HostPortEnv must emit the gotenberg var so a compose that defers to it
+	// resolves.
+	env := HostPortEnv()
+	want := EnvGotenbergHostPort + "=8209"
+	found := false
+	for _, kv := range env {
+		if kv == want {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("HostPortEnv() did not emit %q", want)
+	}
+}
+
 // TestReservedCitadelPortsPairwiseDistinct asserts that no two DISTINCT
 // citadel-owned listeners are registered on the same port. Reserved ports are
 // a set-to-avoid for modules/apps (covered by the apps collision guard), but


### PR DESCRIPTION
## What

Registers the `gotenberg` document-conversion module's host port in `services/ports.go`, wired identically to `claudecode` and `meeting`:

1. `EnvGotenbergHostPort = "CITADEL_GOTENBERG_HOST_PORT"` alongside the other `Env*` constants.
2. `GotenbergHostPort = 8209` in the 8200+ block — next free slot after `meeting`'s 8207/8208.
3. `"gotenberg": GotenbergHostPort` added to `ServiceHostPorts`.
4. `"gotenberg": EnvGotenbergHostPort` added to `serviceHostPortEnv`.
5. Added `TestGotenbergHostPortRegistered` in `services/ports_test.go`, mirroring the existing `TestMeetingHostPortsRegistered` pinning test.

## Why

[aceteam-ai/citadel-services#10](https://github.com/aceteam-ai/citadel-services/pull/10) added the `gotenberg` catalog module (LibreOffice + Chromium → PDF, container port 3000, host port 8209, loopback-only) but was deliberately catalog-only and left citadel-cli untouched — its own description calls out that `CITADEL_GOTENBERG_HOST_PORT` / `GotenbergHostPort = 8209` needed a citadel-cli follow-up before `citadel module install gotenberg` would inject the port. This PR is that follow-up.

This unblocks Sovereign Sign P2 ([aceteam-ai/aceteam#5793](https://github.com/aceteam-ai/aceteam/issues/5793)): converting DOCX to PDF on the customer's own Citadel node so the source document never leaves their hardware before it's hashed and signed.

## Test report (honest, verbatim)

Like `claudecode` and `meeting`, gotenberg's compose file lives in the separate `aceteam-ai/citadel-services` repo, not in `services/compose/*.yml` here. `internal/apps/hostport_collision_test.go`'s `TestHostPortNoCollisions` — the "union guard" that parses `services.ServiceMap` compose files plus the apps catalog — structurally does **not** cover gotenberg, because it never claims `services.ServiceHostPorts` registry entries into its collision set (by design, per its own comment: doing so would be a self-collision) and gotenberg has no compose file in this repo to parse. It passes, but doesn't validate anything gotenberg-specific — same as the existing `claudecode`/`meeting`/`storage` entries today.

The actual in-repo collision guard for external-compose modules is the dedicated pinning test pattern (`TestMeetingHostPortsRegistered`), so I added `TestGotenbergHostPortRegistered` following it: asserts registration in both maps, pairwise-uniqueness against every other `ServiceHostPorts` entry, exclusion from the apps auto-allocation range (8100-8199) and from `ReservedCitadelPorts`, and that `HostPortEnv()` emits `CITADEL_GOTENBERG_HOST_PORT=8209`.

```
$ go test ./services/... ./internal/apps/... ./cmd/... -run 'HostPort|ComposeCommandInjectsHostPortEnv|Reserved|ControlMTLS|Collision' -v
=== RUN   TestDiffusersHostPortNonColliding
--- PASS: TestDiffusersHostPortNonColliding (0.00s)
=== RUN   TestMeetingHostPortsRegistered
--- PASS: TestMeetingHostPortsRegistered (0.00s)
=== RUN   TestGotenbergHostPortRegistered
--- PASS: TestGotenbergHostPortRegistered (0.00s)
=== RUN   TestReservedCitadelPortsPairwiseDistinct
--- PASS: TestReservedCitadelPortsPairwiseDistinct (0.00s)
=== RUN   TestControlMTLSPortAvoidsKnownSurfaces
--- PASS: TestControlMTLSPortAvoidsKnownSurfaces (0.00s)
PASS
ok      github.com/aceteam-ai/citadel-cli/services     0.004s
=== RUN   TestHostPortNoCollisions
--- PASS: TestHostPortNoCollisions (0.00s)
PASS
ok      github.com/aceteam-ai/citadel-cli/internal/apps        0.003s
=== RUN   TestGatewayVPNBindErrorMessageCollisionHint
--- PASS: TestGatewayVPNBindErrorMessageCollisionHint (0.00s)
=== RUN   TestComposeCommandInjectsHostPortEnv
--- PASS: TestComposeCommandInjectsHostPortEnv (0.00s)
PASS
ok      github.com/aceteam-ai/citadel-cli/cmd  0.007s
```

Full suite also green: `go test ./...` — all packages pass. `gofmt -l` clean on both changed files, `go vet ./services/... ./internal/apps/... ./cmd/...` clean, `go build ./...` clean.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...` (scoped run on touched packages, clean)
- [x] `gofmt -l` clean
- [x] `go test ./...` full suite green
- [x] New `TestGotenbergHostPortRegistered` passes
- [x] `TestComposeCommandInjectsHostPortEnv` (regression guard for #426) now asserts `CITADEL_GOTENBERG_HOST_PORT` is injected into every compose invocation

---
Generated by Claude Sonnet 5