### PR TITLE
feat(worker): INSTANCE_* job family with Proxmox provisioner (aceteam#5963 phase 1)

### DIFF
--- a/cmd/instance_ops.go
+++ b/cmd/instance_ops.go
@@ -1,0 +1,47 @@
+// cmd/instance_ops.go
+//
+// Live wiring for the INSTANCE_* job family (aceteam#5963): builds the
+// proxmox.Provisioner from this node's saved proxmox.json. Provisioning is
+// opt-in -- the config must exist AND carry an enabled "provisioning" section
+// with a cloud-init template VMID.
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/aceteam-ai/citadel-cli/internal/proxmox"
+	"github.com/aceteam-ai/citadel-cli/internal/worker"
+)
+
+// newInstanceProviderFactory returns the lazy provider loader the
+// InstanceHandler uses. Each job re-reads proxmox.json so config changes are
+// picked up without a worker restart.
+func newInstanceProviderFactory(configDir string, log func(format string, args ...any)) func() (worker.InstanceProvider, error) {
+	return func() (worker.InstanceProvider, error) {
+		if configDir == "" {
+			return nil, fmt.Errorf("no config directory: this node has no proxmox configuration")
+		}
+		cfg, err := proxmox.LoadConfig(configDir)
+		if err != nil {
+			return nil, err
+		}
+		if cfg == nil || cfg.BaseURL == "" {
+			return nil, fmt.Errorf("proxmox is not configured on this node (missing %s)", proxmox.ConfigPath(configDir))
+		}
+		if cfg.Provisioning == nil || !cfg.Provisioning.Enabled {
+			return nil, fmt.Errorf("instance provisioning is not enabled in %s (set provisioning.enabled)", proxmox.ConfigPath(configDir))
+		}
+
+		client := proxmox.NewClient(proxmox.ClientConfig{
+			BaseURL:     cfg.BaseURL,
+			TokenID:     cfg.TokenID,
+			TokenSecret: cfg.TokenSecret,
+		})
+
+		pcfg := *cfg.Provisioning
+		if pcfg.PVENode == "" {
+			pcfg.PVENode = cfg.NodeName
+		}
+		return proxmox.NewProvisioner(client, pcfg, nil, log)
+	}
+}

--- a/cmd/nodejobs.go
+++ b/cmd/nodejobs.go
@@ -89,4 +89,13 @@ func registerPrivilegedNodeJobHandlers(runner *worker.Runner, opts nodeJobHandle
 		Ops: newLiveModuleOps(opts.HandlerLog),
 		Log: opts.HandlerLog,
 	}))
+
+	// INSTANCE_* (aceteam#5963): fabric instance provisioning on this node's
+	// Proxmox hypervisor. Registered unconditionally so nodes without a proxmox
+	// provisioning config fail these jobs with a clear message; the lazy factory
+	// gates on proxmox.json's provisioning.enabled.
+	runner.RegisterHandler(worker.NewInstanceHandler(worker.InstanceHandlerConfig{
+		Provider: newInstanceProviderFactory(opts.ConfigDir, opts.HandlerLog),
+		Log:      opts.HandlerLog,
+	}))
 }

--- a/internal/proxmox/config.go
+++ b/internal/proxmox/config.go
@@ -15,6 +15,10 @@ type Config struct {
 	TokenID     string `json:"token_id,omitempty"`
 	TokenSecret string `json:"token_secret,omitempty"`
 	NodeName    string `json:"node_name,omitempty"`
+
+	// Provisioning enables and configures fabric instance provisioning
+	// (INSTANCE_* jobs, aceteam#5963) on this node. Nil means disabled.
+	Provisioning *ProvisioningConfig `json:"provisioning,omitempty"`
 }
 
 // ConfigPath returns the absolute path of the Proxmox config file for the

--- a/internal/proxmox/provision.go
+++ b/internal/proxmox/provision.go
@@ -1,0 +1,260 @@
+// internal/proxmox/provision.go
+//
+// Provisioning-oriented Proxmox VE API methods (aceteam#5963): clone from a
+// cloud-init template, size the VM, manage lifecycle, and group instances into
+// per-org resource pools. These extend the read-mostly Client in client.go with
+// the mutating calls the fabric INSTANCE_* job family needs.
+//
+// All methods speak the standard PVE REST API (/api2/json) with token auth.
+// Long-running operations (clone, delete) return a UPID task id; WaitForTask
+// polls the task endpoint until it finishes.
+package proxmox
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// put performs an authenticated PUT request with form data.
+func (c *Client) put(ctx context.Context, path string, form url.Values) (json.RawMessage, error) {
+	var body = strings.NewReader(form.Encode())
+	return c.doRequest(ctx, http.MethodPut, path, body)
+}
+
+// delete performs an authenticated DELETE request.
+func (c *Client) delete(ctx context.Context, path string) (json.RawMessage, error) {
+	return c.doRequest(ctx, http.MethodDelete, path, nil)
+}
+
+// NextID returns the next free VMID in the cluster.
+func (c *Client) NextID(ctx context.Context) (int, error) {
+	data, err := c.get(ctx, "/cluster/nextid")
+	if err != nil {
+		return 0, err
+	}
+	// PVE returns the id as a JSON string (e.g. "105").
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		// Some versions return a bare number.
+		var n int
+		if err2 := json.Unmarshal(data, &n); err2 == nil {
+			return n, nil
+		}
+		return 0, fmt.Errorf("parsing nextid: %w", err)
+	}
+	id, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("parsing nextid %q: %w", s, err)
+	}
+	return id, nil
+}
+
+// CloneOptions holds optional parameters for CloneVM.
+type CloneOptions struct {
+	// Name is the new VM's name (DNS-safe).
+	Name string
+	// Full requests a full (non-linked) clone.
+	Full bool
+	// Storage is the target storage for a full clone (optional).
+	Storage string
+	// Pool assigns the new VM to a resource pool at creation (optional).
+	Pool string
+}
+
+// CloneVM clones srcVMID on the given node into newVMID. Returns the UPID of
+// the asynchronous clone task.
+func (c *Client) CloneVM(ctx context.Context, node string, srcVMID, newVMID int, opts CloneOptions) (string, error) {
+	form := url.Values{"newid": {strconv.Itoa(newVMID)}}
+	if opts.Name != "" {
+		form.Set("name", opts.Name)
+	}
+	if opts.Full {
+		form.Set("full", "1")
+	}
+	if opts.Storage != "" {
+		form.Set("storage", opts.Storage)
+	}
+	if opts.Pool != "" {
+		form.Set("pool", opts.Pool)
+	}
+	data, err := c.post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/clone", node, srcVMID), form)
+	if err != nil {
+		return "", err
+	}
+	return parseUPID(data)
+}
+
+// ConfigureVM applies configuration key/values to a QEMU VM (cores, memory,
+// cloud-init fields such as cicustom/ipconfig0, tags, ...).
+func (c *Client) ConfigureVM(ctx context.Context, node string, vmid int, params map[string]string) error {
+	form := url.Values{}
+	for k, v := range params {
+		form.Set(k, v)
+	}
+	_, err := c.post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/config", node, vmid), form)
+	return err
+}
+
+// ResizeDisk grows a VM disk to the given absolute size (e.g. "40G").
+// Proxmox only grows disks; shrinking is rejected by the API.
+func (c *Client) ResizeDisk(ctx context.Context, node string, vmid int, disk, size string) error {
+	form := url.Values{"disk": {disk}, "size": {size}}
+	_, err := c.put(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/resize", node, vmid), form)
+	return err
+}
+
+// DeleteVM destroys a VM and (with purge) all its references (backups, replication
+// jobs) and unreferenced disks. Returns the UPID of the asynchronous delete task.
+func (c *Client) DeleteVM(ctx context.Context, node string, vmid int, purge bool) (string, error) {
+	path := fmt.Sprintf("/nodes/%s/qemu/%d", node, vmid)
+	if purge {
+		path += "?purge=1&destroy-unreferenced-disks=1"
+	}
+	data, err := c.delete(ctx, path)
+	if err != nil {
+		return "", err
+	}
+	return parseUPID(data)
+}
+
+// TaskStatus describes the state of an asynchronous PVE task.
+type TaskStatus struct {
+	Status     string `json:"status"`     // "running" | "stopped"
+	ExitStatus string `json:"exitstatus"` // "OK" on success (set once stopped)
+	UPID       string `json:"upid"`
+	Type       string `json:"type"`
+}
+
+// GetTaskStatus returns the current status of a task by UPID.
+func (c *Client) GetTaskStatus(ctx context.Context, node, upid string) (*TaskStatus, error) {
+	data, err := c.get(ctx, fmt.Sprintf("/nodes/%s/tasks/%s/status", node, url.PathEscape(upid)))
+	if err != nil {
+		return nil, err
+	}
+	var ts TaskStatus
+	if err := json.Unmarshal(data, &ts); err != nil {
+		return nil, fmt.Errorf("parsing task status: %w", err)
+	}
+	return &ts, nil
+}
+
+// WaitForTask polls a task until it stops or the context/timeout expires.
+// A task that stops with an exit status other than "OK" is an error.
+func (c *Client) WaitForTask(ctx context.Context, node, upid string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		ts, err := c.GetTaskStatus(ctx, node, upid)
+		if err != nil {
+			return fmt.Errorf("polling task %s: %w", upid, err)
+		}
+		if ts.Status == "stopped" {
+			if ts.ExitStatus != "OK" {
+				return fmt.Errorf("task %s failed: %s", upid, ts.ExitStatus)
+			}
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("task %s timed out after %s", upid, timeout)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(taskPollInterval):
+		}
+	}
+}
+
+// taskPollInterval is how often WaitForTask polls. Overridable in tests.
+var taskPollInterval = 2 * time.Second
+
+// Pool represents a PVE resource pool.
+type Pool struct {
+	PoolID  string `json:"poolid"`
+	Comment string `json:"comment,omitempty"`
+}
+
+// PoolMember is a guest or storage assigned to a pool.
+type PoolMember struct {
+	ID   string `json:"id"`
+	Type string `json:"type"` // "qemu" | "lxc" | "storage"
+	VMID int    `json:"vmid,omitempty"`
+	Node string `json:"node,omitempty"`
+}
+
+// poolDetail is the response shape of GET /pools/{poolid}.
+type poolDetail struct {
+	Comment string       `json:"comment,omitempty"`
+	Members []PoolMember `json:"members"`
+}
+
+// ListPools returns all resource pools in the cluster.
+func (c *Client) ListPools(ctx context.Context) ([]Pool, error) {
+	data, err := c.get(ctx, "/pools")
+	if err != nil {
+		return nil, err
+	}
+	var pools []Pool
+	if err := json.Unmarshal(data, &pools); err != nil {
+		return nil, fmt.Errorf("parsing pools: %w", err)
+	}
+	return pools, nil
+}
+
+// CreatePool creates a resource pool.
+func (c *Client) CreatePool(ctx context.Context, poolID, comment string) error {
+	form := url.Values{"poolid": {poolID}}
+	if comment != "" {
+		form.Set("comment", comment)
+	}
+	_, err := c.post(ctx, "/pools", form)
+	return err
+}
+
+// GetPoolMembers returns the members of a pool.
+func (c *Client) GetPoolMembers(ctx context.Context, poolID string) ([]PoolMember, error) {
+	data, err := c.get(ctx, fmt.Sprintf("/pools/%s", url.PathEscape(poolID)))
+	if err != nil {
+		return nil, err
+	}
+	var detail poolDetail
+	if err := json.Unmarshal(data, &detail); err != nil {
+		return nil, fmt.Errorf("parsing pool detail: %w", err)
+	}
+	return detail.Members, nil
+}
+
+// EnsurePool creates the pool if it does not already exist and returns whether
+// it was created.
+func (c *Client) EnsurePool(ctx context.Context, poolID, comment string) (bool, error) {
+	pools, err := c.ListPools(ctx)
+	if err != nil {
+		return false, fmt.Errorf("listing pools: %w", err)
+	}
+	for _, p := range pools {
+		if p.PoolID == poolID {
+			return false, nil
+		}
+	}
+	if err := c.CreatePool(ctx, poolID, comment); err != nil {
+		return false, fmt.Errorf("creating pool %s: %w", poolID, err)
+	}
+	return true, nil
+}
+
+// parseUPID extracts a task UPID from a raw API response.
+func parseUPID(data json.RawMessage) (string, error) {
+	var upid string
+	if err := json.Unmarshal(data, &upid); err != nil {
+		return "", fmt.Errorf("parsing task UPID: %w", err)
+	}
+	if !strings.HasPrefix(upid, "UPID:") {
+		return "", fmt.Errorf("unexpected task response %q", upid)
+	}
+	return upid, nil
+}

--- a/internal/proxmox/provision_test.go
+++ b/internal/proxmox/provision_test.go
@@ -1,0 +1,209 @@
+package proxmox
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNextID(t *testing.T) {
+	_, client := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api2/json/cluster/nextid" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Write([]byte(`{"data":"105"}`))
+	})
+	id, err := client.NextID(context.Background())
+	if err != nil {
+		t.Fatalf("NextID: %v", err)
+	}
+	if id != 105 {
+		t.Errorf("expected 105, got %d", id)
+	}
+}
+
+func TestCloneVM(t *testing.T) {
+	var gotForm url.Values
+	_, client := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api2/json/nodes/pve1/qemu/9000/clone" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		r.ParseForm()
+		gotForm = r.PostForm
+		w.Write([]byte(`{"data":"UPID:pve1:0001:clone:"}`))
+	})
+
+	upid, err := client.CloneVM(context.Background(), "pve1", 9000, 105, CloneOptions{
+		Name: "test-vm", Full: true, Storage: "local-lvm", Pool: "aceteam-org-abc",
+	})
+	if err != nil {
+		t.Fatalf("CloneVM: %v", err)
+	}
+	if !strings.HasPrefix(upid, "UPID:") {
+		t.Errorf("expected UPID, got %q", upid)
+	}
+	for k, want := range map[string]string{
+		"newid": "105", "name": "test-vm", "full": "1",
+		"storage": "local-lvm", "pool": "aceteam-org-abc",
+	} {
+		if got := gotForm.Get(k); got != want {
+			t.Errorf("form[%s] = %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestConfigureVM(t *testing.T) {
+	var gotForm url.Values
+	_, client := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api2/json/nodes/pve1/qemu/105/config" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		r.ParseForm()
+		gotForm = r.PostForm
+		w.Write([]byte(`{"data":null}`))
+	})
+
+	err := client.ConfigureVM(context.Background(), "pve1", 105, map[string]string{
+		"cores": "2", "memory": "4096", "cicustom": "user=local:snippets/aceteam-x.yaml",
+	})
+	if err != nil {
+		t.Fatalf("ConfigureVM: %v", err)
+	}
+	if gotForm.Get("cores") != "2" || gotForm.Get("memory") != "4096" {
+		t.Errorf("sizing params not sent: %v", gotForm)
+	}
+	if gotForm.Get("cicustom") != "user=local:snippets/aceteam-x.yaml" {
+		t.Errorf("cicustom not sent: %v", gotForm)
+	}
+}
+
+func TestResizeDisk(t *testing.T) {
+	_, client := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api2/json/nodes/pve1/qemu/105/resize" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		r.ParseForm()
+		if r.PostForm.Get("disk") != "scsi0" || r.PostForm.Get("size") != "40G" {
+			t.Errorf("unexpected form: %v", r.PostForm)
+		}
+		w.Write([]byte(`{"data":null}`))
+	})
+	if err := client.ResizeDisk(context.Background(), "pve1", 105, "scsi0", "40G"); err != nil {
+		t.Fatalf("ResizeDisk: %v", err)
+	}
+}
+
+func TestDeleteVM(t *testing.T) {
+	_, client := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		if r.URL.Path != "/api2/json/nodes/pve1/qemu/105" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("purge") != "1" {
+			t.Errorf("expected purge=1, got %s", r.URL.RawQuery)
+		}
+		w.Write([]byte(`{"data":"UPID:pve1:0002:delete:"}`))
+	})
+	upid, err := client.DeleteVM(context.Background(), "pve1", 105, true)
+	if err != nil {
+		t.Fatalf("DeleteVM: %v", err)
+	}
+	if !strings.HasPrefix(upid, "UPID:") {
+		t.Errorf("expected UPID, got %q", upid)
+	}
+}
+
+func TestWaitForTask(t *testing.T) {
+	orig := taskPollInterval
+	taskPollInterval = time.Millisecond
+	defer func() { taskPollInterval = orig }()
+
+	calls := 0
+	_, client := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls < 3 {
+			w.Write([]byte(`{"data":{"status":"running","upid":"UPID:x"}}`))
+			return
+		}
+		w.Write([]byte(`{"data":{"status":"stopped","exitstatus":"OK","upid":"UPID:x"}}`))
+	})
+	if err := client.WaitForTask(context.Background(), "pve1", "UPID:x", time.Second); err != nil {
+		t.Fatalf("WaitForTask: %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 polls, got %d", calls)
+	}
+}
+
+func TestWaitForTaskFailure(t *testing.T) {
+	_, client := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"data":{"status":"stopped","exitstatus":"clone failed: no space","upid":"UPID:x"}}`))
+	})
+	err := client.WaitForTask(context.Background(), "pve1", "UPID:x", time.Second)
+	if err == nil || !strings.Contains(err.Error(), "no space") {
+		t.Fatalf("expected task failure error, got %v", err)
+	}
+}
+
+func TestEnsurePool(t *testing.T) {
+	created := false
+	_, client := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api2/json/pools":
+			w.Write([]byte(`{"data":[{"poolid":"existing"}]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api2/json/pools":
+			r.ParseForm()
+			if r.PostForm.Get("poolid") != "aceteam-org-abc" {
+				t.Errorf("unexpected poolid: %v", r.PostForm)
+			}
+			created = true
+			w.Write([]byte(`{"data":null}`))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	})
+
+	didCreate, err := client.EnsurePool(context.Background(), "aceteam-org-abc", "test")
+	if err != nil {
+		t.Fatalf("EnsurePool: %v", err)
+	}
+	if !didCreate || !created {
+		t.Error("expected pool to be created")
+	}
+
+	// Existing pool: no create call.
+	didCreate, err = client.EnsurePool(context.Background(), "existing", "test")
+	if err != nil {
+		t.Fatalf("EnsurePool existing: %v", err)
+	}
+	if didCreate {
+		t.Error("expected no create for existing pool")
+	}
+}
+
+func TestGetPoolMembers(t *testing.T) {
+	_, client := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api2/json/pools/aceteam-org-abc" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Write([]byte(`{"data":{"members":[{"id":"qemu/105","type":"qemu","vmid":105,"node":"pve1"}]}}`))
+	})
+	members, err := client.GetPoolMembers(context.Background(), "aceteam-org-abc")
+	if err != nil {
+		t.Fatalf("GetPoolMembers: %v", err)
+	}
+	if len(members) != 1 || members[0].VMID != 105 {
+		t.Errorf("unexpected members: %+v", members)
+	}
+}

--- a/internal/proxmox/provisioner.go
+++ b/internal/proxmox/provisioner.go
@@ -1,0 +1,436 @@
+// internal/proxmox/provisioner.go
+//
+// Provisioner turns fabric INSTANCE_* jobs (aceteam#5963) into Proxmox VE API
+// calls: clone a cloud-init template, size the VM from a small instance-type
+// table, inject an org-scoped mesh authkey via a cloud-init user-data snippet,
+// group the customer org's instances into a PVE resource pool (used for the
+// per-org instance cap), and drive start/stop/destroy/status.
+//
+// Mesh delivery: the platform mints a headscale authkey for the CUSTOMER org
+// (org_<id>), the provision payload carries it here, and the rendered
+// cloud-config installs tailscale on first boot and joins the mesh with that
+// key -- so the instance lands in the customer's namespace, not the
+// operator's. Renewal/revocation composes with the device-identity work
+// (aceteam#5959); once its device-profile leaf issuance ships, first boot
+// should additionally enroll a device identity so mesh membership becomes
+// derived state. TODO(aceteam#5959): swap the one-shot authkey for the
+// device-identity enrolment flow when available.
+//
+// Snippet delivery assumes the citadel node runs ON the PVE host (or has the
+// snippets directory mounted): the PVE API cannot upload snippet files itself.
+package proxmox
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ProvisioningConfig configures instance provisioning on a PVE host. It lives
+// under the "provisioning" key of proxmox.json.
+type ProvisioningConfig struct {
+	// Enabled gates the whole INSTANCE_* job family on this node.
+	Enabled bool `json:"enabled"`
+	// PVENode is the PVE node name to provision on (defaults to Config.NodeName).
+	PVENode string `json:"pve_node,omitempty"`
+	// TemplateVMID is the cloud-init template VM to clone from. Required.
+	TemplateVMID int `json:"template_vmid"`
+	// Storage is the target storage for full clones (optional; PVE default).
+	Storage string `json:"storage,omitempty"`
+	// DiskDevice is the boot disk to resize (default "scsi0").
+	DiskDevice string `json:"disk_device,omitempty"`
+	// SnippetsDir is the local directory backing the snippets content type of
+	// SnippetsStorage (default "/var/lib/vz/snippets").
+	SnippetsDir string `json:"snippets_dir,omitempty"`
+	// SnippetsStorage is the PVE storage id that serves SnippetsDir (default "local").
+	SnippetsStorage string `json:"snippets_storage,omitempty"`
+	// LoginServer is the mesh coordination server new instances join
+	// (default "https://nexus.aceteam.ai").
+	LoginServer string `json:"login_server,omitempty"`
+	// MaxInstancesPerOrg caps instances per customer org, enforced via the
+	// org's PVE resource pool (default 3; 0 uses the default, -1 disables).
+	MaxInstancesPerOrg int `json:"max_instances_per_org,omitempty"`
+}
+
+const (
+	defaultDiskDevice         = "scsi0"
+	defaultSnippetsDir        = "/var/lib/vz/snippets"
+	defaultSnippetsStorage    = "local"
+	defaultLoginServer        = "https://nexus.aceteam.ai"
+	defaultMaxInstancesPerOrg = 3
+	provisionTaskTimeout      = 5 * time.Minute
+)
+
+// InstanceType describes one row of the instance sizing table.
+type InstanceType struct {
+	Name     string
+	Cores    int
+	MemoryMB int
+	DiskGB   int
+}
+
+// InstanceTypes is the built-in sizing table for fabric instances. It mirrors
+// the platform's tier table (models/fabric_instance.py in aceteam); keep the
+// two in sync.
+var InstanceTypes = map[string]InstanceType{
+	"small":  {Name: "small", Cores: 1, MemoryMB: 2048, DiskGB: 20},
+	"medium": {Name: "medium", Cores: 2, MemoryMB: 4096, DiskGB: 40},
+	"large":  {Name: "large", Cores: 4, MemoryMB: 8192, DiskGB: 80},
+	"xlarge": {Name: "xlarge", Cores: 8, MemoryMB: 16384, DiskGB: 160},
+}
+
+// ProvisionRequest is the input for provisioning one instance.
+type ProvisionRequest struct {
+	// InstanceID is the platform's instance UUID (used in snippet/tag names).
+	InstanceID string
+	// Name is the requested instance name (sanitized to DNS-safe).
+	Name string
+	// InstanceType selects a row of InstanceTypes.
+	InstanceType string
+	// OrgID is the CUSTOMER org UUID the instance belongs to.
+	OrgID string
+	// AuthKey is the org-scoped mesh authkey injected at first boot. Required.
+	AuthKey string
+	// LoginServer overrides the configured mesh coordination server (optional).
+	LoginServer string
+	// SSHAuthorizedKeys are added to the default user via cloud-init (optional).
+	SSHAuthorizedKeys []string
+}
+
+// ProvisionResult reports a successfully provisioned instance.
+type ProvisionResult struct {
+	VMID     int    `json:"vmid"`
+	PVENode  string `json:"pve_node"`
+	Name     string `json:"name"`
+	Cores    int    `json:"cores"`
+	MemoryMB int    `json:"memory_mb"`
+	DiskGB   int    `json:"disk_gb"`
+	Pool     string `json:"pool"`
+}
+
+// InstanceRef identifies an existing instance VM.
+type InstanceRef struct {
+	VMID    int
+	PVENode string
+}
+
+// InstanceStatus reports the live state of an instance VM.
+type InstanceStatus struct {
+	VMID          int    `json:"vmid"`
+	Status        string `json:"status"` // "running" | "stopped"
+	UptimeSeconds int64  `json:"uptime_seconds"`
+	CPUs          int    `json:"cpus"`
+	MaxMemBytes   int64  `json:"max_mem_bytes"`
+}
+
+// SnippetStore persists cloud-init user-data snippets where the PVE storage
+// layer can see them. The live implementation writes to the snippets directory
+// on the PVE host; tests use an in-memory fake.
+type SnippetStore interface {
+	// Write stores content under the given file name and returns the PVE
+	// volume reference (e.g. "local:snippets/aceteam-<id>.yaml").
+	Write(name, content string) (string, error)
+	// Remove deletes a snippet by file name. Missing files are not an error.
+	Remove(name string) error
+}
+
+// LocalSnippetStore writes snippets to a directory on the local filesystem
+// (the PVE host's snippets dir, when citadel runs on the hypervisor).
+type LocalSnippetStore struct {
+	Dir     string // e.g. /var/lib/vz/snippets
+	Storage string // e.g. "local"
+}
+
+// Write implements SnippetStore.
+func (s *LocalSnippetStore) Write(name, content string) (string, error) {
+	if err := os.MkdirAll(s.Dir, 0o755); err != nil {
+		return "", fmt.Errorf("creating snippets dir: %w", err)
+	}
+	path := filepath.Join(s.Dir, name)
+	// 0600: the snippet carries a mesh authkey; only root on the hypervisor
+	// (which already owns the VMs) should read it.
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		return "", fmt.Errorf("writing snippet: %w", err)
+	}
+	return fmt.Sprintf("%s:snippets/%s", s.Storage, name), nil
+}
+
+// Remove implements SnippetStore.
+func (s *LocalSnippetStore) Remove(name string) error {
+	err := os.Remove(filepath.Join(s.Dir, name))
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// Provisioner orchestrates instance provisioning against one PVE host.
+type Provisioner struct {
+	client   *Client
+	cfg      ProvisioningConfig
+	snippets SnippetStore
+	log      func(format string, args ...any)
+}
+
+// NewProvisioner builds a Provisioner. cfg.TemplateVMID and cfg.PVENode must be
+// set (PVENode may be defaulted by the caller from the connection config).
+func NewProvisioner(client *Client, cfg ProvisioningConfig, snippets SnippetStore, log func(format string, args ...any)) (*Provisioner, error) {
+	if client == nil {
+		return nil, fmt.Errorf("proxmox client is required")
+	}
+	if !cfg.Enabled {
+		return nil, fmt.Errorf("instance provisioning is not enabled on this node")
+	}
+	if cfg.TemplateVMID <= 0 {
+		return nil, fmt.Errorf("provisioning.template_vmid is required")
+	}
+	if cfg.PVENode == "" {
+		return nil, fmt.Errorf("provisioning.pve_node is required")
+	}
+	if cfg.DiskDevice == "" {
+		cfg.DiskDevice = defaultDiskDevice
+	}
+	if cfg.LoginServer == "" {
+		cfg.LoginServer = defaultLoginServer
+	}
+	if cfg.MaxInstancesPerOrg == 0 {
+		cfg.MaxInstancesPerOrg = defaultMaxInstancesPerOrg
+	}
+	if snippets == nil {
+		dir := cfg.SnippetsDir
+		if dir == "" {
+			dir = defaultSnippetsDir
+		}
+		storage := cfg.SnippetsStorage
+		if storage == "" {
+			storage = defaultSnippetsStorage
+		}
+		snippets = &LocalSnippetStore{Dir: dir, Storage: storage}
+	}
+	if log == nil {
+		log = func(string, ...any) {}
+	}
+	return &Provisioner{client: client, cfg: cfg, snippets: snippets, log: log}, nil
+}
+
+// PoolForOrg returns the PVE resource pool name for a customer org.
+// PVE pool ids allow [A-Za-z0-9\-_.]; org UUIDs are shortened for readability.
+func PoolForOrg(orgID string) string {
+	id := strings.ReplaceAll(orgID, "-", "")
+	if len(id) > 12 {
+		id = id[:12]
+	}
+	return "aceteam-org-" + id
+}
+
+var nameSanitizer = regexp.MustCompile(`[^a-z0-9-]+`)
+
+// sanitizeName makes a DNS-safe VM name.
+func sanitizeName(name string) string {
+	n := strings.ToLower(strings.TrimSpace(name))
+	n = nameSanitizer.ReplaceAllString(n, "-")
+	n = strings.Trim(n, "-")
+	if len(n) > 48 {
+		n = n[:48]
+	}
+	if n == "" {
+		n = "instance"
+	}
+	return n
+}
+
+// snippetName returns the user-data snippet file name for an instance.
+func snippetName(instanceID string) string {
+	return "aceteam-" + sanitizeName(instanceID) + ".yaml"
+}
+
+// renderCloudInit renders the #cloud-config user-data that joins the instance
+// to the customer org's mesh namespace on first boot.
+func renderCloudInit(hostname, loginServer, authKey string, sshKeys []string) string {
+	var b strings.Builder
+	b.WriteString("#cloud-config\n")
+	fmt.Fprintf(&b, "hostname: %s\n", hostname)
+	b.WriteString("manage_etc_hosts: true\n")
+	if len(sshKeys) > 0 {
+		b.WriteString("ssh_authorized_keys:\n")
+		for _, k := range sshKeys {
+			fmt.Fprintf(&b, "  - %s\n", strings.TrimSpace(k))
+		}
+	}
+	b.WriteString("package_update: true\n")
+	b.WriteString("runcmd:\n")
+	b.WriteString("  - ['sh', '-c', 'curl -fsSL https://tailscale.com/install.sh | sh']\n")
+	fmt.Fprintf(&b, "  - ['tailscale', 'up', '--login-server=%s', '--authkey=%s', '--hostname=%s']\n",
+		loginServer, authKey, hostname)
+	return b.String()
+}
+
+// Provision clones, sizes, mesh-enrolls, pools, and starts a new instance VM.
+func (p *Provisioner) Provision(ctx context.Context, req ProvisionRequest) (*ProvisionResult, error) {
+	tier, ok := InstanceTypes[strings.ToLower(strings.TrimSpace(req.InstanceType))]
+	if !ok {
+		return nil, fmt.Errorf("unknown instance_type %q (want one of small|medium|large|xlarge)", req.InstanceType)
+	}
+	if req.OrgID == "" {
+		return nil, fmt.Errorf("org_id is required")
+	}
+	if req.AuthKey == "" {
+		return nil, fmt.Errorf("authkey is required: an instance without a mesh identity is unreachable")
+	}
+	if req.InstanceID == "" {
+		return nil, fmt.Errorf("instance_id is required")
+	}
+
+	// Per-org cap, enforced via the org's resource pool.
+	pool := PoolForOrg(req.OrgID)
+	if _, err := p.client.EnsurePool(ctx, pool, "AceTeam fabric instances for org "+req.OrgID); err != nil {
+		return nil, err
+	}
+	if p.cfg.MaxInstancesPerOrg > 0 {
+		members, err := p.client.GetPoolMembers(ctx, pool)
+		if err != nil {
+			return nil, fmt.Errorf("checking org instance cap: %w", err)
+		}
+		count := 0
+		for _, m := range members {
+			if m.Type == "qemu" {
+				count++
+			}
+		}
+		if count >= p.cfg.MaxInstancesPerOrg {
+			return nil, fmt.Errorf("org %s is at its instance cap (%d) on this node", req.OrgID, p.cfg.MaxInstancesPerOrg)
+		}
+	}
+
+	vmid, err := p.client.NextID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("allocating vmid: %w", err)
+	}
+	name := sanitizeName(req.Name)
+
+	// Cloud-init user-data snippet: mesh join at first boot.
+	loginServer := req.LoginServer
+	if loginServer == "" {
+		loginServer = p.cfg.LoginServer
+	}
+	snipName := snippetName(req.InstanceID)
+	volRef, err := p.snippets.Write(snipName, renderCloudInit(name, loginServer, req.AuthKey, req.SSHAuthorizedKeys))
+	if err != nil {
+		return nil, fmt.Errorf("writing cloud-init snippet: %w", err)
+	}
+
+	p.log("INSTANCE_PROVISION: cloning template %d -> vmid %d (%s, %s)", p.cfg.TemplateVMID, vmid, name, tier.Name)
+	upid, err := p.client.CloneVM(ctx, p.cfg.PVENode, p.cfg.TemplateVMID, vmid, CloneOptions{
+		Name:    name,
+		Full:    true,
+		Storage: p.cfg.Storage,
+		Pool:    pool,
+	})
+	if err != nil {
+		_ = p.snippets.Remove(snipName)
+		return nil, fmt.Errorf("cloning template: %w", err)
+	}
+	if err := p.client.WaitForTask(ctx, p.cfg.PVENode, upid, provisionTaskTimeout); err != nil {
+		_ = p.snippets.Remove(snipName)
+		return nil, fmt.Errorf("clone task: %w", err)
+	}
+
+	// From here on, failures leave a cloned VM behind; clean it up best-effort.
+	fail := func(err error) (*ProvisionResult, error) {
+		p.log("INSTANCE_PROVISION: rolling back vmid %d after failure: %v", vmid, err)
+		p.cleanup(ctx, vmid, snipName)
+		return nil, err
+	}
+
+	if err := p.client.ConfigureVM(ctx, p.cfg.PVENode, vmid, map[string]string{
+		"cores":       strconv.Itoa(tier.Cores),
+		"memory":      strconv.Itoa(tier.MemoryMB),
+		"cicustom":    "user=" + volRef,
+		"ipconfig0":   "ip=dhcp",
+		"tags":        "aceteam;" + PoolForOrg(req.OrgID),
+		"description": fmt.Sprintf("AceTeam fabric instance %s (org %s, %s)", req.InstanceID, req.OrgID, tier.Name),
+	}); err != nil {
+		return fail(fmt.Errorf("configuring VM: %w", err))
+	}
+
+	if err := p.client.ResizeDisk(ctx, p.cfg.PVENode, vmid, p.cfg.DiskDevice, fmt.Sprintf("%dG", tier.DiskGB)); err != nil {
+		return fail(fmt.Errorf("resizing disk: %w", err))
+	}
+
+	if err := p.client.StartGuest(ctx, p.cfg.PVENode, "qemu", vmid); err != nil {
+		return fail(fmt.Errorf("starting VM: %w", err))
+	}
+
+	return &ProvisionResult{
+		VMID:     vmid,
+		PVENode:  p.cfg.PVENode,
+		Name:     name,
+		Cores:    tier.Cores,
+		MemoryMB: tier.MemoryMB,
+		DiskGB:   tier.DiskGB,
+		Pool:     pool,
+	}, nil
+}
+
+// cleanup best-effort destroys a partially provisioned VM and its snippet.
+func (p *Provisioner) cleanup(ctx context.Context, vmid int, snipName string) {
+	_ = p.client.StopGuest(ctx, p.cfg.PVENode, "qemu", vmid)
+	if upid, err := p.client.DeleteVM(ctx, p.cfg.PVENode, vmid, true); err == nil {
+		_ = p.client.WaitForTask(ctx, p.cfg.PVENode, upid, provisionTaskTimeout)
+	}
+	_ = p.snippets.Remove(snipName)
+}
+
+// Start starts an instance VM.
+func (p *Provisioner) Start(ctx context.Context, ref InstanceRef) error {
+	return p.client.StartGuest(ctx, p.node(ref), "qemu", ref.VMID)
+}
+
+// Stop force-stops an instance VM.
+func (p *Provisioner) Stop(ctx context.Context, ref InstanceRef) error {
+	return p.client.StopGuest(ctx, p.node(ref), "qemu", ref.VMID)
+}
+
+// Destroy stops (best-effort) and deletes an instance VM plus its snippet.
+func (p *Provisioner) Destroy(ctx context.Context, ref InstanceRef, instanceID string) error {
+	node := p.node(ref)
+	_ = p.client.StopGuest(ctx, node, "qemu", ref.VMID)
+	upid, err := p.client.DeleteVM(ctx, node, ref.VMID, true)
+	if err != nil {
+		return fmt.Errorf("deleting VM %d: %w", ref.VMID, err)
+	}
+	if err := p.client.WaitForTask(ctx, node, upid, provisionTaskTimeout); err != nil {
+		return fmt.Errorf("delete task: %w", err)
+	}
+	if instanceID != "" {
+		_ = p.snippets.Remove(snippetName(instanceID))
+	}
+	return nil
+}
+
+// Status returns the live status of an instance VM.
+func (p *Provisioner) Status(ctx context.Context, ref InstanceRef) (*InstanceStatus, error) {
+	st, err := p.client.GetGuestStatus(ctx, p.node(ref), "qemu", ref.VMID)
+	if err != nil {
+		return nil, err
+	}
+	return &InstanceStatus{
+		VMID:          ref.VMID,
+		Status:        st.Status,
+		UptimeSeconds: st.Uptime,
+		CPUs:          st.CPUs,
+		MaxMemBytes:   st.MaxMem,
+	}, nil
+}
+
+func (p *Provisioner) node(ref InstanceRef) string {
+	if ref.PVENode != "" {
+		return ref.PVENode
+	}
+	return p.cfg.PVENode
+}

--- a/internal/proxmox/provisioner_test.go
+++ b/internal/proxmox/provisioner_test.go
@@ -1,0 +1,336 @@
+package proxmox
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeSnippets is an in-memory SnippetStore.
+type fakeSnippets struct {
+	files map[string]string
+}
+
+func newFakeSnippets() *fakeSnippets {
+	return &fakeSnippets{files: map[string]string{}}
+}
+
+func (f *fakeSnippets) Write(name, content string) (string, error) {
+	f.files[name] = content
+	return "local:snippets/" + name, nil
+}
+
+func (f *fakeSnippets) Remove(name string) error {
+	delete(f.files, name)
+	return nil
+}
+
+// pveMock is a stateful mock PVE API for full provisioning flows.
+type pveMock struct {
+	t          *testing.T
+	pools      map[string][]PoolMember
+	cloned     bool
+	configForm url.Values
+	resized    bool
+	started    bool
+	stopped    bool
+	deleted    bool
+	failClone  bool
+	failResize bool
+}
+
+func (m *pveMock) handler(w http.ResponseWriter, r *http.Request) {
+	r.ParseForm()
+	path := strings.TrimPrefix(r.URL.Path, "/api2/json")
+	switch {
+	case r.Method == http.MethodGet && path == "/pools":
+		var pools []Pool
+		for id := range m.pools {
+			pools = append(pools, Pool{PoolID: id})
+		}
+		fmt.Fprintf(w, `{"data":%s}`, marshalOrDie(m.t, pools))
+	case r.Method == http.MethodPost && path == "/pools":
+		m.pools[r.PostForm.Get("poolid")] = nil
+		w.Write([]byte(`{"data":null}`))
+	case r.Method == http.MethodGet && strings.HasPrefix(path, "/pools/"):
+		id := strings.TrimPrefix(path, "/pools/")
+		fmt.Fprintf(w, `{"data":{"members":%s}}`, marshalOrDie(m.t, m.pools[id]))
+	case r.Method == http.MethodGet && path == "/cluster/nextid":
+		w.Write([]byte(`{"data":"105"}`))
+	case r.Method == http.MethodPost && strings.HasSuffix(path, "/clone"):
+		if m.failClone {
+			http.Error(w, `{"errors":{"newid":"already exists"}}`, 400)
+			return
+		}
+		m.cloned = true
+		// Cloning with pool= assigns membership.
+		if pool := r.PostForm.Get("pool"); pool != "" {
+			m.pools[pool] = append(m.pools[pool], PoolMember{Type: "qemu", VMID: 105})
+		}
+		w.Write([]byte(`{"data":"UPID:pve1:0001:qmclone:"}`))
+	case r.Method == http.MethodGet && strings.Contains(path, "/tasks/"):
+		w.Write([]byte(`{"data":{"status":"stopped","exitstatus":"OK"}}`))
+	case r.Method == http.MethodPost && strings.HasSuffix(path, "/config"):
+		m.configForm = r.PostForm
+		w.Write([]byte(`{"data":null}`))
+	case r.Method == http.MethodPut && strings.HasSuffix(path, "/resize"):
+		if m.failResize {
+			http.Error(w, `{"errors":"disk not found"}`, 400)
+			return
+		}
+		m.resized = true
+		w.Write([]byte(`{"data":null}`))
+	case r.Method == http.MethodPost && strings.HasSuffix(path, "/status/start"):
+		m.started = true
+		w.Write([]byte(`{"data":null}`))
+	case r.Method == http.MethodPost && strings.HasSuffix(path, "/status/stop"):
+		m.stopped = true
+		w.Write([]byte(`{"data":null}`))
+	case r.Method == http.MethodDelete && strings.Contains(path, "/qemu/"):
+		m.deleted = true
+		w.Write([]byte(`{"data":"UPID:pve1:0002:qmdestroy:"}`))
+	case r.Method == http.MethodGet && strings.HasSuffix(path, "/status/current"):
+		w.Write([]byte(`{"data":{"status":"running","vmid":105,"uptime":42,"cpus":2,"maxmem":4294967296}}`))
+	default:
+		m.t.Errorf("unexpected request: %s %s", r.Method, path)
+		http.Error(w, "not found", 404)
+	}
+}
+
+func marshalOrDie(t *testing.T, v any) string {
+	t.Helper()
+	if v == nil {
+		return "[]"
+	}
+	data := wrapData(t, v)
+	return strings.TrimSuffix(strings.TrimPrefix(string(data), `{"data":`), "}")
+}
+
+func newTestProvisioner(t *testing.T, mock *pveMock, cfg ProvisioningConfig) (*Provisioner, *fakeSnippets) {
+	t.Helper()
+	orig := taskPollInterval
+	taskPollInterval = time.Millisecond
+	t.Cleanup(func() { taskPollInterval = orig })
+
+	_, client := newTestServer(t, mock.handler)
+	snips := newFakeSnippets()
+	if cfg.PVENode == "" {
+		cfg.PVENode = "pve1"
+	}
+	if cfg.TemplateVMID == 0 {
+		cfg.TemplateVMID = 9000
+	}
+	cfg.Enabled = true
+	p, err := NewProvisioner(client, cfg, snips, nil)
+	if err != nil {
+		t.Fatalf("NewProvisioner: %v", err)
+	}
+	return p, snips
+}
+
+func validRequest() ProvisionRequest {
+	return ProvisionRequest{
+		InstanceID:   "11111111-2222-3333-4444-555555555555",
+		Name:         "My Test Box",
+		InstanceType: "medium",
+		OrgID:        "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+		AuthKey:      "hskey-auth-test123",
+		SSHAuthorizedKeys: []string{
+			"ssh-ed25519 AAAA test@host",
+		},
+	}
+}
+
+func TestProvisionHappyPath(t *testing.T) {
+	mock := &pveMock{t: t, pools: map[string][]PoolMember{}}
+	p, snips := newTestProvisioner(t, mock, ProvisioningConfig{})
+
+	res, err := p.Provision(context.Background(), validRequest())
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	if res.VMID != 105 || res.PVENode != "pve1" {
+		t.Errorf("unexpected result: %+v", res)
+	}
+	if res.Cores != 2 || res.MemoryMB != 4096 || res.DiskGB != 40 {
+		t.Errorf("medium tier not applied: %+v", res)
+	}
+	if res.Name != "my-test-box" {
+		t.Errorf("name not sanitized: %q", res.Name)
+	}
+	if !mock.cloned || !mock.resized || !mock.started {
+		t.Errorf("lifecycle incomplete: cloned=%v resized=%v started=%v", mock.cloned, mock.resized, mock.started)
+	}
+
+	// Sizing + cloud-init config was applied.
+	if mock.configForm.Get("cores") != "2" || mock.configForm.Get("memory") != "4096" {
+		t.Errorf("sizing config not applied: %v", mock.configForm)
+	}
+	cicustom := mock.configForm.Get("cicustom")
+	if !strings.HasPrefix(cicustom, "user=local:snippets/aceteam-") {
+		t.Errorf("cicustom not set: %q", cicustom)
+	}
+
+	// The snippet carries the mesh join with the CUSTOMER org's authkey.
+	var content string
+	for _, c := range snips.files {
+		content = c
+	}
+	if !strings.Contains(content, "hskey-auth-test123") {
+		t.Error("snippet missing authkey")
+	}
+	if !strings.Contains(content, "--login-server=https://nexus.aceteam.ai") {
+		t.Error("snippet missing login server")
+	}
+	if !strings.Contains(content, "ssh-ed25519 AAAA test@host") {
+		t.Error("snippet missing ssh key")
+	}
+	if !strings.Contains(content, "hostname: my-test-box") {
+		t.Error("snippet missing hostname")
+	}
+
+	// Pool created for the org.
+	pool := PoolForOrg(validRequest().OrgID)
+	if _, ok := mock.pools[pool]; !ok {
+		t.Errorf("org pool %q not created (pools: %v)", pool, mock.pools)
+	}
+}
+
+func TestProvisionRejectsUnknownTier(t *testing.T) {
+	mock := &pveMock{t: t, pools: map[string][]PoolMember{}}
+	p, _ := newTestProvisioner(t, mock, ProvisioningConfig{})
+	req := validRequest()
+	req.InstanceType = "mega"
+	if _, err := p.Provision(context.Background(), req); err == nil || !strings.Contains(err.Error(), "unknown instance_type") {
+		t.Fatalf("expected tier error, got %v", err)
+	}
+}
+
+func TestProvisionRequiresAuthKey(t *testing.T) {
+	mock := &pveMock{t: t, pools: map[string][]PoolMember{}}
+	p, _ := newTestProvisioner(t, mock, ProvisioningConfig{})
+	req := validRequest()
+	req.AuthKey = ""
+	if _, err := p.Provision(context.Background(), req); err == nil || !strings.Contains(err.Error(), "authkey is required") {
+		t.Fatalf("expected authkey error, got %v", err)
+	}
+}
+
+func TestProvisionEnforcesOrgCap(t *testing.T) {
+	req := validRequest()
+	pool := PoolForOrg(req.OrgID)
+	mock := &pveMock{t: t, pools: map[string][]PoolMember{
+		pool: {
+			{Type: "qemu", VMID: 101},
+			{Type: "qemu", VMID: 102},
+		},
+	}}
+	p, _ := newTestProvisioner(t, mock, ProvisioningConfig{MaxInstancesPerOrg: 2})
+	if _, err := p.Provision(context.Background(), req); err == nil || !strings.Contains(err.Error(), "instance cap") {
+		t.Fatalf("expected cap error, got %v", err)
+	}
+	if mock.cloned {
+		t.Error("clone must not run when the org is at cap")
+	}
+}
+
+func TestProvisionRollsBackOnResizeFailure(t *testing.T) {
+	mock := &pveMock{t: t, pools: map[string][]PoolMember{}, failResize: true}
+	p, snips := newTestProvisioner(t, mock, ProvisioningConfig{})
+	if _, err := p.Provision(context.Background(), validRequest()); err == nil {
+		t.Fatal("expected resize failure")
+	}
+	if !mock.deleted {
+		t.Error("expected best-effort VM cleanup after failure")
+	}
+	if len(snips.files) != 0 {
+		t.Error("expected snippet cleanup after failure")
+	}
+}
+
+func TestProvisionCleansSnippetOnCloneFailure(t *testing.T) {
+	mock := &pveMock{t: t, pools: map[string][]PoolMember{}, failClone: true}
+	p, snips := newTestProvisioner(t, mock, ProvisioningConfig{})
+	if _, err := p.Provision(context.Background(), validRequest()); err == nil {
+		t.Fatal("expected clone failure")
+	}
+	if len(snips.files) != 0 {
+		t.Error("expected snippet cleanup after clone failure")
+	}
+	if mock.deleted {
+		t.Error("no VM to delete when clone itself failed")
+	}
+}
+
+func TestDestroyStopsDeletesAndRemovesSnippet(t *testing.T) {
+	mock := &pveMock{t: t, pools: map[string][]PoolMember{}}
+	p, snips := newTestProvisioner(t, mock, ProvisioningConfig{})
+	snips.files[snippetName("inst-1")] = "content"
+
+	if err := p.Destroy(context.Background(), InstanceRef{VMID: 105}, "inst-1"); err != nil {
+		t.Fatalf("Destroy: %v", err)
+	}
+	if !mock.stopped || !mock.deleted {
+		t.Errorf("expected stop+delete, got stopped=%v deleted=%v", mock.stopped, mock.deleted)
+	}
+	if len(snips.files) != 0 {
+		t.Error("expected snippet removal")
+	}
+}
+
+func TestStatus(t *testing.T) {
+	mock := &pveMock{t: t, pools: map[string][]PoolMember{}}
+	p, _ := newTestProvisioner(t, mock, ProvisioningConfig{})
+	st, err := p.Status(context.Background(), InstanceRef{VMID: 105})
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if st.Status != "running" || st.UptimeSeconds != 42 {
+		t.Errorf("unexpected status: %+v", st)
+	}
+}
+
+func TestNewProvisionerValidation(t *testing.T) {
+	client := NewClient(ClientConfig{BaseURL: "https://example:8006"})
+	cases := []struct {
+		name string
+		cfg  ProvisioningConfig
+		want string
+	}{
+		{"disabled", ProvisioningConfig{}, "not enabled"},
+		{"no template", ProvisioningConfig{Enabled: true, PVENode: "pve1"}, "template_vmid"},
+		{"no node", ProvisioningConfig{Enabled: true, TemplateVMID: 9000}, "pve_node"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewProvisioner(client, tc.cfg, newFakeSnippets(), nil)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected %q error, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestPoolForOrg(t *testing.T) {
+	got := PoolForOrg("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	if got != "aceteam-org-aaaaaaaabbbb" {
+		t.Errorf("unexpected pool name: %q", got)
+	}
+}
+
+func TestSanitizeName(t *testing.T) {
+	cases := map[string]string{
+		"My Test Box":  "my-test-box",
+		"  weird__x  ": "weird-x",
+		"":             "instance",
+	}
+	for in, want := range cases {
+		if got := sanitizeName(in); got != want {
+			t.Errorf("sanitizeName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/worker/instance_handler.go
+++ b/internal/worker/instance_handler.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/aceteam-ai/citadel-cli/internal/proxmox"
 )
@@ -52,6 +53,15 @@ type InstanceHandlerConfig struct {
 // InstanceHandler processes INSTANCE_* jobs.
 type InstanceHandler struct {
 	cfg InstanceHandlerConfig
+
+	// provisionAttempted dedupes INSTANCE_PROVISION by instance_id. The runner
+	// Nacks failed jobs (redelivered up to MaxAttempts on this same per-node
+	// stream), but provisioning is NOT idempotent: a redelivered attempt after
+	// a partial failure could clone a second VM the platform never hears about
+	// (its waiter already consumed the first error event). First attempt wins;
+	// redeliveries fail terminally with a pointer to inspect hypervisor state.
+	mu                 sync.Mutex
+	provisionAttempted map[string]bool
 }
 
 // NewInstanceHandler constructs an INSTANCE_* handler.
@@ -59,7 +69,7 @@ func NewInstanceHandler(cfg InstanceHandlerConfig) *InstanceHandler {
 	if cfg.Log == nil {
 		cfg.Log = func(string, ...any) {}
 	}
-	return &InstanceHandler{cfg: cfg}
+	return &InstanceHandler{cfg: cfg, provisionAttempted: map[string]bool{}}
 }
 
 // CanHandle reports whether this handler processes the given job type.
@@ -120,6 +130,18 @@ func (h *InstanceHandler) Execute(ctx context.Context, job *Job, stream StreamWr
 }
 
 func (h *InstanceHandler) provision(ctx context.Context, provider InstanceProvider, p instancePayload) (*JobResult, error) {
+	if p.InstanceID != "" {
+		h.mu.Lock()
+		attempted := h.provisionAttempted[p.InstanceID]
+		h.provisionAttempted[p.InstanceID] = true
+		h.mu.Unlock()
+		if attempted {
+			return h.failure(fmt.Errorf(
+				"INSTANCE_PROVISION refused: instance %s was already attempted on this node "+
+					"(likely a redelivered failed job); inspect the hypervisor before re-provisioning",
+				p.InstanceID)), nil
+		}
+	}
 	h.cfg.Log("INSTANCE_PROVISION: instance=%s org=%s type=%s", p.InstanceID, p.OrgID, p.InstanceType)
 	res, err := provider.Provision(ctx, proxmox.ProvisionRequest{
 		InstanceID:        p.InstanceID,

--- a/internal/worker/instance_handler.go
+++ b/internal/worker/instance_handler.go
@@ -1,0 +1,229 @@
+// internal/worker/instance_handler.go
+//
+// INSTANCE_* job handlers (aceteam#5963): EC2-style instance provisioning as a
+// fabric capability. The platform dispatches org-scoped INSTANCE_PROVISION /
+// INSTANCE_START / INSTANCE_STOP / INSTANCE_DESTROY / INSTANCE_STATUS jobs to
+// nodes advertising the `hypervisor:proxmox` capability tag; this handler
+// drives the local hypervisor through an injected provider (the live one wraps
+// internal/proxmox.Provisioner).
+//
+// # Queue gating
+//
+// Instance jobs mutate the hypervisor, so they are honored only when they
+// arrive on a queue the PLATFORM controls targeting: the hypervisor capability
+// queue (jobs:v1:tag:hypervisor:...) or this node's per-node stream. The
+// shared org shell pool is refused (fail closed), mirroring MODULE_SET /
+// AGENT_UPDATE's privilege gating.
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/aceteam-ai/citadel-cli/internal/proxmox"
+)
+
+// hypervisorQueuePrefix matches capability queues that route hypervisor work
+// (e.g. jobs:v1:tag:hypervisor:proxmox, plus any WORKER_QUEUE_SUFFIX variant).
+const hypervisorQueuePrefix = "jobs:v1:tag:hypervisor:"
+
+// InstanceProvider is the hypervisor-side surface the handler drives. The live
+// implementation is *proxmox.Provisioner; tests inject a fake.
+type InstanceProvider interface {
+	Provision(ctx context.Context, req proxmox.ProvisionRequest) (*proxmox.ProvisionResult, error)
+	Start(ctx context.Context, ref proxmox.InstanceRef) error
+	Stop(ctx context.Context, ref proxmox.InstanceRef) error
+	Destroy(ctx context.Context, ref proxmox.InstanceRef, instanceID string) error
+	Status(ctx context.Context, ref proxmox.InstanceRef) (*proxmox.InstanceStatus, error)
+}
+
+// InstanceHandlerConfig configures an InstanceHandler.
+type InstanceHandlerConfig struct {
+	// Provider lazily builds the hypervisor provider. Loading is deferred so a
+	// node whose proxmox.json appears/changes after startup picks it up, and so
+	// unconfigured nodes fail jobs with a clear message instead of at boot.
+	Provider func() (InstanceProvider, error)
+	// Log reports progress. Nil is a no-op.
+	Log func(format string, args ...any)
+}
+
+// InstanceHandler processes INSTANCE_* jobs.
+type InstanceHandler struct {
+	cfg InstanceHandlerConfig
+}
+
+// NewInstanceHandler constructs an INSTANCE_* handler.
+func NewInstanceHandler(cfg InstanceHandlerConfig) *InstanceHandler {
+	if cfg.Log == nil {
+		cfg.Log = func(string, ...any) {}
+	}
+	return &InstanceHandler{cfg: cfg}
+}
+
+// CanHandle reports whether this handler processes the given job type.
+func (h *InstanceHandler) CanHandle(jobType string) bool {
+	switch jobType {
+	case JobTypeInstanceProvision, JobTypeInstanceStart, JobTypeInstanceStop,
+		JobTypeInstanceDestroy, JobTypeInstanceStatus:
+		return true
+	}
+	return false
+}
+
+// instancePayload is the wire payload shared by the INSTANCE_* job family.
+// Provision uses the identity/sizing fields; lifecycle ops use vmid/pve_node.
+type instancePayload struct {
+	InstanceID        string   `json:"instance_id"`
+	Name              string   `json:"name"`
+	InstanceType      string   `json:"instance_type"`
+	OrgID             string   `json:"org_id"`
+	AuthKey           string   `json:"authkey"`
+	LoginServer       string   `json:"login_server"`
+	SSHAuthorizedKeys []string `json:"ssh_authorized_keys"`
+	VMID              int      `json:"vmid"`
+	PVENode           string   `json:"pve_node"`
+}
+
+// Execute dispatches one INSTANCE_* job to the provider.
+func (h *InstanceHandler) Execute(ctx context.Context, job *Job, stream StreamWriter) (*JobResult, error) {
+	if !isInstanceQueue(job.SourceQueue) {
+		return h.failure(fmt.Errorf(
+			"%s refused: must arrive on a hypervisor capability queue or the per-node stream, got source queue %q",
+			job.Type, job.SourceQueue)), nil
+	}
+	if h.cfg.Provider == nil {
+		return h.failure(fmt.Errorf("%s handler is misconfigured: no provider factory", job.Type)), nil
+	}
+
+	p, err := parseInstancePayload(job.Payload)
+	if err != nil {
+		return h.failure(fmt.Errorf("%s: %w", job.Type, err)), nil
+	}
+
+	provider, err := h.cfg.Provider()
+	if err != nil {
+		// Not configured / disabled is terminal for this node: retrying the same
+		// job here cannot help, and failing fast lets the platform reschedule.
+		return h.failure(fmt.Errorf("%s: hypervisor provider unavailable: %w", job.Type, err)), nil
+	}
+
+	switch job.Type {
+	case JobTypeInstanceProvision:
+		return h.provision(ctx, provider, p)
+	case JobTypeInstanceStart, JobTypeInstanceStop, JobTypeInstanceDestroy, JobTypeInstanceStatus:
+		return h.lifecycle(ctx, provider, job.Type, p)
+	default:
+		return h.failure(fmt.Errorf("unhandled instance job type %q", job.Type)), nil
+	}
+}
+
+func (h *InstanceHandler) provision(ctx context.Context, provider InstanceProvider, p instancePayload) (*JobResult, error) {
+	h.cfg.Log("INSTANCE_PROVISION: instance=%s org=%s type=%s", p.InstanceID, p.OrgID, p.InstanceType)
+	res, err := provider.Provision(ctx, proxmox.ProvisionRequest{
+		InstanceID:        p.InstanceID,
+		Name:              p.Name,
+		InstanceType:      p.InstanceType,
+		OrgID:             p.OrgID,
+		AuthKey:           p.AuthKey,
+		LoginServer:       p.LoginServer,
+		SSHAuthorizedKeys: p.SSHAuthorizedKeys,
+	})
+	if err != nil {
+		// Provisioning is NOT idempotent (a retry would clone a second VM), so
+		// fail terminally and let the platform decide whether to re-dispatch.
+		return h.failure(fmt.Errorf("INSTANCE_PROVISION: %w", err)), nil
+	}
+	return &JobResult{
+		Status: JobStatusSuccess,
+		Output: map[string]any{
+			"instance_id": p.InstanceID,
+			"vmid":        res.VMID,
+			"pve_node":    res.PVENode,
+			"name":        res.Name,
+			"cores":       res.Cores,
+			"memory_mb":   res.MemoryMB,
+			"disk_gb":     res.DiskGB,
+			"pool":        res.Pool,
+		},
+	}, nil
+}
+
+func (h *InstanceHandler) lifecycle(ctx context.Context, provider InstanceProvider, jobType string, p instancePayload) (*JobResult, error) {
+	if p.VMID <= 0 {
+		return h.failure(fmt.Errorf("%s: vmid is required", jobType)), nil
+	}
+	ref := proxmox.InstanceRef{VMID: p.VMID, PVENode: p.PVENode}
+	h.cfg.Log("%s: instance=%s vmid=%d", jobType, p.InstanceID, p.VMID)
+
+	out := map[string]any{"instance_id": p.InstanceID, "vmid": p.VMID}
+	var err error
+	switch jobType {
+	case JobTypeInstanceStart:
+		err = provider.Start(ctx, ref)
+		out["state"] = "running"
+	case JobTypeInstanceStop:
+		err = provider.Stop(ctx, ref)
+		out["state"] = "stopped"
+	case JobTypeInstanceDestroy:
+		err = provider.Destroy(ctx, ref, p.InstanceID)
+		out["state"] = "destroyed"
+	case JobTypeInstanceStatus:
+		var st *proxmox.InstanceStatus
+		st, err = provider.Status(ctx, ref)
+		if err == nil {
+			out["state"] = st.Status
+			out["uptime_seconds"] = st.UptimeSeconds
+			out["cpus"] = st.CPUs
+			out["max_mem_bytes"] = st.MaxMemBytes
+		}
+	}
+	if err != nil {
+		// Lifecycle ops are idempotent on the PVE side; a transient API error is
+		// worth a retry (DLQ-bounded by the runner's MaxAttempts).
+		return h.retry(fmt.Errorf("%s: %w", jobType, err)), nil
+	}
+	return &JobResult{Status: JobStatusSuccess, Output: out}, nil
+}
+
+// isInstanceQueue reports whether a source queue is allowed to carry
+// INSTANCE_* jobs: the hypervisor capability queue or the per-node stream.
+func isInstanceQueue(sourceQueue string) bool {
+	return strings.HasPrefix(sourceQueue, hypervisorQueuePrefix) || isPerNodeStream(sourceQueue)
+}
+
+// parseInstancePayload decodes the job payload into the typed instance payload.
+func parseInstancePayload(payload map[string]any) (instancePayload, error) {
+	var p instancePayload
+	if payload == nil {
+		return p, fmt.Errorf("empty payload")
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return p, fmt.Errorf("marshal payload: %w", err)
+	}
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return p, fmt.Errorf("decode instance payload: %w", err)
+	}
+	return p, nil
+}
+
+func (h *InstanceHandler) failure(err error) *JobResult {
+	return &JobResult{
+		Status: JobStatusFailure,
+		Error:  err,
+		Output: map[string]any{"error": err.Error()},
+	}
+}
+
+func (h *InstanceHandler) retry(err error) *JobResult {
+	return &JobResult{
+		Status: JobStatusRetry,
+		Error:  err,
+		Output: map[string]any{"error": err.Error()},
+	}
+}
+
+// Ensure InstanceHandler implements JobHandler.
+var _ JobHandler = (*InstanceHandler)(nil)

--- a/internal/worker/instance_handler_test.go
+++ b/internal/worker/instance_handler_test.go
@@ -1,0 +1,235 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/proxmox"
+)
+
+// fakeInstanceProvider records calls and returns canned results.
+type fakeInstanceProvider struct {
+	calls     []string
+	failWith  error
+	statusRes *proxmox.InstanceStatus
+}
+
+func (f *fakeInstanceProvider) Provision(ctx context.Context, req proxmox.ProvisionRequest) (*proxmox.ProvisionResult, error) {
+	f.calls = append(f.calls, "provision:"+req.InstanceID)
+	if f.failWith != nil {
+		return nil, f.failWith
+	}
+	return &proxmox.ProvisionResult{VMID: 105, PVENode: "pve1", Name: "test", Cores: 2, MemoryMB: 4096, DiskGB: 40, Pool: "aceteam-org-x"}, nil
+}
+
+func (f *fakeInstanceProvider) Start(ctx context.Context, ref proxmox.InstanceRef) error {
+	f.calls = append(f.calls, fmt.Sprintf("start:%d", ref.VMID))
+	return f.failWith
+}
+
+func (f *fakeInstanceProvider) Stop(ctx context.Context, ref proxmox.InstanceRef) error {
+	f.calls = append(f.calls, fmt.Sprintf("stop:%d", ref.VMID))
+	return f.failWith
+}
+
+func (f *fakeInstanceProvider) Destroy(ctx context.Context, ref proxmox.InstanceRef, instanceID string) error {
+	f.calls = append(f.calls, fmt.Sprintf("destroy:%d:%s", ref.VMID, instanceID))
+	return f.failWith
+}
+
+func (f *fakeInstanceProvider) Status(ctx context.Context, ref proxmox.InstanceRef) (*proxmox.InstanceStatus, error) {
+	f.calls = append(f.calls, fmt.Sprintf("status:%d", ref.VMID))
+	if f.failWith != nil {
+		return nil, f.failWith
+	}
+	if f.statusRes != nil {
+		return f.statusRes, nil
+	}
+	return &proxmox.InstanceStatus{VMID: ref.VMID, Status: "running", UptimeSeconds: 42}, nil
+}
+
+// perNodeQueue is declared in agent_update_test.go.
+const (
+	hypervisorQueue = "jobs:v1:tag:hypervisor:proxmox"
+	orgPoolQueue    = "jobs:v1:shell:org_abc"
+)
+
+func newTestInstanceHandler(fake *fakeInstanceProvider, providerErr error) *InstanceHandler {
+	return NewInstanceHandler(InstanceHandlerConfig{
+		Provider: func() (InstanceProvider, error) {
+			if providerErr != nil {
+				return nil, providerErr
+			}
+			return fake, nil
+		},
+	})
+}
+
+func instanceJob(jobType, queue string, payload map[string]any) *Job {
+	return &Job{ID: "job-1", Type: jobType, Payload: payload, SourceQueue: queue}
+}
+
+func TestInstanceHandlerCanHandle(t *testing.T) {
+	h := newTestInstanceHandler(&fakeInstanceProvider{}, nil)
+	for _, jt := range []string{
+		JobTypeInstanceProvision, JobTypeInstanceStart, JobTypeInstanceStop,
+		JobTypeInstanceDestroy, JobTypeInstanceStatus,
+	} {
+		if !h.CanHandle(jt) {
+			t.Errorf("expected CanHandle(%s)", jt)
+		}
+	}
+	if h.CanHandle(JobTypeShellCommand) || h.CanHandle(JobTypeInstanceMessage) {
+		t.Error("must not handle unrelated job types (INSTANCE_MESSAGE is the agent-instance family)")
+	}
+}
+
+func TestInstanceHandlerRefusesOrgPoolQueue(t *testing.T) {
+	fake := &fakeInstanceProvider{}
+	h := newTestInstanceHandler(fake, nil)
+	res, err := h.Execute(context.Background(), instanceJob(JobTypeInstanceProvision, orgPoolQueue, map[string]any{
+		"instance_id": "i-1",
+	}), &NoOpStreamWriter{})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.Status != JobStatusFailure {
+		t.Fatalf("expected failure, got %s", res.Status)
+	}
+	if len(fake.calls) != 0 {
+		t.Error("provider must not be invoked for a refused queue")
+	}
+}
+
+func TestInstanceHandlerAcceptsHypervisorAndPerNodeQueues(t *testing.T) {
+	for _, q := range []string{hypervisorQueue, hypervisorQueue + "_dev", perNodeQueue} {
+		fake := &fakeInstanceProvider{}
+		h := newTestInstanceHandler(fake, nil)
+		res, err := h.Execute(context.Background(), instanceJob(JobTypeInstanceStatus, q, map[string]any{
+			"instance_id": "i-1", "vmid": 105,
+		}), &NoOpStreamWriter{})
+		if err != nil {
+			t.Fatalf("Execute(%s): %v", q, err)
+		}
+		if res.Status != JobStatusSuccess {
+			t.Fatalf("queue %s: expected success, got %s (%v)", q, res.Status, res.Error)
+		}
+	}
+}
+
+func TestInstanceHandlerProvision(t *testing.T) {
+	fake := &fakeInstanceProvider{}
+	h := newTestInstanceHandler(fake, nil)
+	res, err := h.Execute(context.Background(), instanceJob(JobTypeInstanceProvision, hypervisorQueue, map[string]any{
+		"instance_id":   "i-1",
+		"name":          "box",
+		"instance_type": "medium",
+		"org_id":        "org-1",
+		"authkey":       "hskey-x",
+	}), &NoOpStreamWriter{})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.Status != JobStatusSuccess {
+		t.Fatalf("expected success, got %s: %v", res.Status, res.Error)
+	}
+	if res.Output["vmid"] != 105 || res.Output["pve_node"] != "pve1" {
+		t.Errorf("unexpected output: %v", res.Output)
+	}
+	if len(fake.calls) != 1 || fake.calls[0] != "provision:i-1" {
+		t.Errorf("unexpected calls: %v", fake.calls)
+	}
+}
+
+func TestInstanceHandlerProvisionFailureIsTerminal(t *testing.T) {
+	fake := &fakeInstanceProvider{failWith: errors.New("org at cap")}
+	h := newTestInstanceHandler(fake, nil)
+	res, _ := h.Execute(context.Background(), instanceJob(JobTypeInstanceProvision, hypervisorQueue, map[string]any{
+		"instance_id": "i-1", "instance_type": "small", "org_id": "o", "authkey": "k",
+	}), &NoOpStreamWriter{})
+	// Provisioning is not idempotent: never retry (a retry could double-clone).
+	if res.Status != JobStatusFailure {
+		t.Fatalf("expected terminal failure, got %s", res.Status)
+	}
+}
+
+func TestInstanceHandlerLifecycleOps(t *testing.T) {
+	cases := []struct {
+		jobType string
+		want    string
+	}{
+		{JobTypeInstanceStart, "start:105"},
+		{JobTypeInstanceStop, "stop:105"},
+		{JobTypeInstanceDestroy, "destroy:105:i-1"},
+		{JobTypeInstanceStatus, "status:105"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.jobType, func(t *testing.T) {
+			fake := &fakeInstanceProvider{}
+			h := newTestInstanceHandler(fake, nil)
+			res, err := h.Execute(context.Background(), instanceJob(tc.jobType, perNodeQueue, map[string]any{
+				"instance_id": "i-1", "vmid": 105, "pve_node": "pve1",
+			}), &NoOpStreamWriter{})
+			if err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+			if res.Status != JobStatusSuccess {
+				t.Fatalf("expected success, got %s: %v", res.Status, res.Error)
+			}
+			if len(fake.calls) != 1 || fake.calls[0] != tc.want {
+				t.Errorf("unexpected calls: %v (want %s)", fake.calls, tc.want)
+			}
+		})
+	}
+}
+
+func TestInstanceHandlerLifecycleRequiresVMID(t *testing.T) {
+	h := newTestInstanceHandler(&fakeInstanceProvider{}, nil)
+	res, _ := h.Execute(context.Background(), instanceJob(JobTypeInstanceStop, perNodeQueue, map[string]any{
+		"instance_id": "i-1",
+	}), &NoOpStreamWriter{})
+	if res.Status != JobStatusFailure {
+		t.Fatalf("expected failure without vmid, got %s", res.Status)
+	}
+}
+
+func TestInstanceHandlerLifecycleFailureRetries(t *testing.T) {
+	fake := &fakeInstanceProvider{failWith: errors.New("connection refused")}
+	h := newTestInstanceHandler(fake, nil)
+	res, _ := h.Execute(context.Background(), instanceJob(JobTypeInstanceStop, perNodeQueue, map[string]any{
+		"instance_id": "i-1", "vmid": 105,
+	}), &NoOpStreamWriter{})
+	if res.Status != JobStatusRetry {
+		t.Fatalf("expected retry on transient lifecycle failure, got %s", res.Status)
+	}
+}
+
+func TestInstanceHandlerUnconfiguredProviderFailsClearly(t *testing.T) {
+	h := newTestInstanceHandler(nil, errors.New("proxmox is not configured on this node"))
+	res, _ := h.Execute(context.Background(), instanceJob(JobTypeInstanceStatus, hypervisorQueue, map[string]any{
+		"instance_id": "i-1", "vmid": 105,
+	}), &NoOpStreamWriter{})
+	if res.Status != JobStatusFailure {
+		t.Fatalf("expected failure, got %s", res.Status)
+	}
+	if res.Error == nil || res.Output["error"] == "" {
+		t.Error("expected a clear error message")
+	}
+}
+
+func TestInstanceHandlerStatusPayloadUsesNumericVMID(t *testing.T) {
+	// Redis payloads decode numbers as float64; ensure the typed decode copes.
+	fake := &fakeInstanceProvider{}
+	h := newTestInstanceHandler(fake, nil)
+	res, _ := h.Execute(context.Background(), instanceJob(JobTypeInstanceStatus, hypervisorQueue, map[string]any{
+		"instance_id": "i-1", "vmid": float64(105),
+	}), &NoOpStreamWriter{})
+	if res.Status != JobStatusSuccess {
+		t.Fatalf("expected success, got %s: %v", res.Status, res.Error)
+	}
+	if fake.calls[0] != "status:105" {
+		t.Errorf("vmid not decoded from float64: %v", fake.calls)
+	}
+}

--- a/internal/worker/instance_handler_test.go
+++ b/internal/worker/instance_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/aceteam-ai/citadel-cli/internal/proxmox"
@@ -140,6 +141,36 @@ func TestInstanceHandlerProvision(t *testing.T) {
 	}
 	if len(fake.calls) != 1 || fake.calls[0] != "provision:i-1" {
 		t.Errorf("unexpected calls: %v", fake.calls)
+	}
+}
+
+func TestInstanceHandlerProvisionDedupesRedelivery(t *testing.T) {
+	// The runner Nacks failed jobs, so a failed provision is redelivered on the
+	// same per-node stream. A second attempt must be refused without touching
+	// the provider (it could clone a second VM the platform never hears about).
+	fake := &fakeInstanceProvider{failWith: errors.New("resize failed")}
+	h := newTestInstanceHandler(fake, nil)
+	payload := map[string]any{
+		"instance_id": "i-dup", "instance_type": "small", "org_id": "o", "authkey": "k",
+	}
+
+	res, _ := h.Execute(context.Background(), instanceJob(JobTypeInstanceProvision, hypervisorQueue, payload), &NoOpStreamWriter{})
+	if res.Status != JobStatusFailure {
+		t.Fatalf("expected first attempt to fail, got %s", res.Status)
+	}
+	if len(fake.calls) != 1 {
+		t.Fatalf("expected one provider call, got %v", fake.calls)
+	}
+
+	res, _ = h.Execute(context.Background(), instanceJob(JobTypeInstanceProvision, hypervisorQueue, payload), &NoOpStreamWriter{})
+	if res.Status != JobStatusFailure {
+		t.Fatalf("expected redelivery to fail terminally, got %s", res.Status)
+	}
+	if len(fake.calls) != 1 {
+		t.Errorf("provider must not run again on redelivery: %v", fake.calls)
+	}
+	if !strings.Contains(res.Error.Error(), "already attempted") {
+		t.Errorf("expected already-attempted error, got %v", res.Error)
 	}
 }
 

--- a/internal/worker/job.go
+++ b/internal/worker/job.go
@@ -141,6 +141,15 @@ const (
 	JobTypeInstanceMessage   = "INSTANCE_MESSAGE"    // Deliver a turn to a BYOC instance's loopback container (aceteam#5241)
 	JobTypeModuleSet         = "MODULE_SET"          // Set the desired state of a single module on this node (interim, aceteam#5280)
 	JobTypeMeetingJoin       = "MEETING_JOIN"        // Auto-join a video call, record + transcribe it node-locally (aceteam#5098)
+
+	// Fabric instance provisioning on a local hypervisor (aceteam#5963). These
+	// act on hypervisor VMs; JobTypeInstanceMessage above predates this family
+	// and addresses hosted agent instances, not VMs.
+	JobTypeInstanceProvision = "INSTANCE_PROVISION" // Clone + size + mesh-enroll + start a new instance VM
+	JobTypeInstanceStart     = "INSTANCE_START"     // Start an existing instance VM
+	JobTypeInstanceStop      = "INSTANCE_STOP"      // Stop an existing instance VM
+	JobTypeInstanceDestroy   = "INSTANCE_DESTROY"   // Destroy an instance VM and its resources
+	JobTypeInstanceStatus    = "INSTANCE_STATUS"    // Report an instance VM's live status
 )
 
 // allKnownJobTypes enumerates every job type this citadel build knows about.
@@ -191,4 +200,9 @@ var allKnownJobTypes = []string{
 	JobTypeInstanceMessage,
 	JobTypeModuleSet,
 	JobTypeMeetingJoin,
+	JobTypeInstanceProvision,
+	JobTypeInstanceStart,
+	JobTypeInstanceStop,
+	JobTypeInstanceDestroy,
+	JobTypeInstanceStatus,
 }


### PR DESCRIPTION
## Context

Phase 1 of aceteam-ai/aceteam#5963 — EC2-style instances as a fabric capability. The fabric can sell inference, shell, and sandboxes, but not the most universally understood unit of compute: a VM. This PR is the node side: a Citadel worker on (or adjacent to) a Proxmox VE host consumes the new `INSTANCE_*` job family and drives the PVE REST API to clone, size, mesh-enroll, and lifecycle full VMs for customer orgs. The platform side (dispatch, registry, ACET settlement, MCP tools) is the companion PR aceteam-ai/aceteam (feat/5963-instance-provisioning).

The `hypervisor:proxmox` capability tag + PVE host detection already shipped on main (cmd/work.go via `platform.DetectProxmox()`); this PR gives that tag something to do.

## Summary

**`internal/proxmox/provision.go`** — mutating PVE API methods, extending the existing read-mostly client: `NextID`, `CloneVM` (full clone, pool assignment at creation), `ConfigureVM`, `ResizeDisk`, `DeleteVM` (purge), `GetTaskStatus`/`WaitForTask` (UPID polling), and pool ops (`ListPools`/`CreatePool`/`GetPoolMembers`/`EnsurePool`). New file rather than edits to `client.go` to stay out of the way of concurrent proxmox work.

**`internal/proxmox/provisioner.go`** — the orchestration layer:
- Instance-type sizing table (`small` 1/2G/20G → `xlarge` 8/16G/160G), mirrored by the platform's `models/fabric_instance.py` (comment on both sides to keep in sync).
- **Mesh delivery**: renders a `#cloud-config` user-data snippet that installs tailscale and joins with the CUSTOMER org's authkey (minted platform-side), so the instance lands in `org_<customer>` — not the operator's namespace. Delivered via `cicustom` + a `SnippetStore` (live impl writes the PVE snippets dir with 0600; assumes citadel runs on the hypervisor since the PVE API can't upload snippets — remote-adjacent delivery is a follow-up). TODO(#5959) marker for swapping the one-shot key for device-identity enrolment.
- **Per-org caps**: each customer org gets a PVE resource pool (`aceteam-org-<12hex>`); provision refuses when the pool's qemu count ≥ `max_instances_per_org` (default 3).
- Rollback: post-clone failures best-effort stop+purge the half-built VM and remove the snippet.

**`internal/worker/instance_handler.go`** — native `worker.JobHandler` for `INSTANCE_PROVISION/START/STOP/DESTROY/STATUS` with an injectable `InstanceProvider`. Queue gate (fail closed, same pattern as MODULE_SET): jobs are honored only from `jobs:v1:tag:hypervisor:*` queues or the per-node stream, never the shared org shell pool. Provision failures are terminal (a retry would clone a second VM); lifecycle failures retry (idempotent on the PVE side, DLQ-bounded).

**Wiring** — job type consts + `allKnownJobTypes` (job.go), lazy provider factory (`cmd/instance_ops.go`) that re-reads `proxmox.json` per job, registration in `registerPrivilegedNodeJobHandlers` so both `citadel work` and the control-center worker handle the family. Provisioning is opt-in: `proxmox.json` needs an enabled `provisioning` section with a `template_vmid`.

Note on naming: `INSTANCE_MESSAGE` (aceteam#5241) predates this family and addresses hosted *agent* instances, not VMs — called out in the const block.

## Test plan

All PVE interaction mocked (`httptest`); zero live hypervisor calls.

| Area | Tests |
| ---- | ----- |
| PVE client methods | `provision_test.go` — clone params, config, resize, delete+purge, task polling (running→stopped, failure exitstatus), pool ensure/members |
| Provisioner | `provisioner_test.go` — happy path against a stateful mock PVE (sizing applied, cicustom set, snippet carries authkey/login-server/ssh keys/hostname, org pool created), unknown tier, missing authkey, org cap enforcement (clone never runs), rollback on resize failure, snippet cleanup on clone failure, destroy stop+delete+snippet removal, name sanitization |
| Handler | `instance_handler_test.go` — CanHandle set, org-pool queue refused (provider never invoked), hypervisor/per-node queues accepted, provision terminal-fail, lifecycle retry, missing vmid, unconfigured provider fails with clear message, float64 vmid decode |

`go test ./...` green; `go vet` + `gofmt` clean.

## Related

- aceteam-ai/aceteam#5963 (spec; phase 2 — Citadel OS on PVE — out of scope)
- aceteam-ai/aceteam#5959 (device identity; first-boot enrolment TODO)
- aceteam-ai/aceteam#5695 (BYOC epic)

---
*Generated by Claude Opus 4.8*
