### PR TITLE
feat(services): first-class Bonsai-27B (1-bit) inference service

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -580,6 +580,15 @@ a predictable path the compose mount serves (the HF hub cache path carries an
 unpredictable snapshot hash). `bonsaiCacheDir()` and the compose mount must stay
 in sync (guarded by a test).
 
+**Worker inference routing:** the Redis `llm_inference` handler routes
+`backend: "bonsai"` to the bonsai host port via `executeLlamaCppAt` (the bonsai
+llama-server exposes the identical llama.cpp-server API). See
+`internal/jobs/llm_inference.go`. Direct mesh HTTP to `:8210` also works.
+
+**Known limitation:** `MODEL_CACHE_EVICT` (`internal/jobs/model_cache_evict.go`)
+does not yet handle engine `bonsai` (only vllm/llamacpp/ollama), so a bonsai GGUF
+must be removed manually from `~/citadel-cache/bonsai`. Low-priority follow-up.
+
 **Optional long-context KV tuning:** the compose default mirrors the card
 (`-ngl 99`, no KV-quant flags). For long context, add
 `--flash-attn --cache-type-k q4_0 --cache-type-v q4_0` (quantized V-cache needs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -585,9 +585,23 @@ in sync (guarded by a test).
 llama-server exposes the identical llama.cpp-server API). See
 `internal/jobs/llm_inference.go`. Direct mesh HTTP to `:8210` also works.
 
-**Known limitation:** `MODEL_CACHE_EVICT` (`internal/jobs/model_cache_evict.go`)
-does not yet handle engine `bonsai` (only vllm/llamacpp/ollama), so a bonsai GGUF
-must be removed manually from `~/citadel-cache/bonsai`. Low-priority follow-up.
+**First start builds inline (~7min on Ampere):** because bonsai is build-based,
+the first `SERVICE_START` (or `citadel run --service bonsai`) runs `docker
+compose up -d`, which builds the image before returning. This is safe on the
+deploy path: `SERVICE_START` is in the worker watchdog's *unbounded* tier (see
+Consume-Loop Watchdog above) and the compose-up exec carries no context deadline,
+so the inline build is not killed. Subsequent starts reuse the cached image.
+
+**Known limitations:**
+- **Ampere-only image (compute 8.6).** The Dockerfile defaults
+  `CUDA_ARCHITECTURES=86` (RTX 3090, citadel's target node) — this also cuts
+  build time. On a different GPU (4090=89, A100=80, ...) the built image starts
+  but fails at inference with "no kernel image available for execution on the
+  device". Override via the build ARG (`--build-arg CUDA_ARCHITECTURES=89` or a
+  `;`-list) for other hardware.
+- `MODEL_CACHE_EVICT` (`internal/jobs/model_cache_evict.go`) does not yet handle
+  engine `bonsai` (only vllm/llamacpp/ollama), so a bonsai GGUF must be removed
+  manually from `~/citadel-cache/bonsai`. Low-priority follow-up.
 
 **Optional long-context KV tuning:** the compose default mirrors the card
 (`-ngl 99`, no KV-quant flags). For long context, add

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -541,6 +541,74 @@ Status command detects NVIDIA GPUs using:
 ### Service Management
 Services are started with `docker compose -f <path> -p citadel-<name> up -d`. The `-p` flag ensures consistent naming: `citadel-vllm`, `citadel-ollama`, etc.
 
+### Bonsai service (PrismML Bonsai-27B, 1-bit)
+
+Bonsai-27B is PrismML's 1-bit quantized Qwen3.6-27B. The `bonsai` service serves
+`Bonsai-27B-Q1_0.gguf` (~3.8GB) via an OpenAI-compatible `llama-server`, fitting
+an RTX 3090 (24GB) easily (~5-12GB VRAM by context length).
+
+**Why it needs its own service (not `llamacpp`):** stock llama.cpp lacks the
+`Q1_0_g128` hybrid-attention kernels the GGUF requires. Bonsai builds the
+**PrismML fork** (`https://github.com/PrismML-Eng/llama.cpp`, default branch
+`prism`) with `-DGGML_CUDA=ON`.
+
+**Files:**
+- `services/compose/bonsai.yml` — embedded compose (in `services.ServiceMap`).
+  Serves on container `:8080`, host port `8210` (`services/ports.go`
+  `BonsaiHostPort` / `CITADEL_BONSAI_HOST_PORT`). Mounts `~/citadel-cache/bonsai`
+  at `/models` and serves `/models/${BONSAI_MODEL:-Bonsai-27B-Q1_0.gguf}` with
+  `-ngl 99`.
+- `services/compose/bonsai/Dockerfile` — self-contained; clones the fork and
+  builds `llama-server`. Base `nvidia/cuda:12.4.0-devel-ubuntu22.04`.
+
+**First build-based embedded service (important):** every other `ServiceMap`
+entry uses a prebuilt `image:`; bonsai uses `build: {context: ./bonsai}`. On-node
+materialization historically wrote only `<name>.yml`, so a `build:` context would
+be missing its Dockerfile and `docker compose build` would fail. `services.
+ServiceAuxFiles` + `services.WriteAuxFiles()` fix this: both materialization
+sites (`cmd.ensureComposeFile`, `ServiceHandler.ensureEmbeddedComposeFile`)
+now also write `services/bonsai/Dockerfile`. Any future build-based embedded
+service should register its context files the same way.
+
+**Model pull:** `MODEL_CACHE_PULL` with `engine: "bonsai"` (see
+`internal/jobs/model_cache_pull.go`) runs
+`huggingface-cli download prism-ml/Bonsai-27B-gguf Bonsai-27B-Q1_0.gguf
+--local-dir ~/citadel-cache/bonsai` — the SINGLE GGUF file, not the whole repo
+(which also carries a ~53GB F16 and a drafter). The `--local-dir` is a
+deliberate deviation from a bare `huggingface-cli download` so the file lands at
+a predictable path the compose mount serves (the HF hub cache path carries an
+unpredictable snapshot hash). `bonsaiCacheDir()` and the compose mount must stay
+in sync (guarded by a test).
+
+**Optional long-context KV tuning:** the compose default mirrors the card
+(`-ngl 99`, no KV-quant flags). For long context, add
+`--flash-attn --cache-type-k q4_0 --cache-type-v q4_0` (quantized V-cache needs
+flash attention; not default-on because it can't be validated without GPU
+inference).
+
+**Live inference is a documented human step:** node 1084's GPU is VRAM-contended
+(vLLM holds ~21GB); do NOT stop vLLM to validate. Bonsai fits alongside once VRAM
+is free.
+
+**AceTeam-side follow-up (different repo, NOT done here):** to make Bonsai
+deployable from `/fabric/models` (`fabric_catalog_models`), add a catalog entry
+in `aceteam` `data/model_catalog.json` (and the `fabric_catalog_models` source)
+shaped like:
+```json
+{
+  "id": "bonsai-27b",
+  "name": "Bonsai-27B (1-bit)",
+  "engine": "bonsai",
+  "source": "prism-ml/Bonsai-27B-gguf",
+  "gguf_file": "Bonsai-27B-Q1_0.gguf",
+  "vram_gb": { "min": 5, "recommended": 8, "max_context": 12 },
+  "context_length": 262144,
+  "tags": ["gguf", "1-bit", "qwen3.6", "cuda", "llamacpp-fork"]
+}
+```
+The `engine` must be `bonsai` so the node routes `MODEL_CACHE_PULL` to the
+single-file GGUF pull and `SERVICE_START` to `services/compose/bonsai.yml`.
+
 ### Service Idle Detection and Auto-Stop (citadel #416)
 
 Managed services carry a per-service usage/idle signal so a node can tell whether an engine is actually being used or is pinning VRAM/RAM while idle. This is surfaced on the heartbeat and to operators, and can optionally drive auto-eviction.

--- a/cmd/manifest.go
+++ b/cmd/manifest.go
@@ -384,7 +384,10 @@ func ensureComposeFile(configDir, serviceName string) error {
 
 	// Check if file already exists
 	if _, err := os.Stat(destPath); err == nil {
-		return nil // Already exists
+		// Still ensure any build-context aux files exist (idempotent), so a
+		// build-based service like bonsai is startable even if its .yml was
+		// materialized by an older binary that predated WriteAuxFiles.
+		return services.WriteAuxFiles(servicesDir, serviceName)
 	}
 
 	// Get content from embedded services
@@ -403,5 +406,7 @@ func ensureComposeFile(configDir, serviceName string) error {
 		return fmt.Errorf("failed to write compose file: %w", err)
 	}
 
-	return nil
+	// Materialize any build-context files the service needs (e.g. bonsai's
+	// Dockerfile), so `docker compose build` resolves on the node.
+	return services.WriteAuxFiles(servicesDir, serviceName)
 }

--- a/internal/apps/hostport_collision_test.go
+++ b/internal/apps/hostport_collision_test.go
@@ -114,6 +114,7 @@ func publishedHostPorts(composeYAML string) ([]int, error) {
 		services.EnvExtractionHostPort: services.ExtractionHostPort,
 		services.EnvDiffusersHostPort:  services.DiffusersHostPort,
 		services.EnvClaudecodeHostPort: services.ClaudecodeHostPort,
+		services.EnvBonsaiHostPort:     services.BonsaiHostPort,
 	}
 
 	var out []int

--- a/internal/jobs/llm_inference.go
+++ b/internal/jobs/llm_inference.go
@@ -53,9 +53,20 @@ func (h *LLMInferenceHandler) Execute(ctx context.Context, client *redisclient.C
 		return h.executeOllama(ctx, client, job.JobID, rayID, payload)
 	case "llamacpp":
 		return h.executeLlamaCpp(ctx, client, job.JobID, rayID, payload)
+	case "bonsai":
+		// Bonsai serves the same llama.cpp-server API as llamacpp, just on the
+		// bonsai host port (built from the PrismML fork). Reuse the llama.cpp
+		// request/stream path pointed at the bonsai endpoint.
+		return h.executeLlamaCppAt(ctx, client, job.JobID, rayID, payload, bonsaiBaseURL())
 	default:
 		return fmt.Errorf("unsupported backend: %s", payload.Backend)
 	}
+}
+
+// bonsaiBaseURL returns the host-local base URL for the bonsai engine using the
+// citadel-owned host port (services/ports.go).
+func bonsaiBaseURL() string {
+	return fmt.Sprintf("http://localhost:%d", services.BonsaiHostPort)
 }
 
 // extractRayID gets the rayId from a redis.Job's RawData or Payload.
@@ -454,7 +465,14 @@ func (h *LLMInferenceHandler) handleOllamaNonStream(ctx context.Context, client 
 
 // executeLlamaCpp handles inference via llama.cpp server API.
 func (h *LLMInferenceHandler) executeLlamaCpp(ctx context.Context, client *redisclient.Client, jobID, rayID string, payload *LLMInferencePayload) error {
-	llamaCppURL := llamacppBaseURL() + "/completion"
+	return h.executeLlamaCppAt(ctx, client, jobID, rayID, payload, llamacppBaseURL())
+}
+
+// executeLlamaCppAt runs a llama.cpp-server inference against an explicit base
+// URL. Shared by the llamacpp and bonsai backends (bonsai is the PrismML
+// llama.cpp fork serving the identical API on its own host port).
+func (h *LLMInferenceHandler) executeLlamaCppAt(ctx context.Context, client *redisclient.Client, jobID, rayID string, payload *LLMInferencePayload, baseURL string) error {
+	llamaCppURL := baseURL + "/completion"
 
 	reqPayload := map[string]any{
 		"prompt":      payload.Prompt,

--- a/internal/jobs/model_cache_pull.go
+++ b/internal/jobs/model_cache_pull.go
@@ -58,9 +58,65 @@ func (h *ModelCachePullHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte,
 		return h.pullOllama(ctx, job.ID, modelName)
 	case "vllm", "llamacpp":
 		return h.pullHuggingFace(ctx, job.ID, modelName, engine)
+	case "bonsai":
+		return h.pullBonsai(ctx, job.ID)
 	default:
-		return nil, fmt.Errorf("unsupported engine %q: must be ollama, vllm, or llamacpp", engine)
+		return nil, fmt.Errorf("unsupported engine %q: must be ollama, vllm, llamacpp, or bonsai", engine)
 	}
+}
+
+// Bonsai-27B GGUF coordinates. The MODEL_CACHE_PULL for engine "bonsai" pulls
+// exactly this one file (NOT the whole repo, which also carries a ~53GB F16 and
+// a drafter GGUF) into a fixed local dir the bonsai compose mounts at /models.
+const (
+	bonsaiRepo     = "prism-ml/Bonsai-27B-gguf"
+	bonsaiGGUFFile = "Bonsai-27B-Q1_0.gguf"
+)
+
+// bonsaiCacheDir is the fixed local dir the bonsai GGUF is downloaded into. It
+// MUST match services/compose/bonsai.yml's `~/citadel-cache/bonsai:/models`
+// mount, or the served path (/models/Bonsai-27B-Q1_0.gguf) will not exist.
+func bonsaiCacheDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join("citadel-cache", "bonsai")
+	}
+	return filepath.Join(home, "citadel-cache", "bonsai")
+}
+
+// pullBonsai downloads the single Bonsai-27B-Q1_0.gguf file via huggingface-cli
+// into bonsaiCacheDir(). Deviates from the task's bare command by adding
+// --local-dir so the file lands at a predictable path the compose mount can
+// serve (the HF hub cache path carries an unpredictable snapshot hash).
+func (h *ModelCachePullHandler) pullBonsai(ctx JobContext, jobID string) ([]byte, error) {
+	localDir := bonsaiCacheDir()
+	ctx.Log("info", "     - [Job %s] Pulling Bonsai GGUF '%s' from %s into %s via huggingface-cli", jobID, bonsaiGGUFFile, bonsaiRepo, localDir)
+
+	cmd := BuildBonsaiDownloadCommand(localDir)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return output, fmt.Errorf("huggingface-cli download failed: %w", err)
+	}
+
+	var sizeBytes int64
+	if fi, statErr := os.Stat(filepath.Join(localDir, bonsaiGGUFFile)); statErr == nil {
+		sizeBytes = fi.Size()
+	}
+
+	result := modelCachePullResult{
+		Status:    "cached",
+		ModelName: bonsaiGGUFFile,
+		SizeBytes: sizeBytes,
+		Engine:    "bonsai",
+	}
+	return json.Marshal(result)
+}
+
+// BuildBonsaiDownloadCommand returns the exec.Cmd that downloads the single
+// Bonsai-27B-Q1_0.gguf file into localDir. Exported for testing command
+// construction.
+func BuildBonsaiDownloadCommand(localDir string) *exec.Cmd {
+	return exec.Command("huggingface-cli", "download", bonsaiRepo, bonsaiGGUFFile, "--local-dir", localDir)
 }
 
 // pullOllama runs `ollama pull <model>` to cache the model locally.

--- a/internal/jobs/model_cache_pull_bonsai_test.go
+++ b/internal/jobs/model_cache_pull_bonsai_test.go
@@ -52,3 +52,15 @@ func TestBonsaiCacheDirMatchesComposeMount(t *testing.T) {
 		t.Errorf("bonsaiCacheDir() = %q, want it to end with citadel-cache/bonsai (the compose mount)", dir)
 	}
 }
+
+// TestBonsaiBaseURLUsesRegisteredPort pins the worker inference routing for the
+// bonsai backend to the citadel-owned host port (services.BonsaiHostPort),
+// mirroring the llamacpp routing. The bonsai llama-server exposes the identical
+// llama.cpp-server API, so it reuses executeLlamaCppAt against this URL.
+func TestBonsaiBaseURLUsesRegisteredPort(t *testing.T) {
+	got := bonsaiBaseURL()
+	want := "http://localhost:8210"
+	if got != want {
+		t.Errorf("bonsaiBaseURL() = %q, want %q (services.BonsaiHostPort)", got, want)
+	}
+}

--- a/internal/jobs/model_cache_pull_bonsai_test.go
+++ b/internal/jobs/model_cache_pull_bonsai_test.go
@@ -1,0 +1,54 @@
+package jobs
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBuildBonsaiDownloadCommand pins the exact huggingface-cli invocation for a
+// bonsai MODEL_CACHE_PULL: it must download the single Bonsai-27B-Q1_0.gguf file
+// from prism-ml/Bonsai-27B-gguf (NOT the whole repo, which also carries a ~53GB
+// F16 and a drafter GGUF) into the fixed --local-dir the compose mounts.
+func TestBuildBonsaiDownloadCommand(t *testing.T) {
+	localDir := "/home/tester/citadel-cache/bonsai"
+	cmd := BuildBonsaiDownloadCommand(localDir)
+
+	args := cmd.Args
+	if len(args) < 6 {
+		t.Fatalf("expected huggingface-cli download command with local-dir, got %v", args)
+	}
+	if !strings.Contains(args[0], "huggingface-cli") {
+		t.Errorf("expected huggingface-cli, got %q", args[0])
+	}
+	joined := strings.Join(args, " ")
+	for _, want := range []string{"download", "prism-ml/Bonsai-27B-gguf", "Bonsai-27B-Q1_0.gguf", "--local-dir", localDir} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("bonsai download command missing %q; got: %s", want, joined)
+		}
+	}
+	// Must be a single-file pull: the repo id must be immediately followed by the
+	// specific GGUF filename (not a bare repo download).
+	repoIdx, fileIdx := -1, -1
+	for i, a := range args {
+		switch a {
+		case "prism-ml/Bonsai-27B-gguf":
+			repoIdx = i
+		case "Bonsai-27B-Q1_0.gguf":
+			fileIdx = i
+		}
+	}
+	if repoIdx < 0 || fileIdx != repoIdx+1 {
+		t.Errorf("expected the GGUF filename to follow the repo id (single-file pull); args=%v", args)
+	}
+}
+
+// TestBonsaiCacheDirMatchesComposeMount guards the pull-serve coherence
+// contract: the download dir must be ~/citadel-cache/bonsai, exactly what
+// services/compose/bonsai.yml mounts at /models. If these drift, the served
+// path /models/Bonsai-27B-Q1_0.gguf will not exist.
+func TestBonsaiCacheDirMatchesComposeMount(t *testing.T) {
+	dir := bonsaiCacheDir()
+	if !strings.HasSuffix(dir, "citadel-cache/bonsai") {
+		t.Errorf("bonsaiCacheDir() = %q, want it to end with citadel-cache/bonsai (the compose mount)", dir)
+	}
+}

--- a/internal/jobs/queue_types.go
+++ b/internal/jobs/queue_types.go
@@ -73,7 +73,7 @@ type LLMInferencePayload struct {
 	Stream bool `json:"stream"`
 
 	// Backend specifies which inference engine to use
-	Backend string `json:"backend"` // "vllm", "sglang", "ollama", "llamacpp"
+	Backend string `json:"backend"` // "vllm", "sglang", "ollama", "llamacpp", "bonsai"
 
 	// Stop sequences to end generation
 	Stop []string `json:"stop,omitempty"`

--- a/internal/jobs/service_handler.go
+++ b/internal/jobs/service_handler.go
@@ -593,7 +593,9 @@ func (h *ServiceHandler) ensureEmbeddedComposeFile(name string) error {
 	servicesDir := filepath.Join(h.ConfigDir, "services")
 	destPath := filepath.Join(servicesDir, name+".yml")
 	if _, err := os.Stat(destPath); err == nil {
-		return nil // already materialized
+		// Ensure build-context aux files exist even if the .yml was written by
+		// an older binary (idempotent no-op for image-based services).
+		return embeddedservices.WriteAuxFiles(servicesDir, name)
 	}
 	if err := os.MkdirAll(servicesDir, 0755); err != nil {
 		return fmt.Errorf("failed to create services directory: %w", err)
@@ -602,7 +604,9 @@ func (h *ServiceHandler) ensureEmbeddedComposeFile(name string) error {
 	if err := os.WriteFile(destPath, []byte(content), 0600); err != nil {
 		return fmt.Errorf("failed to write compose file: %w", err)
 	}
-	return nil
+	// Materialize any build-context files (e.g. bonsai's Dockerfile) so the
+	// compose `build:` resolves on the node.
+	return embeddedservices.WriteAuxFiles(servicesDir, name)
 }
 
 // addServiceToManifestFile appends a single service block to the citadel.yaml

--- a/services/compose/bonsai.yml
+++ b/services/compose/bonsai.yml
@@ -1,0 +1,54 @@
+# services/compose/bonsai.yml
+#
+# Serves PrismML's Bonsai-27B (1-bit quantized Qwen3.6-27B) via an
+# OpenAI-compatible llama-server built from the PrismML fork of llama.cpp
+# (see services/compose/bonsai/Dockerfile). The 1-bit GGUF is ~3.8GB and fits an
+# RTX 3090 (24GB) easily (~5-12GB VRAM incl. KV cache by context length).
+#
+# UNLIKE every other embedded service (llamacpp, vllm, diffusers, ...), which
+# pull a prebuilt `image:`, bonsai BUILDS its image from a Dockerfile because no
+# prebuilt image for the fork is published. The `build.context: ./bonsai` is
+# relative to this compose file's directory; citadel materializes the Dockerfile
+# to <config>/services/bonsai/Dockerfile via services.WriteAuxFiles so the build
+# resolves on the node.
+#
+# Model file: MODEL_CACHE_PULL for engine "bonsai" downloads exactly
+# Bonsai-27B-Q1_0.gguf from prism-ml/Bonsai-27B-gguf into ~/citadel-cache/bonsai
+# (huggingface-cli ... --local-dir), which is mounted below at /models. Override
+# the served file with BONSAI_MODEL (e.g. a different quant) the same way vllm
+# uses VLLM_MODEL.
+
+services:
+  bonsai:
+    build:
+      context: ./bonsai
+      dockerfile: Dockerfile
+    image: citadel-bonsai:local
+    container_name: citadel-bonsai
+    # Host port is owned by citadel (services/ports.go), supplied via
+    # CITADEL_BONSAI_HOST_PORT; the :? guard fails loudly if citadel forgot to
+    # supply it. Left on the default 0.0.0.0 bind because peers reach this engine
+    # directly over the mesh. The container serves the OpenAI API on :8080.
+    ports:
+      - "${CITADEL_BONSAI_HOST_PORT:?citadel must supply CITADEL_BONSAI_HOST_PORT}:8080"
+    volumes:
+      # MODEL_CACHE_PULL (engine=bonsai) drops Bonsai-27B-Q1_0.gguf here.
+      - ~/citadel-cache/bonsai:/models
+    # -ngl 99 offloads all layers to the GPU (the card's recommended command).
+    # Optional long-context tuning (NOT default-on: quantized V-cache requires
+    # flash attention and can fail startup on some builds, which we cannot
+    # validate here without GPU inference):
+    #   --flash-attn --cache-type-k q4_0 --cache-type-v q4_0
+    command: >-
+      --host 0.0.0.0
+      --port 8080
+      --model /models/${BONSAI_MODEL:-Bonsai-27B-Q1_0.gguf}
+      -ngl 99
+    restart: unless-stopped
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/services/compose/bonsai/Dockerfile
+++ b/services/compose/bonsai/Dockerfile
@@ -47,7 +47,8 @@ WORKDIR /opt/llama.cpp
 # build/bin/llama-server.
 RUN cmake -B build -DGGML_CUDA=ON -DLLAMA_CURL=ON \
         -DCMAKE_CUDA_ARCHITECTURES="${CUDA_ARCHITECTURES}" \
-        -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/cuda/lib64/stubs" \
+        -DCMAKE_SHARED_LINKER_FLAGS="-L/usr/local/cuda/lib64/stubs -lcuda" \
+        -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/cuda/lib64/stubs -lcuda" \
     && cmake --build build --config Release -j "$(nproc)" --target llama-server \
     && cp build/bin/llama-server /usr/local/bin/llama-server
 

--- a/services/compose/bonsai/Dockerfile
+++ b/services/compose/bonsai/Dockerfile
@@ -1,0 +1,41 @@
+# services/compose/bonsai/Dockerfile
+#
+# Builds an OpenAI-compatible llama-server for PrismML's Bonsai-27B (1-bit
+# quantized Qwen3.6-27B) on CUDA. Stock llama.cpp does NOT support the
+# Q1_0_g128 hybrid-attention kernels the Bonsai-27B-Q1_0.gguf needs, so we build
+# the PrismML fork (https://github.com/PrismML-Eng/llama.cpp), whose default
+# branch is `prism`. Verified against the model card + fork on 2026-07: no
+# release tag is published for Bonsai support, so we pin to the branch (override
+# LLAMACPP_REF with a commit for a reproducible build once one is cut).
+#
+# This Dockerfile is self-contained: it clones the fork itself and COPYs nothing
+# from the build context, so the context can be an otherwise-empty directory.
+# citadel materializes it to <config>/services/bonsai/Dockerfile alongside
+# bonsai.yml (services.WriteAuxFiles) so the compose `build.context: ./bonsai`
+# resolves on the node.
+
+ARG CUDA_VERSION=12.4.0
+FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu22.04
+
+ARG LLAMACPP_REPO=https://github.com/PrismML-Eng/llama.cpp
+ARG LLAMACPP_REF=prism
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git cmake build-essential ca-certificates \
+        libcurl4-openssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt
+RUN git clone --depth 1 --branch "${LLAMACPP_REF}" "${LLAMACPP_REPO}" llama.cpp
+
+WORKDIR /opt/llama.cpp
+# -DGGML_CUDA=ON matches the fork's documented build. Build only the server
+# target to keep the image + build time down; llama-server lands at
+# build/bin/llama-server.
+RUN cmake -B build -DGGML_CUDA=ON -DLLAMA_CURL=ON \
+    && cmake --build build --config Release -j "$(nproc)" --target llama-server \
+    && cp build/bin/llama-server /usr/local/bin/llama-server
+
+EXPOSE 8080
+ENTRYPOINT ["/usr/local/bin/llama-server"]

--- a/services/compose/bonsai/Dockerfile
+++ b/services/compose/bonsai/Dockerfile
@@ -19,12 +19,24 @@ FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu22.04
 
 ARG LLAMACPP_REPO=https://github.com/PrismML-Eng/llama.cpp
 ARG LLAMACPP_REF=prism
+# Target GPU compute capability. Default 86 = RTX 3090/Ampere (citadel's target
+# node). This also cuts build time ~5x vs. compiling every arch. Override to
+# build for other GPUs, e.g. 89 (Ada/4090) or "86;89".
+ARG CUDA_ARCHITECTURES=86
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
         git cmake build-essential ca-certificates \
         libcurl4-openssl-dev \
     && rm -rf /var/lib/apt/lists/*
+
+# The -devel image ships the CUDA Driver API only as a link stub under
+# lib64/stubs (libcuda.so). Without it on the link path, the final llama-server
+# link fails with "undefined reference to cuGetErrorString / cuMemMap / ...".
+# LIBRARY_PATH lets ld resolve -lcuda at build time; the real driver is injected
+# by the NVIDIA container runtime at runtime, so the stub is build-only.
+ENV LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LIBRARY_PATH}
+RUN ln -sf /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1
 
 WORKDIR /opt
 RUN git clone --depth 1 --branch "${LLAMACPP_REF}" "${LLAMACPP_REPO}" llama.cpp
@@ -34,6 +46,8 @@ WORKDIR /opt/llama.cpp
 # target to keep the image + build time down; llama-server lands at
 # build/bin/llama-server.
 RUN cmake -B build -DGGML_CUDA=ON -DLLAMA_CURL=ON \
+        -DCMAKE_CUDA_ARCHITECTURES="${CUDA_ARCHITECTURES}" \
+        -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/cuda/lib64/stubs" \
     && cmake --build build --config Release -j "$(nproc)" --target llama-server \
     && cp build/bin/llama-server /usr/local/bin/llama-server
 

--- a/services/embed.go
+++ b/services/embed.go
@@ -3,6 +3,9 @@ package services
 
 import (
 	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
 )
 
@@ -30,6 +33,16 @@ var TranscribeCompose string
 //go:embed compose/diffusers.yml
 var DiffusersCompose string
 
+//go:embed compose/bonsai.yml
+var BonsaiCompose string
+
+// BonsaiDockerfile is the build-context Dockerfile for the bonsai service. It is
+// materialized to <config>/services/bonsai/Dockerfile (see WriteAuxFiles) so the
+// compose `build.context: ./bonsai` resolves on the node.
+//
+//go:embed compose/bonsai/Dockerfile
+var BonsaiDockerfile string
+
 // ServiceMap provides a lookup for pre-packaged service compose files.
 var ServiceMap = map[string]string{
 	"ollama":     OllamaCompose,
@@ -40,6 +53,43 @@ var ServiceMap = map[string]string{
 	"extraction": ExtractionCompose,
 	"transcribe": TranscribeCompose,
 	"diffusers":  DiffusersCompose,
+	"bonsai":     BonsaiCompose,
+}
+
+// ServiceAuxFiles maps a service name to auxiliary build-context files
+// (path relative to the node's services/ dir -> content) that must be
+// materialized alongside the service's <name>.yml for it to start.
+//
+// bonsai is the first embedded service that BUILDS its image from a Dockerfile
+// (every other entry uses a prebuilt image:), so its compose
+// `build.context: ./bonsai` needs services/bonsai/Dockerfile on disk. Without
+// this the .yml materializes fine but `docker compose build` on the node fails
+// with "Dockerfile not found".
+var ServiceAuxFiles = map[string]map[string]string{
+	"bonsai": {
+		filepath.Join("bonsai", "Dockerfile"): BonsaiDockerfile,
+	},
+}
+
+// WriteAuxFiles materializes any build-context files a service needs into
+// servicesDir (the node's <config>/services directory). It is idempotent and a
+// no-op for services with no aux files. Callers invoke it wherever they
+// materialize a service's <name>.yml so a build-based service is startable.
+func WriteAuxFiles(servicesDir, name string) error {
+	aux, ok := ServiceAuxFiles[name]
+	if !ok {
+		return nil
+	}
+	for rel, content := range aux {
+		dest := filepath.Join(servicesDir, rel)
+		if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+			return fmt.Errorf("create build-context dir for %s: %w", name, err)
+		}
+		if err := os.WriteFile(dest, []byte(content), 0644); err != nil {
+			return fmt.Errorf("write build-context file %s: %w", rel, err)
+		}
+	}
+	return nil
 }
 
 // GetAvailableServices returns a sorted list of service names.

--- a/services/embed_test.go
+++ b/services/embed_test.go
@@ -4,6 +4,8 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -91,6 +93,73 @@ func TestDiffusersComposeContract(t *testing.T) {
 	}
 }
 
+// TestBonsaiComposeRegistered ensures the bonsai service (PrismML Bonsai-27B via
+// the llama.cpp fork) is in the ServiceMap so `citadel run --service bonsai`,
+// the manifest, and SERVICE_START can find it.
+func TestBonsaiComposeRegistered(t *testing.T) {
+	if _, ok := ServiceMap["bonsai"]; !ok {
+		t.Fatal("bonsai not found in ServiceMap")
+	}
+	found := false
+	for _, s := range GetAvailableServices() {
+		if s == "bonsai" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("GetAvailableServices() does not include bonsai")
+	}
+}
+
+// TestBonsaiComposeContract verifies bonsai is the one embedded service that
+// BUILDS its image (not a prebuilt image:), so its build context Dockerfile must
+// be materializable via WriteAuxFiles, and its host publish must defer to the
+// citadel-owned env var.
+func TestBonsaiComposeContract(t *testing.T) {
+	content := ServiceMap["bonsai"]
+	if !strings.Contains(content, "build:") {
+		t.Errorf("bonsai compose should use a build: section (no prebuilt image is published)")
+	}
+	if !strings.Contains(content, "${CITADEL_BONSAI_HOST_PORT") {
+		t.Errorf("bonsai compose must defer its host port to CITADEL_BONSAI_HOST_PORT")
+	}
+	// The build-context Dockerfile must be registered so it lands on the node.
+	aux, ok := ServiceAuxFiles["bonsai"]
+	if !ok {
+		t.Fatal("ServiceAuxFiles missing bonsai; the build context Dockerfile would never materialize")
+	}
+	if _, ok := aux[filepath.Join("bonsai", "Dockerfile")]; !ok {
+		t.Errorf("ServiceAuxFiles[bonsai] missing bonsai/Dockerfile")
+	}
+}
+
+// TestWriteAuxFilesMaterializesBonsaiDockerfile proves WriteAuxFiles writes the
+// build-context Dockerfile to disk (the fix for bonsai being the first
+// build-based embedded service; a .yml-only materialization would fail
+// `docker compose build`).
+func TestWriteAuxFilesMaterializesBonsaiDockerfile(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteAuxFiles(dir, "bonsai"); err != nil {
+		t.Fatalf("WriteAuxFiles(bonsai): %v", err)
+	}
+	dockerfile := filepath.Join(dir, "bonsai", "Dockerfile")
+	data, err := os.ReadFile(dockerfile)
+	if err != nil {
+		t.Fatalf("expected %s to exist: %v", dockerfile, err)
+	}
+	if !strings.Contains(string(data), "PrismML-Eng/llama.cpp") {
+		t.Errorf("materialized Dockerfile does not reference the PrismML fork")
+	}
+	// No-op for an image-based service.
+	if err := WriteAuxFiles(dir, "vllm"); err != nil {
+		t.Fatalf("WriteAuxFiles(vllm) should be a no-op, got: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "vllm")); !os.IsNotExist(err) {
+		t.Errorf("WriteAuxFiles(vllm) should not create any files")
+	}
+}
+
 // composeHostPorts returns the host-side ports declared in a compose file's
 // `ports:` list entries ("HOST:CONTAINER"). Pure parse (no Docker) so the
 // host-port collision assertions run in ordinary CI.
@@ -112,6 +181,7 @@ func composeHostPorts(t *testing.T, composeYAML string) []int {
 		EnvVLLMHostPort:       VLLMHostPort,
 		EnvExtractionHostPort: ExtractionHostPort,
 		EnvDiffusersHostPort:  DiffusersHostPort,
+		EnvBonsaiHostPort:     BonsaiHostPort,
 	}
 	var hosts []int
 	for _, svc := range doc.Services {

--- a/services/known_hashes.go
+++ b/services/known_hashes.go
@@ -59,4 +59,7 @@ var KnownComposeHashes = map[string]map[string]bool{
 		"81bac6f3c78623c1c08761b1fb99718717e84891459cc50d012d02e88cdd32f7": true,
 		"83842c7faf86de64d7728e0178690f69a0819354d0f290edbcf3d40ea5f01807": true,
 	},
+	"bonsai": {
+		"124af757f45e93b689bc6a59f08187d48f59c0e62eb2d10c6a006c8ac4d24609": true,
+	},
 }

--- a/services/ports.go
+++ b/services/ports.go
@@ -58,6 +58,12 @@ const (
 	// registered here so `citadel module install gotenberg` injects the port via
 	// the same HostPortEnv() mechanism.
 	EnvGotenbergHostPort = "CITADEL_GOTENBERG_HOST_PORT"
+	// EnvBonsaiHostPort carries the host port for the bonsai inference service
+	// (PrismML Bonsai-27B via the llama.cpp fork). Unlike claudecode/meeting/
+	// gotenberg, bonsai is an EMBEDDED ServiceMap compose (services/compose/
+	// bonsai.yml), so its compose defers the host publish to this var exactly
+	// like llamacpp/vllm.
+	EnvBonsaiHostPort = "CITADEL_BONSAI_HOST_PORT"
 )
 
 // Citadel-assigned host ports for the pre-packaged compose services. These are
@@ -107,6 +113,13 @@ const (
 	// is 3000; this is the HOST publish, bound to 127.0.0.1 only (Gotenberg has
 	// no auth of its own).
 	GotenbergHostPort = 8209
+	// bonsai: PrismML Bonsai-27B (1-bit Qwen3.6-27B) served by an
+	// OpenAI-compatible llama-server built from the PrismML llama.cpp fork
+	// (services/compose/bonsai.yml). Next free slot in the 8200 block after
+	// gotenberg's 8209 (8205 stays earmarked for Hermes/OpenClaw). It is an
+	// embedded ServiceMap compose, so its container serves on :8080 and this is
+	// the HOST publish.
+	BonsaiHostPort = 8210
 )
 
 // ServiceHostPorts maps service name -> citadel-assigned host port. Most entries
@@ -125,6 +138,7 @@ var ServiceHostPorts = map[string]int{
 	"meeting":     MeetingdHostPort,
 	"meeting-cdp": MeetingCDPHostPort,
 	"gotenberg":   GotenbergHostPort,
+	"bonsai":      BonsaiHostPort,
 }
 
 // serviceHostPortEnv maps each managed service to the compose env-var that
@@ -138,6 +152,7 @@ var serviceHostPortEnv = map[string]string{
 	"meeting":     EnvMeetingdHostPort,
 	"meeting-cdp": EnvMeetingCDPHostPort,
 	"gotenberg":   EnvGotenbergHostPort,
+	"bonsai":      EnvBonsaiHostPort,
 }
 
 // HostPortEnv returns "KEY=value" entries for every citadel-managed host port,

--- a/services/ports_test.go
+++ b/services/ports_test.go
@@ -161,3 +161,39 @@ func TestControlMTLSPortAvoidsKnownSurfaces(t *testing.T) {
 		}
 	}
 }
+
+// TestBonsaiHostPortRegistered pins the bonsai inference service's host port
+// (PrismML Bonsai-27B via the llama.cpp fork). Unlike claudecode/meeting/
+// gotenberg, bonsai IS an embedded ServiceMap compose, so its .yml defers the
+// host publish to CITADEL_BONSAI_HOST_PORT and this registry must resolve it.
+func TestBonsaiHostPortRegistered(t *testing.T) {
+	got, ok := ServiceHostPorts["bonsai"]
+	if !ok || got != BonsaiHostPort {
+		t.Errorf("ServiceHostPorts[%q] = %d (present=%v), want %d", "bonsai", got, ok, BonsaiHostPort)
+	}
+	if _, ok := serviceHostPortEnv["bonsai"]; !ok {
+		t.Errorf("serviceHostPortEnv is missing %q; HostPortEnv() will not inject its host port", "bonsai")
+	}
+	if BonsaiHostPort >= AppsPortRangeStart && BonsaiHostPort <= AppsPortRangeEnd {
+		t.Errorf("bonsai host port %d sits inside the apps auto-allocation range %d-%d", BonsaiHostPort, AppsPortRangeStart, AppsPortRangeEnd)
+	}
+	if name, taken := ReservedCitadelPorts[BonsaiHostPort]; taken {
+		t.Errorf("bonsai host port %d collides with reserved citadel port %q", BonsaiHostPort, name)
+	}
+	for svc, port := range ServiceHostPorts {
+		if svc != "bonsai" && port == BonsaiHostPort {
+			t.Errorf("bonsai host port %d collides with managed service %q", BonsaiHostPort, svc)
+		}
+	}
+	// HostPortEnv must emit the bonsai var so its compose resolves.
+	want := EnvBonsaiHostPort + "=8210"
+	found := false
+	for _, kv := range HostPortEnv() {
+		if kv == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("HostPortEnv() did not emit %q", want)
+	}
+}


### PR DESCRIPTION
## Context
Run PrismML's **Bonsai-27B** — a 1-bit ("binary g128", ~1.125 bits/weight) quant of Qwen3.6-27B, ~54GB→3.9GB, ~89.5% of FP16 benchmark avg — on a Citadel NVIDIA node. The MLX build is Apple-only; the CUDA/Linux path is the GGUF `Bonsai-27B-Q1_0.gguf` served by PrismML's **custom llama.cpp fork** (stock llama.cpp lacks the Q1_0_g128 kernels). Fits an RTX 3090 easily (~3.8GB weights + KV).

## What's added
- **`services/compose/bonsai.yml`** — embedded in `services.ServiceMap`; NVIDIA runtime, serves `/models/${BONSAI_MODEL:-Bonsai-27B-Q1_0.gguf}` via `llama-server -ngl 99`. First embedded service to use `build:` (no prebuilt image published).
- **`services/compose/bonsai/Dockerfile`** — clones `github.com/PrismML-Eng/llama.cpp` (branch `prism`, verified live), builds `-DGGML_CUDA=ON`, `CUDA_ARCHITECTURES=86` (Ampere/3090; ARG-overridable, ~5× faster build).
- **Port `8210`** (`BonsaiHostPort` / `CITADEL_BONSAI_HOST_PORT`) — next free after gotenberg 8209; registered in both port maps + resolver tests.
- **Pull mapping:** `MODEL_CACHE_PULL` engine `bonsai` → `huggingface-cli download prism-ml/Bonsai-27B-gguf Bonsai-27B-Q1_0.gguf --local-dir ~/citadel-cache/bonsai` (single file, not the ~53GB repo; local-dir matches the compose mount).
- **Inference routing:** `llm_inference` backend `bonsai` → `:8210` via new `executeLlamaCppAt` (bonsai serves the identical llama.cpp-server API).
- **Materialization fix:** on-node service materialization was `.yml`-only; a `build:` context needs the Dockerfile too. `ServiceAuxFiles`/`WriteAuxFiles()` now writes `services/bonsai/Dockerfile` at both materialization sites (`cmd/manifest.go` + `internal/jobs/service_handler.go`); verified `docker compose config` resolves the build context.

## Docker build: SUCCEEDED
3 iterations. Root cause of the first two link failures: the CUDA devel image ships `libcuda.so` only as a stub, so `libggml-cuda.so` had unresolved driver symbols. Fixed with `-lcuda` + stubs dir on both shared and exe linker flags. Final image builds; `llama-server --version`/`--help` run. **Runtime GPU inference is a documented human step** (real driver injected by the NVIDIA runtime) — not run here, and vLLM / running services were left untouched (node GPU is VRAM-contended).

## Tests
`go build ./...`, `go vet`, full `go test ./...` green. New `model_cache_pull_bonsai_test.go` (pull-command + cache/mount coherence + routing); port/embed resolver tests updated.

## AceTeam-side follow-up (separate repo, NOT in this PR)
Add a `bonsai-27b` entry to `data/model_catalog.json` + `fabric_catalog_models` with `engine: bonsai`, `source: prism-ml/Bonsai-27B-gguf` so it's deployable from /fabric/models. First deploy builds the image inline (~7 min on Ampere) — safe: SERVICE_START is in the worker watchdog's unbounded tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)