### PR TITLE
feat(status): report served model per engine in heartbeat and citadel status (#529)

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -18,9 +18,11 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/network"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
 	"github.com/aceteam-ai/citadel-cli/internal/resmon"
+	statuspkg "github.com/aceteam-ai/citadel-cli/internal/status"
 	"github.com/aceteam-ai/citadel-cli/internal/tui"
 	"github.com/aceteam-ai/citadel-cli/internal/tui/dashboard"
 	"github.com/aceteam-ai/citadel-cli/internal/worklock"
+	svcports "github.com/aceteam-ai/citadel-cli/services"
 	"github.com/fatih/color"
 	"github.com/redis/go-redis/v9"
 	"github.com/shirou/gopsutil/v3/cpu"
@@ -909,6 +911,13 @@ func printServiceInfo(w *tabwriter.Writer) {
 			var statusStr string
 			if strings.Contains(state, "RUNNING") || strings.Contains(state, "UP") {
 				statusStr = goodColor.Sprintf("🟢 %s", state)
+				// For running serving engines, show the model(s) actually loaded,
+				// e.g. "🟢 RUNNING (Qwen/Qwen3-8B)" (#529). Non-engine services and
+				// engines that don't answer within the short probe window print
+				// unchanged.
+				if models := discoverServiceModels(service.Name); len(models) > 0 {
+					statusStr += fmt.Sprintf(" (%s)", strings.Join(models, ", "))
+				}
 			} else if strings.Contains(state, "EXITED") || strings.Contains(state, "DEAD") {
 				statusStr = badColor.Sprintf("🔴 %s", state)
 			} else {
@@ -917,6 +926,34 @@ func printServiceInfo(w *tabwriter.Writer) {
 			fmt.Fprintf(w, "  - %s:\t%s\n", service.Name, statusStr)
 		}
 	}
+}
+
+// discoverServiceModels returns the LOADED model(s) for a running serving
+// engine service (vllm/ollama/llamacpp), or nil for non-engine services and
+// for engines that fail to answer quickly (#529). The port comes from the
+// citadel-owned host-port registry (services.ManagedServiceHostPort), falling
+// back to the engine's well-known native port (e.g. ollama 11434). Failures
+// are silent: status rendering must never stall or error on a slow engine, so
+// the probe is bounded by a short timeout.
+func discoverServiceModels(serviceName string) []string {
+	engine := statuspkg.EngineTypeFromName(serviceName)
+	if engine == "" {
+		return nil
+	}
+	port, ok := svcports.ManagedServiceHostPort(engine)
+	if !ok {
+		port = statuspkg.InferServicePort(engine)
+	}
+	if port <= 0 {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), statuspkg.ModelDiscoveryTimeout)
+	defer cancel()
+	models, err := statuspkg.NewModelDiscovery().DiscoverModels(ctx, engine, port)
+	if err != nil {
+		return nil
+	}
+	return models
 }
 
 func colorizePercent(p float64) string {

--- a/internal/status/collector.go
+++ b/internal/status/collector.go
@@ -335,14 +335,7 @@ func (c *Collector) collectServiceStatus() []ServiceInfo {
 
 // detectLLMServiceType determines the LLM service type from the service name.
 func (c *Collector) detectLLMServiceType(serviceName string) string {
-	name := strings.ToLower(serviceName)
-	if strings.Contains(name, "vllm") {
-		return "vllm"
-	}
-	if strings.Contains(name, "ollama") {
-		return "ollama"
-	}
-	return ""
+	return EngineTypeFromName(serviceName)
 }
 
 // getDockerComposeStatus checks if a docker compose service is running.

--- a/internal/status/engines.go
+++ b/internal/status/engines.go
@@ -19,21 +19,33 @@ import (
 // other engines (sglang, llama.cpp) grow comparable metrics.
 var idleCapableEngines = []string{"vllm"}
 
+// managedProbeEngines lists the managed serving engines the heartbeat path
+// probes for a live signal: an idle signal (idleCapableEngines) and/or the
+// loaded model(s) over the engine's local HTTP API (#529). It must remain a
+// superset of idleCapableEngines (guarded by a test) so extending the idle
+// list never silently drops an engine from the heartbeat.
+var managedProbeEngines = []string{"vllm", "ollama", "llamacpp"}
+
 // collectManagedEngineStatus reports running managed serving engines (from the
-// embedded services.ServiceMap) that carry an idle signal, so the per-service
-// idle telemetry reaches the heartbeat even when no manifest-driven service
-// config was passed to the collector (the common heartbeat case, where
-// c.services is nil).
+// embedded services.ServiceMap) so their telemetry reaches the heartbeat even
+// when no manifest-driven service config was passed to the collector (the
+// common heartbeat case, where c.services is nil). Each entry carries the
+// per-service idle signal when the engine's metrics are scrapeable (citadel
+// #416) and the currently LOADED model(s) discovered from the engine's local
+// API (citadel #529) — e.g. vLLM/llama.cpp `GET /v1/models`, ollama
+// `GET /api/ps`.
 //
-// It only emits an entry for an engine that is actually running AND whose
-// metrics endpoint could be scraped. A running-but-unscrapeable engine (e.g.
-// still loading its model, /metrics not yet up) is skipped rather than reported
-// with a misleading "idle since startup" — the existing manifest-driven
-// collectServiceStatus still reports its up/down state when configured.
+// It only emits an entry for an engine that is actually running AND answered
+// at least one probe (idle scrape or model discovery). An engine that answers
+// model discovery with an empty list (llama.cpp up with no model loaded,
+// ollama with nothing resident) IS emitted — running with no models is real,
+// reportable state. A running-but-unresponsive engine (e.g. still loading its
+// model, HTTP not yet up) is skipped rather than reported with a misleading
+// "idle since startup" — the existing manifest-driven collectServiceStatus
+// still reports its up/down state when configured. Probe failures never fail
+// the collection: each probe is bounded by ModelDiscoveryTimeout and a failure
+// simply leaves the corresponding field empty.
 func (c *Collector) collectManagedEngineStatus() []ServiceInfo {
-	if c.idleTracker == nil {
-		return nil
-	}
 	ctx := context.Background()
 	var out []ServiceInfo
 
@@ -44,26 +56,55 @@ func (c *Collector) collectManagedEngineStatus() []ServiceInfo {
 	// idle signal would never fire on exactly the nodes this feature targets.
 	engineBin := catalog.SelectContainerRuntime().EngineBin
 
-	for _, name := range idleCapableEngines {
+	for _, name := range managedProbeEngines {
 		port, running := managedEnginePortIfRunning(engineBin, name)
 		if !running || port <= 0 {
 			continue
 		}
-		state, ok := c.idleTracker.Observe(ctx, name, name, port)
-		if !ok {
+
+		info := ServiceInfo{
+			Name:   name,
+			Type:   ServiceTypeLLM,
+			Status: ServiceStatusRunning,
+			Port:   port,
+			Health: HealthStatusOK,
+		}
+		responded := false
+
+		if c.idleTracker != nil && engineInList(idleCapableEngines, name) {
+			if state, ok := c.idleTracker.Observe(ctx, name, name, port); ok {
+				idle := state
+				info.IdleState = &idle
+				responded = true
+			}
+		}
+
+		if c.modelDiscovery != nil {
+			mctx, cancel := context.WithTimeout(ctx, ModelDiscoveryTimeout)
+			models, err := c.modelDiscovery.DiscoverModels(mctx, name, port)
+			cancel()
+			if err == nil {
+				info.Models = models
+				responded = true
+			}
+		}
+
+		if !responded {
 			continue
 		}
-		idle := state
-		out = append(out, ServiceInfo{
-			Name:      name,
-			Type:      ServiceTypeLLM,
-			Status:    ServiceStatusRunning,
-			Port:      port,
-			Health:    HealthStatusOK,
-			IdleState: &idle,
-		})
+		out = append(out, info)
 	}
 	return out
+}
+
+// engineInList reports whether name is present in the given engine list.
+func engineInList(list []string, name string) bool {
+	for _, e := range list {
+		if e == name {
+			return true
+		}
+	}
+	return false
 }
 
 // managedEnginePortIfRunning reports whether a managed engine is running and,

--- a/internal/status/engines_test.go
+++ b/internal/status/engines_test.go
@@ -68,6 +68,25 @@ func TestManagedEngineHostPort_VLLM(t *testing.T) {
 	}
 }
 
+// TestManagedProbeEnginesSupersetOfIdleCapable guards against the drift where
+// an engine added to the idle list is silently dropped from the heartbeat's
+// managed-engine sweep (which now iterates managedProbeEngines, #529).
+func TestManagedProbeEnginesSupersetOfIdleCapable(t *testing.T) {
+	for _, name := range idleCapableEngines {
+		if !engineInList(managedProbeEngines, name) {
+			t.Errorf("idle-capable engine %q missing from managedProbeEngines; it would vanish from the heartbeat", name)
+		}
+	}
+	// Every probed engine must be a type DiscoverModels understands, so the
+	// discovery call in collectManagedEngineStatus can never hit the
+	// "unsupported service type" branch.
+	for _, name := range managedProbeEngines {
+		if got := EngineTypeFromName(name); got != name {
+			t.Errorf("EngineTypeFromName(%q) = %q; managedProbeEngines entries must map to themselves", name, got)
+		}
+	}
+}
+
 func TestIdleEngineType_MatchesImage(t *testing.T) {
 	// A catalog slug that doesn't contain "vllm" in the name but whose image does.
 	if got := idleEngineType("llm-server vllm/vllm-openai:latest"); got != "vllm" {

--- a/internal/status/models.go
+++ b/internal/status/models.go
@@ -5,12 +5,22 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 )
+
+// ModelDiscoveryTimeout bounds a single model-discovery probe. Discovery runs
+// on the heartbeat's collection cycle (~30s) and inside `citadel status`, so a
+// slow/hung engine must never stall the whole collection — callers wrap their
+// context with this deadline and treat failure as "no models reported".
+const ModelDiscoveryTimeout = 2 * time.Second
 
 // ModelDiscovery provides model discovery for LLM services.
 type ModelDiscovery struct {
 	httpClient *http.Client
+	// host is the hostname used to reach the engine's local API. Defaults to
+	// "localhost"; tests override it to pin the httptest listener address.
+	host string
 }
 
 // NewModelDiscovery creates a new model discovery instance.
@@ -19,15 +29,40 @@ func NewModelDiscovery() *ModelDiscovery {
 		httpClient: &http.Client{
 			Timeout: 5 * time.Second,
 		},
+		host: "localhost",
 	}
 }
 
-// DiscoverModels queries an LLM service for loaded models.
-// It automatically detects the service type and uses the appropriate API.
+// EngineTypeFromName maps a service/app name to a model-discovery engine type
+// ("vllm", "ollama", "llamacpp"), or "" when the name is not a known serving
+// engine. Order matters: "ollama" contains "llama", so it must be checked
+// before the llama.cpp patterns.
+func EngineTypeFromName(name string) string {
+	n := strings.ToLower(name)
+	switch {
+	case strings.Contains(n, "vllm"):
+		return "vllm"
+	case strings.Contains(n, "ollama"):
+		return "ollama"
+	case strings.Contains(n, "llamacpp"), strings.Contains(n, "llama.cpp"), strings.Contains(n, "llama-cpp"):
+		return "llamacpp"
+	}
+	return ""
+}
+
+// DiscoverModels queries an LLM service for LOADED models (the model(s)
+// currently being served, not merely downloaded). It automatically detects the
+// service type and uses the appropriate API. A running engine with no model
+// loaded returns an empty slice and nil error.
 func (m *ModelDiscovery) DiscoverModels(ctx context.Context, serviceType string, port int) ([]string, error) {
 	switch serviceType {
 	case "vllm":
-		return m.discoverVLLMModels(ctx, port)
+		return m.discoverOpenAIModels(ctx, "vLLM", port)
+	case "llamacpp":
+		// llama.cpp's server exposes the same OpenAI-compatible /v1/models list.
+		// It can be up with NO model loaded (router mode / deferred load): that is
+		// an empty list, not an error.
+		return m.discoverOpenAIModels(ctx, "llama.cpp", port)
 	case "ollama":
 		return m.discoverOllamaModels(ctx, port)
 	default:
@@ -35,10 +70,10 @@ func (m *ModelDiscovery) DiscoverModels(ctx context.Context, serviceType string,
 	}
 }
 
-// discoverVLLMModels queries vLLM's OpenAI-compatible API for loaded models.
-// vLLM exposes: GET /v1/models
-func (m *ModelDiscovery) discoverVLLMModels(ctx context.Context, port int) ([]string, error) {
-	url := fmt.Sprintf("http://localhost:%d/v1/models", port)
+// discoverOpenAIModels queries an OpenAI-compatible API for loaded models.
+// Used for vLLM and llama.cpp, both of which expose: GET /v1/models
+func (m *ModelDiscovery) discoverOpenAIModels(ctx context.Context, engineLabel string, port int) ([]string, error) {
+	url := fmt.Sprintf("http://%s:%d/v1/models", m.host, port)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -47,38 +82,39 @@ func (m *ModelDiscovery) discoverVLLMModels(ctx context.Context, port int) ([]st
 
 	resp, err := m.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query vLLM models: %w", err)
+		return nil, fmt.Errorf("failed to query %s models: %w", engineLabel, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("vLLM returned status %d", resp.StatusCode)
+		return nil, fmt.Errorf("%s returned status %d", engineLabel, resp.StatusCode)
 	}
 
-	// vLLM returns OpenAI-compatible format:
+	// OpenAI-compatible format:
 	// { "data": [{ "id": "model-name", "object": "model" }] }
-	var vllmResp struct {
+	var listResp struct {
 		Data []struct {
 			ID string `json:"id"`
 		} `json:"data"`
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&vllmResp); err != nil {
-		return nil, fmt.Errorf("failed to parse vLLM response: %w", err)
+	if err := json.NewDecoder(resp.Body).Decode(&listResp); err != nil {
+		return nil, fmt.Errorf("failed to parse %s response: %w", engineLabel, err)
 	}
 
-	models := make([]string, 0, len(vllmResp.Data))
-	for _, model := range vllmResp.Data {
+	models := make([]string, 0, len(listResp.Data))
+	for _, model := range listResp.Data {
 		models = append(models, model.ID)
 	}
 
 	return models, nil
 }
 
-// discoverOllamaModels queries Ollama's API for available models.
-// Ollama exposes: GET /api/tags
+// discoverOllamaModels queries Ollama's API for LOADED (running) models.
+// Ollama exposes: GET /api/ps — the models currently loaded into memory.
+// (/api/tags lists DOWNLOADED models, which is not what the heartbeat needs.)
 func (m *ModelDiscovery) discoverOllamaModels(ctx context.Context, port int) ([]string, error) {
-	url := fmt.Sprintf("http://localhost:%d/api/tags", port)
+	url := fmt.Sprintf("http://%s:%d/api/ps", m.host, port)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -96,7 +132,7 @@ func (m *ModelDiscovery) discoverOllamaModels(ctx context.Context, port int) ([]
 	}
 
 	// Ollama returns:
-	// { "models": [{ "name": "llama2:latest", "size": 123456 }] }
+	// { "models": [{ "name": "llama2:latest", "model": "llama2:latest", ... }] }
 	var ollamaResp struct {
 		Models []struct {
 			Name string `json:"name"`
@@ -118,8 +154,9 @@ func (m *ModelDiscovery) discoverOllamaModels(ctx context.Context, port int) ([]
 // CheckServiceHealth performs a health check on an LLM service.
 func (m *ModelDiscovery) CheckServiceHealth(ctx context.Context, serviceType string, port int) (string, error) {
 	switch serviceType {
-	case "vllm":
-		return m.checkVLLMHealth(ctx, port)
+	case "vllm", "llamacpp":
+		// Both vLLM and llama.cpp's server expose GET /health.
+		return m.checkHTTPHealth(ctx, port)
 	case "ollama":
 		return m.checkOllamaHealth(ctx, port)
 	default:
@@ -127,9 +164,10 @@ func (m *ModelDiscovery) CheckServiceHealth(ctx context.Context, serviceType str
 	}
 }
 
-// checkVLLMHealth checks vLLM health via the /health endpoint.
-func (m *ModelDiscovery) checkVLLMHealth(ctx context.Context, port int) (string, error) {
-	url := fmt.Sprintf("http://localhost:%d/health", port)
+// checkHTTPHealth checks engine health via the /health endpoint (vLLM,
+// llama.cpp).
+func (m *ModelDiscovery) checkHTTPHealth(ctx context.Context, port int) (string, error) {
+	url := fmt.Sprintf("http://%s:%d/health", m.host, port)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -151,7 +189,7 @@ func (m *ModelDiscovery) checkVLLMHealth(ctx context.Context, port int) (string,
 
 // checkOllamaHealth checks Ollama health via the root endpoint.
 func (m *ModelDiscovery) checkOllamaHealth(ctx context.Context, port int) (string, error) {
-	url := fmt.Sprintf("http://localhost:%d/", port)
+	url := fmt.Sprintf("http://%s:%d/", m.host, port)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {

--- a/internal/status/models_test.go
+++ b/internal/status/models_test.go
@@ -3,69 +3,186 @@ package status
 import (
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
-func TestDiscoverVLLMModels(t *testing.T) {
-	// Create mock vLLM server
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v1/models" {
-			http.NotFound(w, r)
-			return
-		}
-
-		resp := struct {
-			Data []struct {
-				ID string `json:"id"`
-			} `json:"data"`
-		}{
-			Data: []struct {
-				ID string `json:"id"`
-			}{
-				{ID: "meta-llama/Llama-3-8b"},
-				{ID: "mistralai/Mistral-7B"},
-			},
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
-	}))
-	defer server.Close()
-
-	// Extract port from server URL
-	parts := strings.Split(server.URL, ":")
-	port := 0
-	if len(parts) == 3 {
-		var err error
-		_, err = json.Marshal(parts[2])
-		if err == nil {
-			// Use the test server directly via its handler
-		}
+// newTestDiscovery starts an httptest server with the given handler and
+// returns a ModelDiscovery pinned to the server's address plus the server's
+// port. Pinning host to 127.0.0.1 (httptest's listen address) avoids
+// localhost→::1 resolution flakiness.
+func newTestDiscovery(t *testing.T, handler http.Handler) (*ModelDiscovery, int) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	addr, ok := server.Listener.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("unexpected listener addr type %T", server.Listener.Addr())
 	}
-	_ = port // We'll use the full URL instead
-
-	// For testing, we need to modify the discovery to accept a base URL
-	// Since we can't do that without modifying the code, let's test via collector integration
 	discovery := NewModelDiscovery()
+	discovery.host = "127.0.0.1"
+	return discovery, addr.Port
+}
 
-	// Test with invalid port (will fail, which tests error handling)
-	_, err := discovery.DiscoverModels(context.Background(), "vllm", 99999)
-	if err == nil {
-		// This is expected to fail since we can't reach the test server on a different port
-		// The test verifies the error handling path
+// openAIModelsHandler serves an OpenAI-compatible GET /v1/models list with the
+// given model IDs (the vLLM and llama.cpp dialect).
+func openAIModelsHandler(ids ...string) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/models", func(w http.ResponseWriter, r *http.Request) {
+		data := make([]map[string]string, 0, len(ids))
+		for _, id := range ids {
+			data = append(data, map[string]string{"id": id, "object": "model"})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"object": "list", "data": data})
+	})
+	return mux
+}
+
+func TestDiscoverModels_VLLM(t *testing.T) {
+	discovery, port := newTestDiscovery(t, openAIModelsHandler("Qwen/Qwen3-8B"))
+
+	models, err := discovery.DiscoverModels(context.Background(), "vllm", port)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(models, []string{"Qwen/Qwen3-8B"}) {
+		t.Fatalf("expected [Qwen/Qwen3-8B], got %v", models)
 	}
 }
 
-func TestDiscoverOllamaModels(t *testing.T) {
-	discovery := NewModelDiscovery()
+func TestDiscoverModels_Llamacpp(t *testing.T) {
+	discovery, port := newTestDiscovery(t, openAIModelsHandler("/models/llama-3-8b.Q4_K_M.gguf"))
 
-	// Test with invalid port (will fail, testing error handling)
-	_, err := discovery.DiscoverModels(context.Background(), "ollama", 99999)
+	models, err := discovery.DiscoverModels(context.Background(), "llamacpp", port)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(models) != 1 || models[0] != "/models/llama-3-8b.Q4_K_M.gguf" {
+		t.Fatalf("expected llamacpp model path, got %v", models)
+	}
+}
+
+// TestDiscoverModels_LlamacppNoModelLoaded covers llama.cpp being up with NO
+// model loaded: a 200 with an empty data list is an empty result, not an
+// error.
+func TestDiscoverModels_LlamacppNoModelLoaded(t *testing.T) {
+	discovery, port := newTestDiscovery(t, openAIModelsHandler())
+
+	models, err := discovery.DiscoverModels(context.Background(), "llamacpp", port)
+	if err != nil {
+		t.Fatalf("expected no error for empty model list, got: %v", err)
+	}
+	if len(models) != 0 {
+		t.Fatalf("expected no models, got %v", models)
+	}
+}
+
+// TestDiscoverModels_OllamaLoaded verifies ollama discovery uses /api/ps
+// (LOADED models), not /api/tags (downloaded models).
+func TestDiscoverModels_OllamaLoaded(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/ps", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"models": []map[string]any{
+				{"name": "llama3:8b", "model": "llama3:8b", "size": 5137025024},
+			},
+		})
+	})
+	mux.HandleFunc("/api/tags", func(w http.ResponseWriter, r *http.Request) {
+		t.Error("discovery must query /api/ps (loaded), not /api/tags (downloaded)")
+		http.NotFound(w, r)
+	})
+	discovery, port := newTestDiscovery(t, mux)
+
+	models, err := discovery.DiscoverModels(context.Background(), "ollama", port)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(models, []string{"llama3:8b"}) {
+		t.Fatalf("expected [llama3:8b], got %v", models)
+	}
+}
+
+// TestDiscoverModels_OllamaNothingLoaded covers a running ollama with no
+// models resident in memory: empty result, no error.
+func TestDiscoverModels_OllamaNothingLoaded(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/ps", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"models": []any{}})
+	})
+	discovery, port := newTestDiscovery(t, mux)
+
+	models, err := discovery.DiscoverModels(context.Background(), "ollama", port)
+	if err != nil {
+		t.Fatalf("expected no error for empty /api/ps, got: %v", err)
+	}
+	if len(models) != 0 {
+		t.Fatalf("expected no models, got %v", models)
+	}
+}
+
+func TestDiscoverModels_Unreachable(t *testing.T) {
+	// Bind then immediately close a listener so the port is known-dead.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to reserve port: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close()
+
+	discovery := NewModelDiscovery()
+	discovery.host = "127.0.0.1"
+	for _, engine := range []string{"vllm", "ollama", "llamacpp"} {
+		if _, err := discovery.DiscoverModels(context.Background(), engine, port); err == nil {
+			t.Errorf("%s: expected error for unreachable server", engine)
+		}
+	}
+}
+
+// TestDiscoverModels_Timeout verifies a hung engine can't stall discovery
+// past the caller's context deadline.
+func TestDiscoverModels_Timeout(t *testing.T) {
+	block := make(chan struct{})
+	defer close(block)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/models", func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-block:
+		case <-r.Context().Done():
+		}
+	})
+	discovery, port := newTestDiscovery(t, mux)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := discovery.DiscoverModels(ctx, "vllm", port)
 	if err == nil {
-		// Expected to fail - tests error handling
+		t.Fatal("expected timeout error")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("discovery did not respect context deadline (took %s)", elapsed)
+	}
+}
+
+func TestDiscoverModels_HTTPError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/models", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "loading", http.StatusServiceUnavailable)
+	})
+	discovery, port := newTestDiscovery(t, mux)
+
+	if _, err := discovery.DiscoverModels(context.Background(), "vllm", port); err == nil {
+		t.Fatal("expected error for non-200 response")
 	}
 }
 
@@ -74,46 +191,73 @@ func TestDiscoverModelsUnsupportedType(t *testing.T) {
 
 	_, err := discovery.DiscoverModels(context.Background(), "unsupported", 8000)
 	if err == nil {
-		t.Error("expected error for unsupported service type")
+		t.Fatal("expected error for unsupported service type")
 	}
 	if !strings.Contains(err.Error(), "unsupported service type") {
 		t.Errorf("expected 'unsupported service type' error, got: %v", err)
 	}
 }
 
-func TestCheckVLLMHealth(t *testing.T) {
-	// Create mock healthy vLLM server
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/health" {
-			w.WriteHeader(http.StatusOK)
-			return
-		}
-		http.NotFound(w, r)
-	}))
-	defer server.Close()
-
-	discovery := NewModelDiscovery()
-
-	// Test with unreachable port (tests unhealthy path)
-	health, err := discovery.CheckServiceHealth(context.Background(), "vllm", 99999)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+func TestEngineTypeFromName(t *testing.T) {
+	cases := map[string]string{
+		"vllm":           "vllm",
+		"citadel-vllm":   "vllm",
+		"ollama":         "ollama", // must NOT match llamacpp despite containing "llama"
+		"my-ollama-1":    "ollama",
+		"llamacpp":       "llamacpp",
+		"llama.cpp":      "llamacpp",
+		"llama-cpp":      "llamacpp",
+		"transcribe":     "",
+		"gotenberg":      "",
+		"postgres":       "",
+		"LLAMACPP-serve": "llamacpp",
 	}
-	if health != HealthStatusUnhealthy {
-		t.Errorf("expected 'unhealthy' for unreachable server, got '%s'", health)
+	for name, want := range cases {
+		if got := EngineTypeFromName(name); got != want {
+			t.Errorf("EngineTypeFromName(%q) = %q, want %q", name, got, want)
+		}
 	}
 }
 
-func TestCheckOllamaHealth(t *testing.T) {
-	discovery := NewModelDiscovery()
+func TestCheckServiceHealth(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("Ollama is running"))
+	})
+	discovery, port := newTestDiscovery(t, mux)
 
-	// Test with unreachable port
-	health, err := discovery.CheckServiceHealth(context.Background(), "ollama", 99999)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+	for _, engine := range []string{"vllm", "llamacpp", "ollama"} {
+		health, err := discovery.CheckServiceHealth(context.Background(), engine, port)
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", engine, err)
+		}
+		if health != HealthStatusOK {
+			t.Errorf("%s: expected ok, got %s", engine, health)
+		}
 	}
-	if health != HealthStatusUnhealthy {
-		t.Errorf("expected 'unhealthy' for unreachable server, got '%s'", health)
+}
+
+func TestCheckServiceHealthUnreachable(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to reserve port: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close()
+
+	discovery := NewModelDiscovery()
+	discovery.host = "127.0.0.1"
+	for _, engine := range []string{"vllm", "llamacpp", "ollama"} {
+		health, err := discovery.CheckServiceHealth(context.Background(), engine, port)
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", engine, err)
+		}
+		if health != HealthStatusUnhealthy {
+			t.Errorf("%s: expected unhealthy for unreachable server, got %s", engine, health)
+		}
 	}
 }
 
@@ -133,103 +277,12 @@ func TestNewModelDiscovery(t *testing.T) {
 	discovery := NewModelDiscovery()
 
 	if discovery == nil {
-		t.Error("expected non-nil discovery")
+		t.Fatal("expected non-nil discovery")
 	}
 	if discovery.httpClient == nil {
 		t.Error("expected non-nil http client")
 	}
-}
-
-// TestDiscoverModelsIntegration is a more comprehensive integration test
-// that uses a real HTTP server to test the full flow
-func TestDiscoverModelsIntegrationVLLM(t *testing.T) {
-	// Create mock vLLM server with OpenAI-compatible /v1/models endpoint
-	handler := http.NewServeMux()
-	handler.HandleFunc("/v1/models", func(w http.ResponseWriter, r *http.Request) {
-		resp := map[string]interface{}{
-			"data": []map[string]interface{}{
-				{"id": "llama-3-8b", "object": "model"},
-				{"id": "mistral-7b", "object": "model"},
-			},
-		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
-	})
-	handler.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-
-	server := httptest.NewServer(handler)
-	defer server.Close()
-
-	// The test server runs on a random port, so we can't test the actual
-	// discovery without modifying the code to accept a base URL.
-	// This test validates the server handler setup works correctly.
-	resp, err := http.Get(server.URL + "/v1/models")
-	if err != nil {
-		t.Fatalf("failed to reach test server: %v", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("expected 200, got %d", resp.StatusCode)
-	}
-
-	var result struct {
-		Data []struct {
-			ID string `json:"id"`
-		} `json:"data"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		t.Fatalf("failed to decode response: %v", err)
-	}
-
-	if len(result.Data) != 2 {
-		t.Errorf("expected 2 models, got %d", len(result.Data))
-	}
-}
-
-func TestDiscoverModelsIntegrationOllama(t *testing.T) {
-	// Create mock Ollama server with /api/tags endpoint
-	handler := http.NewServeMux()
-	handler.HandleFunc("/api/tags", func(w http.ResponseWriter, r *http.Request) {
-		resp := map[string]interface{}{
-			"models": []map[string]interface{}{
-				{"name": "llama2:latest", "size": 3826793677},
-				{"name": "codellama:7b", "size": 3826793677},
-			},
-		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
-	})
-	handler.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("Ollama is running"))
-	})
-
-	server := httptest.NewServer(handler)
-	defer server.Close()
-
-	// Validate the server setup
-	resp, err := http.Get(server.URL + "/api/tags")
-	if err != nil {
-		t.Fatalf("failed to reach test server: %v", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("expected 200, got %d", resp.StatusCode)
-	}
-
-	var result struct {
-		Models []struct {
-			Name string `json:"name"`
-		} `json:"models"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		t.Fatalf("failed to decode response: %v", err)
-	}
-
-	if len(result.Models) != 2 {
-		t.Errorf("expected 2 models, got %d", len(result.Models))
+	if discovery.host != "localhost" {
+		t.Errorf("expected default host localhost, got %q", discovery.host)
 	}
 }


### PR DESCRIPTION
Replaces #533 (whose branch never received GitHub Actions webhooks despite open/synchronize/reopen events — recreated as a cherry-pick onto current main; one trivial import conflict with #527 resolved).

## Context
Closes #529. Nothing reported which model vllm/ollama/llamacpp actually serves — `citadel status`, heartbeat, and the platform ("Engines: None reported") were all blind.

## Root Cause
Model discovery existed (`internal/status/models.go`) but was dead code — only reachable via a `Services` list every production collector passed as nil.

## Changes
- `collectManagedEngineStatus` probes vllm/ollama/llamacpp (2s-bounded, failure-safe) and sets `ServiceInfo.Models` → heartbeat `status.services[].models`
- Engines running with no loaded model are now emitted (fixes "Engines: None reported")
- ollama `/api/tags` → `/api/ps` (loaded, not downloaded); llamacpp `/v1/models` + `/health` added
- `citadel status`: `- vllm: 🟢 RUNNING (Qwen/Qwen3-8B)`

## Testing
- build/vet/test pass on the rebased branch; httptest-backed discovery tests
- Live-verified on ubuntu-gpu-1: heartbeat carries `"models": ["Qwen/Qwen3-8B"]`; status line renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)