### PR TITLE
fix(meeting): host-UID container mapping + guaranteed terminal transcribe/lifecycle

### DIFF
--- a/internal/jobs/config_handler.go
+++ b/internal/jobs/config_handler.go
@@ -341,6 +341,13 @@ func (h *ConfigHandler) startServices(configDir string, serviceNames []string) e
 		// compose files that defer their host publish to ${CITADEL_*_HOST_PORT}
 		// (llamacpp/vllm/extraction) resolve.
 		env := append(os.Environ(), services.HostPortEnv()...)
+		// PUID/PGID = this node process's uid/gid, so the meeting media stack runs
+		// as the node owner and writes node-owned files into bind-mounted dirs
+		// (see composeEnv in service_handler.go). Guarded so a non-POSIX host never
+		// emits PUID=-1.
+		if uid := os.Getuid(); uid >= 0 {
+			env = append(env, fmt.Sprintf("PUID=%d", uid), fmt.Sprintf("PGID=%d", os.Getgid()))
+		}
 		// Configure GPU runtime if on Linux
 		if platform.IsLinux() {
 			env = append(env, "DOCKER_DEFAULT_RUNTIME=nvidia")

--- a/internal/jobs/meeting_interactive.go
+++ b/internal/jobs/meeting_interactive.go
@@ -25,6 +25,8 @@ package jobs
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 )
 
@@ -39,7 +41,27 @@ const (
 	// defaultStreamingWindow + defaultStreamingInterval so a segment always
 	// stabilizes and is emitted before it slides out of the re-fed window.
 	defaultStreamingMaxWindow = 90 * time.Second
+	// rollingShutdownGrace bounds how long the interactive loop waits for the
+	// rolling-transcription goroutine to finish after signalling stop. Passes are
+	// windowed (bounded per pass), so this is generous headroom; it exists only so
+	// a pathologically slow final pass can never wedge the terminal result. If it
+	// trips, transcribeMu still serializes the end-of-call batch transcribe.
+	rollingShutdownGrace = 30 * time.Second
 )
+
+// stopRolling signals the rolling-transcription goroutine to stop and waits
+// (bounded) for it to finish, so the caller returns with the goroutine already
+// stopped. Deferred on every interactive-loop exit path. Bounded because the
+// caller's next step (the end-of-call batch transcribe) must always run — a stuck
+// final pass is contained by transcribeMu, not by blocking Execute forever here.
+func (h *MeetingJoinHandler) stopRolling(ctx JobContext, stop chan struct{}, done <-chan struct{}) {
+	close(stop)
+	select {
+	case <-done:
+	case <-time.After(rollingShutdownGrace):
+		ctx.Log("warn", "     - rolling transcriber did not stop within %s; proceeding to batch transcribe (transcribeMu still serializes)", rollingShutdownGrace)
+	}
+}
 
 // meetPage is the browser surface the interactive session drives via page JS:
 // chat read/post, end heuristics, and the leave click. *platform.MeetingBrowser
@@ -120,7 +142,7 @@ func (h *MeetingJoinHandler) waitForMeetingEndInteractive(
 ) interactiveOutcome {
 	segCh := make(chan TranscriptSegment, 64)
 	stop := make(chan struct{})
-	defer close(stop)
+	rollingDone := make(chan struct{})
 
 	// Rolling transcription on its own goroutine. recover() is load-bearing: a
 	// panic in the injected transcribe (or decoding) must not crash the process
@@ -139,6 +161,7 @@ func (h *MeetingJoinHandler) waitForMeetingEndInteractive(
 		Log: func(level, msg string) { ctx.Log(level, "%s", msg) },
 	}
 	go func() {
+		defer close(rollingDone)
 		defer func() {
 			if r := recover(); r != nil {
 				ctx.Log("warn", "     - rolling transcription goroutine panicked (recovered, recording unaffected): %v", r)
@@ -146,6 +169,17 @@ func (h *MeetingJoinHandler) waitForMeetingEndInteractive(
 		}()
 		rt.Run(stop)
 	}()
+
+	// On EVERY exit path (leave, call-ended, or duration cap) signal the rolling
+	// transcriber to stop and WAIT (bounded) for it to actually finish before
+	// returning. This is the Bug B lifecycle fix: Execute must then proceed to the
+	// end-of-call batch transcribe with the rolling goroutine already stopped, so
+	// no pass keeps "firing after leaving" and the terminal result is always
+	// produced (found live on node 1084, 2026-07-16). The wait is bounded so a
+	// pathologically slow final pass can never wedge the terminal outcome —
+	// transcribeMu still serializes the batch transcribe for correctness if the
+	// grace trips.
+	defer h.stopRolling(ctx, stop, rollingDone)
 
 	out := interactiveOutcome{endReason: "max_duration_reached"}
 	seenChat := make(map[int]struct{})
@@ -310,7 +344,13 @@ func (h *MeetingJoinHandler) transcribeSegments(ctx JobContext, meetingID, wavPa
 	transcribePath := wavPath
 	var offset float64
 	clipPath := meetingWindowWavPath(h.WorkspaceDir, meetingID)
-	if off, err := clipWavTail(wavPath, clipPath, h.streamingMaxWindow()); err != nil {
+	// Create the node-owned scratch dir (meetingScratchDirName) up front: it is
+	// distinct from the container-owned meetings/ dir so clipping never depends on
+	// write access there. MkdirAll on a dir this handler owns is cheap and
+	// idempotent; a failure here just degrades this pass to whole-file transcribe.
+	if err := os.MkdirAll(filepath.Dir(clipPath), 0o700); err != nil {
+		ctx.Log("warn", "     - could not create node-owned rolling scratch dir, falling back to whole-file transcribe (non-fatal): %v", err)
+	} else if off, err := clipWavTail(wavPath, clipPath, h.streamingMaxWindow()); err != nil {
 		ctx.Log("warn", "     - rolling window clip failed, falling back to whole-file transcribe (non-fatal): %v", err)
 	} else {
 		transcribePath = clipPath

--- a/internal/jobs/meeting_interactive_test.go
+++ b/internal/jobs/meeting_interactive_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -114,6 +115,49 @@ func TestInteractive_LeaveViaSpokenTranscript(t *testing.T) {
 	}
 	if out.streamedSegments == 0 {
 		t.Error("expected at least one streamed segment to have been processed")
+	}
+}
+
+// TestInteractive_RollingStopsWhenCallEnds is the Bug B lifecycle guard at the
+// loop level (live-prod node 1084, 2026-07-16). Even when EVERY rolling pass
+// fails (simulating the Bug A perms cascade where the scratch clip + whole-file
+// read were both denied), the interactive loop must (1) return promptly with a
+// terminal endReason, and (2) fully stop the rolling goroutine before returning
+// — so Execute proceeds to the batch transcribe and no pass keeps firing after
+// the call ended.
+func TestInteractive_RollingStopsWhenCallEnds(t *testing.T) {
+	h := newTestInteractiveHandler()
+	page := &fakeMeetPage{ended: true} // ends on the first end-check
+	var calls int32
+	failingTranscribe := func() ([]TranscriptSegment, error) {
+		atomic.AddInt32(&calls, 1)
+		return nil, errors.New("whisper unreachable (simulated Bug A cascade)")
+	}
+
+	done := make(chan interactiveOutcome, 1)
+	go func() {
+		done <- h.waitForMeetingEndInteractive(
+			JobContext{}, page, testParams(), failingTranscribe, time.Millisecond, map[string]struct{}{},
+		)
+	}()
+
+	var out interactiveOutcome
+	select {
+	case out = <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("waitForMeetingEndInteractive did not return; rolling loop likely still firing after the call ended")
+	}
+	if out.endReason != "call_ended" {
+		t.Errorf("endReason = %q, want call_ended (terminal outcome despite all rolling passes failing)", out.endReason)
+	}
+
+	// The deferred stopRolling joined the goroutine before the function returned,
+	// so no further rolling passes may run. Snapshot, wait past many tick
+	// intervals (StreamingInterval is 1ms), and re-check the count is frozen.
+	before := atomic.LoadInt32(&calls)
+	time.Sleep(50 * time.Millisecond)
+	if after := atomic.LoadInt32(&calls); after != before {
+		t.Errorf("rolling passes fired AFTER the loop returned: before=%d after=%d (goroutine not stopped)", before, after)
 	}
 }
 

--- a/internal/jobs/meeting_join.go
+++ b/internal/jobs/meeting_join.go
@@ -408,8 +408,21 @@ func (h *MeetingJoinHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, er
 	// ffmpeg's -y does NOT create parent directories (the container's meetingd
 	// makedirs its own, but the dir is on the shared workspace mount either way).
 	wavPath := meetingWavPath(h.WorkspaceDir, p.MeetingID)
-	if err := os.MkdirAll(filepath.Dir(wavPath), 0o700); err != nil {
+	wavDir := filepath.Dir(wavPath)
+	if err := os.MkdirAll(wavDir, 0o777); err != nil {
 		return nil, fmt.Errorf("create meetings dir: %w", err)
+	}
+	// meetings/ is SHARED with the container's meetingd (user bot, UID 10001),
+	// which is the WAV writer in the container media path; this node handler and
+	// the whisper sidecar are the READERS. Whichever side created the dir first
+	// owns it and the OTHER needs access, so it must be world-traversable/
+	// readable/writable. os.MkdirAll is umask-masked and won't relax a PRE-EXISTING
+	// dir (a meetings/ left 0700 by an older meetingd persists on the workspace
+	// mount), so chmod explicitly. Best-effort: if the node does not own a
+	// container-created dir this chmod is EPERM and meetingd's own chmod (which
+	// does own it) relaxes it instead — see services/meeting-service/meetingd.py.
+	if err := os.Chmod(wavDir, 0o777); err != nil {
+		ctx.Log("warn", "     - could not chmod meetings dir world-accessible (non-fatal; meetingd relaxes it on its side): %v", err)
 	}
 	// The rolling-window transcription scratch clip (meeting_transcribe_window.go)
 	// is a per-pass temp; remove it on exit so it does not linger in the workspace.

--- a/internal/jobs/meeting_join.go
+++ b/internal/jobs/meeting_join.go
@@ -407,22 +407,12 @@ func (h *MeetingJoinHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, er
 	// Admitted: begin recording. Ensure the meetings/ dir exists first — the host
 	// ffmpeg's -y does NOT create parent directories (the container's meetingd
 	// makedirs its own, but the dir is on the shared workspace mount either way).
+	// The container writes the WAV as the node's own UID/GID (the meeting image's
+	// PUID/PGID mapping — see services/meeting-service/entrypoint.sh), so the node
+	// and container share ownership and no cross-UID perms fixup is needed here.
 	wavPath := meetingWavPath(h.WorkspaceDir, p.MeetingID)
-	wavDir := filepath.Dir(wavPath)
-	if err := os.MkdirAll(wavDir, 0o777); err != nil {
+	if err := os.MkdirAll(filepath.Dir(wavPath), 0o700); err != nil {
 		return nil, fmt.Errorf("create meetings dir: %w", err)
-	}
-	// meetings/ is SHARED with the container's meetingd (user bot, UID 10001),
-	// which is the WAV writer in the container media path; this node handler and
-	// the whisper sidecar are the READERS. Whichever side created the dir first
-	// owns it and the OTHER needs access, so it must be world-traversable/
-	// readable/writable. os.MkdirAll is umask-masked and won't relax a PRE-EXISTING
-	// dir (a meetings/ left 0700 by an older meetingd persists on the workspace
-	// mount), so chmod explicitly. Best-effort: if the node does not own a
-	// container-created dir this chmod is EPERM and meetingd's own chmod (which
-	// does own it) relaxes it instead — see services/meeting-service/meetingd.py.
-	if err := os.Chmod(wavDir, 0o777); err != nil {
-		ctx.Log("warn", "     - could not chmod meetings dir world-accessible (non-fatal; meetingd relaxes it on its side): %v", err)
 	}
 	// The rolling-window transcription scratch clip (meeting_transcribe_window.go)
 	// is a per-pass temp; remove it on exit so it does not linger in the workspace.

--- a/internal/jobs/meeting_transcribe_rolling.go
+++ b/internal/jobs/meeting_transcribe_rolling.go
@@ -130,6 +130,20 @@ func (r *RollingTranscriber) Run(stop <-chan struct{}) {
 			r.runPass()
 			return
 		case <-ticker.C:
+			// PRIORITIZE stop over the ticker: Go's select picks a uniformly
+			// random ready case, so once stop is closed a fired ticker could win
+			// repeatedly and keep the loop transcribing long after the meeting
+			// ended (observed live on node 1084, 2026-07-16: rolling passes still
+			// firing 68s after "leaving", starving the end-of-call batch pass).
+			// Re-check stop non-blocking so at most the in-flight pass completes,
+			// then we do the single final pass and return — never another periodic
+			// pass after stop.
+			select {
+			case <-stop:
+				r.runPass()
+				return
+			default:
+			}
 			r.runPass()
 		}
 	}

--- a/internal/jobs/meeting_transcribe_rolling_test.go
+++ b/internal/jobs/meeting_transcribe_rolling_test.go
@@ -192,8 +192,8 @@ func TestRollingTranscriber_Run_NoPeriodicPassAfterStop(t *testing.T) {
 	done := make(chan struct{})
 	go func() { rt.Run(stop); close(done) }()
 
-	<-started    // pass 1 is in flight (blocked in runPass)
-	close(stop)  // stop while a pass is in flight and ticks have queued
+	<-started   // pass 1 is in flight (blocked in runPass)
+	close(stop) // stop while a pass is in flight and ticks have queued
 	// Give a buggy random-select a chance to fire extra passes. It can't, because
 	// Run is still blocked inside pass 1 — but this also lets the ticker buffer a
 	// pending tick so the post-release select genuinely races stop vs ticker.

--- a/internal/jobs/meeting_transcribe_rolling_test.go
+++ b/internal/jobs/meeting_transcribe_rolling_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -155,6 +156,57 @@ func TestRollingTranscriber_Run_EmitsAcrossPassesAndFinalizes(t *testing.T) {
 	// exactly once, in order.
 	if want := []float64{0, 5, 12}; !reflect.DeepEqual(startsOf(emitted), want) {
 		t.Fatalf("emitted starts = %v, want %v", startsOf(emitted), want)
+	}
+}
+
+// TestRollingTranscriber_Run_NoPeriodicPassAfterStop is the Bug B lifecycle
+// guard (live-prod node 1084, 2026-07-16: rolling passes still firing 68s after
+// "leaving"). Go's select picks a uniformly random ready case, so once stop is
+// closed a still-firing ticker could keep winning and run more periodic passes.
+// The priority re-check of stop must ensure that after stop closes, at most the
+// in-flight pass completes plus exactly ONE final pass — never another periodic
+// pass. We pin exactly one pass in flight when stop closes, then assert the total
+// is 2 (in-flight + final), which fails on the old random-select behavior.
+func TestRollingTranscriber_Run_NoPeriodicPassAfterStop(t *testing.T) {
+	started := make(chan struct{}) // closed when the first pass begins
+	release := make(chan struct{}) // gates the in-flight pass until we say go
+	var passes int32
+	var once sync.Once
+
+	transcribe := func() ([]TranscriptSegment, error) {
+		n := atomic.AddInt32(&passes, 1)
+		if n == 1 {
+			once.Do(func() { close(started) })
+			<-release // hold the first pass in flight across close(stop)
+		}
+		return nil, nil
+	}
+
+	rt := &RollingTranscriber{
+		Interval:   time.Millisecond, // ticker fires rapidly while pass 1 is held
+		Window:     0,
+		Transcribe: transcribe,
+		Emit:       func(TranscriptSegment) {},
+	}
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() { rt.Run(stop); close(done) }()
+
+	<-started    // pass 1 is in flight (blocked in runPass)
+	close(stop)  // stop while a pass is in flight and ticks have queued
+	// Give a buggy random-select a chance to fire extra passes. It can't, because
+	// Run is still blocked inside pass 1 — but this also lets the ticker buffer a
+	// pending tick so the post-release select genuinely races stop vs ticker.
+	time.Sleep(20 * time.Millisecond)
+	close(release) // let pass 1 finish; Run must now do exactly one final pass
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after stop")
+	}
+	if got := atomic.LoadInt32(&passes); got != 2 {
+		t.Errorf("passes = %d, want 2 (one in-flight + one final; no periodic pass after stop)", got)
 	}
 }
 

--- a/internal/jobs/meeting_transcribe_window.go
+++ b/internal/jobs/meeting_transcribe_window.go
@@ -32,23 +32,21 @@ import (
 	"time"
 )
 
-// meetingScratchDirName is a NODE-OWNED scratch subdir under the workspace,
-// distinct from the shared meetings/ output dir. The container's meetingd never
-// writes here — only this node handler does — so the rolling-window transcriber
-// never depends on WRITE access to the container-owned meetings/ dir. This
-// decouples the scratch clip entirely from the container UID: even when
-// meetings/ is owned by the container's bot user (UID 10001), the node clips
-// into its own dir it always owns. (Found in live-prod E2E on node 1084,
-// 2026-07-16: the node could not create <session>-window.wav inside a
-// container-owned 0700 meetings/ dir, so every rolling pass fell back to a slow
-// whole-file transcribe.)
+// meetingScratchDirName is a scratch subdir under the workspace, distinct from
+// the meetings/ output dir, for the rolling-window transcriber's per-pass clips.
+// Keeping the transient scratch clip out of meetings/ (which holds the durable
+// recordings) is hygiene: it isolates a churny, overwritten-every-pass temp from
+// the artifact the node stores, and keeps the scratch decoupled from the shared
+// mount the meeting container writes into. (The meeting container now writes the
+// WAV as the node's own UID/GID via the image's PUID/PGID mapping, so this is no
+// longer a perms workaround — see services/meeting-service/entrypoint.sh.)
 const meetingScratchDirName = "meeting-scratch"
 
-// meetingWindowWavPath is the NODE-OWNED scratch file each rolling pass clips the
-// trailing window into. It lives under meetingScratchDirName (still inside the
-// workspace, so it passes the transcribe handler's workspace ValidatePath) and is
-// overwritten every pass (passes are serialized under transcribeMu), keyed by the
-// sanitized meeting id.
+// meetingWindowWavPath is the scratch file each rolling pass clips the trailing
+// window into. It lives under meetingScratchDirName (still inside the workspace,
+// so it passes the transcribe handler's workspace ValidatePath) and is overwritten
+// every pass (passes are serialized under transcribeMu), keyed by the sanitized
+// meeting id.
 func meetingWindowWavPath(workspaceDir, meetingID string) string {
 	return filepath.Join(workspaceDir, meetingScratchDirName, sanitizeMeetingFilename(meetingID)+"-window.wav")
 }

--- a/internal/jobs/meeting_transcribe_window.go
+++ b/internal/jobs/meeting_transcribe_window.go
@@ -32,13 +32,25 @@ import (
 	"time"
 )
 
-// meetingWindowWavPath is the workspace-local scratch file each rolling pass
-// clips the trailing window into. It sits beside the recording under meetings/
-// (so it passes the transcribe handler's workspace ValidatePath) and is
-// overwritten every pass (passes are serialized under transcribeMu), keyed by
-// the sanitized meeting id.
+// meetingScratchDirName is a NODE-OWNED scratch subdir under the workspace,
+// distinct from the shared meetings/ output dir. The container's meetingd never
+// writes here — only this node handler does — so the rolling-window transcriber
+// never depends on WRITE access to the container-owned meetings/ dir. This
+// decouples the scratch clip entirely from the container UID: even when
+// meetings/ is owned by the container's bot user (UID 10001), the node clips
+// into its own dir it always owns. (Found in live-prod E2E on node 1084,
+// 2026-07-16: the node could not create <session>-window.wav inside a
+// container-owned 0700 meetings/ dir, so every rolling pass fell back to a slow
+// whole-file transcribe.)
+const meetingScratchDirName = "meeting-scratch"
+
+// meetingWindowWavPath is the NODE-OWNED scratch file each rolling pass clips the
+// trailing window into. It lives under meetingScratchDirName (still inside the
+// workspace, so it passes the transcribe handler's workspace ValidatePath) and is
+// overwritten every pass (passes are serialized under transcribeMu), keyed by the
+// sanitized meeting id.
 func meetingWindowWavPath(workspaceDir, meetingID string) string {
-	return filepath.Join(workspaceDir, "meetings", sanitizeMeetingFilename(meetingID)+"-window.wav")
+	return filepath.Join(workspaceDir, meetingScratchDirName, sanitizeMeetingFilename(meetingID)+"-window.wav")
 }
 
 // wavFormat holds the parsed, size-independent fields of a WAV's fmt chunk plus

--- a/internal/jobs/meeting_transcribe_window_test.go
+++ b/internal/jobs/meeting_transcribe_window_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -48,6 +49,35 @@ func writeTestWav(t *testing.T, path string, seconds int, placeholderSizes bool)
 		t.Fatalf("write test wav: %v", err)
 	}
 	return byteRate, dataBytes
+}
+
+func TestMeetingWindowWavPath_UsesNodeOwnedScratchDir(t *testing.T) {
+	// Bug A (live-prod node 1084, 2026-07-16): the rolling-window scratch clip must
+	// NOT live inside the container-owned meetings/ dir — the node cannot write
+	// there when meetings/ is owned by the container's bot user. It must sit in a
+	// distinct node-owned scratch subdir, still inside the workspace so the
+	// transcribe handler's ValidatePath accepts it.
+	got := meetingWindowWavPath("/ws", "mtg-1")
+
+	meetingsDir := filepath.Join("/ws", "meetings") + string(filepath.Separator)
+	if strings.HasPrefix(got, meetingsDir) {
+		t.Errorf("window scratch clip %q must NOT live under the container-owned meetings/ dir", got)
+	}
+	want := filepath.Join("/ws", meetingScratchDirName, "mtg-1-window.wav")
+	if got != want {
+		t.Errorf("meetingWindowWavPath = %q, want %q", got, want)
+	}
+	// The recording itself stays under meetings/ (the shared, node-readable dir).
+	if recDir := filepath.Dir(meetingWavPath("/ws", "mtg-1")); recDir != filepath.Join("/ws", "meetings") {
+		t.Errorf("recording dir = %q, want it to remain under meetings/", recDir)
+	}
+	// The scratch clip must still resolve inside the workspace (ValidatePath, so
+	// the transcribe handler accepts it). Use a real temp workspace since
+	// ValidatePath resolves symlinks on the workspace root.
+	ws := t.TempDir()
+	if _, err := ValidatePath(ws, meetingWindowWavPath(ws, "mtg-1")); err != nil {
+		t.Errorf("scratch clip path must validate inside the workspace: %v", err)
+	}
 }
 
 func TestClipWavTail_ClipsTrailingWindow(t *testing.T) {

--- a/internal/jobs/meeting_transcribe_window_test.go
+++ b/internal/jobs/meeting_transcribe_window_test.go
@@ -51,17 +51,16 @@ func writeTestWav(t *testing.T, path string, seconds int, placeholderSizes bool)
 	return byteRate, dataBytes
 }
 
-func TestMeetingWindowWavPath_UsesNodeOwnedScratchDir(t *testing.T) {
-	// Bug A (live-prod node 1084, 2026-07-16): the rolling-window scratch clip must
-	// NOT live inside the container-owned meetings/ dir — the node cannot write
-	// there when meetings/ is owned by the container's bot user. It must sit in a
-	// distinct node-owned scratch subdir, still inside the workspace so the
-	// transcribe handler's ValidatePath accepts it.
+func TestMeetingWindowWavPath_UsesSeparateScratchDir(t *testing.T) {
+	// The rolling-window scratch clip is a churny per-pass temp; it must live in a
+	// separate scratch subdir, NOT alongside the durable recordings in meetings/,
+	// and still inside the workspace so the transcribe handler's ValidatePath
+	// accepts it.
 	got := meetingWindowWavPath("/ws", "mtg-1")
 
 	meetingsDir := filepath.Join("/ws", "meetings") + string(filepath.Separator)
 	if strings.HasPrefix(got, meetingsDir) {
-		t.Errorf("window scratch clip %q must NOT live under the container-owned meetings/ dir", got)
+		t.Errorf("window scratch clip %q must NOT live under the meetings/ recordings dir", got)
 	}
 	want := filepath.Join("/ws", meetingScratchDirName, "mtg-1-window.wav")
 	if got != want {

--- a/internal/jobs/service_handler.go
+++ b/internal/jobs/service_handler.go
@@ -900,6 +900,15 @@ func (h *ServiceHandler) composeEnv() []string {
 	// Supply the citadel-owned host ports so compose files that defer their host
 	// publish to ${CITADEL_*_HOST_PORT} (llamacpp/vllm/extraction) resolve.
 	env = append(env, embeddedservices.HostPortEnv()...)
+	// Supply PUID/PGID = this node process's own uid/gid so PUID/PGID-aware module
+	// containers (the meeting media stack) run as the node owner and write files
+	// into bind-mounted workspace dirs owned by the node — no cross-UID perms
+	// fixup. Harmless for compose files that don't reference them; guarded on
+	// os.Getuid()>=0 so a non-POSIX host (Windows returns -1) never emits a bogus
+	// PUID=-1 (the meeting stack is Linux-container-only anyway).
+	if uid := os.Getuid(); uid >= 0 {
+		env = append(env, fmt.Sprintf("PUID=%d", uid), fmt.Sprintf("PGID=%d", os.Getgid()))
+	}
 	return env
 }
 

--- a/internal/jobs/service_handler_test.go
+++ b/internal/jobs/service_handler_test.go
@@ -2,6 +2,7 @@
 package jobs
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -239,6 +240,36 @@ func TestComposeEnv_InjectsWorkspace(t *testing.T) {
 	}
 	if got != "/home/u/citadel-node/workspace" {
 		t.Errorf("CITADEL_WORKSPACE = %q, want the workspace dir", got)
+	}
+}
+
+// TestComposeEnv_InjectsHostUIDGID verifies SERVICE_START exports PUID/PGID =
+// this node process's own uid/gid, so a PUID/PGID-aware module (the meeting media
+// stack) runs as the node owner and writes node-owned files into bind-mounted
+// workspace dirs — no cross-UID perms fixup for the recorded WAV.
+func TestComposeEnv_InjectsHostUIDGID(t *testing.T) {
+	if os.Getuid() < 0 {
+		t.Skip("non-POSIX host: PUID/PGID intentionally not injected")
+	}
+	h := NewServiceHandlerWithWorkspace("/etc/citadel", "/home/u/citadel-node/workspace")
+	env := h.composeEnv()
+
+	wantUID := fmt.Sprintf("PUID=%d", os.Getuid())
+	wantGID := fmt.Sprintf("PGID=%d", os.Getgid())
+	var sawUID, sawGID bool
+	for _, kv := range env {
+		if kv == wantUID {
+			sawUID = true
+		}
+		if kv == wantGID {
+			sawGID = true
+		}
+	}
+	if !sawUID {
+		t.Errorf("composeEnv did not export %q", wantUID)
+	}
+	if !sawGID {
+		t.Errorf("composeEnv did not export %q", wantGID)
 	}
 }
 

--- a/services/meeting-service/Dockerfile
+++ b/services/meeting-service/Dockerfile
@@ -64,9 +64,12 @@ COPY supervisord.conf /etc/supervisor/supervisord.conf
 COPY citadel.pa /etc/pulse/citadel.pa
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 
-# Non-root runtime user with a real home + a pulse runtime dir. The compose file
-# bind-mounts host dirs onto /profile and /workspace; the entrypoint chowns them to
-# `bot` at boot so a fresh host-owned mount "just works" with no manual pre-create.
+# Non-root runtime user with a real home + a pulse runtime dir. 10001 is only the
+# DEFAULT uid: the entrypoint remaps `bot` to the node owner's UID/GID (PUID/PGID,
+# or the /workspace mount owner) at boot so files written into the bind mounts are
+# node-owned. The compose file bind-mounts host dirs onto /profile and /workspace;
+# the entrypoint chowns them to the remapped `bot` so a host-owned mount "just
+# works" with no manual pre-create.
 RUN useradd --create-home --uid 10001 --shell /bin/bash bot \
     && mkdir -p /workspace /profile /run/user/10001/pulse /home/bot/.config/pulse \
     && chown -R bot:bot /home/bot /run/user/10001 /workspace /profile /app \

--- a/services/meeting-service/compose.yml
+++ b/services/meeting-service/compose.yml
@@ -32,6 +32,13 @@ services:
       - XVFB_RESOLUTION=${XVFB_RESOLUTION:-1280x720x24}
       - MEETING_PROFILE_DIR=/profile
       - CITADEL_WORKSPACE=/workspace
+      # Run the in-container `bot` user as the NODE OWNER's UID/GID so the recorded
+      # WAV (written into the /workspace mount) is owned by the node process that
+      # reads it back for transcription — no cross-UID perms fixup. citadel injects
+      # PUID/PGID = its own uid/gid (see internal/jobs/service_handler.go); when
+      # unset the entrypoint auto-derives them from the /workspace mount owner.
+      - PUID=${PUID:-}
+      - PGID=${PGID:-}
     healthcheck:
       # Hits meetingd's /health INSIDE the container (container port 8102), which
       # runs the canary-tone audio probe -- so "container healthy" means "can

--- a/services/meeting-service/entrypoint.sh
+++ b/services/meeting-service/entrypoint.sh
@@ -2,28 +2,63 @@
 # Entrypoint for the Citadel meeting media stack (aceteam-ai/citadel-cli#514).
 #
 # The container runs Xvfb, PulseAudio, meetingd, and per-session Chromium/ffmpeg
-# as the non-root `bot` user (uid 10001). Two dirs are bind-mounted from the host
-# (the signed-in Chrome profile at /profile and the shared node workspace at
-# /workspace); a bind-mount source is owned by whoever created it on the host, NOT
-# 10001, so without a fixup the bot user cannot write the profile or the WAV.
+# as the non-root `bot` user. Two dirs are bind-mounted from the host (the
+# signed-in Chrome profile at /profile and the shared node workspace at
+# /workspace). The WAV recording is written into /workspace and then READ back by
+# the node process (end-of-call transcribe + rolling-window transcriber), which
+# runs as the NODE OWNER on the host — a different UID than the image's built-in
+# `bot` (10001). Writing the WAV as 10001 left it unreadable/un-traversable by the
+# node (live-prod node 1084, 2026-07-16).
 #
-# Fix: start as root (this script, PID via dumb-init), ensure the pulse runtime
-# dir and the mounts are bot-owned, then hand off to supervisord (which drops each
-# program to `bot`). Chrome refuses to run as root anyway, so a real user is
-# required regardless.
+# Fix (PUID/PGID host-UID mapping): remap the `bot` user to the node owner's
+# UID/GID at boot, so every file `bot` writes into the mounts is owned by the node
+# owner from the start — no node-side chown/chmod. The target UID/GID come from
+# PUID/PGID (passed by citadel), else are auto-derived from the OWNER of the
+# bind-mounted workspace (which IS the node owner), else fall back to the image
+# default 10001. We start as root (this script, via dumb-init), remap + fix mount
+# ownership, then hand off to supervisord (which drops each program to `bot`).
+# Chrome refuses to run as root anyway, so a real user is required regardless.
 set -e
 
+PROFILE_DIR="${MEETING_PROFILE_DIR:-/profile}"
+WORKSPACE_DIR="${CITADEL_WORKSPACE:-/workspace}"
+mkdir -p "$PROFILE_DIR" "$WORKSPACE_DIR"
+
+# Resolve the UID/GID `bot` should run as. Prefer explicit PUID/PGID; otherwise
+# adopt the owner of the bind-mounted workspace (the node owner). A 0/empty result
+# (root-owned or unstat-able mount) falls back to the image default 10001 — Chrome
+# cannot run as root, so mapping to 0 is never useful.
+TARGET_UID="${PUID:-$(stat -c '%u' "$WORKSPACE_DIR" 2>/dev/null || echo '')}"
+TARGET_GID="${PGID:-$(stat -c '%g' "$WORKSPACE_DIR" 2>/dev/null || echo '')}"
+[ -n "$TARGET_UID" ] && [ "$TARGET_UID" != "0" ] || TARGET_UID=10001
+[ -n "$TARGET_GID" ] && [ "$TARGET_GID" != "0" ] || TARGET_GID=10001
+
+# Remap the `bot` account to the target UID/GID (idempotent: skip when already
+# correct). -o allows a non-unique id in the unlikely event of a collision with a
+# baked-in account. supervisord's `user=bot` then resolves to the node owner.
+if [ "$TARGET_GID" != "$(id -g bot)" ]; then
+    groupmod -o -g "$TARGET_GID" bot
+fi
+if [ "$TARGET_UID" != "$(id -u bot)" ]; then
+    usermod -o -u "$TARGET_UID" bot
+fi
+
+# The runtime/home/app dirs must be owned by the (possibly remapped) bot so pulse,
+# Chrome, and uvicorn can write them. XDG_RUNTIME_DIR keeps its /run/user/10001
+# path — the numeric label is cosmetic; pulse uses the env var, not a UID match.
 RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/10001}"
 mkdir -p "$RUNTIME_DIR/pulse"
-chown -R bot:bot "$RUNTIME_DIR"
+chown -R bot:bot "$RUNTIME_DIR" /home/bot /app
 chmod 700 "$RUNTIME_DIR"
 
-# Only chown the mounts when needed (a large persisted profile shouldn't be
-# re-chowned top-to-bottom every boot). If the top dir is already bot-owned,
-# assume the tree is fine.
-for dir in "${MEETING_PROFILE_DIR:-/profile}" "${CITADEL_WORKSPACE:-/workspace}"; do
-    mkdir -p "$dir"
-    if [ "$(stat -c '%u' "$dir")" != "10001" ]; then
+# Bring the bind-mounted dirs to the target owner. This is the MIGRATION step for
+# existing nodes: the persisted profile (the signed-in Google session) was created
+# by the old `bot` (10001, mode 700); after remapping `bot` to the node owner it
+# would be unreadable, so chown it across. Only chown when the top dir's owner
+# differs from the target (a large already-correct tree isn't re-chowned every
+# boot). The workspace is normally already node-owned, so it is skipped.
+for dir in "$PROFILE_DIR" "$WORKSPACE_DIR"; do
+    if [ "$(stat -c '%u' "$dir")" != "$TARGET_UID" ]; then
         chown -R bot:bot "$dir"
     fi
 done
@@ -35,7 +70,6 @@ done
 # meeting until a human clears it. Safe to clear here: this runs before any browser
 # starts, meetingd enforces one meeting at a time, and this container is the sole
 # user of the bind-mounted profile.
-PROFILE="${MEETING_PROFILE_DIR:-/profile}"
-rm -f "$PROFILE/SingletonLock" "$PROFILE/SingletonSocket" "$PROFILE/SingletonCookie" 2>/dev/null || true
+rm -f "$PROFILE_DIR/SingletonLock" "$PROFILE_DIR/SingletonSocket" "$PROFILE_DIR/SingletonCookie" 2>/dev/null || true
 
 exec "$@"

--- a/services/meeting-service/meetingd.py
+++ b/services/meeting-service/meetingd.py
@@ -368,6 +368,37 @@ def _safe_workspace_path(rel: str) -> str:
     return full
 
 
+def _ensure_node_accessible_dir(path: str) -> None:
+    """Create a workspace-shared output dir and make it traversable/readable/
+    writable by the host node user.
+
+    meetingd runs as the unprivileged ``bot`` user (UID 10001) while the Citadel
+    node process -- the end-of-call WAV reader AND the rolling-window
+    transcriber -- runs as the node owner (a different UID). Under bot's umask a
+    freshly-created dir lands at ``0700``, which the node cannot even TRAVERSE,
+    so it can neither read the recorded WAV nor (before the node moved its
+    scratch clip out) write into ``meetings/``.
+
+    We ``chmod 0o777`` UNCONDITIONALLY because ``exist_ok=True`` does not relax a
+    PRE-EXISTING ``0700`` dir -- and ``meetings/`` lives on the persistent
+    workspace mount, so a dir left ``0700`` by an older meetingd survives restart,
+    upgrade, and reinstall. World-write (not merely 0755) is required because
+    whichever side created the shared dir OWNS it and the OTHER side needs
+    write: if the node created it, the container must still write the WAV here.
+
+    The chmod is best-effort: when the node created the dir first it owns it and
+    this call is ``EPERM`` -- harmless, because the node relaxed the mode on its
+    own side. This is safe on a single-tenant sovereign node (the whole node
+    belongs to one operator); it is NOT a general multi-tenant-safe mode.
+    """
+    os.makedirs(path, exist_ok=True)
+    try:
+        os.chmod(path, 0o777)
+    except OSError:
+        # Not the owner (the node created the dir) -- it relaxed the mode itself.
+        pass
+
+
 @app.get("/health")
 def health() -> JSONResponse:
     chromium = _chromium_binary()
@@ -422,6 +453,10 @@ def start_session(req: StartSessionRequest) -> JSONResponse:
         sid = req.session_id or uuid.uuid4().hex[:12]
         sink = f"citadel_meeting_{sid}"
         module_id = _load_null_sink(sink)
+        # PROFILE_DIR holds the bot's signed-in Google session cookies. Unlike the
+        # meetings/ output dir, NOTHING node-side reads it, so it is deliberately
+        # left at the bot's default (owner-only) mode -- it must NOT be world-opened
+        # (that would expose live auth cookies). The entrypoint chowns it to bot.
         os.makedirs(PROFILE_DIR, exist_ok=True)
         env = dict(os.environ)
         env["DISPLAY"] = DISPLAY
@@ -489,7 +524,9 @@ def start_record(session_id: str, req: RecordRequest) -> JSONResponse:
     with s.lock:
         if s.recorder is not None and s.recorder.poll() is None:
             return JSONResponse(status_code=409, content={"error": "already recording"})
-        os.makedirs(os.path.dirname(out_path), exist_ok=True)
+        # Shared output dir must be node-readable (see helper): the node reads
+        # this WAV for the end-of-call transcribe.
+        _ensure_node_accessible_dir(os.path.dirname(out_path))
         rec = subprocess.Popen(
             build_record_ffmpeg_args(f"{s.sink_name}.monitor", out_path),
             env=_pactl_env(),
@@ -518,6 +555,14 @@ def stop_record(session_id: str) -> JSONResponse:
                 rec.kill()
         path = s.record_path
         s.recorder = None
+    # ffmpeg writes the WAV under bot's umask; force group/other-readable so the
+    # node owner (a different UID) can read it for the end-of-call transcribe,
+    # regardless of the container's umask.
+    if path and os.path.exists(path):
+        try:
+            os.chmod(path, 0o644)
+        except OSError:
+            pass
     return JSONResponse(content={"recording": False, "path": path})
 
 

--- a/services/meeting-service/meetingd.py
+++ b/services/meeting-service/meetingd.py
@@ -368,37 +368,6 @@ def _safe_workspace_path(rel: str) -> str:
     return full
 
 
-def _ensure_node_accessible_dir(path: str) -> None:
-    """Create a workspace-shared output dir and make it traversable/readable/
-    writable by the host node user.
-
-    meetingd runs as the unprivileged ``bot`` user (UID 10001) while the Citadel
-    node process -- the end-of-call WAV reader AND the rolling-window
-    transcriber -- runs as the node owner (a different UID). Under bot's umask a
-    freshly-created dir lands at ``0700``, which the node cannot even TRAVERSE,
-    so it can neither read the recorded WAV nor (before the node moved its
-    scratch clip out) write into ``meetings/``.
-
-    We ``chmod 0o777`` UNCONDITIONALLY because ``exist_ok=True`` does not relax a
-    PRE-EXISTING ``0700`` dir -- and ``meetings/`` lives on the persistent
-    workspace mount, so a dir left ``0700`` by an older meetingd survives restart,
-    upgrade, and reinstall. World-write (not merely 0755) is required because
-    whichever side created the shared dir OWNS it and the OTHER side needs
-    write: if the node created it, the container must still write the WAV here.
-
-    The chmod is best-effort: when the node created the dir first it owns it and
-    this call is ``EPERM`` -- harmless, because the node relaxed the mode on its
-    own side. This is safe on a single-tenant sovereign node (the whole node
-    belongs to one operator); it is NOT a general multi-tenant-safe mode.
-    """
-    os.makedirs(path, exist_ok=True)
-    try:
-        os.chmod(path, 0o777)
-    except OSError:
-        # Not the owner (the node created the dir) -- it relaxed the mode itself.
-        pass
-
-
 @app.get("/health")
 def health() -> JSONResponse:
     chromium = _chromium_binary()
@@ -453,10 +422,6 @@ def start_session(req: StartSessionRequest) -> JSONResponse:
         sid = req.session_id or uuid.uuid4().hex[:12]
         sink = f"citadel_meeting_{sid}"
         module_id = _load_null_sink(sink)
-        # PROFILE_DIR holds the bot's signed-in Google session cookies. Unlike the
-        # meetings/ output dir, NOTHING node-side reads it, so it is deliberately
-        # left at the bot's default (owner-only) mode -- it must NOT be world-opened
-        # (that would expose live auth cookies). The entrypoint chowns it to bot.
         os.makedirs(PROFILE_DIR, exist_ok=True)
         env = dict(os.environ)
         env["DISPLAY"] = DISPLAY
@@ -524,9 +489,7 @@ def start_record(session_id: str, req: RecordRequest) -> JSONResponse:
     with s.lock:
         if s.recorder is not None and s.recorder.poll() is None:
             return JSONResponse(status_code=409, content={"error": "already recording"})
-        # Shared output dir must be node-readable (see helper): the node reads
-        # this WAV for the end-of-call transcribe.
-        _ensure_node_accessible_dir(os.path.dirname(out_path))
+        os.makedirs(os.path.dirname(out_path), exist_ok=True)
         rec = subprocess.Popen(
             build_record_ffmpeg_args(f"{s.sink_name}.monitor", out_path),
             env=_pactl_env(),
@@ -555,14 +518,6 @@ def stop_record(session_id: str) -> JSONResponse:
                 rec.kill()
         path = s.record_path
         s.recorder = None
-    # ffmpeg writes the WAV under bot's umask; force group/other-readable so the
-    # node owner (a different UID) can read it for the end-of-call transcribe,
-    # regardless of the container's umask.
-    if path and os.path.exists(path):
-        try:
-            os.chmod(path, 0o644)
-        except OSError:
-            pass
     return JSONResponse(content={"recording": False, "path": path})
 
 

--- a/services/meeting-service/test_meetingd.py
+++ b/services/meeting-service/test_meetingd.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import math
 import os
 import struct
+import subprocess
 import tempfile
 import wave
 
@@ -80,41 +81,28 @@ def test_safe_workspace_path(rel, ok, monkeypatch):
             meetingd._safe_workspace_path(rel)
 
 
-def test_ensure_node_accessible_dir_makes_shared_dir_world_accessible():
-    """Bug A (live-prod node 1084, 2026-07-16): the WAV output dir is created by
-    meetingd (bot UID 10001) but READ by the node owner (a different UID). Under
-    bot's umask it lands 0700, which the node cannot even traverse. The helper must
-    force 0o777 so the node can read the recording for the end-of-call transcribe,
-    and must relax a PRE-EXISTING 0700 dir (exist_ok makedirs does not)."""
-    with tempfile.TemporaryDirectory() as d:
-        target = os.path.join(d, "meetings")
+def test_entrypoint_maps_to_host_uid_and_migrates_profile():
+    """Bug A (host-UID mapping). The entrypoint must (1) remap the `bot` account to
+    the node owner's UID/GID -- explicit PUID/PGID, else the /workspace mount owner
+    -- so the recorded WAV is written node-owned (no cross-UID perms fixup), and
+    (2) chown the bind-mounted PROFILE across on existing nodes where it was created
+    by the old bot (uid 10001, mode 700); without that migration the signed-in
+    Google session becomes unreadable after the remap. These are root/docker
+    behaviors not unit-runnable in CI, so syntax-check the script and pin the
+    load-bearing lines against accidental deletion."""
+    script = os.path.join(os.path.dirname(__file__), "entrypoint.sh")
+    subprocess.run(["sh", "-n", script], check=True)
+    body = open(script).read()
 
-        # Fresh create.
-        meetingd._ensure_node_accessible_dir(target)
-        assert os.path.isdir(target)
-        assert (os.stat(target).st_mode & 0o777) == 0o777
-
-        # Pre-existing 0700 dir (an older meetingd left it restrictive) must be
-        # relaxed, not left as-is.
-        os.chmod(target, 0o700)
-        meetingd._ensure_node_accessible_dir(target)
-        assert (os.stat(target).st_mode & 0o777) == 0o777
-
-
-def test_ensure_node_accessible_dir_chmod_failure_is_non_fatal(monkeypatch):
-    """When the node created the dir first it OWNS it and meetingd's chmod is
-    EPERM -- that must be swallowed (the node relaxed the mode itself), never
-    crash the record start."""
-    with tempfile.TemporaryDirectory() as d:
-        target = os.path.join(d, "meetings")
-
-        def _raise(*_a, **_k):
-            raise PermissionError("not the owner")
-
-        monkeypatch.setattr(meetingd.os, "chmod", _raise)
-        # Must not raise despite chmod failing.
-        meetingd._ensure_node_accessible_dir(target)
-        assert os.path.isdir(target)
+    # Remap the bot account to the target UID/GID.
+    assert "usermod -o -u" in body
+    assert "groupmod -o -g" in body
+    # Explicit PUID/PGID honored, with a fallback derived from the workspace owner.
+    assert "PUID" in body and "PGID" in body
+    assert "stat -c '%u'" in body and "WORKSPACE_DIR" in body
+    # Migration: chown the bind mounts (incl. the persisted profile) to the target.
+    assert "PROFILE_DIR" in body
+    assert "chown -R bot:bot" in body
 
 
 def _write_wav(path: str, samples: list[int]):

--- a/services/meeting-service/test_meetingd.py
+++ b/services/meeting-service/test_meetingd.py
@@ -80,6 +80,43 @@ def test_safe_workspace_path(rel, ok, monkeypatch):
             meetingd._safe_workspace_path(rel)
 
 
+def test_ensure_node_accessible_dir_makes_shared_dir_world_accessible():
+    """Bug A (live-prod node 1084, 2026-07-16): the WAV output dir is created by
+    meetingd (bot UID 10001) but READ by the node owner (a different UID). Under
+    bot's umask it lands 0700, which the node cannot even traverse. The helper must
+    force 0o777 so the node can read the recording for the end-of-call transcribe,
+    and must relax a PRE-EXISTING 0700 dir (exist_ok makedirs does not)."""
+    with tempfile.TemporaryDirectory() as d:
+        target = os.path.join(d, "meetings")
+
+        # Fresh create.
+        meetingd._ensure_node_accessible_dir(target)
+        assert os.path.isdir(target)
+        assert (os.stat(target).st_mode & 0o777) == 0o777
+
+        # Pre-existing 0700 dir (an older meetingd left it restrictive) must be
+        # relaxed, not left as-is.
+        os.chmod(target, 0o700)
+        meetingd._ensure_node_accessible_dir(target)
+        assert (os.stat(target).st_mode & 0o777) == 0o777
+
+
+def test_ensure_node_accessible_dir_chmod_failure_is_non_fatal(monkeypatch):
+    """When the node created the dir first it OWNS it and meetingd's chmod is
+    EPERM -- that must be swallowed (the node relaxed the mode itself), never
+    crash the record start."""
+    with tempfile.TemporaryDirectory() as d:
+        target = os.path.join(d, "meetings")
+
+        def _raise(*_a, **_k):
+            raise PermissionError("not the owner")
+
+        monkeypatch.setattr(meetingd.os, "chmod", _raise)
+        # Must not raise despite chmod failing.
+        meetingd._ensure_node_accessible_dir(target)
+        assert os.path.isdir(target)
+
+
 def _write_wav(path: str, samples: list[int]):
     with wave.open(path, "wb") as w:
         w.setnchannels(1)


### PR DESCRIPTION
## Context

Found in **live-prod E2E on node 1084** (ubuntu-gpu, citadel v2.79.0) on **2026-07-16**. The `meeting` container module joined a Google Meet, got admitted, and recorded **real non-silent audio** (106s, -27.6 dBFS) for the first time — but the **record → transcribe → store last mile** was broken by a UID/permission cascade, and the backend `meeting_sessions` row was stranded at `status="joining"` forever.

Two coupled bugs, both fixed here (citadel-cli only — the aceteam backend already has a correct state machine and reads `node_id` from `meta.node_id`).

### Bug A — container-owned output blocked the node reader/writer
`meetingd` ran as `bot` (UID 10001) and wrote the WAV to the bind-mounted `/workspace/meetings/` as 10001. The node-side handler runs as the **node owner** (a different UID) and couldn't traverse/read a 10001-owned dir, so the end-of-call transcribe couldn't read the WAV and the rolling-window transcriber couldn't write its scratch clip.

### Bug B — handler never returned a terminal result
The rolling-window transcriber kept **looping** (still firing 68s after `max duration reached; leaving`), so the handler never produced a terminal `completed` / `recorded_transcription_failed`. The backend row stayed `joining`, `node_id=null` forever.

## Summary

### Bug A — host-UID container mapping (PUID/PGID), no chmod
Per Jason's call, the container now **runs as the node owner's UID/GID** so the WAV is written node-owned from the start — no ownership mismatch, no chmod dance.

- **`entrypoint.sh`**: remaps the in-container `bot` account to the node owner's UID/GID (`usermod`/`groupmod`) at boot, then chowns the runtime/home/app dirs and the bind mounts. The target UID/GID come from explicit **PUID/PGID**, else are **auto-derived from the `/workspace` mount owner** (which *is* the node owner), else fall back to the image default 10001 (Chrome can't run as root, so 0 is never mapped). Because `supervisord` drops every program to `user=bot`, remapping `bot` is enough — no per-program templating.
- **Profile-dir migration (the important part):** existing nodes (e.g. 1084) have a persisted profile at `~/.citadel-cli/meeting-profile` owned by the **old** `bot` (10001, mode 700) holding the signed-in Google session. After remapping `bot` to the node owner, that profile would be unreadable — so the entrypoint **chowns the profile across** to the remapped `bot` when its owner differs from the target UID. The container comes up able to read the existing session; no re-seed. (The `/workspace` mount is normally already node-owned, so it's skipped — no giant recursive chown.)
- **`compose.yml`**: passes `PUID`/`PGID` (empty default → entrypoint derives from the mount owner).
- **`Dockerfile`**: notes 10001 is only the default uid; the entrypoint remaps it.
- **Go wiring** (`service_handler.go` `composeEnv` + `config_handler.go` `startServices`): export `PUID`/`PGID` = the node process's own uid/gid to `docker compose` (guarded on `os.Getuid() >= 0` so a non-POSIX host never emits `PUID=-1`; the meeting stack is Linux-container-only regardless).
- **Scratch-clip relocation kept** as hygiene: the churny per-pass `<session>-window.wav` lives in a separate `meeting-scratch/` dir (still inside the workspace, passes `ValidatePath`) rather than alongside the durable recordings in `meetings/`.

This **eliminates the "stale 0700 dir on 1084 needs an image republish to un-brick" landmine** — there's no perms state to heal; files are simply written with the right owner. (The image still needs a rebuild/republish for the compose/entrypoint change to take effect on nodes.)

### Bug B — guaranteed terminal outcome + lifecycle
- `RollingTranscriber.Run`: **prioritize `stop` over the ticker.** Go's `select` picks a uniformly-random ready case, so once `stop` closed a still-firing ticker could keep winning and run more periodic passes. A non-blocking re-check of `stop` after a tick guarantees at most the in-flight pass + one final pass run after stop.
- `waitForMeetingEndInteractive`: `stopRolling` signals `stop` **and waits (bounded)** for the rolling goroutine to fully finish on every exit path before returning, so Execute proceeds to the batch transcribe and returns a terminal doc even when every rolling pass failed. `transcribeMu` still serializes the batch transcribe for correctness if the grace trips.
- `node_id`: already carried on the terminal event — `internal/redis` injects `NodeMeta{ "node_id": … }` into every stream event, and the backend reads `meta.node_id`. Guaranteeing the terminal return is sufficient.

### Ships on two vehicles (deploy note)
The **Bug B** fix ships with the **citadel binary**, so sessions reach a terminal state (`recorded_transcription_failed` → backend `failed`) immediately — no more stranded `joining` rows — even before the image rebuild. The **Bug A** host-UID mapping needs the **`ghcr.io/aceteam-ai/meeting-service` image rebuilt/republished** (CI publishes it) for the compose/entrypoint change to take effect.

## Test plan

| Area | Test | Covers |
|---|---|---|
| Bug A (Go) | `TestComposeEnv_InjectsHostUIDGID` | `composeEnv` exports `PUID`/`PGID` = the node process's uid/gid |
| Bug A (Go) | `TestMeetingWindowWavPath_UsesSeparateScratchDir` | scratch clip lives in `meeting-scratch/`, not `meetings/`; passes `ValidatePath` |
| Bug A (Py) | `test_entrypoint_maps_to_host_uid_and_migrates_profile` | entrypoint syntax + load-bearing lines: `bot` remap, PUID/PGID + workspace-owner fallback, **profile chown migration** (root/docker behavior isn't unit-runnable in CI, so this is a static guard against deletion) |
| Bug B (Go) | `TestRollingTranscriber_Run_NoPeriodicPassAfterStop` | priority-stop: exactly in-flight + 1 final pass, no periodic pass after stop (**verified it fails on the old random-select behavior**: passes=3) |
| Bug B (Go) | `TestInteractive_RollingStopsWhenCallEnds` | terminal `endReason` + rolling goroutine fully stopped even when **every** pass fails |

`go build ./... && go vet ./... && go test ./...` green; existing meeting tests unchanged and passing. 16 `meetingd` python tests pass. `entrypoint.sh` shellcheck-clean; UID-resolution simulated (PUID override + workspace-owner fallback both correct).

## Backend follow-up (not in this PR)

Intermediate `recording` progress reporting needs **both**: (1) a backend change — `_dispatch_meeting_job` (routes/meeting_bot.py) only consumes the terminal `end`/`error` event and ignores `start`/`chunk`, so it advances `joining → recording` only from the terminal result today; and (2) node plumbing — the legacy handler interface gives handlers only `LogFn`, no `StreamWriter`, so a handler cannot emit an intermediate progress event. Until both land, the row leaves `joining` only when the terminal result arrives (now guaranteed). Recommend a follow-up issue to emit `recording` promptly when recording starts.