### PR TITLE
feat(worker): publish claimed event when a job is read (aceteam#6000)

### DIFF
--- a/internal/redis/client.go
+++ b/internal/redis/client.go
@@ -412,6 +412,16 @@ func (c *Client) PublishStreamEvent(ctx context.Context, jobID, rayID, eventType
 	return c.client.Publish(ctx, streamName, eventJSON).Err()
 }
 
+// PublishClaimed publishes a "claimed" event for a job, emitted the moment the
+// worker reads it off the queue (before handler execution). The backend
+// dispatcher (aceteam#6000) uses it to fast-fail a wedged/dead node that never
+// claims, instead of waiting the full result budget.
+func (c *Client) PublishClaimed(ctx context.Context, jobID, rayID, agentVersion string) error {
+	return c.PublishStreamEvent(ctx, jobID, rayID, "claimed", map[string]interface{}{
+		"agent_version": agentVersion,
+	})
+}
+
 // PublishStart publishes a "start" event for a job.
 func (c *Client) PublishStart(ctx context.Context, jobID, rayID, message string) error {
 	return c.PublishStreamEvent(ctx, jobID, rayID, "start", map[string]interface{}{

--- a/internal/redisapi/pubsub.go
+++ b/internal/redisapi/pubsub.go
@@ -69,6 +69,16 @@ func (c *Client) PublishStreamEvent(ctx context.Context, jobID, rayID, eventType
 	return c.Publish(ctx, streamName, event)
 }
 
+// PublishClaimed publishes a "claimed" event for a job, emitted the moment the
+// worker reads it off the queue (before handler execution). The backend
+// dispatcher (aceteam#6000) uses it to fast-fail a wedged/dead node that never
+// claims, instead of waiting the full result budget.
+func (c *Client) PublishClaimed(ctx context.Context, jobID, rayID, agentVersion string) error {
+	return c.PublishStreamEvent(ctx, jobID, rayID, "claimed", map[string]any{
+		"agent_version": agentVersion,
+	})
+}
+
 // PublishStart publishes a "start" event for a job.
 func (c *Client) PublishStart(ctx context.Context, jobID, rayID, message string) error {
 	return c.PublishStreamEvent(ctx, jobID, rayID, "start", map[string]any{

--- a/internal/worker/handler.go
+++ b/internal/worker/handler.go
@@ -18,6 +18,14 @@ type JobHandler interface {
 // For Redis sources, this publishes to Redis Pub/Sub.
 // For Nexus sources, this may be a no-op.
 type StreamWriter interface {
+	// WriteClaimed signals that this worker has read the job off the queue and
+	// committed to running it, published BEFORE handler execution. The backend
+	// dispatcher (aceteam#6000) waits a short window for this event before
+	// committing the full result budget: a wedged/dead-but-heartbeating node
+	// never emits it, so the dispatcher fast-fails in ~3s instead of burning the
+	// whole deadline. agentVersion lets the backend attribute the claim.
+	WriteClaimed(agentVersion string) error
+
 	// WriteStart signals the beginning of job processing.
 	WriteStart(message string) error
 
@@ -38,6 +46,7 @@ type StreamWriter interface {
 // Used when streaming is not supported or needed.
 type NoOpStreamWriter struct{}
 
+func (n *NoOpStreamWriter) WriteClaimed(agentVersion string) error       { return nil }
 func (n *NoOpStreamWriter) WriteStart(message string) error              { return nil }
 func (n *NoOpStreamWriter) WriteChunk(content string, index int) error   { return nil }
 func (n *NoOpStreamWriter) WriteEnd(result map[string]any) error         { return nil }

--- a/internal/worker/integration_test.go
+++ b/internal/worker/integration_test.go
@@ -18,10 +18,20 @@ type recordingStreamWriter struct {
 	endResult       map[string]any
 	cancelledReason string
 	errMessage      string
+	claimedVersion  string
+	claimed         bool
 	started         bool
 	ended           bool
 	cancelled       bool
 	errored         bool
+}
+
+func (w *recordingStreamWriter) WriteClaimed(agentVersion string) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.claimed = true
+	w.claimedVersion = agentVersion
+	return nil
 }
 
 func (w *recordingStreamWriter) WriteStart(message string) error {

--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -336,6 +336,15 @@ runLoop:
 	return nil
 }
 
+// newStreamWriter builds the per-job stream writer, falling back to a no-op
+// writer when no factory is configured (e.g. Nexus HTTP source).
+func (r *Runner) newStreamWriter(job *Job) StreamWriter {
+	if r.streamWriterFactory != nil {
+		return r.streamWriterFactory(job)
+	}
+	return &NoOpStreamWriter{}
+}
+
 // processJob dispatches a job to the appropriate handler.
 func (r *Runner) processJob(ctx context.Context, job *Job) {
 	atomic.AddInt64(&r.activeJobs, 1)
@@ -365,15 +374,21 @@ func (r *Runner) processJob(ctx context.Context, job *Job) {
 		}
 	}
 
+	// Claim-ack (aceteam#6000): publish a lightweight "claimed" event the moment
+	// this node takes ownership of the job -- after the target-node filter (so
+	// only the owning node claims a shared-stream message) and before any
+	// handler work. The backend dispatcher waits a short window for this event;
+	// a wedged or dead-but-heartbeating node never reaches this line, so the
+	// dispatcher fast-fails in ~3s instead of burning the full result budget.
+	// Best-effort: a publish failure must not block execution.
+	stream := r.newStreamWriter(job)
+	if err := stream.WriteClaimed(r.agentVersion); err != nil {
+		r.log("warning", "Failed to publish claimed event for job %s: %v", job.ID, err)
+	}
+
 	// JQS-Core Section 5.6: Check cancellation before processing
 	if r.source.IsJobCancelled(ctx, job.ID) {
 		r.log("info", "Job %s was cancelled before processing", job.ID)
-		var stream StreamWriter
-		if r.streamWriterFactory != nil {
-			stream = r.streamWriterFactory(job)
-		} else {
-			stream = &NoOpStreamWriter{}
-		}
 		if err := stream.WriteCancelled("Job cancelled before processing"); err != nil {
 			r.log("warning", "Failed to publish cancelled event for job %s: %v", job.ID, err)
 		}
@@ -408,12 +423,6 @@ func (r *Runner) processJob(ctx context.Context, job *Job) {
 					err := fmt.Errorf("requested GPU %d is unavailable", gpuIdx)
 					r.log("error", "GPU unavailable: %v", err)
 					r.recordJob(buildUsageRecord(job, "failed", startTime, time.Now(), nil, err))
-					var stream StreamWriter
-					if r.streamWriterFactory != nil {
-						stream = r.streamWriterFactory(job)
-					} else {
-						stream = &NoOpStreamWriter{}
-					}
 					stream.WriteError(err, false)
 					r.source.Nack(ctx, job, err)
 					return
@@ -439,15 +448,7 @@ func (r *Runner) processJob(ctx context.Context, job *Job) {
 		job.Payload["_gpuIndex"] = gpuIndex
 	}
 
-	// Create stream writer
-	var stream StreamWriter
-	if r.streamWriterFactory != nil {
-		stream = r.streamWriterFactory(job)
-	} else {
-		stream = &NoOpStreamWriter{}
-	}
-
-	// Execute handler
+	// Execute handler (stream writer created above, at claim time)
 	stream.WriteStart("Job processing started")
 
 	// Per-job execution deadline (aceteam#6000). When the payload carries a

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -167,6 +167,8 @@ func (m *MockJobHandler) ExecutedJobs() []*Job {
 
 // MockStreamWriter is a test implementation of StreamWriter.
 type MockStreamWriter struct {
+	claimed        bool
+	claimedVersion string
 	started        bool
 	chunks         []string
 	ended          bool
@@ -174,6 +176,12 @@ type MockStreamWriter struct {
 	erroredErr     error
 	erroredRecover bool
 	cancelled      bool
+}
+
+func (m *MockStreamWriter) WriteClaimed(agentVersion string) error {
+	m.claimed = true
+	m.claimedVersion = agentVersion
+	return nil
 }
 
 func (m *MockStreamWriter) WriteStart(message string) error {
@@ -448,6 +456,72 @@ func TestRunnerKnownJobTypeStillDispatches(t *testing.T) {
 	}
 	if len(source.FailedJobs()) != 0 {
 		t.Errorf("Failed jobs = %d, want 0 for a known type", len(source.FailedJobs()))
+	}
+}
+
+// TestRunnerPublishesClaimedBeforeExecution verifies the claim-ack contract
+// (aceteam#6000): when a job is read off the queue the runner publishes a
+// "claimed" event carrying the node's agent version BEFORE any handler work, so
+// the backend dispatcher can distinguish a live worker from a wedged/dead one
+// within a short window.
+func TestRunnerPublishesClaimedBeforeExecution(t *testing.T) {
+	jobs := []*Job{
+		{ID: "job-1", Type: "SHELL_COMMAND", Payload: map[string]any{}},
+	}
+
+	source := NewMockJobSource("test", jobs)
+	handler := NewMockJobHandler("SHELL_COMMAND", false)
+	config := RunnerConfig{WorkerID: "test-worker", AgentVersion: "v2.81.0"}
+
+	runner := NewRunner(source, []JobHandler{handler}, config)
+
+	stream := &MockStreamWriter{}
+	runner.WithStreamWriterFactory(func(job *Job) StreamWriter { return stream })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	runner.Run(ctx)
+
+	if !stream.claimed {
+		t.Fatal("expected a claimed event to be published when the job was read")
+	}
+	if stream.claimedVersion != "v2.81.0" {
+		t.Errorf("claimed agent_version = %q, want v2.81.0", stream.claimedVersion)
+	}
+	if !stream.started {
+		t.Error("expected the job to also proceed to WriteStart after claiming")
+	}
+}
+
+// TestRunnerDoesNotClaimForeignTargetedJob verifies that a shared-stream message
+// addressed to a different node (target_node mismatch) is skipped WITHOUT
+// publishing a claim. Only the owning node claims; otherwise the dispatcher
+// would see a false claim from a node that never runs the job.
+func TestRunnerDoesNotClaimForeignTargetedJob(t *testing.T) {
+	jobs := []*Job{
+		{ID: "job-1", Type: "SHELL_COMMAND", Payload: map[string]any{"target_node": "other-node"}},
+	}
+
+	source := NewMockJobSource("test", jobs)
+	handler := NewMockJobHandler("SHELL_COMMAND", false)
+	config := RunnerConfig{WorkerID: "test-worker", NodeID: "this-node", AgentVersion: "v2.81.0"}
+
+	runner := NewRunner(source, []JobHandler{handler}, config)
+
+	stream := &MockStreamWriter{}
+	runner.WithStreamWriterFactory(func(job *Job) StreamWriter { return stream })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	runner.Run(ctx)
+
+	if stream.claimed {
+		t.Error("a job targeted at another node must not be claimed by this node")
+	}
+	if len(handler.ExecutedJobs()) != 0 {
+		t.Errorf("Executed jobs = %d, want 0 for a foreign-targeted job", len(handler.ExecutedJobs()))
 	}
 }
 

--- a/internal/worker/stream.go
+++ b/internal/worker/stream.go
@@ -26,6 +26,12 @@ func NewRedisStreamWriter(ctx context.Context, client *redisclient.Client, jobID
 	}
 }
 
+// WriteClaimed signals that this worker has claimed the job (read it off the
+// queue, before handler execution). See StreamWriter.WriteClaimed.
+func (w *RedisStreamWriter) WriteClaimed(agentVersion string) error {
+	return w.client.PublishClaimed(w.ctx, w.jobID, w.rayID, agentVersion)
+}
+
 // WriteStart signals the beginning of job processing.
 func (w *RedisStreamWriter) WriteStart(message string) error {
 	w.client.SetJobStatus(w.ctx, w.jobID, "processing", nil)
@@ -81,6 +87,12 @@ func NewAPIStreamWriter(ctx context.Context, client *redisapi.Client, jobID, ray
 		rayID:  rayID,
 		ctx:    ctx,
 	}
+}
+
+// WriteClaimed signals that this worker has claimed the job (read it off the
+// queue, before handler execution). See StreamWriter.WriteClaimed.
+func (w *APIStreamWriter) WriteClaimed(agentVersion string) error {
+	return w.client.PublishClaimed(w.ctx, w.jobID, w.rayID, agentVersion)
 }
 
 // WriteStart signals the beginning of job processing.


### PR DESCRIPTION
## Context

Step 2 of the fix for aceteam#6000 (the "wedged/dead node holds a job to the deadline" residual). Step 1 (per-job `timeout_ms`, aceteam #6060 / citadel #552) bounds a hung *handler*. This step closes the earlier gap: a node that is dead-but-recently-heartbeating (still inside the ~120s `node:load` TTL) or wedged never even reads the job, so the backend dispatcher (`_dispatch_file_job`) burns the entire result budget waiting on a job nobody picked up.

The fix is a lightweight **claim-ack**: the worker publishes a `claimed` event on the job's result channel the instant it reads the job off the stream. The aceteam dispatcher waits a short window (~3s) for that claim before committing the full budget. No claim within the window ⇒ the dispatcher fast-fails (and, for reads like `memory_search`, degrades to its KB fallback). This shrinks the blind spot from ~120s to ~3s and catches the never-claims wedge, **without** reassigning per-node file jobs (data locality, #3914/#4426, is unchanged).

## Summary

- **`StreamWriter.WriteClaimed(agentVersion)`** — new terminal-adjacent event on the interface, implemented on `RedisStreamWriter`, `APIStreamWriter`, and `NoOpStreamWriter`.
- **`PublishClaimed`** on both pub/sub clients (`internal/redis`, `internal/redisapi`) — publishes a `"claimed"` event on `stream:v1:{jobId}` carrying the node's `agent_version` for backend attribution. Mirrors the `"claimed"` status the Python `base_worker` already uses.
- **`runner.processJob`** — emits the claim right after the target-node filter passes (so only the owning node claims a shared-stream message) and before any handler work. Best-effort: a publish failure logs a warning and never blocks execution.
- **Cleanup** — consolidated the four duplicate per-job stream-writer creations (claim / cancellation / GPU-error / execution paths) behind one `newStreamWriter` helper.

## Test plan

| Test | Covers |
| --- | --- |
| `TestRunnerPublishesClaimedBeforeExecution` | claimed emitted with agent version, before WriteStart |
| `TestRunnerDoesNotClaimForeignTargetedJob` | a `target_node` mismatch is skipped without a false claim |
| existing runner / redis / redisapi suites | no regression; mocks extended with `WriteClaimed` |

`go build ./...`, `go vet ./...`, `go test ./...` all green.

## Related

- aceteam#6000 (parent), aceteam#6060 / citadel#552 (step 1: per-job timeout)
- Backend counterpart PR: https://github.com/aceteam-ai/aceteam/pull/6209

---
*Generated by Claude Opus 4.8*
