### PR TITLE
fix(work): API-mode GPU nodes subscribe to gpu-general (#6315)

### DIFF
--- a/cmd/work.go
+++ b/cmd/work.go
@@ -667,6 +667,18 @@ func runWork(cmd *cobra.Command, args []string) {
 			Debug("shell queue: %s", shellQueue)
 		}
 
+		// GPU nodes must also consume the GPU inference queues. In API mode the
+		// server's worker-config returns only the CPU base queue today (#6315),
+		// so gateway inference dispatched to jobs:v1:gpu-general (+ gpu tag
+		// queues) with a target_node would never reach this node. Self-subscribe
+		// from locally-detected GPU capabilities, mirroring direct-Redis mode.
+		// Additive to whatever worker-config returned; a CPU-only node adds
+		// nothing (GPUInferenceQueues returns nil without a GPU).
+		if gpuQueues := capabilities.GPUInferenceQueues(nodeCaps); len(gpuQueues) > 0 {
+			apiQueueNames = appendUniqueQueues(apiQueueNames, gpuQueues)
+			Debug("gpu node: also subscribing to GPU inference queues %v", gpuQueues)
+		}
+
 		apiSource = worker.NewAPISource(worker.APISourceConfig{
 			BaseURL:       apiBaseURL,
 			Token:         deviceConfig.DeviceAPIToken,
@@ -2187,6 +2199,24 @@ func stopManagedServices(started []startedService) {
 // Every online worker in the org consumes it, so any of them may claim a job.
 func shellQueueName(orgID string) string {
 	return fmt.Sprintf("jobs:v1:shell:org_%s", orgID)
+}
+
+// appendUniqueQueues appends each queue in extra to base, skipping any already
+// present, and returns the combined slice preserving order. Used to merge the
+// GPU inference queues into the API-mode queue list without duplicating whatever
+// worker-config already returned.
+func appendUniqueQueues(base, extra []string) []string {
+	seen := make(map[string]bool, len(base))
+	for _, q := range base {
+		seen[q] = true
+	}
+	for _, q := range extra {
+		if !seen[q] {
+			seen[q] = true
+			base = append(base, q)
+		}
+	}
+	return base
 }
 
 // meetingQueueName returns the org-scoped meeting-notetaker tag queue name.

--- a/cmd/work_queues_test.go
+++ b/cmd/work_queues_test.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAppendUniqueQueues(t *testing.T) {
+	base := []string{"jobs:v1:cpu-general", "jobs:v1:shell:org_x"}
+	extra := []string{"jobs:v1:tag:gpu:rtx3090", "jobs:v1:gpu-general", "jobs:v1:cpu-general"}
+	got := appendUniqueQueues(base, extra)
+	want := []string{
+		"jobs:v1:cpu-general",
+		"jobs:v1:shell:org_x",
+		"jobs:v1:tag:gpu:rtx3090",
+		"jobs:v1:gpu-general",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("appendUniqueQueues() = %v, want %v", got, want)
+	}
+}

--- a/internal/capabilities/detector.go
+++ b/internal/capabilities/detector.go
@@ -363,6 +363,31 @@ func ResolveQueues(caps []Capability, baseQueue string) []string {
 	return queues
 }
 
+// GPUInferenceQueues returns the GPU inference queues a node should consume when
+// it has at least one GPU: the gpu-general base queue plus every gpu/engine/vram
+// capability tag queue. It returns nil for a node with no GPU, which must NOT
+// join the gpu-general base queue.
+//
+// This lets an API-mode worker self-subscribe to the GPU queues from its own
+// locally-detected hardware. In API mode the server's worker-config currently
+// returns only the CPU base queue, so gateway inference dispatched to
+// jobs:v1:gpu-general (+ gpu tag queues) with a target_node would otherwise never
+// reach a GPU node (issue #6315).
+func GPUInferenceQueues(caps *NodeCapabilities) []string {
+	if caps == nil || caps.GPU == nil || len(caps.GPU.Devices) == 0 {
+		return nil
+	}
+	tagCaps := make([]Capability, 0, len(caps.Tags))
+	for _, tag := range caps.Tags {
+		category := tag
+		if idx := strings.Index(tag, ":"); idx > 0 {
+			category = tag[:idx]
+		}
+		tagCaps = append(tagCaps, Capability{Tag: tag, Category: category})
+	}
+	return ResolveQueues(tagCaps, "jobs:v1:gpu-general")
+}
+
 func detectGPU() []Capability {
 	ctx, cancel := context.WithTimeout(context.Background(), detectionTimeout)
 	defer cancel()

--- a/internal/capabilities/detector_test.go
+++ b/internal/capabilities/detector_test.go
@@ -131,6 +131,42 @@ func TestResolveQueues(t *testing.T) {
 	}
 }
 
+func TestGPUInferenceQueues(t *testing.T) {
+	// GPU node: gets gpu-general base + gpu/vram tag queues, never cpu-general.
+	gpu := &NodeCapabilities{
+		GPU:  &GPUCapabilities{Count: 1, Devices: []GPUDevice{{Name: "NVIDIA GeForce RTX 3090", Tag: "rtx3090", VRAMTag: "24gb"}}},
+		Tags: []string{"gpu:rtx3090", "vram:24gb", "cpu:general"},
+	}
+	queues := GPUInferenceQueues(gpu)
+	got := make(map[string]bool, len(queues))
+	for _, q := range queues {
+		got[q] = true
+	}
+	if !got["jobs:v1:gpu-general"] {
+		t.Errorf("GPU node must consume jobs:v1:gpu-general; got %v", queues)
+	}
+	if !got["jobs:v1:tag:gpu:rtx3090"] {
+		t.Errorf("GPU node must consume its gpu tag queue; got %v", queues)
+	}
+	for _, q := range queues {
+		if q == "jobs:v1:cpu-general" || q == "jobs:v1:tag:cpu:general" {
+			t.Errorf("cpu tag must not produce a queue; got %v", queues)
+		}
+	}
+
+	// No-GPU node: must NOT join the gpu-general base queue.
+	if q := GPUInferenceQueues(&NodeCapabilities{Tags: []string{"cpu:general"}}); q != nil {
+		t.Errorf("CPU-only node must not subscribe to any GPU queue; got %v", q)
+	}
+	// GPU present but zero devices, and nil caps: also nil.
+	if q := GPUInferenceQueues(&NodeCapabilities{GPU: &GPUCapabilities{}}); q != nil {
+		t.Errorf("GPU with no devices must return nil; got %v", q)
+	}
+	if q := GPUInferenceQueues(nil); q != nil {
+		t.Errorf("nil caps must return nil; got %v", q)
+	}
+}
+
 func TestTagsHelper(t *testing.T) {
 	caps := []Capability{
 		{Tag: "gpu:rtx4090"},


### PR DESCRIPTION
## Context
Closes the node-side half of #6315. Verifying Bonsai on `api.aceteam.ai` (after #6236/#6301 shipped model resolution + dispatch) surfaced that `inference_chat model=bonsai-27b` **504s** — the job resolves and dispatches but no node consumes it.

## Root Cause
Gateway inference dispatches to the Redis stream `jobs:v1:gpu-general` with `target_node` in the payload; nodes consume that shared queue with per-node consumer groups and ACK-skip non-matching `target_node` (`fabric_dispatch.py`, #5086). The target node's worker **must be subscribed to `gpu-general`**.

But in **API mode** the worker's queues come solely from `GET /api/fabric/worker-config` (which returns only the CPU base queue), and `cmd/work.go`'s API-mode branch did **not** append GPU capability queues from local detection — unlike direct-Redis mode (`baseQueue = jobs:v1:gpu-general` + `ResolveQueues`). So no API-mode GPU node ever subscribed to `gpu-general`.

Evidence on node 1084 (RTX 3090 running Bonsai) — `citadel_worker_status`:
```
queues: [ cpu-general, shell×2, tag:meeting ]   # no gpu-general
processed: 0
```

## Changes
- `internal/capabilities/detector.go`: new `GPUInferenceQueues(nodeCaps)` — returns `gpu-general` + `jobs:v1:tag:*` capability queues **only when the node has a GPU**; returns nil otherwise (a CPU-only node must never join `gpu-general`).
- `cmd/work.go`: API-mode branch now merges `GPUInferenceQueues(nodeCaps)` into the subscribed queue list (additive to worker-config's result), via a new `appendUniqueQueues` helper.
- Tests: `TestGPUInferenceQueues` (GPU node gets gpu-general + gpu tag queue, no cpu queue; CPU/no-device/nil → nil) and `TestAppendUniqueQueues`.

This is the **node-side** half of the "Both" fix; the backend `worker-config` change (stop hardcoding CPU_GENERAL for GPU nodes) is tracked separately under #6315.

## Testing
- `go build ./cmd/citadel`, `go test ./internal/capabilities/ ./cmd/`, `go vet ./...` — all pass.
- Manual: built from `main` + this change, installed on node 1084, restarted worker → worker now subscribes to `jobs:v1:gpu-general` and processes gateway inference (Bonsai) instead of 504ing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)