### PR TITLE
gate :8080 control endpoints behind org token (#5028 lever B)

### DIFF
--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1183,6 +1183,13 @@ func runWork(cmd *cobra.Command, args []string) {
 			Port:    workStatusPort,
 			Version: Version,
 			Agent:   agentProviders,
+			// Interim bearer-token enforcement on the :8080 control endpoints
+			// (#5028 lever B). When set, the mesh-origin bypass in requireVPNOrAuth
+			// is dropped and the per-org terminal token is mandatory even for mesh
+			// peers, closing cross-org control access on the flat mesh. Default OFF
+			// so older relays that dial over the mesh without a bearer keep working;
+			// flip it on in a planned window once the relay presents the token.
+			RequireControlToken: status.RequireControlTokenEnabled(),
 		}
 
 		// Publish the gateway's self-signed leaf cert at GET /gateway-cert.pem so
@@ -1210,6 +1217,18 @@ func runWork(cmd *cobra.Command, args []string) {
 			}
 			serverCfg.TokenValidator = terminal.NewCachingTokenValidator(baseURL, statusOrgID, statusAPIToken, 30*time.Second)
 			serverCfg.OrgID = statusOrgID
+		}
+
+		// Surface the control-token posture so an operator is not surprised (#5028).
+		// With the flip on but no validator (no org ID / base URL), every control
+		// endpoint fails closed -- safe, but worth flagging so it is not mistaken
+		// for a bug.
+		if serverCfg.RequireControlToken {
+			if serverCfg.TokenValidator != nil {
+				fmt.Printf("   - Control-token enforcement ON (%s): mesh peers must present the org terminal token on :%d (#5028)\n", status.RequireControlTokenEnvVar, workStatusPort)
+			} else {
+				fmt.Fprintf(os.Stderr, "   - ⚠️ %s is set but no org token validator is configured (no org ID/base URL); ALL control endpoints on :%d fail closed\n", status.RequireControlTokenEnvVar, workStatusPort)
+			}
 		}
 
 		// Register desktop endpoints when permissions allow and auth is available.

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1186,9 +1186,9 @@ func runWork(cmd *cobra.Command, args []string) {
 			// Interim bearer-token enforcement on the :8080 control endpoints
 			// (#5028 lever B). When set, the mesh-origin bypass in requireVPNOrAuth
 			// is dropped and the per-org terminal token is mandatory even for mesh
-			// peers, closing cross-org control access on the flat mesh. Default OFF
-			// so older relays that dial over the mesh without a bearer keep working;
-			// flip it on in a planned window once the relay presents the token.
+			// peers. Default OFF so older relays that dial over the mesh without a
+			// bearer keep working; flip it on in a planned window once the relay
+			// presents the token.
 			RequireControlToken: status.RequireControlTokenEnabled(),
 		}
 

--- a/internal/status/server.go
+++ b/internal/status/server.go
@@ -35,6 +35,14 @@ type Server struct {
 	orgID          string
 	enableDesktop  bool
 
+	// requireControlToken, when true, drops the isVPNOrigin mesh-origin bypass in
+	// requireVPNOrAuth so the per-org terminal token becomes mandatory on every
+	// control endpoint even for callers on the Headscale mesh (issue #5028 lever
+	// B). Default false preserves the legacy VPN-origin trust so the change is a
+	// deliberate, flippable enforcement rather than a hard break at merge. Wired
+	// from CITADEL_REQUIRE_CONTROL_TOKEN.
+	requireControlToken bool
+
 	// gatewayCertPath is the on-disk path to the gateway's self-signed leaf cert
 	// PEM. When set, the status server serves it unauthenticated at
 	// GET /gateway-cert.pem so the backend can fetch (and re-fetch on rotation)
@@ -89,6 +97,12 @@ type ServerConfig struct {
 	OrgID          string                  // Required when TokenValidator is set
 	EnableDesktop  bool                    // When true AND TokenValidator is set, registers /api/screenshot and /api/actions
 
+	// RequireControlToken drops the VPN-origin bypass on the control endpoints so
+	// the per-org terminal token is mandatory even for mesh callers (issue #5028
+	// lever B). Default false keeps legacy VPN-origin trust; set to true (via
+	// CITADEL_REQUIRE_CONTROL_TOKEN) only after the relay presents the bearer.
+	RequireControlToken bool
+
 	// Agent, when set, registers the /agent/* introspection & control
 	// endpoints (issue #236). These are served over the same dual (LAN+VPN)
 	// listeners but gated by requireVPNOrAuth.
@@ -139,18 +153,19 @@ func NewServer(cfg ServerConfig, collector *Collector) *Server {
 		cfg.ControlPort = DefaultControlPort
 	}
 	return &Server{
-		collector:         collector,
-		port:              cfg.Port,
-		version:           cfg.Version,
-		tokenValidator:    cfg.TokenValidator,
-		orgID:             cfg.OrgID,
-		enableDesktop:     cfg.EnableDesktop,
-		agent:             cfg.Agent,
-		extraRoutes:       cfg.ExtraRoutes,
-		gatewayCertPath:   cfg.GatewayCertPath,
-		caVerifier:        cfg.CAVerifier,
-		controlPort:       cfg.ControlPort,
-		controlServerCert: cfg.ControlServerCert,
+		collector:           collector,
+		port:                cfg.Port,
+		version:             cfg.Version,
+		tokenValidator:      cfg.TokenValidator,
+		orgID:               cfg.OrgID,
+		enableDesktop:       cfg.EnableDesktop,
+		requireControlToken: cfg.RequireControlToken,
+		agent:               cfg.Agent,
+		extraRoutes:         cfg.ExtraRoutes,
+		gatewayCertPath:     cfg.GatewayCertPath,
+		caVerifier:          cfg.CAVerifier,
+		controlPort:         cfg.ControlPort,
+		controlServerCert:   cfg.ControlServerCert,
 	}
 }
 

--- a/internal/status/server.go
+++ b/internal/status/server.go
@@ -214,7 +214,7 @@ func (s *Server) buildControlMux() *http.ServeMux {
 	// Liveness probe (still requires the mTLS handshake to reach, but no identity
 	// check) so a coordinator can confirm the control listener is up.
 	mux.HandleFunc("/ping", s.handlePing)
-	// SSH-key injection: the host-takeover crown jewel. Coordinator identity only.
+	// SSH key deployment is mutating and host-sensitive: coordinator identity only.
 	mux.HandleFunc("/ssh/authorized-keys", s.caVerifier.requireCoordinator(s.handleSSHAuthorizedKeys))
 	return mux
 }
@@ -251,13 +251,13 @@ func (s *Server) buildMux() *http.ServeMux {
 		mux.HandleFunc("/api/actions", s.requireAuth(s.handleActions))
 	}
 
-	// SSH key deployment is a MUTATING, host-takeover-capable endpoint. It is no
-	// longer served over this plaintext, VPN-origin-trusting listener (issue
-	// #5028): mesh origin is not an identity, so any node on the flat mesh could
-	// inject a key. It now lives ONLY on the dedicated mTLS control listener,
-	// gated by a coordinator client certificate (see buildControlMux). Here we
-	// register a fail-closed stub so the old path refuses with a clear signal
-	// instead of silently 404ing or, worse, still writing keys.
+	// SSH key deployment is a mutating, host-sensitive endpoint. It is no longer
+	// served over this plaintext, VPN-origin-trusting listener (issue #5028):
+	// mesh origin is a coarse network signal, not a caller identity. It now lives
+	// ONLY on the dedicated mTLS control listener, gated by a coordinator client
+	// certificate (see buildControlMux). Here we register a fail-closed stub so
+	// the old path refuses with a clear signal instead of silently 404ing or,
+	// worse, still writing keys.
 	mux.HandleFunc("/ssh/authorized-keys", s.handleSSHMovedToControl)
 
 	// Agent introspection & control endpoints (issue #236), gated the same way

--- a/internal/status/ssh_handler.go
+++ b/internal/status/ssh_handler.go
@@ -30,9 +30,30 @@ type sshAuthorizedKeysResponse struct {
 	Total   int `json:"total"`
 }
 
-// vpnCIDR is the Headscale CGNAT range. Requests from this range are trusted
-// because only nodes on the Headscale VPN mesh can originate from it.
+// vpnCIDR is the Headscale CGNAT range. On a flat mesh this range is NOT an
+// identity (any org's node can originate from it), which is why the mesh-origin
+// bypass is being retired behind RequireControlTokenEnvVar (issue #5028).
 const vpnCIDR = "100.64.0.0/10"
+
+// RequireControlTokenEnvVar gates the interim :8080 control-token enforcement
+// (issue #5028 lever B). It is OFF unless explicitly set to a truthy value
+// ("1", "true", "yes", "on"). When on, requireVPNOrAuth drops the VPN-origin
+// bypass and demands the per-org terminal token even from mesh peers. Kept OFF
+// by default so the change is a deliberate, reversible flip (a code-free
+// rollback is just unsetting the env) rather than a hard break for older relays
+// that still dial the mesh without a bearer.
+const RequireControlTokenEnvVar = "CITADEL_REQUIRE_CONTROL_TOKEN"
+
+// RequireControlTokenEnabled reports whether the control-token flip is on,
+// reading RequireControlTokenEnvVar with the same truthy set used elsewhere.
+func RequireControlTokenEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(RequireControlTokenEnvVar))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
 
 // isVPNOrigin checks if the request originates from the Headscale VPN mesh.
 func isVPNOrigin(r *http.Request) bool {
@@ -55,19 +76,36 @@ func isVPNOrigin(r *http.Request) bool {
 	return cidr.Contains(ip)
 }
 
-// requireVPNOrAuth allows the request if it comes from the VPN mesh OR if
-// a valid terminal token is presented. SSH key deployment from the platform
-// relay will use VPN-origin auth (the relay runs on the VPN). Direct API
-// callers can use token-based auth.
+// requireVPNOrAuth gates the control endpoints (/agent/*, provisioning, workflow)
+// on the plaintext status listener.
+//
+// Historically it accepted ANY request whose source IP is in the Headscale CGNAT
+// range without a token, on the assumption that only trusted mesh peers can
+// originate from it. On a FLAT mesh that assumption is false (issue #5028): every
+// org's nodes share the same tailnet, so a mesh IP is not an identity and a
+// cross-org peer gets a free pass. Lever B closes that hole by requiring the
+// per-org terminal token (the same server-decryptable token already validated on
+// the :7860 terminal listener) for mesh origins too.
+//
+// The mesh-origin bypass is dropped only when requireControlToken is set (the
+// deliberate flip, wired from CITADEL_REQUIRE_CONTROL_TOKEN in cmd/work.go).
+// Default keeps the legacy VPN-origin trust so older relays that dial over the
+// mesh without presenting a token do not break at merge; the flip is thrown in a
+// planned window after the relay is updated to send the bearer. See issue #5028
+// section 8 and mtls.go for the durable per-caller identity (#5959) that
+// supersedes this interim bearer.
 func (s *Server) requireVPNOrAuth(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		// Accept VPN-origin requests without a token
-		if isVPNOrigin(r) {
+		// Accept VPN-origin requests without a token UNLESS the control-token flip
+		// is on, in which case mesh origin no longer auto-trusts (#5028 lever B).
+		if !s.requireControlToken && isVPNOrigin(r) {
 			next(w, r)
 			return
 		}
 
-		// Fall back to token-based auth if available
+		// Require a valid per-org terminal token. This is the only accepted path
+		// once requireControlToken is set, and the fallback for non-mesh callers
+		// otherwise.
 		if s.tokenValidator != nil {
 			token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
 			if token != "" && token != r.Header.Get("Authorization") {
@@ -79,7 +117,7 @@ func (s *Server) requireVPNOrAuth(next http.HandlerFunc) http.HandlerFunc {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		http.Error(w, `{"error":"authorization required: VPN origin or valid token"}`, http.StatusUnauthorized)
+		http.Error(w, `{"error":"authorization required: valid org token"}`, http.StatusUnauthorized)
 	}
 }
 

--- a/internal/status/ssh_handler.go
+++ b/internal/status/ssh_handler.go
@@ -30,9 +30,9 @@ type sshAuthorizedKeysResponse struct {
 	Total   int `json:"total"`
 }
 
-// vpnCIDR is the Headscale CGNAT range. On a flat mesh this range is NOT an
-// identity (any org's node can originate from it), which is why the mesh-origin
-// bypass is being retired behind RequireControlTokenEnvVar (issue #5028).
+// vpnCIDR is the Headscale CGNAT range. Source IP in this range is a coarse
+// network signal, not a caller identity, so mesh-origin trust is being retired
+// in favor of a per-org token behind RequireControlTokenEnvVar (issue #5028).
 const vpnCIDR = "100.64.0.0/10"
 
 // RequireControlTokenEnvVar gates the interim :8080 control-token enforcement
@@ -79,13 +79,12 @@ func isVPNOrigin(r *http.Request) bool {
 // requireVPNOrAuth gates the control endpoints (/agent/*, provisioning, workflow)
 // on the plaintext status listener.
 //
-// Historically it accepted ANY request whose source IP is in the Headscale CGNAT
-// range without a token, on the assumption that only trusted mesh peers can
-// originate from it. On a FLAT mesh that assumption is false (issue #5028): every
-// org's nodes share the same tailnet, so a mesh IP is not an identity and a
-// cross-org peer gets a free pass. Lever B closes that hole by requiring the
-// per-org terminal token (the same server-decryptable token already validated on
-// the :7860 terminal listener) for mesh origins too.
+// Historically it accepted a request whose source IP is in the Headscale CGNAT
+// range without a token, treating mesh origin as sufficient trust. Source IP is
+// a coarse network signal rather than a caller identity (issue #5028), so this
+// tightens the check to require the per-org terminal token (the same
+// server-decryptable token already validated on the :7860 terminal listener)
+// for mesh origins too.
 //
 // The mesh-origin bypass is dropped only when requireControlToken is set (the
 // deliberate flip, wired from CITADEL_REQUIRE_CONTROL_TOKEN in cmd/work.go).

--- a/internal/status/ssh_handler_test.go
+++ b/internal/status/ssh_handler_test.go
@@ -300,9 +300,8 @@ func TestSSHPlaintextPathFailsClosed(t *testing.T) {
 
 	key1 := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl test@example.com"
 
-	// A VPN-origin POST (the exact attack the flat mesh allowed) must be refused
-	// and write nothing. SSH-key injection now lives only on the mTLS control
-	// listener (see TestSSHInjectionOverMTLS).
+	// A VPN-origin POST must be refused and write nothing. SSH-key injection now
+	// lives only on the mTLS control listener (see TestSSHInjectionOverMTLS).
 	t.Run("VPN origin no longer deploys keys", func(t *testing.T) {
 		body, _ := json.Marshal(sshAuthorizedKeysRequest{Keys: []string{key1}})
 		req := httptest.NewRequest(http.MethodPost, "/ssh/authorized-keys", bytes.NewReader(body))

--- a/internal/status/ssh_handler_test.go
+++ b/internal/status/ssh_handler_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/terminal"
 )
 
 func TestValidateSSHPublicKey(t *testing.T) {
@@ -403,6 +405,101 @@ func TestRequireVPNOrAuthNoValidator(t *testing.T) {
 
 		if w.Code != http.StatusUnauthorized {
 			t.Errorf("status = %d, want 401", w.Code)
+		}
+	})
+}
+
+// TestRequireControlTokenEnforcement is the #5028 lever B contract: with the
+// control-token flip on, a mesh (VPN-origin) request must present a valid token
+// for THIS node's org. An unauthenticated, wrong-token, or cross-org-token mesh
+// request is rejected; the correct org token passes. It also pins the default:
+// with the flip off, a mesh origin still gets the legacy no-token pass so older
+// relays are not broken at merge.
+func TestRequireControlTokenEnforcement(t *testing.T) {
+	const nodeOrg = "org-a"
+
+	// terminal.MockTokenValidator enforces org matching (returns ErrUnauthorized
+	// when the token's org != the node's org), so it models the cross-org case
+	// that the local mockTokenValidator (which echoes the org back) cannot.
+	validator := terminal.NewMockTokenValidator()
+	validator.AddValidToken("org-a-token", &terminal.TokenInfo{UserID: "u1", OrgID: nodeOrg})
+	validator.AddValidToken("org-b-token", &terminal.TokenInfo{UserID: "u2", OrgID: "org-b"})
+
+	collector := NewCollector(CollectorConfig{NodeName: "test-node"})
+
+	newHandler := func(requireControlToken bool) http.HandlerFunc {
+		srv := NewServer(ServerConfig{
+			TokenValidator:      validator,
+			OrgID:               nodeOrg,
+			RequireControlToken: requireControlToken,
+		}, collector)
+		return srv.requireVPNOrAuth(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "ok")
+		})
+	}
+
+	// The mesh CGNAT source IP an attacking cross-org peer (or the legit relay)
+	// dials from. Under the flip, presence in this range no longer grants access.
+	const meshAddr = "100.64.0.5:12345"
+
+	t.Run("enforcement on", func(t *testing.T) {
+		handler := newHandler(true)
+
+		t.Run("unauthenticated mesh request rejected", func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/agent/worker-restart", nil)
+			req.RemoteAddr = meshAddr // no Authorization header
+			w := httptest.NewRecorder()
+			handler(w, req)
+			if w.Code != http.StatusUnauthorized {
+				t.Errorf("status = %d, want 401 (mesh origin must no longer auto-pass)", w.Code)
+			}
+		})
+
+		t.Run("wrong token from mesh rejected", func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/agent/worker-restart", nil)
+			req.RemoteAddr = meshAddr
+			req.Header.Set("Authorization", "Bearer not-a-real-token")
+			w := httptest.NewRecorder()
+			handler(w, req)
+			if w.Code != http.StatusUnauthorized {
+				t.Errorf("status = %d, want 401", w.Code)
+			}
+		})
+
+		t.Run("cross-org token from mesh rejected", func(t *testing.T) {
+			// A token valid for org-b, presented to an org-a node over the mesh.
+			req := httptest.NewRequest(http.MethodPost, "/agent/worker-restart", nil)
+			req.RemoteAddr = meshAddr
+			req.Header.Set("Authorization", "Bearer org-b-token")
+			w := httptest.NewRecorder()
+			handler(w, req)
+			if w.Code != http.StatusUnauthorized {
+				t.Errorf("status = %d, want 401 (cross-org token must not pass)", w.Code)
+			}
+		})
+
+		t.Run("correct org token from mesh accepted", func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/agent/worker-restart", nil)
+			req.RemoteAddr = meshAddr
+			req.Header.Set("Authorization", "Bearer org-a-token")
+			w := httptest.NewRecorder()
+			handler(w, req)
+			if w.Code != http.StatusOK {
+				t.Errorf("status = %d, want 200 (valid org token must pass)", w.Code)
+			}
+		})
+	})
+
+	t.Run("enforcement off preserves legacy mesh trust", func(t *testing.T) {
+		handler := newHandler(false)
+
+		req := httptest.NewRequest(http.MethodPost, "/agent/worker-restart", nil)
+		req.RemoteAddr = meshAddr // no token
+		w := httptest.NewRecorder()
+		handler(w, req)
+		if w.Code != http.StatusOK {
+			t.Errorf("status = %d, want 200 (default must keep VPN-origin trust for older relays)", w.Code)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Hardens authentication on the node `:8080` status/control server. Control endpoints (`/provision/*`, `/workflow/run`, `/agent/*`) previously trusted callers by source-IP range; this PR adds the ability to require a per-org bearer token for those endpoints instead, as defense-in-depth. Part of the `aceteam-ai/aceteam#5028` hardening track.

## Approach

- Reuses the existing server-decryptable **per-org token** already validated on the `:7860` listener via `terminal.TokenValidator.ValidateToken(token, orgID)` — no new key material or secret store. Presented as `Authorization: Bearer <token>`.
- The token authenticates "a valid token for this node's own org." Durable per-caller identity (coordinator mTLS, #5959) is the follow-up; the SSH-key route already runs on that mTLS listener.

## What changed

- `internal/status/ssh_handler.go` — when enforcement is on, the per-org token becomes mandatory. Adds `RequireControlTokenEnvVar` + `RequireControlTokenEnabled()` (truthy set `1/true/yes/on`, matching the `autostop.go` pattern).
- `internal/status/server.go` — `RequireControlToken` field on `Server` + `ServerConfig`.
- `cmd/work.go` — wires `RequireControlToken` from `CITADEL_REQUIRE_CONTROL_TOKEN`; logs the posture and warns loudly if enforcement is on but no validator is configured (so the fail-closed state is not mistaken for a bug).
- `internal/status/ssh_handler_test.go` — `TestRequireControlTokenEnforcement`: unauth / wrong-token / cross-org-token requests rejected (401); correct org token accepted (200); default-off path preserves existing behavior.

## Rollout (breaking change, so gated)

Default is **OFF** so existing relays keep working at merge. Enable per node via `CITADEL_REQUIRE_CONTROL_TOKEN=true` **after** the relay is updated to present the bearer, in a planned window. Rollback is code-free (unset env + restart). With enforcement on but no validator configured, control endpoints fail closed.

This is the deliberate exception to no-feature-flags-by-default: a breaking-change kill-switch, not a feature flag.

## Testing

- `go build ./...` — clean.
- `go vet ./internal/status/ ./cmd/` — clean.
- `go test ./internal/status/` — pass, including the new enforcement test.

*Generated by Claude Opus 4.8*
