### PR TITLE
fix(jobs): use 'hf download' + detect no-op pulls (#566); bound Bonsai context/VRAM (#567)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -603,11 +603,15 @@ so the inline build is not killed. Subsequent starts reuse the cached image.
   engine `bonsai` (only vllm/llamacpp/ollama), so a bonsai GGUF must be removed
   manually from `~/citadel-cache/bonsai`. Low-priority follow-up.
 
-**Optional long-context KV tuning:** the compose default mirrors the card
-(`-ngl 99`, no KV-quant flags). For long context, add
-`--flash-attn --cache-type-k q4_0 --cache-type-v q4_0` (quantized V-cache needs
-flash attention; not default-on because it can't be validated without GPU
-inference).
+**VRAM tuning (default-on, citadel #567):** the compose now bounds context and
+quantizes the KV cache: `--ctx-size ${BONSAI_CTX:-8192} --flash-attn on
+--cache-type-k q4_0 --cache-type-v q4_0`. Without `--ctx-size`, llama-server
+allocates Bonsai's full 262K training context, whose KV cache alone is ~17GB — the
+3.9GB model then pins ~21GB VRAM. Bounding context to 8192 (32x smaller) is what
+does ~all the VRAM work (~5-6GB total); the 4-bit KV quant trims a little more.
+Quantized V-cache requires flash attention, so `--flash-attn on` is mandatory here.
+Flag names verified against the PrismML fork's `common/arg.cpp` (`-fa` takes an
+`[on|off|auto]` value). Override the context via the `BONSAI_CTX` env var.
 
 **Live inference is a documented human step:** node 1084's GPU is VRAM-contended
 (vLLM holds ~21GB); do NOT stop vLLM to validate. Bonsai fits alongside once VRAM

--- a/internal/jobs/model_cache_pull.go
+++ b/internal/jobs/model_cache_pull.go
@@ -84,23 +84,32 @@ func bonsaiCacheDir() string {
 	return filepath.Join(home, "citadel-cache", "bonsai")
 }
 
-// pullBonsai downloads the single Bonsai-27B-Q1_0.gguf file via huggingface-cli
-// into bonsaiCacheDir(). Deviates from the task's bare command by adding
-// --local-dir so the file lands at a predictable path the compose mount can
-// serve (the HF hub cache path carries an unpredictable snapshot hash).
+// pullBonsai downloads the single Bonsai-27B-Q1_0.gguf file via the HuggingFace
+// CLI into bonsaiCacheDir(). Deviates from a bare download by adding --local-dir
+// so the file lands at a predictable path the compose mount can serve (the HF
+// hub cache path carries an unpredictable snapshot hash).
 func (h *ModelCachePullHandler) pullBonsai(ctx JobContext, jobID string) ([]byte, error) {
 	localDir := bonsaiCacheDir()
-	ctx.Log("info", "     - [Job %s] Pulling Bonsai GGUF '%s' from %s into %s via huggingface-cli", jobID, bonsaiGGUFFile, bonsaiRepo, localDir)
 
-	cmd := BuildBonsaiDownloadCommand(localDir)
+	bin, err := resolveHFDownloader()
+	if err != nil {
+		return nil, err
+	}
+	ctx.Log("info", "     - [Job %s] Pulling Bonsai GGUF '%s' from %s into %s via %s", jobID, bonsaiGGUFFile, bonsaiRepo, localDir, bin)
+
+	cmd := BuildBonsaiDownloadCommand(bin, localDir)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return output, fmt.Errorf("huggingface-cli download failed: %w", err)
+		return output, fmt.Errorf("hf download failed: %w", err)
 	}
 
-	var sizeBytes int64
-	if fi, statErr := os.Stat(filepath.Join(localDir, bonsaiGGUFFile)); statErr == nil {
-		sizeBytes = fi.Size()
+	// No-op detection (citadel #566): the deprecated `huggingface-cli` no-ops on
+	// huggingface_hub >= 1.x — it prints a warning, creates --local-dir, and exits
+	// 0 WITHOUT downloading. A zero-exit is therefore NOT proof of success; the
+	// only reliable signal is the file actually existing with non-zero size.
+	sizeBytes, err := verifyDownloadedFile(filepath.Join(localDir, bonsaiGGUFFile))
+	if err != nil {
+		return output, fmt.Errorf("bonsai pull reported success but produced no file (%w); output: %s", err, strings.TrimSpace(string(output)))
 	}
 
 	result := modelCachePullResult{
@@ -113,10 +122,88 @@ func (h *ModelCachePullHandler) pullBonsai(ctx JobContext, jobID string) ([]byte
 }
 
 // BuildBonsaiDownloadCommand returns the exec.Cmd that downloads the single
-// Bonsai-27B-Q1_0.gguf file into localDir. Exported for testing command
+// Bonsai-27B-Q1_0.gguf file into localDir using the given HuggingFace CLI binary
+// (bin, resolved via resolveHFDownloader). Exported for testing command
 // construction.
-func BuildBonsaiDownloadCommand(localDir string) *exec.Cmd {
-	return exec.Command("huggingface-cli", "download", bonsaiRepo, bonsaiGGUFFile, "--local-dir", localDir)
+func BuildBonsaiDownloadCommand(bin, localDir string) *exec.Cmd {
+	return exec.Command(bin, hfDownloadArgs(bonsaiRepo, bonsaiGGUFFile, localDir)...)
+}
+
+// hfDownloadArgs builds the argument list for a HuggingFace CLI download. Both
+// the modern `hf` and the deprecated `huggingface-cli` share the identical
+// `download <repo> [file] [--local-dir <dir>]` grammar, so only the binary name
+// differs. A non-empty file pulls that single file; an empty file pulls the repo.
+// A non-empty localDir materializes into a predictable path (vs the hub cache).
+func hfDownloadArgs(repo, file, localDir string) []string {
+	args := []string{"download", repo}
+	if file != "" {
+		args = append(args, file)
+	}
+	if localDir != "" {
+		args = append(args, "--local-dir", localDir)
+	}
+	return args
+}
+
+// resolveHFDownloader locates the HuggingFace download CLI, preferring the modern
+// `hf` binary and falling back to the deprecated `huggingface-cli` only if `hf`
+// is absent (older envs). CRITICAL (citadel #566): `huggingface-cli` is a no-op
+// on huggingface_hub >= 1.x, so `hf` must win whenever it exists.
+//
+// PATH first (exec.LookPath), then common install locations, because the systemd
+// worker's PATH often omits the user's pip/uv bin dirs where huggingface_hub
+// installs the CLI (on node 1084 it lives under ~/.uv/python/*/bin). Returns a
+// clear error if neither binary can be found anywhere.
+func resolveHFDownloader() (string, error) {
+	for _, name := range []string{"hf", "huggingface-cli"} {
+		if p, err := exec.LookPath(name); err == nil {
+			return p, nil
+		}
+		for _, dir := range hfBinDirs() {
+			cand := filepath.Join(dir, name)
+			if fi, err := os.Stat(cand); err == nil && !fi.IsDir() && fi.Mode()&0o111 != 0 {
+				return cand, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("no HuggingFace CLI found: install the `hf` command (pip install -U huggingface_hub) — neither `hf` nor `huggingface-cli` is on PATH or in a known location")
+}
+
+// hfBinDirs returns candidate directories to search for the HuggingFace CLI when
+// it is not on PATH. Includes a glob for uv's per-interpreter layout
+// (~/.uv/python/*/bin) since that dir has no single stable name.
+func hfBinDirs() []string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return []string{"/usr/local/bin"}
+	}
+	dirs := []string{
+		filepath.Join(home, ".local", "bin"),
+		filepath.Join(home, ".uv", "python", "bin"),
+		filepath.Join(home, "bin"),
+		"/usr/local/bin",
+	}
+	if matches, err := filepath.Glob(filepath.Join(home, ".uv", "python", "*", "bin")); err == nil {
+		dirs = append(dirs, matches...)
+	}
+	return dirs
+}
+
+// verifyDownloadedFile returns the size of path if it is a regular, non-empty
+// file, or an error otherwise. Used to distinguish a real single-file pull from
+// the huggingface-cli no-op (which leaves the --local-dir empty).
+func verifyDownloadedFile(path string) (int64, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return 0, fmt.Errorf("expected file %s not found: %w", path, err)
+	}
+	if fi.IsDir() {
+		return 0, fmt.Errorf("expected file %s is a directory", path)
+	}
+	if fi.Size() == 0 {
+		return 0, fmt.Errorf("expected file %s is empty", path)
+	}
+	return fi.Size(), nil
 }
 
 // pullOllama runs `ollama pull <model>` to cache the model locally.
@@ -190,18 +277,29 @@ func parseHumanSize(numStr, unit string) int64 {
 	}
 }
 
-// pullHuggingFace runs `huggingface-cli download <model>` for vllm/llamacpp engines.
+// pullHuggingFace runs `hf download <model>` (falling back to the deprecated
+// `huggingface-cli download <model>`) for vllm/llamacpp engines. The repo lands
+// in the HF hub cache (no --local-dir).
 func (h *ModelCachePullHandler) pullHuggingFace(ctx JobContext, jobID, modelName, engine string) ([]byte, error) {
-	ctx.Log("info", "     - [Job %s] Pulling model '%s' via huggingface-cli for %s", jobID, modelName, engine)
+	bin, err := resolveHFDownloader()
+	if err != nil {
+		return nil, err
+	}
+	ctx.Log("info", "     - [Job %s] Pulling model '%s' via %s for %s", jobID, modelName, bin, engine)
 
-	cmd := exec.Command("huggingface-cli", "download", modelName)
+	cmd := BuildHuggingFaceDownloadCommand(bin, modelName)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return output, fmt.Errorf("huggingface-cli download failed: %w", err)
+		return output, fmt.Errorf("hf download failed: %w", err)
 	}
 
-	// Attempt to determine cache size from HuggingFace cache directory.
+	// No-op detection (citadel #566): a zero exit does not prove the download
+	// happened — the deprecated huggingface-cli exits 0 without pulling anything.
+	// A repo snapshot with zero total bytes means nothing landed, so fail the job.
 	sizeBytes := hfCacheModelSize(modelName)
+	if sizeBytes == 0 {
+		return output, fmt.Errorf("hf download reported success but the model cache for %q is empty — the CLI likely no-oped (deprecated huggingface-cli on huggingface_hub >= 1.x); output: %s", modelName, strings.TrimSpace(string(output)))
+	}
 
 	result := modelCachePullResult{
 		Status:    "cached",
@@ -260,7 +358,8 @@ func BuildOllamaPullCommand(modelName string) *exec.Cmd {
 }
 
 // BuildHuggingFaceDownloadCommand returns the exec.Cmd for downloading a model
-// via huggingface-cli. Exported for testing command construction.
-func BuildHuggingFaceDownloadCommand(modelName string) *exec.Cmd {
-	return exec.Command("huggingface-cli", "download", modelName)
+// repo via the given HuggingFace CLI binary (bin, resolved via
+// resolveHFDownloader). Exported for testing command construction.
+func BuildHuggingFaceDownloadCommand(bin, modelName string) *exec.Cmd {
+	return exec.Command(bin, hfDownloadArgs(modelName, "", "")...)
 }

--- a/internal/jobs/model_cache_pull_bonsai_test.go
+++ b/internal/jobs/model_cache_pull_bonsai_test.go
@@ -11,14 +11,14 @@ import (
 // F16 and a drafter GGUF) into the fixed --local-dir the compose mounts.
 func TestBuildBonsaiDownloadCommand(t *testing.T) {
 	localDir := "/home/tester/citadel-cache/bonsai"
-	cmd := BuildBonsaiDownloadCommand(localDir)
+	cmd := BuildBonsaiDownloadCommand("hf", localDir)
 
 	args := cmd.Args
 	if len(args) < 6 {
-		t.Fatalf("expected huggingface-cli download command with local-dir, got %v", args)
+		t.Fatalf("expected hf download command with local-dir, got %v", args)
 	}
-	if !strings.Contains(args[0], "huggingface-cli") {
-		t.Errorf("expected huggingface-cli, got %q", args[0])
+	if args[0] != "hf" {
+		t.Errorf("expected binary %q, got %q", "hf", args[0])
 	}
 	joined := strings.Join(args, " ")
 	for _, want := range []string{"download", "prism-ml/Bonsai-27B-gguf", "Bonsai-27B-Q1_0.gguf", "--local-dir", localDir} {

--- a/internal/jobs/model_cache_pull_hf_test.go
+++ b/internal/jobs/model_cache_pull_hf_test.go
@@ -1,0 +1,126 @@
+package jobs
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestHFDownloadArgs pins the shared `download <repo> [file] [--local-dir]`
+// grammar used by both `hf` and the deprecated `huggingface-cli` (citadel #566).
+func TestHFDownloadArgs(t *testing.T) {
+	// Single-file pull (bonsai path): repo, file, and --local-dir all present,
+	// with the file immediately following the repo id.
+	got := hfDownloadArgs("prism-ml/Bonsai-27B-gguf", "Bonsai-27B-Q1_0.gguf", "/cache/bonsai")
+	want := []string{"download", "prism-ml/Bonsai-27B-gguf", "Bonsai-27B-Q1_0.gguf", "--local-dir", "/cache/bonsai"}
+	if !equalStrs(got, want) {
+		t.Errorf("single-file args = %v, want %v", got, want)
+	}
+
+	// Repo pull (vllm/llamacpp path): no file, no --local-dir (lands in hub cache).
+	got = hfDownloadArgs("meta-llama/Llama-2-7b-chat-hf", "", "")
+	want = []string{"download", "meta-llama/Llama-2-7b-chat-hf"}
+	if !equalStrs(got, want) {
+		t.Errorf("repo args = %v, want %v", got, want)
+	}
+}
+
+// TestResolveHFDownloaderPrefersHF verifies that when both binaries are present,
+// the modern `hf` wins over the deprecated (no-op) `huggingface-cli`.
+func TestResolveHFDownloaderPrefersHF(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake-executable PATH resolution is unix-specific")
+	}
+	dir := t.TempDir()
+	writeFakeExe(t, filepath.Join(dir, "hf"))
+	writeFakeExe(t, filepath.Join(dir, "huggingface-cli"))
+	t.Setenv("PATH", dir)
+	t.Setenv("HOME", t.TempDir()) // neutralize hfBinDirs fallbacks
+
+	bin, err := resolveHFDownloader()
+	if err != nil {
+		t.Fatalf("resolveHFDownloader: %v", err)
+	}
+	if filepath.Base(bin) != "hf" {
+		t.Errorf("resolved %q, want the modern `hf` binary to be preferred", bin)
+	}
+}
+
+// TestResolveHFDownloaderFallsBackToLegacy verifies that when only the legacy
+// binary is present, it is used (older envs without `hf`).
+func TestResolveHFDownloaderFallsBackToLegacy(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake-executable PATH resolution is unix-specific")
+	}
+	dir := t.TempDir()
+	writeFakeExe(t, filepath.Join(dir, "huggingface-cli"))
+	t.Setenv("PATH", dir)
+	t.Setenv("HOME", t.TempDir())
+
+	bin, err := resolveHFDownloader()
+	if err != nil {
+		t.Fatalf("resolveHFDownloader: %v", err)
+	}
+	if filepath.Base(bin) != "huggingface-cli" {
+		t.Errorf("resolved %q, want huggingface-cli fallback", bin)
+	}
+}
+
+// TestVerifyDownloadedFile covers the no-op detection signal: an absent or empty
+// output file must be an error (the huggingface-cli no-op leaves --local-dir
+// empty), while a non-empty file returns its size.
+func TestVerifyDownloadedFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// Missing file -> error.
+	if _, err := verifyDownloadedFile(filepath.Join(dir, "missing.gguf")); err == nil {
+		t.Error("expected error for missing file, got nil")
+	}
+
+	// Empty file (the no-op signature) -> error.
+	empty := filepath.Join(dir, "empty.gguf")
+	if err := os.WriteFile(empty, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := verifyDownloadedFile(empty); err == nil {
+		t.Error("expected error for empty file, got nil")
+	}
+
+	// Non-empty file -> size returned.
+	full := filepath.Join(dir, "model.gguf")
+	if err := os.WriteFile(full, []byte("GGUFdata"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	size, err := verifyDownloadedFile(full)
+	if err != nil {
+		t.Fatalf("unexpected error for non-empty file: %v", err)
+	}
+	if size != 8 {
+		t.Errorf("size = %d, want 8", size)
+	}
+
+	// A directory at the path -> error (not a file).
+	if _, err := verifyDownloadedFile(dir); err == nil {
+		t.Error("expected error when path is a directory, got nil")
+	}
+}
+
+func writeFakeExe(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func equalStrs(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/jobs/model_cache_test.go
+++ b/internal/jobs/model_cache_test.go
@@ -214,16 +214,25 @@ func TestBuildOllamaRmCommand(t *testing.T) {
 }
 
 func TestBuildHuggingFaceDownloadCommand(t *testing.T) {
-	cmd := BuildHuggingFaceDownloadCommand("meta-llama/Llama-2-7b-chat-hf")
+	cmd := BuildHuggingFaceDownloadCommand("hf", "meta-llama/Llama-2-7b-chat-hf")
 	args := cmd.Args
 	if len(args) != 3 {
 		t.Fatalf("expected 3 args, got %d: %v", len(args), args)
+	}
+	if args[0] != "hf" {
+		t.Errorf("args[0] = %q, want 'hf'", args[0])
 	}
 	if args[1] != "download" {
 		t.Errorf("args[1] = %q, want 'download'", args[1])
 	}
 	if args[2] != "meta-llama/Llama-2-7b-chat-hf" {
 		t.Errorf("args[2] = %q, want 'meta-llama/Llama-2-7b-chat-hf'", args[2])
+	}
+	// A repo pull must NOT pass --local-dir (it lands in the HF hub cache).
+	for _, a := range args {
+		if a == "--local-dir" {
+			t.Errorf("repo pull should not use --local-dir, got %v", args)
+		}
 	}
 }
 

--- a/services/compose/bonsai.yml
+++ b/services/compose/bonsai.yml
@@ -35,15 +35,24 @@ services:
       # MODEL_CACHE_PULL (engine=bonsai) drops Bonsai-27B-Q1_0.gguf here.
       - ~/citadel-cache/bonsai:/models
     # -ngl 99 offloads all layers to the GPU (the card's recommended command).
-    # Optional long-context tuning (NOT default-on: quantized V-cache requires
-    # flash attention and can fail startup on some builds, which we cannot
-    # validate here without GPU inference):
-    #   --flash-attn --cache-type-k q4_0 --cache-type-v q4_0
+    #
+    # VRAM tuning (citadel #567): without --ctx-size, llama-server allocates the
+    # model's full training context (Bonsai = 262144 tokens), whose KV cache alone
+    # is ~17GB — the 3.9GB model then pins ~21GB VRAM. --ctx-size ${BONSAI_CTX:-8192}
+    # bounds context (32x smaller → ~0.5GB KV), and 4-bit KV quant trims it further.
+    # Quantized V-cache (--cache-type-v q4_0) requires flash attention, so
+    # --flash-attn on is mandatory here (verified: the PrismML fork's llama-server
+    # accepts -fa/-ctk/-ctv, and -fa takes an [on|off|auto] value). Net: ~5-6GB VRAM
+    # at the default 8192 context. Override the context with BONSAI_CTX.
     command: >-
       --host 0.0.0.0
       --port 8080
       --model /models/${BONSAI_MODEL:-Bonsai-27B-Q1_0.gguf}
       -ngl 99
+      --ctx-size ${BONSAI_CTX:-8192}
+      --flash-attn on
+      --cache-type-k q4_0
+      --cache-type-v q4_0
     restart: unless-stopped
     deploy:
       resources:

--- a/services/embed_test.go
+++ b/services/embed_test.go
@@ -53,6 +53,28 @@ func TestGetAvailableServicesIncludesSGLang(t *testing.T) {
 	}
 }
 
+// TestBonsaiComposeVRAMTuning guards the VRAM-bounding flags (citadel #567):
+// without --ctx-size llama-server allocates Bonsai's full 262K context and pins
+// ~21GB VRAM. The bounded context plus 4-bit KV cache (which requires flash
+// attention) keep it near ~5-6GB. If these drift out of the command, VRAM usage
+// silently regresses, so pin them here.
+func TestBonsaiComposeVRAMTuning(t *testing.T) {
+	content, ok := ServiceMap["bonsai"]
+	if !ok {
+		t.Fatal("bonsai not found in ServiceMap")
+	}
+	for _, flag := range []string{
+		"--ctx-size",
+		"--flash-attn on",
+		"--cache-type-k q4_0",
+		"--cache-type-v q4_0",
+	} {
+		if !strings.Contains(content, flag) {
+			t.Errorf("bonsai compose command missing VRAM-tuning flag %q", flag)
+		}
+	}
+}
+
 // TestDiffusersComposeRegistered ensures the diffusers service is in the
 // ServiceMap so `citadel init` writes services/diffusers.yml and a node can
 // enable it (aceteam #4468).

--- a/services/known_hashes.go
+++ b/services/known_hashes.go
@@ -61,5 +61,6 @@ var KnownComposeHashes = map[string]map[string]bool{
 	},
 	"bonsai": {
 		"124af757f45e93b689bc6a59f08187d48f59c0e62eb2d10c6a006c8ac4d24609": true,
+		"50132811ec60f1d628599cd0c971cb2732087ee11bca58a3bda1312a8ef13ff0": true,
 	},
 }


### PR DESCRIPTION
## #566 (CRITICAL) — deprecated `huggingface-cli` silently no-ops
On huggingface_hub ≥1.x (1.23.0 on node 1084) `huggingface-cli` is deprecated and **downloads nothing** — prints a warning, creates the `--local-dir`, exits 0. Every HF-based MODEL_CACHE_PULL (vllm/llamacpp/bonsai) silently 'succeeds' with an empty dir; since the pull is fire-and-forget, deploy returns `dispatched` and the serving container then crash-loops on 'GGUF not found'. Reproduced live deploying Bonsai.

`internal/jobs/model_cache_pull.go`:
- **`resolveHFDownloader()`** prefers `hf` (`exec.LookPath`), falls back to `huggingface-cli` only if `hf` is absent; if neither is on PATH, searches common dirs (`~/.local/bin`, `~/.uv/python/bin`, `~/.uv/python/*/bin`, `~/bin`, `/usr/local/bin`) — the systemd worker PATH lacks the user's uv bin. Both binaries share the `download <repo> [file] [--local-dir]` grammar (`hfDownloadArgs`).
- **No-op detection** (core fix — a broken pull was indistinguishable from success): zero exit is no longer proof. Single-file pulls require the expected file to exist and be non-empty (`verifyDownloadedFile`); repo pulls fail if `hfCacheModelSize==0`. On failure the captured CLI output (with the deprecation warning) is returned for diagnosis.
- `pullOllama` unchanged.

## #567 — unbounded Bonsai context → 21GB VRAM
`services/compose/bonsai.yml` ran `llama-server ... -ngl 99` with no context bound → defaulted to Bonsai's 262K context → ~21GB VRAM for a 3.9GB model (verified live). Now adds `--ctx-size ${BONSAI_CTX:-8192} --flash-attn on --cache-type-k q4_0 --cache-type-v q4_0` (flag names verified against the PrismML fork's `common/arg.cpp` on branch `prism`; `-fa` takes on|off|auto and is required for q4_0 V-cache). 262144→8192 does ~all the work (~17GB→~0.5GB KV), targeting ~5-6GB total.

## Testing
New `model_cache_pull_hf_test.go` (args repo-vs-file, downloader preference + fallback via fake PATH binaries, verifyDownloadedFile missing/empty/dir→error), updated command-builder tests for the new `bin` param, new `TestBonsaiComposeVRAMTuning`, regenerated `known_hashes.go`. Verified clean-clone `go build ./...` + `go vet` + `go test ./internal/jobs/ ./services/` all pass.

Fixes #566, #567.

🤖 Generated with [Claude Code](https://claude.com/claude-code)