### PR TITLE
Add SYNTHESIZE_SPEECH handler and kokoro TTS service

### DIFF
--- a/internal/apps/hostport_collision_test.go
+++ b/internal/apps/hostport_collision_test.go
@@ -115,6 +115,7 @@ func publishedHostPorts(composeYAML string) ([]int, error) {
 		services.EnvDiffusersHostPort:  services.DiffusersHostPort,
 		services.EnvClaudecodeHostPort: services.ClaudecodeHostPort,
 		services.EnvBonsaiHostPort:     services.BonsaiHostPort,
+		services.EnvTTSHostPort:        services.TTSHostPort,
 	}
 
 	var out []int

--- a/internal/jobs/synthesize_speech.go
+++ b/internal/jobs/synthesize_speech.go
@@ -1,0 +1,265 @@
+// internal/jobs/synthesize_speech.go
+package jobs
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+	embeddedservices "github.com/aceteam-ai/citadel-cli/services"
+)
+
+// synthesizeServiceURL is the local kokoro TTS sidecar base URL. The host port
+// is owned by citadel (services/ports.go, CITADEL_TTS_HOST_PORT) and reached
+// over loopback -- the compose publishes 127.0.0.1 ONLY, since the service has
+// no auth of its own and its sole consumer is this co-located worker. Built from
+// the registry constant rather than a literal so it tracks the port citadel
+// actually injects (the transcribe handler's hardcoded 8101 is the anti-pattern
+// this avoids).
+func synthesizeServiceURL() string {
+	return fmt.Sprintf("http://localhost:%d", embeddedservices.TTSHostPort)
+}
+
+const (
+	// defaultSynthesizeVoice is the Kokoro voice used when a job omits `voice`.
+	// Matches the service's own KOKORO_DEFAULT_VOICE default (am_michael, the
+	// book-narration voice).
+	defaultSynthesizeVoice = "am_michael"
+
+	// defaultSynthesizeFormat is the output container used when a job omits
+	// `response_format`. Opus is compact and speech-tuned; matches the service's
+	// KOKORO_DEFAULT_FORMAT default.
+	defaultSynthesizeFormat = "opus"
+
+	// synthesizeReadyTimeout bounds how long we wait for the kokoro sidecar to
+	// load its model (Kokoro-82M, ~350 MB) and report healthy. Model load is a
+	// one-time cost on first job; subsequent jobs hit a warm service. This budget
+	// only applies once the sidecar is actually answering connections -- see
+	// synthesizeUnreachableTimeout for the case where nothing is listening.
+	synthesizeReadyTimeout = 120 * time.Second
+
+	// synthesizeUnreachableTimeout bounds how long waitForReady tolerates a
+	// connection-refused health check, i.e. nothing listening on the sidecar's
+	// port at all (the container was never started or crashed before binding).
+	// Kept short so the handler fails well under the backend's request-gateway
+	// budget and the backend can fall back to cloud TTS instead of hanging.
+	synthesizeUnreachableTimeout = 8 * time.Second
+
+	// synthesizeHealthTimeout bounds a single readiness GET so one poll cannot
+	// hang if the sidecar accepts the connection but never answers.
+	synthesizeHealthTimeout = 10 * time.Second
+
+	// synthesizeRequestTimeout bounds a single synthesis POST. Unlike transcribe
+	// (whose budget scales with a potentially multi-hour audio file), TTS input
+	// is bounded text (KOKORO_MAX_INPUT_CHARS, default 5000) and Kokoro-82M runs
+	// near real time even on CPU, so one generous fixed cap is enough.
+	synthesizeRequestTimeout = 5 * time.Minute
+)
+
+// SynthesizeSpeechHandler handles SYNTHESIZE_SPEECH jobs node-locally.
+//
+// It is the synthesis counterpart to TranscribeAudioHandler: the heavy ML
+// dependency (Kokoro-82M) lives in a Docker sidecar (services/compose/kokoro.yml)
+// reachable over loopback, and this Go handler proxies an OpenAI-compatible
+// speech request to it. The text and the resulting audio never leave the node.
+//
+// Unlike transcribe, it needs no workspace: the text arrives inline in the
+// payload and the audio is returned inline (base64), so the handler is
+// registered unconditionally alongside the other sandbox-less inference handlers.
+type SynthesizeSpeechHandler struct {
+	// ServiceURL is the kokoro sidecar base URL; defaults to the registry port.
+	ServiceURL string
+	// HTTPClient lets tests inject a stub; nil uses a default client.
+	HTTPClient *http.Client
+}
+
+// NewSynthesizeSpeechHandler creates a handler pointed at the local kokoro
+// sidecar.
+func NewSynthesizeSpeechHandler() *SynthesizeSpeechHandler {
+	return &SynthesizeSpeechHandler{ServiceURL: synthesizeServiceURL()}
+}
+
+func (h *SynthesizeSpeechHandler) serviceURL() string {
+	if h.ServiceURL != "" {
+		return h.ServiceURL
+	}
+	return synthesizeServiceURL()
+}
+
+// client returns the HTTP client used for both the health poll and the
+// synthesis POST. It carries no fixed Timeout: per-request budgets are governed
+// by context deadlines (synthesizeRequestTimeout / synthesizeHealthTimeout).
+func (h *SynthesizeSpeechHandler) client() *http.Client {
+	if h.HTTPClient != nil {
+		return h.HTTPClient
+	}
+	return &http.Client{}
+}
+
+// Execute synthesizes speech from text via the kokoro sidecar.
+//
+// Payload fields (all strings via nexus.Job):
+//   - text / input:       the text to synthesize (required; `text` preferred,
+//     `input` accepted as an alias for the OpenAI request-body spelling).
+//   - voice:              optional Kokoro voice; empty defaults to am_michael.
+//   - response_format:    optional output container (opus/mp3); empty defaults
+//     to opus (`format` accepted as an alias).
+//
+// Response JSON (this handler DEFINES the envelope; nothing on the aceteam side
+// parses it yet -- the fabric may also call the endpoint directly):
+//
+//	{
+//	  "encoding": "base64",          // the marker the coordinator checks
+//	  "content":  "<base64 audio>",  // the synthesized audio bytes
+//	  "format":   "opus",
+//	  "voice":    "am_michael",
+//	  "receipt": {                   // metering receipt, from the X-TTS-* headers
+//	    "chars":            24,
+//	    "duration_seconds": 3.575,
+//	    "model_version":    "kokoro-0.9.4+hexgrad/Kokoro-82M",
+//	    "cache_key":        "<sha256>",
+//	    "cache_hit":        false
+//	  }
+//	}
+func (h *SynthesizeSpeechHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	text := job.Payload["text"]
+	if text == "" {
+		text = job.Payload["input"]
+	}
+	if text == "" {
+		return nil, fmt.Errorf("job payload missing 'text' field")
+	}
+
+	voice := job.Payload["voice"]
+	if voice == "" {
+		voice = defaultSynthesizeVoice
+	}
+
+	format := job.Payload["response_format"]
+	if format == "" {
+		format = job.Payload["format"]
+	}
+	if format == "" {
+		format = defaultSynthesizeFormat
+	}
+
+	ctx.Log("info", "     - [Job %s] Waiting for TTS service to become ready...", job.ID)
+	if err := h.waitForReady(); err != nil {
+		return nil, err
+	}
+	ctx.Log("info", "     - [Job %s] SYNTHESIZE_SPEECH voice=%s format=%s chars=%d", job.ID, voice, format, len(text))
+
+	requestPayload := map[string]any{
+		"input":           text,
+		"voice":           voice,
+		"response_format": format,
+	}
+	reqBody, err := json.Marshal(requestPayload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	reqCtx, cancel := context.WithTimeout(context.Background(), synthesizeRequestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, h.serviceURL()+"/v1/audio/speech", bytes.NewBuffer(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to build synthesis request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := h.client().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to TTS service: %w", err)
+	}
+	defer resp.Body.Close()
+
+	audio, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		// On error the body is a JSON error, not audio; surface it verbatim.
+		return audio, fmt.Errorf("TTS API returned non-200 status: %s", resp.Status)
+	}
+
+	result := map[string]any{
+		"encoding": "base64",
+		"content":  base64.StdEncoding.EncodeToString(audio),
+		"format":   format,
+		"voice":    voice,
+		"receipt":  synthesizeReceiptFromHeaders(resp.Header),
+	}
+	return json.Marshal(result)
+}
+
+// synthesizeReceiptFromHeaders extracts the per-item metering receipt the kokoro
+// service returns in its X-TTS-* response headers. Parsing is best-effort: a
+// missing or malformed header yields the field's zero value rather than failing
+// the job, since the audio artifact is the primary result and the receipt is
+// advisory metering.
+func synthesizeReceiptFromHeaders(headers http.Header) map[string]any {
+	receipt := map[string]any{
+		"model_version": headers.Get("X-TTS-Model-Version"),
+		"cache_key":     headers.Get("X-TTS-Cache-Key"),
+	}
+	if chars, err := strconv.Atoi(headers.Get("X-TTS-Chars")); err == nil {
+		receipt["chars"] = chars
+	}
+	if secs, err := strconv.ParseFloat(headers.Get("X-TTS-Duration-Seconds"), 64); err == nil {
+		receipt["duration_seconds"] = secs
+	}
+	// X-TTS-Cache-Hit is "0" or "1".
+	receipt["cache_hit"] = headers.Get("X-TTS-Cache-Hit") == "1"
+	return receipt
+}
+
+// waitForReady polls the kokoro sidecar's /health until it reports ready, with
+// the same fast-fail-if-absent / patient-if-loading policy as the transcribe
+// handler: an unreachable port (nothing listening) gives up within
+// synthesizeUnreachableTimeout, while a reachable-but-loading sidecar gets the
+// full synthesizeReadyTimeout budget.
+func (h *SynthesizeSpeechHandler) waitForReady() error {
+	healthURL := h.serviceURL() + "/health"
+	pollInterval := 1 * time.Second
+	startTime := time.Now()
+
+	for {
+		resp, err := h.healthCheck(healthURL)
+		if err == nil {
+			ready := resp.StatusCode == http.StatusOK
+			resp.Body.Close()
+			if ready {
+				return nil
+			}
+			// Reachable, just not ready yet (model still loading) -- fall through
+			// to the patient synthesizeReadyTimeout budget below.
+		} else if isConnectionRefused(err) && time.Since(startTime) >= synthesizeUnreachableTimeout {
+			return fmt.Errorf("TTS service unreachable at %s: %w", h.serviceURL(), err)
+		}
+
+		if time.Since(startTime) >= synthesizeReadyTimeout {
+			break
+		}
+		time.Sleep(pollInterval)
+	}
+	return fmt.Errorf("TTS service did not become ready within %v", synthesizeReadyTimeout)
+}
+
+// healthCheck performs a single readiness GET bounded by synthesizeHealthTimeout.
+func (h *SynthesizeSpeechHandler) healthCheck(healthURL string) (*http.Response, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), synthesizeHealthTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	return h.client().Do(req)
+}
+
+// Ensure SynthesizeSpeechHandler implements JobHandler.
+var _ JobHandler = (*SynthesizeSpeechHandler)(nil)

--- a/internal/jobs/synthesize_speech.go
+++ b/internal/jobs/synthesize_speech.go
@@ -18,7 +18,7 @@ import (
 
 // synthesizeServiceURL is the local kokoro TTS sidecar base URL. The host port
 // is owned by citadel (services/ports.go, CITADEL_TTS_HOST_PORT) and reached
-// over loopback -- the compose publishes 127.0.0.1 ONLY, since the service has
+// over loopback: the compose publishes 127.0.0.1 ONLY, since the service has
 // no auth of its own and its sole consumer is this co-located worker. Built from
 // the registry constant rather than a literal so it tracks the port citadel
 // actually injects (the transcribe handler's hardcoded 8101 is the anti-pattern
@@ -41,7 +41,7 @@ const (
 	// synthesizeReadyTimeout bounds how long we wait for the kokoro sidecar to
 	// load its model (Kokoro-82M, ~350 MB) and report healthy. Model load is a
 	// one-time cost on first job; subsequent jobs hit a warm service. This budget
-	// only applies once the sidecar is actually answering connections -- see
+	// only applies once the sidecar is actually answering connections; see
 	// synthesizeUnreachableTimeout for the case where nothing is listening.
 	synthesizeReadyTimeout = 120 * time.Second
 
@@ -113,7 +113,7 @@ func (h *SynthesizeSpeechHandler) client() *http.Client {
 //     to opus (`format` accepted as an alias).
 //
 // Response JSON (this handler DEFINES the envelope; nothing on the aceteam side
-// parses it yet -- the fabric may also call the endpoint directly):
+// parses it yet; the fabric may also call the endpoint directly):
 //
 //	{
 //	  "encoding": "base64",          // the marker the coordinator checks
@@ -231,12 +231,12 @@ func (h *SynthesizeSpeechHandler) waitForReady() error {
 	for {
 		resp, err := h.healthCheck(healthURL)
 		if err == nil {
-			ready := resp.StatusCode == http.StatusOK
+			ready := synthesizeHealthReady(resp)
 			resp.Body.Close()
 			if ready {
 				return nil
 			}
-			// Reachable, just not ready yet (model still loading) -- fall through
+			// Reachable, just not ready yet (model still loading): fall through
 			// to the patient synthesizeReadyTimeout budget below.
 		} else if isConnectionRefused(err) && time.Since(startTime) >= synthesizeUnreachableTimeout {
 			return fmt.Errorf("TTS service unreachable at %s: %w", h.serviceURL(), err)
@@ -248,6 +248,30 @@ func (h *SynthesizeSpeechHandler) waitForReady() error {
 		time.Sleep(pollInterval)
 	}
 	return fmt.Errorf("TTS service did not become ready within %v", synthesizeReadyTimeout)
+}
+
+// synthesizeHealthReady reports whether a /health response means the kokoro
+// sidecar is actually ready to synthesize. Unlike the whisper sidecar (which
+// returns non-200 until its model loads), kokoro's /health ALWAYS returns 200
+// and carries readiness in the body: {"status":"up"|"loading","model_loaded":
+// true|false}. Gating on the status code alone would let a cold node POST before
+// Kokoro-82M has loaded, so parse model_loaded. A 200 whose body cannot be
+// parsed is treated as not-ready (fail closed) rather than assuming readiness.
+func synthesizeHealthReady(resp *http.Response) bool {
+	if resp.StatusCode != http.StatusOK {
+		return false
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	if err != nil {
+		return false
+	}
+	var health struct {
+		ModelLoaded bool `json:"model_loaded"`
+	}
+	if err := json.Unmarshal(body, &health); err != nil {
+		return false
+	}
+	return health.ModelLoaded
 }
 
 // healthCheck performs a single readiness GET bounded by synthesizeHealthTimeout.

--- a/internal/jobs/synthesize_speech_test.go
+++ b/internal/jobs/synthesize_speech_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -35,7 +36,8 @@ func TestSynthesizeSpeech_Success(t *testing.T) {
 	var gotBody map[string]any
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/health" {
-			w.WriteHeader(http.StatusOK)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"up","model_loaded":true}`))
 			return
 		}
 		if r.URL.Path == "/v1/audio/speech" {
@@ -132,7 +134,8 @@ func TestSynthesizeSpeech_Success(t *testing.T) {
 func TestSynthesizeSpeech_InputAlias(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/health" {
-			w.WriteHeader(http.StatusOK)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"up","model_loaded":true}`))
 			return
 		}
 		w.WriteHeader(http.StatusOK)
@@ -156,7 +159,8 @@ func TestSynthesizeSpeech_InputAlias(t *testing.T) {
 func TestSynthesizeSpeech_ServiceError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/health" {
-			w.WriteHeader(http.StatusOK)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"up","model_loaded":true}`))
 			return
 		}
 		w.WriteHeader(http.StatusRequestEntityTooLarge)
@@ -174,6 +178,47 @@ func TestSynthesizeSpeech_ServiceError(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for non-200 service response")
+	}
+}
+
+// TestSynthesizeSpeech_WaitForReady_LoadingBodyNotReady pins the cold-start
+// gate: kokoro's /health ALWAYS returns 200 and carries readiness in the body
+// (model_loaded), so a 200 with model_loaded:false must NOT count as ready. The
+// stub flips to loaded after a short delay; waitForReady must keep polling past
+// the first (loading) 200 and only return once the body says loaded.
+func TestSynthesizeSpeech_WaitForReady_LoadingBodyNotReady(t *testing.T) {
+	var mu sync.Mutex
+	loaded := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		isLoaded := loaded
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		if isLoaded {
+			_, _ = w.Write([]byte(`{"status":"up","model_loaded":true}`))
+			return
+		}
+		// Always 200, but not ready yet: readiness is in the body, not the code.
+		_, _ = w.Write([]byte(`{"status":"loading","model_loaded":false}`))
+	}))
+	defer srv.Close()
+
+	go func() {
+		time.Sleep(2 * time.Second)
+		mu.Lock()
+		loaded = true
+		mu.Unlock()
+	}()
+
+	h := NewSynthesizeSpeechHandler()
+	h.ServiceURL = srv.URL
+
+	start := time.Now()
+	if err := h.waitForReady(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed < 2*time.Second {
+		t.Fatalf("waitForReady returned after %v; it must keep polling past the loading 200 until model_loaded is true", elapsed)
 	}
 }
 

--- a/internal/jobs/synthesize_speech_test.go
+++ b/internal/jobs/synthesize_speech_test.go
@@ -1,0 +1,207 @@
+package jobs
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+func TestSynthesizeSpeech_MissingText(t *testing.T) {
+	h := NewSynthesizeSpeechHandler()
+	_, err := h.Execute(JobContext{}, &nexus.Job{
+		ID:      "s1",
+		Type:    "SYNTHESIZE_SPEECH",
+		Payload: map[string]string{},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing text")
+	}
+}
+
+// TestSynthesizeSpeech_Success drives the handler against a stub kokoro sidecar.
+// It must POST the OpenAI-compatible request to /v1/audio/speech, return the
+// audio base64-encoded under the "content" marker, and carry the X-TTS-* receipt
+// headers back in the "receipt" object.
+func TestSynthesizeSpeech_Success(t *testing.T) {
+	audioBytes := []byte("OggS-fake-opus-frames")
+
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.URL.Path == "/v1/audio/speech" {
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &gotBody)
+			w.Header().Set("Content-Type", "audio/ogg")
+			w.Header().Set("X-TTS-Chars", "24")
+			w.Header().Set("X-TTS-Duration-Seconds", "3.575")
+			w.Header().Set("X-TTS-Model-Version", "kokoro-0.9.4+hexgrad/Kokoro-82M")
+			w.Header().Set("X-TTS-Cache-Key", "abc123")
+			w.Header().Set("X-TTS-Cache-Hit", "1")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(audioBytes)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	h := NewSynthesizeSpeechHandler()
+	h.ServiceURL = srv.URL
+
+	out, err := h.Execute(JobContext{}, &nexus.Job{
+		ID:   "s2",
+		Type: "SYNTHESIZE_SPEECH",
+		Payload: map[string]string{
+			"text":  "Hello from the Citadel.",
+			"voice": "am_onyx",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The sidecar must receive the text under the OpenAI "input" key, plus voice
+	// and a defaulted response_format.
+	if gotBody["input"] != "Hello from the Citadel." {
+		t.Errorf("forwarded input = %v, want the job text", gotBody["input"])
+	}
+	if gotBody["voice"] != "am_onyx" {
+		t.Errorf("forwarded voice = %v, want am_onyx", gotBody["voice"])
+	}
+	if gotBody["response_format"] != "opus" {
+		t.Errorf("forwarded response_format = %v, want defaulted opus", gotBody["response_format"])
+	}
+
+	var res map[string]any
+	if err := json.Unmarshal(out, &res); err != nil {
+		t.Fatalf("result not JSON: %v", err)
+	}
+	if res["encoding"] != "base64" {
+		t.Errorf("encoding = %v, want base64", res["encoding"])
+	}
+	if res["voice"] != "am_onyx" {
+		t.Errorf("result voice = %v, want am_onyx", res["voice"])
+	}
+	if res["format"] != "opus" {
+		t.Errorf("result format = %v, want opus", res["format"])
+	}
+	// The base64 content must decode back to the exact audio bytes.
+	content, _ := res["content"].(string)
+	decoded, err := base64.StdEncoding.DecodeString(content)
+	if err != nil {
+		t.Fatalf("content is not valid base64: %v", err)
+	}
+	if string(decoded) != string(audioBytes) {
+		t.Errorf("decoded audio = %q, want %q", decoded, audioBytes)
+	}
+
+	// The receipt must carry the X-TTS-* metering headers.
+	receipt, ok := res["receipt"].(map[string]any)
+	if !ok {
+		t.Fatalf("receipt missing or wrong type: %v", res["receipt"])
+	}
+	if receipt["chars"] != float64(24) { // JSON numbers decode to float64
+		t.Errorf("receipt chars = %v, want 24", receipt["chars"])
+	}
+	if receipt["duration_seconds"] != 3.575 {
+		t.Errorf("receipt duration_seconds = %v, want 3.575", receipt["duration_seconds"])
+	}
+	if receipt["model_version"] != "kokoro-0.9.4+hexgrad/Kokoro-82M" {
+		t.Errorf("receipt model_version = %v", receipt["model_version"])
+	}
+	if receipt["cache_key"] != "abc123" {
+		t.Errorf("receipt cache_key = %v, want abc123", receipt["cache_key"])
+	}
+	if receipt["cache_hit"] != true {
+		t.Errorf("receipt cache_hit = %v, want true", receipt["cache_hit"])
+	}
+}
+
+// TestSynthesizeSpeech_InputAlias verifies the OpenAI "input" payload key is
+// accepted as an alias for "text".
+func TestSynthesizeSpeech_InputAlias(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("audio"))
+	}))
+	defer srv.Close()
+
+	h := NewSynthesizeSpeechHandler()
+	h.ServiceURL = srv.URL
+
+	_, err := h.Execute(JobContext{}, &nexus.Job{
+		ID:      "s3",
+		Type:    "SYNTHESIZE_SPEECH",
+		Payload: map[string]string{"input": "spoken via the input alias"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSynthesizeSpeech_ServiceError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusRequestEntityTooLarge)
+		_, _ = w.Write([]byte(`{"error":"input too long"}`))
+	}))
+	defer srv.Close()
+
+	h := NewSynthesizeSpeechHandler()
+	h.ServiceURL = srv.URL
+
+	_, err := h.Execute(JobContext{}, &nexus.Job{
+		ID:      "s4",
+		Type:    "SYNTHESIZE_SPEECH",
+		Payload: map[string]string{"text": "x"},
+	})
+	if err == nil {
+		t.Fatal("expected error for non-200 service response")
+	}
+}
+
+// TestSynthesizeSpeech_WaitForReady_UnreachableFailsFast covers the cold-start
+// hang: a sidecar that was never started (nothing listening) must not make
+// waitForReady block near the full model-load budget; it should give up within
+// the short unreachable window so the backend can fall back to cloud TTS.
+func TestSynthesizeSpeech_WaitForReady_UnreachableFailsFast(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	h := NewSynthesizeSpeechHandler()
+	h.ServiceURL = "http://" + addr
+
+	start := time.Now()
+	err = h.waitForReady()
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error for an unreachable sidecar")
+	}
+	if elapsed > synthesizeUnreachableTimeout+10*time.Second {
+		t.Fatalf("waitForReady took %v, want close to the %v fast-fail budget (not the %v patient budget)", elapsed, synthesizeUnreachableTimeout, synthesizeReadyTimeout)
+	}
+}

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -207,6 +207,15 @@ func CreateLegacyHandlersWithOpts(opts LegacyHandlerOpts) []JobHandler {
 		// it would leave the backend's node-resource pull timing out on nodes
 		// without a configured workspace.
 		NewLegacyHandlerAdapter(JobTypeResourceSnapshot, &jobs.ResourceSnapshotHandler{}),
+		// Node-local speech synthesis (kokoro TTS sidecar, aceteam#6104). The
+		// synthesis counterpart to TRANSCRIBE_AUDIO, but registered
+		// UNCONDITIONALLY like the other inference handlers: it takes text inline
+		// and returns audio inline (base64), touching no workspace file, so
+		// gating it behind WorkspaceDir would needlessly bar workspace-less nodes
+		// from TTS. Nodes that don't run the kokoro sidecar simply never receive
+		// SYNTHESIZE_SPEECH jobs (they only land on nodes carrying the engine:tts
+		// tag).
+		NewLegacyHandlerAdapter(JobTypeSynthesizeSpeech, jobs.NewSynthesizeSpeechHandler()),
 		// Turn delivery to a payload-launched BYOC instance (aceteam#5241).
 		// Registered unconditionally: it resolves the target from its own
 		// on-disk instance store (~/.citadel/instances/state.json, shared with

--- a/internal/worker/job.go
+++ b/internal/worker/job.go
@@ -138,6 +138,7 @@ const (
 	JobTypeVNCActions         = "VNC_ACTIONS"          // Execute pointer/keyboard actions (click, move, drag) on the node's display (issue #4180)
 	JobTypeCobrowse           = "COBROWSE"             // Human-in-the-loop co-browse over CDP (#4079)
 	JobTypeTranscribeAudio    = "TRANSCRIBE_AUDIO"     // Transcribe workspace audio node-locally via the faster-whisper sidecar
+	JobTypeSynthesizeSpeech   = "SYNTHESIZE_SPEECH"    // Synthesize speech node-locally via the kokoro TTS sidecar (aceteam#6104)
 	JobTypeAgentUpdate        = "AGENT_UPDATE"         // Remotely update + restart this node's own citadel agent (aceteam#4427)
 	JobTypeWhatsAppProvision  = "WHATSAPP_PROVISION"   // Remotely deploy + provision the WhatsApp bridge on this node (aceteam#4454)
 	JobTypeResourceSnapshot   = "RESOURCE_SNAPSHOT"    // Return the node's full GPU/host resource-consumer snapshot, managed and unmanaged (issue #427)
@@ -200,6 +201,7 @@ var allKnownJobTypes = []string{
 	JobTypeVNCActions,
 	JobTypeCobrowse,
 	JobTypeTranscribeAudio,
+	JobTypeSynthesizeSpeech,
 	JobTypeAgentUpdate,
 	JobTypeWhatsAppProvision,
 	JobTypeResourceSnapshot,

--- a/services/compose/kokoro.yml
+++ b/services/compose/kokoro.yml
@@ -1,0 +1,59 @@
+# services/compose/kokoro.yml
+#
+# Serves Kokoro-82M (Apache-2.0) text-to-speech via an OpenAI-compatible HTTP
+# API (POST /v1/audio/speech). This is the SYNTHESIS counterpart to the whisper
+# transcribe sidecar (services/compose/transcribe.yml): transcribe backs the
+# fabric `transcribe` engine, kokoro backs the fabric `tts` engine. The node-side
+# handler is internal/jobs/synthesize_speech.go (SYNTHESIZE_SPEECH), the
+# symmetric analog of TranscribeAudioHandler.
+#
+# The generic engine the node advertises for routing is `tts`; this embedded
+# service is named for its implementation (kokoro), the same split the
+# citadel-services catalog module uses (module name kokoro, node_tags
+# engine:tts / tts:kokoro / model:kokoro-82m). The compose ALSO ships as a
+# citadel-services catalog module (services/kokoro); this embedded copy
+# self-contains the capability the same way transcribe/bonsai do. The two copies
+# can drift -- known_hashes only guards this embedded one.
+#
+# Host port: the container serves :8080. citadel owns the host publish via
+# CITADEL_TTS_HOST_PORT (services/ports.go, 8211 -- the next free slot after
+# gotenberg's 8209 and bonsai's 8210). Unlike bonsai's `${VAR:?msg}` guard, the
+# loopback `127.0.0.1:` prefix means this port spec no longer starts with `${`,
+# so a `:?`/`:-` suffix would smear across the host-port test parser's colon
+# split; the bare `${CITADEL_TTS_HOST_PORT}` is deliberate. citadel ALWAYS
+# injects the var (services.HostPortEnv) at every `docker compose up` site, so it
+# resolves; do not add a default/guard back.
+#
+# Loopback-only publish (127.0.0.1), deliberately: the only consumer is the
+# co-located citadel worker dispatching synthesis on this same node, and the
+# service has no auth of its own, so it must not be reachable off-host. The
+# handler's health probe always dials 127.0.0.1, so this does not affect probing.
+services:
+  kokoro:
+    image: ghcr.io/aceteam-ai/kokoro-service:latest
+    container_name: citadel-kokoro
+    ports:
+      - "127.0.0.1:${CITADEL_TTS_HOST_PORT}:8080"
+    environment:
+      - PORT=8080
+      # Inference device: auto (GPU when present, else CPU), cpu, or cuda.
+      # Kokoro-82M is small and roughly real-time on CPU, so no GPU is required.
+      - KOKORO_DEVICE=${KOKORO_DEVICE:-auto}
+      # Concurrent synthesis slots (advertised for fabric backpressure); requests
+      # beyond this queue rather than OOMing the node.
+      - TTS_SLOTS=${TTS_SLOTS:-2}
+      # Max characters per synthesized item; over-cap requests get a 413.
+      - KOKORO_MAX_INPUT_CHARS=${KOKORO_MAX_INPUT_CHARS:-5000}
+      - KOKORO_DEFAULT_VOICE=${KOKORO_DEFAULT_VOICE:-am_michael}
+      - KOKORO_DEFAULT_FORMAT=${KOKORO_DEFAULT_FORMAT:-opus}
+      # LRU cap (GB) for the node-local content-addressed audio cache.
+      - KOKORO_CACHE_MAX_GB=${KOKORO_CACHE_MAX_GB:-5}
+      - KOKORO_OPUS_BITRATE=${KOKORO_OPUS_BITRATE:-32k}
+      - KOKORO_MP3_BITRATE=${KOKORO_MP3_BITRATE:-64k}
+    volumes:
+      # HuggingFace cache: the Kokoro-82M weights + voices download here once and
+      # persist across restarts (shared with other HF-based services).
+      - ~/citadel-cache/huggingface:/root/.cache/huggingface
+      # Content-addressed audio cache (node-local, LRU-capped).
+      - ~/citadel-cache/kokoro:/data
+    restart: unless-stopped

--- a/services/compose/kokoro.yml
+++ b/services/compose/kokoro.yml
@@ -13,10 +13,10 @@
 # engine:tts / tts:kokoro / model:kokoro-82m). The compose ALSO ships as a
 # citadel-services catalog module (services/kokoro); this embedded copy
 # self-contains the capability the same way transcribe/bonsai do. The two copies
-# can drift -- known_hashes only guards this embedded one.
+# can drift; known_hashes only guards this embedded one.
 #
 # Host port: the container serves :8080. citadel owns the host publish via
-# CITADEL_TTS_HOST_PORT (services/ports.go, 8211 -- the next free slot after
+# CITADEL_TTS_HOST_PORT (services/ports.go, 8211, the next free slot after
 # gotenberg's 8209 and bonsai's 8210). Unlike bonsai's `${VAR:?msg}` guard, the
 # loopback `127.0.0.1:` prefix means this port spec no longer starts with `${`,
 # so a `:?`/`:-` suffix would smear across the host-port test parser's colon

--- a/services/embed.go
+++ b/services/embed.go
@@ -36,6 +36,9 @@ var DiffusersCompose string
 //go:embed compose/bonsai.yml
 var BonsaiCompose string
 
+//go:embed compose/kokoro.yml
+var KokoroCompose string
+
 // BonsaiDockerfile is the build-context Dockerfile for the bonsai service. It is
 // materialized to <config>/services/bonsai/Dockerfile (see WriteAuxFiles) so the
 // compose `build.context: ./bonsai` resolves on the node.
@@ -54,6 +57,7 @@ var ServiceMap = map[string]string{
 	"transcribe": TranscribeCompose,
 	"diffusers":  DiffusersCompose,
 	"bonsai":     BonsaiCompose,
+	"kokoro":     KokoroCompose,
 }
 
 // ServiceAuxFiles maps a service name to auxiliary build-context files

--- a/services/embed_test.go
+++ b/services/embed_test.go
@@ -182,6 +182,59 @@ func TestWriteAuxFilesMaterializesBonsaiDockerfile(t *testing.T) {
 	}
 }
 
+// TestKokoroComposeRegistered ensures the kokoro TTS service is in the
+// ServiceMap so `citadel run --service kokoro`, the manifest, and SERVICE_START
+// can find it (aceteam#6104).
+func TestKokoroComposeRegistered(t *testing.T) {
+	if _, ok := ServiceMap["kokoro"]; !ok {
+		t.Fatal("kokoro not found in ServiceMap")
+	}
+	found := false
+	for _, s := range GetAvailableServices() {
+		if s == "kokoro" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("GetAvailableServices() does not include kokoro")
+	}
+}
+
+// TestKokoroComposeContract verifies the embedded kokoro compose satisfies its
+// contract: it uses the prebuilt image (no build context to materialize, unlike
+// bonsai), defers its host publish to the citadel-owned CITADEL_TTS_HOST_PORT,
+// and binds loopback only (the service has no auth of its own). The loopback
+// prefix means the host token must NOT carry bonsai's `${VAR:?msg}` guard, since
+// that smears across the host-port test parser's colon split.
+func TestKokoroComposeContract(t *testing.T) {
+	content, ok := ServiceMap["kokoro"]
+	if !ok {
+		t.Fatal("kokoro not found in ServiceMap")
+	}
+	if !strings.Contains(content, "ghcr.io/aceteam-ai/kokoro-service") {
+		t.Errorf("kokoro compose should use the prebuilt kokoro-service image")
+	}
+	if strings.Contains(content, "build:") {
+		t.Errorf("kokoro compose should NOT declare a build: section (it uses a prebuilt image)")
+	}
+	if !strings.Contains(content, "${CITADEL_TTS_HOST_PORT}") {
+		t.Errorf("kokoro compose must defer its host port to a bare ${CITADEL_TTS_HOST_PORT} (no :?/:- guard, which breaks the loopback host-port parser)")
+	}
+	if !strings.Contains(content, "127.0.0.1:${CITADEL_TTS_HOST_PORT}:8080") {
+		t.Errorf("kokoro compose must bind loopback only (127.0.0.1) -- the service has no auth of its own")
+	}
+	// kokoro must NOT need aux build-context files (it is image-based).
+	if _, ok := ServiceAuxFiles["kokoro"]; ok {
+		t.Errorf("ServiceAuxFiles should not contain kokoro; it uses a prebuilt image, not a build context")
+	}
+}
+
+// NOTE: the embedded kokoro compose publishes exactly the citadel-assigned host
+// port (services.TTSHostPort); that registry-vs-compose agreement is proven by
+// internal/apps/hostport_collision_test.go, which resolves the loopback
+// ${CITADEL_TTS_HOST_PORT} publish against the registry and cross-checks it.
+
 // composeHostPorts returns the host-side ports declared in a compose file's
 // `ports:` list entries ("HOST:CONTAINER"). Pure parse (no Docker) so the
 // host-port collision assertions run in ordinary CI.
@@ -204,6 +257,7 @@ func composeHostPorts(t *testing.T, composeYAML string) []int {
 		EnvExtractionHostPort: ExtractionHostPort,
 		EnvDiffusersHostPort:  DiffusersHostPort,
 		EnvBonsaiHostPort:     BonsaiHostPort,
+		EnvTTSHostPort:        TTSHostPort,
 	}
 	var hosts []int
 	for _, svc := range doc.Services {

--- a/services/embed_test.go
+++ b/services/embed_test.go
@@ -222,7 +222,7 @@ func TestKokoroComposeContract(t *testing.T) {
 		t.Errorf("kokoro compose must defer its host port to a bare ${CITADEL_TTS_HOST_PORT} (no :?/:- guard, which breaks the loopback host-port parser)")
 	}
 	if !strings.Contains(content, "127.0.0.1:${CITADEL_TTS_HOST_PORT}:8080") {
-		t.Errorf("kokoro compose must bind loopback only (127.0.0.1) -- the service has no auth of its own")
+		t.Errorf("kokoro compose must bind loopback only (127.0.0.1); the service has no auth of its own")
 	}
 	// kokoro must NOT need aux build-context files (it is image-based).
 	if _, ok := ServiceAuxFiles["kokoro"]; ok {

--- a/services/known_hashes.go
+++ b/services/known_hashes.go
@@ -64,6 +64,6 @@ var KnownComposeHashes = map[string]map[string]bool{
 		"50132811ec60f1d628599cd0c971cb2732087ee11bca58a3bda1312a8ef13ff0": true,
 	},
 	"kokoro": {
-		"1f55d8d932042e8935444ab616ce4836a0dca478199c39d47ba8a015cbfac875": true,
+		"3ce764e232b286c75f776872bb3554e15b2e03b229863abce271324a815ab777": true,
 	},
 }

--- a/services/known_hashes.go
+++ b/services/known_hashes.go
@@ -63,4 +63,7 @@ var KnownComposeHashes = map[string]map[string]bool{
 		"124af757f45e93b689bc6a59f08187d48f59c0e62eb2d10c6a006c8ac4d24609": true,
 		"50132811ec60f1d628599cd0c971cb2732087ee11bca58a3bda1312a8ef13ff0": true,
 	},
+	"kokoro": {
+		"1f55d8d932042e8935444ab616ce4836a0dca478199c39d47ba8a015cbfac875": true,
+	},
 }

--- a/services/ports.go
+++ b/services/ports.go
@@ -138,7 +138,7 @@ const (
 	// consumer is the co-located citadel worker).
 	//
 	// NOTE: the citadel-services kokoro module (README, service.yaml ports.host
-	// and health_check.port) still names 8210 for this service -- written before
+	// and health_check.port) still names 8210 for this service, written before
 	// bonsai claimed 8210 here. citadel-cli's registry is authoritative for the
 	// injected host port; aligning citadel-services to 8211 is a follow-up in
 	// that repo.

--- a/services/ports.go
+++ b/services/ports.go
@@ -64,6 +64,15 @@ const (
 	// bonsai.yml), so its compose defers the host publish to this var exactly
 	// like llamacpp/vllm.
 	EnvBonsaiHostPort = "CITADEL_BONSAI_HOST_PORT"
+	// EnvTTSHostPort carries the host port for the kokoro text-to-speech service
+	// (Kokoro-82M via an OpenAI-compatible HTTP API). Like bonsai it is an
+	// EMBEDDED ServiceMap compose (services/compose/kokoro.yml), so its compose
+	// defers the host publish to this var. The var is spelled CITADEL_TTS_HOST_PORT
+	// (the generic engine name, `tts`) rather than CITADEL_KOKORO_HOST_PORT because
+	// the citadel-services catalog module's compose already reads it under that
+	// name; the registry KEY stays "kokoro" (the implementation name), mirroring
+	// meeting's key/env-var split (key "meeting" / EnvMeetingdHostPort).
+	EnvTTSHostPort = "CITADEL_TTS_HOST_PORT"
 )
 
 // Citadel-assigned host ports for the pre-packaged compose services. These are
@@ -120,6 +129,20 @@ const (
 	// embedded ServiceMap compose, so its container serves on :8080 and this is
 	// the HOST publish.
 	BonsaiHostPort = 8210
+	// kokoro: Kokoro-82M text-to-speech served over an OpenAI-compatible HTTP API
+	// (services/compose/kokoro.yml), the synthesis counterpart to the whisper
+	// transcribe sidecar. Next free slot in the 8200 block after bonsai's 8210
+	// (8205 stays earmarked for Hermes/OpenClaw). It is an embedded ServiceMap
+	// compose, so its container serves on :8080 and this is the HOST publish,
+	// bound to 127.0.0.1 only (the service has no auth of its own and its sole
+	// consumer is the co-located citadel worker).
+	//
+	// NOTE: the citadel-services kokoro module (README, service.yaml ports.host
+	// and health_check.port) still names 8210 for this service -- written before
+	// bonsai claimed 8210 here. citadel-cli's registry is authoritative for the
+	// injected host port; aligning citadel-services to 8211 is a follow-up in
+	// that repo.
+	TTSHostPort = 8211
 )
 
 // ServiceHostPorts maps service name -> citadel-assigned host port. Most entries
@@ -139,6 +162,7 @@ var ServiceHostPorts = map[string]int{
 	"meeting-cdp": MeetingCDPHostPort,
 	"gotenberg":   GotenbergHostPort,
 	"bonsai":      BonsaiHostPort,
+	"kokoro":      TTSHostPort,
 }
 
 // serviceHostPortEnv maps each managed service to the compose env-var that
@@ -153,6 +177,7 @@ var serviceHostPortEnv = map[string]string{
 	"meeting-cdp": EnvMeetingCDPHostPort,
 	"gotenberg":   EnvGotenbergHostPort,
 	"bonsai":      EnvBonsaiHostPort,
+	"kokoro":      EnvTTSHostPort,
 }
 
 // HostPortEnv returns "KEY=value" entries for every citadel-managed host port,

--- a/services/ports_test.go
+++ b/services/ports_test.go
@@ -197,3 +197,45 @@ func TestBonsaiHostPortRegistered(t *testing.T) {
 		t.Errorf("HostPortEnv() did not emit %q", want)
 	}
 }
+
+// TestTTSHostPortRegistered pins the kokoro TTS service's host port (Kokoro-82M,
+// the synthesis counterpart to the whisper transcribe sidecar). Like bonsai it
+// is an embedded ServiceMap compose, so its .yml defers the host publish to
+// CITADEL_TTS_HOST_PORT and this registry must resolve it. The registry KEY is
+// "kokoro" (the implementation name / ServiceMap key), while the env var is
+// spelled for the generic engine (tts) -- the same key/env split as meeting.
+func TestTTSHostPortRegistered(t *testing.T) {
+	got, ok := ServiceHostPorts["kokoro"]
+	if !ok || got != TTSHostPort {
+		t.Errorf("ServiceHostPorts[%q] = %d (present=%v), want %d", "kokoro", got, ok, TTSHostPort)
+	}
+	if _, ok := serviceHostPortEnv["kokoro"]; !ok {
+		t.Errorf("serviceHostPortEnv is missing %q; HostPortEnv() will not inject its host port", "kokoro")
+	}
+	// 8210 is bonsai's; kokoro must be the distinct next slot, not a re-use.
+	if TTSHostPort == BonsaiHostPort {
+		t.Errorf("TTSHostPort %d collides with BonsaiHostPort; 8210 is taken, kokoro must be the next free slot", TTSHostPort)
+	}
+	if TTSHostPort >= AppsPortRangeStart && TTSHostPort <= AppsPortRangeEnd {
+		t.Errorf("kokoro host port %d sits inside the apps auto-allocation range %d-%d", TTSHostPort, AppsPortRangeStart, AppsPortRangeEnd)
+	}
+	if name, taken := ReservedCitadelPorts[TTSHostPort]; taken {
+		t.Errorf("kokoro host port %d collides with reserved citadel port %q", TTSHostPort, name)
+	}
+	for svc, port := range ServiceHostPorts {
+		if svc != "kokoro" && port == TTSHostPort {
+			t.Errorf("kokoro host port %d collides with managed service %q", TTSHostPort, svc)
+		}
+	}
+	// HostPortEnv must emit the tts var so its compose resolves.
+	want := EnvTTSHostPort + "=8211"
+	found := false
+	for _, kv := range HostPortEnv() {
+		if kv == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("HostPortEnv() did not emit %q", want)
+	}
+}

--- a/services/ports_test.go
+++ b/services/ports_test.go
@@ -203,7 +203,7 @@ func TestBonsaiHostPortRegistered(t *testing.T) {
 // is an embedded ServiceMap compose, so its .yml defers the host publish to
 // CITADEL_TTS_HOST_PORT and this registry must resolve it. The registry KEY is
 // "kokoro" (the implementation name / ServiceMap key), while the env var is
-// spelled for the generic engine (tts) -- the same key/env split as meeting.
+// spelled for the generic engine (tts): the same key/env split as meeting.
 func TestTTSHostPortRegistered(t *testing.T) {
 	got, ok := ServiceHostPorts["kokoro"]
 	if !ok || got != TTSHostPort {


### PR DESCRIPTION
## Summary

Phase 2 of the TTS-on-fabric epic: give a citadel node the ability to run the Kokoro text-to-speech service and handle a `SYNTHESIZE_SPEECH` fabric job by POSTing to the local kokoro container. This is the synthesis counterpart to `TRANSCRIBE_AUDIO` (whisper) and backs the fabric `tts` engine, the way `transcribe` backs whisper.

## Blueprints mirrored

- **Service side, bonsai** (`services/compose/bonsai.yml`, `EnvBonsaiHostPort`/`BonsaiHostPort`, `ServiceMap["bonsai"]`, `known_hashes.go`): embedded ServiceMap compose plus host-port registration plus known-hash. kokoro differs in that it uses a prebuilt image (no build context / `ServiceAuxFiles`, like transcribe) and binds loopback only.
- **Handler side, transcribe** (`internal/jobs/transcribe_audio.go`): a node-side Go handler that health-polls a local sidecar and proxies an HTTP request to it. Reused the fast-fail-if-absent / patient-if-loading `waitForReady` structure. Deliberately did NOT port transcribe's per-audio-byte timeout machinery: TTS input is bounded text (at most `KOKORO_MAX_INPUT_CHARS`, default 5000) and Kokoro-82M is roughly real-time even on CPU, so one fixed generous cap (5m) is used.

## Service-key naming decision: `kokoro`

The registry/ServiceMap KEY is **`kokoro`** (the implementation name); the generic engine advertised for routing is **`tts`**.

- The citadel-services catalog module is literally named `kokoro` (`services/kokoro/`, container `citadel-kokoro`, `name: kokoro`), and its own docstring says it is "named for its implementation (kokoro)... the generic engine it advertises is `tts`".
- Its README "Fabric seam" section explicitly prescribes the citadel-cli work as "add **kokoro** to `ServiceHostPorts`/`serviceHostPortEnv`" and names the consts `EnvTTSHostPort`/`TTSHostPort`.
- transcribe only *looks* like key==engine because it has no separate implementation module; kokoro splits them, exactly like `meeting` splits its key (`meeting`) from its env var (`CITADEL_MEETINGD_HOST_PORT`). So: KEY `kokoro`, env var `CITADEL_TTS_HOST_PORT`, port const `TTSHostPort`.

## Host port: 8211 (contradicts the stale 8210 hint)

8210 is already taken by **bonsai** in `services/ports.go`, so kokoro takes the next free slot **8211** (8205 stays earmarked for Hermes/OpenClaw). The citadel-services kokoro module still names **8210** in three places: the README, `service.yaml` `ports[].host`, and `service.yaml` `health_check.port`, all written before bonsai claimed 8210 here. citadel-cli's registry is authoritative for the injected host port; realigning citadel-services to 8211 is a follow-up in that repo (not touched here).

## Cold-start readiness gate

kokoro's `/health` ALWAYS returns 200 and carries readiness in the body (`{"status":"up"|"loading","model_loaded":true|false}`, verified in the service's `server.py`), unlike whisper which returns non-200 until its model loads. So `waitForReady` parses `model_loaded` rather than trusting the status code; otherwise a cold node would POST before Kokoro-82M finished loading. Covered by `TestSynthesizeSpeech_WaitForReady_LoadingBodyNotReady`.

## Result envelope (this handler DEFINES the contract)

The kokoro service returns audio bytes in the body plus receipt data in `X-TTS-*` headers. Mirroring `file_read_bytes.go`, the handler returns a JSON envelope carrying BOTH:

```json
{
  "encoding": "base64",
  "content":  "<base64 audio>",
  "format":   "opus",
  "voice":    "am_michael",
  "receipt": {
    "chars": 24, "duration_seconds": 3.575,
    "model_version": "kokoro-0.9.4+hexgrad/Kokoro-82M",
    "cache_key": "<sha256>", "cache_hit": false
  }
}
```

`encoding: base64` is the marker the coordinator already checks (per `file_read_bytes.go`). Nothing on the aceteam side parses this envelope yet (citadel-services README point 3 says the handler is optional and "until it exists the fabric calls the endpoint directly"); this PR defines the shape. Payload text key: reads `text`, falling back to `input` (the OpenAI request-body spelling).

## Files changed

- `services/compose/kokoro.yml` (new): embedded compose, prebuilt image `ghcr.io/aceteam-ai/kokoro-service:latest`, container `citadel-kokoro` serving :8080, loopback publish `127.0.0.1:${CITADEL_TTS_HOST_PORT}:8080`.
- `services/ports.go`: `EnvTTSHostPort = "CITADEL_TTS_HOST_PORT"`, `TTSHostPort = 8211`, `ServiceHostPorts["kokoro"]`, `serviceHostPortEnv["kokoro"]`.
- `services/embed.go`: `//go:embed compose/kokoro.yml` plus `ServiceMap["kokoro"]`.
- `services/known_hashes.go`: kokoro current-template hash.
- `internal/jobs/synthesize_speech.go` (new): `SynthesizeSpeechHandler`.
- `internal/jobs/synthesize_speech_test.go` (new): handler tests.
- `internal/worker/job.go`: `JobTypeSynthesizeSpeech = "SYNTHESIZE_SPEECH"` plus `allKnownJobTypes`.
- `internal/worker/handler_adapter.go`: unconditional registration (takes text inline, returns audio inline, needs no workspace, so it sits with the sandbox-less inference handlers, NOT the transcribe workspace gate).
- `services/ports_test.go`, `services/embed_test.go`, `internal/apps/hostport_collision_test.go`: port/compose/collision coverage plus env-var resolution for the new loopback publish.

## Loopback compose note

Unlike bonsai's `${VAR:?msg}` guard, the `127.0.0.1:` prefix means the port spec no longer starts with `${`, so a `:?`/`:-` suffix would smear across the host-port test parsers' colon split. The bare `${CITADEL_TTS_HOST_PORT}` is deliberate; citadel always injects the var via `services.HostPortEnv`. Documented inline so nobody "fixes" it back.

## Test results

```
ok  github.com/aceteam-ai/citadel-cli/services            0.004s
ok  github.com/aceteam-ai/citadel-cli/internal/jobs      42.463s
ok  github.com/aceteam-ai/citadel-cli/internal/worker    10.037s
ok  github.com/aceteam-ai/citadel-cli/internal/apps       0.004s
```

New tests: `TestKokoroComposeRegistered`, `TestKokoroComposeContract`, `TestTTSHostPortRegistered`, `TestSynthesizeSpeech_{MissingText,Success,InputAlias,ServiceError,WaitForReady_LoadingBodyNotReady,WaitForReady_UnreachableFailsFast}`. `go build ./...` and `go vet ./...` clean.

## Dependency: ghcr image not yet published

`ghcr.io/aceteam-ai/kokoro-service:latest` is **NOT yet published** to ghcr (the CI publish workflow is a separate task). This PR is correct and unit-testable without the image; actual fleet deploy is blocked on the image publish. Also blocked-on / follow-up: realigning citadel-services (README plus `service.yaml` host/health port 8210 to 8211) and the aceteam `tts-speech` provisioning template (currently a Coqui/XTTS placeholder) to point at kokoro-service / 8211 / `/v1/audio/speech`.

Refs epic #6074, #6104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
