### PR TITLE
fix(reconcile): fetch desired-state by Headscale node_id + default pull ON (#535)

### DIFF
--- a/cmd/module_ops.go
+++ b/cmd/module_ops.go
@@ -28,11 +28,13 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/redisapi"
 )
 
-// newReconcileLoop builds the config-gated desired-state PULL reconcile loop
-// (aceteam#4273), or returns nil when the operator has not opted in
-// (CITADEL_RECONCILE_PULL unset/false) so the feature adds zero cost by default.
+// newReconcileLoop builds the desired-state PULL reconcile loop (aceteam#4273).
+// The loop is ON by default; it returns nil only when the operator has hit the
+// CITADEL_RECONCILE_PULL kill switch, or when there is no client / node ID to
+// key it by. A node with no desired-state rows converges to a no-op (see
+// RefuseFullWipe below), so default-on adds no churn for unmanaged nodes.
 //
-// When enabled it wires the ProtoProvider (fetch DesiredState + report
+// It wires the ProtoProvider (fetch DesiredState + report
 // ActualState as protobuf over the device-authed client) onto the SAME live
 // ModuleOps adapter and reconcile engine the MODULE_SET handler uses, so a pulled
 // desired state converges through exactly the tested install/uninstall/start/stop
@@ -50,7 +52,7 @@ import (
 // matches, leaving the loop non-functional. Returns nil when nodeID is empty so
 // the loop is skipped rather than started under a wrong key.
 func newReconcileLoop(client *redisapi.Client, nodeID string) *reconcile.Loop {
-	if !reconcile.PullEnabled() {
+	if reconcile.PullDisabled() {
 		return nil
 	}
 	if client == nil || nodeID == "" {

--- a/cmd/module_ops.go
+++ b/cmd/module_ops.go
@@ -41,8 +41,14 @@ import (
 //
 // It must be wired in the WORKER path only (never also the control center): the
 // converge loop is not idempotent telemetry, and two loops on one node would
-// double-apply install/uninstall. The backend serve endpoint does not exist yet,
-// so even when enabled the loop's fetches error until that paired follow-up ships.
+// double-apply install/uninstall.
+//
+// nodeID MUST be the Headscale numeric node ID (e.g. "1084"), NOT the hostname
+// (aceteam#535). The desired-state serve endpoint matches rows by a raw
+// `.eq("node_id", <path param>)` against `fabric_node_status.node_id` (the
+// Headscale numeric ID the backend upserts from heartbeats); a hostname never
+// matches, leaving the loop non-functional. Returns nil when nodeID is empty so
+// the loop is skipped rather than started under a wrong key.
 func newReconcileLoop(client *redisapi.Client, nodeID string) *reconcile.Loop {
 	if !reconcile.PullEnabled() {
 		return nil

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1436,13 +1436,12 @@ func runWork(cmd *cobra.Command, args []string) {
 					fmt.Printf("   - Node-state reporting: every %s\n", nodestate.DefaultInterval)
 				}
 
-				// Optional, config-gated (default OFF) desired-state PULL reconcile
-				// loop (aceteam#4273). When the operator opts in via
-				// CITADEL_RECONCILE_PULL, the node periodically pulls its
-				// control-plane-assigned DesiredState (protobuf) and converges via the
-				// SAME reconcile engine + live ModuleOps adapter MODULE_SET uses. Wired
-				// in the worker path ONLY (never the control center) so a node runs
-				// exactly one converge loop.
+				// Desired-state PULL reconcile loop (aceteam#4273), ON by default.
+				// The node periodically pulls its control-plane-assigned DesiredState
+				// (protobuf) and converges via the SAME reconcile engine + live
+				// ModuleOps adapter MODULE_SET uses. Wired in the worker path ONLY
+				// (never the control center) so a node runs exactly one converge loop.
+				// Disable fleet-wide with the CITADEL_RECONCILE_PULL kill switch.
 				//
 				// The loop is keyed by the Headscale numeric node ID, NOT the hostname
 				// (aceteam#535). The desired-state serve endpoint matches rows by a raw
@@ -1465,11 +1464,12 @@ func runWork(cmd *cobra.Command, args []string) {
 						}
 					}()
 					fmt.Printf("   - Desired-state pull: ENABLED (reconcile every %s)\n", reconcile.DefaultInterval)
-				} else if reconcile.PullEnabled() && headscaleNodeID == "" {
-					// Opted in but the Headscale ID never resolved: skip rather than
-					// fetch/report under the wrong key. Log why — a silent skip here is
-					// exactly the non-functional-loop failure aceteam#535 describes.
-					fmt.Fprintln(os.Stderr, "   - ⚠️ Desired-state pull requested (CITADEL_RECONCILE_PULL) but Headscale node ID is unresolved; skipping (fetching by the wrong key would never match desired rows)")
+				} else if !reconcile.PullDisabled() && headscaleNodeID == "" {
+					// Pull is on (not killed) but the Headscale ID never resolved: skip
+					// rather than fetch/report under the wrong key. Log why — a silent
+					// skip here is exactly the non-functional-loop failure aceteam#535
+					// describes.
+					fmt.Fprintln(os.Stderr, "   - ⚠️ Desired-state pull enabled but Headscale node ID is unresolved; skipping (fetching by the wrong key would never match desired rows)")
 				}
 
 				apiPublisher, err := heartbeat.NewAPIPublisher(heartbeat.APIPublisherConfig{

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1442,10 +1442,18 @@ func runWork(cmd *cobra.Command, args []string) {
 				// control-plane-assigned DesiredState (protobuf) and converges via the
 				// SAME reconcile engine + live ModuleOps adapter MODULE_SET uses. Wired
 				// in the worker path ONLY (never the control center) so a node runs
-				// exactly one converge loop. The backend serve endpoint is the paired
-				// follow-up; until it exists the loop's fetches error and it applies
-				// nothing.
-				if loop := newReconcileLoop(apiSource.Client(), nodeName); loop != nil {
+				// exactly one converge loop.
+				//
+				// The loop is keyed by the Headscale numeric node ID, NOT the hostname
+				// (aceteam#535). The desired-state serve endpoint matches rows by a raw
+				// `.eq("node_id", <path param>)` against `fabric_node_status.node_id`,
+				// which the backend upserts as the Headscale numeric ID (see
+				// python-backend/worker/node_status/worker.py). Fetching by hostname
+				// never matches any desired row, so the loop is non-functional. The
+				// report path is symmetric: the node-state worker re-resolves the
+				// reported id via `get_node_info`, which accepts the numeric ID, so
+				// reporting the numeric ID keys `node_module_state` correctly too.
+				if loop := newReconcileLoop(apiSource.Client(), headscaleNodeID); loop != nil {
 					go func() {
 						runErr := loop.Run(ctx, func(_ reconcile.Plan, _ reconcile.ApplyResult, passErr error) {
 							if passErr != nil {
@@ -1457,6 +1465,11 @@ func runWork(cmd *cobra.Command, args []string) {
 						}
 					}()
 					fmt.Printf("   - Desired-state pull: ENABLED (reconcile every %s)\n", reconcile.DefaultInterval)
+				} else if reconcile.PullEnabled() && headscaleNodeID == "" {
+					// Opted in but the Headscale ID never resolved: skip rather than
+					// fetch/report under the wrong key. Log why — a silent skip here is
+					// exactly the non-functional-loop failure aceteam#535 describes.
+					fmt.Fprintln(os.Stderr, "   - ⚠️ Desired-state pull requested (CITADEL_RECONCILE_PULL) but Headscale node ID is unresolved; skipping (fetching by the wrong key would never match desired rows)")
 				}
 
 				apiPublisher, err := heartbeat.NewAPIPublisher(heartbeat.APIPublisherConfig{

--- a/internal/reconcile/config_env.go
+++ b/internal/reconcile/config_env.go
@@ -5,19 +5,23 @@ import (
 	"strings"
 )
 
-// PullEnvVar gates the desired-state PULL reconcile loop (aceteam#4273). The
-// loop is OFF unless this is explicitly set to a truthy value ("1", "true",
-// "yes", "on"), mirroring status.AutoStopEnvVar: a node NEVER accepts remote
-// desired-state management (which can install/uninstall compose stacks) unless
-// the operator has opted in.
+// PullEnvVar is an operator KILL SWITCH for the desired-state PULL reconcile
+// loop (aceteam#4273). The loop is ON by default — a node with control-plane
+// desired-state rows converges automatically. Set CITADEL_RECONCILE_PULL to a
+// falsy value ("0", "false", "no", "off") to disable it fleet-wide without a
+// binary rollback (emergency brake). Safety against a misconfigured control
+// plane wiping every module is provided independently by Reconciler.RefuseFullWipe,
+// which no-ops an empty desired state; the kill switch additionally covers
+// erroneous installs.
 const PullEnvVar = "CITADEL_RECONCILE_PULL"
 
-// PullEnabled reports whether the operator opted into the pull loop. Default is
-// false; any value other than a recognized truthy token leaves it off. Intended
-// to be read once at startup (the loop is wired or not for the process lifetime).
-func PullEnabled() bool {
+// PullDisabled reports whether the operator has explicitly turned the pull loop
+// OFF via the kill switch. Default (unset or any non-falsy value) is enabled.
+// Intended to be read once at startup (the loop is wired or not for the process
+// lifetime).
+func PullDisabled() bool {
 	switch strings.ToLower(strings.TrimSpace(os.Getenv(PullEnvVar))) {
-	case "1", "true", "yes", "on":
+	case "0", "false", "no", "off":
 		return true
 	default:
 		return false

--- a/internal/reconcile/config_env_test.go
+++ b/internal/reconcile/config_env_test.go
@@ -2,34 +2,37 @@ package reconcile
 
 import "testing"
 
-func TestPullEnabled(t *testing.T) {
+func TestPullDisabled(t *testing.T) {
 	cases := []struct {
 		val  string
 		want bool
 	}{
+		// Kill switch: only explicit falsy tokens disable.
+		{"false", true},
+		{"0", true},
+		{"off", true},
+		{"no", true},
+		{"FALSE", true},
+		{" off ", true},
+		// Default-on: unset or anything non-falsy keeps the loop enabled.
 		{"", false},
-		{"false", false},
-		{"0", false},
-		{"off", false},
+		{"1", false},
+		{"true", false},
+		{"on", false},
 		{"nope", false},
-		{"1", true},
-		{"true", true},
-		{"TRUE", true},
-		{" yes ", true},
-		{"on", true},
 	}
 	for _, c := range cases {
 		t.Setenv(PullEnvVar, c.val)
-		if got := PullEnabled(); got != c.want {
-			t.Errorf("PullEnabled() with %q = %v, want %v", c.val, got, c.want)
+		if got := PullDisabled(); got != c.want {
+			t.Errorf("PullDisabled() with %q = %v, want %v", c.val, got, c.want)
 		}
 	}
 }
 
-func TestPullEnabledDefaultsOffWhenUnset(t *testing.T) {
+func TestPullDefaultsOnWhenUnset(t *testing.T) {
 	// Ensure the var is not inherited from the environment.
 	t.Setenv(PullEnvVar, "")
-	if PullEnabled() {
-		t.Fatal("pull loop must default OFF when unset")
+	if PullDisabled() {
+		t.Fatal("pull loop must default ON when unset (kill switch not engaged)")
 	}
 }

--- a/internal/reconcile/proto_provider.go
+++ b/internal/reconcile/proto_provider.go
@@ -39,8 +39,12 @@ type ActualStateReporter interface {
 type ProtoProvider struct {
 	Fetcher  DesiredStateFetcher
 	Reporter ActualStateReporter
-	// NodeID is the Headscale hostname: the fetch path parameter and the identity
-	// stamped into the report envelope.
+	// NodeID is the Headscale numeric node ID (e.g. "1084"): the fetch path
+	// parameter AND the identity stamped into the report envelope. It must match
+	// `fabric_node_status.node_id`, which the backend keys by the Headscale
+	// numeric ID — the desired-state serve endpoint matches rows by a raw
+	// `.eq("node_id", NodeID)` with no hostname resolution, so a hostname here
+	// never matches any desired row (aceteam#535).
 	NodeID string
 	// Version is the citadel-cli version, reported as agent_version.
 	Version string

--- a/internal/reconcile/proto_provider_test.go
+++ b/internal/reconcile/proto_provider_test.go
@@ -169,3 +169,52 @@ func TestProtoProviderRevisionHandshakeThroughReconcileOnce(t *testing.T) {
 		t.Fatalf("handshake broken: applied_revision = %q, want rev-100", got.GetAppliedRevision())
 	}
 }
+
+// TestReconcileUsesHeadscaleNodeIDNotHostname is the regression guard for
+// aceteam#535: the pull loop must fetch desired-state AND report actual-state
+// under the Headscale numeric node ID, not the hostname. The desired-state serve
+// endpoint matches rows by a raw `.eq("node_id", <path param>)` against
+// `fabric_node_status.node_id` (keyed by the Headscale numeric ID), so fetching
+// by hostname never matches any desired row and the loop applies nothing.
+//
+// It drives a full ReconcileOnce with the numeric ID threaded exactly as
+// newReconcileLoop wires it (ProtoProvider.NodeID + Reconciler.Node), then
+// asserts the fetch path param and the reported envelope both carry the numeric
+// ID — never a hostname.
+func TestReconcileUsesHeadscaleNodeIDNotHostname(t *testing.T) {
+	const headscaleNodeID = "1084" // fabric_node_status.node_id — Headscale numeric ID
+	const hostname = "ubuntu-gpu"  // the WRONG key the loop used before #535
+
+	tr := &fakeTransport{desired: &fabricpb.DesiredState{
+		Revision: "rev-535",
+		Modules: []*fabricpb.DesiredModule{
+			{Source: "embedding", DesiredStatus: fabricpb.ModuleStatus_MODULE_STATUS_RUNNING},
+		},
+	}}
+	provider := NewProtoProvider(tr, tr, headscaleNodeID, "v1")
+	rec := NewReconciler(provider, newFakeOps(), headscaleNodeID)
+
+	if _, _, err := rec.ReconcileOnce(context.Background()); err != nil {
+		t.Fatalf("ReconcileOnce: %v", err)
+	}
+
+	// Fetch must request the numeric ID, so the serve endpoint's raw node_id match hits.
+	if tr.fetchNodeID != headscaleNodeID {
+		t.Errorf("fetch keyed by %q, want Headscale numeric ID %q", tr.fetchNodeID, headscaleNodeID)
+	}
+	if tr.fetchNodeID == hostname {
+		t.Errorf("fetch keyed by hostname %q — this is the #535 bug", hostname)
+	}
+
+	// Report must stamp the same numeric ID so node_module_state keys correctly.
+	var got fabricpb.ActualState
+	if err := proto.Unmarshal(tr.postBody, &got); err != nil {
+		t.Fatalf("decode posted report: %v", err)
+	}
+	if got.GetNodeId() != headscaleNodeID {
+		t.Errorf("report node_id = %q, want Headscale numeric ID %q", got.GetNodeId(), headscaleNodeID)
+	}
+	if got.GetNodeId() == hostname {
+		t.Errorf("report node_id = hostname %q — fetch/report identity must match the desired-row key", hostname)
+	}
+}


### PR DESCRIPTION
## Context

Two changes that together make the #4273 desired-state control plane actually functional on a real node, end to end.

1. **Node-identity fix (#535).** The pull reconcile loop fetched its DesiredState keyed by the node **hostname**, but the serve endpoint matches rows with a raw `.eq("node_id", <param>)` against `fabric_node_status.node_id` — which the backend upserts as the Headscale **numeric node ID** (e.g. `1084`) from heartbeats (`python-backend/worker/node_status/worker.py`, `routes/fabric_desired_state.py:125`). Fetching by hostname never matched any desired row, so the loop was silently non-functional.

2. **Default the pull loop ON.** It was opt-in behind `CITADEL_RECONCILE_PULL` (default OFF), so #4273 did nothing on a fresh node unless an operator set an env var. That gate was rollout scaffolding. Flip it: the loop is **ON by default**, and the env var inverts into a **kill switch** (`CITADEL_RECONCILE_PULL=0|false|no|off` disables fleet-wide without a binary rollback).

## Summary

**Identity (#535)**
- `cmd/work.go` passes `headscaleNodeID` (not `nodeName`) to `newReconcileLoop`; one `nodeID` arg drives both the fetch path param and the ActualState report envelope.
- Guard that logs-and-skips when pull is on but the Headscale ID is unresolved (same silent-failure class #535 describes), rather than fetching under the wrong key.
- Comment/doc fixes in `module_ops.go` + `proto_provider.go`; regression test `TestReconcileUsesHeadscaleNodeIDNotHostname`.
- Left the separate `nodestate.New` emitter on hostname deliberately — that's #5827 territory and the server re-resolves it; switching it would regress the startup race.

**Default-on kill switch**
- `PullEnabled()` → `PullDisabled()` (inverted default). Only explicit falsy tokens disable.
- `newReconcileLoop` returns nil only when killed, or when there's no client / node ID to key by.
- Safety unchanged: `RefuseFullWipe` still no-ops an empty desired state, so a node with **zero** desired rows converges to nothing. Default-on only activates convergence for nodes that actually have control-plane-assigned rows.

## Test plan

- `go build/vet/test ./...` all green.
- `internal/reconcile` kill-switch truth table (falsy disables; unset/truthy/garbage stay on).
- `cmd` reconcile identity regression test (fetch param + report envelope carry the numeric id, never the hostname).
- **Live convergence** on node 1084 (seed desired rows → observe converge) — done post-merge + release as the final #4273 confirm.

## Related

Closes #535. Unblocks #4273 (desired-state control plane).