### PR TITLE
feat(jobs): SERVICE_START pulls the model for natively-running ollama (#543)

### DIFF
--- a/internal/jobs/model_cache_pull.go
+++ b/internal/jobs/model_cache_pull.go
@@ -2,15 +2,32 @@
 package jobs
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
 )
+
+// ollamaPullTimeout bounds a foreground `ollama pull`. Pulls of large models
+// on slow links can legitimately take a long time, so this is generous — the
+// bound exists only so a wedged pull cannot pin a job slot forever.
+const ollamaPullTimeout = 2 * time.Hour
+
+// runOllamaPull runs `ollama pull <model>` bounded by ollamaPullTimeout.
+// Shared by MODEL_CACHE_PULL (pullOllama) and the SERVICE_START native-ollama
+// path (ensureOllamaModel, #543) so both pull with the same bounds.
+func runOllamaPull(modelName string) ([]byte, error) {
+	cctx, cancel := context.WithTimeout(context.Background(), ollamaPullTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(cctx, "ollama", "pull", modelName)
+	return cmd.CombinedOutput()
+}
 
 // ModelCachePullHandler handles MODEL_CACHE_PULL jobs.
 // It pulls model weights into the local cache for the specified engine.
@@ -50,8 +67,7 @@ func (h *ModelCachePullHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte,
 func (h *ModelCachePullHandler) pullOllama(ctx JobContext, jobID, modelName string) ([]byte, error) {
 	ctx.Log("info", "     - [Job %s] Pulling model '%s' via ollama", jobID, modelName)
 
-	cmd := exec.Command("ollama", "pull", modelName)
-	output, err := cmd.CombinedOutput()
+	output, err := runOllamaPull(modelName)
 	if err != nil {
 		return output, fmt.Errorf("ollama pull failed: %w", err)
 	}

--- a/internal/jobs/service_handler.go
+++ b/internal/jobs/service_handler.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/catalog"
 	"github.com/aceteam-ai/citadel-cli/internal/compose"
@@ -220,17 +221,43 @@ func (h *ServiceHandler) serviceStart(ctx JobContext, svc manifestService, model
 
 	switch kind {
 	case "native":
+		// Native ollama has no compose env to inject, but its model contract is
+		// pull-based: SERVICE_START {service: ollama, model: X} must ensure X is
+		// pulled (idempotent, fast when cached) so the deploy contract holds even
+		// when the preceding MODEL_CACHE_PULL failed or was missed (#543). Other
+		// native engines have no pull mechanism; their model param stays ignored.
+		pullModel := ""
 		if model != "" {
-			ctx.Log("info", "     - Service %s runs natively; model %q ignored (no compose env to inject)", svc.Name, model)
+			if svc.Name == "ollama" {
+				pullModel = model
+			} else {
+				ctx.Log("info", "     - Service %s runs natively; model %q ignored (no pull mechanism for this engine)", svc.Name, model)
+			}
 		}
-		if services.IsNativeServiceRunning(svc.Name) {
+		alreadyRunning := services.IsNativeServiceRunning(svc.Name)
+		if !alreadyRunning {
+			logDir := filepath.Join(h.ConfigDir, "logs")
+			_, err = services.StartNativeService(svc.Name, logDir)
+		}
+		if err == nil && pullModel != "" {
+			// Hard error on pull failure (job FAILURE), deliberately unlike the
+			// soft serviceResult.Error path below: a deploy that could not make
+			// the model available must not report success (#543).
+			if pullErr := ensureOllamaModel(ctx, pullModel, !alreadyRunning); pullErr != nil {
+				return nil, pullErr
+			}
+			appliedModel = pullModel
+		}
+		if alreadyRunning {
+			msg := svc.Name + " is already running"
+			if appliedModel != "" {
+				msg = fmt.Sprintf("%s is already running; model %s pulled and available", svc.Name, appliedModel)
+			}
 			return json.Marshal(serviceResult{
 				Name: svc.Name, Running: true, Kind: kind,
-				Action: "start", Message: svc.Name + " is already running",
+				Action: "start", Message: msg,
 			})
 		}
-		logDir := filepath.Join(h.ConfigDir, "logs")
-		_, err = services.StartNativeService(svc.Name, logDir)
 
 	case "docker":
 		modelChanged := false
@@ -472,6 +499,47 @@ func (h *ServiceHandler) persistServiceModel(ctx JobContext, svc manifestService
 	}
 	ctx.Log("info", "     - Persisted %s=%s to %s", envVar, model, envPath)
 	return envVar, true, nil
+}
+
+// ollamaServerWaitTimeout bounds the readiness poll before pulling on a
+// freshly-started native ollama: `ollama pull` needs the server up.
+const ollamaServerWaitTimeout = 30 * time.Second
+
+// ensureOllamaModel makes a model available on a natively-running ollama by
+// running `ollama pull <model>` (#543). The pull is idempotent and fast when
+// the model is already cached, so it is safe to run on every SERVICE_START —
+// it is the node-side guarantee that the deploy contract (MODEL_CACHE_PULL
+// then SERVICE_START {service, model}) holds even when the weights pull was
+// missed or dispatched to the wrong engine. Failures are returned as errors so
+// the job reports FAILURE instead of silently serving nothing. When
+// waitForServer is set (service just started), the server is polled via
+// `ollama list` before pulling; on poll timeout the pull still runs and
+// surfaces the real connection error.
+func ensureOllamaModel(ctx JobContext, model string, waitForServer bool) error {
+	// The model is backend-controlled input passed to exec: validate with the
+	// same allowlist the compose env persistence uses.
+	if !modelIDPattern.MatchString(model) {
+		return fmt.Errorf("invalid model identifier %q", model)
+	}
+	if _, err := exec.LookPath("ollama"); err != nil {
+		return fmt.Errorf("cannot pull model %q: ollama binary not found in PATH", model)
+	}
+	if waitForServer {
+		deadline := time.Now().Add(ollamaServerWaitTimeout)
+		for time.Now().Before(deadline) {
+			if exec.Command("ollama", "list").Run() == nil {
+				break
+			}
+			time.Sleep(time.Second)
+		}
+	}
+	ctx.Log("info", "     - Ensuring ollama model %q is pulled (idempotent; fast when cached)", model)
+	out, err := runOllamaPull(model)
+	if err != nil {
+		return fmt.Errorf("ollama pull %s failed: %w: %s", model, err, strings.TrimSpace(string(out)))
+	}
+	ctx.Log("info", "     - Model %q pulled and available on ollama", model)
+	return nil
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/jobs/service_handler_native_model_test.go
+++ b/internal/jobs/service_handler_native_model_test.go
@@ -1,0 +1,183 @@
+// internal/jobs/service_handler_native_model_test.go
+//
+// SERVICE_START model on a natively-running ollama (#543): the model contract
+// for ollama is pull-based, so instead of dropping the model param ("ignored"),
+// the handler must run `ollama pull <model>` — idempotent, fast when cached —
+// and report FAILURE when the pull cannot be performed. These tests fake the
+// ollama (and pgrep) binaries on PATH so nothing real is executed.
+package jobs
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+// fakeBinDir creates a temp dir set as the ONLY PATH entry, and returns it
+// together with a helper that writes an executable shell script into it.
+func fakeBinDir(t *testing.T) (string, func(name, script string)) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake-binary shell scripts are not runnable on windows")
+	}
+	dir := t.TempDir()
+	t.Setenv("PATH", dir)
+	write := func(name, script string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("#!/bin/sh\n"+script), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir, write
+}
+
+// newNativeOllamaHandler writes a citadel.yaml declaring ollama (and llamacpp)
+// as type: native so resolveKind never probes binaries.
+func newNativeOllamaHandler(t *testing.T) *ServiceHandler {
+	t.Helper()
+	dir := t.TempDir()
+	manifest := `node:
+  name: test-node
+services:
+  - name: ollama
+    type: native
+  - name: llamacpp
+    type: native
+`
+	if err := os.WriteFile(filepath.Join(dir, "citadel.yaml"), []byte(manifest), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return NewServiceHandler(dir)
+}
+
+func TestEnsureOllamaModel_InvalidModel(t *testing.T) {
+	// Validation happens before any exec, so no fake binary is needed.
+	t.Setenv("PATH", t.TempDir())
+	for _, bad := range []string{"a b", "$(rm -rf /)", "-leading", ""} {
+		if err := ensureOllamaModel(JobContext{}, bad, false); err == nil {
+			t.Errorf("ensureOllamaModel accepted invalid model %q", bad)
+		}
+	}
+}
+
+func TestEnsureOllamaModel_MissingBinary(t *testing.T) {
+	t.Setenv("PATH", t.TempDir()) // no ollama anywhere
+	err := ensureOllamaModel(JobContext{}, "qwen2.5:7b", false)
+	if err == nil || !strings.Contains(err.Error(), "ollama binary not found") {
+		t.Errorf("err = %v, want ollama-binary-not-found error", err)
+	}
+}
+
+func TestEnsureOllamaModel_PullSuccess(t *testing.T) {
+	dir, write := fakeBinDir(t)
+	argsFile := filepath.Join(dir, "args.log")
+	write("ollama", `echo "$@" >> `+argsFile+`
+exit 0`)
+
+	// waitForServer=true also exercises the readiness poll (`ollama list`),
+	// which the fake answers immediately.
+	if err := ensureOllamaModel(JobContext{}, "qwen2.5:7b", true); err != nil {
+		t.Fatalf("ensureOllamaModel: %v", err)
+	}
+	logged, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("fake ollama was never invoked: %v", err)
+	}
+	if !strings.Contains(string(logged), "pull qwen2.5:7b") {
+		t.Errorf("fake ollama invocations = %q, want a 'pull qwen2.5:7b' call", logged)
+	}
+}
+
+func TestEnsureOllamaModel_PullFailure(t *testing.T) {
+	_, write := fakeBinDir(t)
+	write("ollama", `if [ "$1" = "pull" ]; then echo "pull failed: manifest not found" >&2; exit 1; fi
+exit 0`)
+
+	err := ensureOllamaModel(JobContext{}, "no-such-model", false)
+	if err == nil {
+		t.Fatal("expected error from failing pull, got nil")
+	}
+	if !strings.Contains(err.Error(), "manifest not found") {
+		t.Errorf("pull failure should surface command output, got: %v", err)
+	}
+}
+
+// TestServiceStartNativeOllama_PullsModel drives the full Execute path on the
+// observed node-1084 shape: ollama already running natively (fake pgrep exits
+// 0) and SERVICE_START carries a model. The model must be pulled — not ignored
+// — and the result message must say so.
+func TestServiceStartNativeOllama_PullsModel(t *testing.T) {
+	dir, write := fakeBinDir(t)
+	argsFile := filepath.Join(dir, "args.log")
+	write("pgrep", "exit 0") // "already running"
+	write("ollama", `echo "$@" >> `+argsFile+`
+exit 0`)
+	h := newNativeOllamaHandler(t)
+
+	out, err := h.Execute(JobContext{}, &nexus.Job{
+		ID:      "job-543-1",
+		Type:    "SERVICE_START",
+		Payload: map[string]string{"service": "ollama", "model": "qwen2.5:7b"},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	logged, rErr := os.ReadFile(argsFile)
+	if rErr != nil || !strings.Contains(string(logged), "pull qwen2.5:7b") {
+		t.Errorf("ollama pull not invoked (log=%q, err=%v)", logged, rErr)
+	}
+	if !strings.Contains(string(out), "pulled") {
+		t.Errorf("result should report the model as pulled, got: %s", out)
+	}
+	if strings.Contains(string(out), "ignored") {
+		t.Errorf("result still reports the model as ignored: %s", out)
+	}
+}
+
+// TestServiceStartNativeOllama_PullFailureIsJobFailure: when the pull cannot
+// run (here: ollama binary absent), the job must FAIL — a hard error, not a
+// soft serviceResult — so the deploy gets honest feedback (#543).
+func TestServiceStartNativeOllama_PullFailureIsJobFailure(t *testing.T) {
+	_, write := fakeBinDir(t)
+	write("pgrep", "exit 0") // running, but no ollama binary on PATH
+	h := newNativeOllamaHandler(t)
+
+	_, err := h.Execute(JobContext{}, &nexus.Job{
+		ID:      "job-543-2",
+		Type:    "SERVICE_START",
+		Payload: map[string]string{"service": "ollama", "model": "qwen2.5:7b"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "ollama binary not found") {
+		t.Errorf("err = %v, want hard ollama-binary-not-found failure", err)
+	}
+}
+
+// TestServiceStartNativeNonOllama_ModelStillIgnored pins the unchanged
+// behavior for native engines with no pull mechanism: the model is logged as
+// ignored and the start succeeds without any pull attempt.
+func TestServiceStartNativeNonOllama_ModelStillIgnored(t *testing.T) {
+	_, write := fakeBinDir(t)
+	write("pgrep", "exit 0") // llamacpp "already running"
+	h := newNativeOllamaHandler(t)
+
+	var logs []string
+	ctx := JobContext{LogFn: func(_, msg string) { logs = append(logs, msg) }}
+	out, err := h.Execute(ctx, &nexus.Job{
+		ID:      "job-543-3",
+		Type:    "SERVICE_START",
+		Payload: map[string]string{"service": "llamacpp", "model": "some/model"},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(string(out), "already running") {
+		t.Errorf("result = %s, want already-running", out)
+	}
+	if !strings.Contains(strings.Join(logs, "\n"), "ignored") {
+		t.Errorf("expected 'ignored' log for non-ollama native engine, logs: %v", logs)
+	}
+}


### PR DESCRIPTION
## Context
Live deploy test today (aceteam#5996): SERVICE_START `{service: ollama, model: qwen2.5:7b}` on node 1084 (native ollama) logged `model "qwen2.5:7b" ignored (no compose env to inject)` and dropped the model. Combined with the backend dispatching the weights pull to the wrong engine, the deploy silently served nothing. Fixes #543.

## Changes
- `internal/jobs/service_handler.go`: native ollama SERVICE_START with a model now runs `ollama pull` on both sub-paths (already-running — the observed case — and freshly-started, after a ≤30s readiness poll of `ollama list`). New `ensureOllamaModel()` validates the model id against the existing `modelIDPattern` allowlist and errors clearly if the `ollama` binary is absent. **Pull failure = hard job FAILURE** (honest feedback, deliberately unlike the soft start path). Result message now says `model qwen2.5:7b pulled and available`. Other native engines (vllm/llamacpp, no pull mechanism) keep the ignore behavior with clarified wording.
- `internal/jobs/model_cache_pull.go`: extracted shared `runOllamaPull` with a 2h `exec.CommandContext` bound; MODEL_CACHE_PULL's `pullOllama` (previously unbounded) and the new path both use it.
- `internal/jobs/service_handler_native_model_test.go` (new): 6 tests with fake `ollama`/`pgrep` binaries on PATH — invalid model rejected pre-exec, missing binary error, pull success incl. readiness poll, pull failure surfaces output, full Execute on the node-1084 shape, non-ollama native engine unchanged.

## Testing
`go build ./...`, `go vet ./...`, `go test ./internal/jobs/` all pass; 6 new tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)