### PR TITLE
Do not publish a second heartbeat when a dedicated worker holds the node (#571 Phase 0)

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -1894,15 +1894,26 @@ func runTUIWorker(ctx context.Context, activityFn func(level, msg string)) error
 					activity("info", "Node-state reporting started")
 				}
 
-				apiPublisher, err := heartbeat.NewAPIPublisher(heartbeat.APIPublisherConfig{
+				// Only the control center publishes heartbeat when NO dedicated
+				// worker owns this node. A `citadel work` daemon holding the lock
+				// already publishes heartbeat for this nodeId (see runWork); a
+				// second publisher here would double the control-plane heartbeat
+				// volume (the 429 self-DoS class the worklock work targeted) and
+				// flap node status between two competing publishers. The monitor-only
+				// gate below stops job consumption but not heartbeat publishing, so
+				// gating the publisher start here is what closes #571 (Phase 0).
+				// When skipped, the heartbeat indicator (ccHeartbeatFn) is left unset
+				// so the TUI never falsely claims "Heartbeat publishing started".
+				if workerHeld {
+					activity("info", fmt.Sprintf("Dedicated worker holds this node (PID %d); control center will NOT publish a second heartbeat (monitor-only)", workerPID))
+				} else if apiPublisher, err := heartbeat.NewAPIPublisher(heartbeat.APIPublisherConfig{
 					Client:          apiSource.Client(),
 					NodeID:          nodeName,
 					HeadscaleNodeID: headscaleNodeID,
 					OrgID:           orgID,
 					DebugFunc:       nil,
 					LogFn:           activity, // Route logs through TUI
-				}, collector)
-				if err == nil {
+				}, collector); err == nil {
 					// Include current permissions in heartbeat
 					apiPublisher.SetPermissions(permissionsToHeartbeat(config.LoadPermissions(platform.ConfigDir())))
 					go func() {


### PR DESCRIPTION
## Context

Part of #571 (Phase 0). When a dedicated `citadel work` daemon already holds this node's single-instance worklock, the `citadel` control center (TUI worker) was starting its own heartbeat publisher too, so the same nodeId got TWO heartbeat publishers.

## Root Cause

In `cmd/controlcenter.go`, `runTUIWorker` computes `workerHeld, workerPID := worklock.IsHeld(...)` (around line 1751). The heartbeat publisher (`heartbeat.NewAPIPublisher(...)` then `apiPublisher.Start(ctx)`, around lines 1897 to 1946) was started BEFORE the monitor-only gate (`if workerHeld { block until ctx done; return }`, around line 1945). That gate stopped job consumption but not heartbeat publishing. Result when a worker held the lock: duplicate and flapping node status, plus doubled control-plane heartbeat volume (the 429 self-DoS class the worklock work targeted).

## Changes

- `cmd/controlcenter.go` (`runTUIWorker`, publisher block near lines 1897 to 1947): gate the `apiPublisher` creation, its `SetPermissions`, and its `Start`/indicator goroutine on `!workerHeld`. When a worker holds the lock, log a clear monitor-only line via `activity(...)` (includes the worker PID) and skip starting the publisher entirely.
- The TUI heartbeat indicator (`ccHeartbeatFn`) lives inside the gated goroutine, so it is left unset in monitor-only mode: the TUI never falsely reports "Heartbeat publishing started" when the daemon owns heartbeat.
- Deliberately narrow: `telemetry.Configure(...)` (a process-global singleton for the TUI process, not a node-status duplicate) and the node-state emitter are left unchanged. No feature flag: standalone `citadel` with no worker still publishes exactly as before (natural fallback).

## Testing

Ran from the worktree root:

- `go build ./...` : rc=0 (clean, no output)
- `go vet ./...` : rc=0 (clean, no output)
- `go test ./...` : rc=0, 62 packages ok, no FAIL or panic (the `cmd` and `internal/worklock` packages build and pass)

Manual expectation:
- Standalone `citadel` (no `citadel work` running): still publishes heartbeat as before.
- `citadel` running beside a live `citadel work` daemon that holds the worklock: control center no longer starts a second heartbeat publisher; it logs the monitor-only line and leaves heartbeat/telemetry to the daemon. No double heartbeat for the same nodeId.

Generated by Claude Opus 4.8.
Requested by Jason.