### PR TITLE
fix(meeting): transcribe timeout scales for long meetings (43-min WAV timed out)

### DIFF
--- a/internal/jobs/transcribe_audio.go
+++ b/internal/jobs/transcribe_audio.go
@@ -3,10 +3,12 @@ package jobs
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -37,9 +39,56 @@ const transcribeReadyTimeout = 120 * time.Second
 // fetch" once the gateway times out first.
 const transcribeUnreachableTimeout = 8 * time.Second
 
-// transcribeRequestTimeout bounds a single transcription. Whisper on CPU is
-// roughly real-time-ish for the "base" model, so a long meeting needs headroom.
-const transcribeRequestTimeout = 30 * time.Minute
+// The transcribe request timeout is sized PER REQUEST from the audio file's
+// byte length rather than a single fixed cap. A fixed 30-minute cap was too
+// short in the field: a real 43-minute meeting recorded an ~83 MB WAV whose
+// end-of-call batch transcription ran past 30 minutes on CPU whisper and the
+// client aborted mid-request ("Client.Timeout exceeded while awaiting
+// headers"). The sidecar responds only once the WHOLE file is transcribed
+// (there is no streaming/offset API), so the client must tolerate a budget
+// proportional to the audio's real duration.
+//
+// Sizing by bytes also makes the rolling/windowed passes cheap for free: those
+// transcribe only a short trailing clip (small file -> short budget), while the
+// end-of-call batch pass over the full recording (large file -> long budget)
+// gets the headroom it needs. Both flow through the same handler.
+const (
+	// transcribeBytesPerSecond estimates recorded audio duration from a WAV
+	// file's size. The meeting recorder captures mono 16 kHz signed-16-bit PCM
+	// (platform.buildAudioFFmpegArgs: "-ac 1 -ar 16000"), i.e.
+	// 16000 * 2 bytes = 32000 bytes per second of audio. This is used ONLY to
+	// size the request timeout, so an approximate rate is fine — the generous
+	// per-second multiplier below absorbs the WAV header and any format slack.
+	// NOTE: this is coupled to the recorder's uncompressed WAV format. The batch
+	// pass transcribes the WAV (not the Opus backup added in #555); if the
+	// transcribed input ever becomes compressed, revisit this constant so the
+	// budget does not silently under-time.
+	transcribeBytesPerSecond = 32000
+
+	// transcribeSecondsPerAudioSecond is the wall-clock budget allowed per
+	// second of recorded audio. faster-whisper "base" (int8) on CPU runs near
+	// real time but can be slower on a loaded or modest node, so we budget a
+	// generous multiple of the audio's own duration.
+	transcribeSecondsPerAudioSecond = 3
+
+	// transcribeMinRequestTimeout floors the per-request budget so tiny inputs
+	// (short rolling clips, model warm-up, scheduling jitter) always get a
+	// workable window even when the size-derived estimate is small.
+	transcribeMinRequestTimeout = 2 * time.Minute
+
+	// transcribeMaxRequestTimeout caps the per-request budget. At the
+	// transcribeSecondsPerAudioSecond multiple, a full-length recording at the
+	// defaultMeetingMaxDuration hard cap (4h) needs ~12h of budget, so this
+	// ceiling is sized to cover it while still bounding a corrupt or absurdly
+	// large file from wedging a worker slot indefinitely.
+	transcribeMaxRequestTimeout = 12 * time.Hour
+
+	// transcribeHealthTimeout bounds a single health-check GET. The readiness
+	// loop's own budgets (transcribeReadyTimeout / transcribeUnreachableTimeout)
+	// govern total wait; this just stops one poll from hanging if the sidecar
+	// accepts the connection but never answers.
+	transcribeHealthTimeout = 10 * time.Second
+)
 
 // TranscribeAudioHandler handles TRANSCRIBE_AUDIO jobs node-locally.
 //
@@ -73,11 +122,51 @@ func (h *TranscribeAudioHandler) serviceURL() string {
 	return defaultTranscribeServiceURL
 }
 
+// client returns the HTTP client used for both the health poll and the
+// transcribe POST. It deliberately carries NO fixed Timeout: the whole-request
+// budget is governed by a per-request context deadline sized to the input (see
+// requestTimeout / transcribeTimeoutForAudioBytes), so a long meeting's batch
+// pass is not capped by a one-size-fits-all client timeout while a short rolling
+// clip is not made to wait needlessly.
 func (h *TranscribeAudioHandler) client() *http.Client {
 	if h.HTTPClient != nil {
 		return h.HTTPClient
 	}
-	return &http.Client{Timeout: transcribeRequestTimeout}
+	return &http.Client{}
+}
+
+// transcribeTimeoutForAudioBytes maps an audio file's byte length to a
+// generous request timeout. It estimates the audio's real duration from the
+// byte count (uncompressed 16 kHz mono PCM WAV) and multiplies it by
+// transcribeSecondsPerAudioSecond, clamped to [min, max]. Pure and
+// table-testable; callers stat the file and pass its size.
+func transcribeTimeoutForAudioBytes(sizeBytes int64) time.Duration {
+	if sizeBytes <= 0 {
+		// Unknown/empty size: prefer the generous ceiling over under-timing,
+		// since a premature client timeout is the exact bug being fixed.
+		return transcribeMaxRequestTimeout
+	}
+	estSeconds := sizeBytes / transcribeBytesPerSecond
+	budget := time.Duration(estSeconds*transcribeSecondsPerAudioSecond) * time.Second
+	if budget < transcribeMinRequestTimeout {
+		return transcribeMinRequestTimeout
+	}
+	if budget > transcribeMaxRequestTimeout {
+		return transcribeMaxRequestTimeout
+	}
+	return budget
+}
+
+// requestTimeout sizes the transcribe request budget from the file at
+// validatedPath. On stat failure it returns the generous ceiling rather than a
+// small default: under-timing is precisely the failure mode being fixed, and a
+// missing file surfaces as a transcribe error anyway.
+func (h *TranscribeAudioHandler) requestTimeout(validatedPath string) time.Duration {
+	info, err := os.Stat(validatedPath)
+	if err != nil {
+		return transcribeMaxRequestTimeout
+	}
+	return transcribeTimeoutForAudioBytes(info.Size())
 }
 
 // Execute transcribes a workspace-local audio file via the whisper sidecar.
@@ -149,11 +238,21 @@ func (h *TranscribeAudioHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	resp, err := h.client().Post(
-		h.serviceURL()+"/transcribe",
-		"application/json",
-		bytes.NewBuffer(reqBody),
-	)
+	// Size the whole-request budget from the audio's byte length so a long
+	// meeting's full-file transcription is not cut off mid-flight. The context
+	// governs the entire request including the body read below, so cancel only
+	// after Execute is done with the response.
+	reqTimeout := h.requestTimeout(validated)
+	reqCtx, cancel := context.WithTimeout(context.Background(), reqTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, h.serviceURL()+"/transcribe", bytes.NewBuffer(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to build transcription request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := h.client().Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to transcription service: %w", err)
 	}
@@ -173,7 +272,7 @@ func (h *TranscribeAudioHandler) waitForReady() error {
 	startTime := time.Now()
 
 	for {
-		resp, err := h.client().Get(healthURL)
+		resp, err := h.healthCheck(healthURL)
 		if err == nil {
 			ready := resp.StatusCode == http.StatusOK
 			resp.Body.Close()
@@ -195,6 +294,20 @@ func (h *TranscribeAudioHandler) waitForReady() error {
 		time.Sleep(pollInterval)
 	}
 	return fmt.Errorf("transcription service did not become ready within %v", transcribeReadyTimeout)
+}
+
+// healthCheck performs a single readiness GET bounded by transcribeHealthTimeout
+// so one poll cannot hang now that the shared client carries no fixed timeout.
+// A dead port still returns connection-refused immediately (before the
+// deadline), preserving the fast-fail path in waitForReady.
+func (h *TranscribeAudioHandler) healthCheck(healthURL string) (*http.Response, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), transcribeHealthTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	return h.client().Do(req)
 }
 
 // isConnectionRefused reports whether err indicates nothing is listening on

--- a/internal/jobs/transcribe_audio_test.go
+++ b/internal/jobs/transcribe_audio_test.go
@@ -131,6 +131,118 @@ func TestTranscribeAudio_ServiceError(t *testing.T) {
 	}
 }
 
+// TestTranscribeTimeoutForAudioBytes covers the size -> timeout mapping that
+// replaced the fixed 30-minute client cap. The field bug was a 43-minute /
+// ~83 MB WAV whose transcription ran past 30 minutes; the budget must now scale
+// with the audio's real length, floored for tiny clips and ceilinged for
+// absurdly large inputs.
+func TestTranscribeTimeoutForAudioBytes(t *testing.T) {
+	const bytesPerMinute = transcribeBytesPerSecond * 60 // 32000 * 60 = 1.92 MB/min
+
+	cases := []struct {
+		name string
+		size int64
+		want time.Duration
+	}{
+		{
+			// Zero/unknown size falls back to the generous ceiling, never a
+			// small default — under-timing is the exact regression being fixed.
+			name: "unknown size uses ceiling",
+			size: 0,
+			want: transcribeMaxRequestTimeout,
+		},
+		{
+			// A short rolling-window clip (~90s of audio) stays at the floor:
+			// 90s * 3 = 4.5min > 2min floor, so it is the raw budget here.
+			name: "90s rolling clip",
+			size: 90 * transcribeBytesPerSecond,
+			want: 90 * transcribeSecondsPerAudioSecond * time.Second,
+		},
+		{
+			// A tiny clip is floored so warm-up/jitter never trips it.
+			name: "tiny clip floored",
+			size: 5 * transcribeBytesPerSecond,
+			want: transcribeMinRequestTimeout,
+		},
+		{
+			// The field case: 43 minutes of audio -> ~2h15m budget, comfortably
+			// past the 30-minute cap that failed.
+			name: "43 minute meeting",
+			size: 43 * bytesPerMinute,
+			want: 43 * 60 * transcribeSecondsPerAudioSecond * time.Second,
+		},
+		{
+			// A 4-hour meeting (the MEETING_JOIN hard cap) sits right at the
+			// ceiling and must NOT be clamped below its real need.
+			name: "four hour meeting at ceiling",
+			size: 4 * 60 * bytesPerMinute,
+			want: transcribeMaxRequestTimeout,
+		},
+		{
+			// Absurdly large input is bounded so a corrupt file can't wedge a
+			// worker slot forever.
+			name: "oversized input clamped to ceiling",
+			size: 100 * 60 * bytesPerMinute,
+			want: transcribeMaxRequestTimeout,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := transcribeTimeoutForAudioBytes(tc.size)
+			if got != tc.want {
+				t.Errorf("transcribeTimeoutForAudioBytes(%d) = %v, want %v", tc.size, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTranscribeTimeout_BatchLongerThanRolling proves requirement 4: the
+// end-of-call batch pass over the full recording gets a far longer budget than a
+// short rolling-window clip, since both flow through the same handler and are
+// discriminated purely by the file size. This is the client-side selector the
+// wire test cannot observe (the context deadline never crosses the wire).
+func TestTranscribeTimeout_BatchLongerThanRolling(t *testing.T) {
+	dir := t.TempDir()
+
+	// A short rolling clip (~90s) vs a long batch recording (~43min), sized so
+	// their byte lengths mirror the real recorder format.
+	rollingPath := filepath.Join(dir, "rolling.wav")
+	if err := os.WriteFile(rollingPath, make([]byte, 90*transcribeBytesPerSecond), 0o644); err != nil {
+		t.Fatalf("setup rolling: %v", err)
+	}
+	batchPath := filepath.Join(dir, "batch.wav")
+	if err := os.WriteFile(batchPath, make([]byte, 43*60*transcribeBytesPerSecond), 0o644); err != nil {
+		t.Fatalf("setup batch: %v", err)
+	}
+
+	h := NewTranscribeAudioHandler(dir)
+	rolling := h.requestTimeout(rollingPath)
+	batch := h.requestTimeout(batchPath)
+
+	if batch <= rolling {
+		t.Fatalf("batch budget %v should exceed rolling budget %v", batch, rolling)
+	}
+	// The batch pass must clear the fixed 30-minute cap that failed in the field.
+	if batch <= 30*time.Minute {
+		t.Errorf("batch budget %v does not exceed the old 30m cap", batch)
+	}
+	// The rolling clip must stay short — the long budget is only for the full file.
+	if rolling > 10*time.Minute {
+		t.Errorf("rolling budget %v is unexpectedly large", rolling)
+	}
+}
+
+// TestTranscribeTimeout_MissingFileUsesCeiling verifies the stat-failure
+// direction: a missing file yields the generous ceiling, not a small default.
+func TestTranscribeTimeout_MissingFileUsesCeiling(t *testing.T) {
+	h := NewTranscribeAudioHandler(t.TempDir())
+	got := h.requestTimeout(filepath.Join(t.TempDir(), "does-not-exist.wav"))
+	if got != transcribeMaxRequestTimeout {
+		t.Errorf("requestTimeout(missing) = %v, want ceiling %v", got, transcribeMaxRequestTimeout)
+	}
+}
+
 // TestTranscribeAudio_WaitForReady_UnreachableFailsFast covers the cold-start
 // hang: a sidecar that was never started (nothing listening on its port) must
 // not make waitForReady block anywhere near the full 120s model-load budget.

--- a/internal/status/collector.go
+++ b/internal/status/collector.go
@@ -27,11 +27,11 @@ type Collector struct {
 	services       []ServiceConfig
 	startTime      time.Time
 	modelDiscovery *ModelDiscovery
-	capabilities   *NodeCapabilities     // cached capabilities (set once at startup)
+	capabilities   *NodeCapabilities      // cached capabilities (set once at startup)
 	workerLiveness func() *WorkerLiveness // live worker consume-loop liveness (issue #548), optional
-	idleTracker    *IdleTracker          // metrics-based per-service idle detection (aceteam#4472 / citadel #416)
-	fpIdleTracker  *FootprintIdleTracker // footprint-derived idle for engines #416 can't scrape (citadel #421)
-	netIdleTracker *IdleTracker          // network-activity idle for non-vLLM services (citadel #433)
+	idleTracker    *IdleTracker           // metrics-based per-service idle detection (aceteam#4472 / citadel #416)
+	fpIdleTracker  *FootprintIdleTracker  // footprint-derived idle for engines #416 can't scrape (citadel #421)
+	netIdleTracker *IdleTracker           // network-activity idle for non-vLLM services (citadel #433)
 }
 
 // ServiceConfig holds the configuration for a service from the manifest.


### PR DESCRIPTION
## Context

First real long-meeting E2E on prod node 1084 (2026-07-17) caught this. A 43-minute meeting recorded an ~83 MB WAV, and the **end-of-call batch transcribe** died:

```
failed to connect to transcription service: Post "http://localhost:8101/transcribe":
context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

The whisper sidecar (`:8101`, faster-whisper `base` on CPU) was healthy — it just takes many minutes to transcribe 43 minutes of audio. The node's HTTP client to it used a **fixed 30-minute `http.Client{Timeout}`**, which is a hard cap on the whole request. Since the sidecar has no streaming/offset API and only responds once the entire file is transcribed, a long meeting blows straight past the cap. Short clips (~100s) were always fine; long meetings timed out. Rolling/windowed transcription (short scratch clips) was never affected — only the full-file batch pass.

Root cause (`internal/jobs/transcribe_audio.go`): `transcribeRequestTimeout = 30 * time.Minute` on the shared `http.Client`, applied uniformly regardless of audio length.

## Summary

- **Per-request context deadline sized from the audio's byte length**, replacing the fixed client cap. The recorder captures uncompressed mono 16 kHz s16le PCM WAV (`-ac 1 -ar 16000` -> 32000 B/s), so bytes -> real duration is a clean estimate. Budget = `3x` realtime, clamped to `[2m, 12h]`. A 4-hour meeting (the `defaultMeetingMaxDuration` hard cap) needs ~12h of budget and sits right at the ceiling; the ceiling still bounds a corrupt/huge file from wedging a worker slot forever.
- **Rolling passes stay cheap for free.** Batch and rolling flow through the same handler; sizing by the actual file discriminates them automatically — a ~90s window clip gets ~4.5m, the full recording gets hours. No parameterization needed, and rolling latency is untouched.
- **Shared client carries no fixed timeout anymore**; the context governs the whole request (including the body read). The **health poll** got its own short per-request context (`transcribeHealthTimeout = 10s`) so a single poll can't hang now that the client timeout is gone. The `connection-refused` fast-fail path in `waitForReady` is preserved (a dead port refuses before any deadline).
- **On `os.Stat` failure the budget falls back to the ceiling, not a small default** — under-timing is the exact bug being fixed.

Key change: `internal/jobs/transcribe_audio.go` — new pure `transcribeTimeoutForAudioBytes(sizeBytes) time.Duration` + `requestTimeout(path)` selector; POST switched from `client.Post` to `http.NewRequestWithContext` + `client.Do`.

**Drive-by:** `gofmt -w internal/status/collector.go`. A pre-existing gofmt violation landed on `main` with #548 and has reddened the CI gofmt gate on every branch since. Purely mechanical comment re-alignment, no behavior change — included so this PR's CI goes green.

## Test plan

| Test | Coverage |
|------|----------|
| `TestTranscribeTimeoutForAudioBytes` (table-driven) | size -> timeout: unknown-size ceiling, 90s clip, tiny-clip floor, 43-min field case, 4h-at-ceiling, oversized clamp |
| `TestTranscribeTimeout_BatchLongerThanRolling` | batch (full file) budget > rolling (clip) budget, batch clears the old 30m cap, rolling stays short — the client-side selector the wire can't observe |
| `TestTranscribeTimeout_MissingFileUsesCeiling` | stat-failure returns ceiling, not a small default |
| existing `waitForReady` fast-fail / patient-loading tests | still green — health poll context preserves connection-refused fast-fail and warm-up patience |

`go build ./... && go vet ./... && go test ./...` all green; `gofmt -l .` empty.

## Deploy note

Needs a **citadel release** to ship to nodes.

## Related

- Meeting notetaker bot epic #5097 (sovereign auto-join)
- Found during the first live long-meeting E2E on node 1084