### PR TITLE
feat(device): automatic leaf renewal + grace-aware self-heal (aceteam#5959 follow-up)

### DIFF
--- a/cmd/device.go
+++ b/cmd/device.go
@@ -44,6 +44,22 @@ const deviceCheckIntervalEnv = "CITADEL_DEVICE_CHECK_INTERVAL"
 
 const defaultDeviceCheckInterval = 15 * time.Minute
 
+// leafRenewDaysEnv overrides how many days of remaining leaf life trigger an
+// automatic renewal (default devicemode.DefaultLeafRenewThreshold, 30d).
+// Non-positive values fall back to the default — renewal cannot be disabled by
+// env; a device that never renews is a device that eventually bricks.
+const leafRenewDaysEnv = "CITADEL_DEVICE_LEAF_RENEW_DAYS"
+
+// leafRenewThreshold resolves the renewal window from env or default.
+func leafRenewThreshold() time.Duration {
+	if raw := os.Getenv(leafRenewDaysEnv); raw != "" {
+		if days, err := strconv.Atoi(raw); err == nil && days > 0 {
+			return time.Duration(days) * 24 * time.Hour
+		}
+	}
+	return devicemode.DefaultLeafRenewThreshold
+}
+
 var deviceCmd = &cobra.Command{
 	Use:   "device",
 	Short: "Enroll and maintain this machine as a personal device on your org's network",
@@ -248,16 +264,25 @@ func deviceTick(ctx context.Context, cfg *devicemode.Config, store *nodeidentity
 		return
 	}
 
-	decision := devicemode.Decide(st.BackendState, st.Self.KeyExpiry, leaf.NotAfter, now)
+	decision := devicemode.Decide(st.BackendState, st.Self.KeyExpiry, leaf.NotAfter, now, leafRenewThreshold())
 	logDevice("state=%s leaf_expires=%s: %s",
 		st.BackendState, leaf.NotAfter.Format("2006-01-02"), decision.Reason)
 
 	if decision.LeafExpired {
 		return
 	}
-	if decision.LeafExpiresSoon {
-		logDevice("WARNING: identity certificate expires %s — re-run 'citadel device enroll' before then",
-			leaf.NotAfter.Format("2006-01-02"))
+	if decision.RenewLeaf {
+		// Renewal failure never blocks session self-heal: log and keep going;
+		// the window is ~30d of 15m ticks, so transient failures are cheap.
+		httpClient := &http.Client{Timeout: 30 * time.Second}
+		notAfter, err := devicemode.RenewLeaf(tickCtx, httpClient, cfg.APIBaseURL, store)
+		if err != nil {
+			logDevice("leaf renewal failed (will retry next tick): %v", err)
+			logDevice("WARNING: identity certificate expires %s — if renewal keeps failing, re-run 'citadel device enroll' before then",
+				leaf.NotAfter.Format("2006-01-02"))
+		} else {
+			logDevice("identity certificate renewed; now valid until %s", notAfter.Format("2006-01-02"))
+		}
 	}
 	if !decision.Reenroll {
 		return
@@ -319,7 +344,7 @@ func runDeviceStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	if !leafNotAfter.IsZero() {
-		decision := devicemode.Decide(st.BackendState, st.Self.KeyExpiry, leafNotAfter, now)
+		decision := devicemode.Decide(st.BackendState, st.Self.KeyExpiry, leafNotAfter, now, leafRenewThreshold())
 		fmt.Printf("Health:      %s\n", decision.Reason)
 	}
 	return nil

--- a/internal/devicemode/config.go
+++ b/internal/devicemode/config.go
@@ -40,6 +40,11 @@ const (
 	// DefaultNexusURL is the mesh coordination server handed to
 	// `tailscale up --login-server`.
 	DefaultNexusURL = "https://nexus.aceteam.ai"
+
+	// DefaultAPIBaseURL is the platform base URL (pairing, CA chain, leaf
+	// renewal). Filled in for configs written before leaf renewal existed so
+	// the daemon can renew without a re-enrollment.
+	DefaultAPIBaseURL = "https://aceteam.ai"
 )
 
 // Config is the persisted device-mode state written by `citadel device enroll`
@@ -85,6 +90,9 @@ func loadConfigFrom(path string) (*Config, error) {
 	}
 	if cfg.ReenrollURL == "" {
 		cfg.ReenrollURL = DefaultReenrollURL
+	}
+	if cfg.APIBaseURL == "" {
+		cfg.APIBaseURL = DefaultAPIBaseURL
 	}
 	return &cfg, nil
 }

--- a/internal/devicemode/health.go
+++ b/internal/devicemode/health.go
@@ -1,8 +1,8 @@
 // Pure self-heal decision logic for the device daemon (#5959).
 //
-// Kept free of I/O so the exact conditions under which a device reenrolls —
-// the load-bearing behavior of device mode — are unit-testable without a
-// tailscale daemon or a live mesh.
+// Kept free of I/O so the exact conditions under which a device reenrolls or
+// renews its leaf — the load-bearing behavior of device mode — are
+// unit-testable without a tailscale daemon or a live mesh.
 package devicemode
 
 import (
@@ -16,12 +16,21 @@ const (
 	// renewer's 24h threshold (internal/network/keyhealth.go).
 	KeyRenewThreshold = 24 * time.Hour
 
-	// LeafWarnThreshold: how close to leaf expiry the daemon starts warning.
-	// There is no leaf-renewal endpoint yet (see #5959 follow-ups), and the
-	// reenroll terminator rejects EXPIRED client certs at the TLS handshake,
-	// so an expiring leaf needs a fresh interactive enrollment before
-	// not_after — the warning is the operator's runway.
-	LeafWarnThreshold = 30 * 24 * time.Hour
+	// DefaultLeafRenewThreshold: renew the fabric leaf while it still has
+	// this much life left (env CITADEL_DEVICE_LEAF_RENEW_DAYS overrides).
+	// Renewal is fully automatic (platform POST /api/fabric/ca/renew with a
+	// CSR proof-of-possession) and requires a still-valid leaf, so the window
+	// must be comfortably wider than the daemon's check interval and any
+	// plausible laptop-in-a-drawer stretch.
+	DefaultLeafRenewThreshold = 30 * 24 * time.Hour
+
+	// LeafGraceDays mirrors the reenroll service's REENROLL_GRACE_DAYS
+	// default: an expired-but-not-revoked leaf may still authenticate to the
+	// reenroll service (for a mesh authkey only — NOT for leaf renewal) until
+	// not_after + this many days. Past it, only interactive enrollment
+	// remains. Kept as a client-side mirror so the daemon's messaging matches
+	// what the service will actually do.
+	LeafGraceDays = 60
 )
 
 // Decision is what the daemon should do this tick.
@@ -29,36 +38,62 @@ type Decision struct {
 	// Reenroll: present the leaf to the reenroll service for a fresh authkey
 	// and re-run tailscale up.
 	Reenroll bool
+	// RenewLeaf: the leaf is still valid but inside the renewal window —
+	// obtain a successor leaf from the platform before it expires.
+	RenewLeaf bool
 	// Reason is a human-readable explanation for the log line.
 	Reason string
-	// LeafExpiresSoon: warn the operator to re-enroll interactively.
+	// LeafExpiresSoon: the leaf is inside the renewal window. If automatic
+	// renewal keeps failing, the operator eventually needs to re-enroll
+	// interactively before not_after.
 	LeafExpiresSoon bool
-	// LeafExpired: the leaf can no longer authenticate at the mTLS
-	// terminator; self-heal is impossible and the device must re-enroll
-	// interactively. Overrides Reenroll.
+	// LeafExpiredInGrace: the leaf is expired but within the reenroll grace
+	// window — mesh self-heal (Reenroll) can still work, but the leaf itself
+	// can no longer be renewed; re-enroll interactively to restore it.
+	LeafExpiredInGrace bool
+	// LeafExpired: the leaf is expired PAST the grace window; nothing
+	// automatic remains and the device must re-enroll interactively.
+	// Overrides Reenroll.
 	LeafExpired bool
 }
 
 // Decide evaluates one daemon tick.
 //
 // backendState is tailscale's BackendState; keyExpiry is the node key expiry
-// (nil = non-expiring); leafNotAfter is the fabric leaf's expiry.
-func Decide(backendState string, keyExpiry *time.Time, leafNotAfter, now time.Time) Decision {
+// (nil = non-expiring); leafNotAfter is the fabric leaf's expiry;
+// leafRenewThreshold is how much remaining leaf life triggers renewal
+// (use DefaultLeafRenewThreshold unless overridden).
+func Decide(
+	backendState string,
+	keyExpiry *time.Time,
+	leafNotAfter, now time.Time,
+	leafRenewThreshold time.Duration,
+) Decision {
 	d := Decision{}
 
 	if !leafNotAfter.After(now) {
-		// The nginx mTLS terminator refuses an expired client cert at the
-		// handshake, so the grace window is unreachable from a device: past
-		// not_after the only path back is interactive enrollment.
-		d.LeafExpired = true
-		d.Reason = fmt.Sprintf(
-			"fabric identity certificate expired %s — run 'citadel device enroll' to re-enroll",
-			leafNotAfter.Format(time.RFC3339),
-		)
-		return d
-	}
-	if leafNotAfter.Sub(now) < LeafWarnThreshold {
-		d.LeafExpiresSoon = true
+		graceDeadline := leafNotAfter.Add(LeafGraceDays * 24 * time.Hour)
+		if now.After(graceDeadline) {
+			// Past grace nothing can authenticate: not the reenroll service,
+			// not renewal. Interactive enrollment is the only path back.
+			d.LeafExpired = true
+			d.Reason = fmt.Sprintf(
+				"fabric identity certificate expired %s (past the %dd grace window) — run 'citadel device enroll' to re-enroll",
+				leafNotAfter.Format(time.RFC3339), LeafGraceDays,
+			)
+			return d
+		}
+		// Expired but in grace: the reenroll service still accepts the leaf
+		// for mesh authkeys (nexus#37 made this reachable through the
+		// terminator), so session self-heal continues below. The leaf itself
+		// cannot be renewed anymore — renewal requires a valid leaf — so keep
+		// pointing the operator at interactive enrollment.
+		d.LeafExpiredInGrace = true
+	} else {
+		if leafNotAfter.Sub(now) < leafRenewThreshold {
+			d.RenewLeaf = true
+			d.LeafExpiresSoon = true
+		}
 	}
 
 	switch backendState {
@@ -87,6 +122,17 @@ func Decide(backendState string, keyExpiry *time.Time, leafNotAfter, now time.Ti
 		}
 	}
 
-	d.Reason = "healthy"
+	switch {
+	case d.RenewLeaf:
+		d.Reason = fmt.Sprintf(
+			"identity certificate expires %s — renewing", leafNotAfter.Format("2006-01-02"))
+	case d.LeafExpiredInGrace:
+		d.Reason = fmt.Sprintf(
+			"identity certificate expired %s but within the %dd grace window — mesh self-heal still works; re-run 'citadel device enroll' to restore the certificate",
+			leafNotAfter.Format("2006-01-02"), LeafGraceDays,
+		)
+	default:
+		d.Reason = "healthy"
+	}
 	return d
 }

--- a/internal/devicemode/health_test.go
+++ b/internal/devicemode/health_test.go
@@ -10,19 +10,23 @@ var testNow = time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
 
 func ptr(t time.Time) *time.Time { return &t }
 
+func decide(backendState string, keyExpiry *time.Time, leafNotAfter time.Time) Decision {
+	return Decide(backendState, keyExpiry, leafNotAfter, testNow, DefaultLeafRenewThreshold)
+}
+
 func TestDecideHealthy(t *testing.T) {
 	leafNotAfter := testNow.Add(200 * 24 * time.Hour)
 	keyExpiry := ptr(testNow.Add(90 * 24 * time.Hour))
 
-	d := Decide("Running", keyExpiry, leafNotAfter, testNow)
-	if d.Reenroll || d.LeafExpired || d.LeafExpiresSoon {
+	d := decide("Running", keyExpiry, leafNotAfter)
+	if d.Reenroll || d.RenewLeaf || d.LeafExpired || d.LeafExpiresSoon {
 		t.Fatalf("expected healthy no-op, got %+v", d)
 	}
 }
 
 func TestDecideNoKeyExpiry(t *testing.T) {
 	leafNotAfter := testNow.Add(200 * 24 * time.Hour)
-	d := Decide("Running", nil, leafNotAfter, testNow)
+	d := decide("Running", nil, leafNotAfter)
 	if d.Reenroll {
 		t.Fatalf("non-expiring key must not trigger reenroll: %+v", d)
 	}
@@ -30,7 +34,7 @@ func TestDecideNoKeyExpiry(t *testing.T) {
 
 func TestDecideNeedsLogin(t *testing.T) {
 	leafNotAfter := testNow.Add(200 * 24 * time.Hour)
-	d := Decide("NeedsLogin", nil, leafNotAfter, testNow)
+	d := decide("NeedsLogin", nil, leafNotAfter)
 	if !d.Reenroll {
 		t.Fatalf("NeedsLogin must trigger reenroll: %+v", d)
 	}
@@ -40,7 +44,7 @@ func TestDecideStoppedRespectsOperator(t *testing.T) {
 	// `tailscale down` is a deliberate operator action; a fresh authkey would
 	// not restart the engine and we must not fight the user.
 	leafNotAfter := testNow.Add(200 * 24 * time.Hour)
-	d := Decide("Stopped", nil, leafNotAfter, testNow)
+	d := decide("Stopped", nil, leafNotAfter)
 	if d.Reenroll {
 		t.Fatalf("Stopped must not trigger reenroll: %+v", d)
 	}
@@ -50,7 +54,7 @@ func TestDecideKeyExpiringSoon(t *testing.T) {
 	leafNotAfter := testNow.Add(200 * 24 * time.Hour)
 	keyExpiry := ptr(testNow.Add(6 * time.Hour)) // < 24h threshold
 
-	d := Decide("Running", keyExpiry, leafNotAfter, testNow)
+	d := decide("Running", keyExpiry, leafNotAfter)
 	if !d.Reenroll {
 		t.Fatalf("key inside renew threshold must trigger reenroll: %+v", d)
 	}
@@ -60,36 +64,93 @@ func TestDecideKeyAlreadyExpired(t *testing.T) {
 	leafNotAfter := testNow.Add(200 * 24 * time.Hour)
 	keyExpiry := ptr(testNow.Add(-time.Hour))
 
-	d := Decide("Running", keyExpiry, leafNotAfter, testNow)
+	d := decide("Running", keyExpiry, leafNotAfter)
 	if !d.Reenroll {
 		t.Fatalf("expired key must trigger reenroll: %+v", d)
 	}
 }
 
-func TestDecideLeafExpiringSoonWarns(t *testing.T) {
-	leafNotAfter := testNow.Add(10 * 24 * time.Hour) // < 30d warn threshold
-	d := Decide("Running", nil, leafNotAfter, testNow)
+func TestDecideLeafInsideRenewWindowRenews(t *testing.T) {
+	leafNotAfter := testNow.Add(10 * 24 * time.Hour) // < 30d renew threshold
+	d := decide("Running", nil, leafNotAfter)
+	if !d.RenewLeaf {
+		t.Fatalf("leaf inside renew window must trigger renewal: %+v", d)
+	}
 	if !d.LeafExpiresSoon {
-		t.Fatalf("leaf inside warn threshold must warn: %+v", d)
+		t.Fatalf("leaf inside renew window must warn: %+v", d)
 	}
 	if d.Reenroll || d.LeafExpired {
-		t.Fatalf("warn-only case must not reenroll/expire: %+v", d)
+		t.Fatalf("renew-only case must not reenroll/expire: %+v", d)
 	}
 }
 
-func TestDecideLeafExpiredBlocksSelfHeal(t *testing.T) {
-	// The mTLS terminator rejects expired client certs at the handshake, so
-	// past not_after the ONLY path is interactive re-enrollment — even when
-	// the session is broken.
-	leafNotAfter := testNow.Add(-time.Hour)
-	d := Decide("NeedsLogin", nil, leafNotAfter, testNow)
-	if !d.LeafExpired {
-		t.Fatalf("expired leaf must be flagged: %+v", d)
+func TestDecideCustomRenewThreshold(t *testing.T) {
+	leafNotAfter := testNow.Add(10 * 24 * time.Hour)
+	// A 5d threshold leaves a 10d-remaining leaf alone...
+	d := Decide("Running", nil, leafNotAfter, testNow, 5*24*time.Hour)
+	if d.RenewLeaf {
+		t.Fatalf("leaf outside custom threshold must not renew: %+v", d)
 	}
-	if d.Reenroll {
-		t.Fatalf("expired leaf must suppress reenroll: %+v", d)
+	// ...and a 60d threshold renews it.
+	d = Decide("Running", nil, leafNotAfter, testNow, 60*24*time.Hour)
+	if !d.RenewLeaf {
+		t.Fatalf("leaf inside custom threshold must renew: %+v", d)
+	}
+}
+
+func TestDecideRenewAndReenrollCanCoincide(t *testing.T) {
+	// A broken session and an expiring leaf in the same tick: fix both.
+	leafNotAfter := testNow.Add(10 * 24 * time.Hour)
+	d := decide("NeedsLogin", nil, leafNotAfter)
+	if !d.Reenroll || !d.RenewLeaf {
+		t.Fatalf("expected both reenroll and renew, got %+v", d)
+	}
+}
+
+func TestDecideLeafExpiredInGraceStillSelfHeals(t *testing.T) {
+	// Expired-but-in-grace: the reenroll service accepts the leaf for mesh
+	// authkeys (nexus#37 made the grace window reachable through the
+	// terminator), so session self-heal must still fire. Renewal must NOT:
+	// it requires a currently-valid leaf.
+	leafNotAfter := testNow.Add(-10 * 24 * time.Hour) // 10d expired, grace 60d
+	d := decide("NeedsLogin", nil, leafNotAfter)
+	if !d.LeafExpiredInGrace {
+		t.Fatalf("expired-in-grace leaf must be flagged: %+v", d)
+	}
+	if !d.Reenroll {
+		t.Fatalf("expired-in-grace leaf must still attempt session self-heal: %+v", d)
+	}
+	if d.RenewLeaf {
+		t.Fatalf("expired leaf must never attempt renewal: %+v", d)
+	}
+	if d.LeafExpired {
+		t.Fatalf("in-grace leaf is not terminally expired: %+v", d)
+	}
+}
+
+func TestDecideLeafExpiredInGraceHealthySessionPointsAtRemedy(t *testing.T) {
+	leafNotAfter := testNow.Add(-10 * 24 * time.Hour)
+	d := decide("Running", nil, leafNotAfter)
+	if d.Reenroll || d.RenewLeaf {
+		t.Fatalf("healthy session must not reenroll/renew: %+v", d)
 	}
 	if !strings.Contains(d.Reason, "citadel device enroll") {
-		t.Fatalf("expired-leaf reason must point at the remedy, got %q", d.Reason)
+		t.Fatalf("in-grace reason must point at the remedy, got %q", d.Reason)
+	}
+}
+
+func TestDecideLeafExpiredPastGraceBlocksSelfHeal(t *testing.T) {
+	// Past not_after + grace nothing can authenticate — even a broken session
+	// must not trigger a doomed reenroll loop.
+	leafNotAfter := testNow.Add(-time.Duration(LeafGraceDays+10) * 24 * time.Hour)
+	d := decide("NeedsLogin", nil, leafNotAfter)
+	if !d.LeafExpired {
+		t.Fatalf("past-grace leaf must be flagged terminal: %+v", d)
+	}
+	if d.Reenroll || d.RenewLeaf {
+		t.Fatalf("past-grace leaf must suppress reenroll/renew: %+v", d)
+	}
+	if !strings.Contains(d.Reason, "citadel device enroll") {
+		t.Fatalf("past-grace reason must point at the remedy, got %q", d.Reason)
 	}
 }

--- a/internal/devicemode/renew.go
+++ b/internal/devicemode/renew.go
@@ -1,0 +1,157 @@
+// Leaf renewal client: refresh the fabric identity certificate BEFORE it
+// expires, so a device never has to fall back to the interactive enrollment
+// ceremony (aceteam #5959 follow-up; platform endpoint POST /api/fabric/ca/renew).
+//
+// The security model is application-layer proof-of-possession: the platform
+// coordinator cannot terminate client-cert TLS, so instead of an mTLS
+// handshake the request carries a CSR self-signed by the SAME key as the
+// current leaf. Only the holder of the leaf's private key can produce that
+// CSR, and the server verifies chain + revocation + key equality before
+// issuing a successor leaf with the same identity and lifetime class. The
+// private key never leaves the machine and is NOT rotated — the identity
+// store keeps one stable key, which is also what makes the CSR a possession
+// proof.
+package devicemode
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nodeidentity"
+)
+
+type renewRequest struct {
+	LeafPem string `json:"leaf_pem"`
+	CSRPem  string `json:"csr_pem"`
+}
+
+type renewResponse struct {
+	OK       bool   `json:"ok"`
+	LeafPem  string `json:"leaf_pem"`
+	ChainPem string `json:"chain_pem"`
+	NodeUID  string `json:"node_uid"`
+	NotAfter string `json:"not_after"`
+}
+
+// RenewLeaf exchanges the current (still valid) leaf + a CSR for a successor
+// leaf and persists it to the identity store. Returns the new expiry.
+//
+// The returned leaf is verified locally before it replaces the old one: it
+// must parse and its public key must match our private key — a response that
+// fails either check is rejected so we never overwrite a working identity
+// with an unusable cert.
+func RenewLeaf(
+	ctx context.Context,
+	client *http.Client,
+	apiBaseURL string,
+	store *nodeidentity.Store,
+) (time.Time, error) {
+	if !store.HasKey() || !store.HasLeaf() {
+		return time.Time{}, fmt.Errorf(
+			"no fabric identity found in %s — run 'citadel device enroll' first", store.Dir())
+	}
+	key, err := store.GetOrCreateKey() // key exists (checked above): loads, never creates
+	if err != nil {
+		return time.Time{}, fmt.Errorf("load identity key: %w", err)
+	}
+	leafPEM, err := os.ReadFile(store.LeafPath())
+	if err != nil {
+		return time.Time{}, fmt.Errorf("read current leaf: %w", err)
+	}
+	csrPEM, err := store.GenerateCSR(key)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("generate renewal CSR: %w", err)
+	}
+
+	payload, err := json.Marshal(renewRequest{LeafPem: string(leafPEM), CSRPem: string(csrPEM)})
+	if err != nil {
+		return time.Time{}, fmt.Errorf("marshal renewal request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodPost,
+		strings.TrimSuffix(apiBaseURL, "/")+"/api/fabric/ca/renew",
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("build renewal request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("renewal request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 256*1024))
+	if err != nil {
+		return time.Time{}, fmt.Errorf("read renewal response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return time.Time{}, renewError(resp.StatusCode, body)
+	}
+
+	var result renewResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return time.Time{}, fmt.Errorf("parse renewal response: %w", err)
+	}
+	newLeaf, err := parseLeafForKey(result.LeafPem, key)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if err := store.StoreLeaf(result.LeafPem, result.ChainPem); err != nil {
+		return time.Time{}, fmt.Errorf("store renewed leaf: %w", err)
+	}
+	return newLeaf.NotAfter, nil
+}
+
+// parseLeafForKey validates that a returned leaf PEM parses and is bound to
+// OUR private key. A mismatched cert would be worse than none: it would
+// silently replace a working identity with one we cannot use.
+func parseLeafForKey(leafPEM string, key *ecdsa.PrivateKey) (*x509.Certificate, error) {
+	block, _ := pem.Decode([]byte(leafPEM))
+	if block == nil || block.Type != "CERTIFICATE" {
+		return nil, fmt.Errorf("renewal response leaf is not a PEM certificate")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse renewed leaf: %w", err)
+	}
+	pub, ok := cert.PublicKey.(*ecdsa.PublicKey)
+	if !ok || !pub.Equal(&key.PublicKey) {
+		return nil, fmt.Errorf("renewed leaf is not bound to this device's key; refusing to store it")
+	}
+	return cert, nil
+}
+
+// renewError maps the renewal endpoint's documented status codes to
+// operator-actionable errors.
+func renewError(status int, body []byte) error {
+	detail := strings.TrimSpace(string(body))
+	switch status {
+	case http.StatusForbidden:
+		return fmt.Errorf(
+			"renewal refused (HTTP 403 — certificate expired, revoked, or possession not proven): %s\n"+
+				"If the certificate has expired, re-enroll with 'citadel device enroll'", detail)
+	case http.StatusUnauthorized:
+		return fmt.Errorf(
+			"renewal refused (HTTP 401 — certificate not recognized by the platform): %s", detail)
+	case http.StatusTooManyRequests:
+		return fmt.Errorf("renewal rate-limited (HTTP 429); will retry later: %s", detail)
+	case http.StatusServiceUnavailable:
+		return fmt.Errorf(
+			"renewal unavailable (HTTP 503 — certificate authority not active); will retry: %s", detail)
+	default:
+		return fmt.Errorf("renewal returned HTTP %d: %s", status, detail)
+	}
+}

--- a/internal/devicemode/renew_test.go
+++ b/internal/devicemode/renew_test.go
@@ -1,0 +1,232 @@
+package devicemode
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nodeidentity"
+)
+
+// renewTestCA mints leaves bound to a CALLER-SUPPLIED public key — renewal's
+// whole contract is "same key, new cert", so the test CA must be able to
+// issue for the device's existing key (unlike testPKI's self-generated leaves).
+type renewTestCA struct {
+	key  *ecdsa.PrivateKey
+	cert *x509.Certificate
+}
+
+func newRenewCA(t *testing.T) *renewTestCA {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "renew-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(48 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &renewTestCA{key: key, cert: cert}
+}
+
+func (ca *renewTestCA) issue(t *testing.T, pub *ecdsa.PublicKey, notAfter time.Time) []byte {
+	t.Helper()
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: "device-leaf"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     notAfter,
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca.cert, pub, ca.key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+// seedStore writes a device key + CA-issued leaf into a fresh identity store,
+// returning the store and the device key.
+func seedStore(t *testing.T, ca *renewTestCA) (*nodeidentity.Store, *ecdsa.PrivateKey) {
+	t.Helper()
+	dir := t.TempDir()
+	store := nodeidentity.New(dir)
+	key, err := store.GetOrCreateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	leafPEM := ca.issue(t, &key.PublicKey, time.Now().Add(20*24*time.Hour))
+	if err := os.WriteFile(filepath.Join(dir, "node.crt"), leafPEM, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return store, key
+}
+
+func TestRenewLeafSuccess(t *testing.T) {
+	ca := newRenewCA(t)
+	store, key := seedStore(t, ca)
+	oldLeaf, err := store.LoadLeaf()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newNotAfter := time.Now().Add(365 * 24 * time.Hour).Truncate(time.Second)
+	var gotReq renewRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/fabric/ca/renew" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotReq); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		// The wire shape carries the leaf + a CSR self-signed by the SAME
+		// key — verify the possession material server-side like the platform
+		// endpoint does.
+		block, _ := pem.Decode([]byte(gotReq.CSRPem))
+		if block == nil {
+			t.Error("request csr_pem is not PEM")
+		} else if csr, err := x509.ParseCertificateRequest(block.Bytes); err != nil {
+			t.Errorf("parse CSR: %v", err)
+		} else if err := csr.CheckSignature(); err != nil {
+			t.Errorf("CSR self-signature invalid: %v", err)
+		} else if !csr.PublicKey.(*ecdsa.PublicKey).Equal(&key.PublicKey) {
+			t.Error("CSR key does not match the device key")
+		}
+		resp := renewResponse{
+			OK:      true,
+			LeafPem: string(ca.issue(t, &key.PublicKey, newNotAfter)),
+			NodeUID: "device-node-uid",
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	notAfter, err := RenewLeaf(context.Background(), srv.Client(), srv.URL, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !notAfter.After(oldLeaf.NotAfter) {
+		t.Fatalf("renewed notAfter %s not after old %s", notAfter, oldLeaf.NotAfter)
+	}
+	// The private key must NEVER ride the wire.
+	if strings.Contains(gotReq.LeafPem+gotReq.CSRPem, "PRIVATE KEY") {
+		t.Fatal("request payload contains private key material")
+	}
+	// The store now holds the successor.
+	stored, err := store.LoadLeaf()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stored.NotAfter.Equal(notAfter) {
+		t.Fatalf("stored leaf notAfter %s != returned %s", stored.NotAfter, notAfter)
+	}
+}
+
+func TestRenewLeafRejectsForeignKeyLeaf(t *testing.T) {
+	// A response leaf bound to a DIFFERENT key must be refused and the
+	// existing (working) leaf left untouched — storing it would replace a
+	// usable identity with one we hold no key for.
+	ca := newRenewCA(t)
+	store, _ := seedStore(t, ca)
+	oldLeaf, _ := store.LoadLeaf()
+
+	foreignKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := renewResponse{
+			OK:      true,
+			LeafPem: string(ca.issue(t, &foreignKey.PublicKey, time.Now().Add(365*24*time.Hour))),
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	if _, err := RenewLeaf(context.Background(), srv.Client(), srv.URL, store); err == nil {
+		t.Fatal("expected error for foreign-key leaf")
+	} else if !strings.Contains(err.Error(), "not bound to this device's key") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	stored, _ := store.LoadLeaf()
+	if !stored.NotAfter.Equal(oldLeaf.NotAfter) {
+		t.Fatal("store was overwritten with an unusable leaf")
+	}
+}
+
+func TestRenewLeafErrorMapping(t *testing.T) {
+	ca := newRenewCA(t)
+	cases := []struct {
+		status  int
+		wantSub string
+	}{
+		{http.StatusForbidden, "citadel device enroll"},
+		{http.StatusUnauthorized, "not recognized"},
+		{http.StatusTooManyRequests, "rate-limited"},
+		{http.StatusServiceUnavailable, "will retry"},
+		{http.StatusBadGateway, "HTTP 502"},
+	}
+	for _, tc := range cases {
+		store, _ := seedStore(t, ca)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(tc.status)
+			_, _ = w.Write([]byte(`{"detail":"nope"}`))
+		}))
+		_, err := RenewLeaf(context.Background(), srv.Client(), srv.URL, store)
+		if err == nil {
+			t.Fatalf("status %d: expected error", tc.status)
+		}
+		if !strings.Contains(err.Error(), tc.wantSub) {
+			t.Fatalf("status %d: error %q missing %q", tc.status, err.Error(), tc.wantSub)
+		}
+		srv.Close()
+	}
+}
+
+func TestRenewLeafNotEnrolled(t *testing.T) {
+	store := nodeidentity.New(t.TempDir())
+	_, err := RenewLeaf(context.Background(), http.DefaultClient, "http://unused", store)
+	if err == nil || !strings.Contains(err.Error(), "citadel device enroll") {
+		t.Fatalf("expected not-enrolled error, got %v", err)
+	}
+}
+
+func TestRenewLeafGarbageResponse(t *testing.T) {
+	ca := newRenewCA(t)
+	store, _ := seedStore(t, ca)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"ok": true, "leaf_pem": "not a pem"}`))
+	}))
+	defer srv.Close()
+
+	if _, err := RenewLeaf(context.Background(), srv.Client(), srv.URL, store); err == nil {
+		t.Fatal("expected error for garbage leaf in response")
+	}
+}


### PR DESCRIPTION
## Context

Companion to aceteam-ai/aceteam#6028 (platform leaf-renewal endpoint) and the nexus#37 terminator fix. Device mode (#541) shipped with two known lifecycle gaps, both flagged in the aceteam#5959 progress comment:

1. **No renewal**: the daemon could only *warn* 30 days before the leaf expired — the actual fix was an interactive `citadel device enroll` ceremony.
2. **Grace unreachable**: the daemon treated an expired leaf as terminal, because the nginx terminator rejected expired client certs at the handshake (nexus#37) — a doomed retry loop was worse than a clear message.

Both upstream halves now exist, so the daemon closes the loop: **a healthy device renews its certificate automatically and never reaches the ceremony; an expired-in-grace device still self-heals its mesh session.**

## Summary

- **`internal/devicemode/renew.go`** — renewal client for `POST /api/fabric/ca/renew`. Sends the current leaf + a CSR self-signed by the SAME key (the identity store's single stable key — that same-key signature IS the proof of possession; the platform verifies chain, revocation, and key equality). The response leaf is validated locally before it replaces anything: it must parse AND be bound to our private key, so a bad response can never overwrite a working identity with an unusable cert. Error mapping (403/401/429/503) mirrors reenroll.go's operator-actionable style.
- **`internal/devicemode/health.go`** — the pure decision logic learns the full lifecycle:
  - leaf valid, < renew threshold (default 30d, `CITADEL_DEVICE_LEAF_RENEW_DAYS`) → `RenewLeaf`;
  - leaf expired but within the 60d grace window (`LeafGraceDays`, mirroring the reenroll service) → mesh self-heal (`Reenroll`) still fires — nexus#37 makes the grace window reachable through the terminator — but renewal is suppressed (it requires a valid leaf) and the reason points at interactive re-enrollment to restore the cert;
  - past grace → terminal, no doomed retry loop, clear remedy.
- **`cmd/device.go`** — daemon tick wires `RenewLeaf` in (renewal failure logs + retries next tick and never blocks session self-heal); env knob for the threshold; `device status` health line uses the same decision.
- **`internal/devicemode/config.go`** — `APIBaseURL` gets a default for configs written before renewal existed, so pre-existing enrollments renew without touching their config.

Note on rollout order: until the nexus#37 terminator change is deployed, an expired-in-grace device's reenroll attempt fails at the TLS handshake — the daemon logs it and retries next tick (one TLS dial per 15m, harmless), and starts working the moment the terminator is updated. Devices that renew on time never enter that state at all.

## Test plan

| Group | Coverage |
| --- | --- |
| `renew_test.go` (5) | happy path (CSR self-signature + same-key verified server-side, store updated, **private key never on the wire**); **foreign-key response leaf refused + store untouched**; 403/401/429/503/5xx error mapping; not-enrolled pointed error; garbage response leaf |
| `health_test.go` (13) | every branch: healthy, renew window (default + custom threshold), renew+reenroll same tick, **expired-in-grace still self-heals + never renews**, in-grace healthy-session messaging, past-grace terminal suppresses everything, plus all pre-existing session/key branches |
| Suite | `go build ./... && go vet ./... && go test ./...` green |

## Related

- aceteam-ai/aceteam#5959 (parent) / #4583 (PKI epic)
- aceteam-ai/aceteam#6028 (platform renewal endpoint — merge that first)
- aceteam-ai/nexus#37 (grace window reachable; nexus PR stays gated on Jason's deploy)
- #541 (device mode this extends)

---
*Generated by Claude Opus 4.8*
