### PR TITLE
feat: serve Bonsai (& non-vLLM engines) via api.aceteam.ai — heartbeat + worker chat path

### DIFF
--- a/internal/jobs/llm_inference.go
+++ b/internal/jobs/llm_inference.go
@@ -115,6 +115,13 @@ func (h *LLMInferenceHandler) executeVLLM(ctx context.Context, client *redisclie
 		return err
 	}
 
+	// Chat-style requests (gateway `messages`) use the OpenAI-compatible
+	// /v1/chat/completions so vLLM applies the served model's chat template;
+	// the legacy /v1/completions prompt path is kept for prompt-style jobs.
+	if len(payload.Messages) > 0 {
+		return h.executeChatCompletionsAt(ctx, client, jobID, rayID, payload, vllmBaseURL())
+	}
+
 	vllmURL := vllmBaseURL() + "/v1/completions"
 
 	reqPayload := map[string]any{
@@ -472,6 +479,16 @@ func (h *LLMInferenceHandler) executeLlamaCpp(ctx context.Context, client *redis
 // URL. Shared by the llamacpp and bonsai backends (bonsai is the PrismML
 // llama.cpp fork serving the identical API on its own host port).
 func (h *LLMInferenceHandler) executeLlamaCppAt(ctx context.Context, client *redisclient.Client, jobID, rayID string, payload *LLMInferencePayload, baseURL string) error {
+	// Chat-style requests (the OpenAI gateway sends `messages`, not `prompt`)
+	// go to the server's OpenAI-compatible /v1/chat/completions so the engine
+	// applies the model's chat template. This is required for chat/instruct
+	// models — and essential for thinking models like Bonsai whose template
+	// emits the reasoning/answer split. The legacy /completion path below is
+	// kept for prompt-style jobs.
+	if len(payload.Messages) > 0 {
+		return h.executeChatCompletionsAt(ctx, client, jobID, rayID, payload, baseURL)
+	}
+
 	llamaCppURL := baseURL + "/completion"
 
 	reqPayload := map[string]any{
@@ -578,4 +595,197 @@ func (h *LLMInferenceHandler) handleLlamaCppNonStream(ctx context.Context, clien
 	})
 
 	return nil
+}
+
+// executeChatCompletionsAt runs a chat-style inference against an OpenAI-
+// compatible /v1/chat/completions endpoint. vLLM, llama.cpp, and the bonsai
+// llama.cpp fork all expose it identically. Sending `messages` (rather than a
+// flattened prompt) lets the engine apply the served model's chat template,
+// which is required for instruct/chat models and essential for thinking models
+// like Bonsai. Used whenever an llm_inference job carries `messages` (the shape
+// the OpenAI inference gateway dispatches).
+func (h *LLMInferenceHandler) executeChatCompletionsAt(ctx context.Context, client *redisclient.Client, jobID, rayID string, payload *LLMInferencePayload, baseURL string) error {
+	chatURL := baseURL + "/v1/chat/completions"
+
+	messages := make([]map[string]string, 0, len(payload.Messages))
+	for _, m := range payload.Messages {
+		messages = append(messages, map[string]string{"role": m.Role, "content": m.Content})
+	}
+
+	reqPayload := map[string]any{
+		"model":       payload.Model,
+		"messages":    messages,
+		"max_tokens":  payload.MaxTokens,
+		"temperature": payload.Temperature,
+		"stream":      payload.Stream,
+	}
+	if payload.MaxTokens == 0 {
+		reqPayload["max_tokens"] = 512
+	}
+	if payload.TopP > 0 {
+		reqPayload["top_p"] = payload.TopP
+	}
+	if len(payload.Stop) > 0 {
+		reqPayload["stop"] = payload.Stop
+	}
+
+	reqBody, _ := json.Marshal(reqPayload)
+	req, err := http.NewRequestWithContext(ctx, "POST", chatURL, bytes.NewBuffer(reqBody))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to connect to chat endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("chat endpoint returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	if payload.Stream {
+		return h.handleChatCompletionsStream(ctx, client, jobID, rayID, resp.Body)
+	}
+	return h.handleChatCompletionsNonStream(ctx, client, jobID, rayID, resp.Body)
+}
+
+// handleChatCompletionsNonStream parses a buffered OpenAI chat-completions
+// response and publishes the assistant's message content.
+func (h *LLMInferenceHandler) handleChatCompletionsNonStream(ctx context.Context, client *redisclient.Client, jobID, rayID string, body io.Reader) error {
+	bodyBytes, err := io.ReadAll(body)
+	if err != nil {
+		return err
+	}
+
+	content, finishReason, usage, err := parseChatCompletionResponse(bodyBytes)
+	if err != nil {
+		return err
+	}
+
+	client.PublishChunk(ctx, jobID, rayID, content, 0)
+	client.PublishEnd(ctx, jobID, rayID, map[string]any{
+		"content":       content,
+		"finish_reason": finishReason,
+		"usage":         usage,
+	})
+	return nil
+}
+
+// parseChatCompletionResponse extracts the assistant content, finish reason,
+// and usage from a buffered OpenAI chat-completions body. Content falls back to
+// reasoning_content when the answer field is empty (thinking models like Bonsai
+// whose token budget was spent mid-reasoning), so a caller never gets a blank
+// reply while tokens were clearly generated.
+func parseChatCompletionResponse(bodyBytes []byte) (content, finishReason string, usage map[string]any, err error) {
+	var response struct {
+		Choices []struct {
+			Message struct {
+				Content          string `json:"content"`
+				ReasoningContent string `json:"reasoning_content"`
+			} `json:"message"`
+			FinishReason string `json:"finish_reason"`
+		} `json:"choices"`
+		Usage struct {
+			PromptTokens     int `json:"prompt_tokens"`
+			CompletionTokens int `json:"completion_tokens"`
+			TotalTokens      int `json:"total_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(bodyBytes, &response); err != nil {
+		return "", "", nil, fmt.Errorf("failed to parse chat completions response: %w", err)
+	}
+
+	finishReason = "stop"
+	if len(response.Choices) > 0 {
+		content = response.Choices[0].Message.Content
+		if content == "" {
+			content = response.Choices[0].Message.ReasoningContent
+		}
+		if response.Choices[0].FinishReason != "" {
+			finishReason = response.Choices[0].FinishReason
+		}
+	}
+
+	usage = map[string]any{
+		"prompt_tokens":     response.Usage.PromptTokens,
+		"completion_tokens": response.Usage.CompletionTokens,
+		"total_tokens":      response.Usage.TotalTokens,
+	}
+	return content, finishReason, usage, nil
+}
+
+// handleChatCompletionsStream translates an OpenAI chat-completions SSE stream
+// into Redis chunks. Each `data:` frame carries a choices[].delta. The answer
+// is streamed from delta.content (matching the buffered path and standard
+// OpenAI clients). Thinking models like Bonsai emit the chain-of-thought in
+// delta.reasoning_content and the answer in delta.content; the reasoning is
+// accumulated but only surfaced if the stream ends with NO answer (token budget
+// spent mid-reasoning), so a reply is never silently blank while staying
+// consistent with the non-stream content-only result.
+func (h *LLMInferenceHandler) handleChatCompletionsStream(ctx context.Context, client *redisclient.Client, jobID, rayID string, body io.Reader) error {
+	scanner := bufio.NewScanner(body)
+	// Allow long SSE lines (large deltas) beyond bufio's default 64KiB cap.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	chunkIndex := 0
+	var answer strings.Builder
+	var reasoning strings.Builder
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		data := strings.TrimPrefix(line, "data: ")
+		if data == "[DONE]" {
+			break
+		}
+
+		var chunk struct {
+			Choices []struct {
+				Delta struct {
+					Content          string `json:"content"`
+					ReasoningContent string `json:"reasoning_content"`
+				} `json:"delta"`
+				FinishReason string `json:"finish_reason"`
+			} `json:"choices"`
+		}
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			continue
+		}
+		if len(chunk.Choices) == 0 {
+			continue
+		}
+
+		if text := chunk.Choices[0].Delta.Content; text != "" {
+			answer.WriteString(text)
+			client.PublishChunk(ctx, jobID, rayID, text, chunkIndex)
+			chunkIndex++
+		} else if rc := chunk.Choices[0].Delta.ReasoningContent; rc != "" {
+			reasoning.WriteString(rc)
+		}
+
+		if chunk.Choices[0].FinishReason != "" {
+			break
+		}
+	}
+
+	final := answer.String()
+	if final == "" {
+		// No answer was produced (thinking model ran out of budget mid-reason);
+		// surface the reasoning so the reply is not blank, mirroring the
+		// buffered path's reasoning_content fallback.
+		if final = reasoning.String(); final != "" {
+			client.PublishChunk(ctx, jobID, rayID, final, chunkIndex)
+		}
+	}
+
+	client.PublishEnd(ctx, jobID, rayID, map[string]any{
+		"content":       final,
+		"finish_reason": "stop",
+	})
+	return scanner.Err()
 }

--- a/internal/jobs/llm_inference_chat_test.go
+++ b/internal/jobs/llm_inference_chat_test.go
@@ -1,0 +1,61 @@
+package jobs
+
+import "testing"
+
+// TestParseChatCompletionResponse covers the OpenAI chat-completions body
+// parsing used by the chat path (executeChatCompletionsAt), including the
+// thinking-model reasoning_content fallback that keeps Bonsai from returning a
+// blank reply when the token budget is spent mid-reasoning.
+func TestParseChatCompletionResponse(t *testing.T) {
+	cases := []struct {
+		name           string
+		body           string
+		wantContent    string
+		wantFinish     string
+		wantCompletion int
+	}{
+		{
+			name:           "normal content wins over reasoning",
+			body:           `{"choices":[{"message":{"content":"42","reasoning_content":"6*7=42"},"finish_reason":"stop"}],"usage":{"prompt_tokens":24,"completion_tokens":131,"total_tokens":155}}`,
+			wantContent:    "42",
+			wantFinish:     "stop",
+			wantCompletion: 131,
+		},
+		{
+			name:        "empty content falls back to reasoning (thinking model, length-capped)",
+			body:        `{"choices":[{"message":{"content":"","reasoning_content":"still thinking..."},"finish_reason":"length"}]}`,
+			wantContent: "still thinking...",
+			wantFinish:  "length",
+		},
+		{
+			name:        "no choices yields empty content and default stop",
+			body:        `{"choices":[],"usage":{}}`,
+			wantContent: "",
+			wantFinish:  "stop",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			content, finish, usage, err := parseChatCompletionResponse([]byte(tc.body))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if content != tc.wantContent {
+				t.Errorf("content = %q, want %q", content, tc.wantContent)
+			}
+			if finish != tc.wantFinish {
+				t.Errorf("finish_reason = %q, want %q", finish, tc.wantFinish)
+			}
+			if tc.wantCompletion != 0 {
+				if got, _ := usage["completion_tokens"].(int); got != tc.wantCompletion {
+					t.Errorf("completion_tokens = %v, want %d", usage["completion_tokens"], tc.wantCompletion)
+				}
+			}
+		})
+	}
+
+	if _, _, _, err := parseChatCompletionResponse([]byte(`not json`)); err == nil {
+		t.Error("expected error for malformed body, got nil")
+	}
+}

--- a/internal/status/engines.go
+++ b/internal/status/engines.go
@@ -24,7 +24,12 @@ var idleCapableEngines = []string{"vllm"}
 // loaded model(s) over the engine's local HTTP API (#529). It must remain a
 // superset of idleCapableEngines (guarded by a test) so extending the idle
 // list never silently drops an engine from the heartbeat.
-var managedProbeEngines = []string{"vllm", "ollama", "llamacpp"}
+//
+// bonsai (PrismML Bonsai-27B on the llama.cpp fork, host port 8210) exposes the
+// same OpenAI-compatible /v1/models API as llama.cpp, so probing it surfaces the
+// served GGUF in the heartbeat's services[].models — which is how the inference
+// gateway learns a node is serving Bonsai and can route to it (backend=bonsai).
+var managedProbeEngines = []string{"vllm", "ollama", "llamacpp", "bonsai"}
 
 // collectManagedEngineStatus reports running managed serving engines (from the
 // embedded services.ServiceMap) so their telemetry reaches the heartbeat even

--- a/internal/status/models.go
+++ b/internal/status/models.go
@@ -34,9 +34,11 @@ func NewModelDiscovery() *ModelDiscovery {
 }
 
 // EngineTypeFromName maps a service/app name to a model-discovery engine type
-// ("vllm", "ollama", "llamacpp"), or "" when the name is not a known serving
-// engine. Order matters: "ollama" contains "llama", so it must be checked
-// before the llama.cpp patterns.
+// ("vllm", "ollama", "llamacpp", "bonsai"), or "" when the name is not a known
+// serving engine. Order matters: "ollama" contains "llama", so it must be
+// checked before the llama.cpp patterns. "bonsai" is kept as its own type (it
+// serves the llama.cpp /v1/models API but the heartbeat reports it under its own
+// engine name so the gateway can route with backend=bonsai).
 func EngineTypeFromName(name string) string {
 	n := strings.ToLower(name)
 	switch {
@@ -44,6 +46,8 @@ func EngineTypeFromName(name string) string {
 		return "vllm"
 	case strings.Contains(n, "ollama"):
 		return "ollama"
+	case strings.Contains(n, "bonsai"):
+		return "bonsai"
 	case strings.Contains(n, "llamacpp"), strings.Contains(n, "llama.cpp"), strings.Contains(n, "llama-cpp"):
 		return "llamacpp"
 	}
@@ -63,6 +67,10 @@ func (m *ModelDiscovery) DiscoverModels(ctx context.Context, serviceType string,
 		// It can be up with NO model loaded (router mode / deferred load): that is
 		// an empty list, not an error.
 		return m.discoverOpenAIModels(ctx, "llama.cpp", port)
+	case "bonsai":
+		// bonsai (PrismML Bonsai-27B) is served by the llama.cpp fork, so it
+		// exposes the identical OpenAI-compatible /v1/models endpoint.
+		return m.discoverOpenAIModels(ctx, "bonsai", port)
 	case "ollama":
 		return m.discoverOllamaModels(ctx, port)
 	default:
@@ -154,8 +162,8 @@ func (m *ModelDiscovery) discoverOllamaModels(ctx context.Context, port int) ([]
 // CheckServiceHealth performs a health check on an LLM service.
 func (m *ModelDiscovery) CheckServiceHealth(ctx context.Context, serviceType string, port int) (string, error) {
 	switch serviceType {
-	case "vllm", "llamacpp":
-		// Both vLLM and llama.cpp's server expose GET /health.
+	case "vllm", "llamacpp", "bonsai":
+		// vLLM, llama.cpp, and the bonsai llama.cpp fork all expose GET /health.
 		return m.checkHTTPHealth(ctx, port)
 	case "ollama":
 		return m.checkOllamaHealth(ctx, port)

--- a/internal/status/models_test.go
+++ b/internal/status/models_test.go
@@ -207,6 +207,8 @@ func TestEngineTypeFromName(t *testing.T) {
 		"llamacpp":       "llamacpp",
 		"llama.cpp":      "llamacpp",
 		"llama-cpp":      "llamacpp",
+		"bonsai":         "bonsai",
+		"citadel-bonsai": "bonsai",
 		"transcribe":     "",
 		"gotenberg":      "",
 		"postgres":       "",


### PR DESCRIPTION
## Context
Goal: use Bonsai on `api.aceteam.ai`. Tracing the path surfaced a 3-layer gap; this PR is the **citadel (node) half** (paired with aceteam PR `feat/bonsai-inference-gateway` — both must deploy together).

## Root Cause
1. **Heartbeat didn't advertise Bonsai.** `managedProbeEngines` was `{vllm,ollama,llamacpp}` — the node never probed `:8210`, so the gateway couldn't learn Bonsai was served.
2. **Worker ignored `messages` (pre-existing, all-backends).** The OpenAI gateway dispatches `messages` (no `prompt`), but every executor read only `payload.Prompt` and hit the engines' `/completion` endpoints — so a gateway chat request reached the engine with an **empty prompt**. Only mocked shape tests existed; no e2e ever exercised it.

## Changes
- `internal/status/engines.go`, `models.go`: add `bonsai` to `managedProbeEngines` + discovery/health switches (bonsai speaks the llama.cpp `/v1/models` API), so the heartbeat reports the served GGUF under `services[].models`.
- `internal/jobs/llm_inference.go`: new `executeChatCompletionsAt` — when a job carries `messages`, POST to the engine's `/v1/chat/completions` so it applies the model's chat template (essential for Bonsai's think/answer split). Wired for vllm + llamacpp/bonsai. Content falls back to `reasoning_content` when the answer is empty (budget spent mid-think) so replies are never blank; streaming mirrors this.

## Testing
- `go test ./internal/status/ ./internal/jobs/` green; new `TestParseChatCompletionResponse`.
- Verified against the **live** Bonsai `:8210`: non-stream returns `content:"42"` + separate `reasoning_content`; streaming emits `delta.reasoning_content` frames (no inline `<think>`) — parsers match.
- **Pending e2e** (needs deploy): citadel release + `citadel update` on node 1084, then confirm `bonsai` in `node:service_usage:{id}` and a real `api.aceteam.ai` request returns Bonsai output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)