### PR TITLE
feat(cli): discover-and-attach when a worker is already running (#524)

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -19,6 +20,7 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/resmon"
 	"github.com/aceteam-ai/citadel-cli/internal/tui"
 	"github.com/aceteam-ai/citadel-cli/internal/tui/dashboard"
+	"github.com/aceteam-ai/citadel-cli/internal/worklock"
 	"github.com/fatih/color"
 	"github.com/redis/go-redis/v9"
 	"github.com/shirou/gopsutil/v3/cpu"
@@ -95,6 +97,9 @@ func runStandardStatus() {
 
 	headerColor.Fprintf(w, "--- 📊 Citadel Node Status (%s) ---\n", Version)
 
+	headerColor.Fprintln(w, "\n🛠️ WORKER")
+	printWorkerInfo(w)
+
 	headerColor.Fprintln(w, "\n💻 SYSTEM VITALS")
 	printMemInfo(w)
 	printCPUInfo(w)
@@ -124,6 +129,30 @@ func runStandardStatus() {
 
 	headerColor.Fprintln(w, "\n🚀 MANAGED SERVICES")
 	printServiceInfo(w)
+}
+
+// printWorkerInfo reports whether a `citadel work` worker currently holds the
+// single-instance lock for this node (issue #524). It mirrors the control-center
+// precedent (cmd/controlcenter.go) which uses worklock.IsHeld to detect a live
+// worker, and enriches the line with the recorded PID / version. Read-only: it
+// never touches the lock (IsHeld probes on a separate fd and unlocks immediately).
+func printWorkerInfo(w io.Writer) {
+	stateDir := network.GetStateDir()
+	held, pid := worklock.IsHeld(stateDir)
+	if !held {
+		fmt.Fprintf(w, "  %s\t%s\n", labelColor.Sprint("Status:"), warnColor.Sprint("not running"))
+		return
+	}
+	detail := fmt.Sprintf("PID %d", pid)
+	if holder, ok := worklock.ReadHolder(stateDir); ok {
+		if holder.Version != "" {
+			detail += ", v" + holder.Version
+		}
+		if !holder.StartTime.IsZero() {
+			detail += ", uptime " + humanizeUptime(time.Since(holder.StartTime))
+		}
+	}
+	fmt.Fprintf(w, "  %s\t%s (%s)\n", labelColor.Sprint("Status:"), goodColor.Sprint("running"), detail)
 }
 
 // runInteractiveDashboard runs the interactive TUI dashboard

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -100,6 +100,12 @@ var (
 	// direct-Redis worker alongside the API-mode one in development).
 	workNoSingleInstance bool
 
+	// Discover-and-attach overrides (issue #524): when a worker is already
+	// running, --attach forces the friendly status banner (even off a TTY) and
+	// --no-attach forces the legacy exit-1 refusal. Default is TTY-gated.
+	workAttach   bool
+	workNoAttach bool
+
 	// Node-key renewer flag (epic #4583): disable the background loop that
 	// refreshes the Headscale node key before expiry while online.
 	workNoKeyRenew bool
@@ -315,6 +321,15 @@ func runWork(cmd *cobra.Command, args []string) {
 		if lockErr != nil {
 			var running *worklock.ErrAlreadyRunning
 			if errors.As(lockErr, &running) {
+				// Discover-and-attach (issue #524, increment 1): on an interactive
+				// TTY, print the running worker's status instead of a bare error
+				// (docker-daemon style). Non-TTY (systemd, scripts) keeps today's
+				// exit-1 refusal UNCHANGED so a misconfigured double systemd unit
+				// still fails visibly. --attach / --no-attach override the heuristic.
+				if decideAttach(stdoutIsTTY(), workAttach, workNoAttach) {
+					renderWorkAttach(network.GetStateDir(), running)
+					os.Exit(0)
+				}
 				fmt.Fprintf(os.Stderr, "Error: %v\n", running)
 				fmt.Fprintln(os.Stderr, "\nAnother 'citadel work' is already serving this node.")
 				fmt.Fprintln(os.Stderr, "Stop it first (e.g. 'systemctl --user stop citadel' or kill the PID above),")
@@ -2567,6 +2582,8 @@ func init() {
 	workCmd.Flags().BoolVar(&workNoUpdate, "no-update", false, "(Deprecated) No longer has any effect - use 'citadel update disable' instead")
 	workCmd.Flags().BoolVar(&workNoFootprint, "no-footprint", false, "Disable the background resource-footprint sampler")
 	workCmd.Flags().BoolVar(&workNoSingleInstance, "no-single-instance", false, "Allow a second worker to run for this node (skips the single-instance lock)")
+	workCmd.Flags().BoolVar(&workAttach, "attach", false, "When a worker is already running, print its status banner instead of refusing (default: only on an interactive terminal)")
+	workCmd.Flags().BoolVar(&workNoAttach, "no-attach", false, "When a worker is already running, refuse with exit 1 instead of printing the status banner")
 	workCmd.Flags().BoolVar(&workNoKeyRenew, "no-key-renew", false, "Disable the background Headscale node-key renewer (renews the key before expiry while online)")
 	workCmd.Flags().MarkDeprecated("no-update", "use 'citadel update disable' to disable auto-update checks")
 

--- a/cmd/work_attach.go
+++ b/cmd/work_attach.go
@@ -1,0 +1,242 @@
+// cmd/work_attach.go
+//
+// Discover-and-attach UX for the single-instance worker (issue #524, increment 1).
+//
+// When `citadel work` is refused by the single-instance lock (another worker
+// already serves this node), an interactive invocation should not dead-end on a
+// bare error. Docker-daemon style, it discovers the running instance and prints
+// its status instead of duplicating or refusing silently. This file holds that
+// increment: the refusal-path attach banner (read-only), rendered from the lock
+// record plus an unauthenticated GET /status on the local status server.
+//
+// Deliberately additive and zero-daemon-change: no new endpoint, no lock
+// mutation. The banner is a read-only HTTP client of the already-running worker.
+// TTY-gated so systemd / scripts keep today's exit-1 refusal (see decideAttach).
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/worklock"
+	"golang.org/x/term"
+)
+
+// defaultStatusPort mirrors the status server's default bind port (internal/status
+// server.go, and the auto-enable in cmd/work.go). Used as the fallback when
+// gateway-facts.json is absent or records no status port.
+const defaultStatusPort = 8080
+
+// attachStatus is the minimal subset of the /status payload the attach banner
+// renders. Kept local (rather than importing status.NodeStatus) so the banner
+// only depends on the handful of fields it prints and tolerates schema drift.
+type attachStatus struct {
+	Version string
+	// NodeName is the worker's node identity (status.NodeInfo.Name).
+	NodeName string
+	// Health is the /health status string ("ok", ...), empty when unknown.
+	Health string
+}
+
+// decideAttach reports whether to render the friendly discover-and-attach banner
+// (true) versus the legacy exit-1 refusal (false). Pure so the TTY/flag policy is
+// unit tested without a terminal.
+//
+//   - --no-attach forces the legacy refusal (scripts that want the old behavior).
+//   - --attach forces the banner (e.g. capturing it from a non-TTY).
+//   - otherwise the banner is shown only on an interactive TTY. Non-TTY (systemd,
+//     journald, pipelines) keeps the exit-1 refusal so a misconfigured double
+//     systemd unit still fails visibly instead of "succeeding" as an attach.
+func decideAttach(isTTY, attachFlag, noAttachFlag bool) bool {
+	if noAttachFlag {
+		return false
+	}
+	if attachFlag {
+		return true
+	}
+	return isTTY
+}
+
+// resolveStatusPort returns the plaintext status server port to probe for attach
+// info: the port the running gateway persisted in gateway-facts.json, else the
+// compile-time default (8080). A daemon started with --no-gateway (no facts file,
+// status disabled) degrades attach to lock-record-only info via the default port
+// simply failing to connect.
+func resolveStatusPort() int {
+	if f, ok := readGatewayFacts(); ok && f.StatusPort > 0 {
+		return f.StatusPort
+	}
+	return defaultStatusPort
+}
+
+// probeLocalStatus fetches the minimal attach status from the local status server
+// over loopback. Best-effort: any error (no server, wrong port, timeout, wedged
+// daemon) returns ok=false and the caller falls back to the lock-record-only
+// banner. It never blocks `citadel work` for long — a short timeout and a literal
+// 127.0.0.1 URL (not "localhost", to dodge IPv6/DNS) keep it snappy.
+func probeLocalStatus(port int) (attachStatus, bool) {
+	if port <= 0 {
+		return attachStatus{}, false
+	}
+	client := &http.Client{Timeout: 2 * time.Second}
+
+	st, ok := fetchStatusJSON(client, port)
+	if !ok {
+		return attachStatus{}, false
+	}
+	// /health is a cheap, separate endpoint; a failure here just leaves Health
+	// blank (the /status probe already proved the server is up).
+	st.Health = fetchHealth(client, port)
+	return st, true
+}
+
+// fetchStatusJSON GETs /status and extracts the fields the banner renders.
+func fetchStatusJSON(client *http.Client, port int) (attachStatus, bool) {
+	body, ok := httpGetBody(client, fmt.Sprintf("http://127.0.0.1:%d/status", port))
+	if !ok {
+		return attachStatus{}, false
+	}
+	var payload struct {
+		Version string `json:"version"`
+		Node    struct {
+			Name string `json:"name"`
+		} `json:"node"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return attachStatus{}, false
+	}
+	return attachStatus{Version: payload.Version, NodeName: payload.Node.Name}, true
+}
+
+// fetchHealth GETs /health and returns its status string, or "" on any error.
+func fetchHealth(client *http.Client, port int) string {
+	body, ok := httpGetBody(client, fmt.Sprintf("http://127.0.0.1:%d/health", port))
+	if !ok {
+		return ""
+	}
+	var payload struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return ""
+	}
+	return payload.Status
+}
+
+// httpGetBody performs a bounded GET and returns the body on a 2xx, else ok=false.
+func httpGetBody(client *http.Client, url string) ([]byte, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, false
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+		return nil, false
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, false
+	}
+	return body, true
+}
+
+// buildAttachBanner renders the discover-and-attach banner. Pure (no IO) so it is
+// unit tested against a fixed lock record + status payload.
+//
+// It always renders from the lock record (holder PID, version, and uptime derived
+// from the recorded start time — the WORKER's uptime, available even when the
+// status probe fails). When st is non-nil it enriches the banner with the live
+// node identity and health from /status. The action lines only reference verbs
+// that exist today (`citadel logs -f`, systemctl/kill, --no-single-instance);
+// richer verbs (`--stop`, `logs --worker`) are later increments.
+func buildAttachBanner(holder worklock.HolderRecord, now time.Time, st *attachStatus) string {
+	var b strings.Builder
+	b.WriteString("Citadel worker already running for this node:\n")
+
+	// Line 1: identity from the lock record (always available).
+	version := holder.Version
+	if version == "" && st != nil && st.Version != "" {
+		version = st.Version
+	}
+	line := fmt.Sprintf("  PID %d", holder.PID)
+	if !holder.StartTime.IsZero() {
+		line += fmt.Sprintf(", started %s", holder.StartTime.Format(time.RFC3339))
+		line += fmt.Sprintf(", uptime %s", humanizeUptime(now.Sub(holder.StartTime)))
+	}
+	if version != "" {
+		line += fmt.Sprintf(", version %s", version)
+	}
+	b.WriteString(line + "\n")
+
+	// Line 2: live node identity from /status when the probe succeeded.
+	if st != nil && st.NodeName != "" {
+		node := "  Node: " + st.NodeName
+		if st.Health != "" {
+			node += fmt.Sprintf(" (%s)", st.Health)
+		}
+		b.WriteString(node + "\n")
+	}
+
+	b.WriteString("\n")
+	b.WriteString("View logs:      citadel logs -f\n")
+	b.WriteString("Stop it:        systemctl --user stop citadel  (or kill the PID above)\n")
+	b.WriteString("Run a second worker anyway: citadel work --no-single-instance\n")
+	return b.String()
+}
+
+// humanizeUptime formats a duration as a compact "Nd Nh Nm" (dropping leading
+// zero units), e.g. 51h3m -> "2d 3h". Sub-minute durations render as "0m".
+func humanizeUptime(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	days := int(d.Hours()) / 24
+	hours := int(d.Hours()) % 24
+	mins := int(d.Minutes()) % 60
+	switch {
+	case days > 0:
+		return fmt.Sprintf("%dd %dh", days, hours)
+	case hours > 0:
+		return fmt.Sprintf("%dh %dm", hours, mins)
+	default:
+		return fmt.Sprintf("%dm", mins)
+	}
+}
+
+// renderWorkAttach prints the discover-and-attach banner for a refused
+// `citadel work`, reading the holder metadata and probing the local status
+// server. It writes to stdout (this is informational success for an interactive
+// user, not an error) and is only reached after decideAttach approved the banner.
+// stateDir is the resolved node state dir the lock is keyed to.
+func renderWorkAttach(stateDir string, running *worklock.ErrAlreadyRunning) {
+	holder, ok := worklock.ReadHolder(stateDir)
+	if !ok {
+		// The lock file was unreadable between the refusal and now (holder exited?).
+		// Fall back to the error's own PID/start so the banner still names a holder.
+		holder = worklock.HolderRecord{PID: running.PID, StartTime: running.StartTime}
+	}
+	var st *attachStatus
+	if probed, probeOK := probeLocalStatus(resolveStatusPort()); probeOK {
+		st = &probed
+	}
+	fmt.Fprint(os.Stdout, buildAttachBanner(holder, time.Now(), st))
+}
+
+// stdoutIsTTY reports whether stdout is an interactive terminal (repo precedent:
+// internal/tui/styles.go). Systemd / journald / pipes are not TTYs.
+func stdoutIsTTY() bool {
+	return term.IsTerminal(int(os.Stdout.Fd()))
+}

--- a/cmd/work_attach_test.go
+++ b/cmd/work_attach_test.go
@@ -1,0 +1,145 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/worklock"
+)
+
+func TestDecideAttach(t *testing.T) {
+	cases := []struct {
+		name         string
+		isTTY        bool
+		attachFlag   bool
+		noAttachFlag bool
+		want         bool
+	}{
+		{"tty shows banner", true, false, false, true},
+		{"non-tty refuses (systemd)", false, false, false, false},
+		{"attach flag forces banner off tty", false, true, false, true},
+		{"no-attach flag forces refusal on tty", true, false, true, false},
+		{"no-attach beats attach", true, true, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := decideAttach(tc.isTTY, tc.attachFlag, tc.noAttachFlag); got != tc.want {
+				t.Fatalf("decideAttach(tty=%v, attach=%v, noAttach=%v) = %v, want %v",
+					tc.isTTY, tc.attachFlag, tc.noAttachFlag, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildAttachBanner_LockRecordOnly(t *testing.T) {
+	// Degraded path: no status probe (st == nil). The banner must still render the
+	// holder PID, version, and worker uptime derived from the recorded start time.
+	start := time.Date(2026, 7, 15, 9, 12, 44, 0, time.UTC)
+	now := start.Add(51*time.Hour + 3*time.Minute)
+	holder := worklock.HolderRecord{PID: 41372, StartTime: start, Version: "2.75.0"}
+
+	out := buildAttachBanner(holder, now, nil)
+
+	for _, want := range []string{
+		"already running",
+		"PID 41372",
+		"version 2.75.0",
+		"uptime 2d 3h",
+		"citadel logs -f",
+		"--no-single-instance",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("banner missing %q\n---\n%s", want, out)
+		}
+	}
+	// No status payload -> must not invent a Node line.
+	if strings.Contains(out, "Node:") {
+		t.Errorf("banner should omit Node line without status probe\n---\n%s", out)
+	}
+}
+
+func TestBuildAttachBanner_WithStatus(t *testing.T) {
+	start := time.Date(2026, 7, 15, 9, 12, 44, 0, time.UTC)
+	now := start.Add(90 * time.Minute)
+	holder := worklock.HolderRecord{PID: 100, StartTime: start, Version: "2.75.0"}
+	st := &attachStatus{Version: "2.75.0", NodeName: "gpu-1084", Health: "ok"}
+
+	out := buildAttachBanner(holder, now, st)
+
+	for _, want := range []string{"Node: gpu-1084 (ok)", "uptime 1h 30m"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("banner missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+func TestBuildAttachBanner_VersionFallsBackToStatus(t *testing.T) {
+	// Legacy lock record with no version -> the banner borrows the version from the
+	// live /status payload rather than dropping it.
+	holder := worklock.HolderRecord{PID: 7, StartTime: time.Now().Add(-time.Minute)}
+	st := &attachStatus{Version: "9.9.9", NodeName: "n1"}
+
+	out := buildAttachBanner(holder, time.Now(), st)
+	if !strings.Contains(out, "version 9.9.9") {
+		t.Errorf("banner should fall back to status version\n---\n%s", out)
+	}
+}
+
+func TestHumanizeUptime(t *testing.T) {
+	cases := []struct {
+		d    time.Duration
+		want string
+	}{
+		{30 * time.Second, "0m"},
+		{5 * time.Minute, "5m"},
+		{90 * time.Minute, "1h 30m"},
+		{51*time.Hour + 3*time.Minute, "2d 3h"},
+		{-time.Hour, "0m"},
+	}
+	for _, tc := range cases {
+		if got := humanizeUptime(tc.d); got != tc.want {
+			t.Errorf("humanizeUptime(%s) = %q, want %q", tc.d, got, tc.want)
+		}
+	}
+}
+
+func TestResolveStatusPort(t *testing.T) {
+	// Isolate the gateway-facts read to a temp dir via the existing test hook so
+	// no real node state or sockets are touched.
+	prev := provisionedStateDirOverride
+	t.Cleanup(func() { provisionedStateDirOverride = prev })
+	dir := t.TempDir()
+	provisionedStateDirOverride = dir
+
+	// No facts file -> default port.
+	if got := resolveStatusPort(); got != defaultStatusPort {
+		t.Fatalf("resolveStatusPort() without facts = %d, want %d", got, defaultStatusPort)
+	}
+
+	// Facts file with a recorded status port -> that port.
+	writeFactsFile(t, dir, gatewayFacts{Port: 8443, UseTLS: true, StatusPort: 9099})
+	if got := resolveStatusPort(); got != 9099 {
+		t.Fatalf("resolveStatusPort() with facts = %d, want 9099", got)
+	}
+
+	// Facts file recording no status port -> fall back to default.
+	writeFactsFile(t, dir, gatewayFacts{Port: 8443, UseTLS: true})
+	if got := resolveStatusPort(); got != defaultStatusPort {
+		t.Fatalf("resolveStatusPort() with zero status port = %d, want %d", got, defaultStatusPort)
+	}
+}
+
+func writeFactsFile(t *testing.T, dir string, f gatewayFacts) {
+	t.Helper()
+	data, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, gatewayFactsFileName), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/worklock/read_holder_test.go
+++ b/internal/worklock/read_holder_test.go
@@ -1,0 +1,62 @@
+package worklock
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestReadHolderNoFile verifies ReadHolder reports ok=false when no lock file
+// exists, so a node with no worker never yields a bogus holder record.
+func TestReadHolderNoFile(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "network")
+	if rec, ok := ReadHolder(stateDir); ok {
+		t.Fatalf("ReadHolder on missing lock file = ok (%+v), want not ok", rec)
+	}
+}
+
+// TestReadHolderParsesRecord verifies ReadHolder returns the recorded PID, start
+// time, and version from a JSON lock record, WITHOUT checking liveness (it is the
+// metadata companion to IsHeld). A fabricated far-future PID would be dead, but
+// ReadHolder must still report it.
+func TestReadHolderParsesRecord(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "network")
+	path := LockPathForStateDir(stateDir)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	rec := lockRecord{PID: 4242, StartUnix: 1700000000, Version: "2.75.0"}
+	if err := os.WriteFile(path, encodeRecord(rec), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok := ReadHolder(stateDir)
+	if !ok {
+		t.Fatal("ReadHolder returned ok=false for a valid record")
+	}
+	if got.PID != 4242 {
+		t.Errorf("PID = %d, want 4242", got.PID)
+	}
+	if got.Version != "2.75.0" {
+		t.Errorf("Version = %q, want 2.75.0", got.Version)
+	}
+	if got.StartTime.Unix() != 1700000000 {
+		t.Errorf("StartTime = %d, want 1700000000", got.StartTime.Unix())
+	}
+}
+
+// TestReadHolderEmptyRecord verifies an empty/garbage lock file (PID <= 0) reports
+// not ok, matching the reclaim classification (a garbage record is not a holder).
+func TestReadHolderEmptyRecord(t *testing.T) {
+	stateDir := filepath.Join(t.TempDir(), "network")
+	path := LockPathForStateDir(stateDir)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("   \n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if rec, ok := ReadHolder(stateDir); ok {
+		t.Fatalf("ReadHolder on empty record = ok (%+v), want not ok", rec)
+	}
+}

--- a/internal/worklock/worklock.go
+++ b/internal/worklock/worklock.go
@@ -29,6 +29,7 @@ package worklock
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -162,4 +163,38 @@ func (e *ErrAlreadyRunning) Error() string {
 		return fmt.Sprintf("citadel worker already running (PID %d, started %s); refusing to start a second instance", e.PID, started)
 	}
 	return "citadel worker already running; refusing to start a second instance"
+}
+
+// HolderRecord is the read-only public view of the recorded lock holder. It
+// carries the identity metadata the lock file persists so discover-and-attach
+// callers can name the running worker without acquiring or probing the lock.
+type HolderRecord struct {
+	// PID is the recorded holder PID (> 0 when ok is true).
+	PID int
+	// StartTime is the recorded holder start time, or the zero value for a legacy
+	// bare-PID lock file that carried no timestamp.
+	StartTime time.Time
+	// Version is the recorded holder's citadel version, or "" when unknown.
+	Version string
+}
+
+// ReadHolder reads the recorded holder metadata (PID / start time / version) from
+// the lock file for the node keyed to stateDir, WITHOUT taking or probing the OS
+// lock. It is the metadata companion to IsHeld: IsHeld answers "is a live worker
+// holding the lock" (with a flock probe + liveness check), while ReadHolder just
+// reports what the holder recorded about itself. Because it does not check
+// liveness, callers that need "alive" should pair it with IsHeld.
+//
+// Returns ok=false when the lock file is absent, unreadable, or carries no usable
+// PID (an empty/garbage record), so a missing worker never yields a bogus holder.
+func ReadHolder(stateDir string) (HolderRecord, bool) {
+	data, err := os.ReadFile(LockPathForStateDir(stateDir))
+	if err != nil {
+		return HolderRecord{}, false
+	}
+	rec := decodeRecord(data)
+	if rec.PID <= 0 {
+		return HolderRecord{}, false
+	}
+	return HolderRecord{PID: rec.PID, StartTime: startTime(rec), Version: rec.Version}, true
 }


### PR DESCRIPTION
## Context

Citadel can end up with multiple `citadel work` daemons on one box (systemd + a stray interactive run + a sudo run) — the amplifier behind the node-identity churn incident (#443 / #435). `internal/worklock` already prevents the duplicate with an OS advisory flock that **refuses** a second `citadel work`, naming the holder PID. But the UX is a dead end: the second invocation just errors out.

Jason's ask (#524) is to go one step further, docker-daemon style: an invocation should **discover the already-running instance and show its status** rather than refuse or duplicate. `docker ps` doesn't spawn a second daemon; it talks to the one that's running.

This PR is **increment 1** of the [design posted on #524](https://github.com/aceteam-ai/citadel-cli/issues/524#issuecomment-anchor): purely additive, **zero daemon changes**, no new endpoint, no protocol churn. It's a read-only HTTP client of the worker that's already up.

```
$ citadel work        # (on a TTY, when one is already running)
Citadel worker already running for this node:
  PID 41372, started 2026-07-15T09:12:44Z, uptime 2d 3h, version 2.75.0
  Node: gpu-1084 (ok)

View logs:      citadel logs -f
Stop it:        systemctl --user stop citadel  (or kill the PID above)
Run a second worker anyway: citadel work --no-single-instance
```

## Summary

**`runWork` refusal path → attach banner** (`cmd/work.go`, `cmd/work_attach.go`)
- On an interactive TTY, render the banner and **exit 0** instead of a bare error. Identity (PID / start / version / worker uptime) comes from the lock record; node name + health come from an unauthenticated `GET /status` (+ `/health`) on the local status server over `127.0.0.1`.
- **TTY-gated for exit-code compatibility:** non-TTY (systemd, journald, pipelines) keeps today's stderr refusal + `exit 1` byte-for-byte, so a misconfigured double systemd unit still fails visibly instead of "succeeding" as an attach. `--attach` / `--no-attach` override the heuristic.
- **Status port** resolved from `gateway-facts.json` (`StatusPort`), falling back to `8080`. The probe uses a 2s timeout and a literal `127.0.0.1` URL (dodging IPv6/DNS); **any** probe failure (no gateway, wrong port, wedged daemon) degrades cleanly to a lock-record-only banner — it never hangs or fails `citadel work`. Worker uptime is derived from the recorded start time, so it renders even when the probe fails.

**`citadel status` worker line** (`cmd/status.go`)
- New `WORKER` section reporting `running (PID N, vX, uptime …)` vs `not running` via `worklock.IsHeld`, mirroring the control-center precedent (`cmd/controlcenter.go`). Read-only; never touches the lock.

**`worklock.ReadHolder`** (`internal/worklock/worklock.go`)
- Cross-platform, read-only lock-record accessor (no flock) returning the recorded PID / start time / version. The metadata companion to `IsHeld` (which answers liveness); used for version/uptime in both the banner and the status line. Lives in the shared file, out of the flock-critical platform variants.

**Explicitly deferred to later increments** (left to the issue): the local `/agent/*` attach token + `requireLocalAttach`, `citadel logs --worker`, the `--stop` verb, and the §1 "status server answers while `IsHeld`=false" divergence warning (wiring an HTTP call into the currently all-local `citadel status` is more than "add a line" — kept out to hold the diff to the two task bullets). Banner action lines reference only verbs that exist **today**.

## Test plan

| Area | Coverage |
|---|---|
| `decideAttach` (TTY gate) | 5 cases: TTY→banner, non-TTY→refuse, `--attach` forces on off-TTY, `--no-attach` forces refuse, `--no-attach` beats `--attach` |
| `buildAttachBanner` | degraded (lock-record-only, no `Node:` line), enriched (`Node: gpu-1084 (ok)`), version fallback to `/status` when lock record has none |
| `humanizeUptime` | sub-minute, minutes, hours, days, negative clamp |
| `resolveStatusPort` | facts file present → recorded port; absent → 8080; zero status port → 8080 (isolated via `provisionedStateDirOverride` temp dir) |
| `worklock.ReadHolder` | missing file → not ok, valid JSON record parsed, empty/garbage record → not ok |

All hermetic — no real sockets. `go build ./...`, `go vet ./...`, `go test ./...` green (60 pkgs); `GOOS=windows go build ./...` green. New `--attach`/`--no-attach` flags verified in the real `citadel work --help`.

## Related

- Closes part of #524 (increment 1 of 3)
- Builds on #443 / #435 (worklock), #5028 (mTLS control listener)