### PR TITLE
feat(cli): `citadel connect <name|ip>` — mesh-native remote shell (#582)

### DIFF
--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -16,44 +16,69 @@ import (
 )
 
 var (
-	connectTimeout int
+	connectTimeout      int
+	connectTerminalPort int
+	connectToken        string
 )
 
 var connectCmd = &cobra.Command{
-	Use:   "connect [peer:port]",
-	Short: "Connect to a service on another node",
-	Long: `Establishes a raw TCP connection to a service on another node and pipes
-stdin/stdout to it.
+	Use:   "connect [peer|peer:port]",
+	Short: "Open a remote shell on another node, or pipe a raw TCP service",
+	Long: `Two modes, selected by whether you give a port:
 
-This is useful for:
-  - Testing connectivity to services
-  - Piping data through the network
-  - Using as SSH ProxyCommand (used internally by 'citadel ssh')
+  citadel connect <node-name | ip>          Open an interactive remote shell
+  citadel connect <node-name | ip>:<port>   Pipe a raw TCP service (stdin/stdout)
 
-PEER IDENTIFICATION:
-  You can specify the peer in multiple ways:
-  - By hostname:  citadel connect gpu-node-1:5432
-  - By IP:        citadel connect 100.64.0.25:5432
-  - Interactive:  citadel connect  (prompts for peer and port)
+REMOTE SHELL (no port):
+  Drops you into an interactive shell on the target node over the AceTeam
+  Network mesh — collapsing the old multi-hop SSH chain
+  (ssh a -> ssh b -> tmux) into a single command from any machine on the mesh.
+  No host SSH config, no '.local' mDNS, no manual hops.
+
+  The target node must be running its terminal endpoint, which 'citadel work'
+  starts by default (disable with --no-terminal). Authentication uses a terminal
+  token: pass --token or set CITADEL_TERMINAL_TOKEN.
+
+RAW TCP (with port):
+  Establishes a raw TCP connection to a service on the target and pipes
+  stdin/stdout to it. Used internally by 'citadel ssh' as a ProxyCommand,
+  and useful for testing connectivity or piping data through the network.
+
+PEER IDENTIFICATION (both modes):
+  - By hostname:  citadel connect gpu-node-1
+  - By IP:        citadel connect 100.64.0.25
+  - Interactive:  citadel connect  (prompts for peer and port, raw TCP)
 
 The connection uses the tsnet userspace network, so it can reach peers
 that system networking cannot.`,
-	Example: `  # Interactive mode - select peer and port
-  citadel connect
+	Example: `  # Open an interactive remote shell (by name or mesh IP)
+  citadel connect gpu-node-1
+  citadel connect 100.64.0.25
 
-  # Connect to a PostgreSQL server
+  # Remote shell with an explicit terminal token / port
+  citadel connect gpu-node-1 --token tok_... --terminal-port 7860
+
+  # Raw TCP: connect to a PostgreSQL server
   citadel connect gpu-node-1:5432
 
-  # Connect to Redis
-  citadel connect gpu-node-1:6379
-
-  # Connect by IP address
+  # Raw TCP by IP address
   citadel connect 100.64.0.25:11434
 
-  # Connect with timeout
-  citadel connect gpu-node-1:11434 --timeout 30`,
+  # Interactive mode - select peer and port (raw TCP)
+  citadel connect`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		// Remote-shell mode: a single bare target (name or IP) with no :port.
+		// A port (host:port) always routes to the existing raw-TCP path, which
+		// keeps 'citadel ssh's ProxyCommand (always ip:port) unchanged.
+		if len(args) == 1 && connectIsShellTarget(args[0]) {
+			if err := runRemoteShell(args[0]); err != nil {
+				badColor.Printf("Error: %v\n", err)
+				os.Exit(1)
+			}
+			return
+		}
+
 		// Ensure network connection
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		if err := ensureNetworkConnected(ctx); err != nil {
@@ -233,7 +258,28 @@ func setupConnectInteractive() (peer string, port string, err error) {
 	return peer, port, nil
 }
 
+// connectIsShellTarget reports whether a single positional argument should be
+// treated as a remote-shell target (a bare node name or mesh/LAN IP) rather
+// than a raw-TCP "host:port". The ordering matters because tsnet also assigns
+// IPv6 addresses (all-colons), which must not be misread as host:port:
+//
+//  1. A valid IP (v4 or v6) -> shell.
+//  2. Otherwise, a well-formed host:port -> raw TCP (unchanged).
+//  3. Otherwise (bare name, no port) -> shell.
+func connectIsShellTarget(arg string) bool {
+	if isValidIP(arg) {
+		return true
+	}
+	_, port, err := parsePeerPort(arg)
+	if err != nil || port == "" {
+		return true
+	}
+	return false
+}
+
 func init() {
 	rootCmd.AddCommand(connectCmd)
-	connectCmd.Flags().IntVar(&connectTimeout, "timeout", 0, "Connection timeout in seconds (0 = no timeout)")
+	connectCmd.Flags().IntVar(&connectTimeout, "timeout", 0, "Connection timeout in seconds (0 = no timeout, raw-TCP mode)")
+	connectCmd.Flags().IntVar(&connectTerminalPort, "terminal-port", 7860, "Terminal endpoint port on the target (remote-shell mode)")
+	connectCmd.Flags().StringVar(&connectToken, "token", "", "Terminal auth token (remote-shell mode; or set CITADEL_TERMINAL_TOKEN)")
 }

--- a/cmd/connect_shell.go
+++ b/cmd/connect_shell.go
@@ -1,0 +1,225 @@
+// cmd/connect_shell.go
+//
+// Remote-shell client for `citadel connect <name|ip>`. This is the client half
+// of the terminal WebSocket server that `citadel work` runs by default (see
+// internal/terminal/server.go). It resolves the target to a mesh IP, dials the
+// node's /terminal endpoint *over the tsnet mesh* (not a host socket — bare
+// tsnet only forwards to ports Citadel explicitly ListenVPNs, and the terminal
+// server does exactly that on :7860), negotiates a PTY, and streams stdin/stdout
+// with terminal-resize propagation.
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/network"
+	"github.com/aceteam-ai/citadel-cli/internal/terminal"
+	"github.com/gorilla/websocket"
+	"golang.org/x/term"
+)
+
+// runRemoteShell opens an interactive shell on the target node over the mesh.
+//
+// Idempotency (issue #582 / coordinate with #571): this client publishes no
+// heartbeat and holds no worklock, so repeated `citadel connect <target>` never
+// creates duplicate node state — each invocation is an independent view, and on
+// exit the terminal is always restored and the socket closed cleanly. Stateful
+// re-attach (reconnecting to the *same* live shell with its running command and
+// scrollback after a dropped connection) is provided by the node-side terminal
+// server when it backs sessions with a persistent per-user tmux session
+// (CITADEL_TERMINAL_SESSION). With the default (bare-shell) node config each
+// connection is a fresh shell. See the PR / follow-up for making tmux-backed
+// sessions the default so `connect` re-attach is seamless out of the box.
+func runRemoteShell(target string) error {
+	// Ensure the mesh is up before resolving/dialing.
+	netCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if err := ensureNetworkConnected(netCtx); err != nil {
+		return err
+	}
+
+	// Resolve name -> mesh IP (or accept a literal IP).
+	ip, hostname, err := resolvePeer(target)
+	if err != nil {
+		suggestAvailablePeers()
+		return fmt.Errorf("could not resolve '%s': %w", target, err)
+	}
+
+	// Auth token: --token flag or CITADEL_TERMINAL_TOKEN env.
+	token := connectToken
+	if token == "" {
+		token = os.Getenv("CITADEL_TERMINAL_TOKEN")
+	}
+	if token == "" {
+		return fmt.Errorf("no terminal token provided\n"+
+			"  A terminal token authenticates the remote shell. Provide one with:\n"+
+			"    --token <token>            or\n"+
+			"    CITADEL_TERMINAL_TOKEN=<token> citadel connect %s\n"+
+			"  (Tokens are issued by the AceTeam platform terminal feature.)", target)
+	}
+
+	addr := net.JoinHostPort(ip, fmt.Sprintf("%d", connectTerminalPort))
+	wsURL := url.URL{
+		Scheme:   "ws",
+		Host:     addr,
+		Path:     "/terminal",
+		RawQuery: url.Values{"token": {token}}.Encode(),
+	}
+
+	display := hostname
+	if display == "" {
+		display = ip
+	}
+	fmt.Fprintf(os.Stderr, "Connecting to %s (%s) over the mesh...\r\n", display, addr)
+
+	// Dial the WebSocket *through the mesh*: NetDialContext routes the TCP
+	// handshake through tsnet userspace networking so we reach 100.64.x.x peers
+	// that host networking can't.
+	dialer := websocket.Dialer{
+		NetDialContext:   network.Dial,
+		HandshakeTimeout: 20 * time.Second,
+	}
+	dialCtx, dialCancel := context.WithTimeout(context.Background(), 25*time.Second)
+	defer dialCancel()
+
+	conn, resp, err := dialer.DialContext(dialCtx, wsURL.String(), nil)
+	if err != nil {
+		return remoteShellDialError(err, resp, display, addr)
+	}
+	defer conn.Close()
+
+	fmt.Fprintf(os.Stderr, "Connected. (Ctrl-D or 'exit' to disconnect)\r\n")
+
+	return pumpRemoteShell(conn)
+}
+
+// remoteShellDialError turns a WebSocket dial failure into an actionable message.
+func remoteShellDialError(err error, resp *http.Response, display, addr string) error {
+	if resp != nil {
+		switch resp.StatusCode {
+		case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
+			return fmt.Errorf("authentication rejected by %s (HTTP %d): the terminal token is invalid or not authorized for this node's org", display, resp.StatusCode)
+		case http.StatusServiceUnavailable:
+			return fmt.Errorf("%s is at capacity or its auth service is unavailable (HTTP %d)", display, resp.StatusCode)
+		default:
+			return fmt.Errorf("terminal handshake with %s failed (HTTP %d): %w", display, resp.StatusCode, err)
+		}
+	}
+	// No HTTP response => transport-level failure (refused / unreachable).
+	return fmt.Errorf("could not reach a terminal endpoint on %s (%s): %w\n"+
+		"  The target may not be running 'citadel work' (its terminal endpoint is\n"+
+		"  enabled by default), may have it disabled (--no-terminal), or may be\n"+
+		"  offline / not yet reachable on the mesh.", display, addr, err)
+}
+
+// pumpRemoteShell drives the interactive session: local raw terminal <-> PTY.
+func pumpRemoteShell(conn *websocket.Conn) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// All WebSocket writes must be serialized (gorilla forbids concurrent writes).
+	var writeMu sync.Mutex
+	send := func(msg *terminal.Message) error {
+		data, err := msg.Marshal()
+		if err != nil {
+			return err
+		}
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		return conn.WriteMessage(websocket.TextMessage, data)
+	}
+
+	// Put the local terminal into raw mode so keystrokes stream unbuffered.
+	stdinFd := int(os.Stdin.Fd())
+	var restore func()
+	if term.IsTerminal(stdinFd) {
+		oldState, err := term.MakeRaw(stdinFd)
+		if err != nil {
+			return fmt.Errorf("failed to set raw terminal mode: %w", err)
+		}
+		restore = func() { _ = term.Restore(stdinFd, oldState) }
+		defer restore()
+	}
+
+	// Send the initial size and propagate resizes to the remote PTY.
+	sendResize := func() {
+		if cols, rows, err := term.GetSize(stdinFd); err == nil && cols > 0 && rows > 0 {
+			_ = send(terminal.NewResizeMessage(uint16(cols), uint16(rows)))
+		}
+	}
+	sendResize()
+	watchResize(ctx, sendResize)
+
+	// stdin -> PTY (input messages).
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			n, err := os.Stdin.Read(buf)
+			if n > 0 {
+				if serr := send(terminal.NewInputMessage(buf[:n])); serr != nil {
+					cancel()
+					return
+				}
+			}
+			if err != nil {
+				cancel()
+				return
+			}
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+		}
+	}()
+
+	// PTY -> stdout (output messages). This is the main loop; when the remote
+	// shell exits, the server closes the socket and we return.
+	for {
+		mt, data, err := conn.ReadMessage()
+		if err != nil {
+			// The remote shell exiting (`exit` / Ctrl-D) tears the socket down.
+			// The server does not always send a close frame first, so accept the
+			// normal, going-away, no-status, and abnormal-closure codes as a clean
+			// end-of-session (exit 0) rather than surfacing them as an error.
+			if websocket.IsCloseError(err,
+				websocket.CloseNormalClosure,
+				websocket.CloseGoingAway,
+				websocket.CloseNoStatusReceived,
+				websocket.CloseAbnormalClosure) {
+				return nil
+			}
+			select {
+			case <-ctx.Done():
+				return nil
+			default:
+			}
+			return fmt.Errorf("connection closed: %w", err)
+		}
+		if mt != websocket.TextMessage {
+			continue
+		}
+		msg, err := terminal.UnmarshalMessage(data)
+		if err != nil {
+			continue
+		}
+		switch msg.Type {
+		case terminal.MessageTypeOutput:
+			if len(msg.Payload) > 0 {
+				_, _ = os.Stdout.Write(msg.Payload)
+			}
+		case terminal.MessageTypeError:
+			// Terminal is restored by the deferred restore().
+			return fmt.Errorf("remote error: %s", msg.Error)
+		case terminal.MessageTypePing:
+			_ = send(terminal.NewPongMessage())
+		}
+	}
+}

--- a/cmd/connect_shell_test.go
+++ b/cmd/connect_shell_test.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/terminal"
+)
+
+// TestConnectIsShellTarget locks the routing discriminator that decides whether
+// a `citadel connect <arg>` invocation is a remote shell (bare name/IP) or the
+// existing raw-TCP pipe (host:port). The IPv6 cases guard the all-colons trap:
+// tsnet assigns IPv6 addresses that must not be misread as host:port.
+func TestConnectIsShellTarget(t *testing.T) {
+	cases := []struct {
+		arg   string
+		shell bool
+	}{
+		{"gpu-node-1", true},           // bare hostname -> shell
+		{"ubuntu-gpu", true},           // bare hostname -> shell
+		{"100.64.0.5", true},           // bare IPv4 -> shell
+		{"192.168.2.10", true},         // bare LAN IPv4 -> shell
+		{"fd7a:115c:a1e0::1", true},    // bare IPv6 (all colons) -> shell, not host:port
+		{"gpu-node-1:5432", false},     // host:port -> raw TCP
+		{"100.64.0.5:11434", false},    // ip:port -> raw TCP
+		{"[fd7a:115c:a1e0::1]:22", false}, // bracketed IPv6 with port -> raw TCP
+	}
+	for _, c := range cases {
+		if got := connectIsShellTarget(c.arg); got != c.shell {
+			t.Errorf("connectIsShellTarget(%q) = %v, want %v", c.arg, got, c.shell)
+		}
+	}
+}
+
+// TestRemoteShellProtocolRoundtrip verifies the client encodes and decodes the
+// same wire protocol the terminal server speaks (internal/terminal.Message), so
+// input/resize/pong the client sends and output the server sends survive a
+// marshal/unmarshal roundtrip with payloads and dimensions intact.
+func TestRemoteShellProtocolRoundtrip(t *testing.T) {
+	t.Run("input", func(t *testing.T) {
+		data, err := terminal.NewInputMessage([]byte("ls -la\n")).Marshal()
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		msg, err := terminal.UnmarshalMessage(data)
+		if err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if msg.Type != terminal.MessageTypeInput || string(msg.Payload) != "ls -la\n" {
+			t.Fatalf("input roundtrip mismatch: type=%q payload=%q", msg.Type, msg.Payload)
+		}
+	})
+
+	t.Run("resize", func(t *testing.T) {
+		data, err := terminal.NewResizeMessage(120, 40).Marshal()
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		msg, err := terminal.UnmarshalMessage(data)
+		if err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if msg.Type != terminal.MessageTypeResize || msg.Cols != 120 || msg.Rows != 40 {
+			t.Fatalf("resize roundtrip mismatch: type=%q cols=%d rows=%d", msg.Type, msg.Cols, msg.Rows)
+		}
+	})
+
+	t.Run("output", func(t *testing.T) {
+		data, err := terminal.NewOutputMessage([]byte("hello\r\n")).Marshal()
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		msg, err := terminal.UnmarshalMessage(data)
+		if err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if msg.Type != terminal.MessageTypeOutput || string(msg.Payload) != "hello\r\n" {
+			t.Fatalf("output roundtrip mismatch: type=%q payload=%q", msg.Type, msg.Payload)
+		}
+	})
+}

--- a/cmd/connect_shell_test.go
+++ b/cmd/connect_shell_test.go
@@ -15,13 +15,13 @@ func TestConnectIsShellTarget(t *testing.T) {
 		arg   string
 		shell bool
 	}{
-		{"gpu-node-1", true},           // bare hostname -> shell
-		{"ubuntu-gpu", true},           // bare hostname -> shell
-		{"100.64.0.5", true},           // bare IPv4 -> shell
-		{"192.168.2.10", true},         // bare LAN IPv4 -> shell
-		{"fd7a:115c:a1e0::1", true},    // bare IPv6 (all colons) -> shell, not host:port
-		{"gpu-node-1:5432", false},     // host:port -> raw TCP
-		{"100.64.0.5:11434", false},    // ip:port -> raw TCP
+		{"gpu-node-1", true},              // bare hostname -> shell
+		{"ubuntu-gpu", true},              // bare hostname -> shell
+		{"100.64.0.5", true},              // bare IPv4 -> shell
+		{"192.168.2.10", true},            // bare LAN IPv4 -> shell
+		{"fd7a:115c:a1e0::1", true},       // bare IPv6 (all colons) -> shell, not host:port
+		{"gpu-node-1:5432", false},        // host:port -> raw TCP
+		{"100.64.0.5:11434", false},       // ip:port -> raw TCP
 		{"[fd7a:115c:a1e0::1]:22", false}, // bracketed IPv6 with port -> raw TCP
 	}
 	for _, c := range cases {

--- a/cmd/connect_shell_unix.go
+++ b/cmd/connect_shell_unix.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// watchResize invokes onResize whenever the local terminal is resized, using
+// the SIGWINCH signal (available on Unix-like platforms). It stops when ctx is
+// cancelled.
+func watchResize(ctx context.Context, onResize func()) {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGWINCH)
+	go func() {
+		defer signal.Stop(ch)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ch:
+				onResize()
+			}
+		}
+	}()
+}

--- a/cmd/connect_shell_windows.go
+++ b/cmd/connect_shell_windows.go
@@ -1,0 +1,34 @@
+//go:build windows
+
+package cmd
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"golang.org/x/term"
+)
+
+// watchResize invokes onResize when the local terminal size changes. Windows
+// has no SIGWINCH, so we poll the console size and fire onResize on a change.
+func watchResize(ctx context.Context, onResize func()) {
+	go func() {
+		fd := int(os.Stdin.Fd())
+		lastCols, lastRows, _ := term.GetSize(fd)
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				cols, rows, err := term.GetSize(fd)
+				if err == nil && (cols != lastCols || rows != lastRows) {
+					lastCols, lastRows = cols, rows
+					onResize()
+				}
+			}
+		}
+	}()
+}


### PR DESCRIPTION
Closes #582.

## Context

Operating a remote citadel node meant chaining raw SSH across machines
(`laptop → ssh aceteamvm → ssh ubuntu-gpu → tmux a`): brittle per-host SSH
config, `.local` hostnames that only resolve on some LANs, SSH required on every
hop, and none of it uses the mesh we already have. Every node is already on the
embedded-tsnet mesh (`100.64.x.x`) and authenticated to the same coordination
server, so it should be reachable by name or IP with one command.

## Design

`citadel connect` is now **two modes, selected by whether a port is given** —
backward compatible, and the requested `<name|ip>` UX from #582:

| Invocation | Behavior |
|---|---|
| `citadel connect <name\|ip>` | **NEW** interactive remote shell over the mesh |
| `citadel connect <name\|ip>:<port>` | raw TCP pipe (unchanged; `citadel ssh`'s ProxyCommand always passes `ip:port`, so it is untouched) |
| `citadel connect` (no args) | interactive peer/port picker (unchanged, raw TCP) |

The remote-shell path is the **client half of the terminal WebSocket server**
that `citadel work` already runs by default (`internal/terminal/server.go`). It:

1. Resolves name → mesh IP via the existing peer lister (`resolvePeer`), or
   accepts a literal mesh/LAN IP.
2. Dials the target's `/terminal` endpoint **over the mesh** —
   `websocket.Dialer{NetDialContext: network.Dial}` routes the TCP handshake
   through tsnet userspace networking, reaching `100.64.x.x` peers host
   networking can't.
3. Puts the local terminal in raw mode (`x/term`), streams stdin→input /
   output→stdout using the server's own JSON protocol (`terminal.Message`), and
   propagates terminal resizes. Clean teardown restores the terminal on exit.

### Routing discriminator (IPv6 trap)

Ordered IP-first so tsnet's all-colons IPv6 addresses are never misread as
`host:port`: valid IP → shell; else well-formed `host:port` → raw TCP; else bare
name → shell. Unit-tested as a table.

### Mesh-reachability reality

Bare tsnet does **not** forward inbound mesh traffic to arbitrary host ports —
only ports Citadel explicitly `ListenVPN`s answer over the mesh. The terminal
server is one of them: `citadel work` binds it on the node's VPN IP `:7860` **by
default** (disable with `--no-terminal`). So `connect` works against any node
running `citadel work`. When the endpoint is absent/unreachable, the error is
actionable ("the target may not be running `citadel work` …").

### Auth

Reuses the existing terminal-token path (`--token` / `CITADEL_TERMINAL_TOKEN`).
There is no token-*mint* endpoint today, so the token is supplied by the
operator for now. Making it truly one-command (trust mesh-peer identity on the
VPN listener, no manual token) is a node-side change tracked in the follow-up.

### Idempotency (#582 requirement; coordinate with #571)

- **Client-side (guaranteed here):** `connect` publishes no heartbeat and holds
  no worklock, so repeated `citadel connect <target>` never creates duplicate
  node state — each invocation is an independent view, and the terminal is always
  restored + socket closed on exit. This is *not* the #571 double-`work` case.
- **Stateful re-attach (node-side dependency):** reconnecting to the *same* live
  shell (running command + scrollback) after a drop is provided by the terminal
  server's persistent per-user tmux session — but `CITADEL_TERMINAL_SESSION`
  defaults to empty, so tmux backing is **OFF by default** and each connection is
  a fresh shell. Defaulting tmux-backed sessions on is folded into the follow-up.

## Follow-up

**#585** (node-side): trust mesh-peer identity on the terminal VPN listener (drop
the manual `--token`) and default tmux-backed per-user sessions so `connect`
re-attach is seamless out of the box. The two gaps that keep this from being
fully "one idempotent command" are node-side and tracked there.

## Changes

- `cmd/connect.go` — route bare `<name|ip>` to the new remote shell; `--token`,
  `--terminal-port` flags; overload documented in help. `connectIsShellTarget`
  discriminator.
- `cmd/connect_shell.go` — mesh WebSocket client: resolve, dial-over-mesh, raw
  PTY streaming, resize, actionable dial errors.
- `cmd/connect_shell_unix.go` / `cmd/connect_shell_windows.go` — build-tagged
  resize watchers (SIGWINCH on Unix; size-poll fallback on Windows) so release
  cross-compiles stay green.
- `cmd/connect_shell_test.go` — routing table + protocol encode/decode roundtrip.

## Testing

```bash
go build ./cmd/citadel   # + GOOS=windows / GOOS=darwin cross-compile: all pass
go vet ./...             # clean
go test ./...            # pass
```

Manual (end-to-end, integration): on a node running `citadel work`, from any mesh
peer: `CITADEL_TERMINAL_TOKEN=… citadel connect <node-name>` drops into a shell;
resize propagates; `exit`/Ctrl-D tears down cleanly. Interactive PTY behavior is
integration-only by nature; the pure routing/protocol parts are unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)