### PR TITLE
feat(controlcenter): scannable QR in the TUI device-auth modal (#553)

### DIFF
--- a/internal/tui/controlcenter/actions.go
+++ b/internal/tui/controlcenter/actions.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/network"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
 	"github.com/aceteam-ai/citadel-cli/internal/recommend"
+	"github.com/aceteam-ai/citadel-cli/internal/ui"
 )
 
 // showListModal displays a modal with a list of items and calls onSelect when one is chosen.
@@ -1223,6 +1224,48 @@ func (cc *ControlCenter) startDeviceAuthFlow() {
 	}()
 }
 
+// buildDeviceAuthContent renders the text body of the device-auth modal (the URL
+// fallback, the manual-code box, the countdown/status line, and the hotkey row).
+// It is a pure function of its inputs so it can be unit-tested; the QR code is
+// rendered separately into its own TextView by showDeviceAuthModal.
+func buildDeviceAuthContent(config *DeviceAuthConfig, completeURL, status string, expiresAt time.Time) string {
+	codeLen := len(config.UserCode)
+	boxWidth := codeLen + 6 // 3 spaces padding on each side
+	topBottom := strings.Repeat("═", boxWidth)
+
+	var sb strings.Builder
+	sb.WriteString("\n[yellow::b]Device Authorization[-:-:-]\n\n")
+	sb.WriteString("Scan the QR code above, or open this URL in your browser:\n\n")
+	sb.WriteString(fmt.Sprintf("[white::b]%s[-:-:-]\n\n", completeURL))
+	sb.WriteString("Or enter this code manually:\n\n")
+	sb.WriteString(fmt.Sprintf("   [cyan::b]╔%s╗[-:-:-]\n", topBottom))
+	sb.WriteString(fmt.Sprintf("   [cyan::b]║   %s   ║[-:-:-]\n", config.UserCode))
+	sb.WriteString(fmt.Sprintf("   [cyan::b]╚%s╝[-:-:-]\n\n", topBottom))
+
+	if status == "waiting" {
+		remaining := time.Until(expiresAt)
+		if remaining < 0 {
+			remaining = 0
+		}
+		minutes := int(remaining.Minutes())
+		seconds := int(remaining.Seconds()) % 60
+		sb.WriteString(fmt.Sprintf("[gray]Waiting for authorization... (%d:%02d remaining)[-]\n", minutes, seconds))
+	} else if status == "success" {
+		sb.WriteString("[green::b]Authorization successful![-:-:-]\n")
+	} else if strings.HasPrefix(status, "error:") {
+		errMsg := strings.TrimPrefix(status, "error:")
+		sb.WriteString(fmt.Sprintf("[red]%s[-]\n", errMsg))
+	}
+
+	// macOS firewall warning
+	if runtime.GOOS == "darwin" {
+		sb.WriteString("\n[gray]Note: macOS may ask to allow network access. Click 'Allow'.[-]\n")
+	}
+
+	sb.WriteString("\n[yellow]B[-] open browser  [yellow]C[-] copy link  [gray]Esc[-] cancel")
+	return sb.String()
+}
+
 // showDeviceAuthModal displays the device authorization code and polls for completion
 func (cc *ControlCenter) showDeviceAuthModal(config *DeviceAuthConfig) {
 	cc.inModal = true
@@ -1238,56 +1281,46 @@ func (cc *ControlCenter) showDeviceAuthModal(config *DeviceAuthConfig) {
 	// Calculate expiry
 	expiresAt := time.Now().Add(time.Duration(config.ExpiresIn) * time.Second)
 
-	// Build complete URL with code
-	completeURL := config.VerificationURI
-	if !strings.Contains(completeURL, "?") {
-		completeURL += "?code=" + config.UserCode
+	// Build the complete verification URL. This is the exact enrollment payload
+	// encoded in the QR code (verification_uri_complete + &v=1), so the QR, the
+	// shown URL, and the B/copy-link actions all point to the identical target.
+	// The web approval page ignores the extra v= param (see ui.BuildEnrollPayload).
+	completeURL := ui.BuildEnrollPayload(config.VerificationURI, config.UserCode)
+
+	// Render the scannable QR once (not per countdown tick). It reaches parity
+	// with the CLI login flow so a phone can scan instead of typing the code.
+	// Uses the plain full-block renderer (no ANSI) that displays correctly inside
+	// a tview.TextView; see ui.RenderQRCodeBlocks and whatsapp_page.go for the
+	// same proven pattern.
+	qrStr := ui.RenderEnrollQRBlocks(config.VerificationURI, config.UserCode)
+	if qrStr != "" {
+		qrView := tview.NewTextView()
+		qrView.SetDynamicColors(false) // block chars must not be parsed as color tags
+		qrView.SetWrap(false)          // narrow terminals clip the QR rather than garbling it
+		qrView.SetText(qrStr)
+		qrView.SetBorder(true).SetTitle(" Scan to Connect ")
+		// QR gets the flexible (proportional) top region; the URL + manual-code
+		// fallback below is FIXED-height so it is ALWAYS visible, even on an
+		// 80x24 SSH session where the full-block QR (~33 rows) cannot fit. If the
+		// QR were the fixed item it would reserve all rows and push the fallback
+		// (and the cancel hotkey) off-screen — the opposite of the requirement.
+		flex.AddItem(qrView, 0, 1, false)
 	}
 
-	// Calculate box width based on code length
-	codeLen := len(config.UserCode)
-	boxWidth := codeLen + 6 // 3 spaces padding on each side
-	topBottom := strings.Repeat("═", boxWidth)
-
-	// Update function for countdown
+	// Update function for countdown (touches only the content view; the QR is
+	// rendered once above).
 	updateContent := func(status string) {
-		var sb strings.Builder
-		sb.WriteString("\n[yellow::b]Device Authorization[-:-:-]\n\n")
-		sb.WriteString("Open this URL in your browser:\n\n")
-		sb.WriteString(fmt.Sprintf("[white::b]%s[-:-:-]\n\n", completeURL))
-		sb.WriteString("Or enter this code manually:\n\n")
-		sb.WriteString(fmt.Sprintf("   [cyan::b]╔%s╗[-:-:-]\n", topBottom))
-		sb.WriteString(fmt.Sprintf("   [cyan::b]║   %s   ║[-:-:-]\n", config.UserCode))
-		sb.WriteString(fmt.Sprintf("   [cyan::b]╚%s╝[-:-:-]\n\n", topBottom))
-
-		if status == "waiting" {
-			remaining := time.Until(expiresAt)
-			if remaining < 0 {
-				remaining = 0
-			}
-			minutes := int(remaining.Minutes())
-			seconds := int(remaining.Seconds()) % 60
-			sb.WriteString(fmt.Sprintf("[gray]Waiting for authorization... (%d:%02d remaining)[-]\n", minutes, seconds))
-		} else if status == "success" {
-			sb.WriteString("[green::b]Authorization successful![-:-:-]\n")
-		} else if strings.HasPrefix(status, "error:") {
-			errMsg := strings.TrimPrefix(status, "error:")
-			sb.WriteString(fmt.Sprintf("[red]%s[-]\n", errMsg))
-		}
-
-		// macOS firewall warning
-		if runtime.GOOS == "darwin" {
-			sb.WriteString("\n[gray]Note: macOS may ask to allow network access. Click 'Allow'.[-]\n")
-		}
-
-		sb.WriteString("\n[yellow]B[-] open browser  [yellow]C[-] copy link  [gray]Esc[-] cancel")
-		contentView.SetText(sb.String())
+		contentView.SetText(buildDeviceAuthContent(config, completeURL, status, expiresAt))
 	}
 
 	updateContent("waiting")
 	contentView.SetBorder(true).SetTitle(" Connect to AceTeam Network ")
+	contentView.SetScrollable(true) // never truncate the URL/code/hotkeys if body grows
 
-	flex.AddItem(contentView, 0, 1, true)
+	// Fixed height sized to the actual rendered body (+2 for the border) so the
+	// fallback always fits and the QR takes the remaining space above it.
+	bodyLines := len(strings.Split(buildDeviceAuthContent(config, completeURL, "waiting", expiresAt), "\n"))
+	flex.AddItem(contentView, bodyLines+2, 0, true)
 
 	// Channel to signal completion
 	doneChan := make(chan struct{})

--- a/internal/tui/controlcenter/controlcenter_test.go
+++ b/internal/tui/controlcenter/controlcenter_test.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/rivo/tview"
+
+	"github.com/aceteam-ai/citadel-cli/internal/ui"
 )
 
 // TestJobRecordStruct tests the JobRecord struct fields
@@ -617,6 +619,63 @@ func TestDeviceAuthConfig(t *testing.T) {
 	}
 	if cfg.Interval != 5 {
 		t.Errorf("DeviceAuthConfig.Interval = %d, want 5", cfg.Interval)
+	}
+}
+
+// TestDeviceAuthModalContentIncludesEnrollPayload asserts the device-auth modal
+// body shows the exact enrollment payload (verification_uri_complete + &v=1) —
+// the same string encoded into the scannable QR — so the URL, copy-link, and QR
+// all point to an identical target. Mirrors qrcode_test.go's payload assertion.
+func TestDeviceAuthModalContentIncludesEnrollPayload(t *testing.T) {
+	cfg := &DeviceAuthConfig{
+		UserCode:        "ABCD-1234",
+		VerificationURI: "https://aceteam.ai/device",
+		DeviceCode:      "device-secret-should-never-appear",
+		ExpiresIn:       900,
+		Interval:        5,
+	}
+	payload := ui.BuildEnrollPayload(cfg.VerificationURI, cfg.UserCode)
+	if payload != "https://aceteam.ai/device?code=ABCD-1234&v=1" {
+		t.Fatalf("unexpected enroll payload: %q", payload)
+	}
+
+	content := buildDeviceAuthContent(cfg, payload, "waiting", time.Now().Add(15*time.Minute))
+
+	if !strings.Contains(content, payload) {
+		t.Errorf("modal content missing enroll payload %q:\n%s", payload, content)
+	}
+	if !strings.Contains(content, cfg.UserCode) {
+		t.Errorf("modal content missing manual user code %q", cfg.UserCode)
+	}
+	// The hotkey row must be preserved.
+	if !strings.Contains(content, "open browser") || !strings.Contains(content, "copy link") {
+		t.Errorf("modal content missing hotkey row:\n%s", content)
+	}
+	// Security guardrail: the device_code polling secret must never be shown.
+	if strings.Contains(content, cfg.DeviceCode) {
+		t.Errorf("modal content leaked device_code secret")
+	}
+}
+
+// TestDeviceAuthQRMatchesPayload asserts the modal's QR renders the exact
+// enrollment payload via the tview-safe full-block renderer.
+func TestDeviceAuthQRMatchesPayload(t *testing.T) {
+	cfg := &DeviceAuthConfig{UserCode: "WXYZ-5678", VerificationURI: "https://aceteam.ai/device"}
+
+	qr := ui.RenderEnrollQRBlocks(cfg.VerificationURI, cfg.UserCode)
+	if strings.TrimSpace(qr) == "" {
+		t.Fatal("device-auth QR is empty")
+	}
+	want := ui.RenderQRCodeBlocks(ui.BuildEnrollPayload(cfg.VerificationURI, cfg.UserCode))
+	if qr != want {
+		t.Error("device-auth QR does not match the exact BuildEnrollPayload rendering")
+	}
+	// tview-safe: no ANSI escapes, full blocks present (see ui.RenderQRCodeBlocks).
+	if strings.Contains(qr, "\x1b[") {
+		t.Error("device-auth QR leaked ANSI escapes (would corrupt in tview)")
+	}
+	if !strings.Contains(qr, "██") {
+		t.Error("device-auth QR missing full-block glyphs")
 	}
 }
 

--- a/internal/ui/qrcode.go
+++ b/internal/ui/qrcode.go
@@ -91,3 +91,34 @@ func RenderQRCode(content string) string {
 func RenderEnrollQR(verificationURI, userCode string) string {
 	return RenderQRCode(BuildEnrollPayload(verificationURI, userCode))
 }
+
+// RenderQRCodeBlocks renders the given content as a scannable QR code using
+// plain full-block characters with NO ANSI escape sequences, so it displays
+// correctly inside a tview.TextView (which mangles the half-block/ANSI output
+// of RenderQRCode when SetDynamicColors is involved).
+//
+// It mirrors the proven rendering used by the control center's WhatsApp pairing
+// page (internal/whatsapp.RenderQRBlocks): each QR module is two cells wide and
+// one row tall, light modules render as filled blocks ("██") and dark modules
+// as spaces. On the tview default (dark) background this yields correct-polarity
+// output that scans; on a light-background terminal the polarity inverts and it
+// may not scan (a known limitation shared with the WhatsApp page). The quiet
+// zone (white border) is always included — omitting it is the most common reason
+// terminal QR codes fail to scan.
+func RenderQRCodeBlocks(content string) string {
+	var buf bytes.Buffer
+	qrterminal.GenerateWithConfig(content, qrterminal.Config{
+		Writer:    &buf,
+		Level:     qrterminal.L, // matches the proven WhatsApp-page rendering
+		BlackChar: "  ",         // QR dark module -> two spaces (terminal background)
+		WhiteChar: "██",         // QR light/quiet module -> filled blocks
+		QuietZone: 2,
+	})
+	return buf.String()
+}
+
+// RenderEnrollQRBlocks is a convenience wrapper that builds the enrollment
+// payload and renders it with the plain full-block renderer for tview.
+func RenderEnrollQRBlocks(verificationURI, userCode string) string {
+	return RenderQRCodeBlocks(BuildEnrollPayload(verificationURI, userCode))
+}

--- a/internal/ui/qrcode_test.go
+++ b/internal/ui/qrcode_test.go
@@ -79,3 +79,51 @@ func TestRenderEnrollQR(t *testing.T) {
 		t.Fatal("RenderEnrollQR produced empty output")
 	}
 }
+
+func TestRenderQRCodeBlocksScannable(t *testing.T) {
+	out := RenderQRCodeBlocks("https://aceteam.ai/device?code=ABCD-1234&v=1")
+	if strings.TrimSpace(out) == "" {
+		t.Fatal("RenderQRCodeBlocks produced empty output")
+	}
+	// Plain full-block renderer must NOT emit half-block runes or ANSI escapes
+	// (those corrupt inside a tview.TextView). It uses "██" for light modules
+	// and spaces for dark modules.
+	if strings.ContainsAny(out, "▀▄") {
+		t.Errorf("block renderer leaked half-block runes: %q", out)
+	}
+	if strings.Contains(out, "\x1b[") {
+		t.Errorf("block renderer leaked ANSI escape sequences: %q", out)
+	}
+	if !strings.Contains(out, "██") {
+		t.Errorf("output does not look like a full-block QR: %q", out)
+	}
+
+	// Quiet-zone check: the QR must be wrapped by an all-block border (QuietZone
+	// of 2 light modules). The first and last non-empty rows must be entirely
+	// blocks/spaces (no other glyphs), which is the required white border.
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) < 10 {
+		t.Fatalf("QR output suspiciously short: %d lines", len(lines))
+	}
+	for _, idx := range []int{0, len(lines) - 1} {
+		row := lines[idx]
+		if strings.TrimSpace(row) == "" {
+			continue // a blank spacer row is still a valid quiet-zone edge
+		}
+		if strings.Trim(row, "█ ") != "" {
+			t.Errorf("quiet-zone row %d contains non-block glyphs (border missing): %q", idx, row)
+		}
+	}
+}
+
+func TestRenderEnrollQRBlocks(t *testing.T) {
+	out := RenderEnrollQRBlocks("https://aceteam.ai/device", "ABCD-1234")
+	if strings.TrimSpace(out) == "" {
+		t.Fatal("RenderEnrollQRBlocks produced empty output")
+	}
+	// Must equal rendering the exact BuildEnrollPayload output.
+	want := RenderQRCodeBlocks(BuildEnrollPayload("https://aceteam.ai/device", "ABCD-1234"))
+	if out != want {
+		t.Error("RenderEnrollQRBlocks does not match RenderQRCodeBlocks(BuildEnrollPayload(...))")
+	}
+}


### PR DESCRIPTION
## Context
When Citadel prompts to log in, the user wants a QR to scan with their phone (AceTeam iOS app / camera) instead of typing the URL+code. The **CLI** login flow already renders this QR (since v2.47.0), but the **control center TUI** device-auth modal only printed the text link — even though the control center's own WhatsApp pairing page already shows a QR. Fixes #553.

## Changes
- `internal/ui/qrcode.go`: added `RenderQRCodeBlocks` / `RenderEnrollQRBlocks` (plain full-block, no ANSI). Additive — existing half-block renderers untouched.
- `internal/tui/controlcenter/actions.go`: device-auth modal renders the enrollment QR above the existing URL + manual-code fallback; extracted pure `buildDeviceAuthContent(...)` helper.
- Tests in `internal/ui/qrcode_test.go` + `internal/tui/controlcenter/controlcenter_test.go`.

## Why it scans in tview
The half-block ANSI `RenderQRCode` corrupts inside a tview `TextView`. Mirrored the control center's proven WhatsApp pattern (`internal/whatsapp.RenderQRBlocks`): plain full-block, no ANSI, Level L, `BlackChar:"  "`/`WhiteChar:"██"`, QuietZone 2, rendered with `SetDynamicColors(false)` + `SetWrap(false)`. Same `ui.BuildEnrollPayload` string as the CLI (`...?code=XXXX&v=1`) — no new payload, no protocol change, never encodes the device_code secret.

## Layout
Fullscreen FlexRow: the QR is the flexible top item, the URL+code+`B open browser  C copy link  Esc cancel` fallback is fixed-height and always visible. Tall terminal → full QR; short SSH (80x24) → QR clips (unscannable anyway) but the fallback + cancel stay on-screen.

## Testing
`go build ./...`, `go vet`, `go test ./internal/tui/controlcenter/ ./internal/ui/` pass. Tests assert the modal body contains the exact BuildEnrollPayload output (never the device_code), and the block QR has a quiet zone with no ANSI leakage.

## Human-verify caveat
Can't scan a phone in CI — **please scan the rendered QR (camera + AceTeam iOS app) to confirm it opens the approval page.** tview forces black bg / white text so polarity is theme-independent (same known caveat the WhatsApp page carries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)