### PR TITLE
Add opt-in per-job execution timeout to the worker

### DIFF
--- a/internal/jobs/handler.go
+++ b/internal/jobs/handler.go
@@ -2,6 +2,7 @@
 package jobs
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
@@ -11,6 +12,23 @@ import (
 type JobContext struct {
 	// LogFn is an optional callback for logging (if nil, prints to stdout)
 	LogFn func(level, msg string)
+
+	// Ctx is the per-job execution context threaded from the worker runner.
+	// Handlers that shell out or perform cancellable I/O should honor it (e.g.
+	// exec.CommandContext) so a per-job deadline or cancellation actually
+	// terminates in-flight work (aceteam#6000). It may be nil for callers that
+	// predate deadline propagation; use Context() to read it safely.
+	Ctx context.Context
+}
+
+// Context returns the job's execution context, falling back to
+// context.Background() when unset so handlers can pass it to exec.CommandContext
+// unconditionally.
+func (c *JobContext) Context() context.Context {
+	if c.Ctx != nil {
+		return c.Ctx
+	}
+	return context.Background()
 }
 
 // Log outputs a message - uses LogFn callback if set, otherwise prints to stdout.

--- a/internal/jobs/shell_command.go
+++ b/internal/jobs/shell_command.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
 )
@@ -226,7 +227,13 @@ func (h *ShellCommandHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, e
 	}
 	ctx.Log("info", "     - [Job %s] Running shell command: '%s'", job.ID, cmdString)
 
-	cmd := exec.Command("/bin/sh", "-c", cmdString)
+	// Bind the command to the job context so a per-job deadline / cancellation
+	// terminates the child process instead of leaking it (aceteam#6000).
+	// CommandContext sends Kill when ctx is done; WaitDelay bounds how long
+	// CombinedOutput waits on inherited stdio pipes afterwards, so a backgrounded
+	// grandchild holding the pipe can't keep the handler blocked indefinitely.
+	cmd := exec.CommandContext(ctx.Context(), "/bin/sh", "-c", cmdString)
+	cmd.WaitDelay = 10 * time.Second
 	cmd.Env = scrubEnv(os.Environ(), parseJobEnv(job))
 	if h.WorkspaceDir != "" {
 		cmd.Dir = h.WorkspaceDir

--- a/internal/worker/deadline.go
+++ b/internal/worker/deadline.go
@@ -1,0 +1,148 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// jobTimeoutPayloadKey is the wire field the backend dispatcher injects to give
+// a job a per-execution budget (aceteam#6000). It is a RELATIVE duration in
+// milliseconds measured from the moment the worker begins executing the job --
+// NOT an absolute epoch deadline. A relative duration is deliberate: nodes are
+// user-owned hardware, so an absolute deadline would be hostage to clock skew
+// between the backend and the node. Keep this string in sync with the backend
+// (`python-backend/routes/aceteam_mcp_code.py`).
+const jobTimeoutPayloadKey = "timeout_ms"
+
+// jobExecTimeout extracts the optional per-job execution budget from a job
+// payload. It returns (duration, true) only when jobTimeoutPayloadKey is present
+// and strictly positive; every other case returns ok=false so the caller
+// preserves the pre-existing no-timeout behavior exactly.
+//
+// This keeps the timeout strictly opt-in. Older backends that never set the
+// field, and job types that are legitimately unbounded (model download, build,
+// provision), are never capped -- there is deliberately no blanket ceiling.
+func jobExecTimeout(job *Job) (time.Duration, bool) {
+	if job == nil || job.Payload == nil {
+		return 0, false
+	}
+	raw, ok := job.Payload[jobTimeoutPayloadKey]
+	if !ok {
+		return 0, false
+	}
+	ms, ok := coerceToInt64(raw)
+	if !ok || ms <= 0 {
+		return 0, false
+	}
+	return time.Duration(ms) * time.Millisecond, true
+}
+
+// coerceToInt64 best-effort converts a JSON-decoded payload value to an int64.
+// Redis payloads reach the worker via json.Unmarshal, so a numeric field is a
+// float64; a payload assembled directly may carry int/int64/json.Number, and a
+// stringly-typed transport may carry a decimal string. Anything else fails.
+func coerceToInt64(v any) (int64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return int64(n), true
+	case float32:
+		return int64(n), true
+	case int:
+		return int64(n), true
+	case int64:
+		return n, true
+	case json.Number:
+		if i, err := n.Int64(); err == nil {
+			return i, true
+		}
+		if f, err := n.Float64(); err == nil {
+			return int64(f), true
+		}
+		return 0, false
+	case string:
+		if i, err := strconv.ParseInt(n, 10, 64); err == nil {
+			return i, true
+		}
+		if f, err := strconv.ParseFloat(n, 64); err == nil {
+			return int64(f), true
+		}
+		return 0, false
+	default:
+		return 0, false
+	}
+}
+
+// deadlineExceededError marks a handler that was abandoned because it exceeded
+// its per-job execution budget. It flows through the SAME terminal-error path
+// as any other handler failure, so the backend dispatcher (subscribed to
+// stream:v1:{jobId}) receives a fast, honest error instead of hanging until its
+// own wait deadline.
+type deadlineExceededError struct {
+	timeout time.Duration
+}
+
+func (e *deadlineExceededError) Error() string {
+	return fmt.Sprintf(
+		"job exceeded its execution deadline of %s and was abandoned by the worker",
+		e.timeout,
+	)
+}
+
+// executeWithDeadline runs handler.Execute under a child context bounded by
+// timeout, but never blocks the job loop past that deadline (aceteam#6000).
+//
+// The handler runs in its own goroutine. If it honors context cancellation
+// (e.g. SHELL_COMMAND via exec.CommandContext) the underlying child process is
+// terminated; if it ignores cancellation the goroutine keeps running in the
+// background while this function returns and the loop advances. Either way one
+// wedged handler can no longer stall every subsequent job on the node.
+//
+// On timeout it returns a *deadlineExceededError; the caller's existing failure
+// path publishes the terminal error event and Nacks on the LIVE parent context
+// (never the expired child) so the dispatcher receives a real error event.
+func (r *Runner) executeWithDeadline(
+	ctx context.Context,
+	handler JobHandler,
+	job *Job,
+	stream StreamWriter,
+	timeout time.Duration,
+) (*JobResult, error) {
+	execCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	type handlerResult struct {
+		result *JobResult
+		err    error
+	}
+	// Buffered (size 1) so a handler that ignores cancellation and finishes
+	// AFTER the deadline can still send its result and exit, rather than leaking
+	// blocked on the channel forever.
+	done := make(chan handlerResult, 1)
+	go func() {
+		result, err := handler.Execute(execCtx, job, stream)
+		done <- handlerResult{result: result, err: err}
+	}()
+
+	select {
+	case hr := <-done:
+		// If the handler returned an error exactly as the deadline elapsed (e.g.
+		// exec.CommandContext killed the child, yielding "signal: killed"),
+		// prefer the clear deadline message over the incidental one.
+		if hr.err != nil && errors.Is(execCtx.Err(), context.DeadlineExceeded) {
+			return nil, &deadlineExceededError{timeout: timeout}
+		}
+		return hr.result, hr.err
+	case <-execCtx.Done():
+		if errors.Is(execCtx.Err(), context.DeadlineExceeded) {
+			r.log("error", "Job %s abandoned: exceeded execution deadline of %s", job.ID, timeout)
+			return nil, &deadlineExceededError{timeout: timeout}
+		}
+		// Parent context cancelled (worker shutdown): surface the raw error so
+		// the loop unwinds without misreporting a deadline breach.
+		return nil, execCtx.Err()
+	}
+}

--- a/internal/worker/deadline_test.go
+++ b/internal/worker/deadline_test.go
@@ -1,0 +1,232 @@
+package worker
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// ctxHandler honors its context: it returns as soon as the deadline elapses,
+// recording that it observed cancellation.
+type ctxHandler struct {
+	jobType   string
+	sawCancel atomic.Bool
+}
+
+func (h *ctxHandler) CanHandle(jobType string) bool { return h.jobType == jobType }
+
+func (h *ctxHandler) Execute(ctx context.Context, job *Job, stream StreamWriter) (*JobResult, error) {
+	<-ctx.Done()
+	h.sawCancel.Store(true)
+	return nil, ctx.Err()
+}
+
+// signalHandler closes done the first time it runs, so a test can observe that
+// the job loop reached a later job.
+type signalHandler struct {
+	jobType string
+	done    chan struct{}
+	once    sync.Once
+}
+
+func newSignalHandler(jobType string) *signalHandler {
+	return &signalHandler{jobType: jobType, done: make(chan struct{})}
+}
+
+func (h *signalHandler) CanHandle(jobType string) bool { return h.jobType == jobType }
+
+func (h *signalHandler) Execute(ctx context.Context, job *Job, stream StreamWriter) (*JobResult, error) {
+	h.once.Do(func() { close(h.done) })
+	return &JobResult{Status: JobStatusSuccess}, nil
+}
+
+// hangingHandler blocks forever (until release is closed) and deliberately
+// IGNORES its context, modeling the dominant wedge case: a handler that does
+// not honor cancellation. It proves the runner's watchdog -- not handler
+// cooperation -- is what unblocks the job loop at the deadline (aceteam#6000).
+type hangingHandler struct {
+	jobType string
+	release chan struct{}
+	started chan struct{}
+	once    sync.Once
+}
+
+func newHangingHandler(jobType string) *hangingHandler {
+	return &hangingHandler{
+		jobType: jobType,
+		release: make(chan struct{}),
+		started: make(chan struct{}),
+	}
+}
+
+func (h *hangingHandler) CanHandle(jobType string) bool { return h.jobType == jobType }
+
+func (h *hangingHandler) Execute(ctx context.Context, job *Job, stream StreamWriter) (*JobResult, error) {
+	h.once.Do(func() { close(h.started) })
+	<-h.release // block until the test releases us; never observe ctx
+	return &JobResult{Status: JobStatusSuccess}, nil
+}
+
+// recordingFactory hands out one MockStreamWriter per job and remembers them so
+// the test can assert which terminal events were published for which job.
+type recordingFactory struct {
+	mu      sync.Mutex
+	writers map[string]*MockStreamWriter
+}
+
+func newRecordingFactory() *recordingFactory {
+	return &recordingFactory{writers: make(map[string]*MockStreamWriter)}
+}
+
+func (f *recordingFactory) factory(job *Job) StreamWriter {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	w := &MockStreamWriter{}
+	f.writers[job.ID] = w
+	return w
+}
+
+func (f *recordingFactory) get(jobID string) *MockStreamWriter {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.writers[jobID]
+}
+
+// TestExecuteWithDeadlineUnblocksHungHandler is the core regression test: a
+// handler that blocks forever and ignores cancellation, dispatched with a
+// per-job timeout budget, must NOT wedge the sequential job loop. Within ~the
+// deadline the runner publishes the terminal error and advances to the next
+// job.
+func TestExecuteWithDeadlineUnblocksHungHandler(t *testing.T) {
+	hang := newHangingHandler("HANG_JOB")
+	// Let the leaked goroutine exit at test end instead of blocking forever.
+	defer close(hang.release)
+
+	normal := newSignalHandler("TEST_JOB")
+
+	jobs := []*Job{
+		// job-1 hangs, but carries an 80ms budget so the watchdog abandons it.
+		{ID: "job-1", Type: "HANG_JOB", Payload: map[string]any{"timeout_ms": float64(80)}},
+		// job-2 must still run -- proof the loop was not wedged.
+		{ID: "job-2", Type: "TEST_JOB", Payload: map[string]any{}},
+	}
+
+	source := NewMockJobSource("test", jobs)
+	factory := newRecordingFactory()
+	runner := NewRunner(source, []JobHandler{hang, normal}, RunnerConfig{WorkerID: "test"})
+	runner.WithStreamWriterFactory(factory.factory)
+
+	// Run keeps polling until ctx is cancelled; drive it in a goroutine and stop
+	// it once the loop has demonstrably reached job-2.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	runDone := make(chan struct{})
+	start := time.Now()
+	go func() {
+		runner.Run(ctx)
+		close(runDone)
+	}()
+
+	select {
+	case <-normal.done:
+		// The loop advanced to job-2 despite job-1 hanging, and did so near
+		// job-1's 80ms deadline -- not the multi-second ctx bound.
+		if elapsed := time.Since(start); elapsed > 2*time.Second {
+			t.Errorf("second job ran after %s; the hung job appears to have blocked the loop", elapsed)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("second job never ran; the loop was wedged by the hung handler")
+	}
+	cancel()
+	<-runDone
+
+	// The hung handler actually started (so we exercised the timeout, not a skip).
+	select {
+	case <-hang.started:
+	default:
+		t.Fatal("hanging handler never started; the timeout path was not exercised")
+	}
+
+	// job-1 published a terminal ERROR carrying the deadline reason.
+	w1 := factory.get("job-1")
+	if w1 == nil || !w1.errored {
+		t.Fatal("job-1 did not publish a terminal error event")
+	}
+	if w1.erroredErr == nil || !strings.Contains(w1.erroredErr.Error(), "execution deadline") {
+		t.Errorf("job-1 error = %v, want an execution-deadline message", w1.erroredErr)
+	}
+	if w1.erroredRecover {
+		t.Error("deadline error should be published as non-recoverable")
+	}
+
+	// job-1 was nacked; job-2 acked.
+	if n := source.NackedJobs(); len(n) != 1 || n[0].ID != "job-1" {
+		t.Errorf("nacked = %v, want [job-1]", n)
+	}
+	if a := source.AckedJobs(); len(a) != 1 || a[0].ID != "job-2" {
+		t.Errorf("acked = %v, want [job-2]", a)
+	}
+}
+
+// TestExecuteWithDeadlineHonorsCancellingHandler verifies the cooperative path:
+// a handler that DOES honor ctx returns promptly when the deadline elapses, and
+// the runner still reports the clear deadline error.
+func TestExecuteWithDeadlineHonorsCancellingHandler(t *testing.T) {
+	coop := &ctxHandler{jobType: "COOP_JOB"}
+	jobs := []*Job{
+		{ID: "job-1", Type: "COOP_JOB", Payload: map[string]any{"timeout_ms": float64(50)}},
+	}
+	source := NewMockJobSource("test", jobs)
+	factory := newRecordingFactory()
+	runner := NewRunner(source, []JobHandler{coop}, RunnerConfig{WorkerID: "test"})
+	runner.WithStreamWriterFactory(factory.factory)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	runner.Run(ctx)
+
+	if !coop.sawCancel.Load() {
+		t.Error("cooperative handler did not observe context cancellation")
+	}
+	w := factory.get("job-1")
+	if w == nil || !w.errored || w.erroredErr == nil ||
+		!strings.Contains(w.erroredErr.Error(), "execution deadline") {
+		t.Errorf("job-1 terminal error = %v, want deadline message", w)
+	}
+}
+
+func TestJobExecTimeout(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload map[string]any
+		wantOK  bool
+		wantDur time.Duration
+	}{
+		{"absent", map[string]any{}, false, 0},
+		{"nil payload", nil, false, 0},
+		{"float64 (json)", map[string]any{"timeout_ms": float64(1500)}, true, 1500 * time.Millisecond},
+		{"int", map[string]any{"timeout_ms": 250}, true, 250 * time.Millisecond},
+		{"string", map[string]any{"timeout_ms": "2000"}, true, 2000 * time.Millisecond},
+		{"zero (opt-out)", map[string]any{"timeout_ms": float64(0)}, false, 0},
+		{"negative (opt-out)", map[string]any{"timeout_ms": float64(-5)}, false, 0},
+		{"garbage string", map[string]any{"timeout_ms": "soon"}, false, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var job *Job
+			if tc.payload != nil || tc.name == "nil payload" {
+				job = &Job{ID: "j", Payload: tc.payload}
+			}
+			dur, ok := jobExecTimeout(job)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if ok && dur != tc.wantDur {
+				t.Errorf("dur = %s, want %s", dur, tc.wantDur)
+			}
+		})
+	}
+}

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -79,8 +79,10 @@ func (a *LegacyHandlerAdapter) Execute(ctx context.Context, job *Job, stream Str
 		}
 	}
 
-	// Execute the legacy handler with log callback
-	jobCtx := jobs.JobContext{LogFn: a.logFn}
+	// Execute the legacy handler with log callback. Thread the worker context so
+	// handlers that shell out (e.g. SHELL_COMMAND) honor a per-job deadline or
+	// cancellation and actually terminate their child process (aceteam#6000).
+	jobCtx := jobs.JobContext{LogFn: a.logFn, Ctx: ctx}
 	output, err := a.handler.Execute(jobCtx, nexusJob)
 
 	duration := time.Since(start)

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -441,7 +441,23 @@ func (r *Runner) processJob(ctx context.Context, job *Job) {
 
 	// Execute handler
 	stream.WriteStart("Job processing started")
-	result, err := handler.Execute(ctx, job, stream)
+
+	// Per-job execution deadline (aceteam#6000). When the payload carries a
+	// positive timeout budget, run the handler under a bounded context plus a
+	// watchdog so a single hung/blocked handler cannot wedge this node's whole
+	// sequential job loop: on expiry executeWithDeadline returns a deadline
+	// error and the failure path below publishes the terminal error + Nacks on
+	// the live parent ctx, letting the loop advance to the next job. With no
+	// budget present (older backend, or a legitimately unbounded job type like
+	// model download / build / provision) the call stays exactly as before --
+	// synchronous, no timeout, no watchdog goroutine.
+	var result *JobResult
+	var err error
+	if timeout, ok := jobExecTimeout(job); ok {
+		result, err = r.executeWithDeadline(ctx, handler, job, stream, timeout)
+	} else {
+		result, err = handler.Execute(ctx, job, stream)
+	}
 
 	endTime := time.Now()
 	duration := endTime.Sub(startTime)


### PR DESCRIPTION
## Context

A single hung or blocked handler (e.g. a wedged `SHELL_COMMAND` or a `FILE_*` op stuck on unresponsive storage) could stall an entire Citadel node. The worker consume loop is sequential and `handler.Execute` was called with the consume-loop context, which has no per-job deadline. So one stuck handler blocked every subsequent job on that node indefinitely, while the status/heartbeat goroutine kept beating — the node still looked alive but did no work.

Cross-repo companion: aceteam-ai/aceteam PR `feat/per-job-timeout` (backend injects the deadline). Ref aceteam-ai/aceteam#6000.

## Wire field

`timeout_ms` — a **relative** execution budget in **milliseconds**, measured from when the worker begins executing the job. It is deliberately relative (a duration), not an absolute epoch deadline: nodes are user-owned hardware, so an absolute deadline would be hostage to clock skew between the backend and the node. Documented in `internal/worker/deadline.go` and mirrored in the backend.

## Changes

- `internal/worker/deadline.go` (new): `jobExecTimeout` reads `timeout_ms` from the payload (handles float64/int/json.Number/string), returning opt-in only when present and strictly positive. `executeWithDeadline` runs `handler.Execute` under a `context.WithTimeout` child in a goroutine and `select`s on completion vs. the child's `Done()`. On expiry it returns a `deadlineExceededError`.
- `internal/worker/runner.go`: when a positive budget is present, `processJob` runs the handler via `executeWithDeadline`; the deadline error flows through the **existing** failure path, which publishes the same terminal `error` event and Nacks — on the **live parent context**, never the expired child — then the loop advances. With no budget the call is byte-for-byte unchanged (synchronous, no timeout, no goroutine).
- `internal/jobs/handler.go` + `internal/worker/handler_adapter.go`: thread the worker context into `jobs.JobContext.Ctx` (nil-safe `Context()` accessor) so legacy handlers can honor cancellation.
- `internal/jobs/shell_command.go`: `exec.CommandContext` + `cmd.WaitDelay` so cancellation terminates the child process for the dominant `SHELL_COMMAND` hang case.

## Cancellation honored / not honored

- **Honored (child process killed):** `SHELL_COMMAND` via `exec.CommandContext`. `WaitDelay` bounds the wait on inherited stdio pipes afterwards.
- **Loop always unblocks regardless:** the runner-level goroutine + `select` is the actual guarantee — even a handler that completely ignores `ctx` (most legacy file ops, which perform blocking syscalls) no longer wedges the loop; its goroutine is left running in the background (the buffered done channel lets it exit when it finally returns).

## Residual hang classes the timeout still can't *interrupt* (loop still advances)

- `exec.CommandContext` is best-effort: a backgrounded grandchild that reparents and holds the stdout pipe can keep `CombinedOutput` blocked past the kill (mitigated, not eliminated, by `WaitDelay`).
- A truly wedged cgo / GPU call (e.g. a stuck driver ioctl) ignores `ctx` entirely; that goroutine leaks until the process restarts.
- Jobs with no `timeout_ms` (older backend, or unbounded types like model download / build / provision) are intentionally never capped.

In all residual cases the node's **job loop still advances** and the dispatcher still receives a fast terminal error; only the leaked worker goroutine lingers.

## Test plan

`internal/worker/deadline_test.go`:
- `TestExecuteWithDeadlineUnblocksHungHandler` — handler blocks forever and ignores `ctx`; asserts the loop reaches job 2 near the 80ms deadline (not the multi-second ctx bound), job 1 publishes a terminal error with an "execution deadline" message (non-recoverable), job 1 nacked / job 2 acked.
- `TestExecuteWithDeadlineHonorsCancellingHandler` — cooperative handler observes cancellation and still reports the deadline error.
- `TestJobExecTimeout` — parsing table (absent/nil/float64/int/string/zero/negative/garbage).

Commands run locally (all green):
- `go build ./...` — ok
- `go vet ./...` — ok
- `go test ./...` — ok (0 failures); new tests pass under `-race`.

Do NOT merge / do NOT release per request.


---
*Generated by Claude Opus 4.8*
