### PR TITLE
fix(worker): watchdog + self-heal + liveness for consumption-wedged worker (#548)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -568,6 +568,72 @@ Environment variables:
 | `SERVICE_AUTO_STOP_WHEN_IDLE` | unset (OFF) | Opt-in to auto-stop idle services. Truthy: `1`/`true`/`yes`/`on`. |
 | `SERVICE_AUTO_STOP_IDLE_SECONDS` | idle threshold | Idle seconds before auto-stop acts. |
 
+### Consume-Loop Watchdog, Self-Heal & Liveness (citadel #548)
+
+A hung job handler must never silently stall the whole node. The wedge that
+motivated this: a meeting/transcribe handler stuck in a `permission denied` +
+"waiting for service to become ready" retry loop blocked the sequential consume
+goroutine for 4+ hours. Heartbeats kept flowing from a separate goroutine, so the
+node showed green while executing nothing. Three defenses (`internal/worker/`):
+
+1. **Per-job watchdog (root fix, `deadline.go` + `runner.go`).** Every handler
+   dispatch runs in its own goroutine bounded by a deadline (`executeWithDeadline`).
+   On timeout the loop abandons the job and advances. CRITICAL: legacy handlers do
+   NOT receive the context (`LegacyHandlerAdapter.Execute` builds a bare
+   `jobs.JobContext`), so a context-cancel alone can't unblock them — the
+   goroutine+select is what keeps the loop alive; the orphaned handler goroutine
+   leaks until it finishes on its own (accepted tradeoff; threading ctx into
+   legacy handlers is the follow-up that lets the leak be fixed). Timeout
+   precedence: an explicit payload `timeout_ms` (backend budget, PR #552) wins;
+   otherwise a **generous per-class fallback** applies so the wedge is bounded even
+   when the backend sends no budget (the exact wedge condition). Classes:
+   - Default 60min (`WORKER_JOB_TIMEOUT_SECONDS`): inference, shell, file, VNC,
+     transcribe (its own single-shot self-bound is ~32min, comfortably under).
+   - Long 4h (`WORKER_JOB_TIMEOUT_LONG_SECONDS`): `MEETING_JOIN`, `COBROWSE` —
+     real human-session length; 4h catches a wedge without killing a live meeting.
+   - Unbounded (no fallback cap): model pulls/downloads, builds, `SERVICE_START`,
+     `INSTANCE_PROVISION`, `AGENT_UPDATE`, `WHATSAPP_PROVISION` — opaque long
+     progress; a blanket cap would risk killing a legit job. Set either env to `0`
+     to make that tier unbounded. A watchdog abandon is terminal: it routes to
+     `source.Fail` (DLQ), not `Nack`, so a hung job isn't retried into a repeat
+     wedge (esp. important in sequential mode).
+
+2. **Self-heal monitor (`selfheal.go`, default ON).** Backstop for a wedge the
+   per-job watchdog can't catch (outside a handler, or watchdog disabled). Reads
+   the shared `WorkerState` and exits non-zero (systemd `Restart=on-failure`
+   restarts clean) only on a clear loss of progress: no poll for
+   `WORKER_SELF_HEAL_STALL_SECONDS` (default 600) **while `in_flight==0`** (a busy
+   long job legitimately stops polling, so in-flight gates it), or a single job
+   in flight past `WORKER_SELF_HEAL_STUCK_SECONDS` (default 18000/5h, above the
+   long cap). Skips while draining (auto-update) and during a startup grace.
+   Disable with `WORKER_SELF_HEAL=false`.
+
+3. **Heartbeat liveness (`internal/status/` `WorkerLiveness`).** The heartbeat's
+   `NodeStatus.worker` now carries `consuming`, `last_job_consumed_at`,
+   `last_poll_at`, `in_flight` so the platform can flag a "green but wedged" node.
+   Read them together: `consuming==false && in_flight==0` ⇒ wedged;
+   `consuming==false && in_flight>0` ⇒ possibly a legit long job. `consuming`
+   (poll freshness) is the alarm; `last_job_consumed_at` alone is ambiguous
+   (stale on an idle node). Additive/omitempty; the same `WorkerState` pointer
+   feeds both the runner and the collector.
+
+**Remote restart break-glass (`cmd/agent_tools.go`).** `/agent/worker-restart`
+(the `citadel_worker_restart` MCP tool) now performs a real restart — it exits
+non-zero for the service manager to restart, but **only when
+`managedByServiceManager()` is true** (systemd sets `INVOCATION_ID`); otherwise it
+degrades to guidance so it can never exit into a node nothing will bring back. The
+aceteam MCP side already POSTs to this endpoint (no wiring change needed); it
+should render the new `{ok:true, restarting:true}` response instead of the old
+"not yet supported" guidance.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `WORKER_JOB_TIMEOUT_SECONDS` | `3600` | Fallback per-job deadline for ordinary job types. `0` = unbounded. |
+| `WORKER_JOB_TIMEOUT_LONG_SECONDS` | `14400` | Fallback deadline for long-session types (MEETING_JOIN, COBROWSE). `0` = unbounded. |
+| `WORKER_SELF_HEAL` | on | Set falsey (`0`/`false`/`no`/`off`) to disable the self-heal monitor. |
+| `WORKER_SELF_HEAL_STALL_SECONDS` | `600` | No-poll gap (with nothing in flight) before self-heal restarts. |
+| `WORKER_SELF_HEAL_STUCK_SECONDS` | `18000` | Single-job in-flight ceiling before self-heal restarts. `0` = disabled. |
+
 ### Docker Runtime Requirements
 vLLM and llama.cpp require NVIDIA runtime configured in `/etc/docker/daemon.json`:
 ```json

--- a/cmd/agent_tools.go
+++ b/cmd/agent_tools.go
@@ -73,17 +73,56 @@ func buildAgentProviders(ctx context.Context, d agentProviderDeps) *status.Agent
 			return agentResubscribe(ctx, d, orgID)
 		},
 		WorkerRestart: func() (any, error) {
-			// A safe in-place run-loop restart (Drain + reconnect + re-AddQueue)
-			// is non-trivial because Runner.Run blocks and owns the source. Rather
-			// than ship a half-working goroutine swap, return an actionable result
-			// pointing the agent at the supported recovery paths. Tracked as
-			// future work in #236.
-			return map[string]any{
-				"ok":      false,
-				"message": "in-place worker restart is not yet supported; use /agent/resubscribe to recover a dead consume loop, or restart the citadel systemd service (sudo systemctl restart citadel)",
-			}, nil
+			return agentWorkerRestart()
 		},
 	}
+}
+
+// processExiter is swappable in tests so agentWorkerRestart can be exercised
+// without actually terminating the test binary.
+var processExiter = func(code int) { os.Exit(code) }
+
+// serviceRestartDelay is the grace window between returning the HTTP result and
+// exiting, so the restart acknowledgement flushes to the caller first.
+var serviceRestartDelay = 500 * time.Millisecond
+
+// managedByServiceManager reports whether THIS process was launched by a service
+// manager that will restart it after a non-zero exit. systemd sets INVOCATION_ID
+// on the processes of the units it starts; this is the signal that an exit is a
+// restart, not a suicide. Deliberately conservative: if we cannot prove we are
+// under such a manager we do NOT exit (that would leave the node dead), and fall
+// back to guidance instead.
+func managedByServiceManager() bool {
+	return strings.TrimSpace(os.Getenv("INVOCATION_ID")) != ""
+}
+
+// agentWorkerRestart is the break-glass remote restart behind
+// /agent/worker-restart (issue #548). The prior implementation was a no-op that
+// only returned guidance, so a consumption-wedged headless node could only be
+// recovered by an operator with shell access. A safe in-place run-loop swap is
+// non-trivial (Runner.Run blocks and owns the source), so we instead do the
+// thing an operator's `systemctl restart` does: exit non-zero and let the
+// service manager restart the process clean -- clearing any leaked/wedged
+// handler goroutines. Gated on managedByServiceManager() so we never exit into a
+// dead node when nothing will bring us back.
+func agentWorkerRestart() (any, error) {
+	if !managedByServiceManager() {
+		return map[string]any{
+			"ok":      false,
+			"message": "remote worker restart requires the agent to run under a service manager (systemd) that will restart it; this process is not service-managed. Use /agent/resubscribe to recover a lost subscription, or restart the citadel service manually.",
+		}, nil
+	}
+	Log("agent: remote worker-restart requested; exiting for service-manager restart in %s", serviceRestartDelay)
+	go func() {
+		time.Sleep(serviceRestartDelay) // let the HTTP acknowledgement flush first
+		processExiter(1)
+	}()
+	return map[string]any{
+		"ok":         true,
+		"restarting": true,
+		"method":     "process-exit",
+		"message":    "worker is restarting via the service manager; it will reconnect and resume consuming shortly",
+	}, nil
 }
 
 // agentResubscribe re-establishes the per-node shell stream subscription on the

--- a/cmd/agent_tools_test.go
+++ b/cmd/agent_tools_test.go
@@ -186,3 +186,51 @@ func TestAgentNodeInfoFields(t *testing.T) {
 		t.Fatalf("uptime should be ~60s, got %d", up)
 	}
 }
+
+// TestAgentWorkerRestartServiceManaged verifies that when the process is
+// service-managed (systemd sets INVOCATION_ID), a remote restart schedules a
+// non-zero process exit and returns a restarting acknowledgement (issue #548).
+func TestAgentWorkerRestartServiceManaged(t *testing.T) {
+	t.Setenv("INVOCATION_ID", "test-unit-123")
+	exited := make(chan int, 1)
+	origExit, origDelay := processExiter, serviceRestartDelay
+	processExiter = func(code int) { exited <- code }
+	serviceRestartDelay = 1 * time.Millisecond
+	defer func() { processExiter, serviceRestartDelay = origExit, origDelay }()
+
+	res, err := agentWorkerRestart()
+	if err != nil {
+		t.Fatalf("agentWorkerRestart() error = %v", err)
+	}
+	m := res.(map[string]any)
+	if m["ok"] != true || m["restarting"] != true {
+		t.Errorf("result = %+v, want ok=true restarting=true", m)
+	}
+	select {
+	case code := <-exited:
+		if code != 1 {
+			t.Errorf("exit code = %d, want 1", code)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("process exit was never scheduled")
+	}
+}
+
+// TestAgentWorkerRestartNotServiceManaged verifies the safety guard: when
+// nothing will restart the process, a remote restart must NOT exit -- it returns
+// guidance instead, so it can never leave the node dead.
+func TestAgentWorkerRestartNotServiceManaged(t *testing.T) {
+	t.Setenv("INVOCATION_ID", "")
+	origExit := processExiter
+	processExiter = func(int) { t.Fatal("must not exit when not service-managed") }
+	defer func() { processExiter = origExit }()
+
+	res, err := agentWorkerRestart()
+	if err != nil {
+		t.Fatalf("agentWorkerRestart() error = %v", err)
+	}
+	if m := res.(map[string]any); m["ok"] != false {
+		t.Errorf("result = %+v, want ok=false (guidance, no exit)", m)
+	}
+	time.Sleep(5 * time.Millisecond) // give any errant goroutine a chance to fire
+}

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1124,14 +1124,31 @@ func runWork(cmd *cobra.Command, args []string) {
 		workStatusPort = 8080
 	}
 
+	// Live worker consume-loop liveness for the heartbeat (issue #548). Reads the
+	// same *WorkerState the runner updates, so the heartbeat can surface a
+	// "green but wedged" node (heartbeating from a separate goroutine while the
+	// consume loop is blocked and draining nothing).
+	workerLivenessFn := func() *status.WorkerLiveness {
+		snap := workerState.Snapshot()
+		return &status.WorkerLiveness{
+			Consuming:         snap.Consuming,
+			LastJobConsumedAt: snap.LastJobAt,
+			LastPollAt:        snap.LastPollAt,
+			InFlight:          snap.InFlight,
+			Processed:         snap.Processed,
+			Failed:            snap.Failed,
+		}
+	}
+
 	// Create status collector (used by status server and Redis status publisher)
 	var collector *status.Collector
 	if workStatusPort > 0 {
 		collector = status.NewCollector(status.CollectorConfig{
-			NodeName:     nodeName,
-			ConfigDir:    "",
-			Services:     nil,
-			Capabilities: statusCaps,
+			NodeName:       nodeName,
+			ConfigDir:      "",
+			Services:       nil,
+			Capabilities:   statusCaps,
+			WorkerLiveness: workerLivenessFn,
 		})
 	}
 
@@ -1384,10 +1401,11 @@ func runWork(cmd *cobra.Command, args []string) {
 		// Create collector if not already created
 		if collector == nil {
 			collector = status.NewCollector(status.CollectorConfig{
-				NodeName:     nodeName,
-				ConfigDir:    "",
-				Services:     nil,
-				Capabilities: statusCaps,
+				NodeName:       nodeName,
+				ConfigDir:      "",
+				Services:       nil,
+				Capabilities:   statusCaps,
+				WorkerLiveness: workerLivenessFn,
 			})
 		}
 
@@ -1988,6 +2006,15 @@ func runWork(cmd *cobra.Command, args []string) {
 			},
 		})
 		go updater.Run(ctx)
+	}
+
+	// Start the self-heal liveness monitor (issue #548). It is the backstop for a
+	// consumption-wedged worker that the per-job watchdog can't catch (a wedge
+	// outside a handler, or a build with the watchdog disabled): it watches the
+	// shared workerState and, on a clear loss of forward progress, exits non-zero
+	// so systemd restarts the process clean. No-op if disabled (WORKER_SELF_HEAL).
+	if monitor := worker.NewLivenessMonitor(workerState, runner.IsDraining, func(level, msg string) { Log("%s", msg) }); monitor != nil {
+		go monitor.Run(ctx)
 	}
 
 	// Run the worker

--- a/internal/status/collector.go
+++ b/internal/status/collector.go
@@ -28,6 +28,7 @@ type Collector struct {
 	startTime      time.Time
 	modelDiscovery *ModelDiscovery
 	capabilities   *NodeCapabilities     // cached capabilities (set once at startup)
+	workerLiveness func() *WorkerLiveness // live worker consume-loop liveness (issue #548), optional
 	idleTracker    *IdleTracker          // metrics-based per-service idle detection (aceteam#4472 / citadel #416)
 	fpIdleTracker  *FootprintIdleTracker // footprint-derived idle for engines #416 can't scrape (citadel #421)
 	netIdleTracker *IdleTracker          // network-activity idle for non-vLLM services (citadel #433)
@@ -47,6 +48,10 @@ type CollectorConfig struct {
 	ConfigDir    string
 	Services     []ServiceConfig
 	Capabilities *NodeCapabilities // pre-detected capabilities (optional)
+	// WorkerLiveness, when set, returns the live consume-loop liveness attached
+	// to each heartbeat so the platform can flag "green but wedged" nodes
+	// (issue #548). Optional: nil on nodes with no worker loop.
+	WorkerLiveness func() *WorkerLiveness
 }
 
 // NewCollector creates a new status collector.
@@ -58,6 +63,7 @@ func NewCollector(cfg CollectorConfig) *Collector {
 		startTime:      time.Now(),
 		modelDiscovery: NewModelDiscovery(),
 		capabilities:   cfg.Capabilities,
+		workerLiveness: cfg.WorkerLiveness,
 		idleTracker:    NewIdleTracker(IdleThresholdSeconds()),
 		fpIdleTracker:  NewFootprintIdleTracker(),
 		netIdleTracker: NewIdleTracker(IdleThresholdSeconds()),
@@ -158,6 +164,12 @@ func (c *Collector) Collect() (*NodeStatus, error) {
 	// keys) so the fabric can schedule engine-specific deploys only to capable
 	// nodes (aceteam#4483).
 	populateServices(status.Capabilities)
+
+	// Attach live worker consume-loop liveness so the platform can distinguish a
+	// heartbeating-but-wedged node from one actually draining jobs (issue #548).
+	if c.workerLiveness != nil {
+		status.Worker = c.workerLiveness()
+	}
 
 	return status, nil
 }

--- a/internal/status/collector_test.go
+++ b/internal/status/collector_test.go
@@ -143,3 +143,40 @@ func TestCollectorConfig(t *testing.T) {
 		t.Errorf("Services count = %v, want 2", len(cfg.Services))
 	}
 }
+
+// TestCollectorWorkerLiveness verifies the #548 heartbeat liveness attachment:
+// when a WorkerLiveness provider is set, Collect() attaches it; when it is not,
+// the field is omitted so the payload stays back-compatible for non-worker nodes.
+func TestCollectorWorkerLiveness(t *testing.T) {
+	consumedAt := time.Now().Add(-time.Minute)
+
+	withFn := NewCollector(CollectorConfig{
+		NodeName: "test-node",
+		WorkerLiveness: func() *WorkerLiveness {
+			return &WorkerLiveness{
+				Consuming:         true,
+				LastJobConsumedAt: &consumedAt,
+				InFlight:          2,
+			}
+		},
+	})
+	st, err := withFn.Collect()
+	if err != nil {
+		t.Fatalf("Collect() error = %v", err)
+	}
+	if st.Worker == nil {
+		t.Fatal("Worker liveness not attached when provider was set")
+	}
+	if !st.Worker.Consuming || st.Worker.InFlight != 2 || st.Worker.LastJobConsumedAt == nil {
+		t.Errorf("Worker = %+v, want consuming=true in_flight=2 with a consumed-at time", st.Worker)
+	}
+
+	without := NewCollector(CollectorConfig{NodeName: "test-node"})
+	st2, err := without.Collect()
+	if err != nil {
+		t.Fatalf("Collect() error = %v", err)
+	}
+	if st2.Worker != nil {
+		t.Errorf("Worker = %+v, want nil (omitted) when no provider set", st2.Worker)
+	}
+}

--- a/internal/status/types.go
+++ b/internal/status/types.go
@@ -34,6 +34,40 @@ type NodeStatus struct {
 	// backward-compatible: legacy nodes omit it and are treated as "unknown".
 	DesktopCapabilities map[string]bool `json:"desktop_capabilities,omitempty"`
 	VNCPort             int             `json:"vnc_port"`
+	// Worker carries live job-consumption liveness so the platform can tell a
+	// process that is alive & heartbeating from one that is actually draining
+	// jobs (issue #548). Additive and back-compatible: omitted on nodes that run
+	// no worker loop (pure status/desktop nodes) and on legacy builds.
+	Worker *WorkerLiveness `json:"worker,omitempty"`
+}
+
+// WorkerLiveness is the heartbeat-facing view of the job consume loop. It is the
+// signal the platform uses to flag a "green but wedged" node -- one whose
+// heartbeat keeps flowing from a separate goroutine while the consume loop is
+// blocked and draining nothing (issue #548).
+//
+// Interpreting the fields together (the platform must qualify, not read one in
+// isolation):
+//   - Consuming==false && InFlight==0  -> WEDGED: the loop stopped polling and
+//     nothing is running. Alert.
+//   - Consuming==false && InFlight>0   -> possibly a legitimate long job holding
+//     the sequential loop; not necessarily wedged.
+//   - Consuming==true                  -> healthy; polling recently.
+//
+// LastJobConsumedAt alone is intentionally ambiguous (naturally stale on an idle
+// node with no work), so it is context, not the alarm.
+type WorkerLiveness struct {
+	// Consuming is true when a poll cycle completed recently (freshness bound).
+	Consuming bool `json:"consuming"`
+	// LastJobConsumedAt is when a job was most recently pulled off the queue.
+	LastJobConsumedAt *time.Time `json:"last_job_consumed_at,omitempty"`
+	// LastPollAt is when the consume loop last completed a poll (job or empty).
+	LastPollAt *time.Time `json:"last_poll_at,omitempty"`
+	// InFlight is the number of jobs currently executing in a handler.
+	InFlight int64 `json:"in_flight"`
+	// Processed / Failed are cumulative since worker start (diagnostic context).
+	Processed int64 `json:"processed,omitempty"`
+	Failed    int64 `json:"failed,omitempty"`
 }
 
 // AppInfo contains information about an installed catalog app.

--- a/internal/worker/deadline.go
+++ b/internal/worker/deadline.go
@@ -5,9 +5,105 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
+	"strings"
 	"time"
 )
+
+// Fallback per-job execution budgets (issue #548). PR #552 added an OPT-IN
+// per-job timeout carried in the payload (timeout_ms). But the wedge that
+// motivated #548 -- a meeting/transcribe handler stuck in a permission-denied
+// retry loop that silently blocked the whole sequential consume loop for 4+
+// hours -- happened precisely BECAUSE no backend budget was present: with no
+// timeout_ms the handler ran synchronously and unbounded. So the worker now
+// applies a GENEROUS default deadline even when the backend sends none, chosen
+// per job-type so a legitimately long job (a huge model pull, a long recording)
+// is never killed while a genuinely wedged handler is bounded and abandoned.
+//
+// Precedence: an explicit payload timeout_ms always wins; otherwise the default
+// for the job's class applies; a class configured to 0 seconds is unbounded.
+const (
+	// defaultJobTimeoutSeconds bounds ordinary jobs (inference, shell, file ops,
+	// VNC, transcribe, ...). 60min comfortably exceeds every legitimate case --
+	// e.g. a single CPU whisper transcription self-bounds at ~32min -- so a job
+	// that blows past it is wedged, not merely slow.
+	defaultJobTimeoutSeconds = 3600
+	// defaultLongJobTimeoutSeconds bounds long-SESSION jobs whose real-world
+	// duration is naturally large but finite (a recorded meeting, an
+	// interactive co-browse). 4h catches a wedge while not killing a real
+	// long meeting.
+	defaultLongJobTimeoutSeconds = 14400
+)
+
+// jobTimeoutDefaultEnvVar / jobTimeoutLongEnvVar tune the two fallback tiers.
+// Following the SERVICE_* env convention already used in the repo. Set either to
+// 0 to make that tier unbounded (restore the pre-#548 no-cap behavior).
+const (
+	jobTimeoutDefaultEnvVar = "WORKER_JOB_TIMEOUT_SECONDS"
+	jobTimeoutLongEnvVar    = "WORKER_JOB_TIMEOUT_LONG_SECONDS"
+)
+
+// longSessionJobTypes get the generous long-tier fallback. These legitimately
+// run for the length of a human session but are still bounded in the real world.
+var longSessionJobTypes = map[string]struct{}{
+	JobTypeMeetingJoin: {},
+	JobTypeCobrowse:    {},
+}
+
+// unboundedJobTypes get NO fallback deadline: their duration is dominated by
+// external factors (download size / build time / VM clone) with opaque progress,
+// so any blanket cap risks killing a legitimate job. They are still bounded when
+// the backend sends an explicit timeout_ms, and the self-heal monitor (#548) is
+// the backstop if one of these ever truly wedges.
+var unboundedJobTypes = map[string]struct{}{
+	JobTypeDownloadModel:     {},
+	JobTypeOllamaPull:        {},
+	JobTypeModelCachePull:    {},
+	JobTypeServiceStart:      {},
+	JobTypeIOSBuild:          {},
+	JobTypeAndroidBuild:      {},
+	JobTypeGomobileBuild:     {},
+	JobTypeInstanceProvision: {},
+	JobTypeAgentUpdate:       {},
+	JobTypeWhatsAppProvision: {},
+}
+
+// resolveJobTimeout returns the execution budget the runner should apply to a
+// job. An explicit payload timeout_ms wins; otherwise the per-class fallback
+// applies. ok=false means "run unbounded" (no watchdog), preserving the exact
+// prior behavior for that path.
+func (r *Runner) resolveJobTimeout(job *Job) (time.Duration, bool) {
+	if d, ok := jobExecTimeout(job); ok {
+		return d, true // explicit backend budget always wins
+	}
+	if job == nil {
+		return 0, false
+	}
+	if _, unbounded := unboundedJobTypes[job.Type]; unbounded {
+		return 0, false
+	}
+	if _, long := longSessionJobTypes[job.Type]; long {
+		return envTimeoutSeconds(jobTimeoutLongEnvVar, defaultLongJobTimeoutSeconds)
+	}
+	return envTimeoutSeconds(jobTimeoutDefaultEnvVar, defaultJobTimeoutSeconds)
+}
+
+// envTimeoutSeconds reads a seconds-valued env var, falling back to def. A value
+// of 0 (or a negative/garbage value that we clamp) means "unbounded" and returns
+// ok=false. A positive value returns that many seconds as a duration.
+func envTimeoutSeconds(envVar string, def int) (time.Duration, bool) {
+	secs := def
+	if v := strings.TrimSpace(os.Getenv(envVar)); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			secs = n
+		}
+	}
+	if secs <= 0 {
+		return 0, false
+	}
+	return time.Duration(secs) * time.Second, true
+}
 
 // jobTimeoutPayloadKey is the wire field the backend dispatcher injects to give
 // a job a per-execution budget (aceteam#6000). It is a RELATIVE duration in

--- a/internal/worker/deadline_test.go
+++ b/internal/worker/deadline_test.go
@@ -162,12 +162,20 @@ func TestExecuteWithDeadlineUnblocksHungHandler(t *testing.T) {
 		t.Error("deadline error should be published as non-recoverable")
 	}
 
-	// job-1 was nacked; job-2 acked.
-	if n := source.NackedJobs(); len(n) != 1 || n[0].ID != "job-1" {
-		t.Errorf("nacked = %v, want [job-1]", n)
+	// job-1 was Failed (terminal DLQ, NOT Nacked): a watchdog abandon must not
+	// be retried into a repeated wedge (issue #548). job-2 acked.
+	if f := source.FailedJobs(); len(f) != 1 || f[0].ID != "job-1" {
+		t.Errorf("failed = %v, want [job-1]", f)
+	}
+	if n := source.NackedJobs(); len(n) != 0 {
+		t.Errorf("nacked = %v, want [] (deadline abandon should Fail, not Nack)", n)
 	}
 	if a := source.AckedJobs(); len(a) != 1 || a[0].ID != "job-2" {
 		t.Errorf("acked = %v, want [job-2]", a)
+	}
+	// The failure data marks it as an agent-side deadline abandon.
+	if d := source.FailedData(); len(d) != 1 || d[0]["deadline_exceeded"] != true {
+		t.Errorf("failed data = %v, want deadline_exceeded=true", d)
 	}
 }
 
@@ -229,4 +237,71 @@ func TestJobExecTimeout(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestResolveJobTimeout covers the #548 fallback tiers: an explicit payload
+// budget always wins; otherwise a generous per-class default applies; unbounded
+// classes (model pulls, builds, provision) get no fallback cap; and either tier
+// can be tuned or disabled by env.
+func TestResolveJobTimeout(t *testing.T) {
+	r := &Runner{}
+
+	t.Run("explicit payload wins over fallback", func(t *testing.T) {
+		job := &Job{Type: JobTypeLLMInference, Payload: map[string]any{"timeout_ms": float64(1234)}}
+		d, ok := r.resolveJobTimeout(job)
+		if !ok || d != 1234*time.Millisecond {
+			t.Fatalf("got (%s, %v), want (1.234s, true)", d, ok)
+		}
+	})
+
+	t.Run("default tier for an ordinary job type", func(t *testing.T) {
+		d, ok := r.resolveJobTimeout(&Job{Type: JobTypeLLMInference})
+		if !ok || d != defaultJobTimeoutSeconds*time.Second {
+			t.Fatalf("got (%s, %v), want (%ds, true)", d, ok, defaultJobTimeoutSeconds)
+		}
+	})
+
+	t.Run("transcribe uses the default tier and exceeds its own 32min self-bound", func(t *testing.T) {
+		d, ok := r.resolveJobTimeout(&Job{Type: JobTypeTranscribeAudio})
+		if !ok || d <= 33*time.Minute {
+			t.Fatalf("got (%s, %v), want a bound comfortably above ~32min", d, ok)
+		}
+	})
+
+	t.Run("long tier for a session job type", func(t *testing.T) {
+		d, ok := r.resolveJobTimeout(&Job{Type: JobTypeMeetingJoin})
+		if !ok || d != defaultLongJobTimeoutSeconds*time.Second {
+			t.Fatalf("got (%s, %v), want (%ds, true)", d, ok, defaultLongJobTimeoutSeconds)
+		}
+	})
+
+	t.Run("unbounded types get no fallback cap (must not kill model pulls)", func(t *testing.T) {
+		for _, jt := range []string{JobTypeModelCachePull, JobTypeDownloadModel, JobTypeOllamaPull, JobTypeServiceStart, JobTypeAndroidBuild, JobTypeInstanceProvision} {
+			if _, ok := r.resolveJobTimeout(&Job{Type: jt}); ok {
+				t.Errorf("%s got a fallback cap; want unbounded (ok=false)", jt)
+			}
+		}
+	})
+
+	t.Run("unbounded type still honors an explicit payload budget", func(t *testing.T) {
+		job := &Job{Type: JobTypeModelCachePull, Payload: map[string]any{"timeout_ms": float64(5000)}}
+		if d, ok := r.resolveJobTimeout(job); !ok || d != 5*time.Second {
+			t.Fatalf("got (%s, %v), want (5s, true)", d, ok)
+		}
+	})
+
+	t.Run("env override tunes the default tier", func(t *testing.T) {
+		t.Setenv(jobTimeoutDefaultEnvVar, "120")
+		d, ok := r.resolveJobTimeout(&Job{Type: JobTypeLLMInference})
+		if !ok || d != 120*time.Second {
+			t.Fatalf("got (%s, %v), want (2m, true)", d, ok)
+		}
+	})
+
+	t.Run("env 0 disables the default tier (unbounded)", func(t *testing.T) {
+		t.Setenv(jobTimeoutDefaultEnvVar, "0")
+		if _, ok := r.resolveJobTimeout(&Job{Type: JobTypeLLMInference}); ok {
+			t.Fatal("default tier set to 0 should be unbounded (ok=false)")
+		}
+	})
 }

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -487,6 +487,15 @@ func (r *Runner) processJob(ctx context.Context, job *Job) {
 		// removed from the pending list rather than retried into a repeated
 		// wedge (issue #548). Every other failure keeps the existing Nack/retry
 		// semantics.
+		// Accepted tradeoff on abandon: like the orphaned handler goroutine, any
+		// GPU slot this job holds is released when processJob returns (the
+		// deferred gpuTracker.Release), so a still-running orphan and the next job
+		// can briefly share a slot. In practice the tracker schedules routing
+		// fairness rather than exclusive CUDA ownership (inference is an HTTP call
+		// into the engine container, which batches concurrent requests), and the
+		// orphan self-terminates when its own client/handler timeout fires, so the
+		// overlap window is bounded. We prefer this to permanently leaking the slot
+		// (which would slowly exhaust GPU capacity across repeated abandons).
 		var deadlineErr *deadlineExceededError
 		if errors.As(actualErr, &deadlineErr) {
 			r.source.Fail(ctx, job, actualErr, map[string]any{

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -177,6 +178,13 @@ func (r *Runner) Drain() {
 // isDraining reports whether Drain has been called.
 func (r *Runner) isDraining() bool {
 	return atomic.LoadInt32(&r.draining) == 1
+}
+
+// IsDraining is the exported view of isDraining, used by the self-heal monitor
+// to skip a wedge check while the loop is intentionally paused for an
+// auto-update drain (issue #548).
+func (r *Runner) IsDraining() bool {
+	return r.isDraining()
 }
 
 // WithStreamWriterFactory sets a factory for creating stream writers.
@@ -453,7 +461,7 @@ func (r *Runner) processJob(ctx context.Context, job *Job) {
 	// synchronous, no timeout, no watchdog goroutine.
 	var result *JobResult
 	var err error
-	if timeout, ok := jobExecTimeout(job); ok {
+	if timeout, ok := r.resolveJobTimeout(job); ok {
 		result, err = r.executeWithDeadline(ctx, handler, job, stream, timeout)
 	} else {
 		result, err = handler.Execute(ctx, job, stream)
@@ -470,6 +478,25 @@ func (r *Runner) processJob(ctx context.Context, job *Job) {
 		r.log("error", "Job %s failed (%v): %v", job.ID, duration, actualErr)
 		r.recordJob(buildUsageRecord(job, "failed", startTime, endTime, result, actualErr))
 		stream.WriteError(actualErr, false)
+
+		// A watchdog abandon (deadline exceeded) is terminal, not a transient
+		// failure: the handler goroutine is orphaned and still running, so
+		// Nack -> redeliver -> re-execute would just re-wedge the slot for
+		// another full budget (and, in sequential mode, block every other job
+		// again). Fail (record failed + ACK -> DLQ) instead so a hung job is
+		// removed from the pending list rather than retried into a repeated
+		// wedge (issue #548). Every other failure keeps the existing Nack/retry
+		// semantics.
+		var deadlineErr *deadlineExceededError
+		if errors.As(actualErr, &deadlineErr) {
+			r.source.Fail(ctx, job, actualErr, map[string]any{
+				"deadline_exceeded":  true,
+				"deadline_seconds":   deadlineErr.timeout.Seconds(),
+				"abandoned_by_agent": true,
+			})
+			return
+		}
+
 		r.source.Nack(ctx, job, actualErr)
 		return
 	}

--- a/internal/worker/selfheal.go
+++ b/internal/worker/selfheal.go
@@ -35,7 +35,12 @@ type LivenessMonitor struct {
 	stallTimeout  time.Duration // max no-poll gap while in_flight==0
 	stuckTimeout  time.Duration // max single-job in-flight duration (0 = disabled)
 	checkInterval time.Duration
-	graceStart    time.Duration // don't act until the worker has been up this long
+	graceStart    time.Duration // don't act until the monitor has run this long
+	// startedAt is stamped when Run begins (NOT WorkerState.startedAt, which is
+	// created early in startup). Grace is measured from here so the slow startup
+	// BEFORE the consume loop (network verify, identity, queue setup) can never
+	// be misread as "never polled" and trigger a restart loop (issue #548).
+	startedAt time.Time
 
 	isDraining func() bool
 	onWedge    func(reason string) // default: log + os.Exit(1)
@@ -87,6 +92,7 @@ func NewLivenessMonitor(state *WorkerState, isDraining func() bool, log func(lev
 	}
 	return &LivenessMonitor{
 		state:         state,
+		startedAt:     time.Now(), // re-stamped when Run begins
 		stallTimeout:  envSecondsOrDefault(selfHealStallEnvVar, defaultSelfHealStallSeconds),
 		stuckTimeout:  envSecondsOrDefault(selfHealStuckEnvVar, defaultSelfHealStuckSeconds),
 		checkInterval: defaultSelfHealCheckInterval,
@@ -123,6 +129,9 @@ func (m *LivenessMonitor) Run(ctx context.Context) {
 	if m == nil {
 		return
 	}
+	// Stamp grace from the moment the monitor (and thus the consume loop) starts,
+	// so pre-loop startup time is never counted against the "never polled" check.
+	m.startedAt = time.Now()
 	m.log("info", "Self-heal monitor active (stall="+m.stallTimeout.String()+")")
 	ticker := time.NewTicker(m.checkInterval)
 	defer ticker.Stop()
@@ -149,9 +158,10 @@ func (m *LivenessMonitor) check(now time.Time) (reason string, wedged bool) {
 	}
 	snap := m.state.Snapshot()
 
-	// Respect a startup grace period so a just-launched worker (no poll yet) is
-	// never mistaken for a wedge.
-	if time.Duration(snap.UptimeSeconds)*time.Second < m.graceStart {
+	// Respect a startup grace period, measured from when the MONITOR started (see
+	// startedAt), so the slow work before the consume loop begins is never
+	// mistaken for a wedge and cannot trigger a restart loop.
+	if now.Sub(m.startedAt) < m.graceStart {
 		return "", false
 	}
 

--- a/internal/worker/selfheal.go
+++ b/internal/worker/selfheal.go
@@ -1,0 +1,178 @@
+package worker
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// LivenessMonitor is the self-heal backstop for a consumption-wedged worker
+// (issue #548). The per-job watchdog (executeWithDeadline) is the primary fix --
+// it bounds every handler dispatch so one hung handler can no longer stall the
+// consume loop. This monitor covers the residual cases the per-job watchdog
+// cannot: a wedge OUTSIDE a handler (a stuck source.Next / dead loop), or a
+// deployment that has disabled the per-job watchdog. It watches the worker's
+// live introspection state and, when the loop has clearly stopped making
+// forward progress, restarts the process so the service manager (systemd
+// Restart=on-failure) brings it back clean.
+//
+// It is deliberately conservative -- it must never restart a healthy node that
+// is merely busy with a legitimate long job:
+//   - STALL: no poll cycle has completed for stallTimeout WHILE nothing is in
+//     flight. A healthy idle node records a poll every few seconds (the source
+//     block timeout), so a long no-poll gap with in_flight==0 means the loop
+//     itself is dead, not that a job is legitimately running.
+//   - STUCK: a job has been in flight longer than stuckTimeout. This only fires
+//     when the per-job watchdog is off or configured beyond stuckTimeout; with
+//     the watchdog on, in_flight naturally clears when a job is abandoned.
+//
+// Draining (auto-update) is skipped: the loop intentionally stops polling then.
+type LivenessMonitor struct {
+	state *WorkerState
+
+	stallTimeout  time.Duration // max no-poll gap while in_flight==0
+	stuckTimeout  time.Duration // max single-job in-flight duration (0 = disabled)
+	checkInterval time.Duration
+	graceStart    time.Duration // don't act until the worker has been up this long
+
+	isDraining func() bool
+	onWedge    func(reason string) // default: log + os.Exit(1)
+	log        func(level, msg string)
+}
+
+// Self-heal tuning. Following the SERVICE_* env convention already used in the
+// repo. WORKER_SELF_HEAL=false disables the monitor entirely.
+const (
+	selfHealEnabledEnvVar = "WORKER_SELF_HEAL"
+	selfHealStallEnvVar   = "WORKER_SELF_HEAL_STALL_SECONDS"
+	selfHealStuckEnvVar   = "WORKER_SELF_HEAL_STUCK_SECONDS"
+
+	// defaultSelfHealStallSeconds: 10min. Far above the source block timeout and
+	// the max consume backoff, so a healthy loop never trips it.
+	defaultSelfHealStallSeconds = 600
+	// defaultSelfHealStuckSeconds: 5h, above the 4h long-session job cap, so it
+	// is a pure backstop for a job that outlives even the generous per-job
+	// watchdog.
+	defaultSelfHealStuckSeconds = 18000
+
+	defaultSelfHealCheckInterval = 30 * time.Second
+	defaultSelfHealGrace         = 2 * time.Minute
+)
+
+// selfHealEnabled reports whether the self-heal monitor should run. Default ON;
+// set WORKER_SELF_HEAL to a falsey value (0/false/no/off) to disable.
+func selfHealEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(selfHealEnabledEnvVar))) {
+	case "0", "false", "no", "off":
+		return false
+	default:
+		return true
+	}
+}
+
+// NewLivenessMonitor builds a monitor with env-tuned thresholds and sensible
+// defaults. Returns nil if self-heal is disabled or state is nil (a nil monitor
+// is safe to Run -- it's a no-op).
+func NewLivenessMonitor(state *WorkerState, isDraining func() bool, log func(level, msg string)) *LivenessMonitor {
+	if state == nil || !selfHealEnabled() {
+		return nil
+	}
+	if isDraining == nil {
+		isDraining = func() bool { return false }
+	}
+	if log == nil {
+		log = func(string, string) {}
+	}
+	return &LivenessMonitor{
+		state:         state,
+		stallTimeout:  envSecondsOrDefault(selfHealStallEnvVar, defaultSelfHealStallSeconds),
+		stuckTimeout:  envSecondsOrDefault(selfHealStuckEnvVar, defaultSelfHealStuckSeconds),
+		checkInterval: defaultSelfHealCheckInterval,
+		graceStart:    defaultSelfHealGrace,
+		isDraining:    isDraining,
+		log:           log,
+		onWedge: func(reason string) {
+			// Exit non-zero so systemd (Restart=on-failure) restarts the
+			// process clean -- clearing any leaked/wedged goroutines that an
+			// in-process goroutine restart could not.
+			os.Exit(1)
+		},
+	}
+}
+
+// envSecondsOrDefault reads a seconds-valued env var. A value <= 0 disables that
+// check (returns 0 duration). Garbage falls back to def.
+func envSecondsOrDefault(envVar string, def int) time.Duration {
+	secs := def
+	if v := strings.TrimSpace(os.Getenv(envVar)); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			secs = n
+		}
+	}
+	if secs <= 0 {
+		return 0
+	}
+	return time.Duration(secs) * time.Second
+}
+
+// Run polls the worker state until ctx is cancelled, restarting the process via
+// onWedge when a wedge is detected. Safe to call on a nil *LivenessMonitor.
+func (m *LivenessMonitor) Run(ctx context.Context) {
+	if m == nil {
+		return
+	}
+	m.log("info", "Self-heal monitor active (stall="+m.stallTimeout.String()+")")
+	ticker := time.NewTicker(m.checkInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if reason, wedged := m.check(time.Now()); wedged {
+				m.log("error", "Self-heal: "+reason+"; restarting worker process")
+				m.onWedge(reason)
+				return
+			}
+		}
+	}
+}
+
+// check evaluates the current state at time now and returns a non-empty reason
+// with wedged=true when the worker should be restarted. Split out from Run so it
+// is unit-testable without a real ticker or process exit.
+func (m *LivenessMonitor) check(now time.Time) (reason string, wedged bool) {
+	if m.isDraining() {
+		return "", false // intentional pause (auto-update): not a wedge
+	}
+	snap := m.state.Snapshot()
+
+	// Respect a startup grace period so a just-launched worker (no poll yet) is
+	// never mistaken for a wedge.
+	if time.Duration(snap.UptimeSeconds)*time.Second < m.graceStart {
+		return "", false
+	}
+
+	// STALL: loop not polling while nothing is running.
+	if snap.InFlight == 0 && m.stallTimeout > 0 {
+		if snap.LastPollAt == nil {
+			// Up past grace, nothing in flight, and never a single poll: the
+			// loop never started consuming.
+			return "consume loop never polled since startup", true
+		}
+		if gap := now.Sub(*snap.LastPollAt); gap > m.stallTimeout {
+			return "consume loop stalled: no poll for " + gap.Truncate(time.Second).String() + " with no jobs in flight", true
+		}
+	}
+
+	// STUCK: a single job has occupied the loop far past any legitimate budget.
+	if snap.InFlight > 0 && m.stuckTimeout > 0 && snap.LastJobAt != nil {
+		if held := now.Sub(*snap.LastJobAt); held > m.stuckTimeout {
+			return "job stuck in handler for " + held.Truncate(time.Second).String() + " (exceeds self-heal ceiling)", true
+		}
+	}
+
+	return "", false
+}

--- a/internal/worker/selfheal_test.go
+++ b/internal/worker/selfheal_test.go
@@ -13,9 +13,12 @@ func newTestMonitor(state *WorkerState, draining bool) *LivenessMonitor {
 		stallTimeout: 10 * time.Minute,
 		stuckTimeout: 5 * time.Hour,
 		graceStart:   2 * time.Minute,
-		isDraining:   func() bool { return draining },
-		log:          func(string, string) {},
-		onWedge:      func(string) {},
+		// Default: monitor started long ago so grace has passed. The startup-grace
+		// case overrides this to a recent value.
+		startedAt:  time.Now().Add(-time.Hour),
+		isDraining: func() bool { return draining },
+		log:        func(string, string) {},
+		onWedge:    func(string) {},
 	}
 }
 
@@ -75,10 +78,12 @@ func TestLivenessMonitorCheck(t *testing.T) {
 		}
 	})
 
-	t.Run("startup grace: a just-booted worker with no poll yet is not wedged", func(t *testing.T) {
+	t.Run("startup grace: a just-started monitor with no poll yet is not wedged", func(t *testing.T) {
 		s := stateWith(now.Add(-30*time.Second), time.Time{}, time.Time{}, 0)
-		if _, wedged := newTestMonitor(s, false).check(now); wedged {
-			t.Fatal("worker inside startup grace flagged wedged")
+		m := newTestMonitor(s, false)
+		m.startedAt = now.Add(-30 * time.Second) // monitor within its 2min grace
+		if _, wedged := m.check(now); wedged {
+			t.Fatal("monitor inside startup grace flagged wedged")
 		}
 	})
 

--- a/internal/worker/selfheal_test.go
+++ b/internal/worker/selfheal_test.go
@@ -1,0 +1,118 @@
+package worker
+
+import (
+	"testing"
+	"time"
+)
+
+// newTestMonitor builds a monitor with fixed thresholds and no real exit, so
+// check() can be exercised deterministically.
+func newTestMonitor(state *WorkerState, draining bool) *LivenessMonitor {
+	return &LivenessMonitor{
+		state:        state,
+		stallTimeout: 10 * time.Minute,
+		stuckTimeout: 5 * time.Hour,
+		graceStart:   2 * time.Minute,
+		isDraining:   func() bool { return draining },
+		log:          func(string, string) {},
+		onWedge:      func(string) {},
+	}
+}
+
+// stateWith stamps a WorkerState with a chosen startedAt, lastPoll, lastJob and
+// in-flight count so check() sees a specific liveness snapshot.
+func stateWith(started, lastPoll, lastJob time.Time, inFlight int64) *WorkerState {
+	s := NewWorkerState()
+	s.startedAt = started
+	if !lastPoll.IsZero() {
+		s.lastPollUnixNano = lastPoll.UnixNano()
+	}
+	if !lastJob.IsZero() {
+		s.lastJobUnixNano = lastJob.UnixNano()
+	}
+	s.inFlight = inFlight
+	return s
+}
+
+func TestLivenessMonitorCheck(t *testing.T) {
+	now := time.Now()
+
+	t.Run("healthy: polling recently, nothing in flight", func(t *testing.T) {
+		s := stateWith(now.Add(-time.Hour), now.Add(-3*time.Second), time.Time{}, 0)
+		if reason, wedged := newTestMonitor(s, false).check(now); wedged {
+			t.Fatalf("healthy node flagged wedged: %s", reason)
+		}
+	})
+
+	t.Run("stall: no poll for > threshold with nothing in flight -> wedged", func(t *testing.T) {
+		s := stateWith(now.Add(-time.Hour), now.Add(-15*time.Minute), time.Time{}, 0)
+		if _, wedged := newTestMonitor(s, false).check(now); !wedged {
+			t.Fatal("stalled loop (no poll 15m, in_flight 0) not flagged wedged")
+		}
+	})
+
+	t.Run("busy long job: no poll but a job is in flight -> NOT wedged (stuck ceiling not reached)", func(t *testing.T) {
+		// A legitimate long job: last poll is old (loop is inside the handler),
+		// in_flight==1, but the job has only been running 15m -- far under the
+		// stuck ceiling. Must not restart.
+		s := stateWith(now.Add(-time.Hour), now.Add(-15*time.Minute), now.Add(-15*time.Minute), 1)
+		if reason, wedged := newTestMonitor(s, false).check(now); wedged {
+			t.Fatalf("busy node with a legitimate long job flagged wedged: %s", reason)
+		}
+	})
+
+	t.Run("stuck: a job in flight past the stuck ceiling -> wedged", func(t *testing.T) {
+		s := stateWith(now.Add(-10*time.Hour), now.Add(-6*time.Hour), now.Add(-6*time.Hour), 1)
+		if _, wedged := newTestMonitor(s, false).check(now); !wedged {
+			t.Fatal("job in flight 6h (> 5h ceiling) not flagged wedged")
+		}
+	})
+
+	t.Run("draining: intentional pause is never a wedge", func(t *testing.T) {
+		s := stateWith(now.Add(-time.Hour), now.Add(-15*time.Minute), time.Time{}, 0)
+		if _, wedged := newTestMonitor(s, true).check(now); wedged {
+			t.Fatal("draining worker flagged wedged")
+		}
+	})
+
+	t.Run("startup grace: a just-booted worker with no poll yet is not wedged", func(t *testing.T) {
+		s := stateWith(now.Add(-30*time.Second), time.Time{}, time.Time{}, 0)
+		if _, wedged := newTestMonitor(s, false).check(now); wedged {
+			t.Fatal("worker inside startup grace flagged wedged")
+		}
+	})
+
+	t.Run("never polled past grace with nothing in flight -> wedged", func(t *testing.T) {
+		s := stateWith(now.Add(-10*time.Minute), time.Time{}, time.Time{}, 0)
+		if _, wedged := newTestMonitor(s, false).check(now); !wedged {
+			t.Fatal("worker up 10m that never polled not flagged wedged")
+		}
+	})
+}
+
+func TestSelfHealEnabled(t *testing.T) {
+	t.Run("default on", func(t *testing.T) {
+		t.Setenv(selfHealEnabledEnvVar, "")
+		if !selfHealEnabled() {
+			t.Fatal("self-heal should default ON")
+		}
+	})
+	for _, v := range []string{"0", "false", "no", "off", "FALSE"} {
+		t.Run("disabled by "+v, func(t *testing.T) {
+			t.Setenv(selfHealEnabledEnvVar, v)
+			if selfHealEnabled() {
+				t.Fatalf("%q should disable self-heal", v)
+			}
+		})
+	}
+}
+
+func TestNewLivenessMonitorDisabled(t *testing.T) {
+	t.Setenv(selfHealEnabledEnvVar, "false")
+	if m := NewLivenessMonitor(NewWorkerState(), nil, nil); m != nil {
+		t.Fatal("NewLivenessMonitor should return nil when disabled")
+	}
+	// A nil monitor's Run is a safe no-op.
+	var nilMon *LivenessMonitor
+	nilMon.Run(nil)
+}


### PR DESCRIPTION
## Context
Node 1084's worker went silent for 4+ hours consuming zero jobs while heartbeating green (issue #548): a handler blocked the sequential consume goroutine indefinitely, and `LegacyHandlerAdapter.Execute` never threads `ctx` into legacy handlers, so context cancellation alone can't unblock them. `citadel service stop && start` was the only recovery. Builds on the opt-in `timeout_ms` from #552.

## Changes (all env-gated, additive)
**1. Per-job watchdog** — handler runs in its own goroutine + `select` (the only design that survives ctx-ignoring legacy handlers; orphan goroutine leaks until it self-finishes — documented tradeoff). Applies a **generous per-class fallback deadline only when the backend sends no budget** (the exact wedge condition):
- default **60min** (`WORKER_JOB_TIMEOUT_SECONDS`) — inference/shell/file/VNC/transcribe (transcribe self-bounds ~32min);
- long **4h** (`WORKER_JOB_TIMEOUT_LONG_SECONDS`) — `MEETING_JOIN`/`COBROWSE`;
- **unbounded** — model pulls/downloads, builds, `SERVICE_START`, `INSTANCE_PROVISION`, `AGENT_UPDATE`, `WHATSAPP_PROVISION` (so model pulls / long inference are never killed).
Watchdog abandon routes to `Fail` (DLQ), not `Nack` — a hung job isn't retried into a repeat wedge.

**2. Self-heal** (default ON, `WORKER_SELF_HEAL=false` to disable) — `LivenessMonitor` exits non-zero (systemd `Restart=on-failure`) only on clear loss of progress: no poll while `in_flight==0` past `WORKER_SELF_HEAL_STALL_SECONDS` (600s), or a job stuck past `WORKER_SELF_HEAL_STUCK_SECONDS` (5h). Grace measured from monitor start (avoids slow-startup restart-loop).

**3. Heartbeat liveness** — `NodeStatus.worker` now carries `consuming` / `last_job_consumed_at` / `last_poll_at` / `in_flight` (additive, omitempty). `consuming==false && in_flight==0` ⇒ wedged; `false && >0` ⇒ possibly-legit long job. Lets the platform flag wedged-but-green nodes.

**4. Real remote restart** — `/agent/worker-restart` (+ `WorkerRestart` provider) now actually restarts (exits for the service manager) **only when `INVOCATION_ID` is set** (systemd-launched); otherwise degrades to guidance so it never exits into a node nothing will restart. The aceteam MCP tool already POSTs here — it only needs to render the new `{ok:true, restarting:true}` response.

## Honest limitation
The `MEETING_JOIN` 4h reproducer is a loose backstop: self-heal won't catch it (`in_flight>0` looks legit) and the heartbeat won't alarm for up to 4h. Catching it fast needs an internal meeting-loop progress signal — out of scope, noted as follow-up.

## Testing
Fallback timeout tiers, deadline→Fail routing, self-heal matrix + startup-grace, heartbeat liveness attach/omit, service-managed-vs-not restart guard. `go build ./...`, `go vet`, `go test ./internal/worker/ ./internal/heartbeat/ ./internal/status/` (+ `./cmd/ -run TestAgent`) pass. Documented in CLAUDE.md.

Fixes #548.

🤖 Generated with [Claude Code](https://claude.com/claude-code)