### PR TITLE
feat(device): device mode — durable self-healing mesh identity for laptops (aceteam#5959)

### DIFF
--- a/cmd/device.go
+++ b/cmd/device.go
@@ -1,0 +1,354 @@
+// cmd/device.go
+// Device mode (#5959): give plain mesh devices (laptops) the same durable
+// fabric identity Citadel nodes have, so their mesh membership self-heals
+// instead of silently expiring.
+//
+// A device is NOT a compute node — no worker, no job queues. It:
+//  1. enrolls interactively once (browser approve = the trust-root event),
+//     receiving an org authkey + a long-TTL fabric CA leaf for its keypair;
+//  2. joins the mesh through the SYSTEM tailscale client (incl. the macOS
+//     App Store app), not embedded tsnet;
+//  3. runs a tiny daemon that watches the session and, when it breaks or the
+//     node key nears expiry, proves possession of its leaf over mTLS to the
+//     nexus reenroll service, gets a fresh org authkey, and re-runs
+//     tailscale up. Membership becomes derived state; offboarding is one CRL
+//     revocation.
+//
+// Bonus: an enrolled laptop is a ready BYOC candidate — the identity store is
+// the same one `citadel init` uses, so flipping device -> node later is a
+// config change, not a re-enrollment.
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/devicemode"
+	"github.com/aceteam-ai/citadel-cli/internal/nodeidentity"
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
+	"github.com/aceteam-ai/citadel-cli/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+// deviceCheckIntervalEnv overrides the daemon's health-check interval in
+// seconds. Non-positive values fall back to the default (they do NOT disable
+// the loop — a disabled device daemon is just a stopped daemon).
+const deviceCheckIntervalEnv = "CITADEL_DEVICE_CHECK_INTERVAL"
+
+const defaultDeviceCheckInterval = 15 * time.Minute
+
+var deviceCmd = &cobra.Command{
+	Use:   "device",
+	Short: "Enroll and maintain this machine as a personal device on your org's network",
+	Long: `Device mode connects a personal machine (laptop, workstation) to your
+organization's AceTeam Network with a durable, self-healing identity.
+
+Unlike 'citadel init' (which provisions a compute node), device mode runs no
+workloads. It enrolls this machine once via a browser approval, then keeps its
+network membership alive automatically: when the session breaks or its key
+nears expiry, the device proves its identity with a certificate and rejoins
+without any human involvement.
+
+Requires the Tailscale client to be installed (device mode drives it; it does
+not replace it).`,
+}
+
+var deviceEnrollCmd = &cobra.Command{
+	Use:   "enroll",
+	Short: "Enroll this machine as a device (one-time browser approval)",
+	Long: `Enroll generates this machine's identity keypair, opens an approval
+request, and prints a link (and QR code) for you to approve in your browser
+while signed in to AceTeam. On approval the machine receives:
+
+  - an identity certificate (issued by your org's fabric CA, ~1 year), and
+  - a one-time key to join your org's network,
+
+then joins the network via the system Tailscale client. Run
+'citadel device install' afterwards to keep the membership self-healing.`,
+	RunE: runDeviceEnroll,
+}
+
+var deviceRunCmd = &cobra.Command{
+	Use:   "run",
+	Short: "Run the device daemon (watches the session, self-heals it)",
+	RunE:  runDeviceDaemon,
+}
+
+var deviceStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show device identity and network session health",
+	RunE:  runDeviceStatus,
+}
+
+var deviceInstallCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Install the device daemon as a background service (launchd/systemd)",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if _, err := devicemode.LoadConfig(); err != nil {
+			return fmt.Errorf("this machine is not enrolled yet — run 'citadel device enroll' first")
+		}
+		if err := devicemode.InstallService(); err != nil {
+			return err
+		}
+		fmt.Println("✅ Device daemon installed. It will keep this machine's network membership alive.")
+		return nil
+	},
+}
+
+var deviceUninstallCmd = &cobra.Command{
+	Use:   "uninstall",
+	Short: "Remove the device daemon background service",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := devicemode.UninstallService(); err != nil {
+			return err
+		}
+		fmt.Println("Device daemon service removed.")
+		return nil
+	},
+}
+
+func runDeviceEnroll(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	store := nodeidentity.Default()
+	httpClient := &http.Client{Timeout: 15 * time.Second}
+
+	machineID, err := devicemode.MachineID()
+	if err != nil {
+		return err
+	}
+	hostname, _ := os.Hostname()
+
+	code, err := devicemode.NewPairingCode()
+	if err != nil {
+		return err
+	}
+
+	if err := devicemode.StartDevicePairing(
+		ctx, httpClient, authServiceURL, code, store, hostname, machineID,
+	); err != nil {
+		return err
+	}
+
+	pairURL := devicemode.PairURL(authServiceURL, code)
+	fmt.Println("Approve this device in your browser (you must be signed in to AceTeam):")
+	fmt.Printf("\n   %s\n\n", pairURL)
+	fmt.Println(ui.RenderQRCode(pairURL))
+	fmt.Println("Waiting for approval (link expires in 5 minutes)...")
+
+	result, err := devicemode.WaitForApproval(ctx, httpClient, authServiceURL, code)
+	if err != nil {
+		return err
+	}
+	fmt.Println("✅ Approved.")
+
+	if result.LeafPem == "" {
+		// Without a leaf there is no self-heal identity — the whole point of
+		// device mode. Join anyway (the authkey is valid) but be loud.
+		fmt.Fprintln(os.Stderr, "⚠️  The server did not issue an identity certificate (fabric CA inactive?).")
+		fmt.Fprintln(os.Stderr, "   This device will join the network but will NOT self-heal; re-enroll later.")
+	} else if err := store.StoreLeaf(result.LeafPem, result.ChainPem); err != nil {
+		return fmt.Errorf("store identity certificate: %w", err)
+	} else {
+		fmt.Printf("   Identity certificate stored (%s)\n", store.LeafPath())
+	}
+
+	cfg := &devicemode.Config{
+		NodeUID:     result.NodeUID,
+		NexusURL:    nexusURL,
+		ReenrollURL: reenrollURLFor(nexusURL),
+		APIBaseURL:  authServiceURL,
+	}
+	if err := devicemode.SaveConfig(cfg); err != nil {
+		return err
+	}
+
+	bin, err := devicemode.FindTailscale()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "⚠️  %v\n", err)
+		fmt.Fprintln(os.Stderr, "   Install Tailscale, then join manually with the authkey printed by")
+		fmt.Fprintln(os.Stderr, "   'citadel device status', or re-run 'citadel device enroll'.")
+		return fmt.Errorf("tailscale CLI not found")
+	}
+
+	fmt.Println("\n--- 🌐 Joining your org's network ---")
+	if err := devicemode.Up(ctx, bin, cfg.NexusURL, result.Authkey, false); err != nil {
+		return tailscaleUpErrorHint(err)
+	}
+
+	fmt.Println("✅ This device is enrolled and on your org's network.")
+	fmt.Println("   Run 'citadel device install' to keep it self-healing in the background.")
+	return nil
+}
+
+func runDeviceDaemon(cmd *cobra.Command, args []string) error {
+	cfg, err := devicemode.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("this machine is not enrolled yet — run 'citadel device enroll' first (%v)", err)
+	}
+	store := nodeidentity.Default()
+
+	interval := defaultDeviceCheckInterval
+	if raw := os.Getenv(deviceCheckIntervalEnv); raw != "" {
+		if secs, err := strconv.Atoi(raw); err == nil && secs > 0 {
+			interval = time.Duration(secs) * time.Second
+		}
+	}
+
+	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	fmt.Printf("Device daemon: node_uid=%s check every %s\n", cfg.NodeUID, interval)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	deviceTick(ctx, cfg, store)
+	for {
+		select {
+		case <-ctx.Done():
+			fmt.Println("Device daemon stopping.")
+			return nil
+		case <-ticker.C:
+			deviceTick(ctx, cfg, store)
+		}
+	}
+}
+
+// deviceTick runs one health evaluation + (if needed) self-heal pass. It never
+// returns an error: the daemon's job is to keep trying, so failures are logged
+// and retried next tick.
+func deviceTick(ctx context.Context, cfg *devicemode.Config, store *nodeidentity.Store) {
+	now := time.Now()
+
+	leaf, err := store.LoadLeaf()
+	if err != nil {
+		logDevice("no identity certificate (%v) — run 'citadel device enroll'", err)
+		return
+	}
+
+	bin, err := devicemode.FindTailscale()
+	if err != nil {
+		logDevice("%v", err)
+		return
+	}
+
+	tickCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+
+	st, err := devicemode.Status(tickCtx, bin)
+	if err != nil {
+		logDevice("cannot read tailscale status (%v) — is the Tailscale app/daemon running?", err)
+		return
+	}
+
+	decision := devicemode.Decide(st.BackendState, st.Self.KeyExpiry, leaf.NotAfter, now)
+	logDevice("state=%s leaf_expires=%s: %s",
+		st.BackendState, leaf.NotAfter.Format("2006-01-02"), decision.Reason)
+
+	if decision.LeafExpired {
+		return
+	}
+	if decision.LeafExpiresSoon {
+		logDevice("WARNING: identity certificate expires %s — re-run 'citadel device enroll' before then",
+			leaf.NotAfter.Format("2006-01-02"))
+	}
+	if !decision.Reenroll {
+		return
+	}
+
+	clientCert, err := devicemode.LoadClientCertificate(store)
+	if err != nil {
+		logDevice("self-heal blocked: %v", err)
+		return
+	}
+	result, err := devicemode.Reenroll(tickCtx, cfg.ReenrollURL, clientCert)
+	if err != nil {
+		logDevice("reenroll failed (will retry): %v", err)
+		return
+	}
+	logDevice("reenrolled as node_uid=%s; re-authenticating tailscale", result.NodeUID)
+
+	if err := devicemode.Up(tickCtx, bin, cfg.NexusURL, result.Authkey, true); err != nil {
+		logDevice("tailscale re-auth failed (will retry): %v", tailscaleUpErrorHint(err))
+		return
+	}
+	logDevice("session restored")
+}
+
+func runDeviceStatus(cmd *cobra.Command, args []string) error {
+	cfg, err := devicemode.LoadConfig()
+	if err != nil {
+		fmt.Println("Not enrolled. Run 'citadel device enroll' to add this machine to your org's network.")
+		return nil
+	}
+	fmt.Printf("Device:      node_uid=%s\n", cfg.NodeUID)
+	fmt.Printf("Coordinator: %s\n", cfg.NexusURL)
+
+	store := nodeidentity.Default()
+	now := time.Now()
+	var leafNotAfter time.Time
+	if leaf, err := store.LoadLeaf(); err != nil {
+		fmt.Printf("Identity:    MISSING (%v)\n", err)
+	} else {
+		leafNotAfter = leaf.NotAfter
+		days := int(leaf.NotAfter.Sub(now).Hours() / 24)
+		fmt.Printf("Identity:    certificate valid until %s (%d days)\n",
+			leaf.NotAfter.Format("2006-01-02"), days)
+	}
+
+	bin, err := devicemode.FindTailscale()
+	if err != nil {
+		fmt.Printf("Network:     %v\n", err)
+		return nil
+	}
+	st, err := devicemode.Status(cmd.Context(), bin)
+	if err != nil {
+		fmt.Printf("Network:     cannot read status (%v)\n", err)
+		return nil
+	}
+	fmt.Printf("Network:     %s\n", st.BackendState)
+	if st.Self.KeyExpiry != nil && !st.Self.KeyExpiry.IsZero() {
+		fmt.Printf("Key expiry:  %s\n", st.Self.KeyExpiry.Format(time.RFC3339))
+	}
+
+	if !leafNotAfter.IsZero() {
+		decision := devicemode.Decide(st.BackendState, st.Self.KeyExpiry, leafNotAfter, now)
+		fmt.Printf("Health:      %s\n", decision.Reason)
+	}
+	return nil
+}
+
+// reenrollURLFor derives the mTLS reenroll endpoint from the coordinator URL.
+func reenrollURLFor(nexus string) string {
+	return strings.TrimSuffix(nexus, "/") + "/fabric/reenroll"
+}
+
+// tailscaleUpErrorHint decorates a failed `tailscale up` with the most common
+// remedy (on Linux the tailscale socket is root-owned unless an operator is
+// configured).
+func tailscaleUpErrorHint(err error) error {
+	if platform.IsLinux() {
+		return fmt.Errorf("%w\nHint: allow your user to manage Tailscale once with:\n  sudo tailscale set --operator=$USER", err)
+	}
+	return err
+}
+
+func logDevice(format string, args ...interface{}) {
+	fmt.Printf("[%s] %s\n", time.Now().Format(time.RFC3339), fmt.Sprintf(format, args...))
+}
+
+func init() {
+	rootCmd.AddCommand(deviceCmd)
+	deviceCmd.AddCommand(deviceEnrollCmd)
+	deviceCmd.AddCommand(deviceRunCmd)
+	deviceCmd.AddCommand(deviceStatusCmd)
+	deviceCmd.AddCommand(deviceInstallCmd)
+	deviceCmd.AddCommand(deviceUninstallCmd)
+}

--- a/internal/devicemode/config.go
+++ b/internal/devicemode/config.go
@@ -1,0 +1,147 @@
+// Package devicemode implements the lightweight "device" profile for
+// non-Citadel mesh devices (laptops) — aceteam #5959.
+//
+// A device is NOT a compute node: no worker, no job queues, no Redis. It holds
+// the same fabric mTLS identity a Citadel node does (EC P-256 key + CA-signed
+// leaf, via internal/nodeidentity) and uses it for exactly one thing: keeping
+// its mesh membership alive. First join is interactive (browser approve on the
+// platform pairing page — the trust-root event); everything after is derived
+// from the leaf:
+//
+//	session broken / key expiring  ->  mTLS POST to the nexus reenroll service
+//	                               ->  fresh org authkey
+//	                               ->  re-run `tailscale up`
+//
+// Unlike Citadel nodes (embedded tsnet), a device babysits the SYSTEM
+// tailscale daemon — the Tailscale app people already run on laptops —
+// including the macOS App Store variant whose CLI lives inside Tailscale.app.
+package devicemode
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
+)
+
+const (
+	configFileName    = "device.json"
+	machineIDFileName = "machine-id"
+
+	// DefaultReenrollURL is the sovereign mTLS re-enrollment endpoint (#4583
+	// PR-3): nginx on nexus terminates client-cert TLS and forwards the
+	// handshake-verified leaf to the keyless verifier, which mints an org
+	// authkey. The platform API is deliberately NOT in this path.
+	DefaultReenrollURL = "https://nexus.aceteam.ai/fabric/reenroll"
+
+	// DefaultNexusURL is the mesh coordination server handed to
+	// `tailscale up --login-server`.
+	DefaultNexusURL = "https://nexus.aceteam.ai"
+)
+
+// Config is the persisted device-mode state written by `citadel device enroll`
+// and read by the daemon loop. It contains no secrets — the private key and
+// leaf live in the nodeidentity store (ConfigDir()/identity/).
+type Config struct {
+	// NodeUID is the stable fabric identity assigned at enrollment (the leaf's
+	// CN / aceteam:node: SAN value).
+	NodeUID string `json:"node_uid"`
+	// OrgName is display-only context from enrollment (may be empty).
+	OrgName string `json:"org_name,omitempty"`
+	// NexusURL is the login server for tailscale.
+	NexusURL string `json:"nexus_url"`
+	// ReenrollURL is the mTLS self-heal endpoint.
+	ReenrollURL string `json:"reenroll_url"`
+	// APIBaseURL is the platform base URL used at enrollment (pairing + CA chain).
+	APIBaseURL string `json:"api_base_url"`
+}
+
+// ConfigPath returns the device-mode config file location.
+func ConfigPath() string {
+	return filepath.Join(platform.ConfigDir(), configFileName)
+}
+
+// LoadConfig reads the persisted device config. A missing file returns
+// (nil, os.ErrNotExist) so callers can distinguish "not enrolled" from a
+// corrupt file.
+func LoadConfig() (*Config, error) {
+	return loadConfigFrom(ConfigPath())
+}
+
+func loadConfigFrom(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse device config %s: %w", path, err)
+	}
+	if cfg.NexusURL == "" {
+		cfg.NexusURL = DefaultNexusURL
+	}
+	if cfg.ReenrollURL == "" {
+		cfg.ReenrollURL = DefaultReenrollURL
+	}
+	return &cfg, nil
+}
+
+// SaveConfig persists the device config (0600 — no secrets, but it is
+// per-device state nobody else needs to read).
+func SaveConfig(cfg *Config) error {
+	return saveConfigTo(ConfigPath(), cfg)
+}
+
+func saveConfigTo(path string, cfg *Config) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal device config: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write device config: %w", err)
+	}
+	return nil
+}
+
+// MachineID returns a stable per-machine identifier used so a re-enrolled
+// device keeps its node_uid (the backend keys cert rows on (machine_id, org)).
+// It is a random ID persisted on first use — OS-agnostic and requiring no
+// privileged reads. Wiping the citadel config directory forfeits the mapping,
+// which simply yields a fresh node_uid on the next enrollment.
+func MachineID() (string, error) {
+	return machineIDAt(filepath.Join(platform.ConfigDir(), machineIDFileName))
+}
+
+func machineIDAt(path string) (string, error) {
+	if data, err := os.ReadFile(path); err == nil {
+		id := string(data)
+		if len(id) > 0 {
+			return trimNewline(id), nil
+		}
+	}
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate machine id: %w", err)
+	}
+	id := fmt.Sprintf("%x", buf)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return "", fmt.Errorf("create config dir: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(id+"\n"), 0o600); err != nil {
+		return "", fmt.Errorf("persist machine id: %w", err)
+	}
+	return id, nil
+}
+
+func trimNewline(s string) string {
+	for len(s) > 0 && (s[len(s)-1] == '\n' || s[len(s)-1] == '\r') {
+		s = s[:len(s)-1]
+	}
+	return s
+}

--- a/internal/devicemode/config_test.go
+++ b/internal/devicemode/config_test.go
@@ -1,0 +1,103 @@
+package devicemode
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestConfigRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "device.json")
+	in := &Config{
+		NodeUID:     "uid-123",
+		NexusURL:    "https://nexus.example",
+		ReenrollURL: "https://nexus.example/fabric/reenroll",
+		APIBaseURL:  "https://aceteam.example",
+	}
+	if err := saveConfigTo(path, in); err != nil {
+		t.Fatal(err)
+	}
+	out, err := loadConfigFrom(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if *out != *in {
+		t.Fatalf("round trip mismatch: %+v != %+v", out, in)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("config perms = %v, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestLoadConfigMissingIsNotExist(t *testing.T) {
+	_, err := loadConfigFrom(filepath.Join(t.TempDir(), "nope.json"))
+	if !os.IsNotExist(err) {
+		t.Fatalf("expected os.ErrNotExist, got %v", err)
+	}
+}
+
+func TestLoadConfigFillsDefaults(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "device.json")
+	if err := os.WriteFile(path, []byte(`{"node_uid": "uid-1"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := loadConfigFrom(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.NexusURL != DefaultNexusURL || cfg.ReenrollURL != DefaultReenrollURL {
+		t.Fatalf("defaults not applied: %+v", cfg)
+	}
+}
+
+func TestMachineIDStable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "machine-id")
+	first, err := machineIDAt(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 32 {
+		t.Fatalf("machine id length = %d, want 32 hex chars", len(first))
+	}
+	second, err := machineIDAt(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Fatalf("machine id not stable: %q != %q", first, second)
+	}
+}
+
+func TestPairingCodeShape(t *testing.T) {
+	seen := map[string]bool{}
+	for i := 0; i < 50; i++ {
+		code, err := NewPairingCode()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(code) != 6 {
+			t.Fatalf("code %q length != 6", code)
+		}
+		for _, c := range code {
+			if !((c >= 'A' && c <= 'Z') || (c >= '2' && c <= '9')) {
+				t.Fatalf("code %q contains invalid char %q", code, c)
+			}
+		}
+		seen[code] = true
+	}
+	if len(seen) < 40 {
+		t.Fatalf("codes look non-random: %d unique of 50", len(seen))
+	}
+}
+
+func TestPairURL(t *testing.T) {
+	got := PairURL("https://aceteam.ai", "ABC234")
+	if got != "https://aceteam.ai/fabric/pair?code=ABC234" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/internal/devicemode/health.go
+++ b/internal/devicemode/health.go
@@ -1,0 +1,92 @@
+// Pure self-heal decision logic for the device daemon (#5959).
+//
+// Kept free of I/O so the exact conditions under which a device reenrolls —
+// the load-bearing behavior of device mode — are unit-testable without a
+// tailscale daemon or a live mesh.
+package devicemode
+
+import (
+	"fmt"
+	"time"
+)
+
+const (
+	// KeyRenewThreshold: reenroll while the node key still has this much
+	// life left, so the session never actually lapses. Mirrors the node-side
+	// renewer's 24h threshold (internal/network/keyhealth.go).
+	KeyRenewThreshold = 24 * time.Hour
+
+	// LeafWarnThreshold: how close to leaf expiry the daemon starts warning.
+	// There is no leaf-renewal endpoint yet (see #5959 follow-ups), and the
+	// reenroll terminator rejects EXPIRED client certs at the TLS handshake,
+	// so an expiring leaf needs a fresh interactive enrollment before
+	// not_after — the warning is the operator's runway.
+	LeafWarnThreshold = 30 * 24 * time.Hour
+)
+
+// Decision is what the daemon should do this tick.
+type Decision struct {
+	// Reenroll: present the leaf to the reenroll service for a fresh authkey
+	// and re-run tailscale up.
+	Reenroll bool
+	// Reason is a human-readable explanation for the log line.
+	Reason string
+	// LeafExpiresSoon: warn the operator to re-enroll interactively.
+	LeafExpiresSoon bool
+	// LeafExpired: the leaf can no longer authenticate at the mTLS
+	// terminator; self-heal is impossible and the device must re-enroll
+	// interactively. Overrides Reenroll.
+	LeafExpired bool
+}
+
+// Decide evaluates one daemon tick.
+//
+// backendState is tailscale's BackendState; keyExpiry is the node key expiry
+// (nil = non-expiring); leafNotAfter is the fabric leaf's expiry.
+func Decide(backendState string, keyExpiry *time.Time, leafNotAfter, now time.Time) Decision {
+	d := Decision{}
+
+	if !leafNotAfter.After(now) {
+		// The nginx mTLS terminator refuses an expired client cert at the
+		// handshake, so the grace window is unreachable from a device: past
+		// not_after the only path back is interactive enrollment.
+		d.LeafExpired = true
+		d.Reason = fmt.Sprintf(
+			"fabric identity certificate expired %s — run 'citadel device enroll' to re-enroll",
+			leafNotAfter.Format(time.RFC3339),
+		)
+		return d
+	}
+	if leafNotAfter.Sub(now) < LeafWarnThreshold {
+		d.LeafExpiresSoon = true
+	}
+
+	switch backendState {
+	case "NeedsLogin", "NoState":
+		d.Reenroll = true
+		d.Reason = fmt.Sprintf("tailscale session needs login (state=%s)", backendState)
+		return d
+	case "Stopped":
+		// Deliberate `tailscale down` — respect the operator's choice; a
+		// fresh authkey would not start the engine anyway.
+		d.Reason = "tailscale is stopped (operator action); not intervening"
+		return d
+	}
+
+	if keyExpiry != nil && !keyExpiry.IsZero() {
+		until := keyExpiry.Sub(now)
+		if until <= 0 {
+			d.Reenroll = true
+			d.Reason = fmt.Sprintf("node key expired %s", keyExpiry.Format(time.RFC3339))
+			return d
+		}
+		if until < KeyRenewThreshold {
+			d.Reenroll = true
+			d.Reason = fmt.Sprintf("node key expires in %s (< %s)", until.Round(time.Minute), KeyRenewThreshold)
+			return d
+		}
+	}
+
+	d.Reason = "healthy"
+	return d
+}

--- a/internal/devicemode/health_test.go
+++ b/internal/devicemode/health_test.go
@@ -1,0 +1,95 @@
+package devicemode
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+var testNow = time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+
+func ptr(t time.Time) *time.Time { return &t }
+
+func TestDecideHealthy(t *testing.T) {
+	leafNotAfter := testNow.Add(200 * 24 * time.Hour)
+	keyExpiry := ptr(testNow.Add(90 * 24 * time.Hour))
+
+	d := Decide("Running", keyExpiry, leafNotAfter, testNow)
+	if d.Reenroll || d.LeafExpired || d.LeafExpiresSoon {
+		t.Fatalf("expected healthy no-op, got %+v", d)
+	}
+}
+
+func TestDecideNoKeyExpiry(t *testing.T) {
+	leafNotAfter := testNow.Add(200 * 24 * time.Hour)
+	d := Decide("Running", nil, leafNotAfter, testNow)
+	if d.Reenroll {
+		t.Fatalf("non-expiring key must not trigger reenroll: %+v", d)
+	}
+}
+
+func TestDecideNeedsLogin(t *testing.T) {
+	leafNotAfter := testNow.Add(200 * 24 * time.Hour)
+	d := Decide("NeedsLogin", nil, leafNotAfter, testNow)
+	if !d.Reenroll {
+		t.Fatalf("NeedsLogin must trigger reenroll: %+v", d)
+	}
+}
+
+func TestDecideStoppedRespectsOperator(t *testing.T) {
+	// `tailscale down` is a deliberate operator action; a fresh authkey would
+	// not restart the engine and we must not fight the user.
+	leafNotAfter := testNow.Add(200 * 24 * time.Hour)
+	d := Decide("Stopped", nil, leafNotAfter, testNow)
+	if d.Reenroll {
+		t.Fatalf("Stopped must not trigger reenroll: %+v", d)
+	}
+}
+
+func TestDecideKeyExpiringSoon(t *testing.T) {
+	leafNotAfter := testNow.Add(200 * 24 * time.Hour)
+	keyExpiry := ptr(testNow.Add(6 * time.Hour)) // < 24h threshold
+
+	d := Decide("Running", keyExpiry, leafNotAfter, testNow)
+	if !d.Reenroll {
+		t.Fatalf("key inside renew threshold must trigger reenroll: %+v", d)
+	}
+}
+
+func TestDecideKeyAlreadyExpired(t *testing.T) {
+	leafNotAfter := testNow.Add(200 * 24 * time.Hour)
+	keyExpiry := ptr(testNow.Add(-time.Hour))
+
+	d := Decide("Running", keyExpiry, leafNotAfter, testNow)
+	if !d.Reenroll {
+		t.Fatalf("expired key must trigger reenroll: %+v", d)
+	}
+}
+
+func TestDecideLeafExpiringSoonWarns(t *testing.T) {
+	leafNotAfter := testNow.Add(10 * 24 * time.Hour) // < 30d warn threshold
+	d := Decide("Running", nil, leafNotAfter, testNow)
+	if !d.LeafExpiresSoon {
+		t.Fatalf("leaf inside warn threshold must warn: %+v", d)
+	}
+	if d.Reenroll || d.LeafExpired {
+		t.Fatalf("warn-only case must not reenroll/expire: %+v", d)
+	}
+}
+
+func TestDecideLeafExpiredBlocksSelfHeal(t *testing.T) {
+	// The mTLS terminator rejects expired client certs at the handshake, so
+	// past not_after the ONLY path is interactive re-enrollment — even when
+	// the session is broken.
+	leafNotAfter := testNow.Add(-time.Hour)
+	d := Decide("NeedsLogin", nil, leafNotAfter, testNow)
+	if !d.LeafExpired {
+		t.Fatalf("expired leaf must be flagged: %+v", d)
+	}
+	if d.Reenroll {
+		t.Fatalf("expired leaf must suppress reenroll: %+v", d)
+	}
+	if !strings.Contains(d.Reason, "citadel device enroll") {
+		t.Fatalf("expired-leaf reason must point at the remedy, got %q", d.Reason)
+	}
+}

--- a/internal/devicemode/pairing.go
+++ b/internal/devicemode/pairing.go
@@ -1,0 +1,191 @@
+// Device enrollment via the platform's interactive pairing flow (#5959).
+//
+// The pairing flow is the same trust-root event Citadel OS nodes use, with
+// profile="device": the device generates a code + CSR, the operator approves
+// in a signed-in browser (aceteam.ai/fabric/pair?code=...), and the platform
+// returns an org authkey PLUS a long-TTL fabric CA leaf bound to the device's
+// key. The leaf is what makes everything afterwards derived state.
+package devicemode
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nodeidentity"
+)
+
+const (
+	// pairingPollInterval matches the backend's documented 2s node poll.
+	pairingPollInterval = 2 * time.Second
+	// pairingSessionTTL mirrors the backend's 5-minute session TTL; polling
+	// stops shortly after it since the session cannot confirm anymore.
+	pairingSessionTTL = 5 * time.Minute
+
+	codeAlphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789" // no 0/O/1/I ambiguity
+	codeLength   = 6
+)
+
+// devicePairingStartRequest is the pairing-start body with the device profile.
+// It extends the node request shape (nodeidentity.PairingStartRequest) with
+// the profile field the backend uses to select the device leaf TTL.
+type devicePairingStartRequest struct {
+	Code      string                `json:"code"`
+	NodeInfo  nodeidentity.NodeInfo `json:"node_info"`
+	CSRPem    string                `json:"csr_pem,omitempty"`
+	MachineID string                `json:"machine_id,omitempty"`
+	Profile   string                `json:"profile"`
+}
+
+// EnrollResult is what a confirmed pairing session yields.
+type EnrollResult struct {
+	Authkey  string
+	NodeUID  string
+	LeafPem  string
+	ChainPem string
+}
+
+// NewPairingCode generates a random 6-char pairing code from an unambiguous
+// alphabet.
+func NewPairingCode() (string, error) {
+	buf := make([]byte, codeLength)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate pairing code: %w", err)
+	}
+	code := make([]byte, codeLength)
+	for i, b := range buf {
+		code[i] = codeAlphabet[int(b)%len(codeAlphabet)]
+	}
+	return string(code), nil
+}
+
+// PairURL returns the browser approval URL the operator opens.
+func PairURL(apiBaseURL, code string) string {
+	return fmt.Sprintf("%s/fabric/pair?code=%s", apiBaseURL, code)
+}
+
+// StartDevicePairing opens a pairing session carrying the device CSR and
+// profile. The CSR is generated from the identity store's key (created on
+// first use), so the private key never leaves the machine.
+func StartDevicePairing(
+	ctx context.Context,
+	client *http.Client,
+	apiBaseURL, code string,
+	store *nodeidentity.Store,
+	hostname, machineID string,
+) error {
+	key, err := store.GetOrCreateKey()
+	if err != nil {
+		return fmt.Errorf("device identity key: %w", err)
+	}
+	csrPEM, err := store.GenerateCSR(key)
+	if err != nil {
+		return fmt.Errorf("generate CSR: %w", err)
+	}
+
+	body := devicePairingStartRequest{
+		Code:      code,
+		NodeInfo:  nodeidentity.NodeInfo{Hostname: hostname},
+		CSRPem:    string(csrPEM),
+		MachineID: machineID,
+		Profile:   "device",
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal pairing request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, apiBaseURL+"/api/fabric/pairing/start", bytes.NewReader(payload),
+	)
+	if err != nil {
+		return fmt.Errorf("build pairing request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("start pairing session: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("pairing start returned HTTP %d: %s", resp.StatusCode, raw)
+	}
+	return nil
+}
+
+// WaitForApproval polls the pairing status endpoint until the operator
+// approves in the browser, the session expires, or ctx is canceled.
+func WaitForApproval(
+	ctx context.Context,
+	client *http.Client,
+	apiBaseURL, code string,
+) (*EnrollResult, error) {
+	deadline := time.Now().Add(pairingSessionTTL + 30*time.Second)
+	ticker := time.NewTicker(pairingPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("pairing session expired without approval")
+		}
+
+		status, err := pollStatus(ctx, client, apiBaseURL, code)
+		if err != nil {
+			// Transient network errors should not abort an interactive wait.
+			continue
+		}
+		switch status.Status {
+		case "confirmed":
+			if status.Authkey == "" {
+				return nil, fmt.Errorf("pairing confirmed but no authkey returned")
+			}
+			return &EnrollResult{
+				Authkey:  status.Authkey,
+				NodeUID:  status.NodeUID,
+				LeafPem:  status.LeafPem,
+				ChainPem: status.ChainPem,
+			}, nil
+		case "expired":
+			return nil, fmt.Errorf("pairing session expired without approval")
+		}
+	}
+}
+
+func pollStatus(
+	ctx context.Context,
+	client *http.Client,
+	apiBaseURL, code string,
+) (*nodeidentity.PairingStatusResponse, error) {
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodGet,
+		fmt.Sprintf("%s/api/fabric/pairing/%s/status", apiBaseURL, code), nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("pairing status returned HTTP %d", resp.StatusCode)
+	}
+	var status nodeidentity.PairingStatusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
+		return nil, fmt.Errorf("parse pairing status: %w", err)
+	}
+	return &status, nil
+}

--- a/internal/devicemode/pairing_test.go
+++ b/internal/devicemode/pairing_test.go
@@ -1,0 +1,143 @@
+package devicemode
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nodeidentity"
+)
+
+// TestStartDevicePairingWireShape verifies the request body the platform's
+// pairing/start endpoint receives: device profile, CSR, machine_id — and that
+// the private key is NOT in it.
+func TestStartDevicePairingWireShape(t *testing.T) {
+	var received map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/fabric/pairing/start" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
+			t.Error(err)
+		}
+		_, _ = w.Write([]byte(`{"ok": true, "expires_in": 300}`))
+	}))
+	defer srv.Close()
+
+	store := nodeidentity.New(t.TempDir())
+	err := StartDevicePairing(
+		context.Background(), srv.Client(), srv.URL, "ABC234", store, "my-laptop", "machine-1",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if received["profile"] != "device" {
+		t.Fatalf("profile = %v, want device", received["profile"])
+	}
+	if received["machine_id"] != "machine-1" {
+		t.Fatalf("machine_id = %v", received["machine_id"])
+	}
+	csr, _ := received["csr_pem"].(string)
+	if csr == "" || !containsPEMBlock(csr, "CERTIFICATE REQUEST") {
+		t.Fatalf("csr_pem missing or malformed: %q", csr)
+	}
+	if containsPEMBlock(csr, "PRIVATE KEY") {
+		t.Fatal("private key leaked into pairing request")
+	}
+	nodeInfo, _ := received["node_info"].(map[string]any)
+	if nodeInfo["hostname"] != "my-laptop" {
+		t.Fatalf("hostname = %v", nodeInfo["hostname"])
+	}
+}
+
+func TestStartDevicePairingSurfacesHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"detail": "rate limited"}`))
+	}))
+	defer srv.Close()
+
+	store := nodeidentity.New(t.TempDir())
+	err := StartDevicePairing(
+		context.Background(), srv.Client(), srv.URL, "ABC234", store, "h", "m",
+	)
+	if err == nil {
+		t.Fatal("expected error on HTTP 429")
+	}
+}
+
+func TestWaitForApprovalConfirmed(t *testing.T) {
+	var polls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&polls, 1)
+		if n < 3 {
+			_, _ = w.Write([]byte(`{"status": "pending"}`))
+			return
+		}
+		_, _ = fmt.Fprint(w, `{
+			"status": "confirmed",
+			"authkey": "hskey-auth-abc",
+			"leaf_pem": "LEAF",
+			"chain_pem": "CHAIN",
+			"node_uid": "uid-1"
+		}`)
+	}))
+	defer srv.Close()
+
+	result, err := WaitForApproval(context.Background(), srv.Client(), srv.URL, "ABC234")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Authkey != "hskey-auth-abc" || result.NodeUID != "uid-1" ||
+		result.LeafPem != "LEAF" || result.ChainPem != "CHAIN" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if atomic.LoadInt32(&polls) < 3 {
+		t.Fatalf("expected >= 3 polls, got %d", polls)
+	}
+}
+
+func TestWaitForApprovalExpired(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"status": "expired"}`))
+	}))
+	defer srv.Close()
+
+	if _, err := WaitForApproval(context.Background(), srv.Client(), srv.URL, "ABC234"); err == nil {
+		t.Fatal("expected expiry error")
+	}
+}
+
+func TestWaitForApprovalConfirmedWithoutAuthkeyFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"status": "confirmed", "authkey": ""}`))
+	}))
+	defer srv.Close()
+
+	if _, err := WaitForApproval(context.Background(), srv.Client(), srv.URL, "ABC234"); err == nil {
+		t.Fatal("expected error for confirmed-without-authkey")
+	}
+}
+
+func TestWaitForApprovalHonorsContextCancel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"status": "pending"}`))
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := WaitForApproval(ctx, srv.Client(), srv.URL, "ABC234"); err == nil {
+		t.Fatal("expected context cancellation error")
+	}
+}
+
+func containsPEMBlock(s, blockType string) bool {
+	return strings.Contains(s, "-----BEGIN "+blockType+"-----")
+}

--- a/internal/devicemode/reenroll.go
+++ b/internal/devicemode/reenroll.go
@@ -1,0 +1,123 @@
+// mTLS self-heal client: present the fabric leaf to the nexus reenroll
+// service and receive a fresh org authkey (#5959, reusing #4583's machinery).
+//
+// The security model is proof-of-possession: the leaf PEM is public, so the
+// only thing that authenticates this call is the TLS client-auth handshake —
+// the caller must sign with the private key matching the leaf. nginx on nexus
+// verifies the chain at the handshake and forwards the verified cert to the
+// keyless verifier, which gates on grace + CRL and mints the authkey.
+package devicemode
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nodeidentity"
+)
+
+// ReenrollResult is the reenroll service's success payload.
+type ReenrollResult struct {
+	OK       bool   `json:"ok"`
+	Authkey  string `json:"authkey"`
+	NexusURL string `json:"nexus_url"`
+	NodeUID  string `json:"node_uid"`
+}
+
+// LoadClientCertificate assembles the TLS client certificate from the
+// identity store's leaf + private key. It fails with a pointed error when
+// either half is missing (device not enrolled yet).
+func LoadClientCertificate(store *nodeidentity.Store) (tls.Certificate, error) {
+	if !store.HasKey() || !store.HasLeaf() {
+		return tls.Certificate{}, fmt.Errorf(
+			"no fabric identity found in %s — run 'citadel device enroll' first", store.Dir())
+	}
+	cert, err := tls.LoadX509KeyPair(store.LeafPath(), store.KeyPath())
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("load fabric identity: %w", err)
+	}
+	return cert, nil
+}
+
+// Reenroll POSTs to the mTLS reenroll endpoint with the device's leaf as the
+// TLS client certificate and returns the fresh org authkey. The endpoint's
+// server certificate is verified against the system roots (nexus serves a
+// public TLS cert).
+func Reenroll(ctx context.Context, reenrollURL string, clientCert tls.Certificate) (*ReenrollResult, error) {
+	return reenrollWithRoots(ctx, reenrollURL, clientCert, nil)
+}
+
+// reenrollWithRoots is the testable core: rootCAs == nil means system roots.
+func reenrollWithRoots(
+	ctx context.Context,
+	reenrollURL string,
+	clientCert tls.Certificate,
+	rootCAs *x509.CertPool,
+) (*ReenrollResult, error) {
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				Certificates: []tls.Certificate{clientCert},
+				RootCAs:      rootCAs,
+				MinVersion:   tls.VersionTLS12,
+			},
+		},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reenrollURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build reenroll request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("reenroll request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if err != nil {
+		return nil, fmt.Errorf("read reenroll response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, reenrollError(resp.StatusCode, body)
+	}
+
+	var result ReenrollResult
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("parse reenroll response: %w", err)
+	}
+	if result.Authkey == "" {
+		return nil, fmt.Errorf("reenroll succeeded but returned no authkey")
+	}
+	return &result, nil
+}
+
+// reenrollError maps the reenroll service's documented status codes to
+// operator-actionable errors (mirrors nexus reenroll/app.py's error table).
+func reenrollError(status int, body []byte) error {
+	detail := strings.TrimSpace(string(body))
+	switch status {
+	case http.StatusForbidden:
+		return fmt.Errorf(
+			"reenroll refused (HTTP 403 — certificate revoked or past grace): %s\n"+
+				"Re-enroll this device with 'citadel device enroll'", detail)
+	case http.StatusUnauthorized:
+		return fmt.Errorf(
+			"reenroll refused (HTTP 401 — certificate not trusted by the fabric CA): %s", detail)
+	case http.StatusServiceUnavailable:
+		return fmt.Errorf(
+			"reenroll unavailable (HTTP 503 — revocation status unavailable, fail-closed); "+
+				"will retry: %s", detail)
+	default:
+		return fmt.Errorf("reenroll returned HTTP %d: %s", status, detail)
+	}
+}

--- a/internal/devicemode/reenroll_test.go
+++ b/internal/devicemode/reenroll_test.go
@@ -1,0 +1,227 @@
+package devicemode
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nodeidentity"
+)
+
+// testPKI builds an in-memory CA, a server cert for 127.0.0.1, and a
+// CA-signed client leaf — the same trust shape as nginx + the fabric CA.
+type testPKI struct {
+	caPool     *x509.CertPool
+	serverCert tls.Certificate
+	clientCert tls.Certificate
+	clientPEM  []byte
+	clientKey  []byte
+}
+
+func newTestPKI(t *testing.T) *testPKI {
+	t.Helper()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-fabric-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := x509.NewCertPool()
+	pool.AddCert(caCert)
+
+	newLeaf := func(cn string, isServer bool) (tls.Certificate, []byte, []byte) {
+		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		tmpl := &x509.Certificate{
+			SerialNumber: big.NewInt(time.Now().UnixNano()),
+			Subject:      pkix.Name{CommonName: cn},
+			NotBefore:    time.Now().Add(-time.Hour),
+			NotAfter:     time.Now().Add(12 * time.Hour),
+			KeyUsage:     x509.KeyUsageDigitalSignature,
+		}
+		if isServer {
+			tmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+			tmpl.IPAddresses = []net.IP{net.ParseIP("127.0.0.1")}
+		} else {
+			tmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+		}
+		der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, &key.PublicKey, caKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+		keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+		cert, err := tls.X509KeyPair(certPEM, keyPEM)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return cert, certPEM, keyPEM
+	}
+
+	serverCert, _, _ := newLeaf("127.0.0.1", true)
+	clientCert, clientPEM, clientKey := newLeaf("device-node-uid", false)
+
+	return &testPKI{
+		caPool:     pool,
+		serverCert: serverCert,
+		clientCert: clientCert,
+		clientPEM:  clientPEM,
+		clientKey:  clientKey,
+	}
+}
+
+// startMTLSServer runs an httptest TLS server that REQUIRES a client cert
+// chaining to the test CA — mirroring the nginx terminator's contract.
+func startMTLSServer(t *testing.T, pki *testPKI, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewUnstartedServer(handler)
+	srv.TLS = &tls.Config{
+		Certificates: []tls.Certificate{pki.serverCert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    pki.caPool,
+		MinVersion:   tls.VersionTLS12,
+	}
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestReenrollSuccess(t *testing.T) {
+	pki := newTestPKI(t)
+	var sawClientCert bool
+	srv := startMTLSServer(t, pki, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
+			sawClientCert = true
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok": true, "authkey": "hskey-auth-fresh", "nexus_url": "https://nexus.test", "node_uid": "device-node-uid"}`))
+	})
+
+	result, err := reenrollWithRoots(context.Background(), srv.URL, pki.clientCert, pki.caPool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sawClientCert {
+		t.Fatal("server did not receive the client certificate")
+	}
+	if result.Authkey != "hskey-auth-fresh" || result.NodeUID != "device-node-uid" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func TestReenrollWithoutClientCertRejectedAtHandshake(t *testing.T) {
+	// Proof-of-possession is the security property: without the private key
+	// the TLS handshake itself must fail — the handler is never reached.
+	pki := newTestPKI(t)
+	srv := startMTLSServer(t, pki, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler must not be reached without a client cert")
+	})
+
+	_, err := reenrollWithRoots(context.Background(), srv.URL, tls.Certificate{}, pki.caPool)
+	if err == nil {
+		t.Fatal("expected handshake failure without client cert")
+	}
+}
+
+func TestReenrollErrorMapping(t *testing.T) {
+	pki := newTestPKI(t)
+	cases := []struct {
+		status  int
+		body    string
+		wantSub string
+	}{
+		{http.StatusForbidden, `{"error":"certificate revoked"}`, "citadel device enroll"},
+		{http.StatusUnauthorized, `{"error":"not trusted"}`, "not trusted"},
+		{http.StatusServiceUnavailable, `{"error":"CRL unavailable"}`, "will retry"},
+		{http.StatusBadGateway, `{"error":"headscale down"}`, "HTTP 502"},
+	}
+	for _, tc := range cases {
+		srv := startMTLSServer(t, pki, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(tc.status)
+			_, _ = w.Write([]byte(tc.body))
+		})
+		_, err := reenrollWithRoots(context.Background(), srv.URL, pki.clientCert, pki.caPool)
+		if err == nil {
+			t.Fatalf("status %d: expected error", tc.status)
+		}
+		if !strings.Contains(err.Error(), tc.wantSub) {
+			t.Fatalf("status %d: error %q missing %q", tc.status, err.Error(), tc.wantSub)
+		}
+		srv.Close()
+	}
+}
+
+func TestReenrollRejectsEmptyAuthkey(t *testing.T) {
+	pki := newTestPKI(t)
+	srv := startMTLSServer(t, pki, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"ok": true, "authkey": ""}`))
+	})
+	if _, err := reenrollWithRoots(context.Background(), srv.URL, pki.clientCert, pki.caPool); err == nil {
+		t.Fatal("expected error for empty authkey")
+	}
+}
+
+func TestLoadClientCertificate(t *testing.T) {
+	pki := newTestPKI(t)
+	dir := t.TempDir()
+	store := nodeidentity.New(dir)
+
+	// Not enrolled: pointed error.
+	if _, err := LoadClientCertificate(store); err == nil ||
+		!strings.Contains(err.Error(), "citadel device enroll") {
+		t.Fatalf("expected not-enrolled error, got %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "node.key"), pki.clientKey, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "node.crt"), pki.clientPEM, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cert, err := LoadClientCertificate(store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cert.Certificate) == 0 {
+		t.Fatal("loaded certificate is empty")
+	}
+}

--- a/internal/devicemode/service.go
+++ b/internal/devicemode/service.go
@@ -1,0 +1,193 @@
+// Background-service installation for the device daemon (#5959).
+//
+// Deliberately separate from internal/service (which manages the Citadel node
+// agent under the ai.aceteam.citadel label): a laptop in device mode is not a
+// node, and flipping it into one later must not collide with this unit. The
+// daemon runs as a per-user service — device mode never needs root.
+//
+//	macOS: ~/Library/LaunchAgents/ai.aceteam.citadel-device.plist
+//	Linux: ~/.config/systemd/user/citadel-device.service
+package devicemode
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+)
+
+const (
+	// LaunchdLabel identifies the macOS LaunchAgent.
+	LaunchdLabel = "ai.aceteam.citadel-device"
+	// SystemdUnitName identifies the Linux systemd user unit.
+	SystemdUnitName = "citadel-device.service"
+)
+
+// LaunchdPlist renders the LaunchAgent plist that keeps `citadel device run`
+// alive across logins. Exported for tests.
+func LaunchdPlist(execPath, home string) string {
+	logDir := filepath.Join(home, "Library", "Logs", "citadel")
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>%s</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>%s</string>
+        <string>device</string>
+        <string>run</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>%s/citadel-device.log</string>
+    <key>StandardErrorPath</key>
+    <string>%s/citadel-device.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>%s</string>
+    </dict>
+</dict>
+</plist>
+`, LaunchdLabel, execPath, logDir, logDir, home)
+}
+
+// SystemdUnit renders the systemd user unit for the device daemon. Exported
+// for tests.
+func SystemdUnit(execPath string) string {
+	return fmt.Sprintf(`[Unit]
+Description=AceTeam device identity daemon (citadel device run)
+After=network-online.target
+
+[Service]
+ExecStart=%s device run
+Restart=always
+RestartSec=30
+
+[Install]
+WantedBy=default.target
+`, execPath)
+}
+
+// InstallService installs and starts the device daemon as a per-user service
+// for the current OS.
+func InstallService() error {
+	execPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve citadel binary path: %w", err)
+	}
+	if execPath, err = filepath.EvalSymlinks(execPath); err != nil {
+		return fmt.Errorf("resolve citadel binary path: %w", err)
+	}
+
+	switch runtime.GOOS {
+	case "darwin":
+		return installLaunchd(execPath)
+	case "linux":
+		return installSystemdUser(execPath)
+	default:
+		return fmt.Errorf(
+			"automatic service install is not supported on %s yet; "+
+				"run 'citadel device run' under your preferred supervisor", runtime.GOOS)
+	}
+}
+
+// UninstallService stops and removes the per-user device daemon service.
+func UninstallService() error {
+	switch runtime.GOOS {
+	case "darwin":
+		pp, err := launchdPlistPath()
+		if err != nil {
+			return err
+		}
+		_ = exec.Command("launchctl", "unload", pp).Run()
+		if err := os.Remove(pp); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove plist: %w", err)
+		}
+		return nil
+	case "linux":
+		_ = exec.Command("systemctl", "--user", "disable", "--now", SystemdUnitName).Run()
+		up, err := systemdUnitPath()
+		if err != nil {
+			return err
+		}
+		if err := os.Remove(up); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove unit: %w", err)
+		}
+		return nil
+	default:
+		return fmt.Errorf("automatic service uninstall is not supported on %s", runtime.GOOS)
+	}
+}
+
+func launchdPlistPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("determine home directory: %w", err)
+	}
+	return filepath.Join(home, "Library", "LaunchAgents", LaunchdLabel+".plist"), nil
+}
+
+func systemdUnitPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("determine home directory: %w", err)
+	}
+	return filepath.Join(home, ".config", "systemd", "user", SystemdUnitName), nil
+}
+
+func installLaunchd(execPath string) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("determine home directory: %w", err)
+	}
+	pp, err := launchdPlistPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(pp), 0o755); err != nil {
+		return fmt.Errorf("create LaunchAgents dir: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, "Library", "Logs", "citadel"), 0o755); err != nil {
+		return fmt.Errorf("create log dir: %w", err)
+	}
+	if err := os.WriteFile(pp, []byte(LaunchdPlist(execPath, home)), 0o644); err != nil {
+		return fmt.Errorf("write plist: %w", err)
+	}
+	// Reload cleanly if a previous copy is loaded.
+	_ = exec.Command("launchctl", "unload", pp).Run()
+	if out, err := exec.Command("launchctl", "load", pp).CombinedOutput(); err != nil {
+		return fmt.Errorf("launchctl load: %w: %s", err, out)
+	}
+	fmt.Printf("Installed LaunchAgent: %s\n", pp)
+	return nil
+}
+
+func installSystemdUser(execPath string) error {
+	up, err := systemdUnitPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(up), 0o755); err != nil {
+		return fmt.Errorf("create systemd user dir: %w", err)
+	}
+	if err := os.WriteFile(up, []byte(SystemdUnit(execPath)), 0o644); err != nil {
+		return fmt.Errorf("write unit: %w", err)
+	}
+	if out, err := exec.Command("systemctl", "--user", "daemon-reload").CombinedOutput(); err != nil {
+		return fmt.Errorf("systemctl daemon-reload: %w: %s", err, out)
+	}
+	if out, err := exec.Command(
+		"systemctl", "--user", "enable", "--now", SystemdUnitName,
+	).CombinedOutput(); err != nil {
+		return fmt.Errorf("systemctl enable: %w: %s", err, out)
+	}
+	fmt.Printf("Installed systemd user unit: %s\n", up)
+	return nil
+}

--- a/internal/devicemode/service_test.go
+++ b/internal/devicemode/service_test.go
@@ -1,0 +1,42 @@
+package devicemode
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLaunchdPlist(t *testing.T) {
+	plist := LaunchdPlist("/usr/local/bin/citadel", "/Users/alice")
+
+	for _, want := range []string{
+		"<string>" + LaunchdLabel + "</string>",
+		"<string>/usr/local/bin/citadel</string>",
+		"<string>device</string>",
+		"<string>run</string>",
+		"<key>KeepAlive</key>",
+		"<key>RunAtLoad</key>",
+		"/Users/alice/Library/Logs/citadel/citadel-device.log",
+	} {
+		if !strings.Contains(plist, want) {
+			t.Errorf("plist missing %q", want)
+		}
+	}
+	// Distinct label from the node-agent service — device mode must be able
+	// to coexist with a later device->node flip.
+	if strings.Contains(plist, "<string>ai.aceteam.citadel</string>") {
+		t.Error("device plist must not reuse the node agent's launchd label")
+	}
+}
+
+func TestSystemdUnit(t *testing.T) {
+	unit := SystemdUnit("/usr/local/bin/citadel")
+	for _, want := range []string{
+		"ExecStart=/usr/local/bin/citadel device run",
+		"Restart=always",
+		"WantedBy=default.target",
+	} {
+		if !strings.Contains(unit, want) {
+			t.Errorf("unit missing %q", want)
+		}
+	}
+}

--- a/internal/devicemode/tailscale.go
+++ b/internal/devicemode/tailscale.go
@@ -1,0 +1,136 @@
+// System-tailscale babysitting for device mode (#5959).
+//
+// A device runs the REAL Tailscale client (system daemon or the macOS App
+// Store app), not citadel's embedded tsnet — laptops already have it and the
+// user's other traffic policies live there. Device mode only needs three
+// things from it: where the binary is, whether the session is healthy, and a
+// way to re-run login with a fresh authkey.
+package devicemode
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// MacAppStoreTailscale is the CLI binary bundled inside the macOS App Store /
+// standalone GUI variant of Tailscale, which does not install `tailscale`
+// onto PATH.
+const MacAppStoreTailscale = "/Applications/Tailscale.app/Contents/MacOS/Tailscale"
+
+// tailscaleBinEnv overrides binary discovery (tests, exotic installs).
+const tailscaleBinEnv = "CITADEL_TAILSCALE_BIN"
+
+// FindTailscale locates the tailscale CLI: env override, then PATH, then the
+// macOS app-bundle variant.
+func FindTailscale() (string, error) {
+	return findTailscale(runtime.GOOS, exec.LookPath, os.Stat, os.Getenv(tailscaleBinEnv))
+}
+
+// findTailscale is the testable core of FindTailscale.
+func findTailscale(
+	goos string,
+	lookPath func(string) (string, error),
+	stat func(string) (os.FileInfo, error),
+	envOverride string,
+) (string, error) {
+	if envOverride != "" {
+		if _, err := stat(envOverride); err != nil {
+			return "", fmt.Errorf("%s=%s: %w", tailscaleBinEnv, envOverride, err)
+		}
+		return envOverride, nil
+	}
+	if path, err := lookPath("tailscale"); err == nil {
+		return path, nil
+	}
+	if goos == "darwin" {
+		if _, err := stat(MacAppStoreTailscale); err == nil {
+			return MacAppStoreTailscale, nil
+		}
+	}
+	return "", fmt.Errorf(
+		"tailscale CLI not found — install Tailscale (https://tailscale.com/download) " +
+			"or set " + tailscaleBinEnv)
+}
+
+// TailscaleStatus is the subset of `tailscale status --json` device mode
+// reasons about.
+type TailscaleStatus struct {
+	// BackendState is tailscale's engine state: "Running", "NeedsLogin",
+	// "Stopped", "Starting", "NoState".
+	BackendState string `json:"BackendState"`
+	Self         struct {
+		// KeyExpiry is the node key's expiry; nil/zero when the key does not
+		// expire. RFC3339 in the JSON output.
+		KeyExpiry *time.Time `json:"KeyExpiry"`
+	} `json:"Self"`
+}
+
+// Status runs `tailscale status --json` and parses the fields device mode
+// needs.
+func Status(ctx context.Context, bin string) (*TailscaleStatus, error) {
+	out, err := exec.CommandContext(ctx, bin, "status", "--json").Output()
+	if err != nil {
+		// `tailscale status` exits non-zero in some unhealthy states while
+		// still printing valid JSON (e.g. logged out); prefer parsing it.
+		if len(out) == 0 {
+			return nil, fmt.Errorf("tailscale status: %w", err)
+		}
+	}
+	return ParseStatusJSON(out)
+}
+
+// ParseStatusJSON parses `tailscale status --json` output.
+func ParseStatusJSON(out []byte) (*TailscaleStatus, error) {
+	var st TailscaleStatus
+	if err := json.Unmarshal(out, &st); err != nil {
+		return nil, fmt.Errorf("parse tailscale status JSON: %w", err)
+	}
+	if st.BackendState == "" {
+		return nil, fmt.Errorf("tailscale status JSON missing BackendState")
+	}
+	return &st, nil
+}
+
+// Up (re-)authenticates the system tailscale against the mesh coordinator
+// with a fresh org authkey. forceReauth rotates the node key in place, which
+// is required both to recover a broken session and to extend an expiring one.
+//
+// The authkey is passed via TS_AUTHKEY in the environment, not argv, so it
+// never shows up in `ps` output.
+func Up(ctx context.Context, bin, loginServer string, authkey string, forceReauth bool) error {
+	args := []string{"up", "--login-server=" + loginServer, "--authkey=env:TS_AUTHKEY"}
+	if forceReauth {
+		args = append(args, "--force-reauth")
+	}
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Env = append(os.Environ(), "TS_AUTHKEY="+authkey)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(out))
+		if strings.Contains(msg, "env:TS_AUTHKEY") || strings.Contains(msg, "unknown value") {
+			// Older tailscale CLIs (< 1.40) lack env: authkey indirection;
+			// fall back to argv (slightly weaker: key visible to local ps).
+			return upArgvFallback(ctx, bin, loginServer, authkey, forceReauth)
+		}
+		return fmt.Errorf("tailscale up failed: %w: %s", err, msg)
+	}
+	return nil
+}
+
+func upArgvFallback(ctx context.Context, bin, loginServer, authkey string, forceReauth bool) error {
+	args := []string{"up", "--login-server=" + loginServer, "--authkey=" + authkey}
+	if forceReauth {
+		args = append(args, "--force-reauth")
+	}
+	out, err := exec.CommandContext(ctx, bin, args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("tailscale up failed: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/internal/devicemode/tailscale.go
+++ b/internal/devicemode/tailscale.go
@@ -101,29 +101,11 @@ func ParseStatusJSON(out []byte) (*TailscaleStatus, error) {
 // with a fresh org authkey. forceReauth rotates the node key in place, which
 // is required both to recover a broken session and to extend an expiring one.
 //
-// The authkey is passed via TS_AUTHKEY in the environment, not argv, so it
-// never shows up in `ps` output.
+// The authkey travels on argv, which every tailscale CLI version accepts
+// (file:/env: indirections are version-dependent and fail as a LITERAL key on
+// older CLIs — a silent server-side rejection, worse than brief ps
+// visibility of a single-use key that expires within the hour).
 func Up(ctx context.Context, bin, loginServer string, authkey string, forceReauth bool) error {
-	args := []string{"up", "--login-server=" + loginServer, "--authkey=env:TS_AUTHKEY"}
-	if forceReauth {
-		args = append(args, "--force-reauth")
-	}
-	cmd := exec.CommandContext(ctx, bin, args...)
-	cmd.Env = append(os.Environ(), "TS_AUTHKEY="+authkey)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		msg := strings.TrimSpace(string(out))
-		if strings.Contains(msg, "env:TS_AUTHKEY") || strings.Contains(msg, "unknown value") {
-			// Older tailscale CLIs (< 1.40) lack env: authkey indirection;
-			// fall back to argv (slightly weaker: key visible to local ps).
-			return upArgvFallback(ctx, bin, loginServer, authkey, forceReauth)
-		}
-		return fmt.Errorf("tailscale up failed: %w: %s", err, msg)
-	}
-	return nil
-}
-
-func upArgvFallback(ctx context.Context, bin, loginServer, authkey string, forceReauth bool) error {
 	args := []string{"up", "--login-server=" + loginServer, "--authkey=" + authkey}
 	if forceReauth {
 		args = append(args, "--force-reauth")

--- a/internal/devicemode/tailscale_test.go
+++ b/internal/devicemode/tailscale_test.go
@@ -1,0 +1,112 @@
+package devicemode
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+)
+
+func fakeStat(existing ...string) func(string) (os.FileInfo, error) {
+	set := map[string]bool{}
+	for _, p := range existing {
+		set[p] = true
+	}
+	return func(path string) (os.FileInfo, error) {
+		if set[path] {
+			return nil, nil //nolint:nilnil // only existence is checked
+		}
+		return nil, os.ErrNotExist
+	}
+}
+
+func lookPathHit(path string) func(string) (string, error) {
+	return func(string) (string, error) { return path, nil }
+}
+
+func lookPathMiss(string) (string, error) {
+	return "", fmt.Errorf("not found")
+}
+
+func TestFindTailscaleEnvOverride(t *testing.T) {
+	got, err := findTailscale("linux", lookPathMiss, fakeStat("/opt/ts/tailscale"), "/opt/ts/tailscale")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "/opt/ts/tailscale" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestFindTailscaleEnvOverrideMissingFails(t *testing.T) {
+	// A broken explicit override must error, not silently fall back.
+	if _, err := findTailscale("linux", lookPathHit("/usr/bin/tailscale"), fakeStat(), "/nope"); err == nil {
+		t.Fatal("expected error for missing override")
+	}
+}
+
+func TestFindTailscalePath(t *testing.T) {
+	got, err := findTailscale("linux", lookPathHit("/usr/bin/tailscale"), fakeStat(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "/usr/bin/tailscale" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestFindTailscaleMacAppStoreFallback(t *testing.T) {
+	got, err := findTailscale("darwin", lookPathMiss, fakeStat(MacAppStoreTailscale), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != MacAppStoreTailscale {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestFindTailscaleNotFound(t *testing.T) {
+	if _, err := findTailscale("linux", lookPathMiss, fakeStat(), ""); err == nil {
+		t.Fatal("expected not-found error")
+	}
+}
+
+func TestParseStatusJSON(t *testing.T) {
+	out := []byte(`{
+		"BackendState": "Running",
+		"Self": {"KeyExpiry": "2026-12-01T00:00:00Z"}
+	}`)
+	st, err := ParseStatusJSON(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.BackendState != "Running" {
+		t.Fatalf("BackendState=%q", st.BackendState)
+	}
+	want := time.Date(2026, 12, 1, 0, 0, 0, 0, time.UTC)
+	if st.Self.KeyExpiry == nil || !st.Self.KeyExpiry.Equal(want) {
+		t.Fatalf("KeyExpiry=%v", st.Self.KeyExpiry)
+	}
+}
+
+func TestParseStatusJSONNoExpiry(t *testing.T) {
+	st, err := ParseStatusJSON([]byte(`{"BackendState": "NeedsLogin", "Self": {}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.BackendState != "NeedsLogin" {
+		t.Fatalf("BackendState=%q", st.BackendState)
+	}
+	if st.Self.KeyExpiry != nil {
+		t.Fatalf("expected nil KeyExpiry, got %v", st.Self.KeyExpiry)
+	}
+}
+
+func TestParseStatusJSONRejectsGarbage(t *testing.T) {
+	if _, err := ParseStatusJSON([]byte(`not json`)); err == nil {
+		t.Fatal("expected parse error")
+	}
+	if _, err := ParseStatusJSON([]byte(`{}`)); err == nil {
+		t.Fatal("expected missing-BackendState error")
+	}
+}


### PR DESCRIPTION
## Context

aceteam-ai/aceteam#5959: plain mesh devices (laptops) get a one-shot org authkey at join and then nothing — membership silently expires, re-auth is manual key minting, offboarding means hunting devices in the coordinator by hand. Citadel nodes already solved this with a fabric mTLS leaf + the nexus reenroll service (#4583). This PR gives devices the same identity spine via a lightweight `citadel device` mode: no worker, no job queues, no Redis — just identity + session babysitting.

```
citadel device enroll     # one browser approval -> leaf + mesh join
citadel device install    # launchd/systemd user service
citadel device status     # identity + session health
```

First join stays interactive (the trust-root event): enroll generates the EC P-256 keypair + CSR (reusing internal/nodeidentity — the same store `citadel init` uses), opens a pairing session with `profile: "device"` (platform PR aceteam#5973), and prints the `/fabric/pair?code=...` link + QR. Approval returns an org authkey plus a ~1y fabric CA leaf. Everything after is derived: the daemon watches the SYSTEM tailscale session and, when it needs login or the node key nears expiry, proves possession of the leaf over mTLS to `nexus.aceteam.ai/fabric/reenroll`, gets a fresh org authkey, and re-runs `tailscale up --force-reauth`. Offboarding = one CRL revocation (same `fabric_node_certs` row as nodes).

Bonus: the identity store is shared with `citadel init`, so flipping device -> node later is a config change, not a re-enrollment.

## Summary

- **`internal/devicemode/`** (new)
  - `pairing.go` — drives the platform pairing flow with the device profile; CSR only ever carries the public key.
  - `reenroll.go` — mTLS client for the nexus reenroll service; identity = TLS client-auth handshake (the leaf PEM is public; possession of the key is the credential). Maps the service's 401/403/503 contract to operator-actionable errors.
  - `tailscale.go` — system-tailscale babysitting: binary discovery (`$CITADEL_TAILSCALE_BIN` -> PATH -> `/Applications/Tailscale.app/Contents/MacOS/Tailscale` for the macOS app-bundle variant), `status --json` parsing, `up` with authkey. Authkey rides argv deliberately: `file:`/`env:` indirections are version-dependent and degrade to a silent server-side rejection on older CLIs, vs brief ps visibility of a single-use key that expires within the hour.
  - `health.go` — pure decision logic (unit-testable, no I/O): NeedsLogin/NoState -> reenroll; key expiry within 24h -> proactive reenroll (mirrors the node renewer threshold); `Stopped` -> respect the operator; leaf <30d -> warn; leaf expired -> self-heal impossible (the nginx terminator rejects expired client certs at the handshake, so the grace window is unreachable from a device — pre-existing for nodes too), point at re-enrollment.
  - `service.go` — per-user daemon install: launchd LaunchAgent `ai.aceteam.citadel-device` (macOS), systemd user unit (Linux). Deliberately distinct from the node agent's `ai.aceteam.citadel` label so a later device->node flip cannot collide. Windows: clear "run under your supervisor" error for now.
  - `config.go` — `device.json` (no secrets) + persisted machine-id so a re-enrolled device keeps its node_uid.
- **`cmd/device.go`** — `citadel device enroll|run|status|install|uninstall`. The daemon never exits on failure — it logs and retries next tick (default 15m, `CITADEL_DEVICE_CHECK_INTERVAL`). Linux `tailscale up` permission failures get the `sudo tailscale set --operator=$USER` hint.

## Test plan

| Group | Coverage |
| --- | --- |
| `health_test.go` (8) | every decision branch: healthy, no-expiry key, NeedsLogin, Stopped-respects-operator, key <24h, key expired, leaf warn, leaf expired suppresses reenroll + points at remedy |
| `reenroll_test.go` (5) | real mTLS httptest server (`RequireAndVerifyClientCert` against an in-memory CA — the nginx contract): success round-trip, **handshake rejection without the client key (proof-of-possession)**, 401/403/503/5xx error mapping, empty-authkey rejection, identity-store loading |
| `pairing_test.go` (5) | wire shape (profile=device, CSR present, **private key absent**), HTTP error surfacing, poll-until-confirmed, expiry, context cancel |
| `tailscale_test.go` (8) | discovery precedence incl. broken-override fail-loud + macOS app path; status JSON parse/garbage |
| `config_test.go` (6) | round-trip, 0600 perms, defaults, machine-id stability, pairing-code shape |
| `service_test.go` (2) | plist/unit rendering; label distinct from node agent |
| Suite | `go build ./... && go vet ./... && go test ./...` green |

### Manual verification still owed (unit tests cannot cover this)

- [ ] `citadel device enroll` on a real macOS laptop (App Store Tailscale variant) — approve in browser, confirm the device lands under `org_<id>` in headscale
- [ ] Same on Linux (after `sudo tailscale set --operator=$USER`)
- [ ] Break the session (`headscale nodes expire`) and watch the daemon self-heal via the reenroll service
- [ ] Note: end-to-end self-heal additionally requires the fabric CA to be active in prod (env secrets on the coordinator) — without it, enroll degrades loudly to authkey-only (no leaf, no self-heal)
- [ ] Caveat to verify on macOS: if the App Store build refuses `--login-server`, the standalone (direct download) Tailscale build is required; the binary path is the same

## Related

- aceteam-ai/aceteam#5959 (parent) / #4583 (mTLS PKI + reenroll service this reuses)
- aceteam-ai/aceteam#5973 (platform half: device profile -> long-TTL leaf)
- aceteam-ai/nexus#23 / nexus#36 (org-namespace hardening that removed the old OIDC join path)

---
*Generated by Claude Opus 4.8*
