### PR TITLE
fix(services): TUI stop no-op — standardize compose project, durable stop markers, manifest merge (#528)

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -1374,12 +1374,25 @@ func ccStartService(name string) error {
 
 	for _, service := range manifest.Services {
 		if service.Name == name {
+			// Clear the durable stopped marker FIRST (mirrors liveModuleOps.Start):
+			// an explicit start restores start-on-boot even if the compose up below
+			// fails transiently. Best-effort: the service is in the manifest (we
+			// just found it), so a failure here is unexpected but must not block
+			// the start.
+			_ = setServiceDesiredStatus(configDir, name, "")
+			// Transitional (#528): drop any container still under the legacy
+			// "citadel-<name>" project so the no-`-p` up below does not conflict
+			// on the pinned container_name.
+			removeLegacyCitadelProject(name)
 			fullComposePath := filepath.Join(configDir, service.ComposeFile)
 			// Include the least-privilege sandbox override when present so a
 			// TUI-installed untrusted module also starts hardened here (the
 			// override would otherwise be bypassed by this start site).
+			// No -p: the default compose project (dir basename, "services") is the
+			// standardized convention shared with the boot/run/stop/job paths and
+			// the no-`-p` status reads (#528).
 			composeArgs := composeFileArgs(fullComposePath, fullComposePath)
-			composeArgs = append(composeArgs, "-p", "citadel-"+name, "up", "-d")
+			composeArgs = append(composeArgs, "up", "-d")
 			// composeCommand injects the citadel-owned host ports so the
 			// ${CITADEL_*_HOST_PORT:?...} guard resolves; without this the TUI
 			// start button dies for llamacpp/vllm/extraction/diffusers on
@@ -1400,10 +1413,26 @@ func ccStopService(name string) error {
 
 	for _, service := range manifest.Services {
 		if service.Name == name {
+			// Mark durably stopped FIRST (mirrors liveModuleOps.Stop): even if the
+			// compose down below is interrupted, a worker restart / reboot will not
+			// resurrect the service (cmd/work.go and cmd/run.go skip services with
+			// desired_status: stopped). This is also what makes the TUI stop
+			// survive `citadel work` restarting managed services (#528).
+			if err := setServiceDesiredStatus(configDir, name, "stopped"); err != nil {
+				return err
+			}
 			fullComposePath := filepath.Join(configDir, service.ComposeFile)
-			downArgs := append(composeFileArgs(fullComposePath, fullComposePath), "-p", "citadel-"+name, "down")
+			// No -p: production containers run under the default compose project
+			// (dir basename, "services"). The old `-p citadel-<name>` down matched
+			// zero containers and exited 0 -- the silent no-op of #528.
+			downArgs := append(composeFileArgs(fullComposePath, fullComposePath), "down")
 			cmd := composeCommand(downArgs...)
-			return cmd.Run()
+			runErr := cmd.Run()
+			// Transitional (#528): also remove containers a pre-fix start left
+			// under the legacy "citadel-<name>" project, which the no-`-p` down
+			// above cannot see.
+			removeLegacyCitadelProject(name)
+			return runErr
 		}
 	}
 
@@ -1419,8 +1448,19 @@ func ccRestartService(name string) error {
 
 	for _, service := range manifest.Services {
 		if service.Name == name {
+			// A restart expresses "keep this running": clear any durable stopped
+			// marker so the service also starts on the next boot. Best-effort.
+			_ = setServiceDesiredStatus(configDir, name, "")
+			// Transitional (#528): a container still under the legacy
+			// "citadel-<name>" project is invisible to a no-`-p` `compose restart`
+			// (silent no-op) AND conflicts with a no-`-p` up on the pinned
+			// container_name. Remove it, then converge with `up -d
+			// --force-recreate`, which restarts a default-project container and
+			// (re)creates one when the legacy container was just removed --
+			// `restart` alone would no-op in that case.
+			removeLegacyCitadelProject(name)
 			fullComposePath := filepath.Join(configDir, service.ComposeFile)
-			restartArgs := append(composeFileArgs(fullComposePath, fullComposePath), "-p", "citadel-"+name, "restart")
+			restartArgs := append(composeFileArgs(fullComposePath, fullComposePath), "up", "-d", "--force-recreate")
 			cmd := composeCommand(restartArgs...)
 			return cmd.Run()
 		}
@@ -1443,8 +1483,9 @@ func ccGetServiceDetail(name string) *controlcenter.ServiceDetailInfo {
 				ComposePath: service.ComposeFile,
 			}
 
-			// Get container info via docker compose ps
-			psArgs := append(composeFileArgs(fullComposePath, fullComposePath), "-p", "citadel-"+name, "ps", "--format", "json")
+			// Get container info via docker compose ps (no -p: default project,
+			// matching where production containers actually run, #528)
+			psArgs := append(composeFileArgs(fullComposePath, fullComposePath), "ps", "--format", "json")
 			psCmd := composeCommand(psArgs...)
 			if output, err := psCmd.Output(); err == nil {
 				var container struct {
@@ -1486,7 +1527,9 @@ func ccGetServiceLogs(name string) ([]string, error) {
 	for _, service := range manifest.Services {
 		if service.Name == name {
 			fullComposePath := filepath.Join(configDir, service.ComposeFile)
-			logArgs := append(composeFileArgs(fullComposePath, fullComposePath), "-p", "citadel-"+name, "logs", "--tail", "50", "--no-color")
+			// No -p: read logs from the default compose project, where production
+			// containers actually run (#528).
+			logArgs := append(composeFileArgs(fullComposePath, fullComposePath), "logs", "--tail", "50", "--no-color")
 			cmd := composeCommand(logArgs...)
 			output, err := cmd.Output()
 			if err != nil {

--- a/cmd/desired_status_marker_test.go
+++ b/cmd/desired_status_marker_test.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// readServicesFromManifest re-reads the manifest written by the helper and
+// returns the services list, so tests can assert on the durable marker.
+func readServicesFromManifest(t *testing.T, nodeDir string) []Service {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(nodeDir, "citadel.yaml"))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	var m CitadelManifest
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		t.Fatalf("parse manifest: %v", err)
+	}
+	return m.Services
+}
+
+func findServiceByName(services []Service, name string) *Service {
+	for i := range services {
+		if services[i].Name == name {
+			return &services[i]
+		}
+	}
+	return nil
+}
+
+// TestCCStopServiceSetsDurableMarker is the regression test for #528's
+// persistence half: the TUI stop must record desired_status: stopped in
+// citadel.yaml BEFORE tearing containers down, so a `citadel work` restart or
+// reboot does not resurrect the service. The compose call itself may fail in
+// this environment (no docker / no compose file) -- the marker must be set
+// regardless. Uses a synthetic service name so no real container is touched.
+func TestCCStopServiceSetsDurableMarker(t *testing.T) {
+	nodeDir := writeManifestWithServices(t, []Service{
+		{Name: "stub-528", Type: "docker", ComposeFile: filepath.Join("services", "stub-528.yml")},
+	})
+
+	_ = ccStopService("stub-528") // compose down may fail here; irrelevant
+
+	svc := findServiceByName(readServicesFromManifest(t, nodeDir), "stub-528")
+	if svc == nil {
+		t.Fatal("stub-528 missing from manifest after stop")
+	}
+	if !serviceStartDisabled(*svc) {
+		t.Errorf("desired_status = %q, want stopped (TUI stop must be durable)", svc.DesiredStatus)
+	}
+}
+
+// TestCCStartServiceClearsDurableMarker: the TUI start restores start-on-boot
+// by clearing the marker, mirroring liveModuleOps.Start.
+func TestCCStartServiceClearsDurableMarker(t *testing.T) {
+	nodeDir := writeManifestWithServices(t, []Service{
+		{Name: "stub-528", Type: "docker", ComposeFile: filepath.Join("services", "stub-528.yml"), DesiredStatus: "stopped"},
+	})
+
+	_ = ccStartService("stub-528") // compose up may fail here; irrelevant
+
+	svc := findServiceByName(readServicesFromManifest(t, nodeDir), "stub-528")
+	if svc == nil {
+		t.Fatal("stub-528 missing from manifest after start")
+	}
+	if serviceStartDisabled(*svc) {
+		t.Error("TUI start must clear the durable stopped marker")
+	}
+}
+
+// TestCCRestartServiceClearsDurableMarker: a restart expresses "keep running",
+// so it clears the marker too.
+func TestCCRestartServiceClearsDurableMarker(t *testing.T) {
+	nodeDir := writeManifestWithServices(t, []Service{
+		{Name: "stub-528", Type: "docker", ComposeFile: filepath.Join("services", "stub-528.yml"), DesiredStatus: "stopped"},
+	})
+
+	_ = ccRestartService("stub-528")
+
+	svc := findServiceByName(readServicesFromManifest(t, nodeDir), "stub-528")
+	if svc == nil {
+		t.Fatal("stub-528 missing from manifest after restart")
+	}
+	if serviceStartDisabled(*svc) {
+		t.Error("TUI restart must clear the durable stopped marker")
+	}
+}
+
+// TestSetServiceDesiredStatusRoundTrip covers the cmd-side marker primitive
+// used by the TUI and `citadel stop` paths: set, clear, and the loud error on
+// an unknown name (a silent no-op would mask a typo'd stop).
+func TestSetServiceDesiredStatusRoundTrip(t *testing.T) {
+	nodeDir := writeManifestWithServices(t, []Service{
+		{Name: "stub-528", Type: "docker", ComposeFile: filepath.Join("services", "stub-528.yml")},
+	})
+
+	if err := setServiceDesiredStatus(nodeDir, "stub-528", "stopped"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	svc := findServiceByName(readServicesFromManifest(t, nodeDir), "stub-528")
+	if svc == nil || !serviceStartDisabled(*svc) {
+		t.Fatalf("marker not set: %+v", svc)
+	}
+
+	if err := setServiceDesiredStatus(nodeDir, "stub-528", ""); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	svc = findServiceByName(readServicesFromManifest(t, nodeDir), "stub-528")
+	if svc == nil || serviceStartDisabled(*svc) {
+		t.Fatalf("marker not cleared: %+v", svc)
+	}
+
+	if err := setServiceDesiredStatus(nodeDir, "nope", "stopped"); err == nil {
+		t.Error("expected error for unknown service, got nil")
+	}
+}

--- a/cmd/module_update.go
+++ b/cmd/module_update.go
@@ -275,11 +275,17 @@ func composeUpDetached(name, composePath string) error {
 	if _, err := os.Stat(composePath); err != nil {
 		return fmt.Errorf("compose file not found: %s", composePath)
 	}
+	// Transitional (#528): remove any container still under the legacy
+	// "citadel-<name>" project so the no-`-p` up below does not conflict on the
+	// pinned container_name.
+	removeLegacyCitadelProject(name)
 	// Include the least-privilege sandbox override when present (untrusted/Tier-2
 	// modules) so an updated/rolled-back sandboxed module restarts hardened.
+	// No -p: default compose project (dir basename), the standardized convention
+	// production containers run under (#528).
 	args := []string{"compose"}
 	args = append(args, composeFileArgs(composePath, composePath)...)
-	args = append(args, "-p", "citadel-"+name, "up", "-d")
+	args = append(args, "up", "-d")
 	c := exec.Command("docker", args...)
 	// Inject CITADEL_WORKSPACE + host-port vars so compose files guarded with
 	// ${VAR:?...} (transcribe/meeting workspace mount, #525) interpolate.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -200,6 +200,14 @@ func runSingleService(serviceName string) {
 		fmt.Printf("✅ Added '%s' to manifest\n", serviceName)
 	}
 
+	// An explicit `citadel run <service>` clears the durable stopped marker
+	// (mirrors liveModuleOps.Start, #528) so the service starts on the next boot
+	// again. Cleared FIRST so a transiently-failed start still records the
+	// operator's run intent. Best-effort: the service is in the manifest by now.
+	if err := setServiceDesiredStatus(configDir, serviceName, ""); err != nil {
+		fmt.Fprintf(os.Stderr, "⚠️  Could not clear stopped marker for %s: %v\n", serviceName, err)
+	}
+
 	// Start the service
 	fmt.Printf("--- 🚀 Starting service: %s ---\n", serviceName)
 

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -61,7 +61,7 @@ func composeEnv() []string {
 //     resolve instead of dying on the :? guard.
 //
 // Callers pass their compose args verbatim (e.g. "-f", path, "restart" or
-// "-f", path, "-p", "citadel-"+name, "ps", "--format", "json") and invoke
+// "-f", path, "ps", "--format", "json") and invoke
 // .Run()/.Output()/.CombinedOutput() on the result. Every cmd/ compose call site
 // that interpolates a citadel compose file MUST route through this; a bare
 // exec.Command("docker", "compose", ...) reintroduces the v2.57.0 regression
@@ -71,6 +71,20 @@ func composeCommand(args ...string) *exec.Cmd {
 	cmd := exec.Command(rt.Bin, rt.ComposeArgs(args...)...)
 	cmd.Env = composeEnv()
 	return cmd
+}
+
+// removeLegacyCitadelProject is the cmd/-tree wrapper around the transitional
+// cleanup for the compose project-name unification (#528): it force-removes any
+// containers still living under the legacy per-service project
+// "citadel-<name>" so the no-`-p` compose invocations (the standardized
+// convention; default project = compose dir basename, "services") neither miss
+// them on `down` nor conflict with them on `up` (a pinned container_name owned
+// by another compose project makes `up` fail; --force-recreate does not clear a
+// cross-project name conflict). Resolves the engine binary through the same
+// runtime selection composeCommand uses. Best-effort: no error surface.
+func removeLegacyCitadelProject(name string) {
+	rt := catalog.SelectContainerRuntime()
+	compose.RemoveLegacyProjectContainers(rt.EngineBin, name)
 }
 
 // prepareCacheDirectories creates the cache directories for all services.

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -128,14 +128,27 @@ func stopAllServices() {
 		fullComposePath := filepath.Join(configDir, service.ComposeFile)
 		fmt.Printf("🔻 Stopping service: %s\n", service.Name)
 
+		// Mark durably stopped FIRST (mirrors liveModuleOps.Stop, #528): the stop
+		// must survive a `citadel work` restart / reboot, whose boot paths skip
+		// services with desired_status: stopped. `citadel run [service]` clears
+		// the marker again.
+		if err := setServiceDesiredStatus(configDir, service.Name, "stopped"); err != nil {
+			fmt.Fprintf(os.Stderr, "   ⚠️  Could not record stopped state for %s: %v\n", service.Name, err)
+		}
+
 		if err := stopServiceByCompose(fullComposePath, removeContainer); err != nil {
 			fmt.Fprintf(os.Stderr, "   ❌ Failed to stop service %s: %v\n", service.Name, err)
 		} else {
 			fmt.Printf("   ✅ Service %s is stopped.\n", service.Name)
 		}
+		// Transitional (#528): also remove containers a pre-fix start left under
+		// the legacy "citadel-<name>" compose project, invisible to the no-`-p`
+		// down above.
+		removeLegacyCitadelProject(service.Name)
 	}
 
 	fmt.Println("\n🎉 All services stopped.")
+	fmt.Println("   Services stay stopped across restarts. Use 'citadel run <service>' to start one again.")
 }
 
 // stopSingleService stops a specific service.
@@ -188,11 +201,22 @@ func stopSingleService(serviceName string) {
 	fmt.Printf("--- 🛑 Stopping service: %s ---\n", serviceName)
 
 	if composePath != "" {
+		// Mark durably stopped FIRST (mirrors liveModuleOps.Stop, #528): the stop
+		// must survive a `citadel work` restart / reboot, whose boot paths skip
+		// services with desired_status: stopped. `citadel run <service>` clears
+		// the marker again.
+		if err := setServiceDesiredStatus(configDir, serviceName, "stopped"); err != nil {
+			fmt.Fprintf(os.Stderr, "⚠️  Could not record stopped state for %s: %v\n", serviceName, err)
+		}
 		// Use docker compose down if we have the compose file
 		if err := stopServiceByCompose(composePath, removeContainer); err != nil {
 			fmt.Fprintf(os.Stderr, "❌ Failed to stop service '%s': %v\n", serviceName, err)
 			os.Exit(1)
 		}
+		// Transitional (#528): also remove containers a pre-fix start left under
+		// the legacy "citadel-<name>" compose project, invisible to the no-`-p`
+		// down above.
+		removeLegacyCitadelProject(serviceName)
 	} else {
 		// Fallback to direct container stop
 		if err := stopServiceByContainer(serviceName); err != nil {

--- a/internal/compose/legacyproject.go
+++ b/internal/compose/legacyproject.go
@@ -1,0 +1,53 @@
+// internal/compose/legacyproject.go
+//
+// Transitional cleanup for the compose project-name unification (citadel #528).
+//
+// Historically three divergent compose project-name regimes existed: most paths
+// (boot, `citadel run`/`stop`, SERVICE_START/STOP jobs, all status reads) passed
+// no -p (default project = compose dir basename, i.e. "services"), while the TUI
+// service actions, APPLY_DEVICE_CONFIG startServices, and `module update` passed
+// `-p citadel-<name>`. Production containers therefore live under the default
+// project, and the minority `-p citadel-<name>` invocations silently matched
+// nothing (the TUI stop no-op). The fix standardizes on NO -p everywhere.
+//
+// The transitional hazard: a container previously started WITH `-p
+// citadel-<name>` carries a com.docker.compose.project=citadel-<name> label, so
+// (a) a no-p `docker compose down` cannot see it, and (b) a no-p `docker compose
+// up` conflicts on the pinned container_name ("citadel-<name>") because the
+// existing container belongs to another compose project (--force-recreate does
+// NOT resolve a cross-project name conflict; compose refuses to adopt it).
+// RemoveLegacyProjectContainers force-removes every container labeled with the
+// legacy per-service project so both up and down converge under the default
+// project. Call it before a compose up and after a compose down.
+package compose
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// RemoveLegacyProjectContainers force-removes all containers created under the
+// legacy per-service compose project "citadel-<serviceName>". engineBin is the
+// container engine binary ("docker" or "podman"). Best-effort by design: it
+// returns the removed container IDs for logging, and swallows engine errors (a
+// missing engine or no matching containers is the common, healthy case).
+func RemoveLegacyProjectContainers(engineBin, serviceName string) []string {
+	if engineBin == "" || serviceName == "" {
+		return nil
+	}
+	legacyProject := "citadel-" + serviceName
+	out, err := exec.Command(engineBin, "ps", "-aq",
+		"--filter", "label=com.docker.compose.project="+legacyProject).Output()
+	if err != nil {
+		return nil
+	}
+	ids := strings.Fields(strings.TrimSpace(string(out)))
+	if len(ids) == 0 {
+		return nil
+	}
+	args := append([]string{"rm", "-f"}, ids...)
+	if err := exec.Command(engineBin, args...).Run(); err != nil {
+		return nil
+	}
+	return ids
+}

--- a/internal/jobs/config_handler.go
+++ b/internal/jobs/config_handler.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"regexp"
 
+	"github.com/aceteam-ai/citadel-cli/internal/compose"
 	citadelconfig "github.com/aceteam-ai/citadel-cli/internal/config"
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
@@ -164,19 +165,36 @@ func (h *ConfigHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) 
 }
 
 // CitadelManifest represents the citadel.yaml configuration file.
+//
+// It mirrors every field cmd/manifest.go's CitadelManifest models (org_id,
+// capabilities, per-service type/port/desired_status): updateManifest
+// round-trips the whole document through this struct, so any field missing
+// here would be silently DROPPED from citadel.yaml on every
+// APPLY_DEVICE_CONFIG (#528). Capabilities is kept as a raw yaml.Node so its
+// structure survives without duplicating cmd's types (a VALUE node, not
+// *yaml.Node: yaml.v3 does not populate pointer-to-Node fields on decode, so a
+// pointer would silently drop the section again).
 type CitadelManifest struct {
 	Node struct {
-		Name string   `yaml:"name"`
-		Tags []string `yaml:"tags"`
+		Name  string   `yaml:"name"`
+		Tags  []string `yaml:"tags"`
+		OrgID string   `yaml:"org_id,omitempty"`
 	} `yaml:"node"`
-	Services []ManifestService `yaml:"services,omitempty"`
-	Config   ManifestConfig    `yaml:"config,omitempty"`
+	Services     []ManifestService `yaml:"services,omitempty"`
+	Config       ManifestConfig    `yaml:"config,omitempty"`
+	Capabilities yaml.Node         `yaml:"capabilities,omitempty"`
 }
 
-// ManifestService represents a service entry in the manifest.
+// ManifestService represents a service entry in the manifest. DesiredStatus is
+// the durable stop marker (see cmd/manifest.go Service.DesiredStatus): it must
+// round-trip through APPLY_DEVICE_CONFIG or a dashboard config save would
+// silently resurrect stopped services on the next boot (#528).
 type ManifestService struct {
-	Name        string `yaml:"name"`
-	ComposeFile string `yaml:"compose_file"`
+	Name          string `yaml:"name"`
+	Type          string `yaml:"type,omitempty"`
+	ComposeFile   string `yaml:"compose_file"`
+	Port          int    `yaml:"port,omitempty"`
+	DesiredStatus string `yaml:"desired_status,omitempty"`
 }
 
 // ManifestConfig represents additional configuration in the manifest.
@@ -212,11 +230,24 @@ func (h *ConfigHandler) updateManifest(configDir string, config *DeviceConfig) e
 		manifest.Node.Tags = append(baseTags, config.CustomTags...)
 	}
 
-	// Update services
+	// Update services: MERGE the config's service list into the existing one
+	// (#528). The previous implementation did `manifest.Services = nil` and
+	// rebuilt from config.Services alone, which (a) wiped every durable
+	// desired_status stop marker and (b) dropped every service the onboarding
+	// wizard doesn't know about -- most importantly module-installed services
+	// (registered via MODULE_SET / `citadel module install`), which would be
+	// silently de-registered by any dashboard config save. The wizard config is
+	// therefore treated as ADDITIVE for the service list: listed services are
+	// materialized and registered if missing, existing entries (and their
+	// DesiredStatus/Type/Port) are preserved untouched, and removal remains the
+	// job of the explicit uninstall paths (MODULE_SET, `citadel module remove`).
 	servicesDir := filepath.Join(configDir, "services")
 	os.MkdirAll(servicesDir, 0755)
 
-	manifest.Services = nil
+	existing := make(map[string]bool, len(manifest.Services))
+	for _, s := range manifest.Services {
+		existing[s.Name] = true
+	}
 	for _, svcName := range config.Services {
 		// Validate service name to prevent path traversal
 		if !serviceNamePattern.MatchString(svcName) {
@@ -236,10 +267,14 @@ func (h *ConfigHandler) updateManifest(configDir string, config *DeviceConfig) e
 			}
 		}
 
+		if existing[svcName] {
+			continue // Already registered: preserve the entry as-is.
+		}
 		manifest.Services = append(manifest.Services, ManifestService{
 			Name:        svcName,
 			ComposeFile: filepath.Join("./services", svcName+".yml"),
 		})
+		existing[svcName] = true
 	}
 
 	// Update config options
@@ -281,11 +316,18 @@ func (h *ConfigHandler) startServices(configDir string, serviceNames []string) e
 			continue
 		}
 
-		// Start the service
-		projectName := fmt.Sprintf("citadel-%s", svcName)
+		// Transitional (#528): remove any container still under the legacy
+		// "citadel-<svcName>" project so the no-`-p` up below does not conflict
+		// on the pinned container_name.
+		compose.RemoveLegacyProjectContainers("docker", svcName)
+
+		// Start the service. No -p: the default compose project (dir basename,
+		// "services") is the standardized convention shared with the boot/run/
+		// stop/job paths and the no-`-p` status reads (#528). The old
+		// `-p citadel-<name>` here created containers the stop paths could not
+		// see.
 		cmd := exec.Command("docker", "compose",
 			"-f", composeFile,
-			"-p", projectName,
 			"up", "-d",
 		)
 

--- a/internal/jobs/desired_status_test.go
+++ b/internal/jobs/desired_status_test.go
@@ -1,0 +1,257 @@
+package jobs
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+	"gopkg.in/yaml.v3"
+)
+
+// testManifestYAML is a realistic citadel.yaml with fields the minimal
+// serviceManifest struct does not model (org_id, capabilities, a module
+// service). The durable-stop tests assert these survive every rewrite.
+const testManifestYAML = `node:
+  name: test-node
+  tags:
+    - gpu
+  org_id: org-123
+services:
+  - name: vllm
+    type: docker
+    compose_file: ./services/vllm.yml
+  - name: my-module
+    compose_file: ./services/my-module.yml
+    desired_status: stopped
+  - name: stub-528
+    type: docker
+    compose_file: ./services/stub-528.yml
+capabilities:
+  engines:
+    - vllm
+`
+
+func writeTestManifest(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "citadel.yaml"), []byte(testManifestYAML), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	return dir
+}
+
+// readManifestMap parses the manifest into a generic map for assertions on
+// fields the typed structs do not model.
+func readManifestMap(t *testing.T, dir string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, "citadel.yaml"))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	var m map[string]any
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		t.Fatalf("parse manifest: %v", err)
+	}
+	return m
+}
+
+// manifestServiceEntry returns the service entry with the given name, or nil.
+func manifestServiceEntry(t *testing.T, m map[string]any, name string) map[string]any {
+	t.Helper()
+	services, _ := m["services"].([]any)
+	for _, raw := range services {
+		entry, _ := raw.(map[string]any)
+		if entry != nil && entry["name"] == name {
+			return entry
+		}
+	}
+	return nil
+}
+
+func TestSetDesiredStatusInManifestFile(t *testing.T) {
+	dir := writeTestManifest(t)
+	h := NewServiceHandler(dir)
+
+	t.Run("set stopped", func(t *testing.T) {
+		if err := h.setDesiredStatusInManifestFile("vllm", "stopped"); err != nil {
+			t.Fatalf("set: %v", err)
+		}
+		m := readManifestMap(t, dir)
+		entry := manifestServiceEntry(t, m, "vllm")
+		if entry == nil {
+			t.Fatal("vllm entry missing after rewrite")
+		}
+		if entry["desired_status"] != "stopped" {
+			t.Errorf("desired_status = %v, want stopped", entry["desired_status"])
+		}
+		// The rewrite must not disturb fields outside the target entry.
+		if entry["type"] != "docker" {
+			t.Errorf("type = %v, want docker (dropped by rewrite?)", entry["type"])
+		}
+		node, _ := m["node"].(map[string]any)
+		if node == nil || node["org_id"] != "org-123" {
+			t.Errorf("node.org_id lost in rewrite: %v", m["node"])
+		}
+		if m["capabilities"] == nil {
+			t.Error("capabilities section lost in rewrite")
+		}
+		if other := manifestServiceEntry(t, m, "my-module"); other == nil || other["desired_status"] != "stopped" {
+			t.Errorf("unrelated service my-module disturbed: %v", other)
+		}
+	})
+
+	t.Run("clear", func(t *testing.T) {
+		if err := h.setDesiredStatusInManifestFile("vllm", ""); err != nil {
+			t.Fatalf("clear: %v", err)
+		}
+		entry := manifestServiceEntry(t, readManifestMap(t, dir), "vllm")
+		if entry == nil {
+			t.Fatal("vllm entry missing after clear")
+		}
+		if _, present := entry["desired_status"]; present {
+			t.Errorf("desired_status still present after clear: %v", entry["desired_status"])
+		}
+	})
+
+	t.Run("unknown service errors", func(t *testing.T) {
+		if err := h.setDesiredStatusInManifestFile("nope", "stopped"); err == nil {
+			t.Error("expected error for unknown service, got nil")
+		}
+	})
+}
+
+// TestServiceStopJobSetsDurableMarker verifies the operator-intent contract of
+// #528: a remote SERVICE_STOP marks the service durably stopped in citadel.yaml
+// (so `citadel work`/`citadel run` will not resurrect it), and a SERVICE_START
+// clears the marker again. Uses the synthetic service "stub-528" (never a real
+// engine name) so the test cannot touch actual containers on a dev machine;
+// without a matching container the compose calls fail or short-circuit, but
+// the marker write happens first.
+func TestServiceStopJobSetsDurableMarker(t *testing.T) {
+	dir := writeTestManifest(t)
+	h := NewServiceHandler(dir)
+	ctx := JobContext{LogFn: func(string, string) {}}
+
+	stop := &nexus.Job{ID: "j1", Type: "SERVICE_STOP", Payload: map[string]string{"service": "stub-528"}}
+	if _, err := h.Execute(ctx, stop); err != nil {
+		t.Fatalf("SERVICE_STOP execute: %v", err)
+	}
+	entry := manifestServiceEntry(t, readManifestMap(t, dir), "stub-528")
+	if entry == nil || entry["desired_status"] != "stopped" {
+		t.Fatalf("SERVICE_STOP did not set durable marker: %v", entry)
+	}
+
+	start := &nexus.Job{ID: "j2", Type: "SERVICE_START", Payload: map[string]string{"service": "stub-528"}}
+	// The start itself may fail (no docker / no compose file in this test env);
+	// the marker must be cleared regardless, recording the operator's intent.
+	_, _ = h.Execute(ctx, start)
+	entry = manifestServiceEntry(t, readManifestMap(t, dir), "stub-528")
+	if entry == nil {
+		t.Fatal("stub-528 entry missing after SERVICE_START")
+	}
+	if _, present := entry["desired_status"]; present {
+		t.Errorf("SERVICE_START did not clear durable marker: %v", entry["desired_status"])
+	}
+}
+
+// TestStopServiceByNameDoesNotSetMarker pins the autostop contract: the
+// auto-stop-when-idle reconciler (#416) evicts ACTUAL state only. It must not
+// write desired_status:stopped, or an idle-evicted engine would never come
+// back on the next boot.
+func TestStopServiceByNameDoesNotSetMarker(t *testing.T) {
+	dir := writeTestManifest(t)
+	h := NewServiceHandler(dir)
+
+	_ = h.StopServiceByName("stub-528") // may error without docker; irrelevant here
+	entry := manifestServiceEntry(t, readManifestMap(t, dir), "stub-528")
+	if entry == nil {
+		t.Fatal("stub-528 entry missing")
+	}
+	if _, present := entry["desired_status"]; present {
+		t.Errorf("autostop path must not set desired_status, got %v", entry["desired_status"])
+	}
+}
+
+// TestUpdateManifestMerges verifies APPLY_DEVICE_CONFIG merges the wizard's
+// service list instead of rebuilding from nil (#528): module-installed
+// services and durable desired_status markers survive, listed services are
+// added, and org_id/capabilities round-trip.
+func TestUpdateManifestMerges(t *testing.T) {
+	dir := writeTestManifest(t)
+	// Mark vllm stopped first so the merge has a marker to preserve.
+	if err := NewServiceHandler(dir).setDesiredStatusInManifestFile("vllm", "stopped"); err != nil {
+		t.Fatalf("seed marker: %v", err)
+	}
+
+	h := NewConfigHandler(dir)
+	cfg := &DeviceConfig{
+		DeviceName: "renamed-node",
+		Services:   []string{"vllm", "ollama"},
+	}
+	if err := h.updateManifest(dir, cfg); err != nil {
+		t.Fatalf("updateManifest: %v", err)
+	}
+
+	m := readManifestMap(t, dir)
+
+	// Module service not in the wizard config must survive, marker intact.
+	if entry := manifestServiceEntry(t, m, "my-module"); entry == nil {
+		t.Error("module service my-module was dropped by config apply")
+	} else if entry["desired_status"] != "stopped" {
+		t.Errorf("my-module desired_status = %v, want stopped", entry["desired_status"])
+	}
+
+	// Existing listed service keeps its durable marker and type.
+	if entry := manifestServiceEntry(t, m, "vllm"); entry == nil {
+		t.Fatal("vllm dropped by config apply")
+	} else {
+		if entry["desired_status"] != "stopped" {
+			t.Errorf("vllm desired_status = %v, want stopped (marker wiped)", entry["desired_status"])
+		}
+		if entry["type"] != "docker" {
+			t.Errorf("vllm type = %v, want docker", entry["type"])
+		}
+	}
+
+	// Newly listed embedded service is registered and materialized.
+	if entry := manifestServiceEntry(t, m, "ollama"); entry == nil {
+		t.Error("ollama not added by config apply")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "services", "ollama.yml")); err != nil {
+		t.Errorf("ollama compose file not materialized: %v", err)
+	}
+
+	// Fields outside the wizard's knowledge must round-trip.
+	node, _ := m["node"].(map[string]any)
+	if node == nil || node["org_id"] != "org-123" {
+		t.Errorf("node.org_id lost: %v", m["node"])
+	}
+	if node != nil && node["name"] != "renamed-node" {
+		t.Errorf("node.name = %v, want renamed-node", node["name"])
+	}
+	if m["capabilities"] == nil {
+		t.Error("capabilities section lost by config apply")
+	}
+	caps, _ := m["capabilities"].(map[string]any)
+	if caps != nil {
+		if engines, _ := caps["engines"].([]any); len(engines) != 1 || engines[0] != "vllm" {
+			t.Errorf("capabilities.engines mangled: %v", caps["engines"])
+		}
+	}
+}
+
+// TestUpdateManifestNoProjectFlag pins the compose invocation convention: the
+// config-apply start path must not reintroduce `-p citadel-<name>` (the
+// project-name mismatch that made stops silent no-ops, #528).
+func TestUpdateManifestNoProjectFlag(t *testing.T) {
+	data, err := os.ReadFile("config_handler.go")
+	if err != nil {
+		t.Skipf("cannot read source: %v", err)
+	}
+	if strings.Contains(string(data), `"-p", projectName`) ||
+		strings.Contains(string(data), `"-p", "citadel-`) {
+		t.Error("config_handler.go passes a compose -p project flag; the standardized convention is NO -p (#528)")
+	}
+}

--- a/internal/jobs/service_handler.go
+++ b/internal/jobs/service_handler.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/aceteam-ai/citadel-cli/internal/catalog"
+	"github.com/aceteam-ai/citadel-cli/internal/compose"
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
 	"github.com/aceteam-ai/citadel-cli/internal/services"
@@ -30,6 +31,11 @@ type manifestService struct {
 	Type        string `yaml:"type,omitempty"`
 	ComposeFile string `yaml:"compose_file,omitempty"`
 	Port        int    `yaml:"port,omitempty"`
+	// DesiredStatus mirrors cmd/manifest.go Service.DesiredStatus: "stopped"
+	// makes an operator stop durable (the boot-time start paths skip the
+	// service). Read here so handlers can reason about it; written via
+	// setDesiredStatusInManifestFile (yaml.Node surgery, not this struct).
+	DesiredStatus string `yaml:"desired_status,omitempty"`
 }
 
 // ServiceHandler manages start/stop/status of services declared in the node's
@@ -147,8 +153,24 @@ func (h *ServiceHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error)
 	case "SERVICE_STATUS":
 		return h.serviceStatus(svc)
 	case "SERVICE_START":
+		// An explicit remote start clears the durable stopped marker (mirrors
+		// liveModuleOps.Start) so the service also starts on the next boot.
+		// Cleared FIRST so a transiently-failed start still records the
+		// operator's run intent. Best-effort: never blocks the start.
+		if err := h.setDesiredStatusInManifestFile(svc.Name, ""); err != nil {
+			ctx.Log("warning", "     - [Job %s] could not clear stopped marker for %s: %v", job.ID, svc.Name, err)
+		}
 		return h.serviceStart(ctx, svc)
 	case "SERVICE_STOP":
+		// A remote SERVICE_STOP is operator/cloud intent: mark the service
+		// durably stopped FIRST (mirrors liveModuleOps.Stop) so the stop
+		// survives a worker restart / reboot even if the compose down below is
+		// interrupted (#528). Deliberately NOT done in StopServiceByName: the
+		// auto-stop-when-idle reconciler (#416) evicts actual state, not desired
+		// state, and must not prevent an evicted service from starting on boot.
+		if err := h.setDesiredStatusInManifestFile(svc.Name, "stopped"); err != nil {
+			ctx.Log("warning", "     - [Job %s] could not set stopped marker for %s: %v", job.ID, svc.Name, err)
+		}
 		return h.serviceStop(ctx, svc)
 	default:
 		return nil, fmt.Errorf("unknown service job type: %s", job.Type)
@@ -205,6 +227,12 @@ func (h *ServiceHandler) serviceStart(ctx JobContext, svc manifestService) ([]by
 		if pathErr != nil {
 			return nil, pathErr
 		}
+		// Transitional (#528): remove any container still under the legacy
+		// "citadel-<name>" compose project (created by pre-fix TUI/config-apply
+		// starts that passed `-p citadel-<name>`). The no-`-p` up below would
+		// otherwise conflict on the pinned container_name -- a cross-project name
+		// conflict that --force-recreate does NOT resolve.
+		compose.RemoveLegacyProjectContainers("docker", svc.Name)
 		// Include the least-privilege sandbox override when present (untrusted/
 		// Tier-2 modules) so a remotely-started module also runs hardened -- the
 		// override would otherwise be bypassed by this start site.
@@ -285,6 +313,10 @@ func (h *ServiceHandler) serviceStop(ctx JobContext, svc manifestService) ([]byt
 		if cmdErr != nil {
 			err = fmt.Errorf("docker compose down failed: %s", strings.TrimSpace(string(out)))
 		}
+		// Transitional (#528): also remove containers a pre-fix start left under
+		// the legacy "citadel-<name>" compose project, which the no-`-p` down
+		// above cannot see (that mismatch was the silent stop no-op of #528).
+		compose.RemoveLegacyProjectContainers("docker", svc.Name)
 	}
 
 	if err != nil {
@@ -468,6 +500,96 @@ func (h *ServiceHandler) addServiceToManifestFile(svc manifestService) error {
 
 	// Encode with 2-space indent to match the citadel.yaml written by
 	// `citadel init` (yaml.v3's default is 4), keeping the reconciled diff minimal.
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(&doc); err != nil {
+		return err
+	}
+	if err := enc.Close(); err != nil {
+		return err
+	}
+	return os.WriteFile(path, buf.Bytes(), 0600)
+}
+
+// setDesiredStatusInManifestFile sets (status == "stopped") or clears
+// (status == "") the durable desired_status marker on a named service in
+// citadel.yaml. It is the jobs-package counterpart of cmd/manifest.go's
+// setServiceDesiredStatus (the jobs package cannot import cmd), implemented as
+// yaml.Node surgery like addServiceToManifestFile so node:, capabilities:, and
+// every field the minimal serviceManifest struct does not model survive the
+// rewrite. Returns an error if the service is not present, so a caller does not
+// silently no-op on a typo'd name.
+func (h *ServiceHandler) setDesiredStatusInManifestFile(name, status string) error {
+	path := filepath.Join(h.ConfigDir, "citadel.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return err
+	}
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
+		return fmt.Errorf("unexpected manifest structure in %s", path)
+	}
+	root := doc.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return fmt.Errorf("manifest root is not a mapping in %s", path)
+	}
+
+	var servicesSeq *yaml.Node
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		if root.Content[i].Value == "services" {
+			servicesSeq = root.Content[i+1]
+			break
+		}
+	}
+	if servicesSeq == nil || servicesSeq.Kind != yaml.SequenceNode {
+		return fmt.Errorf("service %q not found in manifest", name)
+	}
+
+	found := false
+	for _, item := range servicesSeq.Content {
+		if item.Kind != yaml.MappingNode {
+			continue
+		}
+		isTarget := false
+		statusIdx := -1
+		for j := 0; j+1 < len(item.Content); j += 2 {
+			switch item.Content[j].Value {
+			case "name":
+				if item.Content[j+1].Value == name {
+					isTarget = true
+				}
+			case "desired_status":
+				statusIdx = j
+			}
+		}
+		if !isTarget {
+			continue
+		}
+		found = true
+		switch {
+		case status == "" && statusIdx >= 0:
+			// Clear: drop the key/value pair.
+			item.Content = append(item.Content[:statusIdx], item.Content[statusIdx+2:]...)
+		case status != "" && statusIdx >= 0:
+			item.Content[statusIdx+1].Value = status
+			item.Content[statusIdx+1].Tag = "!!str"
+		case status != "":
+			item.Content = append(item.Content,
+				&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "desired_status"},
+				&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: status},
+			)
+		}
+		break
+	}
+	if !found {
+		return fmt.Errorf("service %q not found in manifest", name)
+	}
+
 	var buf bytes.Buffer
 	enc := yaml.NewEncoder(&buf)
 	enc.SetIndent(2)


### PR DESCRIPTION
## Context
Closes #528. TUI service stop appeared to "auto-restart" services — actually the stop was a silent no-op.

## Root Cause
Three divergent compose project-name regimes; TUI ran `docker compose down -p citadel-<name>` while production containers live under the default project `services`, so the down matched nothing. Additionally, stops were never durable (`desired_status: stopped` never set by TUI/CLI/job paths) and `APPLY_DEVICE_CONFIG` wiped the manifest services list.

## Changes
- Standardize on NO `-p` flag everywhere (TUI, config_handler, module_update)
- New `internal/compose/legacyproject.go`: sweep containers under legacy `citadel-<name>` projects before every `up` / after every `down` (compose refuses to adopt a pinned container_name owned by another project — force-recreate does not clear cross-project conflicts)
- Durable stop markers: TUI stop / `citadel stop` / SERVICE_STOP set `desired_status: stopped` before down; start paths clear it. Idle auto-stop deliberately does NOT set it (evicts actual state, not desired state — pinned by test)
- `updateManifest` now merges instead of `Services = nil` — preserves DesiredStatus, module-installed services, and fixes a wider wipe (org_id, capabilities, per-service fields dropped on every config apply)

## Behavior change
`citadel stop` (no args) now durably stops ALL services; `citadel run <service>` recovers (hint printed).

## Testing
- `go build ./... && go vet ./... && go test ./...` pass; new tests for markers, merge, no-`-p` source pin
- Live-verified on ubuntu-gpu-1: planted legacy `project=citadel-vllm` container → `citadel stop vllm` swept it + set marker → `citadel run` skipped it (boot-skip) → `citadel run vllm` cleared marker + started under canonical `services` project

🤖 Generated with [Claude Code](https://claude.com/claude-code)