### PR TITLE
fix(status): inject CITADEL_WORKSPACE into compose env (#525)

### DIFF
--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -134,6 +134,9 @@ func runDockerComposeLogs(serviceName, composePath, tailLines string) error {
 	}
 
 	logCmd := exec.Command("docker", dockerArgs...)
+	// Inject CITADEL_WORKSPACE + host-port vars so compose files guarded with
+	// ${VAR:?...} (transcribe/meeting workspace mount, #525) interpolate.
+	logCmd.Env = composeEnv()
 	logCmd.Stdout = os.Stdout
 	logCmd.Stderr = os.Stderr
 

--- a/cmd/module_update.go
+++ b/cmd/module_update.go
@@ -281,6 +281,9 @@ func composeUpDetached(name, composePath string) error {
 	args = append(args, composeFileArgs(composePath, composePath)...)
 	args = append(args, "-p", "citadel-"+name, "up", "-d")
 	c := exec.Command("docker", args...)
+	// Inject CITADEL_WORKSPACE + host-port vars so compose files guarded with
+	// ${VAR:?...} (transcribe/meeting workspace mount, #525) interpolate.
+	c.Env = composeEnv()
 	if out, err := c.CombinedOutput(); err != nil {
 		return fmt.Errorf("docker compose up failed: %s", strings.TrimSpace(string(out)))
 	}

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -32,8 +32,20 @@ var forceRecreate bool
 // inherited a bare os.Environ() and so failed the :? guard on v2.57.0 for those
 // four services. Every compose-up site in this tree MUST build its command
 // environment from this helper. Mirrors internal/jobs.ServiceHandler.composeEnv.
+//
+// It also guarantees CITADEL_WORKSPACE is set to an absolute workspace path so
+// compose files that bind-mount the node workspace via the guarded
+// ${CITADEL_WORKSPACE:?...} form (transcribe, meeting) interpolate on read-only
+// invocations too (`citadel status` ps, logs, down) instead of dying on the :?
+// guard (#525). Resolution mirrors the worker (env > ~/citadel-node/workspace
+// default via resolveWorkspaceDir); an empty value is never injected -- if the
+// path cannot be resolved the :? guard still fails loudly.
 func composeEnv() []string {
-	return append(os.Environ(), svcports.HostPortEnv()...)
+	env := os.Environ()
+	if ws := resolveWorkspaceDir(); ws != "" {
+		env = append(env, "CITADEL_WORKSPACE="+ws)
+	}
+	return append(env, svcports.HostPortEnv()...)
 }
 
 // composeCommand builds an *exec.Cmd for a `docker/podman compose` invocation

--- a/cmd/service_test.go
+++ b/cmd/service_test.go
@@ -2,11 +2,25 @@
 package cmd
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
 	svcports "github.com/aceteam-ai/citadel-cli/services"
 )
+
+// effectiveWorkspaceEnv returns the value of the LAST CITADEL_WORKSPACE= entry
+// in env (exec.Cmd uses the last duplicate) and whether any entry was present.
+func effectiveWorkspaceEnv(env []string) (string, bool) {
+	val, found := "", false
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "CITADEL_WORKSPACE=") {
+			val = strings.TrimPrefix(kv, "CITADEL_WORKSPACE=")
+			found = true
+		}
+	}
+	return val, found
+}
 
 // TestComposeCommandInjectsHostPortEnv is the regression guard for #426: every
 // cmd/ compose invocation must carry the citadel-owned host-port vars so compose
@@ -37,5 +51,51 @@ func TestComposeCommandInjectsHostPortEnv(t *testing.T) {
 			t.Errorf("composeCommand env is missing host-port entry %q; got env:\n%s",
 				want, strings.Join(cmd.Env, "\n"))
 		}
+	}
+}
+
+// TestComposeCommandInjectsWorkspaceEnv is the regression guard for #525: every
+// cmd/ compose invocation (including read-only ones like `citadel status` ps)
+// must carry CITADEL_WORKSPACE so compose files that bind-mount the workspace
+// via ${CITADEL_WORKSPACE:?...} (transcribe, meeting) interpolate. Mirrors
+// internal/jobs TestComposeEnv_InjectsWorkspace for the CLI/TUI tree.
+func TestComposeCommandInjectsWorkspaceEnv(t *testing.T) {
+	ws := t.TempDir()
+	t.Setenv("CITADEL_WORKSPACE", ws)
+
+	cmd := composeCommand("-f", "/tmp/does-not-matter.yml", "ps", "--format", "json")
+	got, found := effectiveWorkspaceEnv(cmd.Env)
+	if !found {
+		t.Fatal("composeCommand env did not set CITADEL_WORKSPACE")
+	}
+	if got != ws {
+		t.Errorf("CITADEL_WORKSPACE = %q, want the configured workspace %q", got, ws)
+	}
+}
+
+// TestComposeEnvWorkspaceDefaultsAndNeverEmpty verifies that with no workspace
+// configured, composeEnv falls back to the absolute ~/citadel-node/workspace
+// default and never leaves an effective empty CITADEL_WORKSPACE= (which would
+// still fail the :? guard, or worse, mount the wrong path). Mirrors
+// internal/jobs TestComposeEnv_NoWorkspaceLeavesEnvUntouched.
+func TestComposeEnvWorkspaceDefaultsAndNeverEmpty(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // Windows os.UserHomeDir
+	t.Setenv("CITADEL_WORKSPACE", "")
+
+	got, found := effectiveWorkspaceEnv(composeEnv())
+	if !found {
+		t.Fatal("composeEnv did not set CITADEL_WORKSPACE")
+	}
+	if got == "" {
+		t.Fatal("composeEnv left an effective empty CITADEL_WORKSPACE")
+	}
+	want := filepath.Join(home, "citadel-node", "workspace")
+	if got != want {
+		t.Errorf("CITADEL_WORKSPACE = %q, want default %q", got, want)
+	}
+	if !filepath.IsAbs(got) {
+		t.Errorf("CITADEL_WORKSPACE %q is not an absolute path", got)
 	}
 }

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -216,6 +216,9 @@ func stopServiceByCompose(composePath string, remove bool) error {
 	}
 
 	cmd := exec.Command("docker", args...)
+	// Inject CITADEL_WORKSPACE + host-port vars so compose files guarded with
+	// ${VAR:?...} (transcribe/meeting workspace mount, #525) interpolate.
+	cmd.Env = composeEnv()
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("docker compose down failed:\n%s\n   Hint: Is Docker running? Check with 'docker info'", strings.TrimSpace(string(output)))


### PR DESCRIPTION
## Context

Closes #525. On nodes with the `transcribe` service configured, `citadel status` showed:

```
- transcribe:  ⚠️  Could not get status
  error while interpolating services.transcribe.volumes.[]: required variable CITADEL_WORKSPACE is missing a value
```

## Root Cause

`services/compose/transcribe.yml` (and the meeting stack) bind-mount `${CITADEL_WORKSPACE:?...}`, so any `docker compose` invocation — even read-only `ps` — fails interpolation if the var is unset. The worker job path (`internal/jobs/service_handler.go` `composeEnv()`) already injects the var into the compose subprocess env, but the `cmd/` tree did not.

## Changes

- `cmd/service.go` — `composeEnv()` (the shared env builder behind `composeCommand`, used by status/run/TUI/compose-refresh) now injects `CITADEL_WORKSPACE` via the existing `resolveWorkspaceDir()` (env > `~/citadel-node/workspace` default). Only a non-empty absolute path is ever injected; on resolution failure the `:?` guard still fails loudly.
- `cmd/stop.go`, `cmd/logs.go`, `cmd/module_update.go` — one-line `cmd.Env = composeEnv()` at the three call sites that bypass `composeCommand` with bare `exec.Command("docker", "compose", ...)`. Same bug class. (`cmd/test.go` has no compose call sites; `cmd/run.go` already routes through `composeCommand`.)
- `cmd/service_test.go` — tests mirroring `internal/jobs/service_handler_test.go`: configured workspace is propagated; the injected value defaults correctly and is never empty.

## Testing

- Reproduced empirically on a live node with transcribe running: unpatched binary with `CITADEL_WORKSPACE` unset → `⚠️ Could not get status`; patched binary → `🟢 RUNNING`.
- Project-name match verified: the worker's SERVICE_START and status's `ps` both use the same `-f` path with no `-p`, so status found the worker-started container (no false `⚫ STOPPED`).
- `go build ./...`, `go vet ./...`, `go test ./...` all pass.

Minor side effect: `citadel status` now creates `~/citadel-node/workspace` if absent (idempotent, matches worker behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)