### PR TITLE
feat: service preemption + node pinning (pinned_services allowlist) (#577)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -663,6 +663,74 @@ Environment variables:
 | `SERVICE_AUTO_STOP_WHEN_IDLE` | unset (OFF) | Opt-in to auto-stop idle services. Truthy: `1`/`true`/`yes`/`on`. |
 | `SERVICE_AUTO_STOP_IDLE_SECONDS` | idle threshold | Idle seconds before auto-stop acts. |
 
+### Service Preemption and Node Pinning (citadel #577)
+
+A `SERVICE_START` that declares a VRAM budget on a full GPU auto-evicts
+(preempts) other services to make room — UNLESS they are pinned. Generalizes the
+#416 idle signal + #6018 VRAM-fit + durable `desired_status: stopped`.
+
+**Manifest field — `pinned_services` (node-wide allowlist):**
+```yaml
+# citadel.yaml
+pinned_services:
+  - bonsai          # never preempted
+services:
+  - name: bonsai
+  - name: vllm      # preemptible (the default for anything not pinned)
+```
+Modeled on both `CitadelManifest.PinnedServices` (`cmd/manifest.go`) and the
+minimal `serviceManifest.PinnedServices` (`internal/jobs/service_handler.go`).
+Empty/absent ⇒ every service is preemptible.
+
+**Pure decision (`internal/status/preempt.go`, unit-tested):**
+`PlanPreemption(candidates, requiredVRAM, availableVRAM) PreemptPlan` decides
+which non-pinned services to stop. Contract:
+- `requiredVRAM==0` (no declared budget) ⇒ Fits, no preemption. Never evict on an
+  absent signal.
+- Already fits (`availableVRAM >= requiredVRAM`) ⇒ Fits, no preemption.
+- **Pinned candidates are NEVER stopped.** If the deploy can't fit after stopping
+  every non-pinned service, `Fits=false` and `Blocked` names the pinned VRAM
+  holders → the deploy is REJECTED (job FAILURE).
+- Ordering is **idle-first** (stop idle before busy) then **largest-VRAM-first**,
+  name-ascending tie-break. Busy non-pinned services ARE preemptible — idle is
+  ordering, not a gate.
+
+**Executor (`ServiceHandler.preemptForVRAM`):** runs inside the docker
+`serviceStart` branch, gated on the target **not already running** (an
+already-running / model-recreate start already holds its VRAM). Collects live
+node status once (free VRAM from `GPUMetrics`, per-service `Footprint.VRAMBytes`,
+instantaneous idle via `status.FootprintActive` — NOT the debounced
+`FootprintIdleTracker`, which reads non-idle on a fresh collector), builds
+candidates, and executes the plan. Each eviction is **durable**: it sets
+`desired_status: stopped` THEN compose-downs (the SERVICE_STOP path), so the
+manifest reconcile does not restart it out from under the incoming deploy (the
+#528 VRAM-cascade gotcha). Preemption is therefore **sticky** — an evicted
+service stays down across reboots until an explicit `SERVICE_START` (which clears
+the marker) brings it back.
+
+**VRAM budget is a NEW payload contract, currently INERT.** `preemptForVRAM`
+reads `vram_mb` (preferred) or `vram_gb` from the `SERVICE_START` payload
+(`parseRequiredVRAMBytes`). The aceteam backend does **not** yet forward it
+(`fabric_provision` dispatches only `{service, model}`; DeployModel's
+`vram_budget_gb` is explicitly "not yet forwarded to Citadel"), so preemption is
+a no-op until the backend sends one of these keys. **AceTeam-side follow-up (different
+repo):** forward #6018's VRAM-fit budget as `vram_mb` on the model-deploy
+`SERVICE_START` dispatch.
+
+**Surfacing:** `ServiceInfo.Pinned` rides the heartbeat (`pinned`, omitempty);
+`citadel services` shows a `PIN` column (`pinned` / `preemptible`; `-` for apps,
+which are not pinnable via this service-level allowlist). Collectors are fed the
+allowlist via `CollectorConfig.PinnedServices` (the `citadel work` heartbeat path
+and `citadel services`).
+
+**Known limitations / follow-ups:**
+- The decision dimension is VRAM only; RAM preemption is a documented follow-up.
+- Catalog apps are not pinnable and are excluded from preemption candidates here
+  (the eviction path is the service compose-down); the #416 auto-stop reconciler
+  still handles idle catalog apps separately.
+- The TUI control center collector is not yet fed `PinnedServices` (heartbeat and
+  `citadel services` are); low-priority follow-up.
+
 ### Consume-Loop Watchdog, Self-Heal & Liveness (citadel #548)
 
 A hung job handler must never silently stall the whole node. The wedge that

--- a/citadel.yaml
+++ b/citadel.yaml
@@ -24,6 +24,13 @@ services:
   # - name: diffusers
   #   compose_file: ./services/diffusers.yml
 
+# Optional: node-wide preemption allowlist (citadel-cli#577). Services listed
+# here are NEVER auto-stopped to make room for another deploy. Everything else is
+# preemptible: a SERVICE_START that declares a VRAM budget may durably stop
+# non-pinned services to fit. Omit for the default (all services preemptible).
+# pinned_services:
+#   - bonsai
+
 # Optional: declare GPU capabilities explicitly.
 # If omitted, capabilities are auto-detected via nvidia-smi at startup.
 # capabilities:

--- a/cmd/manifest.go
+++ b/cmd/manifest.go
@@ -60,6 +60,22 @@ type CitadelManifest struct {
 	} `yaml:"node"`
 	Services     []Service             `yaml:"services"`
 	Capabilities *ManifestCapabilities `yaml:"capabilities,omitempty"`
+	// PinnedServices is a node-wide allowlist of service names that must NEVER be
+	// preempted (auto-stopped) to make room for another deploy (citadel-cli#577).
+	// Everything not listed is preemptible: a SERVICE_START that declares a VRAM
+	// budget may durably stop non-pinned services to fit. Empty/absent =>
+	// preemption allowed for all services (the default).
+	PinnedServices []string `yaml:"pinned_services,omitempty"`
+}
+
+// manifestPinnedServices returns the pinned_services allowlist for a manifest,
+// nil-safe so heartbeat/collector wiring can pass a possibly-nil manifest
+// (citadel-cli#577).
+func manifestPinnedServices(m *CitadelManifest) []string {
+	if m == nil {
+		return nil
+	}
+	return m.PinnedServices
 }
 
 // findAndReadManifest locates and parses the node's manifest file.

--- a/cmd/services_cmd.go
+++ b/cmd/services_cmd.go
@@ -47,14 +47,17 @@ func init() {
 
 func runServices(_ *cobra.Command, _ []string) error {
 	nodeName := ""
+	var pinned []string
 	if manifest, _, err := findAndReadManifest(); err == nil && manifest != nil {
 		nodeName = manifest.Node.Name
+		pinned = manifest.PinnedServices
 	}
 
 	collector := status.NewCollector(status.CollectorConfig{
-		NodeName:  nodeName,
-		ConfigDir: "",
-		Services:  nil,
+		NodeName:       nodeName,
+		ConfigDir:      "",
+		Services:       nil,
+		PinnedServices: pinned,
 	})
 	nodeStatus, err := collector.Collect()
 	if err != nil {
@@ -82,9 +85,9 @@ func runServices(_ *cobra.Command, _ []string) error {
 
 	fmt.Printf("Managed services on %s:\n\n", displayNodeName(nodeName))
 	w := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
-	fmt.Fprintln(w, "NAME\tKIND\tSTATUS\tUSAGE\tFOOTPRINT\tNOTE")
+	fmt.Fprintln(w, "NAME\tKIND\tSTATUS\tPIN\tUSAGE\tFOOTPRINT\tNOTE")
 	for _, r := range rows {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", r.name, r.kind, r.statusStr, r.usage, r.footprint, r.note)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", r.name, r.kind, r.statusStr, r.pin, r.usage, r.footprint, r.note)
 	}
 	w.Flush()
 
@@ -98,15 +101,15 @@ func runServices(_ *cobra.Command, _ []string) error {
 
 // serviceRow is one rendered line of the services table.
 type serviceRow struct {
-	name, kind, statusStr, usage, footprint, note string
+	name, kind, statusStr, pin, usage, footprint, note string
 }
 
 // collectServiceRows flattens the status services and apps into sorted display
-// rows, annotating each with its usage label, footprint, and an eviction-candidate
-// note when it qualifies.
+// rows, annotating each with its usage label, footprint, pin state, and an
+// eviction-candidate note when it qualifies.
 func collectServiceRows(st *status.NodeStatus, candidates map[string]bool) []serviceRow {
 	var rows []serviceRow
-	add := func(kind, name, statusStr string, idle *status.IdleState, fp *status.ServiceFootprint) {
+	add := func(kind, name, statusStr string, pinned bool, idle *status.IdleState, fp *status.ServiceFootprint) {
 		note := ""
 		if status.IsHeavyAndIdle(fp, idle) {
 			note = "heavy+idle"
@@ -121,6 +124,7 @@ func collectServiceRows(st *status.NodeStatus, candidates map[string]bool) []ser
 			name:      name,
 			kind:      kind,
 			statusStr: statusStr,
+			pin:       pinLabel(kind, pinned),
 			usage:     usageLabel(statusStr, idle),
 			footprint: footprintLabel(fp),
 			note:      note,
@@ -128,11 +132,12 @@ func collectServiceRows(st *status.NodeStatus, candidates map[string]bool) []ser
 	}
 	for i := range st.Services {
 		s := &st.Services[i]
-		add(string(status.EntityService), s.Name, s.Status, s.IdleState, s.Footprint)
+		add(string(status.EntityService), s.Name, s.Status, s.Pinned, s.IdleState, s.Footprint)
 	}
 	for i := range st.Apps {
 		a := &st.Apps[i]
-		add(string(status.EntityApp), a.Name, a.Status, a.IdleState, a.Footprint)
+		// Apps are not pinnable (pinned_services is a service-level allowlist).
+		add(string(status.EntityApp), a.Name, a.Status, false, a.IdleState, a.Footprint)
 	}
 	sort.Slice(rows, func(i, j int) bool {
 		if rows[i].kind != rows[j].kind {
@@ -141,6 +146,19 @@ func collectServiceRows(st *status.NodeStatus, candidates map[string]bool) []ser
 		return rows[i].name < rows[j].name
 	})
 	return rows
+}
+
+// pinLabel renders the PIN column (citadel #577): "pinned" for a pinned service,
+// "preemptible" for any other service, and "-" for apps (pinning is a
+// service-level allowlist, so apps are not pinnable via pinned_services).
+func pinLabel(kind string, pinned bool) string {
+	if kind == string(status.EntityApp) {
+		return "-"
+	}
+	if pinned {
+		return "pinned"
+	}
+	return "preemptible"
 }
 
 // usageLabel renders the usage column: "busy"/"idle <dur>" for a running

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1149,6 +1149,7 @@ func runWork(cmd *cobra.Command, args []string) {
 			Services:       nil,
 			Capabilities:   statusCaps,
 			WorkerLiveness: workerLivenessFn,
+			PinnedServices: manifestPinnedServices(workManifest),
 		})
 	}
 
@@ -1406,6 +1407,7 @@ func runWork(cmd *cobra.Command, args []string) {
 				Services:       nil,
 				Capabilities:   statusCaps,
 				WorkerLiveness: workerLivenessFn,
+				PinnedServices: manifestPinnedServices(workManifest),
 			})
 		}
 

--- a/internal/jobs/service_handler.go
+++ b/internal/jobs/service_handler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
 	"github.com/aceteam-ai/citadel-cli/internal/services"
+	"github.com/aceteam-ai/citadel-cli/internal/status"
 	embeddedservices "github.com/aceteam-ai/citadel-cli/services"
 	"gopkg.in/yaml.v3"
 )
@@ -26,6 +27,22 @@ import (
 // the service handler.  It lives here (not in cmd/) to avoid import cycles.
 type serviceManifest struct {
 	Services []manifestService `yaml:"services"`
+	// PinnedServices is the node-wide allowlist of services that must NEVER be
+	// preempted to make room for another deploy (citadel-cli#577). Mirrors
+	// cmd/manifest.go CitadelManifest.PinnedServices.
+	PinnedServices []string `yaml:"pinned_services,omitempty"`
+}
+
+// pinnedSet returns the pinned_services allowlist as a set for O(1) lookup,
+// trimming blank entries.
+func (m *serviceManifest) pinnedSet() map[string]bool {
+	set := make(map[string]bool, len(m.PinnedServices))
+	for _, n := range m.PinnedServices {
+		if n = strings.TrimSpace(n); n != "" {
+			set[n] = true
+		}
+	}
+	return set
 }
 
 type manifestService struct {
@@ -166,7 +183,12 @@ func (h *ServiceHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error)
 		// dispatches MODEL_CACHE_PULL (weights) then SERVICE_START
 		// {service, model}. The model, when present, is persisted per-service
 		// and injected into the engine's compose interpolation env.
-		return h.serviceStart(ctx, svc, job.Payload["model"])
+		//
+		// Optional VRAM budget (#577): a SERVICE_START that declares vram_mb /
+		// vram_gb triggers node-side preemption of non-pinned services to make
+		// room when the GPU lacks free VRAM. Absent => no preemption (the current
+		// backend does not yet forward it; see parseRequiredVRAMBytes).
+		return h.serviceStart(ctx, svc, job.Payload["model"], parseRequiredVRAMBytes(job.Payload))
 	case "SERVICE_STOP":
 		// A remote SERVICE_STOP is operator/cloud intent: mark the service
 		// durably stopped FIRST (mirrors liveModuleOps.Stop) so the stop
@@ -212,7 +234,7 @@ func (h *ServiceHandler) serviceStatus(svc manifestService) ([]byte, error) {
 // serve-time model (serviceModelEnvVar), it is persisted to the sibling
 // <name>.env BEFORE the already-running short-circuit, so a model change on a
 // running engine falls through to `up -d --force-recreate` and reloads it.
-func (h *ServiceHandler) serviceStart(ctx JobContext, svc manifestService, model string) ([]byte, error) {
+func (h *ServiceHandler) serviceStart(ctx JobContext, svc manifestService, model string, requiredVRAMBytes uint64) ([]byte, error) {
 	kind := h.resolveKind(svc)
 	var err error
 	// appliedModel is the model this start serves via compose env interpolation;
@@ -282,6 +304,17 @@ func (h *ServiceHandler) serviceStart(ctx JobContext, svc manifestService, model
 				Name: svc.Name, Running: true, Kind: kind,
 				Action: "start", Message: msg,
 			})
+		}
+		// Preempt non-pinned services to free VRAM for this deploy (#577). Gated
+		// on the target NOT already running: an already-running start (including
+		// the model-change --force-recreate path below, which reached here with
+		// modelChanged==true) already holds its own VRAM, so evicting peers for it
+		// would be a needless disruption. Returns an error — failing the deploy —
+		// when the requirement cannot be met without evicting a pinned service.
+		if !h.isDockerServiceRunning(svc.Name) {
+			if err := h.preemptForVRAM(ctx, svc, requiredVRAMBytes); err != nil {
+				return nil, err
+			}
 		}
 		composePath, pathErr := h.resolveComposePath(svc)
 		if pathErr != nil {
@@ -442,6 +475,149 @@ func (h *ServiceHandler) StopServiceByName(name string) error {
 		return fmt.Errorf("%s", parsed.Error)
 	}
 	return nil
+}
+
+// ---------------------------------------------------------------------------
+// VRAM preemption + node pinning (#577)
+// ---------------------------------------------------------------------------
+
+// parseRequiredVRAMBytes reads the optional VRAM budget a SERVICE_START job
+// declares, in bytes. It accepts vram_mb (preferred) or vram_gb; a missing,
+// blank, non-numeric, or non-positive value yields 0 (= "no requirement", which
+// disables preemption). NOTE: the current aceteam backend does NOT yet forward a
+// VRAM field on SERVICE_START (fabric_provision dispatches only {service, model};
+// the DeployModel API's vram_budget_gb is explicitly "not yet forwarded to
+// Citadel"). So preemption is INERT until the backend sends one of these keys —
+// wiring that up (forward #6018's VRAM-fit budget as vram_mb) is the aceteam-side
+// follow-up.
+func parseRequiredVRAMBytes(payload map[string]string) uint64 {
+	if v := strings.TrimSpace(payload["vram_mb"]); v != "" {
+		if mb, err := strconv.ParseFloat(v, 64); err == nil && mb > 0 {
+			return uint64(mb * 1024 * 1024)
+		}
+	}
+	if v := strings.TrimSpace(payload["vram_gb"]); v != "" {
+		if gb, err := strconv.ParseFloat(v, 64); err == nil && gb > 0 {
+			return uint64(gb * 1024 * 1024 * 1024)
+		}
+	}
+	return 0
+}
+
+// preemptForVRAM makes room for a deploy that declares a VRAM budget by durably
+// stopping non-pinned services until it fits. It is a no-op when the requirement
+// is unknown (requiredVRAMBytes==0), when free VRAM already suffices, or when the
+// node's free VRAM cannot be determined (fail-safe: never evict on an absent
+// signal). It returns an error — FAILING the deploy — when the requirement cannot
+// be met without evicting a pinned service (pinned_services allowlist, #577).
+//
+// Durability: each preempted service is stopped via the SERVICE_STOP path
+// (desired_status: stopped, then compose down), NOT a bare docker stop, so the
+// boot/manifest-reconcile paths do not restart it out from under the incoming
+// deploy — the VRAM-cascade gotcha from #528. This means preemption is STICKY: an
+// evicted service stays down across reboots until an explicit SERVICE_START (which
+// clears the marker) brings it back.
+func (h *ServiceHandler) preemptForVRAM(ctx JobContext, svc manifestService, requiredVRAMBytes uint64) error {
+	if requiredVRAMBytes == 0 {
+		return nil // no declared budget => nothing to enforce
+	}
+
+	// Collect live node status once: free VRAM + per-service VRAM footprints. A
+	// fresh collector's debounced IdleState is unreliable here (no history), so
+	// the idle ORDERING signal is derived instantaneously from the footprint.
+	collector := status.NewCollector(status.CollectorConfig{ConfigDir: h.ConfigDir})
+	st, err := collector.Collect()
+	if err != nil {
+		ctx.Log("warning", "     - [preempt] could not collect node status: %v; skipping VRAM fit check", err)
+		return nil
+	}
+	freeVRAM, ok := freeVRAMBytes(st.GPU)
+	if !ok {
+		ctx.Log("info", "     - [preempt] GPU free VRAM unknown; skipping VRAM fit check for %s", svc.Name)
+		return nil
+	}
+
+	manifest, err := h.loadManifest()
+	if err != nil {
+		return fmt.Errorf("failed to load manifest for preemption: %w", err)
+	}
+	pinned := manifest.pinnedSet()
+
+	candidates := buildPreemptCandidates(st, svc.Name, pinned)
+	plan := status.PlanPreemption(candidates, requiredVRAMBytes, freeVRAM)
+	if !plan.Fits {
+		// Cannot fit without evicting a pinned service: reject the deploy.
+		return fmt.Errorf("cannot start %s: %s", svc.Name, plan.Reason)
+	}
+	if len(plan.Stop) == 0 {
+		return nil // already fits; no eviction needed
+	}
+
+	ctx.Log("info", "     - [preempt] %s", plan.Reason)
+	for _, name := range plan.Stop {
+		ctx.Log("info", "     - [preempt] durably stopping %s to free VRAM for %s", name, svc.Name)
+		// Durable FIRST (mirrors the SERVICE_STOP job path): mark stopped so the
+		// manifest reconcile does not restart it, then compose down.
+		if err := h.setDesiredStatusInManifestFile(name, "stopped"); err != nil {
+			ctx.Log("warning", "     - [preempt] could not mark %s stopped: %v", name, err)
+		}
+		if err := h.StopServiceByName(name); err != nil {
+			// A failed eviction leaves VRAM unfreed: fail the deploy rather than
+			// start into insufficient VRAM.
+			return fmt.Errorf("cannot start %s: failed to preempt %s: %w", svc.Name, name, err)
+		}
+	}
+	return nil
+}
+
+// freeVRAMBytes sums the currently-free VRAM (total - used) across all GPUs that
+// report a total, in bytes. The bool is false when NO GPU reports a memory total
+// (no GPU / nvidia-smi absent), so callers skip the VRAM fit check rather than
+// treat "unknown" as "zero free".
+func freeVRAMBytes(gpus []status.GPUMetrics) (uint64, bool) {
+	var free uint64
+	found := false
+	for _, g := range gpus {
+		if g.MemoryTotalMB <= 0 {
+			continue
+		}
+		found = true
+		f := g.MemoryTotalMB - g.MemoryUsedMB
+		if f < 0 {
+			f = 0
+		}
+		free += uint64(f) * 1024 * 1024
+	}
+	return free, found
+}
+
+// buildPreemptCandidates turns the live node status into the pure inputs for
+// status.PlanPreemption: every RUNNING managed service except the deploy target,
+// tagged with its VRAM footprint, an instantaneous idle signal (for ordering),
+// and whether it is pinned. Catalog apps are intentionally excluded — pinning is
+// a service-level allowlist and the eviction path here is the service compose
+// down.
+func buildPreemptCandidates(st *status.NodeStatus, exclude string, pinned map[string]bool) []status.PreemptCandidate {
+	out := make([]status.PreemptCandidate, 0, len(st.Services))
+	for i := range st.Services {
+		s := &st.Services[i]
+		if s.Name == exclude || s.Status != status.ServiceStatusRunning {
+			continue
+		}
+		var vram uint64
+		if s.Footprint != nil {
+			vram = s.Footprint.VRAMBytes
+		}
+		out = append(out, status.PreemptCandidate{
+			Name:      s.Name,
+			VRAMBytes: vram,
+			// Instantaneous (not debounced) idle: a fresh collector has no idle
+			// history, so use the footprint's CPU/GPU activity directly.
+			Idle:   !status.FootprintActive(s.Footprint),
+			Pinned: pinned[s.Name],
+		})
+	}
+	return out
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/jobs/service_handler_integration_test.go
+++ b/internal/jobs/service_handler_integration_test.go
@@ -79,7 +79,7 @@ func TestServiceStartPublishesHostPort(t *testing.T) {
 		ComposeFile: "services/" + svcName + ".yml",
 	}
 
-	out, err := h.serviceStart(JobContext{}, svc)
+	out, err := h.serviceStart(JobContext{}, svc, "", 0)
 	if err != nil {
 		t.Fatalf("serviceStart returned error: %v", err)
 	}

--- a/internal/jobs/service_handler_preempt_test.go
+++ b/internal/jobs/service_handler_preempt_test.go
@@ -1,0 +1,85 @@
+package jobs
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/status"
+)
+
+const testGiB = uint64(1) << 30
+
+func TestParseRequiredVRAMBytes(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload map[string]string
+		want    uint64
+	}{
+		{"absent", map[string]string{"service": "vllm"}, 0},
+		{"blank", map[string]string{"vram_mb": "  "}, 0},
+		{"zero", map[string]string{"vram_mb": "0"}, 0},
+		{"negative", map[string]string{"vram_gb": "-4"}, 0},
+		{"garbage", map[string]string{"vram_mb": "lots"}, 0},
+		{"mb", map[string]string{"vram_mb": "8192"}, 8192 * 1024 * 1024},
+		{"gb", map[string]string{"vram_gb": "6"}, 6 * 1024 * 1024 * 1024},
+		{"mb_wins_over_gb", map[string]string{"vram_mb": "1024", "vram_gb": "40"}, 1024 * 1024 * 1024},
+		{"fractional_gb", map[string]string{"vram_gb": "5.5"}, uint64(5.5 * 1024 * 1024 * 1024)},
+	}
+	for _, c := range cases {
+		if got := parseRequiredVRAMBytes(c.payload); got != c.want {
+			t.Errorf("%s: parseRequiredVRAMBytes = %d, want %d", c.name, got, c.want)
+		}
+	}
+}
+
+func TestFreeVRAMBytes(t *testing.T) {
+	// No GPU reporting a total => unknown (found=false), so callers skip the fit
+	// check rather than treat unknown as zero-free.
+	if _, ok := freeVRAMBytes(nil); ok {
+		t.Fatalf("nil GPUs must report unknown")
+	}
+	if _, ok := freeVRAMBytes([]status.GPUMetrics{{MemoryTotalMB: 0}}); ok {
+		t.Fatalf("a GPU with no total must report unknown")
+	}
+	// total 24GB, used 20GB => 4GB free.
+	free, ok := freeVRAMBytes([]status.GPUMetrics{{MemoryTotalMB: 24576, MemoryUsedMB: 20480}})
+	if !ok || free != 4096*1024*1024 {
+		t.Fatalf("expected 4GB free, got %d ok=%v", free, ok)
+	}
+	// Used > total (transient over-report) clamps to 0, doesn't underflow.
+	free, ok = freeVRAMBytes([]status.GPUMetrics{{MemoryTotalMB: 1000, MemoryUsedMB: 2000}})
+	if !ok || free != 0 {
+		t.Fatalf("expected clamp to 0 free, got %d ok=%v", free, ok)
+	}
+}
+
+func TestBuildPreemptCandidates(t *testing.T) {
+	st := &status.NodeStatus{
+		Services: []status.ServiceInfo{
+			{Name: "vllm", Status: status.ServiceStatusRunning,
+				Footprint: &status.ServiceFootprint{VRAMBytes: 20 * testGiB, CPUPercent: 0.5, HasGPU: true, GPUUtilPercent: 0}},
+			{Name: "bonsai", Status: status.ServiceStatusRunning,
+				Footprint: &status.ServiceFootprint{VRAMBytes: 6 * testGiB, CPUPercent: 90, HasGPU: true, GPUUtilPercent: 80}},
+			{Name: "stopped-one", Status: status.ServiceStatusStopped},
+			{Name: "self", Status: status.ServiceStatusRunning,
+				Footprint: &status.ServiceFootprint{VRAMBytes: 3 * testGiB}},
+		},
+	}
+	got := buildPreemptCandidates(st, "self", map[string]bool{"bonsai": true})
+
+	want := []status.PreemptCandidate{
+		// vllm: low CPU + low GPU => instantaneously idle.
+		{Name: "vllm", VRAMBytes: 20 * testGiB, Idle: true, Pinned: false},
+		// bonsai: busy (high CPU/GPU) and pinned.
+		{Name: "bonsai", VRAMBytes: 6 * testGiB, Idle: false, Pinned: true},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("candidates mismatch:\n got=%+v\nwant=%+v", got, want)
+	}
+	// Excluded target and stopped services must not appear.
+	for _, c := range got {
+		if c.Name == "self" || c.Name == "stopped-one" {
+			t.Fatalf("unexpected candidate %q", c.Name)
+		}
+	}
+}

--- a/internal/status/collector.go
+++ b/internal/status/collector.go
@@ -32,6 +32,7 @@ type Collector struct {
 	idleTracker    *IdleTracker           // metrics-based per-service idle detection (aceteam#4472 / citadel #416)
 	fpIdleTracker  *FootprintIdleTracker  // footprint-derived idle for engines #416 can't scrape (citadel #421)
 	netIdleTracker *IdleTracker           // network-activity idle for non-vLLM services (citadel #433)
+	pinnedServices map[string]bool        // node pinned_services allowlist -> ServiceInfo.Pinned (citadel #577)
 }
 
 // ServiceConfig holds the configuration for a service from the manifest.
@@ -52,6 +53,10 @@ type CollectorConfig struct {
 	// to each heartbeat so the platform can flag "green but wedged" nodes
 	// (issue #548). Optional: nil on nodes with no worker loop.
 	WorkerLiveness func() *WorkerLiveness
+	// PinnedServices is the node's pinned_services allowlist (citadel #577). Each
+	// running service whose name is listed is marked ServiceInfo.Pinned=true so
+	// the heartbeat and `citadel services` show pinned vs preemptible. Optional.
+	PinnedServices []string
 }
 
 // NewCollector creates a new status collector.
@@ -67,7 +72,23 @@ func NewCollector(cfg CollectorConfig) *Collector {
 		idleTracker:    NewIdleTracker(IdleThresholdSeconds()),
 		fpIdleTracker:  NewFootprintIdleTracker(),
 		netIdleTracker: NewIdleTracker(IdleThresholdSeconds()),
+		pinnedServices: toStringSet(cfg.PinnedServices),
 	}
+}
+
+// toStringSet builds a lookup set from a slice, trimming blanks. Returns nil for
+// an empty input so a caller can cheaply test len()==0.
+func toStringSet(items []string) map[string]bool {
+	if len(items) == 0 {
+		return nil
+	}
+	set := make(map[string]bool, len(items))
+	for _, it := range items {
+		if it = strings.TrimSpace(it); it != "" {
+			set[it] = true
+		}
+	}
+	return set
 }
 
 // SetCapabilities sets the cached capabilities for heartbeat publishing.
@@ -109,6 +130,17 @@ func (c *Collector) Collect() (*NodeStatus, error) {
 			continue
 		}
 		status.Services = append(status.Services, eng)
+	}
+
+	// Mark pinned services (citadel #577) so the heartbeat and `citadel services`
+	// can show pinned vs preemptible. A pinned service is never auto-evicted to
+	// make room for another deploy.
+	if len(c.pinnedServices) > 0 {
+		for i := range status.Services {
+			if c.pinnedServices[status.Services[i].Name] {
+				status.Services[i].Pinned = true
+			}
+		}
 	}
 
 	// Collect installed app status

--- a/internal/status/footprint.go
+++ b/internal/status/footprint.go
@@ -563,6 +563,17 @@ func footprintActive(fp *ServiceFootprint) bool {
 	return false
 }
 
+// FootprintActive reports whether a footprint indicates the container is doing
+// work (CPU or GPU above the idle thresholds). Exported wrapper over the internal
+// heuristic so callers outside this package (the #577 preemption ordering) can
+// derive an INSTANTANEOUS idle signal (idle == !FootprintActive) without the
+// debounced FootprintIdleTracker, which needs accumulated history to cross its
+// threshold and so reads non-idle for every service on a fresh collector. A nil
+// footprint is not active.
+func FootprintActive(fp *ServiceFootprint) bool {
+	return footprintActive(fp)
+}
+
 // Observe updates the tracker for a container's current footprint and returns
 // its derived idle state. Active containers reset the idle clock and report
 // idle=false with idle_seconds=0. Inactive containers accumulate idle_seconds

--- a/internal/status/preempt.go
+++ b/internal/status/preempt.go
@@ -1,0 +1,138 @@
+package status
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// PreemptCandidate is a running managed service considered as a source of VRAM
+// to reclaim for an incoming deploy. It is the pure input to PlanPreemption:
+// the executor derives these from the live node status (per-service footprint
+// VRAM + an instantaneous idle signal + the manifest's pinned_services
+// allowlist). See citadel-cli#577.
+type PreemptCandidate struct {
+	// Name is the logical service name (matches citadel.yaml services[].name).
+	Name string
+	// VRAMBytes is the VRAM currently attributed to this service's container.
+	// Stopping a service reclaims exactly this much VRAM.
+	VRAMBytes uint64
+	// Idle is an instantaneous "not doing work" signal used ONLY to order
+	// preemption (idle before busy). It is NOT a gate: a busy non-pinned service
+	// is still preemptible when idle candidates cannot free enough VRAM.
+	Idle bool
+	// Pinned reports whether the service is in citadel.yaml pinned_services. A
+	// pinned service is NEVER preempted; if a deploy cannot fit without evicting
+	// one, the deploy is rejected.
+	Pinned bool
+}
+
+// PreemptPlan is the decision returned by PlanPreemption.
+type PreemptPlan struct {
+	// Fits reports whether requiredVRAM can be satisfied. When true, stopping the
+	// services named in Stop (in order) frees enough VRAM (Stop may be empty when
+	// the deploy already fits). When false the deploy MUST be rejected: it cannot
+	// fit without evicting a pinned service.
+	Fits bool
+	// Stop is the ordered list of non-pinned service names to durably stop,
+	// idle-first then largest-VRAM-first. It is the minimal prefix that frees
+	// enough VRAM (or, when !Fits, every non-pinned VRAM holder — still not
+	// enough).
+	Stop []string
+	// Blocked lists pinned services still holding VRAM when the deploy does not
+	// fit — the reason it was rejected. Nil when Fits.
+	Blocked []string
+	// Reason is a human-readable explanation for logs and error messages.
+	Reason string
+}
+
+// PlanPreemption decides which running non-pinned services to stop so a deploy
+// needing requiredVRAM bytes fits, given availableVRAM (currently-free) bytes.
+//
+// Contract:
+//   - requiredVRAM == 0: unknown/undeclared requirement → Fits with no
+//     preemption. Never evict on an absent signal (the fail-safe that keeps a
+//     deploy carrying no VRAM budget from disrupting the node).
+//   - availableVRAM >= requiredVRAM: already fits → Fits, no preemption.
+//   - Pinned candidates are NEVER stopped. If the deploy cannot fit after
+//     stopping every non-pinned candidate, Fits=false and Blocked names the
+//     pinned VRAM holders.
+//
+// Ordering is idle-first (stop idle before busy) then largest-VRAM-first (free
+// the most per eviction so the fewest services are disrupted), name-ascending as
+// a deterministic tie-break. Busy non-pinned services ARE preemptible — idle is
+// ordering, not a gate. Pure (no I/O) so the decision is unit-testable.
+func PlanPreemption(candidates []PreemptCandidate, requiredVRAM, availableVRAM uint64) PreemptPlan {
+	if requiredVRAM == 0 {
+		return PreemptPlan{Fits: true, Reason: "no VRAM requirement declared; preemption skipped"}
+	}
+	if availableVRAM >= requiredVRAM {
+		return PreemptPlan{
+			Fits:   true,
+			Reason: fmt.Sprintf("deploy fits without preemption: %s free ≥ %s required", fmtGB(availableVRAM), fmtGB(requiredVRAM)),
+		}
+	}
+
+	// Partition pinned vs preemptible; remember pinned VRAM holders for the
+	// rejection reason.
+	preemptible := make([]PreemptCandidate, 0, len(candidates))
+	var pinnedHolders []string
+	for _, c := range candidates {
+		if c.Pinned {
+			if c.VRAMBytes > 0 {
+				pinnedHolders = append(pinnedHolders, c.Name)
+			}
+			continue
+		}
+		preemptible = append(preemptible, c)
+	}
+
+	// Order: idle before busy, then larger VRAM first, then name ascending.
+	sort.SliceStable(preemptible, func(i, j int) bool {
+		a, b := preemptible[i], preemptible[j]
+		if a.Idle != b.Idle {
+			return a.Idle // idle first
+		}
+		if a.VRAMBytes != b.VRAMBytes {
+			return a.VRAMBytes > b.VRAMBytes // larger reclaim first
+		}
+		return a.Name < b.Name
+	})
+
+	var (
+		freed uint64
+		stop  []string
+	)
+	for _, c := range preemptible {
+		if availableVRAM+freed >= requiredVRAM {
+			break
+		}
+		if c.VRAMBytes == 0 {
+			continue // stopping a service that holds no VRAM frees nothing
+		}
+		stop = append(stop, c.Name)
+		freed += c.VRAMBytes
+	}
+
+	if availableVRAM+freed >= requiredVRAM {
+		return PreemptPlan{
+			Fits: true,
+			Stop: stop,
+			Reason: fmt.Sprintf("preempting %d service(s) to free %s (%s free + %s reclaimed ≥ %s required)",
+				len(stop), fmtGB(freed), fmtGB(availableVRAM), fmtGB(freed), fmtGB(requiredVRAM)),
+		}
+	}
+
+	sort.Strings(pinnedHolders)
+	reason := fmt.Sprintf("insufficient VRAM: %s free + %s reclaimable from preemptible services < %s required",
+		fmtGB(availableVRAM), fmtGB(freed), fmtGB(requiredVRAM))
+	if len(pinnedHolders) > 0 {
+		reason += fmt.Sprintf("; pinned services hold VRAM and cannot be preempted: %s", strings.Join(pinnedHolders, ", "))
+	}
+	return PreemptPlan{Fits: false, Stop: stop, Blocked: pinnedHolders, Reason: reason}
+}
+
+// fmtGB renders a byte count as a compact "5.5GB" for human-readable reasons.
+func fmtGB(b uint64) string {
+	return fmt.Sprintf("%.1fGB", float64(b)/(1<<30))
+}

--- a/internal/status/preempt_test.go
+++ b/internal/status/preempt_test.go
@@ -1,0 +1,150 @@
+package status
+
+import (
+	"reflect"
+	"testing"
+)
+
+const vgib = uint64(1) << 30
+
+func TestPlanPreemption_NoRequirementIsNoOp(t *testing.T) {
+	// requiredVRAM==0 means "unknown/undeclared": never preempt on an absent
+	// signal, regardless of what is running.
+	plan := PlanPreemption([]PreemptCandidate{
+		{Name: "vllm", VRAMBytes: 21 * vgib, Idle: true},
+	}, 0, 0)
+	if !plan.Fits {
+		t.Fatalf("requiredVRAM==0 must Fit, got %+v", plan)
+	}
+	if len(plan.Stop) != 0 {
+		t.Fatalf("requiredVRAM==0 must not preempt, got Stop=%v", plan.Stop)
+	}
+}
+
+func TestPlanPreemption_AlreadyFitsNoPreemption(t *testing.T) {
+	plan := PlanPreemption([]PreemptCandidate{
+		{Name: "vllm", VRAMBytes: 21 * vgib, Idle: false},
+	}, 8*vgib, 10*vgib) // 10 free >= 8 required
+	if !plan.Fits || len(plan.Stop) != 0 {
+		t.Fatalf("should fit without preemption, got %+v", plan)
+	}
+}
+
+func TestPlanPreemption_StopsIdleFirst(t *testing.T) {
+	// Need 8GB, 0 free. A busy 20GB and an idle 10GB both non-pinned. Idle-first
+	// means the idle 10GB is chosen even though the busy one is larger.
+	plan := PlanPreemption([]PreemptCandidate{
+		{Name: "busy-big", VRAMBytes: 20 * vgib, Idle: false},
+		{Name: "idle-mid", VRAMBytes: 10 * vgib, Idle: true},
+	}, 8*vgib, 0)
+	if !plan.Fits {
+		t.Fatalf("should fit after one eviction, got %+v", plan)
+	}
+	if !reflect.DeepEqual(plan.Stop, []string{"idle-mid"}) {
+		t.Fatalf("expected to stop idle-mid only, got %v", plan.Stop)
+	}
+}
+
+func TestPlanPreemption_LargestFirstWithinSameIdleness(t *testing.T) {
+	// Two idle services; need 12GB, 0 free. Largest-first frees enough with the
+	// single 15GB stop rather than accumulating smaller ones.
+	plan := PlanPreemption([]PreemptCandidate{
+		{Name: "idle-small", VRAMBytes: 5 * vgib, Idle: true},
+		{Name: "idle-large", VRAMBytes: 15 * vgib, Idle: true},
+	}, 12*vgib, 0)
+	if !reflect.DeepEqual(plan.Stop, []string{"idle-large"}) {
+		t.Fatalf("expected largest-first single stop idle-large, got %v", plan.Stop)
+	}
+}
+
+func TestPlanPreemption_BusyPreemptedWhenIdleInsufficient(t *testing.T) {
+	// Idle-first is ordering, NOT a gate: when idle candidates can't free enough,
+	// a busy non-pinned service is still stopped.
+	plan := PlanPreemption([]PreemptCandidate{
+		{Name: "idle-small", VRAMBytes: 2 * vgib, Idle: true},
+		{Name: "busy-big", VRAMBytes: 20 * vgib, Idle: false},
+	}, 10*vgib, 0)
+	if !plan.Fits {
+		t.Fatalf("should fit after stopping busy service, got %+v", plan)
+	}
+	// idle-small (2G) is stopped first but insufficient; then busy-big.
+	if !reflect.DeepEqual(plan.Stop, []string{"idle-small", "busy-big"}) {
+		t.Fatalf("expected [idle-small busy-big], got %v", plan.Stop)
+	}
+}
+
+func TestPlanPreemption_NeverPreemptsPinned_FailsWithBlocked(t *testing.T) {
+	// Need 20GB, 0 free. Only VRAM holder is pinned bonsai -> cannot fit.
+	plan := PlanPreemption([]PreemptCandidate{
+		{Name: "bonsai", VRAMBytes: 12 * vgib, Idle: true, Pinned: true},
+		{Name: "tiny", VRAMBytes: 1 * vgib, Idle: true},
+	}, 20*vgib, 0)
+	if plan.Fits {
+		t.Fatalf("must NOT fit without evicting pinned service, got %+v", plan)
+	}
+	if !reflect.DeepEqual(plan.Blocked, []string{"bonsai"}) {
+		t.Fatalf("expected Blocked=[bonsai], got %v", plan.Blocked)
+	}
+	// A pinned service must never appear in the Stop list.
+	for _, s := range plan.Stop {
+		if s == "bonsai" {
+			t.Fatalf("pinned service bonsai must never be in Stop, got %v", plan.Stop)
+		}
+	}
+	if plan.Reason == "" {
+		t.Fatalf("rejection must carry a reason")
+	}
+}
+
+func TestPlanPreemption_FitsAfterEvictingNonPinnedAroundPinned(t *testing.T) {
+	// Pinned bonsai holds 8GB and must stay; free 4GB; need 16GB. Stopping the
+	// non-pinned vllm (20GB) frees enough (4 free + 20 = 24 >= 16) without
+	// touching bonsai.
+	plan := PlanPreemption([]PreemptCandidate{
+		{Name: "bonsai", VRAMBytes: 8 * vgib, Idle: false, Pinned: true},
+		{Name: "vllm", VRAMBytes: 20 * vgib, Idle: true},
+	}, 16*vgib, 4*vgib)
+	if !plan.Fits {
+		t.Fatalf("should fit by evicting non-pinned vllm, got %+v", plan)
+	}
+	if !reflect.DeepEqual(plan.Stop, []string{"vllm"}) {
+		t.Fatalf("expected to stop vllm only, got %v", plan.Stop)
+	}
+}
+
+func TestPlanPreemption_MinimalPrefixOnly(t *testing.T) {
+	// Need 6GB, 0 free; three idle services of 4GB each. Stopping two (8GB) is
+	// enough; the third must NOT be stopped.
+	plan := PlanPreemption([]PreemptCandidate{
+		{Name: "a", VRAMBytes: 4 * vgib, Idle: true},
+		{Name: "b", VRAMBytes: 4 * vgib, Idle: true},
+		{Name: "c", VRAMBytes: 4 * vgib, Idle: true},
+	}, 6*vgib, 0)
+	if len(plan.Stop) != 2 {
+		t.Fatalf("expected minimal prefix of 2 stops, got %v", plan.Stop)
+	}
+}
+
+func TestPlanPreemption_SkipsZeroVRAMCandidates(t *testing.T) {
+	// A running service holding no VRAM frees nothing when stopped, so it must
+	// not be selected; the real VRAM holder is.
+	plan := PlanPreemption([]PreemptCandidate{
+		{Name: "sidecar", VRAMBytes: 0, Idle: true},
+		{Name: "vllm", VRAMBytes: 20 * vgib, Idle: false},
+	}, 10*vgib, 0)
+	if !reflect.DeepEqual(plan.Stop, []string{"vllm"}) {
+		t.Fatalf("expected to stop vllm only (skip zero-VRAM sidecar), got %v", plan.Stop)
+	}
+}
+
+func TestPlanPreemption_DeterministicNameTieBreak(t *testing.T) {
+	// Equal idleness and equal VRAM -> name-ascending order, so the plan is
+	// deterministic across map/collection ordering.
+	plan := PlanPreemption([]PreemptCandidate{
+		{Name: "zeta", VRAMBytes: 8 * vgib, Idle: true},
+		{Name: "alpha", VRAMBytes: 8 * vgib, Idle: true},
+	}, 8*vgib, 0)
+	if !reflect.DeepEqual(plan.Stop, []string{"alpha"}) {
+		t.Fatalf("expected alpha (name tie-break) first, got %v", plan.Stop)
+	}
+}

--- a/internal/status/types.go
+++ b/internal/status/types.go
@@ -207,6 +207,12 @@ type ServiceInfo struct {
 	// #421). Omitted when stats could not be read. Rides the heartbeat so the
 	// platform can spot a heavy-and-idle eviction candidate.
 	Footprint *ServiceFootprint `json:"footprint,omitempty"`
+
+	// Pinned reports whether this service is in the node's pinned_services
+	// allowlist and therefore NEVER preemptible to make room for another deploy
+	// (citadel-cli#577). Omitted (false) for preemptible services — the default.
+	// The platform reads this to show pinned vs preemptible per node.
+	Pinned bool `json:"pinned,omitempty"`
 }
 
 // HealthResponse is the response for /health endpoint.


### PR DESCRIPTION
Closes #577

## TL;DR — node-side enforcement is complete, but INERT until the backend forwards a VRAM budget

This PR implements node-side service preemption + pinning. It fires **only** once a `SERVICE_START` payload carries a VRAM budget (`vram_mb` / `vram_gb`). The aceteam backend does **not** yet forward one (`fabric_provision` dispatches only `{service, model}`; DeployModel's `vram_budget_gb` is explicitly "not yet forwarded to Citadel"). So on prod today this is a no-op until the aceteam-side follow-up lands (forward #6018's VRAM-fit budget as `vram_mb` on the deploy dispatch). Reviewers: do not assume preemption is live.

## Context
Starting a service that needs VRAM should auto-evict (preempt) other services to make room — UNLESS the node pins a selected set. Generalizes #416 (idle signal) + #6018 (VRAM-fit) + the durable `desired_status: stopped` stop path.

## Design (product decision: node-level allowlist)
```yaml
# citadel.yaml
pinned_services:
  - bonsai        # never preempted
services:
  - name: bonsai
  - name: vllm    # preemptible (default for anything not pinned)
```

## Changes
- **Manifest field** `pinned_services: []string` on `CitadelManifest` (`cmd/manifest.go`) and the minimal `serviceManifest` (`internal/jobs/service_handler.go`). Empty/absent ⇒ all services preemptible.
- **Pure decision** `status.PlanPreemption` (`internal/status/preempt.go`): idle-first then largest-VRAM-first ordering; **never** selects a pinned candidate; returns `Fits=false` + `Blocked` (pinned VRAM holders) when it can't fit without evicting a pinned service; no-op on `requiredVRAM==0` (never evict on an absent signal). Fully unit-tested.
- **Executor** `ServiceHandler.preemptForVRAM` in the docker `serviceStart` branch, **gated on the target not already running** (an already-running / model-recreate start already holds its VRAM). Reuses live footprints (#421), an instantaneous idle signal (`status.FootprintActive`, not the debounced tracker), and GPU free VRAM. Each eviction is **durable** — `desired_status: stopped` THEN compose down (the SERVICE_STOP path), so the manifest reconcile does not restart it out from under the deploy (the #528 VRAM-cascade gotcha). Preemption is therefore **sticky**: an evicted service stays down across reboots until an explicit `SERVICE_START` (which clears the marker).
- **Fail-closed**: a deploy that can't fit without evicting a pinned service returns a hard error ⇒ job FAILURE with a clear reason naming the blocking pinned services.
- **Surfacing**: `ServiceInfo.Pinned` on the heartbeat (`pinned`, omitempty); a `PIN` column on `citadel services` (`pinned` / `preemptible`; `-` for apps). `CollectorConfig.PinnedServices` wired into the `citadel work` heartbeat path and `citadel services`.

## Root cause / gap addressed
#6018 does VRAM-fit UI aceteam-side, but the node had no enforcement: a deploy onto a full GPU had no way to reclaim VRAM from other engines, and no way to protect a chosen engine. This adds that enforcement, with pinning as the safety valve.

## Testing
- `internal/status/preempt_test.go`: ordering (idle-first, largest-first, name tie-break), busy-preempted-when-idle-insufficient, minimal-prefix, zero-VRAM skip, `requiredVRAM==0` no-op, already-fits no-op, and the load-bearing **fail-not-evict-pinned** case (`Fits=false` + `Blocked` names the pinned holder, pinned never in `Stop`).
- `internal/jobs/service_handler_preempt_test.go`: `parseRequiredVRAMBytes` (mb/gb/precedence/garbage), `freeVRAMBytes` (unknown vs clamp), `buildPreemptCandidates` (excludes target + stopped, marks pinned, instantaneous idle).
- `go build ./...`, `go vet ./...`, `go test ./...` all pass. `go build -tags integration ./internal/jobs/` also compiles (fixed a pre-existing stale call there).

## Follow-ups (documented in CLAUDE.md)
- **AceTeam-side (different repo):** forward #6018's VRAM-fit budget as `vram_mb` on the model-deploy `SERVICE_START` dispatch to activate this.
- VRAM-only decision dimension; RAM preemption is a follow-up.
- Catalog apps are not pinnable and excluded from candidates here (the #416 auto-stop reconciler still handles idle apps).
- TUI control center collector not yet fed `PinnedServices` (heartbeat + `citadel services` are).

🤖 Generated with [Claude Code](https://claude.com/claude-code)