### PR TITLE
fix(logs): don't fail /agent/logs read on over-long log lines

### DIFF
--- a/cmd/agent_tools.go
+++ b/cmd/agent_tools.go
@@ -11,6 +11,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -168,6 +169,12 @@ func agentNodeInfo(nodeName, headscaleNodeID, orgID string, startedAt time.Time)
 	return info
 }
 
+// maxLogLineBytes caps the length of any single log line returned to the caller.
+// A line longer than this is truncated with a marker rather than dropped, so one
+// pathological line (e.g. a giant single-line JSON blob) can neither abort the
+// read nor bloat the HTTP response.
+const maxLogLineBytes = 1 << 20 // 1 MiB
+
 // agentTailLogs reads up to opts.Lines lines from ~/.citadel-cli/logs/latest.log,
 // applying optional level/grep/since filters. This is where the previously-lost
 // worker stdout now lives, because #234 routed the source LogFn and we now wire
@@ -202,25 +209,47 @@ func agentTailLogs(opts struct {
 	levelFilter := strings.ToLower(strings.TrimSpace(opts.Level))
 	grep := strings.ToLower(opts.Grep)
 
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	// Read line-by-line with bufio.Reader.ReadString instead of bufio.Scanner.
+	// Scanner hard-fails (bufio.Scanner: token too long) on any line exceeding its
+	// buffer cap, which aborted the whole read — precisely when a node is
+	// misbehaving and emitting long JSON/stacktrace lines (the case an agent most
+	// needs to inspect). ReadString has no token-size limit, so a single long line
+	// can never cause the log read to 500. We still truncate any individual line
+	// to a sane display cap so one pathological line can't bloat the HTTP response.
+	reader := bufio.NewReader(f)
 	var matched []string
-	for scanner.Scan() {
-		line := scanner.Text()
-		lower := strings.ToLower(line)
-		if grep != "" && !strings.Contains(lower, grep) {
-			continue
+	for {
+		line, readErr := reader.ReadString('\n')
+		// Process the line before handling the error: ReadString returns the final
+		// newline-less line together with io.EOF, so checking the error first would
+		// silently drop it.
+		if len(line) > 0 {
+			// Match previous scanner.Text() semantics (no trailing newline).
+			line = strings.TrimRight(line, "\r\n")
+			if len(line) > maxLogLineBytes {
+				line = line[:maxLogLineBytes] + "…[truncated]"
+			}
+			lower := strings.ToLower(line)
+			keep := true
+			if grep != "" && !strings.Contains(lower, grep) {
+				keep = false
+			}
+			if keep && levelFilter != "" && !strings.Contains(lower, levelFilter) {
+				keep = false
+			}
+			if keep && !since.IsZero() && !logLineAfter(line, since) {
+				keep = false
+			}
+			if keep {
+				matched = append(matched, line)
+			}
 		}
-		if levelFilter != "" && !strings.Contains(lower, levelFilter) {
-			continue
+		if readErr != nil {
+			if readErr == io.EOF {
+				break
+			}
+			return "", fmt.Errorf("error reading log: %w", readErr)
 		}
-		if !since.IsZero() && !logLineAfter(line, since) {
-			continue
-		}
-		matched = append(matched, line)
-	}
-	if err := scanner.Err(); err != nil {
-		return "", fmt.Errorf("error reading log: %w", err)
 	}
 
 	// Keep only the last N lines.

--- a/cmd/agent_tools_test.go
+++ b/cmd/agent_tools_test.go
@@ -124,6 +124,56 @@ func TestAgentTailLogsFilters(t *testing.T) {
 	}
 }
 
+// TestAgentTailLogsLongLine reproduces the bug where a single log line longer
+// than bufio.Scanner's buffer aborted the whole read with "bufio.Scanner: token
+// too long", surfacing as `citadel_logs failed: ... 500: error reading log`.
+// The reader must return the (truncated) long line without error, and must not
+// drop a following final line that has no trailing newline.
+func TestAgentTailLogsLongLine(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	logDir := filepath.Join(tmp, ".citadel-cli", "logs")
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// ~2 MiB single line: exceeds both bufio.Scanner's 64 KiB default and the
+	// former 1 MiB Buffer cap, so the old code would have hard-failed here.
+	longLine := "[00:00:00] [CITADEL] error: " + strings.Repeat("X", 2<<20)
+	// A trailing line WITHOUT a newline verifies ReadString's final-token handling.
+	content := longLine + "\n[00:00:01] [CITADEL] info: last line no newline"
+	if err := os.WriteFile(filepath.Join(logDir, "latest.log"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := struct {
+		Lines int
+		Level string
+		Grep  string
+		Since string
+	}{Lines: 100}
+
+	out, err := agentTailLogs(opts)
+	if err != nil {
+		t.Fatalf("long line must not error, got: %v", err)
+	}
+	lines := strings.Split(out, "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+	// Long line is truncated to the display cap plus marker, not returned whole.
+	if !strings.Contains(lines[0], "…[truncated]") {
+		t.Fatalf("expected truncation marker on long line")
+	}
+	if len(lines[0]) > maxLogLineBytes+len("…[truncated]") {
+		t.Fatalf("long line not truncated to cap: len=%d", len(lines[0]))
+	}
+	// Final newline-less line must be preserved (not dropped by EOF handling).
+	if lines[1] != "[00:00:01] [CITADEL] info: last line no newline" {
+		t.Fatalf("final newline-less line lost or altered: %q", lines[1])
+	}
+}
+
 func TestAgentNodeInfoFields(t *testing.T) {
 	info := agentNodeInfo("node-1", "1008", "org-x", time.Now().Add(-time.Minute))
 	if info["node_name"] != "node-1" {


### PR DESCRIPTION
## Context

The `citadel_logs` MCP tool fails with:

```
citadel_logs failed: Node ubuntu-gpu-1 returned 500: error reading log: bufio.Scanner: token too long
```

A single log line exceeding the scanner's token buffer aborts the entire log read, so a node's logs are unreadable precisely when the node is misbehaving and emitting long JSON/stacktrace lines. Tracked in aceteam-ai/aceteam#6000.

## Root Cause

`agentTailLogs` in `cmd/agent_tools.go` backs the status server's `/agent/logs` HTTP endpoint (which the aceteam MCP server wraps as `citadel_logs`). It read the log with `bufio.NewScanner` capped at 1 MiB (`scanner.Buffer(..., 1024*1024)`). Any line longer than that cap makes `scanner.Scan()` stop and `scanner.Err()` return `bufio.ErrTooLong`, which was wrapped as `error reading log: %w` and surfaced by `handleAgentLogs` as a 500.

## Changes

- `cmd/agent_tools.go`: replaced `bufio.Scanner` with `bufio.Reader.ReadString('\n')`, which has no token-size limit, so a long line can never abort the read. Each line is truncated to a 1 MiB display cap (`maxLogLineBytes`) with a `…[truncated]` marker so one pathological line can't bloat the HTTP response. The final newline-less line is processed before the `io.EOF` check so it is never dropped.
- `cmd/agent_tools_test.go`: added `TestAgentTailLogsLongLine` feeding a ~2 MiB single line (exceeds both the old 64 KiB scanner default and the former 1 MiB cap) plus a trailing newline-less line; asserts no error, truncation marker present, line bounded to the cap, and the final line preserved.

Note: `agentTailLogs` is the only log-source reader behind `citadel_logs` (worker stdout is routed into the same `~/.citadel-cli/logs/latest.log`), so this covers all affected readers on that path.

## Testing

```
go build ./...        # clean
go vet ./cmd          # clean
go test ./...         # all packages pass, 0 failures
go test ./cmd -run TestAgentTailLogs -v
  --- PASS: TestAgentTailLogsFilters
  --- PASS: TestAgentTailLogsLongLine
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)