### PR TITLE
feat(meeting): sovereign audio backup — node Opus transcode + upload + retention

### DIFF
--- a/internal/config/devicecreds.go
+++ b/internal/config/devicecreds.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// deviceCredsFile is the global device-auth config written by `citadel init` /
+// device authorization. It is the SAME file cmd.getDeviceConfigFromFile reads;
+// this loader deliberately decodes only the two fields a background handler
+// needs (the device API token + the API base URL) so a handler in internal/
+// can authenticate against the AceTeam backend without importing cmd.
+const deviceCredsFile = "config.yaml"
+
+// DeviceCreds carries the minimal device-auth material needed to call the
+// AceTeam backend as this node: the bearer token and the API base URL.
+type DeviceCreds struct {
+	// Token is the device_api_token minted at device authorization.
+	Token string `yaml:"device_api_token"`
+	// APIBaseURL is the AceTeam API base (e.g. "https://aceteam.ai"). May be
+	// empty in older configs; callers should fall back to their own default.
+	APIBaseURL string `yaml:"api_base_url"`
+}
+
+// LoadDeviceCreds reads the device bearer token + API base URL from
+// {configDir}/config.yaml. A missing or unparseable file yields zero-valued
+// creds (Token == ""), which callers treat as "not authenticated, skip".
+// Reading at use-time (rather than caching at startup) means a token rotated by
+// the worker's in-place reauth is picked up on the next call.
+func LoadDeviceCreds(configDir string) DeviceCreds {
+	data, err := os.ReadFile(filepath.Join(configDir, deviceCredsFile))
+	if err != nil {
+		return DeviceCreds{}
+	}
+	var c DeviceCreds
+	if err := yaml.Unmarshal(data, &c); err != nil {
+		return DeviceCreds{}
+	}
+	return c
+}

--- a/internal/config/devicecreds_test.go
+++ b/internal/config/devicecreds_test.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadDeviceCreds(t *testing.T) {
+	dir := t.TempDir()
+	yaml := "device_api_token: dat_abc123\napi_base_url: https://aceteam.ai\norg_id: 00000000-0000-0000-0000-000000000000\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(yaml), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	c := LoadDeviceCreds(dir)
+	if c.Token != "dat_abc123" {
+		t.Errorf("Token = %q, want dat_abc123", c.Token)
+	}
+	if c.APIBaseURL != "https://aceteam.ai" {
+		t.Errorf("APIBaseURL = %q, want https://aceteam.ai", c.APIBaseURL)
+	}
+}
+
+func TestLoadDeviceCreds_MissingFile(t *testing.T) {
+	c := LoadDeviceCreds(t.TempDir())
+	if c.Token != "" || c.APIBaseURL != "" {
+		t.Errorf("missing file should yield empty creds, got %+v", c)
+	}
+}
+
+func TestLoadDeviceCreds_PartialFile(t *testing.T) {
+	dir := t.TempDir()
+	// Token present, base URL absent (older config): caller falls back to its
+	// own default for the base URL.
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("device_api_token: dat_only\n"), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	c := LoadDeviceCreds(dir)
+	if c.Token != "dat_only" {
+		t.Errorf("Token = %q, want dat_only", c.Token)
+	}
+	if c.APIBaseURL != "" {
+		t.Errorf("APIBaseURL should be empty, got %q", c.APIBaseURL)
+	}
+}
+
+func TestLoadDeviceCreds_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("not: [valid: yaml: {{{"), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	c := LoadDeviceCreds(dir)
+	if c.Token != "" {
+		t.Errorf("invalid yaml should yield empty creds, got %+v", c)
+	}
+}

--- a/internal/config/meeting.go
+++ b/internal/config/meeting.go
@@ -49,6 +49,23 @@ type Meeting struct {
 	// back the churning tail to avoid emitting — and acting on — a partial or
 	// hallucinated segment that the next pass rewrites. Must be positive.
 	StreamingWindowSeconds int `yaml:"streaming_window_seconds" json:"streaming_window_seconds"`
+
+	// AudioBackupEnabled gates the sovereign audio-backup path (aceteam#5097):
+	// after a call is recorded, the lossless WAV is kept on the node AND an
+	// Opus-compressed copy is uploaded to the AceTeam backend as a default-on
+	// dual copy. Default-on (opt-out), same house convention as MeetingEnabled;
+	// the upload is best-effort so a failure never fails the meeting job (the
+	// transcript is already stored). When false, the node keeps the WAV locally
+	// and never transcodes or uploads — the transcript path is unaffected.
+	AudioBackupEnabled bool `yaml:"audio_backup_enabled" json:"audio_backup_enabled"`
+
+	// AudioRetentionDays is the disk-safety retention window for local meeting
+	// recordings. Meeting WAVs (and stray .opus artifacts) older than this are
+	// pruned at meeting-end, and everything prunable is swept under disk
+	// pressure regardless of age. The lossless WAV is otherwise kept. Must be
+	// positive; the accessor clamps a non-positive persisted value to the
+	// default.
+	AudioRetentionDays int `yaml:"audio_retention_days" json:"audio_retention_days"`
 }
 
 // StreamingInterval returns the rolling-transcription cadence as a Duration,
@@ -71,6 +88,18 @@ func (m *Meeting) StreamingWindow() time.Duration {
 	return time.Duration(m.StreamingWindowSeconds) * time.Second
 }
 
+// RetentionAge returns the local-recording retention window as a Duration,
+// clamping a non-positive persisted value (hand-edited or truncated
+// meeting.yaml) to the default so the prune sweep can never use a zero/negative
+// age that would delete freshly recorded WAVs.
+func (m *Meeting) RetentionAge() time.Duration {
+	days := m.AudioRetentionDays
+	if days <= 0 {
+		days = defaultAudioRetentionDays
+	}
+	return time.Duration(days) * 24 * time.Hour
+}
+
 const meetingFile = "meeting.yaml"
 
 // Streaming defaults. Interval trades command latency against whisper load;
@@ -82,6 +111,11 @@ const (
 	defaultStreamingWindowSeconds   = 10
 )
 
+// defaultAudioRetentionDays is how long local meeting recordings are kept before
+// the disk-safety sweep prunes them. 30 days comfortably outlasts any realistic
+// best-effort upload retry window while bounding disk growth on a busy node.
+const defaultAudioRetentionDays = 30
+
 // DefaultMeeting returns a Meeting struct with the capability enabled.
 // Default-on is intentional: it matches the house convention that capabilities
 // are opt-out, so a dep-capable node joins meetings without extra setup.
@@ -91,6 +125,8 @@ func DefaultMeeting() *Meeting {
 		StreamingEnabled:         true,
 		StreamingIntervalSeconds: defaultStreamingIntervalSeconds,
 		StreamingWindowSeconds:   defaultStreamingWindowSeconds,
+		AudioBackupEnabled:       true,
+		AudioRetentionDays:       defaultAudioRetentionDays,
 	}
 }
 

--- a/internal/config/meeting_test.go
+++ b/internal/config/meeting_test.go
@@ -108,6 +108,86 @@ func TestLoadMeeting_InvalidYAML(t *testing.T) {
 	}
 }
 
+func TestDefaultMeeting_AudioBackup(t *testing.T) {
+	m := DefaultMeeting()
+	if !m.AudioBackupEnabled {
+		t.Errorf("DefaultMeeting should have audio backup enabled (opt-out), got %+v", m)
+	}
+	if m.AudioRetentionDays != defaultAudioRetentionDays {
+		t.Errorf("AudioRetentionDays = %d, want %d", m.AudioRetentionDays, defaultAudioRetentionDays)
+	}
+	if m.RetentionAge() != defaultAudioRetentionDays*24*time.Hour {
+		t.Errorf("RetentionAge = %v, want %v", m.RetentionAge(), defaultAudioRetentionDays*24*time.Hour)
+	}
+}
+
+func TestRetentionAgeFallback(t *testing.T) {
+	// Non-positive persisted values clamp to the default (never a zero window
+	// that would delete a freshly recorded WAV).
+	for _, days := range []int{0, -1, -30} {
+		m := &Meeting{AudioRetentionDays: days}
+		if m.RetentionAge() != defaultAudioRetentionDays*24*time.Hour {
+			t.Errorf("RetentionAge(%d) = %v, want default", days, m.RetentionAge())
+		}
+	}
+	// Explicit positive values are honored.
+	m := &Meeting{AudioRetentionDays: 7}
+	if m.RetentionAge() != 7*24*time.Hour {
+		t.Errorf("RetentionAge(7) = %v, want 168h", m.RetentionAge())
+	}
+}
+
+func TestLoadMeeting_AudioBackupDefaultsPreservedOnPartialFile(t *testing.T) {
+	// A file that only sets meeting_enabled must keep the audio-backup defaults.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "meeting.yaml"), []byte("meeting_enabled: false\n"), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	m := LoadMeeting(dir)
+	if !m.AudioBackupEnabled {
+		t.Errorf("partial file should preserve AudioBackupEnabled default (true), got %+v", m)
+	}
+	if m.AudioRetentionDays != defaultAudioRetentionDays {
+		t.Errorf("partial file should preserve retention default, got %d", m.AudioRetentionDays)
+	}
+}
+
+// TestMeetingLoadModifySavePreservesFields is the regression guard for the
+// clobber bug: the SaveMeeting callers (APPLY_DEVICE_CONFIG + Control Center
+// toggle) must load-modify-save, not construct a fresh partial struct. Flipping
+// one field through a load-modify-save round trip must leave every other field
+// intact.
+func TestMeetingLoadModifySavePreservesFields(t *testing.T) {
+	dir := t.TempDir()
+	if err := SaveMeeting(dir, DefaultMeeting()); err != nil {
+		t.Fatalf("seed SaveMeeting: %v", err)
+	}
+
+	// Load-modify-save: flip only MeetingEnabled.
+	m := LoadMeeting(dir)
+	m.MeetingEnabled = false
+	if err := SaveMeeting(dir, m); err != nil {
+		t.Fatalf("SaveMeeting: %v", err)
+	}
+
+	got := LoadMeeting(dir)
+	if got.MeetingEnabled {
+		t.Errorf("MeetingEnabled should be false after modify, got true")
+	}
+	if !got.StreamingEnabled {
+		t.Errorf("StreamingEnabled must survive a MeetingEnabled flip, got %+v", got)
+	}
+	if !got.AudioBackupEnabled {
+		t.Errorf("AudioBackupEnabled must survive a MeetingEnabled flip, got %+v", got)
+	}
+	if got.AudioRetentionDays != defaultAudioRetentionDays {
+		t.Errorf("AudioRetentionDays must survive, got %d", got.AudioRetentionDays)
+	}
+	if got.StreamingIntervalSeconds != defaultStreamingIntervalSeconds {
+		t.Errorf("StreamingIntervalSeconds must survive, got %d", got.StreamingIntervalSeconds)
+	}
+}
+
 func TestSaveMeeting_CreatesDir(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "nested", "dir")
 	if err := SaveMeeting(dir, DefaultMeeting()); err != nil {

--- a/internal/jobs/config_handler.go
+++ b/internal/jobs/config_handler.go
@@ -50,6 +50,14 @@ type DeviceConfig struct {
 	// opt every node out the moment any device config is applied. A non-nil value
 	// writes the same meeting.yaml the Control Center toggle and detector use.
 	MeetingEnabled *bool `json:"meetingEnabled,omitempty"`
+	// AudioBackupEnabled is the programmatic path for the sovereign audio-backup
+	// opt-out (aceteam#5097). Pointer for the same reason as MeetingEnabled: nil
+	// leaves the persisted value untouched.
+	AudioBackupEnabled *bool `json:"audioBackupEnabled,omitempty"`
+	// MeetingRetentionDays sets the local-recording retention window
+	// (aceteam#5097). Pointer so nil leaves the persisted value untouched; a
+	// non-positive value is clamped to the default by the config accessor.
+	MeetingRetentionDays *int `json:"meetingRetentionDays,omitempty"`
 }
 
 // ConfigHandler handles APPLY_DEVICE_CONFIG jobs.
@@ -104,11 +112,33 @@ func (h *ConfigHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) 
 	// the local toggle converge on one effective value (default-on when neither
 	// wrote it). Written to platform.ConfigDir() — the per-concern config location,
 	// which the detector reads — not h.ConfigDir (the manifest dir).
-	if config.MeetingEnabled != nil {
-		if err := citadelconfig.SaveMeeting(platform.ConfigDir(), &citadelconfig.Meeting{MeetingEnabled: *config.MeetingEnabled}); err != nil {
-			result += fmt.Sprintf("\nWarning: failed to persist meeting toggle: %v", err)
+	if config.MeetingEnabled != nil || config.AudioBackupEnabled != nil || config.MeetingRetentionDays != nil {
+		// Load-modify-save: read the current persisted meeting config and set only
+		// the fields the platform pushed. A fresh &Meeting{...} would zero every
+		// unset field on marshal (no omitempty) — silently disabling streaming and
+		// audio backup the moment any device config touched the meeting toggle.
+		meeting := citadelconfig.LoadMeeting(platform.ConfigDir())
+		if config.MeetingEnabled != nil {
+			meeting.MeetingEnabled = *config.MeetingEnabled
+		}
+		if config.AudioBackupEnabled != nil {
+			meeting.AudioBackupEnabled = *config.AudioBackupEnabled
+		}
+		if config.MeetingRetentionDays != nil {
+			meeting.AudioRetentionDays = *config.MeetingRetentionDays
+		}
+		if err := citadelconfig.SaveMeeting(platform.ConfigDir(), meeting); err != nil {
+			result += fmt.Sprintf("\nWarning: failed to persist meeting config: %v", err)
 		} else {
-			result += fmt.Sprintf("\nMeeting capability %s", enabledLabel(*config.MeetingEnabled))
+			if config.MeetingEnabled != nil {
+				result += fmt.Sprintf("\nMeeting capability %s", enabledLabel(*config.MeetingEnabled))
+			}
+			if config.AudioBackupEnabled != nil {
+				result += fmt.Sprintf("\nMeeting audio backup %s", enabledLabel(*config.AudioBackupEnabled))
+			}
+			if config.MeetingRetentionDays != nil {
+				result += fmt.Sprintf("\nMeeting recording retention set to %d days", *config.MeetingRetentionDays)
+			}
 		}
 	}
 

--- a/internal/jobs/config_handler_test.go
+++ b/internal/jobs/config_handler_test.go
@@ -43,3 +43,34 @@ func TestDeviceConfig_MeetingEnabledUnmarshal(t *testing.T) {
 		}
 	})
 }
+
+// TestDeviceConfig_AudioBackupUnmarshal verifies the audio-backup + retention
+// fields carry the same absent(nil)-vs-explicit pointer semantics, so applying
+// a device config that omits them leaves the persisted values untouched.
+func TestDeviceConfig_AudioBackupUnmarshal(t *testing.T) {
+	t.Run("absent -> nil", func(t *testing.T) {
+		var c DeviceConfig
+		if err := json.Unmarshal([]byte(`{"deviceName":"n"}`), &c); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if c.AudioBackupEnabled != nil {
+			t.Errorf("absent audioBackupEnabled should be nil, got %v", *c.AudioBackupEnabled)
+		}
+		if c.MeetingRetentionDays != nil {
+			t.Errorf("absent meetingRetentionDays should be nil, got %v", *c.MeetingRetentionDays)
+		}
+	})
+
+	t.Run("explicit values", func(t *testing.T) {
+		var c DeviceConfig
+		if err := json.Unmarshal([]byte(`{"audioBackupEnabled":false,"meetingRetentionDays":7}`), &c); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if c.AudioBackupEnabled == nil || *c.AudioBackupEnabled {
+			t.Errorf("audioBackupEnabled:false should be non-nil false, got %v", c.AudioBackupEnabled)
+		}
+		if c.MeetingRetentionDays == nil || *c.MeetingRetentionDays != 7 {
+			t.Errorf("meetingRetentionDays:7 should be non-nil 7, got %v", c.MeetingRetentionDays)
+		}
+	})
+}

--- a/internal/jobs/meeting_audio_backup.go
+++ b/internal/jobs/meeting_audio_backup.go
@@ -1,0 +1,294 @@
+// internal/jobs/meeting_audio_backup.go
+//
+// Sovereign meeting-audio backup — the NODE side (aceteam#5097, epic #5097).
+//
+// Product decision (Jason): after a call is recorded, the lossless WAV stays on
+// the user's own Citadel node AND a default-on, Opus-compressed backup is
+// uploaded to the AceTeam backend — a dual copy. This file implements that
+// backup:
+//
+//  1. Transcode the WAV to Opus-in-Ogg by running ffmpeg INSIDE the already
+//     running meeting container (`docker exec citadel-meeting ffmpeg …`). The
+//     meeting module ships ffmpeg+libopus, so this needs no host ffmpeg (not
+//     guaranteed on arbitrary nodes) and no meeting-service image change — the
+//     same pattern as ollama_pull.go's `docker exec citadel-ollama`.
+//  2. Upload the Opus bytes to the backend contract from aceteam #6088:
+//     POST {base}/api/meetings/{meeting_id}/audio with a Bearer device key and
+//     Content-Type audio/ogg;codecs=opus. The job's meeting_id IS the
+//     meeting_sessions UUID the route keys on (backend sets
+//     payload["meeting_id"] = session_id).
+//
+// The whole path is BEST-EFFORT: any failure logs and returns nil so the
+// meeting job still succeeds — the transcript is already stored, the backup is
+// a bonus.
+package jobs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+const (
+	// meetingContainerName is the fixed container_name from the meeting module's
+	// compose (services/meeting-service/compose.yml). We `docker exec` ffmpeg
+	// into it to transcode without a host ffmpeg dependency.
+	meetingContainerName = "citadel-meeting"
+	// meetingContainerWorkspaceMount is where the node workspace is bind-mounted
+	// inside the meeting container (compose: ${CITADEL_WORKSPACE}:/workspace).
+	// The WAV the recorder wrote and the Opus we transcode both live under it,
+	// so ffmpeg's in/out paths are this + the workspace-relative path.
+	meetingContainerWorkspaceMount = "/workspace"
+	// meetingAudioBitrateKbps is the Opus target bitrate. 24 kbps VoIP-mode Opus
+	// is transparent for speech; a 4h meeting lands ~43 MB, well under the cap.
+	meetingAudioBitrateKbps = 24
+	// meetingAudioMaxUploadBytes mirrors the backend's 150 MB cap
+	// (MAX_MEETING_AUDIO_BYTES in the Next.js route + python storage). Enforced
+	// node-side so an oversize file is skipped before we open the connection.
+	meetingAudioMaxUploadBytes = 150 * 1024 * 1024
+	// meetingAudioContentType is the exact upload media type the backend accepts
+	// (it matches on the base type `audio/ogg`, ignoring the codecs parameter).
+	meetingAudioContentType = "audio/ogg;codecs=opus"
+	// meetingTranscodeTimeout bounds the in-container ffmpeg transcode. A whole
+	// meeting re-encodes faster than real time, but a long call plus a busy node
+	// warrants headroom.
+	meetingTranscodeTimeout = 10 * time.Minute
+	// meetingUploadTimeout bounds a single upload POST.
+	meetingUploadTimeout = 5 * time.Minute
+	// defaultBackupRetentionAge is the handler-level fallback used when the
+	// AudioRetentionAge field is unset (zero). Mirrors the config default so a
+	// handler constructed without wiring still prunes sanely.
+	defaultBackupRetentionAge = 30 * 24 * time.Hour
+)
+
+// meetingOpusRelPath is the workspace-RELATIVE Opus path, the sibling of
+// meetingWavRelPath. Kept adjacent so the two can never drift.
+func meetingOpusRelPath(meetingID string) string {
+	return "meetings/" + sanitizeMeetingFilename(meetingID) + ".opus"
+}
+
+// meetingOpusPath is the host-absolute Opus path, the sibling of meetingWavPath.
+func meetingOpusPath(workspaceDir, meetingID string) string {
+	return path.Join(workspaceDir, "meetings", sanitizeMeetingFilename(meetingID)+".opus")
+}
+
+// transcodeDockerArgs builds the full `docker` argv (sans the leading "docker")
+// that execs ffmpeg inside the meeting container to transcode the recorded WAV
+// to Opus-in-Ogg. Both paths are CONTAINER paths under the /workspace mount.
+//
+// When uid >= 0 (Linux) we pass `-u uid:gid` so the file ffmpeg writes is owned
+// by the NODE owner — the same PUID/PGID guarantee the compose entrypoint gives
+// the WAV. `docker exec` bypasses the entrypoint's privilege drop and would
+// otherwise write a root-owned Opus the node process may not be able to read
+// back for upload. On platforms where os.Getuid() returns -1 (Windows) we omit
+// -u and rely on the container's own user.
+//
+// Pure (no I/O) so the arg construction — the load-bearing bitrate/paths/flags —
+// is unit-tested directly.
+func transcodeDockerArgs(container, wavContainerPath, opusContainerPath string, bitrateKbps, uid, gid int) []string {
+	args := []string{"exec"}
+	if uid >= 0 && gid >= 0 {
+		args = append(args, "-u", strconv.Itoa(uid)+":"+strconv.Itoa(gid))
+	}
+	args = append(args,
+		container,
+		"ffmpeg",
+		"-nostdin",
+		"-y",
+		"-i", wavContainerPath,
+		"-c:a", "libopus",
+		"-b:a", strconv.Itoa(bitrateKbps)+"k",
+		"-application", "voip",
+		opusContainerPath,
+	)
+	return args
+}
+
+// runDockerExecReal is the production docker runner used when a handler does not
+// inject a fake. args is the full docker argv (args[0] == "exec"). It honors the
+// context so a per-job deadline or cancellation actually terminates ffmpeg.
+func runDockerExecReal(ctx context.Context, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, "docker", args...).CombinedOutput()
+}
+
+// SetAudioBackup configures the sovereign audio-backup path: the default-on
+// toggle, the local-recording retention window, and a creds provider that
+// returns the backend base URL + device bearer token at call time (read fresh
+// so a rotated token is honored). The worker wires this from the persisted
+// meeting config + the device-auth config; a creds provider that returns an
+// empty token disables only the upload leg (retention still runs).
+func (h *MeetingJoinHandler) SetAudioBackup(enabled bool, retentionAge time.Duration, creds func() (baseURL, token string)) {
+	h.AudioBackupEnabled = enabled
+	h.AudioRetentionAge = retentionAge
+	h.backupCreds = creds
+}
+
+// backupExecUIDGID returns the node process's UID/GID so the in-container ffmpeg
+// (`docker exec -u`) writes a node-owned Opus. On platforms where os.Getuid()
+// returns -1 (Windows), transcodeDockerArgs omits -u.
+func backupExecUIDGID() (int, int) {
+	return os.Getuid(), os.Getgid()
+}
+
+// backupAndPrune is the best-effort post-recording step: upload an Opus backup
+// (when enabled) and then run the retention sweep. It NEVER returns an error and
+// never touches the meeting result — the transcript is the source of truth; the
+// backup and prune are bonuses that must not regress the meeting job.
+func (h *MeetingJoinHandler) backupAndPrune(ctx JobContext, job *nexus.Job, p meetingJoinParams, recordedWavPath string) {
+	maxAge := h.AudioRetentionAge
+	if maxAge <= 0 {
+		maxAge = defaultBackupRetentionAge
+	}
+
+	uploadConfirmed := false
+	if h.AudioBackupEnabled {
+		uploadConfirmed = h.uploadAudioBackup(ctx, job, p)
+	}
+
+	// Protect the just-recorded WAV from the disk-pressure branch. Its age is ~0
+	// so the age branch won't touch it, but under disk pressure an unprotected
+	// sweep could — and if its backup did not confirm, losing it is data loss.
+	protect := []string{}
+	if !uploadConfirmed {
+		protect = append(protect, recordedWavPath)
+	}
+	h.pruneMeetingRecordings(ctx, maxAge, protect...)
+}
+
+// uploadAudioBackup transcodes the recorded WAV to Opus inside the meeting
+// container and uploads it to the backend. Returns true only when the backend
+// confirmed the upload (HTTP 201). Every failure logs and returns false — the
+// caller keeps the local WAV (and the retention sweep later prunes any stray
+// .opus from a failed upload).
+func (h *MeetingJoinHandler) uploadAudioBackup(ctx JobContext, job *nexus.Job, p meetingJoinParams) bool {
+	wavContainer := path.Join(meetingContainerWorkspaceMount, meetingWavRelPath(p.MeetingID))
+	opusContainer := path.Join(meetingContainerWorkspaceMount, meetingOpusRelPath(p.MeetingID))
+	opusHost := meetingOpusPath(h.WorkspaceDir, p.MeetingID)
+
+	// 1) Transcode WAV -> Opus in the meeting container (no host ffmpeg needed).
+	uid, gid := backupExecUIDGID()
+	args := transcodeDockerArgs(meetingContainerName, wavContainer, opusContainer, meetingAudioBitrateKbps, uid, gid)
+	run := h.runDockerExec
+	if run == nil {
+		run = runDockerExecReal
+	}
+	tctx, cancel := context.WithTimeout(ctx.Context(), meetingTranscodeTimeout)
+	defer cancel()
+	if out, err := run(tctx, args...); err != nil {
+		ctx.Log("warn", "     - [Job %s] audio backup transcode failed (non-fatal): %v: %s", job.ID, err, strings.TrimSpace(string(out)))
+		return false
+	}
+
+	// 2) Upload the Opus to the backend contract (aceteam #6088). Creds are read
+	// fresh so a rotated device token is honored.
+	baseURL, token := "", ""
+	if h.backupCreds != nil {
+		baseURL, token = h.backupCreds()
+	}
+	client := h.backupHTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: meetingUploadTimeout}
+	}
+	uctx, ucancel := context.WithTimeout(ctx.Context(), meetingUploadTimeout)
+	defer ucancel()
+	docID, err := uploadMeetingAudio(uctx, client, baseURL, token, p.MeetingID, opusHost, meetingAudioMaxUploadBytes)
+	if err != nil {
+		ctx.Log("warn", "     - [Job %s] audio backup upload failed (non-fatal): %v", job.ID, err)
+		return false
+	}
+	ctx.Log("info", "     - [Job %s] audio backup uploaded (audio_document_id=%s)", job.ID, docID)
+
+	// Upload confirmed: the backend holds the compressed copy, so remove the
+	// local transient .opus (the lossless WAV remains the node's kept copy).
+	if rmErr := os.Remove(opusHost); rmErr != nil {
+		ctx.Log("warn", "     - [Job %s] could not remove local opus after upload (non-fatal): %v", job.ID, rmErr)
+	}
+	return true
+}
+
+// uploadMeetingAudio POSTs the Opus file to the backend audio-backup contract
+// (aceteam #6088). Returns the backend's audio_document_id on 201. Every error
+// path is the CALLER's to log-and-ignore (best-effort); this function only
+// reports what happened.
+//
+// The size guard runs before the connection is opened. Content-Length is set
+// explicitly (an *os.File body does not auto-populate it) so a strict receiver
+// gets a declared length instead of a chunked stream.
+func uploadMeetingAudio(ctx context.Context, client *http.Client, baseURL, token, meetingID, opusPath string, maxBytes int64) (string, error) {
+	if token == "" {
+		return "", fmt.Errorf("no device API token; skipping audio upload")
+	}
+	if baseURL == "" {
+		return "", fmt.Errorf("no API base URL; skipping audio upload")
+	}
+
+	info, err := os.Stat(opusPath)
+	if err != nil {
+		return "", fmt.Errorf("stat opus for upload: %w", err)
+	}
+	if info.Size() == 0 {
+		return "", fmt.Errorf("opus file is empty; skipping upload")
+	}
+	if info.Size() > maxBytes {
+		return "", fmt.Errorf("opus is %d bytes, over the %d-byte cap; skipping upload", info.Size(), maxBytes)
+	}
+
+	f, err := os.Open(opusPath)
+	if err != nil {
+		return "", fmt.Errorf("open opus for upload: %w", err)
+	}
+	defer f.Close()
+
+	url := meetingAudioUploadURL(baseURL, meetingID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, f)
+	if err != nil {
+		return "", fmt.Errorf("build upload request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", meetingAudioContentType)
+	req.ContentLength = info.Size()
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("upload audio: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+
+	if resp.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("upload returned HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	var parsed struct {
+		AudioDocumentID string `json:"audio_document_id"`
+		BytesStored     int64  `json:"bytes_stored"`
+	}
+	// A 201 with an unparseable body is still a success for our purposes; only
+	// the log line loses the document id.
+	_ = json.Unmarshal(body, &parsed)
+	return parsed.AudioDocumentID, nil
+}
+
+// meetingAudioUploadURL builds the backend audio-backup endpoint. meetingID is
+// the meeting_sessions UUID (the route validates it as a UUID); it is safe as a
+// path segment but we still avoid trailing/leading slash surprises.
+func meetingAudioUploadURL(baseURL, meetingID string) string {
+	return trimTrailingSlash(baseURL) + "/api/meetings/" + meetingID + "/audio"
+}
+
+func trimTrailingSlash(s string) string {
+	for len(s) > 0 && s[len(s)-1] == '/' {
+		s = s[:len(s)-1]
+	}
+	return s
+}

--- a/internal/jobs/meeting_audio_backup_test.go
+++ b/internal/jobs/meeting_audio_backup_test.go
@@ -1,0 +1,277 @@
+package jobs
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+func TestTranscodeDockerArgs(t *testing.T) {
+	t.Run("with uid/gid maps ownership", func(t *testing.T) {
+		args := transcodeDockerArgs("citadel-meeting", "/workspace/meetings/m.wav", "/workspace/meetings/m.opus", 24, 1000, 1000)
+		got := strings.Join(args, " ")
+		want := "exec -u 1000:1000 citadel-meeting ffmpeg -nostdin -y -i /workspace/meetings/m.wav -c:a libopus -b:a 24k -application voip /workspace/meetings/m.opus"
+		if got != want {
+			t.Errorf("args =\n  %q\nwant\n  %q", got, want)
+		}
+	})
+
+	t.Run("negative uid omits -u", func(t *testing.T) {
+		args := transcodeDockerArgs("citadel-meeting", "/workspace/a.wav", "/workspace/a.opus", 32, -1, -1)
+		for i, a := range args {
+			if a == "-u" {
+				t.Fatalf("expected no -u flag when uid<0, got at %d: %v", i, args)
+			}
+		}
+		if args[0] != "exec" || args[1] != "citadel-meeting" {
+			t.Errorf("expected 'exec citadel-meeting ...', got %v", args[:2])
+		}
+		if !containsSeq(args, []string{"-b:a", "32k"}) {
+			t.Errorf("expected bitrate 32k, got %v", args)
+		}
+	})
+}
+
+func TestMeetingOpusPaths(t *testing.T) {
+	// The opus paths are siblings of the wav paths (same dir + sanitized name).
+	if got, want := meetingOpusRelPath("abc/../x"), "meetings/abc____x.opus"; got != want {
+		t.Errorf("meetingOpusRelPath = %q, want %q", got, want)
+	}
+	if got, want := meetingOpusPath("/ws", "m1"), filepath.Join("/ws", "meetings", "m1.opus"); got != want {
+		t.Errorf("meetingOpusPath = %q, want %q", got, want)
+	}
+	// wav and opus differ only in extension for the same id.
+	wav := meetingWavRelPath("m1")
+	opus := meetingOpusRelPath("m1")
+	if strings.TrimSuffix(wav, ".wav") != strings.TrimSuffix(opus, ".opus") {
+		t.Errorf("wav/opus base drifted: %q vs %q", wav, opus)
+	}
+}
+
+func TestMeetingAudioUploadURL(t *testing.T) {
+	got := meetingAudioUploadURL("https://aceteam.ai/", "11111111-2222-3333-4444-555555555555")
+	want := "https://aceteam.ai/api/meetings/11111111-2222-3333-4444-555555555555/audio"
+	if got != want {
+		t.Errorf("uploadURL = %q, want %q", got, want)
+	}
+}
+
+func TestUploadMeetingAudio_Success(t *testing.T) {
+	dir := t.TempDir()
+	opus := filepath.Join(dir, "m.opus")
+	payload := []byte("OggS-fake-opus-bytes")
+	if err := os.WriteFile(opus, payload, 0o600); err != nil {
+		t.Fatalf("write opus: %v", err)
+	}
+
+	var gotMethod, gotPath, gotAuth, gotCT string
+	var gotLen int64
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotCT = r.Header.Get("Content-Type")
+		gotLen = r.ContentLength
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"session_id":"sid","audio_document_id":"doc_9","bytes_stored":20}`))
+	}))
+	defer srv.Close()
+
+	docID, err := uploadMeetingAudio(context.Background(), srv.Client(), srv.URL, "tok_1", "sid-uuid", opus, meetingAudioMaxUploadBytes)
+	if err != nil {
+		t.Fatalf("uploadMeetingAudio: %v", err)
+	}
+	if docID != "doc_9" {
+		t.Errorf("docID = %q, want doc_9", docID)
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/api/meetings/sid-uuid/audio" {
+		t.Errorf("path = %q, want /api/meetings/sid-uuid/audio", gotPath)
+	}
+	if gotAuth != "Bearer tok_1" {
+		t.Errorf("auth = %q, want 'Bearer tok_1'", gotAuth)
+	}
+	if gotCT != meetingAudioContentType {
+		t.Errorf("content-type = %q, want %q", gotCT, meetingAudioContentType)
+	}
+	if gotLen != int64(len(payload)) {
+		t.Errorf("content-length = %d, want %d (must be declared, not chunked)", gotLen, len(payload))
+	}
+	if string(gotBody) != string(payload) {
+		t.Errorf("body = %q, want %q", gotBody, payload)
+	}
+}
+
+func TestUploadMeetingAudio_BestEffortErrors(t *testing.T) {
+	dir := t.TempDir()
+	opus := filepath.Join(dir, "m.opus")
+	if err := os.WriteFile(opus, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write opus: %v", err)
+	}
+
+	t.Run("no token", func(t *testing.T) {
+		if _, err := uploadMeetingAudio(context.Background(), http.DefaultClient, "https://x", "", "sid", opus, meetingAudioMaxUploadBytes); err == nil {
+			t.Error("expected error with empty token")
+		}
+	})
+	t.Run("no base url", func(t *testing.T) {
+		if _, err := uploadMeetingAudio(context.Background(), http.DefaultClient, "", "tok", "sid", opus, meetingAudioMaxUploadBytes); err == nil {
+			t.Error("expected error with empty base url")
+		}
+	})
+	t.Run("size guard rejects oversize before request", func(t *testing.T) {
+		called := false
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true }))
+		defer srv.Close()
+		if _, err := uploadMeetingAudio(context.Background(), srv.Client(), srv.URL, "tok", "sid", opus, 1 /*maxBytes*/); err == nil {
+			t.Error("expected size-guard error")
+		}
+		if called {
+			t.Error("server must not be hit when the size guard trips")
+		}
+	})
+	t.Run("empty file", func(t *testing.T) {
+		empty := filepath.Join(dir, "empty.opus")
+		if err := os.WriteFile(empty, nil, 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if _, err := uploadMeetingAudio(context.Background(), http.DefaultClient, "https://x", "tok", "sid", empty, meetingAudioMaxUploadBytes); err == nil {
+			t.Error("expected error for empty file")
+		}
+	})
+	t.Run("missing file", func(t *testing.T) {
+		if _, err := uploadMeetingAudio(context.Background(), http.DefaultClient, "https://x", "tok", "sid", filepath.Join(dir, "nope.opus"), meetingAudioMaxUploadBytes); err == nil {
+			t.Error("expected error for missing file")
+		}
+	})
+	t.Run("non-201 is an error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error":"nope"}`))
+		}))
+		defer srv.Close()
+		if _, err := uploadMeetingAudio(context.Background(), srv.Client(), srv.URL, "tok", "sid", opus, meetingAudioMaxUploadBytes); err == nil {
+			t.Error("expected error on 403")
+		}
+	})
+}
+
+// TestUploadAudioBackup_Success drives the orchestrator with injected seams: a
+// fake docker-exec that writes the opus, and an httptest backend. On 201 it
+// returns true and removes the local opus.
+func TestUploadAudioBackup_Success(t *testing.T) {
+	ws := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(ws, "meetings"), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	meetingID := "sid-uuid"
+	opusHost := meetingOpusPath(ws, meetingID)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"audio_document_id":"doc_x"}`))
+	}))
+	defer srv.Close()
+
+	transcodeCalled := false
+	h := &MeetingJoinHandler{
+		WorkspaceDir:       ws,
+		AudioBackupEnabled: true,
+		backupHTTPClient:   srv.Client(),
+		backupCreds:        func() (string, string) { return srv.URL, "tok" },
+		runDockerExec: func(ctx context.Context, args ...string) ([]byte, error) {
+			transcodeCalled = true
+			// Simulate the in-container ffmpeg writing the opus to the shared mount.
+			if err := os.WriteFile(opusHost, []byte("opus"), 0o600); err != nil {
+				return nil, err
+			}
+			return nil, nil
+		},
+	}
+
+	ok := h.uploadAudioBackup(JobContext{}, &nexus.Job{ID: "j1"}, meetingJoinParams{MeetingID: meetingID})
+	if !ok {
+		t.Fatal("uploadAudioBackup should report success")
+	}
+	if !transcodeCalled {
+		t.Error("transcode should have been invoked")
+	}
+	if _, err := os.Stat(opusHost); !os.IsNotExist(err) {
+		t.Errorf("local opus should be removed after a confirmed upload, stat err = %v", err)
+	}
+}
+
+func TestUploadAudioBackup_TranscodeFailureIsNonFatal(t *testing.T) {
+	ws := t.TempDir()
+	h := &MeetingJoinHandler{
+		WorkspaceDir:       ws,
+		AudioBackupEnabled: true,
+		backupCreds:        func() (string, string) { return "https://x", "tok" },
+		runDockerExec: func(ctx context.Context, args ...string) ([]byte, error) {
+			return []byte("ffmpeg: no such container"), context.DeadlineExceeded
+		},
+	}
+	if h.uploadAudioBackup(JobContext{}, &nexus.Job{ID: "j"}, meetingJoinParams{MeetingID: "m"}) {
+		t.Error("transcode failure must yield false (no upload)")
+	}
+}
+
+// TestBackupAndPrune_DisabledSkipsUploadButPrunes verifies the toggle: when
+// disabled, no transcode/upload happens, but retention still runs.
+func TestBackupAndPrune_DisabledSkipsUploadButPrunes(t *testing.T) {
+	ws := t.TempDir()
+	meetings := filepath.Join(ws, "meetings")
+	if err := os.MkdirAll(meetings, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	oldWav := writeAged(t, meetings, "old.wav", 40*24*time.Hour)
+	current := writeAged(t, meetings, "current.wav", 0)
+
+	transcodeCalled := false
+	h := &MeetingJoinHandler{
+		WorkspaceDir:       ws,
+		AudioBackupEnabled: false,
+		AudioRetentionAge:  30 * 24 * time.Hour,
+		diskPressureFn:     func(string) bool { return false },
+		runDockerExec: func(context.Context, ...string) ([]byte, error) {
+			transcodeCalled = true
+			return nil, nil
+		},
+	}
+
+	h.backupAndPrune(JobContext{}, &nexus.Job{ID: "j"}, meetingJoinParams{MeetingID: "current"}, current)
+
+	if transcodeCalled {
+		t.Error("disabled backup must not transcode")
+	}
+	assertGone(t, oldWav)    // retention still ran
+	assertExists(t, current) // fresh WAV survives age branch
+}
+
+func containsSeq(hay, needle []string) bool {
+	for i := 0; i+len(needle) <= len(hay); i++ {
+		match := true
+		for j := range needle {
+			if hay[i+j] != needle[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/jobs/meeting_join.go
+++ b/internal/jobs/meeting_join.go
@@ -18,6 +18,7 @@
 package jobs
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -364,6 +365,28 @@ type MeetingJoinHandler struct {
 	// module is healthy (#514). Non-nil is used by tests to force a backend
 	// without a live meetingd; nil probes meetingd's /health on the loopback.
 	containerHealthProbe func() bool
+
+	// AudioBackupEnabled gates the sovereign audio-backup path (aceteam#5097):
+	// after the recording is finalized, transcode the WAV to Opus in the meeting
+	// container and upload a default-on compressed copy to the AceTeam backend
+	// (the lossless WAV stays node-local). Default-on, opt-out — the worker sets
+	// it from config.Meeting.AudioBackupEnabled. The whole path is best-effort so
+	// a failure never fails the meeting job (the transcript is already stored).
+	AudioBackupEnabled bool
+	// AudioRetentionAge is the local-recording prune window; the worker sets it
+	// from config.Meeting.RetentionAge(). Zero falls back to a safe default at
+	// use (see backupAndPrune).
+	AudioRetentionAge time.Duration
+	// backupCreds returns the backend base URL + device bearer token, read FRESH
+	// at upload time so a token rotated by the worker's in-place reauth is
+	// honored. nil (or an empty token) disables the upload leg.
+	backupCreds func() (baseURL, token string)
+	// runDockerExec / backupHTTPClient / diskPressureFn are test seams; nil uses
+	// the real docker-exec, HTTP, and gopsutil implementations respectively.
+	// runDockerExec receives the full `docker` argv (i.e. args[0] == "exec").
+	runDockerExec    func(ctx context.Context, args ...string) ([]byte, error)
+	backupHTTPClient *http.Client
+	diskPressureFn   func(dir string) bool
 }
 
 // NewMeetingJoinHandler constructs a handler rooted at the node workspace.
@@ -440,6 +463,13 @@ func (h *MeetingJoinHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, er
 	if recordedPath == "" {
 		recordedPath = wavPath
 	}
+
+	// Sovereign audio backup + retention (aceteam#5097). Runs HERE — after the
+	// WAV is finalized but BEFORE transcription — so the backend still receives
+	// the audio even when transcription fails (the failure path returns early
+	// below, and the backup is MOST valuable exactly then). Fully best-effort:
+	// it never returns an error and never touches the meeting result.
+	h.backupAndPrune(ctx, job, p, recordedPath)
 
 	// Transcribe node-locally by reusing the transcribe handler in-process. This
 	// end-of-call batch pass remains the SOURCE OF TRUTH for the stored

--- a/internal/jobs/meeting_retention.go
+++ b/internal/jobs/meeting_retention.go
@@ -1,0 +1,143 @@
+// internal/jobs/meeting_retention.go
+//
+// Disk-safety retention for local meeting recordings (aceteam#5097).
+//
+// The lossless WAV is kept on the node by design, but it must not accumulate
+// unbounded. At meeting-end (and whenever this sweep runs) we prune meeting
+// recordings that are older than the configured retention window, and — under
+// disk pressure — everything prunable regardless of age. A freshly recorded WAV
+// whose backup upload has not (yet) confirmed is protected from the
+// disk-pressure branch so a full disk can never eat an un-backed-up recording.
+package jobs
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/shirou/gopsutil/v3/disk"
+)
+
+const (
+	// diskPressureFreeBytesFloor: below this much free space on the workspace
+	// filesystem, the sweep prunes all prunable recordings regardless of age.
+	diskPressureFreeBytesFloor = 2 * 1024 * 1024 * 1024 // 2 GiB
+	// diskPressureUsedPercentCeil: at/above this used%, likewise treat the node
+	// as under disk pressure (covers small disks where 2 GiB free is a lot).
+	diskPressureUsedPercentCeil = 92.0
+)
+
+// meetingFileInfo is one candidate for the retention sweep. Kept minimal so the
+// selection logic is a pure, table-tested function decoupled from the
+// filesystem.
+type meetingFileInfo struct {
+	// Path is the absolute file path.
+	Path string
+	// ModTime is when the file was last written (its age reference).
+	ModTime time.Time
+	// Protected marks a file the sweep must never delete — e.g. a WAV whose
+	// backup upload has not been confirmed. Protected files are excluded from
+	// BOTH the age branch and the disk-pressure branch.
+	Protected bool
+}
+
+// selectPrunableMeetingFiles returns the paths to delete. A non-protected file
+// is pruned when it is older than maxAge, OR when the node is under disk
+// pressure (in which case age is ignored). Protected files are never returned.
+//
+// Pure (no I/O, no clock) so both branches are unit-tested table-driven. The
+// input order is preserved in the output so callers/tests are deterministic.
+func selectPrunableMeetingFiles(files []meetingFileInfo, now time.Time, maxAge time.Duration, diskPressure bool) []string {
+	var prune []string
+	for _, f := range files {
+		if f.Protected {
+			continue
+		}
+		expired := now.Sub(f.ModTime) >= maxAge
+		if expired || diskPressure {
+			prune = append(prune, f.Path)
+		}
+	}
+	return prune
+}
+
+// meetingDirUnderDiskPressure reports whether the filesystem holding dir is low
+// on space. Best-effort: an error reading usage returns false (do NOT prune
+// aggressively on unknown state). Uses gopsutil so it is cross-platform.
+func meetingDirUnderDiskPressure(dir string) bool {
+	u, err := disk.Usage(dir)
+	if err != nil || u == nil {
+		return false
+	}
+	if u.Free < diskPressureFreeBytesFloor {
+		return true
+	}
+	return u.UsedPercent >= diskPressureUsedPercentCeil
+}
+
+// pruneMeetingRecordings sweeps {workspace}/meetings for stale .wav/.opus files
+// and deletes those the selection logic returns. protectPaths (absolute) are
+// never deleted — the caller passes the current run's WAV when its backup did
+// not confirm, so a disk-pressure sweep cannot eat it. Best-effort: every step
+// logs and continues; a prune failure never fails the meeting job.
+func (h *MeetingJoinHandler) pruneMeetingRecordings(ctx JobContext, maxAge time.Duration, protectPaths ...string) {
+	meetingsDir := filepath.Join(h.WorkspaceDir, "meetings")
+	entries, err := os.ReadDir(meetingsDir)
+	if err != nil {
+		// No meetings dir yet (or unreadable) — nothing to prune.
+		return
+	}
+
+	protected := make(map[string]struct{}, len(protectPaths))
+	for _, p := range protectPaths {
+		if p != "" {
+			protected[p] = struct{}{}
+		}
+	}
+
+	var candidates []meetingFileInfo
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		lower := strings.ToLower(name)
+		if !strings.HasSuffix(lower, ".wav") && !strings.HasSuffix(lower, ".opus") {
+			continue
+		}
+		abs := filepath.Join(meetingsDir, name)
+		info, statErr := e.Info()
+		if statErr != nil {
+			continue
+		}
+		_, isProtected := protected[abs]
+		candidates = append(candidates, meetingFileInfo{
+			Path:      abs,
+			ModTime:   info.ModTime(),
+			Protected: isProtected,
+		})
+	}
+	if len(candidates) == 0 {
+		return
+	}
+
+	pressure := h.diskUnderPressure(meetingsDir)
+	toPrune := selectPrunableMeetingFiles(candidates, time.Now(), maxAge, pressure)
+	for _, p := range toPrune {
+		if err := os.Remove(p); err != nil {
+			ctx.Log("warn", "     - meeting retention: could not prune %s (non-fatal): %v", p, err)
+			continue
+		}
+		ctx.Log("info", "     - meeting retention: pruned %s", p)
+	}
+}
+
+// diskUnderPressure honors an injected probe (tests) and otherwise delegates to
+// the real gopsutil-backed detector.
+func (h *MeetingJoinHandler) diskUnderPressure(dir string) bool {
+	if h.diskPressureFn != nil {
+		return h.diskPressureFn(dir)
+	}
+	return meetingDirUnderDiskPressure(dir)
+}

--- a/internal/jobs/meeting_retention_test.go
+++ b/internal/jobs/meeting_retention_test.go
@@ -1,0 +1,154 @@
+package jobs
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestSelectPrunableMeetingFiles(t *testing.T) {
+	now := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	maxAge := 30 * 24 * time.Hour
+	old := now.Add(-40 * 24 * time.Hour)   // older than maxAge
+	recent := now.Add(-1 * 24 * time.Hour) // within maxAge
+
+	tests := []struct {
+		name         string
+		files        []meetingFileInfo
+		diskPressure bool
+		want         []string
+	}{
+		{
+			name:  "empty input",
+			files: nil,
+			want:  nil,
+		},
+		{
+			name: "age branch prunes only expired",
+			files: []meetingFileInfo{
+				{Path: "/m/old.wav", ModTime: old},
+				{Path: "/m/recent.wav", ModTime: recent},
+			},
+			want: []string{"/m/old.wav"},
+		},
+		{
+			name: "exactly at maxAge is pruned (>=)",
+			files: []meetingFileInfo{
+				{Path: "/m/edge.wav", ModTime: now.Add(-maxAge)},
+			},
+			want: []string{"/m/edge.wav"},
+		},
+		{
+			name: "disk pressure prunes all non-protected regardless of age",
+			files: []meetingFileInfo{
+				{Path: "/m/old.wav", ModTime: old},
+				{Path: "/m/recent.wav", ModTime: recent},
+				{Path: "/m/recent.opus", ModTime: recent},
+			},
+			diskPressure: true,
+			want:         []string{"/m/old.wav", "/m/recent.wav", "/m/recent.opus"},
+		},
+		{
+			name: "protected never pruned by age",
+			files: []meetingFileInfo{
+				{Path: "/m/old.wav", ModTime: old, Protected: true},
+			},
+			want: nil,
+		},
+		{
+			name: "protected never pruned under disk pressure",
+			files: []meetingFileInfo{
+				{Path: "/m/recent.wav", ModTime: recent, Protected: true},
+				{Path: "/m/other.wav", ModTime: recent},
+			},
+			diskPressure: true,
+			want:         []string{"/m/other.wav"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := selectPrunableMeetingFiles(tt.files, now, maxAge, tt.diskPressure)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("selectPrunableMeetingFiles = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPruneMeetingRecordings_AgeBased exercises the filesystem sweep: only files
+// older than maxAge are removed; recent ones and non-meeting files survive.
+func TestPruneMeetingRecordings_AgeBased(t *testing.T) {
+	ws := t.TempDir()
+	meetings := filepath.Join(ws, "meetings")
+	if err := os.MkdirAll(meetings, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	oldWav := writeAged(t, meetings, "old.wav", 40*24*time.Hour)
+	oldOpus := writeAged(t, meetings, "stray.opus", 40*24*time.Hour)
+	recentWav := writeAged(t, meetings, "recent.wav", 1*24*time.Hour)
+	unrelated := writeAged(t, meetings, "notes.txt", 40*24*time.Hour)
+
+	h := &MeetingJoinHandler{WorkspaceDir: ws, diskPressureFn: func(string) bool { return false }}
+	h.pruneMeetingRecordings(JobContext{}, 30*24*time.Hour)
+
+	assertGone(t, oldWav)
+	assertGone(t, oldOpus)
+	assertExists(t, recentWav)
+	assertExists(t, unrelated) // non-.wav/.opus never touched
+}
+
+// TestPruneMeetingRecordings_DiskPressureProtectsCurrent verifies that under
+// disk pressure a recent WAV is pruned unless it is the protected current run.
+func TestPruneMeetingRecordings_DiskPressureProtectsCurrent(t *testing.T) {
+	ws := t.TempDir()
+	meetings := filepath.Join(ws, "meetings")
+	if err := os.MkdirAll(meetings, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	current := writeAged(t, meetings, "current.wav", 0)
+	otherRecent := writeAged(t, meetings, "other.wav", 1*time.Hour)
+
+	h := &MeetingJoinHandler{WorkspaceDir: ws, diskPressureFn: func(string) bool { return true }}
+	h.pruneMeetingRecordings(JobContext{}, 30*24*time.Hour, current)
+
+	assertExists(t, current)   // protected
+	assertGone(t, otherRecent) // pruned under pressure
+}
+
+func TestPruneMeetingRecordings_NoDir(t *testing.T) {
+	// No meetings/ dir yet — must be a no-op, not a panic.
+	h := &MeetingJoinHandler{WorkspaceDir: t.TempDir(), diskPressureFn: func(string) bool { return false }}
+	h.pruneMeetingRecordings(JobContext{}, 30*24*time.Hour)
+}
+
+func writeAged(t *testing.T, dir, name string, age time.Duration) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	mt := time.Now().Add(-age)
+	if err := os.Chtimes(p, mt, mt); err != nil {
+		t.Fatalf("chtimes %s: %v", name, err)
+	}
+	return p
+}
+
+func assertGone(t *testing.T, p string) {
+	t.Helper()
+	if _, err := os.Stat(p); !os.IsNotExist(err) {
+		t.Errorf("expected %s to be pruned, stat err = %v", p, err)
+	}
+}
+
+func assertExists(t *testing.T, p string) {
+	t.Helper()
+	if _, err := os.Stat(p); err != nil {
+		t.Errorf("expected %s to survive, stat err = %v", p, err)
+	}
+}

--- a/internal/tui/controlcenter/settings_page.go
+++ b/internal/tui/controlcenter/settings_page.go
@@ -238,7 +238,12 @@ func (p *SettingsPage) toggleMeeting() {
 		p.reloadMeeting()
 	}
 
-	next := &config.Meeting{MeetingEnabled: !p.meeting.MeetingEnabled}
+	// Copy the loaded config and flip only MeetingEnabled — a fresh
+	// &config.Meeting{MeetingEnabled: …} would zero every other field on save
+	// (no omitempty), silently disabling streaming + audio backup.
+	nextVal := *p.meeting
+	nextVal.MeetingEnabled = !p.meeting.MeetingEnabled
+	next := &nextVal
 
 	if p.cb.SaveMeeting != nil {
 		if err := p.cb.SaveMeeting(next); err != nil {

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -299,5 +299,14 @@ func newMeetingJoinHandler(opts LegacyHandlerOpts) *jobs.MeetingJoinHandler {
 	h.StreamingEnabled = m.StreamingEnabled
 	h.StreamingInterval = m.StreamingInterval()
 	h.StreamingWindow = m.StreamingWindow()
+
+	// Sovereign audio backup (aceteam#5097): default-on Opus upload + local
+	// retention. Creds (device token + API base) are loaded FRESH on each upload
+	// via the closure so a token rotated by the worker's in-place reauth is
+	// honored — not frozen at handler construction.
+	h.SetAudioBackup(m.AudioBackupEnabled, m.RetentionAge(), func() (string, string) {
+		creds := config.LoadDeviceCreds(platform.ConfigDir())
+		return creds.APIBaseURL, creds.Token
+	})
 	return h
 }


### PR DESCRIPTION
## Context

The AceTeam Notetaker records a meeting to a **lossless WAV on the user's own Citadel node** (sovereign by design — every byte stays on their hardware). Product decision (Jason): keep that WAV node-local **and** upload a **default-on, Opus-compressed backup** to the AceTeam backend, so a meeting has a durable dual copy without giving up sovereignty of the master recording.

This is the **NODE half** of that feature (epic #5097). It consumes the backend receiver already shipped in **aceteam #6088** (`POST /api/meetings/{id}/audio`, device-key auth, `audio/ogg;codecs=opus`, 150 MB cap, idempotent).

## Summary

Hooked into `MeetingJoinHandler.Execute` right after the recording is finalized and **before** transcription (so the backup runs even when transcription fails — it's most valuable exactly then):

**1. Transcode WAV → Opus (`internal/jobs/meeting_audio_backup.go`)**
- Runs ffmpeg **inside the already-running `citadel-meeting` container** via `docker exec … ffmpeg -c:a libopus -b:a 24k -application voip` — the same `docker exec` pattern as `internal/jobs/ollama_pull.go`. **No host ffmpeg dependency and no meeting-service image change** (host ffmpeg isn't guaranteed on arbitrary nodes; that's why meeting is a container module).
- Passes `-u <uid>:<gid>` (the node's own uid/gid) so the Opus lands **node-owned** — `docker exec` bypasses the entrypoint's PUID/PGID privilege drop, so without this it would write a root-owned file the node can't read back (this is exactly the #549 host-UID theme).

**2. Upload (best-effort, non-fatal)**
- `POST {api_base}/api/meetings/{meeting_id}/audio` with `Authorization: Bearer <device_api_key>` and `Content-Type: audio/ogg;codecs=opus`. Verified against the #6088 route: the job's `meeting_id` **is** the `meeting_sessions` UUID the route validates (`payload["meeting_id"] = session_id = row["id"]`).
- Explicit `Content-Length` (an `*os.File` body won't auto-set it), 150 MB size guard **before** opening the connection, and a 201-only success. Any 4xx/5xx/network/size failure logs and returns — **it never fails the meeting job** (the transcript is already the source of truth). Local `.opus` is removed on confirmed upload.
- Device creds (token + API base) are read **fresh on each upload** from `config.yaml`, so a token rotated by the worker's in-place reauth is honored — not frozen at handler construction.

**3. Default-on toggle + retention (`internal/config/meeting.go`)**
- New persisted `AudioBackupEnabled` (default **true**, opt-out) and `AudioRetentionDays` (default **30**) on the existing `Meeting` config, mirroring the `meeting`/`streaming` capability convention. Programmatically settable via `APPLY_DEVICE_CONFIG` (`audioBackupEnabled`, `meetingRetentionDays` — pointer fields so an omitted value leaves the persisted setting untouched). Opt-out disables transcode+upload; the transcript path is unaffected.

**4. Retention prune (`internal/jobs/meeting_retention.go`)**
- Sweep at meeting-end: prunes meeting WAVs (and stray `.opus`) older than N days, and everything prunable **under disk pressure** (gopsutil `disk.Usage`) regardless of age. The lossless WAV is otherwise kept. The current run's WAV is **protected** from the disk-pressure branch so a full disk can never eat a just-recorded, un-backed-up file. Selection logic is a pure, table-tested function.

**Also fixes a pre-existing clobber bug.** The `SaveMeeting` callers (`APPLY_DEVICE_CONFIG` and the Control Center toggle) constructed a fresh partial `&Meeting{MeetingEnabled: …}`, which — because the struct has no `omitempty` — zeroed every unset field on marshal, silently disabling `StreamingEnabled` the moment any device config touched the meeting toggle. Both now **load-modify-save**. (Adding a default-*true* `AudioBackupEnabled` would have widened this bug, so it had to be fixed here.)

## Test plan

| Group | Coverage |
|---|---|
| Transcode args | `-u` present with uid/gid, omitted when uid<0 (Windows); bitrate `24k`/`32k`, `libopus`, `voip`, `-y`, in/out paths, full argv order |
| Upload | correct method/path/`Bearer`/`audio/ogg;codecs=opus`/declared Content-Length/body; 201→`audio_document_id`; best-effort errors: no token, no base, size guard (server not hit), empty/missing file, non-201 |
| Orchestrator | injected docker-exec + httptest: success returns true and removes local `.opus`; transcode failure non-fatal; disabled toggle skips upload but still prunes |
| Config | default-on + retention default, non-positive retention clamp, partial-file preserves defaults, **load-modify-save preserves other fields** (clobber regression), device-creds loader (present/missing/partial/invalid) |
| Retention | table-driven pure selection (age branch, `>=` edge, disk pressure, protection in both branches) + filesystem sweep (age-based, disk-pressure-protects-current, no-dir no-op) |

`go build ./...`, `go vet ./...`, `go test ./...` all green; `gofmt -l .` empty.

## Known limitations (v1, non-blocking)

- **Container path only + docker:** transcode uses `docker exec citadel-meeting`, so backup runs on nodes with the meeting container up (the default/preferred path) and docker (podman not handled — matches `ollama_pull.go`'s hardcoded `docker`). Host-media nodes skip the backup (logged, non-fatal). Follow-up candidates.
- **Retention of un-uploaded WAVs:** a WAV whose upload never confirmed is pruned once it's older than the retention window (best-effort per spec — the current run is protected, and 30 days is the safety margin). A cheaper "sibling stray `.opus` ⇒ protect the WAV" tell is a possible follow-up.

## Ships in a citadel release

This is node-side code — it needs a **citadel-cli release** to reach the fleet.

## Related
- Epic #5097 (sovereign auto-join notetaker)
- Backend contract: aceteam #6088
- Host-UID container mapping precedent: #549