### PR TITLE
feat(chat): `citadel chat` — chat with the model hosted locally on this node (#575)

### DIFF
--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -1,0 +1,253 @@
+// cmd/chat.go
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+
+	"github.com/aceteam-ai/citadel-cli/internal/localchat"
+	"github.com/aceteam-ai/citadel-cli/internal/status"
+	"github.com/aceteam-ai/citadel-cli/internal/ui"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+var (
+	chatEngine    string
+	chatModel     string
+	chatMaxTokens int
+	chatNoReason  bool
+)
+
+var chatCmd = &cobra.Command{
+	Use:   "chat",
+	Short: "Chat with a model hosted locally on this node",
+	Long: `Chat with an AI model served locally on THIS node.
+
+Discovers the inference engine(s) running on this machine (vLLM, Ollama,
+llama.cpp, or Bonsai), lets you pick a model if more than one is available,
+and opens an interactive streaming chat against its local API.
+
+Thinking models (e.g. Bonsai) stream their reasoning separately from the
+answer; the reasoning is shown dimmed and the answer in normal text.
+
+Type your message and press Enter. Ctrl-C interrupts a streaming reply;
+type /exit (or Ctrl-D) to quit.`,
+	// A runtime failure here (no engine running, engine unreachable) is an
+	// operational condition, not misuse — don't dump the usage text on it.
+	SilenceUsage: true,
+	RunE:         runChat,
+}
+
+func init() {
+	chatCmd.Flags().StringVar(&chatEngine, "engine", "", "Pre-select an engine by name (vllm, ollama, llamacpp, bonsai)")
+	chatCmd.Flags().StringVar(&chatModel, "model", "", "Pre-select a model by id")
+	chatCmd.Flags().IntVar(&chatMaxTokens, "max-tokens", localchat.DefaultMaxTokens, "Max tokens to generate per reply")
+	chatCmd.Flags().BoolVar(&chatNoReason, "no-reasoning", false, "Hide the model's chain-of-thought (thinking models only)")
+	rootCmd.AddCommand(chatCmd)
+}
+
+func runChat(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	// Discover engines running on this node and flatten to (engine, model) choices.
+	engines := status.DiscoverLocalEngines(ctx)
+	choices := localchat.BuildChoices(engines)
+	if len(choices) == 0 {
+		return errors.New("no inference engine is running on this node.\n" +
+			"Start one first, e.g.: citadel run --service bonsai  (or vllm / ollama / llamacpp)")
+	}
+
+	// Apply optional --engine / --model filters.
+	choices = filterChoices(choices, chatEngine, chatModel)
+	if len(choices) == 0 {
+		return fmt.Errorf("no running engine/model matched --engine=%q --model=%q", chatEngine, chatModel)
+	}
+
+	choice, err := pickChoice(choices)
+	if err != nil {
+		return err
+	}
+
+	client := localchat.NewClient(choice.Port, choice.Model)
+	if err := client.HealthCheck(ctx); err != nil {
+		return fmt.Errorf("engine %q is not responding on localhost:%d: %w", choice.Engine, choice.Port, err)
+	}
+
+	return chatLoop(ctx, client, choice)
+}
+
+// filterChoices narrows choices by an optional engine and/or model name.
+// Empty filters match everything; matching is case-insensitive.
+func filterChoices(choices []localchat.EngineChoice, engine, model string) []localchat.EngineChoice {
+	if engine == "" && model == "" {
+		return choices
+	}
+	var out []localchat.EngineChoice
+	for _, c := range choices {
+		if engine != "" && !strings.EqualFold(c.Engine, engine) {
+			continue
+		}
+		if model != "" && !strings.EqualFold(c.Model, model) {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+// pickChoice auto-selects when there is exactly one choice, otherwise prompts.
+func pickChoice(choices []localchat.EngineChoice) (localchat.EngineChoice, error) {
+	if len(choices) == 1 {
+		return choices[0], nil
+	}
+	labels := make([]string, len(choices))
+	for i, c := range choices {
+		labels[i] = c.Label()
+	}
+	selected, err := ui.AskSelect("Multiple models are available. Choose one to chat with:", labels)
+	if err != nil {
+		return localchat.EngineChoice{}, err
+	}
+	for i, l := range labels {
+		if l == selected {
+			return choices[i], nil
+		}
+	}
+	return localchat.EngineChoice{}, errors.New("no model selected")
+}
+
+// chatLoop runs the interactive multi-turn conversation.
+func chatLoop(ctx context.Context, client *localchat.Client, choice localchat.EngineChoice) error {
+	promptStyle := color.New(color.FgCyan, color.Bold)
+	assistantStyle := color.New(color.FgGreen, color.Bold)
+	reasonStyle := color.New(color.FgHiBlack)
+	mutedStyle := color.New(color.FgHiBlack)
+
+	label := choice.Model
+	if label == "" {
+		label = choice.Engine + " (default model)"
+	}
+	assistantStyle.Printf("Chatting with %s", label)
+	fmt.Printf(" on localhost:%d\n", choice.Port)
+	mutedStyle.Println("Type your message and press Enter. Ctrl-C interrupts a reply; /exit or Ctrl-D quits.")
+	fmt.Println()
+
+	// Interrupt handling: Ctrl-C cancels an in-flight reply; at the prompt it
+	// exits gracefully. A shared flag + cancel func distinguishes the two.
+	var (
+		mu          sync.Mutex
+		streaming   bool
+		cancelReply context.CancelFunc
+	)
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
+	defer signal.Stop(sigCh)
+	go func() {
+		for range sigCh {
+			mu.Lock()
+			if streaming && cancelReply != nil {
+				cancelReply()
+				mu.Unlock()
+				continue
+			}
+			mu.Unlock()
+			mutedStyle.Println("\nGoodbye.")
+			os.Exit(0)
+		}
+	}()
+
+	messages := []localchat.Message{}
+	reader := bufio.NewReader(os.Stdin)
+
+	for {
+		promptStyle.Print("you> ")
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				mutedStyle.Println("\nGoodbye.")
+				return nil
+			}
+			return err
+		}
+		input := strings.TrimSpace(line)
+		if input == "" {
+			continue
+		}
+		switch strings.ToLower(input) {
+		case "/exit", "/quit", "exit", "quit", ":q":
+			mutedStyle.Println("Goodbye.")
+			return nil
+		}
+
+		messages = append(messages, localchat.Message{Role: "user", Content: input})
+
+		reqCtx, cancel := context.WithCancel(ctx)
+		mu.Lock()
+		streaming = true
+		cancelReply = cancel
+		mu.Unlock()
+
+		assistantStyle.Print("bot> ")
+
+		var answer strings.Builder
+		inReasoning := false
+		answerStarted := false
+		streamErr := client.Stream(reqCtx, messages, chatMaxTokens, func(ch localchat.StreamChunk) {
+			if ch.Reasoning != "" && !chatNoReason {
+				if !inReasoning {
+					reasonStyle.Print("(thinking) ")
+					inReasoning = true
+				}
+				reasonStyle.Print(ch.Reasoning)
+			}
+			if ch.Content != "" {
+				if inReasoning {
+					// Separate the dimmed reasoning from the answer.
+					fmt.Print("\n\n")
+					inReasoning = false
+				}
+				answerStarted = true
+				fmt.Print(ch.Content)
+				answer.WriteString(ch.Content)
+			}
+		})
+
+		mu.Lock()
+		streaming = false
+		cancelReply = nil
+		mu.Unlock()
+		cancel()
+		fmt.Println()
+
+		if streamErr != nil {
+			if errors.Is(streamErr, context.Canceled) || reqCtx.Err() != nil {
+				mutedStyle.Println("[interrupted]")
+			} else {
+				color.New(color.FgRed).Printf("error: %v\n", streamErr)
+				// Drop the unanswered user turn so a retry isn't polluted.
+				messages = messages[:len(messages)-1]
+				continue
+			}
+		}
+
+		// Persist ONLY the answer content in history — never reasoning_content
+		// (per-turn scratch that degrades a thinking model if resent).
+		if answerStarted && answer.Len() > 0 {
+			messages = append(messages, localchat.Message{Role: "assistant", Content: answer.String()})
+		} else {
+			// No usable answer (interrupted before any content): drop the user turn.
+			messages = messages[:len(messages)-1]
+		}
+	}
+}

--- a/internal/localchat/client.go
+++ b/internal/localchat/client.go
@@ -1,0 +1,210 @@
+// Package localchat implements the client used by `citadel chat`
+// (aceteam-ai/citadel-cli#575) to hold a streaming, multi-turn conversation with
+// a model served locally on THIS node over its OpenAI-compatible
+// /v1/chat/completions endpoint (vllm, llamacpp, bonsai, ollama).
+//
+// It is deliberately separate from internal/chat, which is node-to-node peer
+// messaging over the Redis API proxy (a different feature). The build-request
+// and parse-response logic lives here (not in cmd/) so it is unit-testable
+// without a running engine; the interactive loop lives in cmd/chat.go.
+package localchat
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// DefaultMaxTokens is the completion budget used when the caller does not set
+// one. Kept comfortably above the issue's ">= 512" floor so a thinking model
+// (Bonsai) has room for reasoning_content plus an actual answer.
+const DefaultMaxTokens = 1024
+
+// Message is one turn in the conversation, in OpenAI chat format.
+//
+// IMPORTANT: for a thinking model the assistant's chain-of-thought
+// (reasoning_content) is per-turn scratch and MUST NOT be stored here or resent
+// on the next turn — only the final answer content belongs in the history.
+type Message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// chatRequest is the JSON body POSTed to /v1/chat/completions.
+type chatRequest struct {
+	Model     string    `json:"model"`
+	Messages  []Message `json:"messages"`
+	Stream    bool      `json:"stream"`
+	MaxTokens int       `json:"max_tokens,omitempty"`
+}
+
+// BuildRequestBody builds the streaming /v1/chat/completions request body for a
+// conversation. maxTokens <= 0 falls back to DefaultMaxTokens. The model id
+// should be the id discovered from the engine's /v1/models (llama.cpp/bonsai
+// ignore it; vLLM requires an exact match).
+func BuildRequestBody(model string, messages []Message, maxTokens int) ([]byte, error) {
+	if maxTokens <= 0 {
+		maxTokens = DefaultMaxTokens
+	}
+	return json.Marshal(chatRequest{
+		Model:     model,
+		Messages:  messages,
+		Stream:    true,
+		MaxTokens: maxTokens,
+	})
+}
+
+// StreamChunk is the decoded delta from one SSE event: the answer fragment
+// (Content) and/or the chain-of-thought fragment (Reasoning). For a thinking
+// model such as Bonsai the reasoning arrives first (with Content empty) and the
+// answer follows in a separate field — never as inline <think> tags.
+type StreamChunk struct {
+	Content   string
+	Reasoning string
+}
+
+// sseEnvelope is the subset of the OpenAI streaming chunk schema we consume.
+// content/reasoning_content decode "null" JSON values to the empty string.
+type sseEnvelope struct {
+	Choices []struct {
+		Delta struct {
+			Content          string `json:"content"`
+			ReasoningContent string `json:"reasoning_content"`
+		} `json:"delta"`
+	} `json:"choices"`
+}
+
+// ParseSSELine parses one raw line of an SSE stream. It returns:
+//   - handled=false for lines that carry no data event (blank lines, ":"
+//     comment/keep-alive lines, or any non-"data:" line) — the caller skips them.
+//   - done=true when the terminal "data: [DONE]" sentinel is seen.
+//   - a populated StreamChunk for a "data: {json}" payload.
+//
+// A JSON payload that parses but carries no content/reasoning yields a zero
+// chunk with handled=true (e.g. the opening role-only delta), which the caller
+// can safely ignore.
+func ParseSSELine(line string) (chunk StreamChunk, handled bool, done bool, err error) {
+	line = strings.TrimRight(line, "\r")
+	if line == "" || strings.HasPrefix(line, ":") {
+		return StreamChunk{}, false, false, nil
+	}
+	data, ok := strings.CutPrefix(line, "data:")
+	if !ok {
+		return StreamChunk{}, false, false, nil
+	}
+	data = strings.TrimSpace(data)
+	if data == "[DONE]" {
+		return StreamChunk{}, false, true, nil
+	}
+
+	var env sseEnvelope
+	if err := json.Unmarshal([]byte(data), &env); err != nil {
+		return StreamChunk{}, false, false, fmt.Errorf("parse stream chunk: %w", err)
+	}
+	if len(env.Choices) == 0 {
+		return StreamChunk{}, true, false, nil
+	}
+	d := env.Choices[0].Delta
+	return StreamChunk{Content: d.Content, Reasoning: d.ReasoningContent}, true, false, nil
+}
+
+// Client talks to one engine's OpenAI-compatible API at a base URL such as
+// "http://localhost:8210".
+type Client struct {
+	BaseURL string
+	Model   string
+	HTTP    *http.Client
+}
+
+// NewClient builds a Client for the engine at the given localhost port. The HTTP
+// client has no overall timeout because a streaming completion is open-ended;
+// per-request cancellation is done via the context passed to Stream.
+func NewClient(port int, model string) *Client {
+	return &Client{
+		BaseURL: fmt.Sprintf("http://localhost:%d", port),
+		Model:   model,
+		HTTP:    &http.Client{},
+	}
+}
+
+// Stream sends the conversation and invokes onChunk for every streamed delta as
+// it arrives. It returns when the stream completes ([DONE] or EOF), the context
+// is cancelled, or an error occurs. A non-200 response body is read and surfaced
+// as the error (a bad request comes back as plain JSON, not an SSE stream, so a
+// naive line-loop would otherwise show nothing).
+func (c *Client) Stream(ctx context.Context, messages []Message, maxTokens int, onChunk func(StreamChunk)) error {
+	body, err := BuildRequestBody(c.Model, messages, maxTokens)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/v1/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("engine returned %s: %s", resp.Status, strings.TrimSpace(string(msg)))
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	// Allow long SSE lines (a single delta is small, but be generous).
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		chunk, handled, done, perr := ParseSSELine(scanner.Text())
+		if perr != nil {
+			return perr
+		}
+		if done {
+			return nil
+		}
+		if handled && (chunk.Content != "" || chunk.Reasoning != "") {
+			onChunk(chunk)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		// A cancelled context surfaces here as a read error; report the context
+		// error so the caller can distinguish a user interrupt from a real fault.
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return err
+	}
+	return nil
+}
+
+// HealthCheck reports whether the engine's API is reachable, with a short
+// bounded probe. Used before entering the chat loop to fail fast with a clear
+// message rather than on the first send.
+func (c *Client) HealthCheck(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+"/v1/models", nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("engine at %s returned %s", c.BaseURL, resp.Status)
+	}
+	return nil
+}

--- a/internal/localchat/client_test.go
+++ b/internal/localchat/client_test.go
@@ -1,0 +1,186 @@
+package localchat
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestBuildRequestBody_DefaultsAndFields(t *testing.T) {
+	msgs := []Message{
+		{Role: "system", Content: "be brief"},
+		{Role: "user", Content: "hi"},
+	}
+
+	// maxTokens <= 0 falls back to the default.
+	body, err := BuildRequestBody("my-model", msgs, 0)
+	if err != nil {
+		t.Fatalf("BuildRequestBody: %v", err)
+	}
+	var req chatRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if req.Model != "my-model" {
+		t.Errorf("model = %q, want my-model", req.Model)
+	}
+	if !req.Stream {
+		t.Error("stream should be true")
+	}
+	if req.MaxTokens != DefaultMaxTokens {
+		t.Errorf("max_tokens = %d, want default %d", req.MaxTokens, DefaultMaxTokens)
+	}
+	if DefaultMaxTokens < 512 {
+		t.Errorf("DefaultMaxTokens %d below issue floor of 512", DefaultMaxTokens)
+	}
+	if len(req.Messages) != 2 || req.Messages[1].Content != "hi" {
+		t.Errorf("messages not preserved: %+v", req.Messages)
+	}
+
+	// Explicit positive maxTokens is honored.
+	body, _ = BuildRequestBody("m", msgs, 42)
+	_ = json.Unmarshal(body, &req)
+	if req.MaxTokens != 42 {
+		t.Errorf("max_tokens = %d, want 42", req.MaxTokens)
+	}
+}
+
+func TestParseSSELine(t *testing.T) {
+	tests := []struct {
+		name      string
+		line      string
+		wantChunk StreamChunk
+		handled   bool
+		done      bool
+		wantErr   bool
+	}{
+		{name: "blank", line: "", handled: false},
+		{name: "comment", line: ": keep-alive", handled: false},
+		{name: "non-data", line: "event: message", handled: false},
+		{name: "done", line: "data: [DONE]", done: true},
+		{
+			name:      "reasoning only (content null)",
+			line:      `data: {"choices":[{"delta":{"content":null,"reasoning_content":"Here"}}]}`,
+			wantChunk: StreamChunk{Reasoning: "Here"},
+			handled:   true,
+		},
+		{
+			name:      "answer content",
+			line:      `data: {"choices":[{"delta":{"content":"Hello"}}]}`,
+			wantChunk: StreamChunk{Content: "Hello"},
+			handled:   true,
+		},
+		{
+			name:      "role-only opening delta",
+			line:      `data: {"choices":[{"delta":{"role":"assistant","content":null}}]}`,
+			wantChunk: StreamChunk{},
+			handled:   true,
+		},
+		{
+			name:    "empty choices",
+			line:    `data: {"choices":[]}`,
+			handled: true,
+		},
+		{
+			name:      "no data prefix space",
+			line:      `data:{"choices":[{"delta":{"content":"x"}}]}`,
+			wantChunk: StreamChunk{Content: "x"},
+			handled:   true,
+		},
+		{
+			name:    "malformed json",
+			line:    `data: {not json`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chunk, handled, done, err := ParseSSELine(tt.line)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if handled != tt.handled {
+				t.Errorf("handled = %v, want %v", handled, tt.handled)
+			}
+			if done != tt.done {
+				t.Errorf("done = %v, want %v", done, tt.done)
+			}
+			if chunk != tt.wantChunk {
+				t.Errorf("chunk = %+v, want %+v", chunk, tt.wantChunk)
+			}
+		})
+	}
+}
+
+// TestStream_EndToEnd drives Stream against a fake SSE server that emits the
+// Bonsai-shaped sequence (reasoning first, then answer, then [DONE]) and asserts
+// the chunks arrive in order and split cleanly into reasoning vs answer.
+func TestStream_EndToEnd(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		fl, _ := w.(http.Flusher)
+		lines := []string{
+			`data: {"choices":[{"delta":{"role":"assistant","content":null}}]}`,
+			`data: {"choices":[{"delta":{"reasoning_content":"think"}}]}`,
+			`data: {"choices":[{"delta":{"reasoning_content":"ing"}}]}`,
+			`: keep-alive`,
+			`data: {"choices":[{"delta":{"content":"Hi"}}]}`,
+			`data: {"choices":[{"delta":{"content":"!"}}]}`,
+			`data: [DONE]`,
+		}
+		for _, l := range lines {
+			_, _ = w.Write([]byte(l + "\n\n"))
+			if fl != nil {
+				fl.Flush()
+			}
+		}
+	}))
+	defer srv.Close()
+
+	c := &Client{BaseURL: srv.URL, Model: "m", HTTP: srv.Client()}
+
+	var reasoning, answer strings.Builder
+	err := c.Stream(context.Background(), []Message{{Role: "user", Content: "hi"}}, 64, func(ch StreamChunk) {
+		reasoning.WriteString(ch.Reasoning)
+		answer.WriteString(ch.Content)
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	if reasoning.String() != "thinking" {
+		t.Errorf("reasoning = %q, want %q", reasoning.String(), "thinking")
+	}
+	if answer.String() != "Hi!" {
+		t.Errorf("answer = %q, want %q", answer.String(), "Hi!")
+	}
+}
+
+func TestStream_Non200SurfacesBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"bad model"}`))
+	}))
+	defer srv.Close()
+
+	c := &Client{BaseURL: srv.URL, Model: "m", HTTP: srv.Client()}
+	err := c.Stream(context.Background(), []Message{{Role: "user", Content: "hi"}}, 64, func(StreamChunk) {})
+	if err == nil {
+		t.Fatal("expected error on non-200")
+	}
+	if !strings.Contains(err.Error(), "bad model") {
+		t.Errorf("error should surface body, got: %v", err)
+	}
+}

--- a/internal/localchat/select.go
+++ b/internal/localchat/select.go
@@ -1,0 +1,42 @@
+package localchat
+
+import (
+	"fmt"
+
+	"github.com/aceteam-ai/citadel-cli/internal/status"
+)
+
+// EngineChoice is a single selectable chat target: a running engine and one of
+// its served models, plus the localhost port to reach it.
+type EngineChoice struct {
+	Engine string // vllm, ollama, llamacpp, bonsai
+	Model  string // served model id (may be empty for a running engine with no reported model)
+	Port   int
+}
+
+// Label is the human-readable line shown in the picker.
+func (c EngineChoice) Label() string {
+	if c.Model == "" {
+		return fmt.Sprintf("%s (default model) — localhost:%d", c.Engine, c.Port)
+	}
+	return fmt.Sprintf("%s — %s — localhost:%d", c.Engine, c.Model, c.Port)
+}
+
+// BuildChoices flattens discovered local engines into one choice per served
+// model. An engine that is running but reports no loaded model still yields a
+// single choice with an empty Model: llama.cpp/bonsai ignore the request's
+// model field and serve their loaded default, so chatting is still possible.
+// The order follows the engine discovery order, models in reported order.
+func BuildChoices(engines []status.LocalEngine) []EngineChoice {
+	var out []EngineChoice
+	for _, e := range engines {
+		if len(e.Models) == 0 {
+			out = append(out, EngineChoice{Engine: e.Name, Model: "", Port: e.Port})
+			continue
+		}
+		for _, m := range e.Models {
+			out = append(out, EngineChoice{Engine: e.Name, Model: m, Port: e.Port})
+		}
+	}
+	return out
+}

--- a/internal/localchat/select_test.go
+++ b/internal/localchat/select_test.go
@@ -1,0 +1,43 @@
+package localchat
+
+import (
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/status"
+)
+
+func TestBuildChoices(t *testing.T) {
+	engines := []status.LocalEngine{
+		{Name: "bonsai", Port: 8210, Models: []string{"Bonsai-27B-Q1_0.gguf"}},
+		{Name: "vllm", Port: 8201, Models: []string{"a", "b"}},
+		{Name: "llamacpp", Port: 8200, Models: nil}, // running, no model loaded
+	}
+
+	got := BuildChoices(engines)
+	want := []EngineChoice{
+		{Engine: "bonsai", Model: "Bonsai-27B-Q1_0.gguf", Port: 8210},
+		{Engine: "vllm", Model: "a", Port: 8201},
+		{Engine: "vllm", Model: "b", Port: 8201},
+		{Engine: "llamacpp", Model: "", Port: 8200},
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("got %d choices, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("choice[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+
+	// The no-model engine must produce a usable label.
+	if got[3].Label() == "" {
+		t.Error("empty-model choice should still have a label")
+	}
+}
+
+func TestBuildChoices_Empty(t *testing.T) {
+	if got := BuildChoices(nil); len(got) != 0 {
+		t.Errorf("expected no choices, got %+v", got)
+	}
+}

--- a/internal/status/local_engines.go
+++ b/internal/status/local_engines.go
@@ -1,0 +1,58 @@
+package status
+
+import (
+	"context"
+
+	"github.com/aceteam-ai/citadel-cli/internal/catalog"
+)
+
+// LocalEngine describes a managed serving engine currently running on THIS node
+// and the model(s) it is serving. It is the discovery surface used by
+// `citadel chat` (aceteam-ai/citadel-cli#575) to find an engine to talk to.
+//
+// Name is the managed-engine name ("vllm", "ollama", "llamacpp", "bonsai"),
+// Port is the citadel-assigned host port the engine's OpenAI-compatible API
+// listens on (localhost), and Models are the loaded model id(s) discovered from
+// that API. Models may be empty for an engine that is up but has no model
+// loaded (e.g. llama.cpp in deferred-load mode).
+type LocalEngine struct {
+	Name   string
+	Port   int
+	Models []string
+}
+
+// DiscoverLocalEngines probes the managed serving engines (managedProbeEngines)
+// for a live signal on this node and returns those that are running, along with
+// each engine's currently loaded model(s). It reuses the same running-check and
+// model-discovery path the heartbeat uses (managedEnginePortIfRunning +
+// ModelDiscovery), so `citadel chat` sees exactly what the fleet sees.
+//
+// An engine is included when it is running and its port is known, regardless of
+// whether model discovery returned any models — a running-but-empty engine is
+// real state the caller may still want to surface. Model discovery is bounded by
+// ModelDiscoveryTimeout so a slow/hung engine never stalls discovery; a failed
+// probe simply leaves Models empty.
+func DiscoverLocalEngines(ctx context.Context) []LocalEngine {
+	engineBin := catalog.SelectContainerRuntime().EngineBin
+	md := NewModelDiscovery()
+
+	var out []LocalEngine
+	for _, name := range managedProbeEngines {
+		port, running := managedEnginePortIfRunning(engineBin, name)
+		if !running || port <= 0 {
+			continue
+		}
+
+		eng := LocalEngine{Name: name, Port: port}
+
+		mctx, cancel := context.WithTimeout(ctx, ModelDiscoveryTimeout)
+		models, err := md.DiscoverModels(mctx, name, port)
+		cancel()
+		if err == nil {
+			eng.Models = models
+		}
+
+		out = append(out, eng)
+	}
+	return out
+}


### PR DESCRIPTION
## Context
Closes #575. Part of the citadel-chat-and-mesh effort (Phase 1 — local). A user on a node running an inference engine should be able to chat with it directly from the CLI.

## Changes
- **`cmd/chat.go`** — new `citadel chat` command. Discovers the engine(s) running on THIS node, auto-selects when one (engine, model) is available and prompts otherwise (reuses `internal/ui.AskSelect`), then opens an interactive streaming multi-turn REPL against the engine's OpenAI-compatible `/v1/chat/completions`. Ctrl-C interrupts an in-flight reply; `/exit` or Ctrl-D quits. Flags: `--engine`, `--model`, `--max-tokens` (default 1024), `--no-reasoning`.
- **`internal/status/local_engines.go`** — `DiscoverLocalEngines(ctx)` helper that reuses the heartbeat's managed-engine running-check (`managedEnginePortIfRunning`) + `ModelDiscovery` so `citadel chat` sees exactly what the fleet sees (vllm 8201, llamacpp 8200, bonsai 8210, ollama 11434).
- **`internal/localchat/`** — a new package (kept separate from `internal/chat`, which is node-to-node peer messaging) holding the streaming client plus the unit-testable request-build / SSE-parse / choice-build logic.

### Thinking-model handling
Bonsai streams its chain-of-thought in `delta.reasoning_content` (a separate field, not inline `<think>` tags) and the answer in `delta.content`. The command renders reasoning **dimmed** (prefixed `(thinking)`) and the answer in normal text, with a blank-line separator on the transition. Conversation history stores **only** the answer `content` — never `reasoning_content` (per-turn scratch that degrades a thinking model if resent).

## Testing
`go build ./...` and `go test ./...` both pass. Unit tests cover request-build defaults, SSE line parsing (reasoning-only / content / role-only / `[DONE]` / comments / malformed), an end-to-end fake-SSE stream, non-200 body surfacing, and choice-building.

Driven live against Bonsai-27B on `localhost:8210` (node 1084), multi-turn, confirming history retention (turn 2 resolves "that color" → blue), distinct reasoning rendering, and graceful `/exit`:

```
you> bot> (thinking) Here's a thinking process:
   ... blue is one word ...
blue
you> bot> (thinking) ...
   - "That color" refers to "blue"
   - the opposite (complementary) color of blue is orange ...
orange
you> Goodbye.
```

Also verified: clean error when no engine matches a filter, and graceful EOF (Ctrl-D) exit.

## Out of scope
Remote/mesh models (Phase 2, separate issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)