### PR TITLE
feat(meeting): drive containerized meeting module over CDP in MEETING_JOIN (#514)

### DIFF
--- a/cmd/manifest.go
+++ b/cmd/manifest.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/aceteam-ai/citadel-cli/internal/catalog"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
 	"github.com/aceteam-ai/citadel-cli/services"
 	"gopkg.in/yaml.v3"
@@ -306,7 +307,38 @@ func removeServiceFromManifest(configDir, serviceName string) error {
 		kept = append(kept, s)
 	}
 	manifest.Services = kept
+
+	// Symmetric tag cleanup (#514). Install adds a module's node_tags to
+	// Node.Tags (addServiceToManifestWithTags), but uninstall historically left
+	// them behind, so a node kept advertising a capability tag (e.g. `meeting`)
+	// for a module it no longer runs. Best-effort: strip the removed module's
+	// declared node_tags. The capability DETECTOR is the worker's source of truth
+	// (it re-derives tags at startup), so this mainly keeps `citadel status` and
+	// generic routing honest; a missing catalog manifest just skips the cleanup.
+	if mod, mErr := catalog.LoadServiceManifest(serviceName); mErr == nil && len(mod.NodeTags) > 0 {
+		manifest.Node.Tags = stripTags(manifest.Node.Tags, mod.NodeTags)
+	}
 	return writeManifest(manifestPath, manifest)
+}
+
+// stripTags returns tags with every entry in remove filtered out, preserving
+// order. Pure so the uninstall tag cleanup is unit-testable.
+func stripTags(tags, remove []string) []string {
+	if len(remove) == 0 {
+		return tags
+	}
+	drop := make(map[string]struct{}, len(remove))
+	for _, t := range remove {
+		drop[t] = struct{}{}
+	}
+	out := make([]string, 0, len(tags))
+	for _, t := range tags {
+		if _, ok := drop[t]; ok {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
 }
 
 // setServiceDesiredStatus sets (or clears, when status is "") the per-service

--- a/cmd/manifest_test.go
+++ b/cmd/manifest_test.go
@@ -175,3 +175,53 @@ func TestAddServiceToManifest(t *testing.T) {
 	// For now, we'll skip this specific test and rely on integration tests.
 	t.Skip("Skipping addServiceToManifest test - requires platform.ConfigDir() mock")
 }
+
+// TestStripTags covers the uninstall tag-symmetry cleanup (#514): removing a
+// module must drop the node_tags it declared, preserving order and any tags it
+// did not contribute.
+func TestStripTags(t *testing.T) {
+	cases := []struct {
+		name   string
+		tags   []string
+		remove []string
+		want   []string
+	}{
+		{
+			name:   "removes the module's declared tag",
+			tags:   []string{"cpu:general", "meeting", "os:linux"},
+			remove: []string{"meeting"},
+			want:   []string{"cpu:general", "os:linux"},
+		},
+		{
+			name:   "no-op when nothing to remove",
+			tags:   []string{"cpu:general", "meeting"},
+			remove: nil,
+			want:   []string{"cpu:general", "meeting"},
+		},
+		{
+			name:   "removes multiple declared tags",
+			tags:   []string{"a", "meeting", "notetaker", "b"},
+			remove: []string{"meeting", "notetaker"},
+			want:   []string{"a", "b"},
+		},
+		{
+			name:   "tag not present is a no-op",
+			tags:   []string{"cpu:general"},
+			remove: []string{"meeting"},
+			want:   []string{"cpu:general"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := stripTags(c.tags, c.remove)
+			if len(got) != len(c.want) {
+				t.Fatalf("stripTags = %v, want %v", got, c.want)
+			}
+			for i := range got {
+				if got[i] != c.want[i] {
+					t.Fatalf("stripTags = %v, want %v", got, c.want)
+				}
+			}
+		})
+	}
+}

--- a/internal/capabilities/detector.go
+++ b/internal/capabilities/detector.go
@@ -4,15 +4,19 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/aceteam-ai/citadel-cli/internal/catalog"
 	"github.com/aceteam-ai/citadel-cli/internal/config"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
+	"github.com/aceteam-ai/citadel-cli/services"
 )
 
 const detectionTimeout = 5 * time.Second
@@ -443,17 +447,69 @@ func detectCPU() []Capability {
 }
 
 // detectMeetingCapability reports whether this node can run the auto-join meeting
-// notetaker (aceteam#5098). It ANDs the persisted config toggle (default-on, the
-// house opt-out convention) with the three real dependency probes, composed
-// through the pure meetingTagEnabled predicate so the gating logic itself is
-// unit-testable without a live audio stack, browser, or config file.
+// notetaker (aceteam#5098, module packaging #514). It ANDs the persisted config
+// toggle (default-on, the house opt-out convention) with the capability SIGNAL:
+// the containerized meeting module being installed & healthy, OR the legacy host
+// stack being present. The module path is preferred because "healthy" there means
+// meetingd's canary-tone probe passed — proof the node can actually capture
+// non-silent audio — a strictly stronger signal than the three host-binary
+// existence probes. The host stack is kept as a fallback so pre-provisioned nodes
+// (#5097) don't lose capability on upgrade (backwards-compat house rule). The
+// gating is composed through pure predicates so it is unit-testable without a live
+// audio stack, browser, container, or config file.
 func detectMeetingCapability() bool {
 	enabled := config.LoadMeeting(platform.ConfigDir()).MeetingEnabled
-	return meetingTagEnabled(enabled, meetingCapable(
+	return meetingTagEnabled(enabled, meetingCapabilitySignal(
+		meetingModuleHealthy(),
+		legacyHostStack(),
+	))
+}
+
+// meetingCapabilitySignal is the pure "can this node run a meeting" predicate: the
+// containerized module is healthy OR the legacy host stack is present. Extracted
+// so the OR-of-sources logic is testable in isolation from the probes.
+func meetingCapabilitySignal(moduleHealthy, legacyHostOK bool) bool {
+	return moduleHealthy || legacyHostOK
+}
+
+// legacyHostStack reports whether the in-process host meeting stack is present:
+// a working audio-capture stack (PulseAudio + ffmpeg + pactl), a launchable
+// Chromium, and Xvfb for the headless virtual display.
+func legacyHostStack() bool {
+	return meetingCapable(
 		platform.AudioStackAvailable(),
 		platform.ChromiumAvailable(),
 		platform.XvfbAvailable(),
-	))
+	)
+}
+
+// meetingModuleHealthy reports whether the installable meeting module (#514) is
+// present on this node AND its /health probe is green. Presence is the installed
+// compose marker (<ConfigDir>/services/meeting.yml); health is catalog.ProbeHealth
+// against the module's PUBLISHED host control port (services.MeetingdHostPort),
+// whose /health runs the canary-tone audio probe. The presence gate avoids
+// treating a coincidental listener on the port as the module, and short-circuits
+// the probe when the module isn't installed.
+func meetingModuleHealthy() bool {
+	if !meetingModuleInstalled(platform.ConfigDir()) {
+		return false
+	}
+	hc := catalog.HealthCheck{
+		Endpoint: "/health",
+		Port:     services.MeetingdHostPort,
+		Timeout:  detectionTimeout.String(),
+	}
+	return catalog.ProbeHealth(hc) == catalog.ProbeHealthy
+}
+
+// meetingModuleInstalled reports whether the meeting module's compose has been
+// installed on this node. `citadel module install` copies the resolved compose to
+// <configDir>/services/<name>.yml (cmd/module_ops.go), so its presence is the
+// on-disk install marker — checkable without the cmd-package manifest reader
+// (which capabilities cannot import).
+func meetingModuleInstalled(configDir string) bool {
+	_, err := os.Stat(filepath.Join(configDir, "services", "meeting.yml"))
+	return err == nil
 }
 
 // meetingTagEnabled reports whether the `meeting` tag should be advertised: the

--- a/internal/capabilities/detector_test.go
+++ b/internal/capabilities/detector_test.go
@@ -2,6 +2,8 @@ package capabilities
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -428,5 +430,50 @@ func TestMeetingTagEnabled(t *testing.T) {
 					c.enabled, c.depsOK, got, c.want)
 			}
 		})
+	}
+}
+
+func TestMeetingCapabilitySignal(t *testing.T) {
+	// A node is meeting-capable via EITHER the containerized module (healthy) OR
+	// the legacy host stack. Container is preferred, but the host fallback keeps
+	// pre-provisioned nodes working (#514 backwards-compat house rule).
+	cases := []struct {
+		name          string
+		moduleHealthy bool
+		legacyHostOK  bool
+		want          bool
+	}{
+		{"module healthy -> capable", true, false, true},
+		{"legacy host stack only -> capable (fallback)", false, true, true},
+		{"both present -> capable", true, true, true},
+		{"neither -> not capable", false, false, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := meetingCapabilitySignal(c.moduleHealthy, c.legacyHostOK); got != c.want {
+				t.Errorf("meetingCapabilitySignal(module=%v, legacy=%v) = %v, want %v",
+					c.moduleHealthy, c.legacyHostOK, got, c.want)
+			}
+		})
+	}
+}
+
+func TestMeetingModuleInstalled(t *testing.T) {
+	dir := t.TempDir()
+	// Not installed: no services/meeting.yml marker.
+	if meetingModuleInstalled(dir) {
+		t.Error("meetingModuleInstalled = true for a clean config dir, want false")
+	}
+	// Install marker: `citadel module install` copies the compose to
+	// <configDir>/services/meeting.yml.
+	svcDir := filepath.Join(dir, "services")
+	if err := os.MkdirAll(svcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(svcDir, "meeting.yml"), []byte("services: {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !meetingModuleInstalled(dir) {
+		t.Error("meetingModuleInstalled = false after writing the install marker, want true")
 	}
 }

--- a/internal/jobs/meeting_join.go
+++ b/internal/jobs/meeting_join.go
@@ -20,6 +20,7 @@ package jobs
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -270,6 +271,53 @@ func meetingWavPath(workspaceDir, meetingID string) string {
 	return filepath.Join(workspaceDir, "meetings", sanitizeMeetingFilename(meetingID)+".wav")
 }
 
+// meetingWavRelPath is the workspace-RELATIVE form of meetingWavPath: the path
+// the container's meetingd writes under its /workspace mount, which is bound to
+// ${CITADEL_WORKSPACE} == the handler's WorkspaceDir (the SAME mount the
+// whisper/transcribe sidecar reads). filepath.Join(WorkspaceDir, this) equals
+// meetingWavPath, so the container's WAV lands exactly where the transcriber
+// looks — no new hand-off plumbing. Kept adjacent to meetingWavPath so the two
+// can never drift (guarded by a test).
+func meetingWavRelPath(meetingID string) string {
+	return "meetings/" + sanitizeMeetingFilename(meetingID) + ".wav"
+}
+
+// selectMedia returns the media backend for a run, honoring an injected override
+// (tests) and otherwise delegating to defaultSelectMedia.
+func (h *MeetingJoinHandler) selectMedia(p meetingJoinParams) MeetingMedia {
+	if h.newMedia != nil {
+		return h.newMedia(p)
+	}
+	return h.defaultSelectMedia(p)
+}
+
+// defaultSelectMedia picks the containerized meeting module when it is healthy on
+// this node, else the in-process host stack (backwards compat: pre-provisioned
+// host-stack nodes keep working). The container is preferred because its /health
+// is a stronger signal (it proves non-silent audio capture via the canary tone)
+// and it needs no host chrome/pulse/Xvfb/ffmpeg.
+func (h *MeetingJoinHandler) defaultSelectMedia(p meetingJoinParams) MeetingMedia {
+	if h.containerMediaHealthy() {
+		return newContainerMedia(
+			p.MeetingID,
+			meetingWavRelPath(p.MeetingID),
+			meetingWavPath(h.WorkspaceDir, p.MeetingID),
+			p.maxDuration(),
+		)
+	}
+	return newHostMedia(p.MeetingID, h.ProfileDir, meetingWavPath(h.WorkspaceDir, p.MeetingID))
+}
+
+// containerMediaHealthy reports whether the containerized meeting module is up
+// and healthy on this node, honoring an injected probe (tests) and otherwise
+// hitting meetingd's /health on the loopback.
+func (h *MeetingJoinHandler) containerMediaHealthy() bool {
+	if h.containerHealthProbe != nil {
+		return h.containerHealthProbe()
+	}
+	return meetingdHealthy(&http.Client{Timeout: meetingContainerHealthTimeout}, meetingdBaseURL())
+}
+
 // MeetingJoinHandler handles MEETING_JOIN jobs. It reuses the transcribe handler
 // (same workspace) to turn the recording into a transcript node-locally.
 type MeetingJoinHandler struct {
@@ -306,6 +354,16 @@ type MeetingJoinHandler struct {
 	// transcribe — they would otherwise hit the sidecar and read the growing WAV
 	// concurrently.
 	transcribeMu sync.Mutex
+
+	// newMedia selects the media backend for a run (#514). Non-nil overrides the
+	// default selector (container when the meeting module is healthy on this node,
+	// else the in-process host stack); tests inject a fake here. Leaving it nil —
+	// the normal case — uses defaultSelectMedia.
+	newMedia func(p meetingJoinParams) MeetingMedia
+	// containerHealthProbe overrides how the default selector decides the meeting
+	// module is healthy (#514). Non-nil is used by tests to force a backend
+	// without a live meetingd; nil probes meetingd's /health on the loopback.
+	containerHealthProbe func() bool
 }
 
 // NewMeetingJoinHandler constructs a handler rooted at the node workspace.
@@ -329,31 +387,26 @@ func (h *MeetingJoinHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, er
 	}
 	ctx.Log("info", "     - [Job %s] MEETING_JOIN %s (id=%s, bot=%q)", job.ID, p.MeetingURL, p.MeetingID, p.BotDisplayName)
 
-	// Create the per-meeting null sink FIRST so the browser's PULSE_SINK target
-	// exists at launch. rec.Stop unloads the sink even if we never Start it, so
-	// deferring it here covers a browser-launch failure after LoadSink.
-	rec := platform.NewNullSinkRecorder(p.MeetingID)
-	if err := rec.LoadSink(); err != nil {
-		return nil, fmt.Errorf("load meeting audio sink: %w", err)
+	// Pick the media backend for this run: the containerized meeting module when
+	// it is installed and healthy on this node, else the in-process host stack
+	// (#514). media.Start brings up the browser + audio capture and returns the
+	// CDP-driven browser; on failure it cleans up what it partially started, so
+	// Close is deferred only after Start succeeds.
+	media := h.selectMedia(p)
+	br, err := media.Start()
+	if err != nil {
+		return nil, err
 	}
-	defer func() { _, _ = rec.Stop() }()
-
-	// Launch the sibling meeting browser routed into the sink, reusing the
-	// persistent, signed-in bot Chrome profile (issue #5122) rather than a
-	// throwaway one.
-	br := platform.NewMeetingBrowser(rec.SinkName(), h.ProfileDir)
-	if err := br.Start(); err != nil {
-		return nil, fmt.Errorf("start meeting browser: %w", err)
-	}
-	defer func() { _ = br.Close() }()
+	defer func() { _ = media.Close() }()
 
 	// Run the (unverified) Meet join flow.
 	if err := h.runJoinFlow(ctx, br, p); err != nil {
 		return nil, fmt.Errorf("meeting join flow: %w", err)
 	}
 
-	// Admitted: begin recording. Ensure the meetings/ dir exists first — ffmpeg's
-	// -y does NOT create parent directories.
+	// Admitted: begin recording. Ensure the meetings/ dir exists first — the host
+	// ffmpeg's -y does NOT create parent directories (the container's meetingd
+	// makedirs its own, but the dir is on the shared workspace mount either way).
 	wavPath := meetingWavPath(h.WorkspaceDir, p.MeetingID)
 	if err := os.MkdirAll(filepath.Dir(wavPath), 0o700); err != nil {
 		return nil, fmt.Errorf("create meetings dir: %w", err)
@@ -361,7 +414,7 @@ func (h *MeetingJoinHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, er
 	// The rolling-window transcription scratch clip (meeting_transcribe_window.go)
 	// is a per-pass temp; remove it on exit so it does not linger in the workspace.
 	defer func() { _ = os.Remove(meetingWindowWavPath(h.WorkspaceDir, p.MeetingID)) }()
-	if err := rec.Start(wavPath); err != nil {
+	if err := media.StartRecording(); err != nil {
 		return nil, fmt.Errorf("start recording: %w", err)
 	}
 	ctx.Log("info", "     - [Job %s] recording meeting to %s", job.ID, wavPath)
@@ -374,10 +427,10 @@ func (h *MeetingJoinHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, er
 	// record-until-end loop runs exactly as the shipped batch notetaker.
 	outcome := h.runMeetingLoop(ctx, br, p, wavPath)
 
-	// Finalize the recording (also unloads the sink; the deferred Stop is then a
-	// harmless no-op). Take the path from Stop so we transcribe exactly what was
-	// written.
-	recordedPath, stopErr := rec.Stop()
+	// Finalize the recording (host: SIGINT ffmpeg + unload the sink; container:
+	// POST /record/stop). media.Close (deferred) then tears the browser down. Take
+	// the path from StopRecording so we transcribe exactly what was written.
+	recordedPath, stopErr := media.StopRecording()
 	if stopErr != nil {
 		ctx.Log("warn", "     - [Job %s] recorder stop reported: %v", job.ID, stopErr)
 	}
@@ -426,7 +479,7 @@ func (h *MeetingJoinHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, er
 // returns an interactiveOutcome; the plain path fills only endReason so the
 // result shape is uniform (chat/recognized_commands come back empty). Splitting
 // here keeps Execute's happy path readable and the streaming gate in one place.
-func (h *MeetingJoinHandler) runMeetingLoop(ctx JobContext, br *platform.MeetingBrowser, p meetingJoinParams, wavPath string) interactiveOutcome {
+func (h *MeetingJoinHandler) runMeetingLoop(ctx JobContext, br meetingBrowser, p meetingJoinParams, wavPath string) interactiveOutcome {
 	if !h.StreamingEnabled {
 		return interactiveOutcome{endReason: h.waitForMeetingEnd(ctx, br, p)}
 	}
@@ -449,7 +502,7 @@ func (h *MeetingJoinHandler) runMeetingLoop(ctx JobContext, br *platform.Meeting
 // runJoinFlow drives the Google Meet pre-join sequence (partially verified —
 // see the LIVE-TUNING block). Non-fatal steps (permission dismissals, name entry
 // when signed in) log and continue; the join click and admission are fatal.
-func (h *MeetingJoinHandler) runJoinFlow(ctx JobContext, br *platform.MeetingBrowser, p meetingJoinParams) error {
+func (h *MeetingJoinHandler) runJoinFlow(ctx JobContext, br meetingBrowser, p meetingJoinParams) error {
 	if err := br.Navigate(p.MeetingURL); err != nil {
 		return fmt.Errorf("navigate to meeting url: %w", err)
 	}
@@ -548,7 +601,7 @@ func pollForJoinClick(ctx JobContext, page joinPage, botDisplayName string, time
 
 // waitUntilAdmitted polls the admission heuristic until the bot is in-call or the
 // lobby timeout elapses.
-func (h *MeetingJoinHandler) waitUntilAdmitted(ctx JobContext, br *platform.MeetingBrowser, p meetingJoinParams) error {
+func (h *MeetingJoinHandler) waitUntilAdmitted(ctx JobContext, br meetingBrowser, p meetingJoinParams) error {
 	deadline := time.Now().Add(admitTimeout)
 	for time.Now().Before(deadline) {
 		if v, err := br.Evaluate(meetIsAdmittedJS); err == nil {
@@ -568,7 +621,7 @@ func (h *MeetingJoinHandler) waitUntilAdmitted(ctx JobContext, br *platform.Meet
 // left alone), or until the hard duration cap trips. Returns a short reason
 // string for the result. It never errors: reaching the cap or an unreadable DOM
 // still yields a valid recording to transcribe.
-func (h *MeetingJoinHandler) waitForMeetingEnd(ctx JobContext, br *platform.MeetingBrowser, p meetingJoinParams) string {
+func (h *MeetingJoinHandler) waitForMeetingEnd(ctx JobContext, br meetingBrowser, p meetingJoinParams) string {
 	deadline := time.Now().Add(p.maxDuration())
 	for time.Now().Before(deadline) {
 		if reason, ended := checkMeetingEnded(br); ended {

--- a/internal/jobs/meeting_media.go
+++ b/internal/jobs/meeting_media.go
@@ -1,0 +1,360 @@
+// internal/jobs/meeting_media.go
+//
+// MeetingMedia abstracts the meeting media stack (the browser the join flow
+// drives + the audio recorder) so MEETING_JOIN can run against either backend
+// without touching the fragile Google Meet DOM logic (aceteam-ai/citadel-cli#514):
+//
+//   - hostMedia (unchanged, backwards-compat house rule): the in-process host
+//     stack — a PulseAudio null sink (NullSinkRecorder) plus a host Chromium on a
+//     managed Xvfb (MeetingBrowser). This is what pre-provisioned meeting nodes
+//     already use.
+//   - containerMedia: an HTTP client for meetingd, the session supervisor inside
+//     the installable meeting module (published image, PR #517). meetingd owns
+//     the in-container null sink + Chromium + ffmpeg; this drives it over its
+//     loopback control API and drives the browser over the published CDP port.
+//
+// The container path needs NO host chrome/pulse/Xvfb/ffmpeg, and the WAV lands on
+// the SAME ${CITADEL_WORKSPACE} mount the whisper/transcribe sidecar reads, so
+// the MEETING_JOIN -> TRANSCRIBE_AUDIO hand-off is unchanged. See
+// docs/meeting-bot-profile-seeding.md and aceteam#5097.
+package jobs
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
+	"github.com/aceteam-ai/citadel-cli/services"
+)
+
+// meetingBrowser is the CDP surface the MEETING_JOIN join + interactive flow
+// drives. Both the in-process *platform.MeetingBrowser and the container-driving
+// *platform.CDPBrowser satisfy it, so the same Meet DOM logic runs against either
+// backend.
+type meetingBrowser interface {
+	Navigate(url string) error
+	CurrentURL() (string, error)
+	Evaluate(expression string) (any, error)
+	Type(selector, text string) error
+	Close() error
+}
+
+// MeetingMedia is the media backend for one meeting run: bring up the browser +
+// audio capture, record the call audio to the workspace WAV, and tear down. The
+// backend is chosen per run (container when the meeting module is healthy on this
+// node, else host — see MeetingJoinHandler.selectMedia).
+type MeetingMedia interface {
+	// Start brings up the media stack (host: load the null sink then launch
+	// Chromium+Xvfb; container: POST /sessions to meetingd) and returns the
+	// CDP-driven browser. On failure it cleans up anything it partially brought
+	// up, so the caller only defers Close on success.
+	Start() (meetingBrowser, error)
+	// StartRecording begins capturing the call audio to the meeting's workspace
+	// WAV (host: ffmpeg on the sink monitor; container: POST /sessions/{id}/record).
+	StartRecording() error
+	// StopRecording finalizes the recording (valid WAV trailer) and returns the
+	// absolute host path the transcriber should read.
+	StopRecording() (string, error)
+	// Close tears down the browser and audio stack. Idempotent.
+	Close() error
+}
+
+// ---------------------------------------------------------------------------
+// host backend (unchanged in-process stack)
+// ---------------------------------------------------------------------------
+
+type hostMedia struct {
+	meetingID  string
+	profileDir string
+	wavPath    string
+	rec        *platform.NullSinkRecorder
+	br         *platform.MeetingBrowser
+}
+
+func newHostMedia(meetingID, profileDir, wavPath string) *hostMedia {
+	return &hostMedia{meetingID: meetingID, profileDir: profileDir, wavPath: wavPath}
+}
+
+func (m *hostMedia) Start() (meetingBrowser, error) {
+	// Create the per-meeting null sink FIRST so the browser's PULSE_SINK target
+	// exists at launch.
+	rec := platform.NewNullSinkRecorder(m.meetingID)
+	if err := rec.LoadSink(); err != nil {
+		return nil, fmt.Errorf("load meeting audio sink: %w", err)
+	}
+	m.rec = rec
+
+	// Launch the sibling browser routed into the sink, reusing the persistent,
+	// signed-in bot Chrome profile (issue #5122).
+	br := platform.NewMeetingBrowser(rec.SinkName(), m.profileDir)
+	if err := br.Start(); err != nil {
+		// Unload the sink we just loaded so a browser-launch failure does not leak it.
+		_, _ = rec.Stop()
+		m.rec = nil
+		return nil, fmt.Errorf("start meeting browser: %w", err)
+	}
+	m.br = br
+	return br, nil
+}
+
+func (m *hostMedia) StartRecording() error {
+	if m.rec == nil {
+		return fmt.Errorf("host media not started")
+	}
+	return m.rec.Start(m.wavPath)
+}
+
+func (m *hostMedia) StopRecording() (string, error) {
+	if m.rec == nil {
+		return m.wavPath, nil
+	}
+	p, err := m.rec.Stop()
+	if p == "" {
+		p = m.wavPath
+	}
+	return p, err
+}
+
+func (m *hostMedia) Close() error {
+	var firstErr error
+	if m.br != nil {
+		if err := m.br.Close(); err != nil {
+			firstErr = err
+		}
+		m.br = nil
+	}
+	// rec.Stop is idempotent (safe after StopRecording), and unloads the sink.
+	if m.rec != nil {
+		if _, err := m.rec.Stop(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+		m.rec = nil
+	}
+	return firstErr
+}
+
+// ---------------------------------------------------------------------------
+// container backend (meetingd HTTP control API)
+// ---------------------------------------------------------------------------
+
+const (
+	// meetingContainerHealthTimeout bounds the /health probe used to pick the
+	// backend. /health runs meetingd's canary-tone capture (~1.5s record + tone
+	// generation), so it is deliberately generous.
+	meetingContainerHealthTimeout = 20 * time.Second
+	// meetingContainerCDPTimeout bounds waiting for the freshly launched
+	// in-container Chromium to expose CDP through the published port.
+	meetingContainerCDPTimeout = 30 * time.Second
+	// meetingContainerHTTPTimeout bounds a single meetingd control call.
+	meetingContainerHTTPTimeout = 30 * time.Second
+)
+
+// meetingdBaseURL is the loopback base URL for the meeting module's control API.
+// The container publishes meetingd on services.MeetingdHostPort (8207) bound to
+// 127.0.0.1 (compose), so the co-located citadel process reaches it here.
+func meetingdBaseURL() string {
+	return fmt.Sprintf("http://127.0.0.1:%d", services.MeetingdHostPort)
+}
+
+// meetingdHealthy reports whether the containerized meeting module answers a
+// healthy /health on this node's loopback. A 200 is, by meetingd's design, proof
+// it can actually capture non-silent audio (the canary tone probe returns 503
+// otherwise), so this is a strictly stronger signal than the host-binary probes.
+func meetingdHealthy(client *http.Client, base string) bool {
+	resp, err := client.Get(base + "/health")
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return resp.StatusCode == http.StatusOK
+}
+
+// meetingSessionResponse is meetingd's POST /sessions body.
+type meetingSessionResponse struct {
+	SessionID string `json:"session_id"`
+	// CDPPort is the CONTAINER-internal CDP port meetingd reports (9223). The host
+	// reaches CDP at the PUBLISHED port (services.MeetingCDPHostPort) instead, so
+	// this field is intentionally not used to build the CDP client — see
+	// containerMedia.cdpPort.
+	CDPPort int    `json:"cdp_port"`
+	Sink    string `json:"sink"`
+}
+
+type containerMedia struct {
+	// wavRelPath is the workspace-RELATIVE output path meetingd writes under its
+	// /workspace mount (== ${CITADEL_WORKSPACE} == the transcriber's workspace).
+	wavRelPath string
+	// wavAbsPath is the host-absolute form the transcriber reads.
+	wavAbsPath  string
+	maxDuration time.Duration
+	base        string
+	// cdpPort is the PUBLISHED host CDP port (services.MeetingCDPHostPort, 8208).
+	// meetingd's POST /sessions reports the container-internal port (9223); we
+	// ignore it and use the publish, because the advertised port is unreachable
+	// from the host (see internal/platform CDPBrowser).
+	cdpPort   int
+	client    *http.Client
+	sessionID string
+	browser   *platform.CDPBrowser
+}
+
+func newContainerMedia(meetingID, wavRelPath, wavAbsPath string, maxDuration time.Duration) *containerMedia {
+	return &containerMedia{
+		wavRelPath:  wavRelPath,
+		wavAbsPath:  wavAbsPath,
+		maxDuration: maxDuration,
+		base:        meetingdBaseURL(),
+		cdpPort:     services.MeetingCDPHostPort,
+		client:      &http.Client{Timeout: meetingContainerHTTPTimeout},
+		// A deterministic session id (derived from the meeting id) lets a
+		// same-meeting retry reclaim its own orphaned session on a 409.
+		sessionID: sanitizeMeetingFilename(meetingID),
+	}
+}
+
+func (m *containerMedia) Start() (meetingBrowser, error) {
+	if err := m.createSession(); err != nil {
+		return nil, err
+	}
+	br := platform.NewCDPBrowser(m.cdpPort)
+	if err := br.Ready(meetingContainerCDPTimeout); err != nil {
+		_ = m.deleteSession()
+		return nil, err
+	}
+	m.browser = br
+	return br, nil
+}
+
+func (m *containerMedia) createSession() error {
+	body := map[string]any{
+		"session_id":           m.sessionID,
+		"max_duration_seconds": int(m.maxDuration.Seconds()),
+	}
+	respBody, status, err := m.postJSON("/sessions", body)
+	if err != nil {
+		return fmt.Errorf("meetingd create session: %w", err)
+	}
+	if status == http.StatusConflict {
+		// A prior session is still active. meetingd enforces one meeting per node
+		// (fixed CDP port), and its reaper only clears a session at its
+		// max_duration. If the orphan is OURS (a same-meeting retry) it shares our
+		// deterministic id, so clear it and retry once; a DIFFERENT meeting's
+		// orphan we cannot address (meetingd has no list/clear endpoint) and it is
+		// a legitimate busy state, so we surface a clear error below.
+		_ = m.deleteSession()
+		respBody, status, err = m.postJSON("/sessions", body)
+		if err != nil {
+			return fmt.Errorf("meetingd create session (after clearing stale): %w", err)
+		}
+	}
+	switch status {
+	case http.StatusCreated:
+		var sr meetingSessionResponse
+		if err := json.Unmarshal(respBody, &sr); err != nil {
+			return fmt.Errorf("parse meetingd session response: %w", err)
+		}
+		if sr.SessionID != "" {
+			m.sessionID = sr.SessionID
+		}
+		return nil
+	case http.StatusConflict:
+		return fmt.Errorf("meeting module is busy with another active session on this node " +
+			"(one meeting per node); retry after it ends, or restart the meeting module to clear it")
+	case http.StatusServiceUnavailable:
+		return fmt.Errorf("meeting module not ready to start a session: %s", string(respBody))
+	default:
+		return fmt.Errorf("meetingd POST /sessions returned status %d: %s", status, string(respBody))
+	}
+}
+
+func (m *containerMedia) StartRecording() error {
+	respBody, status, err := m.postJSON(m.sessionPath("/record"), map[string]any{"out": m.wavRelPath})
+	if err != nil {
+		return fmt.Errorf("meetingd start recording: %w", err)
+	}
+	if status != http.StatusCreated {
+		return fmt.Errorf("meetingd start recording returned status %d: %s", status, string(respBody))
+	}
+	return nil
+}
+
+func (m *containerMedia) StopRecording() (string, error) {
+	respBody, status, err := m.postJSON(m.sessionPath("/record/stop"), nil)
+	if err != nil {
+		return m.wavAbsPath, fmt.Errorf("meetingd stop recording: %w", err)
+	}
+	if status != http.StatusOK {
+		return m.wavAbsPath, fmt.Errorf("meetingd stop recording returned status %d: %s", status, string(respBody))
+	}
+	return m.wavAbsPath, nil
+}
+
+func (m *containerMedia) Close() error {
+	if m.browser != nil {
+		_ = m.browser.Close()
+		m.browser = nil
+	}
+	return m.deleteSession()
+}
+
+func (m *containerMedia) sessionPath(suffix string) string {
+	return "/sessions/" + url.PathEscape(m.sessionID) + suffix
+}
+
+func (m *containerMedia) deleteSession() error {
+	req, err := http.NewRequest(http.MethodDelete, m.base+"/sessions/"+url.PathEscape(m.sessionID), nil)
+	if err != nil {
+		return err
+	}
+	resp, err := m.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return nil
+}
+
+// postJSON POSTs an optional JSON body to path and returns the response body,
+// status code, and any transport error. A nil body sends an empty POST.
+func (m *containerMedia) postJSON(path string, body any) ([]byte, int, error) {
+	var buf io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return nil, 0, err
+		}
+		buf = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(http.MethodPost, m.base+path, buf)
+	if err != nil {
+		return nil, 0, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := m.client.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+	out, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.StatusCode, err
+	}
+	return out, resp.StatusCode, nil
+}
+
+// Compile-time interface checks.
+var (
+	_ MeetingMedia   = (*hostMedia)(nil)
+	_ MeetingMedia   = (*containerMedia)(nil)
+	_ meetingBrowser = (*platform.MeetingBrowser)(nil)
+	_ meetingBrowser = (*platform.CDPBrowser)(nil)
+)

--- a/internal/jobs/meeting_media_test.go
+++ b/internal/jobs/meeting_media_test.go
@@ -1,0 +1,262 @@
+package jobs
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// newTestContainerMedia builds a containerMedia pointed at a mock meetingd, so
+// the HTTP control contract is exercised without a real container or CDP socket.
+func newTestContainerMedia(base string) *containerMedia {
+	return &containerMedia{
+		wavRelPath:  "meetings/m1.wav",
+		wavAbsPath:  "/ws/meetings/m1.wav",
+		maxDuration: time.Hour,
+		base:        base,
+		cdpPort:     8208,
+		client:      &http.Client{Timeout: 5 * time.Second},
+		sessionID:   "m1",
+	}
+}
+
+func TestContainerMediaCreateSession(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/sessions" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.WriteHeader(http.StatusCreated)
+		// meetingd reports the CONTAINER-internal cdp_port (9223); the client must
+		// ignore it and keep using the published host port.
+		_, _ = w.Write([]byte(`{"session_id":"srv-assigned","cdp_port":9223,"sink":"citadel_meeting_m1"}`))
+	}))
+	defer srv.Close()
+
+	m := newTestContainerMedia(srv.URL)
+	if err := m.createSession(); err != nil {
+		t.Fatalf("createSession: %v", err)
+	}
+	if m.sessionID != "srv-assigned" {
+		t.Errorf("sessionID = %q, want the server-assigned id", m.sessionID)
+	}
+	if m.cdpPort != 8208 {
+		t.Errorf("cdpPort = %d, want the published host port 8208 (not the reported container port 9223)", m.cdpPort)
+	}
+	if got, ok := gotBody["max_duration_seconds"].(float64); !ok || int(got) != 3600 {
+		t.Errorf("max_duration_seconds = %v, want 3600", gotBody["max_duration_seconds"])
+	}
+	if gotBody["session_id"] != "m1" {
+		t.Errorf("session_id sent = %v, want the deterministic id m1", gotBody["session_id"])
+	}
+}
+
+func TestContainerMediaCreateSessionConflictRetriesAfterDelete(t *testing.T) {
+	var mu sync.Mutex
+	var posts, deletes int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/sessions":
+			posts++
+			if posts == 1 {
+				// A stale session is active: 409 the first attempt.
+				w.WriteHeader(http.StatusConflict)
+				_, _ = w.Write([]byte(`{"error":"a meeting session is already active"}`))
+				return
+			}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"session_id":"m1","cdp_port":9223,"sink":"s"}`))
+		case r.Method == http.MethodDelete:
+			deletes++
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"ended":true}`))
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	m := newTestContainerMedia(srv.URL)
+	if err := m.createSession(); err != nil {
+		t.Fatalf("createSession after conflict: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if posts != 2 {
+		t.Errorf("POST /sessions attempts = %d, want 2 (initial 409 + retry)", posts)
+	}
+	if deletes != 1 {
+		t.Errorf("DELETE attempts = %d, want 1 (clear the stale session before retry)", deletes)
+	}
+}
+
+func TestContainerMediaCreateSessionPersistentConflictErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte(`{"error":"a meeting session is already active"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	m := newTestContainerMedia(srv.URL)
+	err := m.createSession()
+	if err == nil {
+		t.Fatal("expected an error when a different meeting occupies the node, got nil")
+	}
+	if !strings.Contains(err.Error(), "busy") {
+		t.Errorf("error = %v, want a clear busy message", err)
+	}
+}
+
+func TestContainerMediaRecordRoundTrip(t *testing.T) {
+	var recordOut string
+	var stopHit bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/sessions/m1/record":
+			var body map[string]any
+			b, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(b, &body)
+			recordOut, _ = body["out"].(string)
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"recording":true,"path":"/workspace/meetings/m1.wav"}`))
+		case "/sessions/m1/record/stop":
+			stopHit = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"recording":false,"path":"/workspace/meetings/m1.wav"}`))
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	m := newTestContainerMedia(srv.URL)
+	if err := m.StartRecording(); err != nil {
+		t.Fatalf("StartRecording: %v", err)
+	}
+	if recordOut != "meetings/m1.wav" {
+		t.Errorf("record out = %q, want the workspace-relative path meetings/m1.wav", recordOut)
+	}
+	got, err := m.StopRecording()
+	if err != nil {
+		t.Fatalf("StopRecording: %v", err)
+	}
+	if !stopHit {
+		t.Error("StopRecording did not hit /record/stop")
+	}
+	// StopRecording returns the host-absolute path the transcriber reads, not
+	// meetingd's in-container /workspace path.
+	if got != "/ws/meetings/m1.wav" {
+		t.Errorf("StopRecording path = %q, want the host-absolute wav path", got)
+	}
+}
+
+func TestContainerMediaStartRecordingError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"no such session"}`))
+	}))
+	defer srv.Close()
+	m := newTestContainerMedia(srv.URL)
+	if err := m.StartRecording(); err == nil {
+		t.Fatal("expected StartRecording to error on a non-201 status")
+	}
+}
+
+func TestMeetingdHealthy(t *testing.T) {
+	healthy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer healthy.Close()
+	unhealthy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// meetingd returns 503 when the canary tone probe fails (silent capture).
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer unhealthy.Close()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	if !meetingdHealthy(client, healthy.URL) {
+		t.Error("meetingdHealthy = false for a 200 /health, want true")
+	}
+	if meetingdHealthy(client, unhealthy.URL) {
+		t.Error("meetingdHealthy = true for a 503 /health, want false")
+	}
+	if meetingdHealthy(client, "http://127.0.0.1:0") {
+		t.Error("meetingdHealthy = true for an unreachable meetingd, want false")
+	}
+}
+
+// fakeMedia is a MeetingMedia stub for selection tests.
+type fakeMedia struct{}
+
+func (fakeMedia) Start() (meetingBrowser, error) { return nil, nil }
+func (fakeMedia) StartRecording() error          { return nil }
+func (fakeMedia) StopRecording() (string, error) { return "", nil }
+func (fakeMedia) Close() error                   { return nil }
+
+func TestSelectMediaUsesOverride(t *testing.T) {
+	called := false
+	h := &MeetingJoinHandler{
+		WorkspaceDir: "/ws",
+		newMedia: func(p meetingJoinParams) MeetingMedia {
+			called = true
+			return fakeMedia{}
+		},
+	}
+	if _, ok := h.selectMedia(meetingJoinParams{MeetingID: "m1"}).(fakeMedia); !ok {
+		t.Error("selectMedia did not use the injected newMedia override")
+	}
+	if !called {
+		t.Error("newMedia override was not called")
+	}
+}
+
+func TestDefaultSelectMediaPicksBackendByHealth(t *testing.T) {
+	p := meetingJoinParams{MeetingID: "m1"}
+
+	container := (&MeetingJoinHandler{
+		WorkspaceDir:         "/ws",
+		containerHealthProbe: func() bool { return true },
+	}).defaultSelectMedia(p)
+	if _, ok := container.(*containerMedia); !ok {
+		t.Errorf("healthy module: got %T, want *containerMedia", container)
+	}
+
+	host := (&MeetingJoinHandler{
+		WorkspaceDir:         "/ws",
+		containerHealthProbe: func() bool { return false },
+	}).defaultSelectMedia(p)
+	if _, ok := host.(*hostMedia); !ok {
+		t.Errorf("unhealthy module: got %T, want *hostMedia (legacy fallback)", host)
+	}
+}
+
+// TestMeetingWavRelPathMatchesAbs guards the container hand-off invariant: the
+// workspace-relative path meetingd writes, joined onto WorkspaceDir, must equal
+// the absolute path the transcriber reads. If these ever drift, the container's
+// WAV lands where the transcriber cannot find it.
+func TestMeetingWavRelPathMatchesAbs(t *testing.T) {
+	for _, id := range []string{"m1", "abc-123", "weird/../id", "café"} {
+		abs := meetingWavPath("/ws", id)
+		joined := filepath.Join("/ws", meetingWavRelPath(id))
+		if abs != joined {
+			t.Errorf("meetingWavRelPath drift for %q: abs=%q, join(ws,rel)=%q", id, abs, joined)
+		}
+	}
+}

--- a/internal/platform/cobrowse.go
+++ b/internal/platform/cobrowse.go
@@ -759,9 +759,19 @@ func cdpCommand(debugPort int, method string, params map[string]any) (map[string
 	if err != nil {
 		return nil, err
 	}
+	return cdpDialAndSend(target.WebSocketDebuggerURL, method, params)
+}
+
+// cdpDialAndSend opens a WebSocket to wsURL, sends one CDP method, and returns
+// the "result" object. Split out from cdpCommand so a caller that must first
+// REWRITE the target's advertised WebSocket URL — a containerized Chrome
+// advertises its container-internal debug port, which is unreachable from the
+// host, see cdpCommandPublished — shares the exact same request/response
+// handling.
+func cdpDialAndSend(wsURL, method string, params map[string]any) (map[string]any, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
-	conn, _, err := websocket.DefaultDialer.DialContext(ctx, target.WebSocketDebuggerURL, nil)
+	conn, _, err := websocket.DefaultDialer.DialContext(ctx, wsURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("CDP dial: %w", err)
 	}

--- a/internal/platform/meeting_browser.go
+++ b/internal/platform/meeting_browser.go
@@ -210,11 +210,24 @@ func typeJS(selector, text string) string {
 //     on a missing selector would masquerade as success — the worst outcome for
 //     the human tuning selectors against a live Meet.
 func cdpEvaluate(debugPort int, expression string) (any, error) {
-	res, err := cdpCommand(debugPort, "Runtime.evaluate", map[string]any{
+	return cdpEvalValue(cdpCommand(debugPort, "Runtime.evaluate", runtimeEvalParams(expression)))
+}
+
+// runtimeEvalParams is the Runtime.evaluate parameter set shared by the host and
+// container (published-port) evaluate paths.
+func runtimeEvalParams(expression string) map[string]any {
+	return map[string]any{
 		"expression":    expression,
 		"returnByValue": true,
 		"awaitPromise":  true,
-	})
+	}
+}
+
+// cdpEvalValue extracts the by-value result of a Runtime.evaluate response,
+// surfacing a JS throw as a Go error (see cdpEvaluate's contract). Takes the raw
+// (res, err) of a CDP command so both the host and published-port evaluate
+// helpers share the exception handling verbatim.
+func cdpEvalValue(res map[string]any, err error) (any, error) {
 	if err != nil {
 		return nil, err
 	}

--- a/internal/platform/meeting_container.go
+++ b/internal/platform/meeting_container.go
@@ -1,0 +1,133 @@
+// internal/platform/meeting_container.go
+//
+// CDPBrowser: drive a Chromium that ANOTHER process launched, over CDP on a
+// host-PUBLISHED debug port (aceteam-ai/citadel-cli#514). This is the container
+// half of the meeting media stack — the meeting module's in-container supervisor
+// (meetingd) launches and reaps Chrome on a managed Xvfb inside the container,
+// and this type only speaks CDP to it. It owns no process, display, or profile,
+// unlike its sibling MeetingBrowser, so the fragile Google Meet DOM logic in the
+// MEETING_JOIN handler runs UNCHANGED against either backend (both satisfy the
+// same browser surface).
+//
+// The load-bearing subtlety (why cdpCommand can't be used verbatim): a
+// containerized Chrome binds its DevTools endpoint on the CONTAINER's loopback
+// (e.g. 127.0.0.1:9222) and advertises exactly that in the webSocketDebuggerUrl
+// it returns from /json. From the host, only the compose's PUBLISHED port
+// (127.0.0.1:8208 -> container 9223 -> socat -> chrome 9222) is reachable; the
+// advertised 9222 is not. So the /json fetch is done through the published port
+// (works — it is forwarded), but the ws URL inside it must be rewritten to the
+// published host:port before dialing. See cdpCommandPublished + rewriteLoopbackWSPort.
+package platform
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// rewriteLoopbackWSPort rewrites the host:port of a DevTools WebSocket URL to
+// 127.0.0.1:port, preserving the scheme and the /devtools/page/<id> path. Pure,
+// so the container CDP rewrite is unit-testable without a live browser.
+func rewriteLoopbackWSPort(wsURL string, port int) (string, error) {
+	u, err := url.Parse(wsURL)
+	if err != nil {
+		return "", fmt.Errorf("parse CDP websocket url %q: %w", wsURL, err)
+	}
+	if u.Scheme != "ws" && u.Scheme != "wss" {
+		return "", fmt.Errorf("not a websocket url: %q", wsURL)
+	}
+	u.Host = fmt.Sprintf("127.0.0.1:%d", port)
+	return u.String(), nil
+}
+
+// cdpCommandPublished is cdpCommand for a Chrome reached through a Docker port
+// PUBLISH. It fetches /json through the published port (forwarded to the
+// container's DevTools endpoint, so this works verbatim) and then rewrites the
+// advertised, container-internal webSocketDebuggerUrl to the published host:port
+// before dialing — the advertised URL names a port that only exists inside the
+// container.
+func cdpCommandPublished(debugPort int, method string, params map[string]any) (map[string]any, error) {
+	target, err := pickTarget(debugPort)
+	if err != nil {
+		return nil, err
+	}
+	wsURL, err := rewriteLoopbackWSPort(target.WebSocketDebuggerURL, debugPort)
+	if err != nil {
+		return nil, err
+	}
+	return cdpDialAndSend(wsURL, method, params)
+}
+
+// cdpEvaluatePublished mirrors cdpEvaluate for the published-port path: it runs a
+// JS expression and returns its by-value result, surfacing a JS throw as a Go
+// error, but rewrites the container-internal ws URL first.
+func cdpEvaluatePublished(debugPort int, expression string) (any, error) {
+	return cdpEvalValue(cdpCommandPublished(debugPort, "Runtime.evaluate", runtimeEvalParams(expression)))
+}
+
+// CDPBrowser drives a Chromium launched by the containerized meeting module over
+// CDP on a host-published debug port. It satisfies the same browser surface the
+// MEETING_JOIN join flow drives (Navigate/CurrentURL/Evaluate/Type/Close) as
+// *MeetingBrowser, so the join/interactive logic is identical across backends.
+// All CDP goes through the *Published helpers, which rewrite the
+// container-internal ws URL to the published host port.
+type CDPBrowser struct {
+	debugPort int
+}
+
+// NewCDPBrowser constructs a CDP driver for a Chromium reachable on the given
+// host-published debug port (the meeting module publishes CDP on
+// services.MeetingCDPHostPort). It does not connect; call Ready first.
+func NewCDPBrowser(debugPort int) *CDPBrowser {
+	return &CDPBrowser{debugPort: debugPort}
+}
+
+// Ready blocks until the CDP endpoint answers AND a trivial Evaluate round-trips
+// through the WebSocket forward, so a broken port publish or socat forward fails
+// HERE with a clear error instead of at the first Navigate mid-join. The /json
+// readiness poll alone is not enough: it is forwarded fine even when the ws path
+// (which the advertised URL misdirects to the container-internal port) is broken.
+func (b *CDPBrowser) Ready(timeout time.Duration) error {
+	if err := waitForCDPReady(b.debugPort, timeout); err != nil {
+		return fmt.Errorf("meeting container CDP not ready on host port %d: %w", b.debugPort, err)
+	}
+	if _, err := cdpEvaluatePublished(b.debugPort, "1"); err != nil {
+		return fmt.Errorf("meeting container CDP websocket unreachable on host port %d "+
+			"(port publish or in-container socat forward broken): %w", b.debugPort, err)
+	}
+	return nil
+}
+
+// Navigate drives the browser to a URL over CDP.
+func (b *CDPBrowser) Navigate(rawURL string) error {
+	_, err := cdpCommandPublished(b.debugPort, "Page.navigate", map[string]any{"url": rawURL})
+	return err
+}
+
+// CurrentURL returns the active page's URL. The /json listing is fetched through
+// the published port (forwarded), so no ws rewrite is needed here.
+func (b *CDPBrowser) CurrentURL() (string, error) {
+	t, err := pickTarget(b.debugPort)
+	if err != nil {
+		return "", err
+	}
+	return t.URL, nil
+}
+
+// Evaluate runs a JS expression and returns its by-value result; a JS throw is a
+// Go error (see cdpEvalValue).
+func (b *CDPBrowser) Evaluate(expression string) (any, error) {
+	return cdpEvaluatePublished(b.debugPort, expression)
+}
+
+// Type sets the value of the first element matching selector, erroring if none
+// matches (same throwing typeJS the host browser uses).
+func (b *CDPBrowser) Type(selector, text string) error {
+	_, err := cdpEvaluatePublished(b.debugPort, typeJS(selector, text))
+	return err
+}
+
+// Close is a no-op: meetingd owns the container browser's process lifecycle
+// (DELETE /sessions tears it down). Present so CDPBrowser satisfies the same
+// interface as MeetingBrowser.
+func (b *CDPBrowser) Close() error { return nil }

--- a/internal/platform/meeting_container_test.go
+++ b/internal/platform/meeting_container_test.go
@@ -1,0 +1,78 @@
+package platform
+
+import "testing"
+
+// TestRewriteLoopbackWSPort is the load-bearing unit for the container CDP path
+// (#514): a containerized Chrome advertises its container-internal debug port in
+// the webSocketDebuggerUrl, which is unreachable from the host, so the driver must
+// rewrite host:port to the PUBLISHED loopback port before dialing. The /devtools
+// path (which identifies the page target) must be preserved verbatim.
+func TestRewriteLoopbackWSPort(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		port int
+		want string
+	}{
+		{
+			name: "container internal port rewritten to published host port",
+			in:   "ws://127.0.0.1:9222/devtools/page/AB12CD34",
+			port: 8208,
+			want: "ws://127.0.0.1:8208/devtools/page/AB12CD34",
+		},
+		{
+			name: "localhost host also normalized to 127.0.0.1",
+			in:   "ws://localhost:9222/devtools/page/XY",
+			port: 8208,
+			want: "ws://127.0.0.1:8208/devtools/page/XY",
+		},
+		{
+			name: "query string preserved",
+			in:   "ws://127.0.0.1:9222/devtools/browser?foo=bar",
+			port: 8208,
+			want: "ws://127.0.0.1:8208/devtools/browser?foo=bar",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := rewriteLoopbackWSPort(tc.in, tc.port)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("rewriteLoopbackWSPort(%q, %d) = %q, want %q", tc.in, tc.port, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRewriteLoopbackWSPort_RejectsNonWebSocket(t *testing.T) {
+	for _, in := range []string{
+		"http://127.0.0.1:9222/devtools/page/AB",
+		"://bad",
+		"not a url at all %%%",
+	} {
+		if _, err := rewriteLoopbackWSPort(in, 8208); err == nil {
+			t.Errorf("rewriteLoopbackWSPort(%q) expected an error, got nil", in)
+		}
+	}
+}
+
+// TestNewCDPBrowserSatisfiesInterface is a compile-time-ish assertion that
+// CDPBrowser exposes the browser surface the MEETING_JOIN flow drives, mirroring
+// MeetingBrowser so the same Meet DOM logic runs against either backend.
+func TestNewCDPBrowserSatisfiesInterface(t *testing.T) {
+	var b interface {
+		Navigate(string) error
+		CurrentURL() (string, error)
+		Evaluate(string) (any, error)
+		Type(string, string) error
+		Close() error
+	} = NewCDPBrowser(8208)
+	if b == nil {
+		t.Fatal("NewCDPBrowser returned nil")
+	}
+	if err := b.Close(); err != nil {
+		t.Errorf("CDPBrowser.Close() = %v, want nil (meetingd owns the process)", err)
+	}
+}


### PR DESCRIPTION
## Context

The meeting/notetaker capability (aceteam#5097) shipped as hardcoded Go that shells out to **host** binaries — a node is meeting-capable only if the box happens to have `google-chrome`, `Xvfb`, `pactl`/PulseAudio, and `ffmpeg`. #514's answer: package the media stack as an **installable citadel module** so capability becomes an on-demand install (via the desired-state path, aceteam#4273) rather than a host-provisioning prerequisite.

**PR1 (#517, merged)** shipped and prod-verified the container: `ghcr.io/aceteam-ai/meeting-service:latest` + the `meetingd` session/control API, with a canary-tone `/health` that returns `503` on silent capture (retiring the core "can we actually record audio in a container" uncertainty). Host ports are registered in `services/ports.go`: meetingd `8207→8102`, CDP `8208→9223`.

**This PR (PR2)** wires the `MEETING_JOIN` handler to drive that container over CDP, keeping the in-process host stack as a backwards-compatible fallback. The fragile Google Meet DOM logic (the LIVE-TUNING block) and the `TRANSCRIBE_AUDIO` hand-off are **untouched** — `meetingd` writes the WAV under the shared `${CITADEL_WORKSPACE}` mount, so the transcriber path is unchanged.

## Summary

**1. `MeetingMedia` interface, two impls (`internal/jobs/meeting_media.go`)**
- `hostMedia` — the existing `NullSinkRecorder` + `platform.MeetingBrowser` stack, kept verbatim (backwards-compat house rule). Pre-provisioned host-stack nodes keep working.
- `containerMedia` — an HTTP client for `meetingd`: `POST /sessions` → `{session_id, cdp_port}`, `POST /sessions/{id}/record` `{out: "meetings/<id>.wav"}`, `POST .../record/stop`, `DELETE /sessions/{id}`. The WAV lands on the same `${CITADEL_WORKSPACE}` mount the whisper sidecar reads, so the hand-off needs no new plumbing.

**2. `platform.CDPBrowser` (`internal/platform/meeting_container.go`)** — a process-less CDP driver satisfying the same browser surface as `MeetingBrowser` (`Navigate`/`CurrentURL`/`Evaluate`/`Type`/`Close`), so the Meet join + interactive logic runs unchanged against either backend. **Load-bearing subtlety:** `cdpCommand` dials the target's advertised `webSocketDebuggerUrl` verbatim, but a containerized Chrome advertises its *container-internal* CDP port (9222), which is unreachable from the host. `CDPBrowser` fetches `/json` through the published port (forwarded, works) and **rewrites the ws host:port to the published `127.0.0.1:8208`** before dialing (`rewriteLoopbackWSPort` + `cdpCommandPublished`). `Ready()` also round-trips a trivial `Evaluate` so a broken port publish / socat forward fails with a clear error *before* the join, not mid-call.

**3. Backend selection (`MeetingJoinHandler.Execute`)** — picks `containerMedia` when the meeting module is healthy on the node (`meetingd /health` green), else `hostMedia`. `media.Start()` returns the CDP browser; `Close()` is deferred only after a successful start (it cleans up partial bring-up itself).

**4. Module-aware capability (`internal/capabilities/detector.go`)** — `detectMeetingCapability() = enabled AND ( meetingModuleHealthy() OR legacyHostStack() )`. `meetingModuleHealthy` = install marker present (`<ConfigDir>/services/meeting.yml`) AND `catalog.ProbeHealth` green against the module's **published host port** (`services.MeetingdHostPort`). Because `/health` runs the canary tone, "healthy" means "can actually capture audio" — strictly stronger than the three host-binary existence probes. Legacy host stack kept as fallback so nodes don't lose capability on upgrade.

**5. Uninstall tag-symmetry (`removeServiceFromManifest`)** — install adds a module's `node_tags`, but uninstall historically left them behind. Now strips the removed module's declared `node_tags` (best-effort via the catalog manifest). The detector is the worker's source of truth, so this mainly keeps `citadel status` / generic routing honest.

### Scoped as follow-up (deliberately not half-wired)

**Runtime worker-restart trigger.** Tags + the `jobs:v1:tag:meeting:*` subscription are computed once at `citadel work` startup, so a `MODULE_SET` install on a *running* worker won't advertise `meeting` until restart. The design's v1 option is "converge triggers a worker restart," but `cmd/agent_tools.go` shows `WorkerRestart` currently returns *"in-place worker restart is not yet supported"* — there is no safe in-place restart to hook, and adding one is out of scope for this diff. Until then, a freshly-installed meeting module is picked up on the next worker restart (systemd) or `/agent/resubscribe`. Tracked as a follow-up.

## Where meetingd's actual API diverged from the design comment

- **CDP port.** The design said "fixed CDP port 9223 published `127.0.0.1:9223:9223`." The shipped image/registry instead publishes **host 8208 → container 9223**, and `POST /sessions` returns `cdp_port: 9223` (the *container* port). `containerMedia` therefore **ignores the returned `cdp_port`** and drives CDP on `services.MeetingCDPHostPort` (8208). This is the one place a naive client would break (readiness passes on `/json`, then the first `Evaluate` refuses).
- **Stale-session reclaim.** `meetingd` has no list/clear endpoint and its reaper only frees a session at `max_duration_seconds` (default 2h). `containerMedia` sends a deterministic `session_id` and, on a `409`, `DELETE`s + retries once (reclaims a *same-meeting* orphan); a different meeting's orphan surfaces a clear "busy" error. Fully clearing an unknown-id orphan would need a meetingd endpoint — noted for a follow-up.

## Test plan

| Group | Coverage |
|---|---|
| `meeting_media_test.go` | containerMedia against a mock meetingd: create-session (ignores container `cdp_port`), 409→DELETE→retry, persistent-409 busy error, record round-trip (sends workspace-relative `out`, returns host-absolute path), start-record error, `meetingdHealthy` (200/503/unreachable), backend selection (override + health branch), wav rel/abs path equivalence |
| `meeting_container_test.go` (platform) | `rewriteLoopbackWSPort` (9222→8208, localhost normalize, query preserved, rejects non-ws), CDPBrowser satisfies the browser interface |
| `detector_test.go` | `meetingCapabilitySignal` (module OR legacy), `meetingModuleInstalled` (marker present/absent) |
| `manifest_test.go` (cmd) | `stripTags` uninstall tag cleanup |
| flags | The two load-bearing chrome flags (`--autoplay-policy=no-user-gesture-required`, `--password-store=basic`) are already asserted in `meeting_browser_test.go` (host) and `test_meetingd.py` (container) |

`go build ./... && go vet ./... && go test ./...` all green.

### Manual test plan (human-gated — why this PR is a draft)

Live-Meet verification cannot be automated (Google blocks automated login; the join DOM is live-tuned). On a clean box **with no host chrome/pulse/Xvfb**:

1. `citadel module install meeting` → `citadel run meeting`; confirm `GET 127.0.0.1:8207/health` → `200` (non-silent canary).
2. Seed the signed-in bot profile (`docs/meeting-bot-profile-seeding.md`).
3. Dispatch a `MEETING_JOIN` for a real 2-party `meet.google.com` call; confirm the container path is selected (not host) and the bot joins.
4. **Watch for a CDP `403`/origin refusal on the first `Evaluate`** — if it happens, the container Chrome needs `--remote-allow-origins` in meetingd (an image gap, not this Go PR); the host path works without it, so this is a checkpoint, not an expectation.
5. Confirm a **non-silent** WAV lands at `<workspace>/meetings/<id>.wav` and the end-of-call transcript is populated.

## Related

- #514 — meeting media stack as an installable module (this is PR2).
- #517 — PR1: the published `meeting-service` image + `meetingd` control API.
- aceteam#5097 — meeting/notetaker epic (the autoplay-silence saga this guards against).
- aceteam#4273 — desired-state module assignment (the install-on-demand mechanism).
