### PR TITLE
feat(mesh): discover models on other nodes over the mesh; scaffold remote chat (#576)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -524,6 +524,62 @@ info, err := auth.ValidateToken(token, orgID)
 - Linux/macOS: Full PTY support via `creack/pty`
 - Windows: Not yet supported (requires ConPTY implementation)
 
+### Mesh Model Discovery & Remote Chat (citadel #576, Phase 2)
+
+`citadel mesh` discovers the models served by OTHER citadel nodes on the mesh and
+routes chat to them node-to-node. Node->node mesh traffic is DIRECT (the Railway
+SOCKS relay caveat only affects backend->node), so a node can probe peers itself.
+
+**Discovery route (`internal/mesh`):** each node already exposes its full
+heartbeat (`services[].models`, `services[].port`) at `GET /status` on its mesh
+VPN listener. `mesh.Discover` enumerates online peers (`network.GetGlobalPeers`),
+probes each peer's `/status` over the mesh (dialing via `network.Dial`), and
+aggregates a fabric-wide `model -> (node, engine, port)` view. Unreachable peers
+are skipped and recorded with their error (a probe never fails the whole call).
+
+**Standalone by design:** `internal/mesh` does NOT import `internal/network` or
+`internal/status`. Callers inject a `Dialer` and a `PeerLister`, and the payload
+subset is decoded into a local struct — this keeps the aggregation pure and
+unit-testable without a live mesh (`discover()` takes a mock `statusFetchFunc`;
+the HTTP + chat paths are tested via `httptest` + an injected dialer). Phase 1's
+local chat REPL (#575) can import the same `Inventory`/`Client` to add a
+remote/peer selection mode. The CLI is deliberately `citadel mesh` (not
+`citadel chat`) to avoid colliding with #575.
+
+**Routing:** all engines (vLLM, llama.cpp, bonsai, Ollama's OpenAI shim) expose
+`/v1/chat/completions`, so `mesh.Client.ChatCompletion(ip, port, body)` routes on
+`(ip, port)` alone; the `engine` field is informational. The function is generic
+and reusable (by #575's REPL too); it lights up the moment a node exposes a
+mesh-reachable chat endpoint.
+
+**Discovery reachability caveat:** a plain `citadel work` (default
+`--status-port 0`) does NOT serve `/status` on the mesh — only `--gateway` (or the
+provisioned gateway, which forces `:8080` + a VPN listener) does. Discovery
+therefore sees only gateway-enabled peers; the probe port is configurable via
+`--port` (`mesh.Options.Port`, default `services.GatewayPort` = 8080).
+
+**Chat reachability gap (KNOWN, tracked in #581):** `mesh chat` is wired but
+routing does NOT work end-to-end yet, because on **embedded-tsnet nodes the
+engine's host port is not reachable over the mesh**. Verified by self-dialing this
+node's own mesh IP:8210 via `network.Dial` while bonsai served fine on
+`localhost:8210` → `connection refused`: embedded tsnet's userspace netstack does
+not forward inbound mesh traffic to a host-bound port lacking a `srv.Listen()`
+(only ports citadel explicitly `ListenVPN`s — status 8080, gateway 8443, terminal,
+vnc, modules — answer over the mesh). The engine compose files bind `0.0.0.0` and
+carry a "peers reach this engine directly over the mesh" comment, but that
+reflects a full-Tailscale/kernel-TUN node, not embedded tsnet. Neither
+`citadel work --gateway` nor `citadel serve` proxies `/v1/chat/completions` (they
+proxy `/v1/embeddings` and control routes only). The node-side gateway chat route
+(model→engine, the complement of aceteam #6236) is the follow-up (#581); until
+then `mesh chat` fails gracefully with a message pointing there.
+
+```bash
+citadel mesh models                 # list model -> node/engine/addr across the mesh
+citadel mesh models --json          # includes unreachable nodes + their errors
+citadel mesh chat --model M "hi"    # one-shot chat to a uniquely-named model
+citadel mesh chat --node N "hi"     # pick a node (hostname or mesh IP) explicitly
+```
+
 ## Important Implementation Notes
 
 ### Manifest Loading

--- a/cmd/mesh.go
+++ b/cmd/mesh.go
@@ -1,0 +1,312 @@
+// cmd/mesh.go
+//
+// `citadel mesh` — discover and chat with models served by OTHER citadel nodes
+// over the mesh (issue #576, Phase 2 of citadel-chat-and-mesh).
+//
+// This is the thin CLI surface over the standalone internal/mesh discovery +
+// routing layer. It is deliberately NOT `citadel chat` so it composes with, and
+// never collides with, Phase 1's local chat REPL (#575) — that command can later
+// import internal/mesh to add a remote/peer selection mode using the same
+// Inventory/Client this command drives.
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"syscall"
+	"text/tabwriter"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/mesh"
+	"github.com/aceteam-ai/citadel-cli/internal/network"
+	"github.com/spf13/cobra"
+)
+
+var (
+	meshPort       int
+	meshModelsJSON bool
+	meshChatNode   string
+	meshChatModel  string
+	meshTimeout    int
+)
+
+// meshDiscoverTimeout bounds peer discovery. Individual probes are already
+// bounded (~4s) with capped concurrency, so this is only an outer safety net;
+// it is kept separate from the chat generation budget so a slow completion is
+// never cut short by discovery time.
+const meshDiscoverTimeout = 30 * time.Second
+
+var meshCmd = &cobra.Command{
+	Use:   "mesh",
+	Short: "Discover and chat with models on other nodes over the mesh",
+	Long: `Discover the models served by OTHER citadel nodes on the AceTeam Network
+(the mesh) and route chat requests to them directly, node-to-node.
+
+Each node publishes its served models at its /status endpoint over the mesh
+(served by ` + "`citadel work --gateway`" + `). ` + "`citadel mesh`" + ` enumerates online peers,
+probes each one's /status, and aggregates a fabric-wide model -> node/engine/port
+view. Peers that are unreachable (not serving the status endpoint on the mesh)
+are skipped gracefully.`,
+}
+
+var meshModelsCmd = &cobra.Command{
+	Use:   "models",
+	Short: "List models served across reachable mesh nodes",
+	Long: `Enumerates online peers, probes each node's /status over the mesh, and lists
+every served model as a model -> node/engine/port row.
+
+Only OTHER nodes are shown (this node is excluded). Nodes that do not serve the
+status endpoint on the mesh (e.g. plain ` + "`citadel work`" + ` without --gateway) are
+skipped.`,
+	Example: `  # List all models served across the mesh
+  citadel mesh models
+
+  # JSON output (includes unreachable nodes and their errors)
+  citadel mesh models --json
+
+  # Probe a non-default status port
+  citadel mesh models --port 8080`,
+	Run: runMeshModels,
+}
+
+var meshChatCmd = &cobra.Command{
+	Use:   "chat [prompt]",
+	Short: "Send a one-shot chat request to a model on another node",
+	Long: `Discovers models across the mesh, selects one by --node and/or --model, and
+sends a single OpenAI chat-completion request to that node's engine over the
+mesh, printing the assistant's reply.
+
+This is a minimal, non-interactive surface (the interactive REPL is Phase 1,
+#575). Selection rules:
+  - If --model uniquely identifies one served model, --node is optional.
+  - If a model is served on multiple nodes, use --node (hostname or IP) to pick.
+  - If a node serves exactly one model, --model is optional.
+
+REACHABILITY: discovery works today, but routing the chat request requires the
+target node to expose a chat endpoint on the mesh. On embedded-tsnet nodes the
+engine's host port is NOT reachable over the mesh (only ports citadel binds a VPN
+listener for answer), and no node gateway yet proxies /v1/chat/completions to the
+local engine, so this command currently fails with connection-refused against
+such nodes. Adding the node-side gateway chat route is tracked in #581.`,
+	Example: `  # Chat with a uniquely-named model anywhere on the mesh
+  citadel mesh chat --model Qwen/Qwen2.5-7B "Explain WireGuard in one line"
+
+  # Pick a specific node when a model is served in several places
+  citadel mesh chat --node gpu-node-1 --model llama3 "hello"
+
+  # Node serves a single model
+  citadel mesh chat --node gpu-node-1 "hello"`,
+	Args: cobra.MinimumNArgs(1),
+	Run:  runMeshChat,
+}
+
+// meshDiscover connects to the mesh and runs discovery, returning the aggregated
+// inventory. Shared by the models and chat subcommands.
+func meshDiscover(ctx context.Context) (*mesh.Inventory, error) {
+	if err := ensureNetworkConnected(ctx); err != nil {
+		return nil, err
+	}
+
+	lister := func(ctx context.Context) ([]mesh.Peer, error) {
+		peers, err := network.GetGlobalPeers(ctx)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]mesh.Peer, 0, len(peers))
+		for _, p := range peers {
+			out = append(out, mesh.Peer{Hostname: p.Hostname, IP: p.IP, Online: p.Online})
+		}
+		return out, nil
+	}
+
+	selfIP, _ := network.GetGlobalIPv4()
+
+	return mesh.Discover(ctx, lister, network.Dial, mesh.Options{
+		Port:   meshPort,
+		SelfIP: selfIP,
+	})
+}
+
+func runMeshModels(cmd *cobra.Command, args []string) {
+	ctx, cancel := context.WithTimeout(context.Background(), meshDiscoverTimeout)
+	defer cancel()
+
+	inv, err := meshDiscover(ctx)
+	if err != nil {
+		badColor.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if meshModelsJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(inv); err != nil {
+			badColor.Fprintf(os.Stderr, "Failed to encode JSON: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	if len(inv.Models) == 0 {
+		fmt.Println("No models found on reachable mesh nodes.")
+		reachable := 0
+		for _, n := range inv.Nodes {
+			if n.Reachable {
+				reachable++
+			}
+		}
+		fmt.Printf("(%d peer(s) probed, %d reachable)\n", len(inv.Nodes), reachable)
+		fmt.Println("Nodes must serve the status endpoint on the mesh (run 'citadel work --gateway').")
+		return
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "MODEL\tNODE\tENGINE\tADDRESS")
+	fmt.Fprintln(w, "-----\t----\t------\t-------")
+	for _, m := range inv.Models {
+		engine := m.Engine
+		if engine == "" {
+			engine = "-"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s:%d\n", m.Model, m.Hostname, engine, m.IP, m.Port)
+	}
+	w.Flush()
+
+	fmt.Printf("\n%d model(s) across %d reachable node(s).\n", len(inv.Models), countReachable(inv))
+}
+
+func countReachable(inv *mesh.Inventory) int {
+	n := 0
+	for _, node := range inv.Nodes {
+		if node.Reachable {
+			n++
+		}
+	}
+	return n
+}
+
+func runMeshChat(cmd *cobra.Command, args []string) {
+	prompt := args[0]
+	for _, a := range args[1:] {
+		prompt += " " + a
+	}
+
+	// Discovery and generation get SEPARATE budgets: a slow completion must not
+	// be cut short because peer discovery ate into a single shared deadline.
+	discCtx, discCancel := context.WithTimeout(context.Background(), meshDiscoverTimeout)
+	inv, err := meshDiscover(discCtx)
+	discCancel()
+	if err != nil {
+		badColor.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	target, err := inv.FindModel(meshChatNode, meshChatModel)
+	if err != nil {
+		badColor.Fprintf(os.Stderr, "Error: %v\n", err)
+		if len(inv.Models) > 0 {
+			fmt.Fprintln(os.Stderr, "\nAvailable models:")
+			for _, m := range inv.Models {
+				fmt.Fprintf(os.Stderr, "  - %s on %s (%s:%d)\n", m.Model, m.Hostname, m.IP, m.Port)
+			}
+		}
+		os.Exit(1)
+	}
+
+	warnColor.Fprintf(os.Stderr, "→ %s on %s (%s:%d)\n", target.Model, target.Hostname, target.IP, target.Port)
+
+	body, err := mesh.BuildChatRequest(target.Model, prompt, false)
+	if err != nil {
+		badColor.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	chatCtx, chatCancel := context.WithTimeout(context.Background(), time.Duration(meshTimeout)*time.Second)
+	defer chatCancel()
+
+	client := mesh.NewClient(network.Dial)
+	resp, err := client.ChatCompletionTo(chatCtx, target, body)
+	if err != nil {
+		badColor.Fprintf(os.Stderr, "Request failed: %v\n", err)
+		// A refused connection to a discovered engine port is the EXPECTED state
+		// today: embedded-tsnet does not forward inbound mesh traffic to a node's
+		// host-bound engine port (only ports citadel ListenVPNs answer over the
+		// mesh), and no node gateway yet proxies /v1/chat/completions to the local
+		// engine. Discovery still works; the reachable chat endpoint is the
+		// follow-up. Make that explicit rather than leaving a bare dial error.
+		if isConnRefused(err) {
+			warnColor.Fprintln(os.Stderr,
+				"\nThe target node has no mesh-reachable chat endpoint yet. Its engine port is\n"+
+					"bound to the host but embedded-tsnet does not expose it on the mesh, and the\n"+
+					"node gateway does not yet proxy /v1/chat/completions to the local engine.\n"+
+					"Tracking: https://github.com/aceteam-ai/citadel-cli/issues/581")
+		}
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	if resp.StatusCode != http.StatusOK {
+		badColor.Fprintf(os.Stderr, "Engine returned %d: %s\n", resp.StatusCode, string(respBody))
+		os.Exit(1)
+	}
+
+	reply, err := extractAssistantReply(respBody)
+	if err != nil {
+		// Fall back to raw JSON so the user still sees the engine's output.
+		fmt.Println(string(respBody))
+		return
+	}
+	fmt.Println(reply)
+}
+
+// isConnRefused reports whether err is a connection-refused dial failure, the
+// expected outcome when a discovered engine port is not exposed on the mesh.
+func isConnRefused(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, syscall.ECONNREFUSED) {
+		return true
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "connection refused")
+}
+
+// extractAssistantReply pulls the assistant message content out of an OpenAI
+// chat-completions response.
+func extractAssistantReply(body []byte) (string, error) {
+	var parsed struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", err
+	}
+	if len(parsed.Choices) == 0 {
+		return "", fmt.Errorf("no choices in response")
+	}
+	return parsed.Choices[0].Message.Content, nil
+}
+
+func init() {
+	rootCmd.AddCommand(meshCmd)
+	meshCmd.AddCommand(meshModelsCmd)
+	meshCmd.AddCommand(meshChatCmd)
+
+	meshCmd.PersistentFlags().IntVar(&meshPort, "port", mesh.DefaultStatusPort, "Peer status endpoint port to probe over the mesh")
+
+	meshModelsCmd.Flags().BoolVar(&meshModelsJSON, "json", false, "Output in JSON format (includes unreachable nodes)")
+
+	meshChatCmd.Flags().StringVar(&meshChatNode, "node", "", "Target node hostname or mesh IP")
+	meshChatCmd.Flags().StringVar(&meshChatModel, "model", "", "Model to chat with")
+	meshChatCmd.Flags().IntVar(&meshTimeout, "timeout", 120, "Chat generation timeout in seconds")
+}

--- a/internal/mesh/client.go
+++ b/internal/mesh/client.go
@@ -1,0 +1,91 @@
+package mesh
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+)
+
+// ChatEndpointPath is the OpenAI-compatible chat-completions path served by
+// every engine citadel routes to: vLLM, llama.cpp, the bonsai llama.cpp fork,
+// and Ollama's OpenAI-compatibility shim all expose it. That uniformity is why
+// routing needs only (ip, port) and not the engine type.
+const ChatEndpointPath = "/v1/chat/completions"
+
+// Client sends OpenAI chat-completion requests to a remote node's engine over
+// the mesh, dialing via the injected Dialer. It is standalone (no
+// internal/network import): cmd constructs it with network.Dial; tests construct
+// it with a dialer targeting a local httptest server.
+type Client struct {
+	http *http.Client
+}
+
+// NewClient builds a mesh chat client. No overall client timeout is set so
+// streaming responses are not cut off mid-stream; callers bound a request with
+// the context they pass to ChatCompletion.
+func NewClient(dialer Dialer) *Client {
+	return &Client{
+		http: &http.Client{
+			Transport: &http.Transport{
+				DialContext:       func(ctx context.Context, netw, addr string) (net.Conn, error) { return dialer(ctx, netw, addr) },
+				DisableKeepAlives: true,
+			},
+		},
+	}
+}
+
+// ChatMessage is a single OpenAI chat message.
+type ChatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// ChatRequest is the minimal OpenAI chat-completions request this package
+// builds. Callers that need more control can marshal their own body and call
+// ChatCompletion directly.
+type ChatRequest struct {
+	Model    string        `json:"model"`
+	Messages []ChatMessage `json:"messages"`
+	Stream   bool          `json:"stream,omitempty"`
+}
+
+// BuildChatRequest marshals a single-user-message chat request for the given
+// model — the common one-shot `citadel mesh chat` case.
+func BuildChatRequest(model, prompt string, stream bool) ([]byte, error) {
+	return json.Marshal(ChatRequest{
+		Model:    model,
+		Messages: []ChatMessage{{Role: "user", Content: prompt}},
+		Stream:   stream,
+	})
+}
+
+// ChatCompletion POSTs a raw OpenAI chat-completions request body to the engine
+// at ip:port over the mesh and returns the HTTP response. The caller owns the
+// response body: read/stream it and Close it. The body is passed through
+// verbatim so the caller controls model, messages, and streaming.
+func (c *Client) ChatCompletion(ctx context.Context, ip string, port int, body []byte) (*http.Response, error) {
+	if ip == "" {
+		return nil, fmt.Errorf("empty target ip")
+	}
+	if port <= 0 {
+		return nil, fmt.Errorf("invalid target port %d", port)
+	}
+	url := fmt.Sprintf("http://%s%s", net.JoinHostPort(ip, strconv.Itoa(port)), ChatEndpointPath)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	return c.http.Do(req)
+}
+
+// ChatCompletionTo is a convenience wrapper that routes to a discovered
+// ServedModel's node/port.
+func (c *Client) ChatCompletionTo(ctx context.Context, target ServedModel, body []byte) (*http.Response, error) {
+	return c.ChatCompletion(ctx, target.IP, target.Port, body)
+}

--- a/internal/mesh/client_test.go
+++ b/internal/mesh/client_test.go
@@ -1,0 +1,93 @@
+package mesh
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestChatCompletionOverInjectedDialer proves ChatCompletion routes an OpenAI
+// chat request to a remote engine over the (injected) dialer end-to-end: the
+// dialer points at a local httptest server standing in for the remote engine.
+func TestChatCompletionOverInjectedDialer(t *testing.T) {
+	var gotPath, gotModel, gotContentType string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotContentType = r.Header.Get("Content-Type")
+		var req ChatRequest
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &req)
+		gotModel = req.Model
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"id":"cmpl-1","choices":[{"message":{"role":"assistant","content":"hello from engine"}}]}`))
+	}))
+	defer srv.Close()
+	srvAddr := strings.TrimPrefix(srv.URL, "http://")
+
+	dialer := func(ctx context.Context, netw, addr string) (net.Conn, error) {
+		var d net.Dialer
+		return d.DialContext(ctx, "tcp", srvAddr)
+	}
+
+	client := NewClient(dialer)
+	body, err := BuildChatRequest("Qwen/Qwen2.5-7B", "hi", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	target := ServedModel{Model: "Qwen/Qwen2.5-7B", IP: "100.64.0.2", Port: 8201, Engine: "vllm"}
+	resp, err := client.ChatCompletionTo(context.Background(), target, body)
+	if err != nil {
+		t.Fatalf("ChatCompletion: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	if gotPath != ChatEndpointPath {
+		t.Errorf("path = %q, want %q", gotPath, ChatEndpointPath)
+	}
+	if gotModel != "Qwen/Qwen2.5-7B" {
+		t.Errorf("model = %q", gotModel)
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("content-type = %q", gotContentType)
+	}
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(respBody), "hello from engine") {
+		t.Errorf("unexpected response body: %s", respBody)
+	}
+}
+
+func TestChatCompletionValidatesTarget(t *testing.T) {
+	client := NewClient(func(ctx context.Context, netw, addr string) (net.Conn, error) {
+		return nil, nil
+	})
+	if _, err := client.ChatCompletion(context.Background(), "", 8201, nil); err == nil {
+		t.Error("expected error for empty ip")
+	}
+	if _, err := client.ChatCompletion(context.Background(), "100.64.0.2", 0, nil); err == nil {
+		t.Error("expected error for zero port")
+	}
+}
+
+func TestBuildChatRequest(t *testing.T) {
+	body, err := BuildChatRequest("m", "hello", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var req ChatRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		t.Fatal(err)
+	}
+	if req.Model != "m" || !req.Stream || len(req.Messages) != 1 || req.Messages[0].Content != "hello" || req.Messages[0].Role != "user" {
+		t.Fatalf("unexpected request: %+v", req)
+	}
+}

--- a/internal/mesh/discovery.go
+++ b/internal/mesh/discovery.go
@@ -1,0 +1,414 @@
+// Package mesh implements Phase 2 of citadel-chat-and-mesh (issue #576):
+// discovering the models served by OTHER citadel nodes on the embedded-tsnet
+// mesh and routing OpenAI chat-completion requests to a chosen remote node's
+// engine.
+//
+// Discovery route: each citadel node already publishes its served models on the
+// heartbeat and exposes the same payload at GET /status on its mesh VPN listener
+// (see internal/status). Node->node traffic on the mesh is DIRECT (the Railway
+// SOCKS relay caveat only affects backend->node), so a node can enumerate its
+// mesh peers and probe each peer's /status directly. This package aggregates
+// those payloads into a fabric-wide model -> (node, engine, port) view.
+//
+// This layer is deliberately standalone: it does NOT import internal/network (or
+// any heavy status deps). Callers inject a Dialer and a PeerLister, which makes
+// the aggregation logic pure and unit-testable without a live mesh. cmd wires
+// network.Dial and network.GetGlobalPeers into it; #575's chat REPL can reuse
+// the same Client/Inventory to add a remote/peer selection mode.
+package mesh
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// DefaultStatusPort is the port a citadel node serves its /status endpoint on
+// over the mesh. It mirrors services.GatewayPort (8080): `citadel work --gateway`
+// (and the provisioned gateway) bind the status server there and add a tsnet VPN
+// listener so peers can reach it. Kept as a local const so this discovery layer
+// stays free of the services/network imports and can be unit-tested in isolation.
+//
+// NOTE: a plain `citadel work` (no --gateway, default --status-port 0) does NOT
+// serve /status on the mesh. Discovery therefore only sees peers running the
+// gateway/status server; unreachable peers are skipped gracefully. The port is
+// configurable (Options.Port) for nodes that bind it elsewhere.
+const DefaultStatusPort = 8080
+
+// defaultProbeTimeout bounds a single peer /status probe. Set a touch above the
+// node's own 2s local model-discovery deadline so a healthy-but-slightly-slow
+// peer is not dropped, while an unreachable peer is skipped quickly.
+const defaultProbeTimeout = 4 * time.Second
+
+// defaultConcurrency caps the number of in-flight peer probes so a large fabric
+// does not open a probe socket per peer all at once.
+const defaultConcurrency = 16
+
+// maxStatusBody caps the /status response we will read from a peer (defensive:
+// a peer is same-org but a bounded read avoids a hostile/buggy peer streaming an
+// unbounded body).
+const maxStatusBody = 4 << 20 // 4 MiB
+
+// Peer is the minimal view of a mesh peer the discovery layer needs. cmd adapts
+// network.PeerInfo into this so internal/mesh never imports internal/network.
+type Peer struct {
+	Hostname string
+	IP       string
+	Online   bool
+}
+
+// Dialer dials addr over the mesh. cmd passes network.Dial (tsnet userspace
+// dialer); tests pass a dialer that targets a local httptest server, exercising
+// the HTTP path without a real mesh.
+type Dialer func(ctx context.Context, network, addr string) (net.Conn, error)
+
+// PeerLister enumerates mesh peers. cmd wraps network.GetGlobalPeers.
+type PeerLister func(ctx context.Context) ([]Peer, error)
+
+// ServedModel is a single model served by a single engine on a single node.
+// The same model served on multiple nodes yields multiple ServedModel entries
+// so --node/--model can disambiguate which one to route to.
+type ServedModel struct {
+	Model    string `json:"model"`
+	NodeName string `json:"node_name,omitempty"`
+	Hostname string `json:"hostname"`
+	IP       string `json:"ip"`
+	Engine   string `json:"engine,omitempty"` // vllm | ollama | llamacpp | bonsai | ""
+	Port     int    `json:"port"`
+}
+
+// NodeInventory is the discovery outcome for one peer: either its served models
+// or the reason it could not be probed (unreachable, non-200, decode error).
+type NodeInventory struct {
+	Hostname  string        `json:"hostname"`
+	IP        string        `json:"ip"`
+	NodeName  string        `json:"node_name,omitempty"`
+	Reachable bool          `json:"reachable"`
+	Error     string        `json:"error,omitempty"`
+	Models    []ServedModel `json:"models,omitempty"`
+}
+
+// Inventory is the fabric-wide aggregation: per-node results plus a flattened,
+// sorted list of every served model across all reachable peers.
+type Inventory struct {
+	Nodes  []NodeInventory `json:"nodes"`
+	Models []ServedModel   `json:"models"`
+}
+
+// Options tunes discovery.
+type Options struct {
+	// Port is the peer /status port to probe. Zero means DefaultStatusPort.
+	Port int
+	// ProbeTimeout bounds a single peer probe. Zero means defaultProbeTimeout.
+	ProbeTimeout time.Duration
+	// Concurrency caps in-flight probes. Zero means defaultConcurrency.
+	Concurrency int
+	// IncludeOffline probes peers the mesh reports as offline too (default:
+	// online-only, matching "OTHER online nodes").
+	IncludeOffline bool
+	// SelfIP, when set, excludes this node from discovery (the issue is about
+	// OTHER nodes). cmd passes network.GetGlobalIPv4().
+	SelfIP string
+}
+
+// nodeStatus is the minimal subset of the /status payload (internal/status.
+// NodeStatus) the discovery layer decodes. Mirroring the JSON here — rather than
+// importing internal/status and its heavy transitive deps (desktop, resmon,
+// terminal, ...) — keeps this layer standalone and cheap to test.
+type nodeStatus struct {
+	Node struct {
+		Name        string `json:"name"`
+		NetworkIP   string `json:"network_ip"`
+		TailscaleIP string `json:"tailscale_ip"`
+	} `json:"node"`
+	Services []struct {
+		Name   string   `json:"name"`
+		Type   string   `json:"type"`
+		Status string   `json:"status"`
+		Port   int      `json:"port"`
+		Models []string `json:"models"`
+	} `json:"services"`
+}
+
+// statusFetchFunc fetches and decodes a peer's /status payload. Abstracted so
+// discover() can be unit-tested with a mock fetcher (no HTTP, no mesh).
+type statusFetchFunc func(ctx context.Context, ip string) (*nodeStatus, error)
+
+// EngineTypeFromName maps a service name to a serving-engine type
+// ("vllm"/"ollama"/"llamacpp"/"bonsai"), or "" when not a known engine. Order
+// matters: "ollama" contains "llama" so it is checked before the llama.cpp
+// patterns. This replicates internal/status.EngineTypeFromName locally to keep
+// this layer standalone (the value is informational for the model->engine view;
+// all four engines expose the same /v1/chat/completions routing path).
+func EngineTypeFromName(name string) string {
+	n := strings.ToLower(name)
+	switch {
+	case strings.Contains(n, "vllm"):
+		return "vllm"
+	case strings.Contains(n, "ollama"):
+		return "ollama"
+	case strings.Contains(n, "bonsai"):
+		return "bonsai"
+	case strings.Contains(n, "llamacpp"), strings.Contains(n, "llama.cpp"), strings.Contains(n, "llama-cpp"):
+		return "llamacpp"
+	}
+	return ""
+}
+
+// modelsFromStatus extracts routable served models from a peer's /status
+// payload. A service is included only when it is running, exposes a host port,
+// and reports at least one model — the exact conditions under which chat can be
+// routed to it. Each model becomes its own ServedModel entry.
+func modelsFromStatus(p Peer, st *nodeStatus) []ServedModel {
+	if st == nil {
+		return nil
+	}
+	var out []ServedModel
+	for _, svc := range st.Services {
+		if !strings.EqualFold(svc.Status, "running") {
+			continue
+		}
+		if svc.Port <= 0 || len(svc.Models) == 0 {
+			// No port -> cannot route; no models -> nothing to serve.
+			continue
+		}
+		engine := EngineTypeFromName(svc.Name)
+		for _, m := range svc.Models {
+			m = strings.TrimSpace(m)
+			if m == "" {
+				continue
+			}
+			out = append(out, ServedModel{
+				Model:    m,
+				NodeName: st.Node.Name,
+				Hostname: p.Hostname,
+				IP:       p.IP,
+				Engine:   engine,
+				Port:     svc.Port,
+			})
+		}
+	}
+	return out
+}
+
+// Discover enumerates mesh peers via lister, probes each reachable peer's
+// /status over the mesh (dialing via dialer), and aggregates the served models
+// into a fabric-wide Inventory. Unreachable peers are skipped and recorded with
+// their error; a peer probe never fails the whole call. Returns an error only if
+// enumerating peers itself fails.
+func Discover(ctx context.Context, lister PeerLister, dialer Dialer, opts Options) (*Inventory, error) {
+	port := opts.Port
+	if port <= 0 {
+		port = DefaultStatusPort
+	}
+	return discover(ctx, lister, httpFetcher(dialer, port), opts)
+}
+
+// discover is the testable core: it takes a statusFetchFunc so tests can inject
+// a fake fetcher and exercise filtering/aggregation/error-handling with no HTTP.
+func discover(ctx context.Context, lister PeerLister, fetch statusFetchFunc, opts Options) (*Inventory, error) {
+	peers, err := lister(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list mesh peers: %w", err)
+	}
+
+	// Filter: routable peers only (has IP), online unless overridden, exclude self.
+	var targets []Peer
+	for _, p := range peers {
+		if p.IP == "" {
+			continue
+		}
+		if !opts.IncludeOffline && !p.Online {
+			continue
+		}
+		if opts.SelfIP != "" && p.IP == opts.SelfIP {
+			continue
+		}
+		targets = append(targets, p)
+	}
+
+	conc := opts.Concurrency
+	if conc <= 0 {
+		conc = defaultConcurrency
+	}
+	probeTimeout := opts.ProbeTimeout
+	if probeTimeout <= 0 {
+		probeTimeout = defaultProbeTimeout
+	}
+
+	// Pre-sized result slice: each goroutine writes a distinct index, so no
+	// mutex is needed for the writes.
+	nodes := make([]NodeInventory, len(targets))
+	sem := make(chan struct{}, conc)
+	var wg sync.WaitGroup
+
+	for i, p := range targets {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(i int, p Peer) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			pctx, cancel := context.WithTimeout(ctx, probeTimeout)
+			defer cancel()
+
+			inv := NodeInventory{Hostname: p.Hostname, IP: p.IP}
+			st, ferr := fetch(pctx, p.IP)
+			if ferr != nil {
+				inv.Reachable = false
+				inv.Error = ferr.Error()
+			} else {
+				inv.Reachable = true
+				inv.NodeName = st.Node.Name
+				inv.Models = modelsFromStatus(p, st)
+			}
+			nodes[i] = inv
+		}(i, p)
+	}
+	wg.Wait()
+
+	// Deterministic ordering for stable CLI/JSON output.
+	sort.Slice(nodes, func(i, j int) bool {
+		if nodes[i].Hostname != nodes[j].Hostname {
+			return nodes[i].Hostname < nodes[j].Hostname
+		}
+		return nodes[i].IP < nodes[j].IP
+	})
+
+	inv := &Inventory{Nodes: nodes, Models: []ServedModel{}}
+	for _, n := range nodes {
+		inv.Models = append(inv.Models, n.Models...)
+	}
+	sortModels(inv.Models)
+	return inv, nil
+}
+
+// sortModels orders models by (model, node, engine, port) for stable output.
+func sortModels(models []ServedModel) {
+	sort.Slice(models, func(i, j int) bool {
+		a, b := models[i], models[j]
+		if a.Model != b.Model {
+			return a.Model < b.Model
+		}
+		if a.Hostname != b.Hostname {
+			return a.Hostname < b.Hostname
+		}
+		if a.Engine != b.Engine {
+			return a.Engine < b.Engine
+		}
+		return a.Port < b.Port
+	})
+}
+
+// httpFetcher builds a statusFetchFunc that GETs http://<ip>:<port>/status over
+// the mesh using the injected dialer. Keep-alives are disabled: each peer is
+// probed once, so pooling connections to many one-shot peers is pointless and
+// risks holding mesh sockets open.
+func httpFetcher(dialer Dialer, port int) statusFetchFunc {
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext:           func(ctx context.Context, netw, addr string) (net.Conn, error) { return dialer(ctx, netw, addr) },
+			DisableKeepAlives:     true,
+			ResponseHeaderTimeout: defaultProbeTimeout,
+		},
+	}
+	return func(ctx context.Context, ip string) (*nodeStatus, error) {
+		url := fmt.Sprintf("http://%s/status", net.JoinHostPort(ip, strconv.Itoa(port)))
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("status endpoint returned %d", resp.StatusCode)
+		}
+		var st nodeStatus
+		if err := json.NewDecoder(io.LimitReader(resp.Body, maxStatusBody)).Decode(&st); err != nil {
+			return nil, fmt.Errorf("decode /status: %w", err)
+		}
+		return &st, nil
+	}
+}
+
+// FindModel selects the served model matching the given node (hostname or IP,
+// optional) and model name (optional). It returns:
+//   - the single match, or
+//   - an error listing candidates when the selection is ambiguous, or
+//   - an error when nothing matches.
+//
+// Matching is case-insensitive; model matches on exact id first, then a unique
+// substring. node matches hostname or IP (exact, case-insensitive).
+func (inv *Inventory) FindModel(node, model string) (ServedModel, error) {
+	node = strings.TrimSpace(node)
+	model = strings.TrimSpace(model)
+
+	var pool []ServedModel
+	for _, m := range inv.Models {
+		if node != "" && !strings.EqualFold(m.Hostname, node) && !strings.EqualFold(m.IP, node) {
+			continue
+		}
+		pool = append(pool, m)
+	}
+	if node != "" && len(pool) == 0 {
+		return ServedModel{}, fmt.Errorf("no served models found on node %q (is it online and serving on the mesh?)", node)
+	}
+	if node == "" {
+		pool = inv.Models
+	}
+
+	if model != "" {
+		// Exact model id match first.
+		var matched []ServedModel
+		for _, m := range pool {
+			if strings.EqualFold(m.Model, model) {
+				matched = append(matched, m)
+			}
+		}
+		if len(matched) == 0 {
+			// Fall back to unique substring match.
+			for _, m := range pool {
+				if strings.Contains(strings.ToLower(m.Model), strings.ToLower(model)) {
+					matched = append(matched, m)
+				}
+			}
+		}
+		pool = matched
+	}
+
+	switch len(pool) {
+	case 0:
+		return ServedModel{}, fmt.Errorf("no served model matches node=%q model=%q", node, model)
+	case 1:
+		return pool[0], nil
+	default:
+		return ServedModel{}, fmt.Errorf("ambiguous selection (%d matches); narrow with --node/--model:\n%s",
+			len(pool), formatCandidates(pool))
+	}
+}
+
+func formatCandidates(models []ServedModel) string {
+	var b strings.Builder
+	for _, m := range models {
+		fmt.Fprintf(&b, "  - %s on %s (%s:%d, engine=%s)\n", m.Model, m.Hostname, m.IP, m.Port, engineOrDash(m.Engine))
+	}
+	return b.String()
+}
+
+func engineOrDash(e string) string {
+	if e == "" {
+		return "-"
+	}
+	return e
+}

--- a/internal/mesh/discovery_test.go
+++ b/internal/mesh/discovery_test.go
@@ -1,0 +1,309 @@
+package mesh
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func mkStatus(nodeName string, svcs ...struct {
+	name, status string
+	port         int
+	models       []string
+}) *nodeStatus {
+	st := &nodeStatus{}
+	st.Node.Name = nodeName
+	for _, s := range svcs {
+		st.Services = append(st.Services, struct {
+			Name   string   `json:"name"`
+			Type   string   `json:"type"`
+			Status string   `json:"status"`
+			Port   int      `json:"port"`
+			Models []string `json:"models"`
+		}{Name: s.name, Type: "llm", Status: s.status, Port: s.port, Models: s.models})
+	}
+	return st
+}
+
+func TestEngineTypeFromName(t *testing.T) {
+	cases := map[string]string{
+		"vllm":             "vllm",
+		"citadel-vllm":     "vllm",
+		"ollama":           "ollama",
+		"bonsai":           "bonsai",
+		"llamacpp":         "llamacpp",
+		"llama.cpp":        "llamacpp",
+		"llama-cpp-server": "llamacpp",
+		"postgres":         "",
+		"OLLAMA-Big":       "ollama", // case-insensitive; ollama checked before llama
+	}
+	for in, want := range cases {
+		if got := EngineTypeFromName(in); got != want {
+			t.Errorf("EngineTypeFromName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestModelsFromStatus(t *testing.T) {
+	p := Peer{Hostname: "gpu-1", IP: "100.64.0.5", Online: true}
+	st := mkStatus("gpu-1-node",
+		struct {
+			name, status string
+			port         int
+			models       []string
+		}{"vllm", "running", 8201, []string{"Qwen/Qwen2.5-7B"}},
+		// stopped service -> excluded
+		struct {
+			name, status string
+			port         int
+			models       []string
+		}{"ollama", "stopped", 11434, []string{"llama3"}},
+		// running but no port -> excluded (cannot route)
+		struct {
+			name, status string
+			port         int
+			models       []string
+		}{"bonsai", "running", 0, []string{"Bonsai-27B"}},
+		// running, no models -> excluded
+		struct {
+			name, status string
+			port         int
+			models       []string
+		}{"llamacpp", "running", 8200, nil},
+		// running with two models -> two entries, blank trimmed
+		struct {
+			name, status string
+			port         int
+			models       []string
+		}{"llamacpp", "running", 8200, []string{"modelA", "  ", "modelB"}},
+	)
+
+	got := modelsFromStatus(p, st)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 served models, got %d: %+v", len(got), got)
+	}
+	// vllm entry
+	assertModel(t, got, "Qwen/Qwen2.5-7B", "vllm", 8201)
+	assertModel(t, got, "modelA", "llamacpp", 8200)
+	assertModel(t, got, "modelB", "llamacpp", 8200)
+	for _, m := range got {
+		if m.Hostname != "gpu-1" || m.IP != "100.64.0.5" || m.NodeName != "gpu-1-node" {
+			t.Errorf("model %q has wrong node identity: %+v", m.Model, m)
+		}
+	}
+}
+
+func assertModel(t *testing.T, models []ServedModel, name, engine string, port int) {
+	t.Helper()
+	for _, m := range models {
+		if m.Model == name {
+			if m.Engine != engine || m.Port != port {
+				t.Errorf("model %q = engine %q port %d, want engine %q port %d", name, m.Engine, m.Port, engine, port)
+			}
+			return
+		}
+	}
+	t.Errorf("model %q not found in %+v", name, models)
+}
+
+func TestDiscoverAggregatesAndSkipsUnreachable(t *testing.T) {
+	peers := []Peer{
+		{Hostname: "self", IP: "100.64.0.1", Online: true},
+		{Hostname: "gpu-a", IP: "100.64.0.2", Online: true},
+		{Hostname: "gpu-b", IP: "100.64.0.3", Online: true},
+		{Hostname: "down", IP: "100.64.0.4", Online: false}, // offline -> filtered
+		{Hostname: "noip", IP: "", Online: true},            // no IP -> filtered
+		{Hostname: "unreachable", IP: "100.64.0.9", Online: true},
+	}
+	lister := func(ctx context.Context) ([]Peer, error) { return peers, nil }
+
+	fetch := func(ctx context.Context, ip string) (*nodeStatus, error) {
+		switch ip {
+		case "100.64.0.2":
+			return mkStatus("gpu-a-node", struct {
+				name, status string
+				port         int
+				models       []string
+			}{"vllm", "running", 8201, []string{"shared-model", "a-only"}}), nil
+		case "100.64.0.3":
+			return mkStatus("gpu-b-node", struct {
+				name, status string
+				port         int
+				models       []string
+			}{"ollama", "running", 11434, []string{"shared-model"}}), nil
+		case "100.64.0.9":
+			return nil, errors.New("connection refused")
+		default:
+			t.Fatalf("unexpected probe to %s (self should be excluded)", ip)
+			return nil, nil
+		}
+	}
+
+	inv, err := discover(context.Background(), lister, fetch, Options{SelfIP: "100.64.0.1"})
+	if err != nil {
+		t.Fatalf("discover error: %v", err)
+	}
+
+	// 3 targets after filtering (self, offline, noip excluded).
+	if len(inv.Nodes) != 3 {
+		t.Fatalf("expected 3 node results, got %d: %+v", len(inv.Nodes), inv.Nodes)
+	}
+
+	// Flattened models: gpu-a has 2, gpu-b has 1 => 3 total.
+	if len(inv.Models) != 3 {
+		t.Fatalf("expected 3 served models, got %d: %+v", len(inv.Models), inv.Models)
+	}
+
+	// shared-model appears on BOTH nodes as distinct entries.
+	var sharedNodes []string
+	for _, m := range inv.Models {
+		if m.Model == "shared-model" {
+			sharedNodes = append(sharedNodes, m.Hostname)
+		}
+	}
+	if len(sharedNodes) != 2 {
+		t.Errorf("shared-model should appear on 2 nodes, got %v", sharedNodes)
+	}
+
+	// unreachable peer recorded with error, not dropped.
+	var foundUnreachable bool
+	for _, n := range inv.Nodes {
+		if n.Hostname == "unreachable" {
+			foundUnreachable = true
+			if n.Reachable {
+				t.Errorf("unreachable node marked reachable")
+			}
+			if n.Error == "" {
+				t.Errorf("unreachable node missing error")
+			}
+		}
+	}
+	if !foundUnreachable {
+		t.Errorf("unreachable node missing from inventory")
+	}
+
+	// Models are sorted deterministically by (model, hostname).
+	prev := ""
+	for _, m := range inv.Models {
+		if m.Model < prev {
+			t.Errorf("models not sorted: %q after %q", m.Model, prev)
+		}
+		prev = m.Model
+	}
+}
+
+func TestDiscoverListerError(t *testing.T) {
+	lister := func(ctx context.Context) ([]Peer, error) { return nil, errors.New("not connected") }
+	fetch := func(ctx context.Context, ip string) (*nodeStatus, error) { return nil, nil }
+	if _, err := discover(context.Background(), lister, fetch, Options{}); err == nil {
+		t.Fatal("expected error when lister fails")
+	}
+}
+
+func TestDiscoverIncludeOffline(t *testing.T) {
+	peers := []Peer{{Hostname: "down", IP: "100.64.0.4", Online: false}}
+	lister := func(ctx context.Context) ([]Peer, error) { return peers, nil }
+	var probed bool
+	fetch := func(ctx context.Context, ip string) (*nodeStatus, error) {
+		probed = true
+		return mkStatus("down-node"), nil
+	}
+	if _, err := discover(context.Background(), lister, fetch, Options{IncludeOffline: true}); err != nil {
+		t.Fatal(err)
+	}
+	if !probed {
+		t.Error("IncludeOffline should probe offline peers")
+	}
+}
+
+func TestFindModel(t *testing.T) {
+	inv := &Inventory{Models: []ServedModel{
+		{Model: "shared", Hostname: "gpu-a", IP: "100.64.0.2", Engine: "vllm", Port: 8201},
+		{Model: "shared", Hostname: "gpu-b", IP: "100.64.0.3", Engine: "ollama", Port: 11434},
+		{Model: "unique", Hostname: "gpu-a", IP: "100.64.0.2", Engine: "vllm", Port: 8201},
+	}}
+
+	// Unique model -> resolves without node.
+	m, err := inv.FindModel("", "unique")
+	if err != nil || m.Hostname != "gpu-a" {
+		t.Fatalf("FindModel(unique) = %+v, %v", m, err)
+	}
+
+	// Ambiguous model without node -> error.
+	if _, err := inv.FindModel("", "shared"); err == nil {
+		t.Error("expected ambiguity error for shared model")
+	}
+
+	// Disambiguate by node (hostname).
+	m, err = inv.FindModel("gpu-b", "shared")
+	if err != nil || m.IP != "100.64.0.3" {
+		t.Fatalf("FindModel(gpu-b, shared) = %+v, %v", m, err)
+	}
+
+	// Disambiguate by node (IP).
+	m, err = inv.FindModel("100.64.0.2", "shared")
+	if err != nil || m.Hostname != "gpu-a" {
+		t.Fatalf("FindModel(ip, shared) = %+v, %v", m, err)
+	}
+
+	// Node with single model -> model optional.
+	single := &Inventory{Models: []ServedModel{{Model: "only", Hostname: "n1", IP: "100.64.0.7", Port: 8201}}}
+	if m, err := single.FindModel("n1", ""); err != nil || m.Model != "only" {
+		t.Fatalf("FindModel(n1, \"\") = %+v, %v", m, err)
+	}
+
+	// Substring fallback.
+	if m, err := inv.FindModel("gpu-a", "uni"); err != nil || m.Model != "unique" {
+		t.Fatalf("FindModel(gpu-a, uni) = %+v, %v", m, err)
+	}
+
+	// Unknown node.
+	if _, err := inv.FindModel("nope", ""); err == nil {
+		t.Error("expected error for unknown node")
+	}
+}
+
+// TestHTTPFetcherOverInjectedDialer exercises the real HTTP path (httpFetcher)
+// against a local httptest server via an injected dialer, proving Discover works
+// end-to-end without a mesh.
+func TestHTTPFetcherOverInjectedDialer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/status" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		fmt.Fprint(w, `{"node":{"name":"probe-node"},"services":[{"name":"vllm","type":"llm","status":"running","port":8201,"models":["m1"]}]}`)
+	}))
+	defer srv.Close()
+	srvAddr := strings.TrimPrefix(srv.URL, "http://")
+
+	// Dialer ignores the mesh target addr and dials the local test server.
+	dialer := func(ctx context.Context, netw, addr string) (net.Conn, error) {
+		var d net.Dialer
+		return d.DialContext(ctx, "tcp", srvAddr)
+	}
+
+	lister := func(ctx context.Context) ([]Peer, error) {
+		return []Peer{{Hostname: "probe", IP: "100.64.0.42", Online: true}}, nil
+	}
+
+	inv, err := Discover(context.Background(), lister, dialer, Options{Port: 8080, ProbeTimeout: 3 * time.Second})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(inv.Models) != 1 || inv.Models[0].Model != "m1" {
+		t.Fatalf("expected 1 model m1, got %+v", inv.Models)
+	}
+	if inv.Models[0].NodeName != "probe-node" || inv.Models[0].Port != 8201 {
+		t.Fatalf("unexpected model identity: %+v", inv.Models[0])
+	}
+	if !inv.Nodes[0].Reachable {
+		t.Fatalf("node should be reachable: %+v", inv.Nodes[0])
+	}
+}


### PR DESCRIPTION
## Context

Phase 2 of citadel-chat-and-mesh (issue #576). Nodes on the embedded-tsnet mesh already publish their served models in the heartbeat (`services[].models`) and expose the same payload at `GET /status`. This adds the node-side **discovery + remote-routing layer**: enumerate reachable nodes, aggregate their served models into a fabric-wide `model -> node/engine/port` view, and provide a generic function to route an OpenAI `/v1/chat/completions` request to a chosen remote node over the mesh.

**Composes with #575 (Phase 1 local REPL).** Standalone, no dependency on #575's uncommitted code. The CLI is `citadel mesh` (not `citadel chat`) so there is no collision; #575's chat loop can import the same `mesh.Inventory` / `mesh.Client` to add a remote/peer selection mode.

## What works (live-verified) vs. what is scaffolded

| Piece | State |
|-------|-------|
| Peer enumeration + `/status` probe over the mesh + aggregation (`mesh models`) | **Live-verified** on a real fabric node |
| `mesh.Client.ChatCompletion(ip, port, body)` routing function | Implemented + unit-tested (httptest + injected dialer) |
| `mesh chat` CLI end-to-end | **Scaffold only** — routing target is not mesh-reachable yet (see below), tracked in #581 |

## Approach

**Discovery route: direct mesh `/status` probe.** Node->node mesh traffic is DIRECT (the Railway SOCKS relay caveat only affects backend->node), so a node probes peers itself rather than via the coordinator. `mesh.Discover` enumerates online peers (`network.GetGlobalPeers`, excludes self), probes each peer's `/status` over the mesh dialing via `network.Dial`, aggregates `services[].models` + `services[].port` into `ServedModel{model, node, engine, port}` entries (same model on multiple nodes stays independently addressable), and skips unreachable peers gracefully (bounded ~4s probe, capped concurrency), recording each error.

**Standalone / testable by design.** `internal/mesh` imports neither `internal/network` nor `internal/status`. Callers inject a `Dialer` and a `PeerLister`; the `/status` payload is decoded into a local struct. `discover()` is exercised with a mock fetcher; the real HTTP probe + chat routing are exercised via `httptest` + an injected dialer (dials a local test server), so the layer is unit-tested without a live mesh.

## Known gap: no mesh-reachable chat endpoint yet (tracked in #581)

`mesh chat` is wired but does **not** work end-to-end today, and the PR is honest about this:

- **Engine host ports are not mesh-reachable on embedded-tsnet nodes.** Although the engine compose files bind `0.0.0.0`, embedded tsnet's userspace netstack does NOT forward inbound mesh traffic to a host-bound port lacking a `srv.Listen()`. **Verified** by self-dialing this node's own mesh IP:8210 via `network.Dial` while bonsai served fine on `localhost:8210` -> `connection refused`. Only ports citadel explicitly `ListenVPN`s (status 8080, gateway 8443, terminal, vnc, modules) answer over the mesh. (The compose "peers reach this engine directly over the mesh" comment reflects a full-Tailscale/kernel-TUN node, not embedded tsnet.)
- **Neither gateway proxies chat.** `citadel work --gateway` and `citadel serve` register `/v1/embeddings` + control-route upstreams, but NOT `/v1/chat/completions`.

So the routing *function* is correct and generic, but there is no node-side target for it yet. `mesh chat` fails gracefully with a message pointing at #581 (the node-side of aceteam #6236: add `/v1/chat/completions` to the node gateway with model->engine routing). It lights up the moment #581 lands.

## Changes

- `internal/mesh/discovery.go` — peer enumeration, per-peer `/status` probe over the mesh, aggregation into `Inventory`, and `Inventory.FindModel` selection with ambiguity handling.
- `internal/mesh/client.go` — mesh-dialing HTTP client + generic `ChatCompletion` / `BuildChatRequest`.
- `internal/mesh/{discovery,client}_test.go` — aggregation/filtering/selection + HTTP probe + chat routing tests.
- `cmd/mesh.go` — `citadel mesh models` (list, `--json`) and `citadel mesh chat --node/--model` (scaffold, honest connection-refused message; separate discovery vs generation timeouts).
- `CLAUDE.md` — documents the feature, the standalone-layer design, the discovery reachability caveat, and the chat reachability gap.

## Testing

- `go build ./...`, `go vet ./...`, `go test ./...` — all pass.
- `go test ./internal/mesh/...` — pure aggregation, offline/self filtering, unreachable-peer handling, model selection/ambiguity, and end-to-end HTTP probe + chat routing via `httptest` + injected dialer.
- **Live mesh (discovery):** `citadel mesh models` on a real fabric node enumerated 4 peers, dialed each over the mesh, and skipped all gracefully (`connection refused` / `context deadline exceeded`) since none run `--gateway`. `--json` shows per-node reachability + errors.
- **Live mesh (chat routing reachability):** self-dial to own mesh IP:8210 through tsnet returned `connection refused` while `localhost:8210` served fine — this is the evidence that engine ports are not mesh-reachable on embedded-tsnet, and why `mesh chat` is scaffold-only pending #581. Chat request/response parsing itself is covered by the httptest-based unit tests; it is **not** live-mesh-verified.

Closes #576 · Follow-up: #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)