### PR TITLE
feat(heartbeat): compact stats block with node-local inference + GPU metrics for Fabric Pulse (#587)

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -30,6 +30,7 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/nodestate"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
 	pmx "github.com/aceteam-ai/citadel-cli/internal/proxmox"
+	"github.com/aceteam-ai/citadel-cli/internal/pulse"
 	"github.com/aceteam-ai/citadel-cli/internal/status"
 	"github.com/aceteam-ai/citadel-cli/internal/teamchat"
 	"github.com/aceteam-ai/citadel-cli/internal/telemetry"
@@ -1916,6 +1917,21 @@ func runTUIWorker(ctx context.Context, activityFn func(level, msg string)) error
 				}, collector); err == nil {
 					// Include current permissions in heartbeat
 					apiPublisher.SetPermissions(permissionsToHeartbeat(config.LoadPermissions(platform.ConfigDir())))
+
+					// Fabric Pulse stats collector (citadel-cli#587), same wiring
+					// as runWork: cached GPU + inference internals attached to
+					// the heartbeat as the optional "stats" block. Started only
+					// when this control center is the node's heartbeat publisher
+					// (workerHeld is false here), so a node never runs two
+					// collectors. CITADEL_HEARTBEAT_STATS=false is the kill
+					// switch.
+					if !pulse.Disabled() {
+						pulseStats := pulse.NewCollector(pulse.CollectorConfig{
+							Interval: pulse.ResolveInterval(""),
+						})
+						go pulseStats.Run(ctx)
+						apiPublisher.SetStatsProvider(pulseStats.Latest)
+					}
 					go func() {
 						activity("info", "Heartbeat publishing started")
 

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -34,6 +34,7 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
 	"github.com/aceteam-ai/citadel-cli/internal/power"
 	"github.com/aceteam-ai/citadel-cli/internal/provision"
+	"github.com/aceteam-ai/citadel-cli/internal/pulse"
 	"github.com/aceteam-ai/citadel-cli/internal/reconcile"
 	"github.com/aceteam-ai/citadel-cli/internal/redisapi"
 	"github.com/aceteam-ai/citadel-cli/internal/service"
@@ -113,6 +114,11 @@ var (
 	// Auto-update (periodic self-update) flags
 	workAutoUpdate         bool
 	workAutoUpdateInterval string
+
+	// Heartbeat stats (Fabric Pulse, citadel-cli#587) interval flag. The
+	// feature itself is ON by default with the CITADEL_HEARTBEAT_STATS env
+	// kill switch (see internal/pulse).
+	workHeartbeatStatsInterval string
 
 	// Capability detection flags
 	workCapabilities string
@@ -1435,6 +1441,23 @@ func runWork(cmd *cobra.Command, args []string) {
 		// stats/nvidia-smi sweep). nil when the operator has not opted in.
 		autoStop := newAutoStopReconciler()
 
+		// Fabric Pulse stats collector (citadel-cli#587): GPU + inference-engine
+		// internals scraped node-locally on a short interval into a cached block
+		// the heartbeat attaches as the optional "stats" field. Runs on its own
+		// goroutine; the heartbeat only reads the cache and never blocks on
+		// collection. ON by default; CITADEL_HEARTBEAT_STATS=false is the kill
+		// switch.
+		var pulseStats *pulse.Collector
+		if pulse.Disabled() {
+			fmt.Printf("   - Heartbeat stats: DISABLED (%s)\n", pulse.EnvVar)
+		} else {
+			pulseStats = pulse.NewCollector(pulse.CollectorConfig{
+				Interval: pulse.ResolveInterval(workHeartbeatStatsInterval),
+			})
+			go pulseStats.Run(ctx)
+			fmt.Printf("   - Heartbeat stats: GPU + inference metrics every %s\n", pulseStats.Interval())
+		}
+
 		if useAPIMode && apiSource != nil {
 			// API mode: use secure API publisher
 			// Get org ID from device config (saved during init)
@@ -1519,6 +1542,9 @@ func runWork(cmd *cobra.Command, args []string) {
 					if autoStop != nil {
 						apiPublisher.SetOnStatus(func(s *status.NodeStatus) { autoStop.Reconcile(s) })
 					}
+					if pulseStats != nil {
+						apiPublisher.SetStatsProvider(pulseStats.Latest)
+					}
 					go func() {
 						fmt.Printf("   - API status: %s (every 30s)\n", apiPublisher.PubSubChannel())
 						if err := apiPublisher.Start(ctx); err != nil && err != context.Canceled {
@@ -1551,6 +1577,9 @@ func runWork(cmd *cobra.Command, args []string) {
 				redisPublisher.SetPermissions(permissionsToHeartbeat(config.LoadPermissions(platform.ConfigDir())))
 				if autoStop != nil {
 					redisPublisher.SetOnStatus(func(s *status.NodeStatus) { autoStop.Reconcile(s) })
+				}
+				if pulseStats != nil {
+					redisPublisher.SetStatsProvider(pulseStats.Latest)
 				}
 				go func() {
 					fmt.Printf("   - Redis status: %s (every 30s)\n", redisPublisher.PubSubChannel())
@@ -2662,6 +2691,10 @@ func init() {
 	// Auto-update (periodic self-update) flags
 	workCmd.Flags().BoolVar(&workAutoUpdate, "auto-update", false, "Periodically check for and install newer releases (or set CITADEL_AUTO_UPDATE=true)")
 	workCmd.Flags().StringVar(&workAutoUpdateInterval, "auto-update-interval", "", "Interval between auto-update checks, e.g. 1h, 30m (default 1h; or set CITADEL_AUTO_UPDATE_INTERVAL)")
+
+	// Heartbeat stats (Fabric Pulse) flags. Collection is on by default; the
+	// kill switch is CITADEL_HEARTBEAT_STATS=false.
+	workCmd.Flags().StringVar(&workHeartbeatStatsInterval, "heartbeat-stats-interval", "", "Interval between GPU/inference stats collections for the heartbeat stats block, e.g. 10s, 30s (default 10s; or set CITADEL_HEARTBEAT_STATS_INTERVAL; disable stats with CITADEL_HEARTBEAT_STATS=false)")
 
 	// Capability detection flags
 	workCmd.Flags().StringVar(&workCapabilities, "capabilities", "", "Additional comma-separated capability tags (e.g., gpu:rtx4090,llm:llama3)")

--- a/internal/heartbeat/api.go
+++ b/internal/heartbeat/api.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/network"
+	"github.com/aceteam-ai/citadel-cli/internal/pulse"
 	"github.com/aceteam-ai/citadel-cli/internal/redisapi"
 	"github.com/aceteam-ai/citadel-cli/internal/status"
 )
@@ -57,6 +58,19 @@ type APIPublisher struct {
 	// that was just published without triggering a second (expensive) collection
 	// pass on an already-loaded node. Optional; nil by default. See citadel #416.
 	onStatus func(*status.NodeStatus)
+
+	// statsFn, when set, returns the latest cached Fabric Pulse stats block
+	// (citadel-cli#587). It is a cache read — it must never block or error —
+	// and may return nil (no stats field on that heartbeat). Optional.
+	statsFn func() *pulse.StatsBlock
+}
+
+// SetStatsProvider registers the Fabric Pulse cached-stats reader
+// (pulse.Collector.Latest). The heartbeat attaches whatever the cache holds;
+// it never triggers collection itself, so a wedged collector degrades to a
+// heartbeat without stats, not a late heartbeat.
+func (p *APIPublisher) SetStatsProvider(fn func() *pulse.StatsBlock) {
+	p.statsFn = fn
 }
 
 // SetOnStatus registers a callback invoked with each collected status. Used to
@@ -208,6 +222,9 @@ func (p *APIPublisher) publishStatus(ctx context.Context) error {
 		HeadscaleNodeID: p.headscaleNodeID,
 		Status:          nodeStatus,
 		Permissions:     p.permissions,
+	}
+	if p.statsFn != nil {
+		msg.Stats = p.statsFn()
 	}
 
 	p.debug("heartbeat: publishing to channel %s", p.pubSubChannel)

--- a/internal/heartbeat/redis.go
+++ b/internal/heartbeat/redis.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/network"
+	"github.com/aceteam-ai/citadel-cli/internal/pulse"
 	"github.com/aceteam-ai/citadel-cli/internal/status"
 	"github.com/redis/go-redis/v9"
 )
@@ -40,6 +41,11 @@ type StatusMessage struct {
 	DeviceCode      string             `json:"deviceCode,omitempty"`
 	Status          *status.NodeStatus `json:"status"`
 	Permissions     *PermissionState   `json:"permissions,omitempty"`
+	// Stats is the compact Fabric Pulse block (GPU + inference internals,
+	// citadel-cli#587). Optional and versioned: legacy backends ignore it,
+	// legacy nodes omit it. Read from the pulse collector's cache via
+	// SetStatsProvider — never collected inline on the heartbeat path.
+	Stats *pulse.StatsBlock `json:"stats,omitempty"`
 }
 
 // PermissionState mirrors config.Permissions for the heartbeat payload.
@@ -87,6 +93,19 @@ type RedisPublisher struct {
 	// successful publish, driving the config-gated auto-stop reconciler off the
 	// heartbeat's existing collection (citadel #416). Optional; nil by default.
 	onStatus func(*status.NodeStatus)
+
+	// statsFn, when set, returns the latest cached Fabric Pulse stats block
+	// (citadel-cli#587). It is a cache read — it must never block or error —
+	// and may return nil (no stats field on that heartbeat). Optional.
+	statsFn func() *pulse.StatsBlock
+}
+
+// SetStatsProvider registers the Fabric Pulse cached-stats reader
+// (pulse.Collector.Latest). The heartbeat attaches whatever the cache holds;
+// it never triggers collection itself, so a wedged collector degrades to a
+// heartbeat without stats, not a late heartbeat.
+func (p *RedisPublisher) SetStatsProvider(fn func() *pulse.StatsBlock) {
+	p.statsFn = fn
 }
 
 // SetOnStatus registers a callback invoked with each collected status. Used to
@@ -262,6 +281,9 @@ func (p *RedisPublisher) publishStatus(ctx context.Context) error {
 		DeviceCode:      deviceCode,
 		Status:          nodeStatus,
 		Permissions:     p.permissions,
+	}
+	if p.statsFn != nil {
+		msg.Stats = p.statsFn()
 	}
 
 	// Marshal to JSON

--- a/internal/heartbeat/stats_test.go
+++ b/internal/heartbeat/stats_test.go
@@ -1,0 +1,90 @@
+package heartbeat
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/pulse"
+	"github.com/aceteam-ai/citadel-cli/internal/status"
+)
+
+// TestStatusMessageWithoutStats proves the heartbeat wire format is unchanged
+// when no stats provider is wired (legacy nodes) or the collector has nothing
+// (provider returned nil): the "stats" key must be entirely absent, not null.
+func TestStatusMessageWithoutStats(t *testing.T) {
+	msg := StatusMessage{
+		Version:   "1.0",
+		Timestamp: "2026-07-22T00:00:00Z",
+		NodeID:    "test-node",
+		Status:    &status.NodeStatus{Version: "1.0"},
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded map[string]json.RawMessage
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := decoded["stats"]; ok {
+		t.Errorf("heartbeat without a stats block must not carry a stats key: %s", data)
+	}
+}
+
+// TestStatusMessageWithStats proves the stats block rides the heartbeat under
+// the exact "stats" key with the contract's inner shape.
+func TestStatusMessageWithStats(t *testing.T) {
+	msg := StatusMessage{
+		Version:   "1.0",
+		Timestamp: "2026-07-22T00:00:00Z",
+		NodeID:    "test-node",
+		Status:    &status.NodeStatus{Version: "1.0"},
+		Stats: &pulse.StatsBlock{
+			V:    pulse.StatsVersion,
+			TS:   1753142400,
+			GPUs: []pulse.GPUStat{{Index: 0}},
+		},
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded map[string]json.RawMessage
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	statsRaw, ok := decoded["stats"]
+	if !ok {
+		t.Fatalf("stats key missing: %s", data)
+	}
+	if want := `{"v":1,"ts":1753142400,"gpus":[{"i":0}]}`; string(statsRaw) != want {
+		t.Errorf("stats shape: got %s, want %s", statsRaw, want)
+	}
+}
+
+// TestPublisherStatsProviderNeverBlocksNilProvider exercises the publisher
+// seam: an unset or nil-returning provider leaves msg.Stats nil, and a
+// provider is a pure cache read (pulse.Collector.Latest) so the heartbeat
+// path never triggers collection.
+func TestPublisherStatsProvider(t *testing.T) {
+	p, err := NewRedisPublisher(RedisPublisherConfig{
+		RedisURL: "redis://localhost:6379",
+		NodeID:   "test-node",
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewRedisPublisher: %v", err)
+	}
+
+	if p.statsFn != nil {
+		t.Error("statsFn must default to nil (no stats field on heartbeats)")
+	}
+
+	c := pulse.NewCollector(pulse.CollectorConfig{Targets: []pulse.EngineTarget{}})
+	p.SetStatsProvider(c.Latest)
+	if got := p.statsFn(); got != nil {
+		t.Errorf("Latest() before any collection must be nil, got %+v", got)
+	}
+}

--- a/internal/jobs/llm_inference.go
+++ b/internal/jobs/llm_inference.go
@@ -288,14 +288,14 @@ func (h *LLMInferenceHandler) waitForVLLMReady(ctx context.Context) error {
 }
 
 // executeSGLang handles inference via SGLang's OpenAI-compatible API.
-// SGLang runs on port 30000 and exposes the same /v1/completions endpoint as vLLM.
+// SGLang runs on services.SGLangHostPort and exposes the same /v1/completions endpoint as vLLM.
 func (h *LLMInferenceHandler) executeSGLang(ctx context.Context, client *redisclient.Client, jobID, rayID string, payload *LLMInferencePayload) error {
 	// Wait for SGLang to be ready
 	if err := h.waitForSGLangReady(ctx); err != nil {
 		return err
 	}
 
-	sglangURL := "http://localhost:30000/v1/completions"
+	sglangURL := fmt.Sprintf("http://localhost:%d/v1/completions", services.SGLangHostPort)
 
 	reqPayload := map[string]any{
 		"model":       payload.Model,
@@ -340,7 +340,7 @@ func (h *LLMInferenceHandler) executeSGLang(ctx context.Context, client *rediscl
 }
 
 func (h *LLMInferenceHandler) waitForSGLangReady(ctx context.Context) error {
-	healthURL := "http://localhost:30000/health"
+	healthURL := fmt.Sprintf("http://localhost:%d/health", services.SGLangHostPort)
 	maxWait := 60 * time.Second
 	pollInterval := 1 * time.Second
 	startTime := time.Now()

--- a/internal/pulse/block.go
+++ b/internal/pulse/block.go
@@ -1,0 +1,93 @@
+// Package pulse collects node-local inference and GPU telemetry for Fabric
+// Pulse (aceteam-ai/aceteam#6334, citadel-cli#587).
+//
+// The sovereign path: Citadel scrapes local vLLM / SGLang Prometheus /metrics
+// endpoints and nvidia-smi, condenses them into a compact versioned stats
+// block, and ships that block on the existing heartbeat. The backend never
+// opens a socket into the node (Railway userspace-tailscaled cannot anyway;
+// see fabric-vpn-relay docs).
+//
+// Wire contract (field names are load-bearing — the aceteam backend/web are
+// built against this exact shape):
+//
+//	"stats": {
+//	  "v": 1,
+//	  "ts": 1753142400,
+//	  "gpus": [{"i": 0, "util_pct": 85, "mem_used_mb": 22528, ...}],
+//	  "inference": [{"engine": "vllm", "model": "Qwen3-9B", "port": 8080, ...}]
+//	}
+//
+// Every field inside a gpus[]/inference[] entry is optional-when-unavailable:
+// a metric an engine does not expose is omitted, never zero-filled. The gpus/
+// inference arrays are omitted entirely when the node has no GPU / no running
+// inference engine. The whole stats block is optional on the heartbeat, so old
+// backends ignore it and old nodes keep heartbeating without it.
+package pulse
+
+// StatsVersion is the wire version of the stats block ("v" field). Bump only
+// on a breaking shape change; additive fields do not need a bump.
+const StatsVersion = 1
+
+// StatsBlock is the compact per-heartbeat stats payload. V and TS are always
+// present; both arrays are omitted when the collector has nothing to report.
+type StatsBlock struct {
+	// V is the stats block wire version (StatsVersion).
+	V int `json:"v"`
+	// TS is the Unix timestamp (seconds) of the collection.
+	TS int64 `json:"ts"`
+	// GPUs holds per-GPU utilization, sourced from nvidia-smi. Omitted when
+	// no NVIDIA GPU / driver is present.
+	GPUs []GPUStat `json:"gpus,omitempty"`
+	// Inference holds per-engine internals scraped from local Prometheus
+	// /metrics endpoints. Omitted when no inference engine is reachable.
+	Inference []InferenceStat `json:"inference,omitempty"`
+}
+
+// GPUStat is one GPU's live utilization snapshot. All fields except the index
+// are pointers so a value nvidia-smi reports as "[N/A]"/"[Not Supported]" is
+// omitted from the JSON instead of shipping a fake zero.
+type GPUStat struct {
+	// Index is the GPU index as reported by nvidia-smi (always present).
+	Index      int      `json:"i"`
+	UtilPct    *float64 `json:"util_pct,omitempty"`
+	MemUsedMB  *int     `json:"mem_used_mb,omitempty"`
+	MemTotalMB *int     `json:"mem_total_mb,omitempty"`
+	TempC      *int     `json:"temp_c,omitempty"`
+	PowerW     *float64 `json:"power_w,omitempty"`
+}
+
+// InferenceStat is one engine's live internals. Engine and Port are always
+// present; every metric is a pointer so a signal the engine does not expose
+// (or that has no baseline yet, for rate/percentile fields) is omitted rather
+// than zero-filled. A present zero (e.g. waiting=0) is real and is shipped.
+type InferenceStat struct {
+	// Engine is the metrics dialect that produced this entry ("vllm", "sglang").
+	Engine string `json:"engine"`
+	// Model is the served model name, from the model_name label when the
+	// engine attaches one to its series. Omitted when unlabeled.
+	Model string `json:"model,omitempty"`
+	// Port is the local host port the metrics were scraped from.
+	Port int `json:"port"`
+	// GenTPS / PromptTPS are generation / prompt token throughput in tokens
+	// per second: the engine's own throughput gauge when exposed, otherwise a
+	// rate computed from token counters across consecutive scrapes (omitted on
+	// the first scrape, which has no baseline).
+	GenTPS    *float64 `json:"gen_tps,omitempty"`
+	PromptTPS *float64 `json:"prompt_tps,omitempty"`
+	// KVCachePct is KV-cache utilization as a percentage (engines report a
+	// 0-1 fraction; scaled here).
+	KVCachePct *float64 `json:"kv_cache_pct,omitempty"`
+	// Running / Waiting are the engine's live request queue gauges.
+	Running *int `json:"running,omitempty"`
+	Waiting *int `json:"waiting,omitempty"`
+	// TTFTMsP50 / E2EMsP50 are median time-to-first-token / end-to-end request
+	// latency in milliseconds, computed from the engine's Prometheus histogram
+	// over the window between consecutive scrapes. Omitted when the engine
+	// exposes no histogram or no request finished in the window.
+	TTFTMsP50 *float64 `json:"ttft_ms_p50,omitempty"`
+	E2EMsP50  *float64 `json:"e2e_ms_p50,omitempty"`
+}
+
+// float64Ptr / intPtr are tiny helpers for building optional fields.
+func float64Ptr(v float64) *float64 { return &v }
+func intPtr(v int) *int             { return &v }

--- a/internal/pulse/block_test.go
+++ b/internal/pulse/block_test.go
@@ -1,0 +1,85 @@
+package pulse
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestStatsBlockContractGolden pins the exact wire shape the aceteam backend
+// is built against (aceteam-ai/aceteam#6334). Field names and omission
+// behavior are load-bearing: if this test fails, the backend contract broke.
+func TestStatsBlockContractGolden(t *testing.T) {
+	block := StatsBlock{
+		V:  StatsVersion,
+		TS: 1753142400,
+		GPUs: []GPUStat{{
+			Index:      0,
+			UtilPct:    float64Ptr(85),
+			MemUsedMB:  intPtr(22528),
+			MemTotalMB: intPtr(24576),
+			TempC:      intPtr(68),
+			PowerW:     float64Ptr(259),
+		}},
+		Inference: []InferenceStat{{
+			Engine:     "vllm",
+			Model:      "Qwen3-9B",
+			Port:       8080,
+			GenTPS:     float64Ptr(252.0),
+			PromptTPS:  float64Ptr(0.0),
+			KVCachePct: float64Ptr(77.7),
+			Running:    intPtr(4),
+			Waiting:    intPtr(0),
+			TTFTMsP50:  float64Ptr(2500),
+			E2EMsP50:   float64Ptr(20000),
+		}},
+	}
+
+	got, err := json.Marshal(block)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	want := `{"v":1,"ts":1753142400,` +
+		`"gpus":[{"i":0,"util_pct":85,"mem_used_mb":22528,"mem_total_mb":24576,"temp_c":68,"power_w":259}],` +
+		`"inference":[{"engine":"vllm","model":"Qwen3-9B","port":8080,"gen_tps":252,"prompt_tps":0,"kv_cache_pct":77.7,"running":4,"waiting":0,"ttft_ms_p50":2500,"e2e_ms_p50":20000}]}`
+	if string(got) != want {
+		t.Errorf("contract shape drifted:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+// TestStatsBlockOmission verifies that empty arrays and unavailable fields are
+// omitted entirely, never zero-filled.
+func TestStatsBlockOmission(t *testing.T) {
+	t.Run("no gpus, no inference", func(t *testing.T) {
+		got, err := json.Marshal(StatsBlock{V: 1, TS: 1753142400})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if want := `{"v":1,"ts":1753142400}`; string(got) != want {
+			t.Errorf("got %s, want %s", got, want)
+		}
+	})
+
+	t.Run("gpu entry with only index", func(t *testing.T) {
+		got, err := json.Marshal(GPUStat{Index: 1})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if want := `{"i":1}`; string(got) != want {
+			t.Errorf("got %s, want %s", got, want)
+		}
+	})
+
+	t.Run("present zero is shipped, absent is omitted", func(t *testing.T) {
+		got, err := json.Marshal(InferenceStat{
+			Engine:  "sglang",
+			Port:    30000,
+			Waiting: intPtr(0),
+		})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if want := `{"engine":"sglang","port":30000,"waiting":0}`; string(got) != want {
+			t.Errorf("got %s, want %s", got, want)
+		}
+	})
+}

--- a/internal/pulse/collector.go
+++ b/internal/pulse/collector.go
@@ -1,0 +1,201 @@
+package pulse
+
+import (
+	"context"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/services"
+)
+
+// EnvVar is the operator KILL SWITCH for heartbeat stats collection
+// (citadel-cli#587). Collection is ON by default; set CITADEL_HEARTBEAT_STATS
+// to a falsy value ("0", "false", "no", "off") to disable it fleet-wide
+// without a binary rollback. Mirrors the CITADEL_RECONCILE_PULL pattern
+// (internal/reconcile/config_env.go).
+const EnvVar = "CITADEL_HEARTBEAT_STATS"
+
+// IntervalEnvVar overrides the collection interval (Go duration syntax, e.g.
+// "10s", "1m"). The --heartbeat-stats-interval flag takes precedence.
+const IntervalEnvVar = "CITADEL_HEARTBEAT_STATS_INTERVAL"
+
+// DefaultInterval is the default collection interval. Kept comfortably under
+// the 30s heartbeat interval so the cached block a heartbeat picks up is
+// always fresh.
+const DefaultInterval = 10 * time.Second
+
+// scrapeTimeout bounds each engine /metrics fetch.
+const scrapeTimeout = 3 * time.Second
+
+// Disabled reports whether the operator has explicitly turned stats collection
+// OFF via the kill switch. Default (unset or any non-falsy value) is enabled.
+func Disabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(EnvVar))) {
+	case "0", "false", "no", "off":
+		return true
+	default:
+		return false
+	}
+}
+
+// ResolveInterval returns the collection interval: flag value > env var >
+// DefaultInterval. A malformed or non-positive duration falls back to the
+// default rather than failing node startup over a telemetry knob.
+func ResolveInterval(flagValue string) time.Duration {
+	for _, v := range []string{flagValue, os.Getenv(IntervalEnvVar)} {
+		if v = strings.TrimSpace(v); v == "" {
+			continue
+		}
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return DefaultInterval
+}
+
+// EngineTarget names a local inference engine metrics endpoint to scrape.
+type EngineTarget struct {
+	Engine string
+	Port   int
+}
+
+// DefaultEngineTargets returns the scrape targets for every engine registered
+// in the host-port registry with a Prometheus /metrics endpoint
+// (services.InferenceMetricsPorts), sorted by engine name for deterministic
+// block ordering.
+func DefaultEngineTargets() []EngineTarget {
+	ports := services.InferenceMetricsPorts()
+	targets := make([]EngineTarget, 0, len(ports))
+	for engine, port := range ports {
+		targets = append(targets, EngineTarget{Engine: engine, Port: port})
+	}
+	sort.Slice(targets, func(i, j int) bool { return targets[i].Engine < targets[j].Engine })
+	return targets
+}
+
+// Collector periodically gathers GPU + inference stats on its own goroutine
+// and caches the latest block. The heartbeat publishers read the cache via
+// Latest() and therefore NEVER block on (or fail because of) collection — a
+// stale block beats a late heartbeat.
+type Collector struct {
+	interval time.Duration
+	targets  []EngineTarget
+	gpuFn    func(context.Context) []GPUStat
+	now      func() time.Time
+
+	scrapers []*engineScraper
+
+	mu          sync.RWMutex
+	latest      *StatsBlock
+	collectedAt time.Time
+}
+
+// CollectorConfig configures a Collector. Zero values select the defaults.
+type CollectorConfig struct {
+	// Interval between collection cycles (default DefaultInterval).
+	Interval time.Duration
+	// Targets are the engine metrics endpoints to scrape (default
+	// DefaultEngineTargets()).
+	Targets []EngineTarget
+	// GPUFn overrides GPU collection (tests). Default: nvidia-smi.
+	GPUFn func(context.Context) []GPUStat
+}
+
+// NewCollector creates a stats collector. Call Run on its own goroutine.
+func NewCollector(cfg CollectorConfig) *Collector {
+	if cfg.Interval <= 0 {
+		cfg.Interval = DefaultInterval
+	}
+	targets := cfg.Targets
+	if targets == nil {
+		targets = DefaultEngineTargets()
+	}
+	gpuFn := cfg.GPUFn
+	if gpuFn == nil {
+		gpuFn = collectGPUStats
+	}
+	c := &Collector{
+		interval: cfg.Interval,
+		targets:  targets,
+		gpuFn:    gpuFn,
+		now:      time.Now,
+	}
+	for _, t := range targets {
+		if _, ok := dialects[t.Engine]; !ok {
+			continue
+		}
+		c.scrapers = append(c.scrapers, newEngineScraper(t.Engine, t.Port, scrapeTimeout))
+	}
+	return c
+}
+
+// Interval returns the configured collection interval.
+func (c *Collector) Interval() time.Duration { return c.interval }
+
+// Run collects immediately and then on every interval tick until the context
+// is cancelled. It never returns an error and never panics out: telemetry
+// must not be able to take down the node process.
+func (c *Collector) Run(ctx context.Context) {
+	c.collectOnce(ctx)
+
+	ticker := time.NewTicker(c.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.collectOnce(ctx)
+		}
+	}
+}
+
+// collectOnce runs one collection cycle and swaps the cached block. Any panic
+// in collection (a parser bug on a hostile /metrics response, a driver
+// oddity) is swallowed: the cache simply keeps its previous value and ages
+// out via the Latest() staleness bound.
+func (c *Collector) collectOnce(ctx context.Context) {
+	defer func() {
+		_ = recover()
+	}()
+
+	block := &StatsBlock{
+		V:    StatsVersion,
+		TS:   c.now().Unix(),
+		GPUs: c.gpuFn(ctx),
+	}
+	for _, s := range c.scrapers {
+		if stat := s.Observe(ctx); stat != nil {
+			block.Inference = append(block.Inference, *stat)
+		}
+	}
+
+	c.mu.Lock()
+	c.latest = block
+	c.collectedAt = c.now()
+	c.mu.Unlock()
+}
+
+// Latest returns the most recently collected stats block, or nil when nothing
+// has been collected yet or the cache has gone stale (the collector stopped
+// refreshing for over 3 intervals — e.g. wedged behind a hung subprocess).
+// Nil means the heartbeat ships no stats field at all, exactly like a legacy
+// node. Never blocks.
+func (c *Collector) Latest() *StatsBlock {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.latest == nil {
+		return nil
+	}
+	maxAge := 3 * c.interval
+	if minAge := 30 * time.Second; maxAge < minAge {
+		maxAge = minAge
+	}
+	if c.now().Sub(c.collectedAt) > maxAge {
+		return nil
+	}
+	return c.latest
+}

--- a/internal/pulse/collector_test.go
+++ b/internal/pulse/collector_test.go
@@ -1,0 +1,143 @@
+package pulse
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestCollectorOmitsEmptyArrays(t *testing.T) {
+	// CPU-only node with no inference engine: the block still ships (v/ts
+	// prove the collector is alive) but carries no gpus/inference arrays.
+	c := NewCollector(CollectorConfig{
+		Targets: []EngineTarget{},
+		GPUFn:   func(context.Context) []GPUStat { return nil },
+	})
+	c.collectOnce(context.Background())
+
+	block := c.Latest()
+	if block == nil {
+		t.Fatal("expected a block after collection")
+	}
+	if block.V != StatsVersion {
+		t.Errorf("v: got %d, want %d", block.V, StatsVersion)
+	}
+	if block.TS == 0 {
+		t.Error("ts must be set")
+	}
+	if block.GPUs != nil || block.Inference != nil {
+		t.Errorf("empty collections must be nil (omitted on the wire): gpus=%v inference=%v", block.GPUs, block.Inference)
+	}
+}
+
+func TestCollectorLatestBeforeFirstCollection(t *testing.T) {
+	c := NewCollector(CollectorConfig{Targets: []EngineTarget{}})
+	if got := c.Latest(); got != nil {
+		t.Errorf("expected nil before first collection, got %+v", got)
+	}
+}
+
+func TestCollectorLatestGoesStale(t *testing.T) {
+	c := NewCollector(CollectorConfig{
+		Interval: 10 * time.Second,
+		Targets:  []EngineTarget{},
+		GPUFn:    func(context.Context) []GPUStat { return []GPUStat{{Index: 0}} },
+	})
+	base := time.Unix(1753142400, 0)
+	c.now = func() time.Time { return base }
+	c.collectOnce(context.Background())
+
+	// Fresh: served.
+	if c.Latest() == nil {
+		t.Fatal("fresh block must be served")
+	}
+	// Within 3 intervals: still served (stale beats absent).
+	c.now = func() time.Time { return base.Add(29 * time.Second) }
+	if c.Latest() == nil {
+		t.Error("block within the staleness bound must be served")
+	}
+	// Beyond 3 intervals: the collector is wedged; ship nothing rather than
+	// ancient numbers.
+	c.now = func() time.Time { return base.Add(31 * time.Second) }
+	if got := c.Latest(); got != nil {
+		t.Errorf("stale block must not be served, got %+v", got)
+	}
+}
+
+func TestCollectorSurvivesPanickingSource(t *testing.T) {
+	c := NewCollector(CollectorConfig{
+		Targets: []EngineTarget{},
+		GPUFn:   func(context.Context) []GPUStat { panic("driver went sideways") },
+	})
+	// Must not propagate: the heartbeat process stays alive and simply has no
+	// stats block.
+	c.collectOnce(context.Background())
+	if got := c.Latest(); got != nil {
+		t.Errorf("panicking collection must leave no block, got %+v", got)
+	}
+}
+
+func TestDefaultEngineTargets(t *testing.T) {
+	targets := DefaultEngineTargets()
+	if len(targets) != 2 {
+		t.Fatalf("expected vllm + sglang, got %+v", targets)
+	}
+	// Sorted by engine name for deterministic block ordering.
+	if targets[0].Engine != "sglang" || targets[1].Engine != "vllm" {
+		t.Errorf("ordering: got %+v", targets)
+	}
+	for _, tgt := range targets {
+		if tgt.Port <= 0 {
+			t.Errorf("%s has no port: %+v", tgt.Engine, tgt)
+		}
+		if _, ok := dialects[tgt.Engine]; !ok {
+			t.Errorf("%s has no metrics dialect", tgt.Engine)
+		}
+	}
+}
+
+func TestDisabled(t *testing.T) {
+	cases := []struct {
+		val  string
+		want bool
+	}{
+		{"", false},
+		{"1", false},
+		{"true", false},
+		{"anything", false},
+		{"0", true},
+		{"false", true},
+		{"no", true},
+		{"off", true},
+		{" FALSE ", true},
+	}
+	for _, tc := range cases {
+		t.Setenv(EnvVar, tc.val)
+		if got := Disabled(); got != tc.want {
+			t.Errorf("Disabled() with %q = %v, want %v", tc.val, got, tc.want)
+		}
+	}
+}
+
+func TestResolveInterval(t *testing.T) {
+	t.Setenv(IntervalEnvVar, "")
+	if got := ResolveInterval(""); got != DefaultInterval {
+		t.Errorf("default: got %v", got)
+	}
+	if got := ResolveInterval("30s"); got != 30*time.Second {
+		t.Errorf("flag: got %v", got)
+	}
+	t.Setenv(IntervalEnvVar, "1m")
+	if got := ResolveInterval(""); got != time.Minute {
+		t.Errorf("env: got %v", got)
+	}
+	// Flag beats env.
+	if got := ResolveInterval("15s"); got != 15*time.Second {
+		t.Errorf("flag precedence: got %v", got)
+	}
+	// Malformed and non-positive fall through to the default.
+	t.Setenv(IntervalEnvVar, "bogus")
+	if got := ResolveInterval("-5s"); got != DefaultInterval {
+		t.Errorf("malformed: got %v", got)
+	}
+}

--- a/internal/pulse/gpu.go
+++ b/internal/pulse/gpu.go
@@ -1,0 +1,103 @@
+package pulse
+
+import (
+	"context"
+	"math"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// nvidiaSMITimeout bounds the nvidia-smi subprocess so a hung driver can never
+// stall a collection cycle (the heartbeat itself is already isolated from the
+// collector, but a wedged cycle would stop refreshing the cache).
+const nvidiaSMITimeout = 3 * time.Second
+
+// nvidiaSMIQuery is the exact --query-gpu field list; parseNvidiaSMICSV
+// depends on this order.
+const nvidiaSMIQuery = "index,utilization.gpu,memory.used,memory.total,temperature.gpu,power.draw"
+
+// collectGPUStats queries nvidia-smi for per-GPU utilization. It returns nil
+// (omit the gpus array) when the binary is absent, times out, or errors —
+// a CPU-only node is the normal case, not a failure.
+func collectGPUStats(ctx context.Context) []GPUStat {
+	path, err := exec.LookPath("nvidia-smi")
+	if err != nil {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, nvidiaSMITimeout)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, path,
+		"--query-gpu="+nvidiaSMIQuery,
+		"--format=csv,noheader,nounits",
+	).Output()
+	if err != nil {
+		return nil
+	}
+	return parseNvidiaSMICSV(string(out))
+}
+
+// parseNvidiaSMICSV parses `nvidia-smi --query-gpu=... --format=csv,noheader,nounits`
+// output, one GPU per line. Fields nvidia-smi reports as unavailable
+// ("[N/A]", "[Not Supported]", ...) are omitted from the entry rather than
+// zero-filled. A row whose index does not parse falls back to its line order.
+func parseNvidiaSMICSV(out string) []GPUStat {
+	var gpus []GPUStat
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Split(line, ",")
+		// index, util, mem.used, mem.total, temp, power
+		if len(fields) < 6 {
+			continue
+		}
+		gpu := GPUStat{Index: len(gpus)}
+		if v, ok := smiInt(fields[0]); ok {
+			gpu.Index = v
+		}
+		if v, ok := smiFloat(fields[1]); ok {
+			gpu.UtilPct = float64Ptr(v)
+		}
+		if v, ok := smiInt(fields[2]); ok {
+			gpu.MemUsedMB = intPtr(v)
+		}
+		if v, ok := smiInt(fields[3]); ok {
+			gpu.MemTotalMB = intPtr(v)
+		}
+		if v, ok := smiInt(fields[4]); ok {
+			gpu.TempC = intPtr(v)
+		}
+		if v, ok := smiFloat(fields[5]); ok {
+			gpu.PowerW = float64Ptr(round1(v))
+		}
+		gpus = append(gpus, gpu)
+	}
+	return gpus
+}
+
+// smiFloat parses one nvidia-smi CSV field, reporting ok=false for the
+// sentinel "not available" markers so callers omit the field.
+func smiFloat(field string) (float64, bool) {
+	s := strings.TrimSpace(field)
+	if s == "" || strings.HasPrefix(s, "[") || strings.EqualFold(s, "N/A") {
+		return 0, false
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}
+
+func smiInt(field string) (int, bool) {
+	v, ok := smiFloat(field)
+	if !ok {
+		return 0, false
+	}
+	return int(math.Round(v)), true
+}

--- a/internal/pulse/gpu_test.go
+++ b/internal/pulse/gpu_test.go
@@ -1,0 +1,64 @@
+package pulse
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseNvidiaSMICSV(t *testing.T) {
+	t.Run("two gpus", func(t *testing.T) {
+		out := "0, 85, 22528, 24576, 68, 259.42\n1, 0, 4, 24576, 31, 18.66\n"
+		gpus := parseNvidiaSMICSV(out)
+		if len(gpus) != 2 {
+			t.Fatalf("expected 2 gpus, got %d", len(gpus))
+		}
+		g := gpus[0]
+		if g.Index != 0 ||
+			g.UtilPct == nil || *g.UtilPct != 85 ||
+			g.MemUsedMB == nil || *g.MemUsedMB != 22528 ||
+			g.MemTotalMB == nil || *g.MemTotalMB != 24576 ||
+			g.TempC == nil || *g.TempC != 68 ||
+			g.PowerW == nil || *g.PowerW != 259.4 {
+			b, _ := json.Marshal(g)
+			t.Errorf("gpu 0 parsed wrong: %s", b)
+		}
+		if gpus[1].Index != 1 {
+			t.Errorf("gpu 1 index: got %d", gpus[1].Index)
+		}
+	})
+
+	t.Run("unavailable fields are omitted, not zero-filled", func(t *testing.T) {
+		out := "0, 85, 22528, 24576, [N/A], [Not Supported]\n"
+		gpus := parseNvidiaSMICSV(out)
+		if len(gpus) != 1 {
+			t.Fatalf("expected 1 gpu, got %d", len(gpus))
+		}
+		if gpus[0].TempC != nil || gpus[0].PowerW != nil {
+			t.Errorf("N/A fields must be nil: temp=%v power=%v", gpus[0].TempC, gpus[0].PowerW)
+		}
+		b, err := json.Marshal(gpus[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := `{"i":0,"util_pct":85,"mem_used_mb":22528,"mem_total_mb":24576}`; string(b) != want {
+			t.Errorf("got %s, want %s", b, want)
+		}
+	})
+
+	t.Run("garbage and empty input", func(t *testing.T) {
+		if gpus := parseNvidiaSMICSV(""); gpus != nil {
+			t.Errorf("empty input: got %+v", gpus)
+		}
+		if gpus := parseNvidiaSMICSV("not,enough\nfields\n"); gpus != nil {
+			t.Errorf("garbage input: got %+v", gpus)
+		}
+	})
+
+	t.Run("unparseable index falls back to row order", func(t *testing.T) {
+		out := "[N/A], 10, 100, 200, 40, 50\n[N/A], 20, 100, 200, 40, 50\n"
+		gpus := parseNvidiaSMICSV(out)
+		if len(gpus) != 2 || gpus[0].Index != 0 || gpus[1].Index != 1 {
+			t.Errorf("row-order fallback failed: %+v", gpus)
+		}
+	})
+}

--- a/internal/pulse/inference.go
+++ b/internal/pulse/inference.go
@@ -1,0 +1,363 @@
+package pulse
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"net/http"
+	"sort"
+	"time"
+)
+
+// engineDialect names the Prometheus series that carry each contract field for
+// one inference engine. Any slice may be empty when the engine has no such
+// signal; the corresponding contract field is then omitted.
+//
+// Metric-name drift across engine versions is handled by listing every known
+// spelling; the first family that yields data wins.
+type engineDialect struct {
+	// genTPSGauges / promptTPSGauges are direct tokens-per-second gauges
+	// (older vLLM exposed these; SGLang exposes gen_throughput).
+	genTPSGauges    []string
+	promptTPSGauges []string
+	// genTokenCounters / promptTokenCounters are monotonic token counters used
+	// to compute a rate across consecutive scrapes when no gauge is exposed.
+	genTokenCounters    []string
+	promptTokenCounters []string
+	// kvCacheFractionGauges report KV-cache utilization as a 0-1 fraction.
+	kvCacheFractionGauges []string
+	// runningGauges / waitingGauges are live request-queue gauges.
+	runningGauges []string
+	waitingGauges []string
+	// ttftHist / e2eHist are histogram base names (seconds) for
+	// time-to-first-token and end-to-end request latency.
+	ttftHist string
+	e2eHist  string
+}
+
+// dialects maps engine name -> metrics dialect.
+//
+// vLLM (OpenAI server, /metrics):
+//   - throughput: vllm:avg_generation_throughput_toks_per_s and
+//     vllm:avg_prompt_throughput_toks_per_s were removed in newer versions in
+//     favor of the counters vllm:generation_tokens_total /
+//     vllm:prompt_tokens_total, so both paths are listed.
+//   - KV cache: vllm:gpu_cache_usage_perc (V0) / vllm:kv_cache_usage_perc (V1),
+//     both 0-1 fractions despite the "perc" name.
+//   - queues: vllm:num_requests_running / vllm:num_requests_waiting.
+//   - latency: vllm:time_to_first_token_seconds and
+//     vllm:e2e_request_latency_seconds histograms.
+//
+// SGLang (/metrics): sglang:gen_throughput gauge (tok/s),
+// sglang:prompt_tokens_total / sglang:generation_tokens_total counters,
+// sglang:token_usage (0-1 KV token capacity in use),
+// sglang:num_running_reqs / sglang:num_queue_reqs, and the same two latency
+// histogram names under the sglang: prefix. SGLang exposes no prompt
+// throughput gauge, so prompt_tps always comes from the counter rate.
+var dialects = map[string]engineDialect{
+	"vllm": {
+		genTPSGauges:          []string{"vllm:avg_generation_throughput_toks_per_s"},
+		promptTPSGauges:       []string{"vllm:avg_prompt_throughput_toks_per_s"},
+		genTokenCounters:      []string{"vllm:generation_tokens_total"},
+		promptTokenCounters:   []string{"vllm:prompt_tokens_total"},
+		kvCacheFractionGauges: []string{"vllm:gpu_cache_usage_perc", "vllm:kv_cache_usage_perc"},
+		runningGauges:         []string{"vllm:num_requests_running"},
+		waitingGauges:         []string{"vllm:num_requests_waiting"},
+		ttftHist:              "vllm:time_to_first_token_seconds",
+		e2eHist:               "vllm:e2e_request_latency_seconds",
+	},
+	"sglang": {
+		genTPSGauges:          []string{"sglang:gen_throughput"},
+		genTokenCounters:      []string{"sglang:generation_tokens_total"},
+		promptTokenCounters:   []string{"sglang:prompt_tokens_total"},
+		kvCacheFractionGauges: []string{"sglang:token_usage"},
+		runningGauges:         []string{"sglang:num_running_reqs"},
+		waitingGauges:         []string{"sglang:num_queue_reqs"},
+		ttftHist:              "sglang:time_to_first_token_seconds",
+		e2eHist:               "sglang:e2e_request_latency_seconds",
+	},
+}
+
+// modelNameLabel is the label both vLLM and SGLang attach to their series to
+// identify the served model.
+const modelNameLabel = "model_name"
+
+// engineScraper scrapes one engine's /metrics endpoint and folds consecutive
+// samples into an InferenceStat. It keeps the previous sample as the baseline
+// for counter rates and windowed histogram percentiles. Not safe for
+// concurrent use; the Collector calls it from a single goroutine.
+type engineScraper struct {
+	engine  string
+	port    int
+	dialect engineDialect
+	client  *http.Client
+	now     func() time.Time
+
+	prev *scrapeSample
+}
+
+// scrapeSample is the rate/percentile baseline retained between scrapes.
+type scrapeSample struct {
+	at time.Time
+
+	genTokens       float64
+	hasGenTokens    bool
+	promptTokens    float64
+	hasPromptTokens bool
+
+	ttft histSnapshot
+	e2e  histSnapshot
+}
+
+// histSnapshot is a cumulative histogram state: bucket upper bound (le) ->
+// cumulative count, summed across label sets.
+type histSnapshot struct {
+	buckets map[float64]float64
+	count   float64
+	has     bool
+}
+
+func newEngineScraper(engine string, port int, timeout time.Duration) *engineScraper {
+	return &engineScraper{
+		engine:  engine,
+		port:    port,
+		dialect: dialects[engine],
+		client:  &http.Client{Timeout: timeout},
+		now:     time.Now,
+	}
+}
+
+// Observe scrapes the engine's metrics endpoint and returns the current
+// InferenceStat, or nil when the engine is absent, unreachable, warming, or
+// exposes none of the dialect's series. Failures also drop the rate baseline
+// so a restarted engine never produces rates computed across the gap.
+func (s *engineScraper) Observe(ctx context.Context) *InferenceStat {
+	samples, err := s.fetch(ctx)
+	if err != nil {
+		s.prev = nil
+		return nil
+	}
+
+	byName := make(map[string][]promSample)
+	for _, sm := range samples {
+		byName[sm.name] = append(byName[sm.name], sm)
+	}
+
+	stat := &InferenceStat{Engine: s.engine, Port: s.port}
+	matched := false
+
+	// Direct gauges.
+	if v, ok := sumGauges(byName, s.dialect.genTPSGauges); ok {
+		stat.GenTPS = float64Ptr(v)
+		matched = true
+	}
+	if v, ok := sumGauges(byName, s.dialect.promptTPSGauges); ok {
+		stat.PromptTPS = float64Ptr(v)
+		matched = true
+	}
+	if v, ok := sumGauges(byName, s.dialect.kvCacheFractionGauges); ok {
+		stat.KVCachePct = float64Ptr(round1(v * 100))
+		matched = true
+	}
+	if v, ok := sumGauges(byName, s.dialect.runningGauges); ok {
+		stat.Running = intPtr(int(math.Round(v)))
+		matched = true
+	}
+	if v, ok := sumGauges(byName, s.dialect.waitingGauges); ok {
+		stat.Waiting = intPtr(int(math.Round(v)))
+		matched = true
+	}
+
+	// Served model, from the model_name label on any dialect series.
+	stat.Model = findModelName(byName, s.dialect)
+
+	// Rate/percentile fields need a previous sample as the baseline.
+	cur := scrapeSample{at: s.now()}
+	cur.genTokens, cur.hasGenTokens = sumGauges(byName, s.dialect.genTokenCounters)
+	cur.promptTokens, cur.hasPromptTokens = sumGauges(byName, s.dialect.promptTokenCounters)
+	cur.ttft = snapshotHistogram(byName, s.dialect.ttftHist)
+	cur.e2e = snapshotHistogram(byName, s.dialect.e2eHist)
+	matched = matched || cur.hasGenTokens || cur.hasPromptTokens || cur.ttft.has || cur.e2e.has
+
+	if s.prev != nil {
+		dt := cur.at.Sub(s.prev.at).Seconds()
+		// Counter-derived throughput fills in only when no gauge was exposed.
+		if stat.GenTPS == nil && cur.hasGenTokens && s.prev.hasGenTokens {
+			if rate, ok := counterRate(s.prev.genTokens, cur.genTokens, dt); ok {
+				stat.GenTPS = float64Ptr(rate)
+			}
+		}
+		if stat.PromptTPS == nil && cur.hasPromptTokens && s.prev.hasPromptTokens {
+			if rate, ok := counterRate(s.prev.promptTokens, cur.promptTokens, dt); ok {
+				stat.PromptTPS = float64Ptr(rate)
+			}
+		}
+		if p50, ok := histogramP50Delta(s.prev.ttft, cur.ttft); ok {
+			stat.TTFTMsP50 = float64Ptr(round1(p50 * 1000))
+		}
+		if p50, ok := histogramP50Delta(s.prev.e2e, cur.e2e); ok {
+			stat.E2EMsP50 = float64Ptr(round1(p50 * 1000))
+		}
+	}
+	s.prev = &cur
+
+	// Nothing recognized at all: some other service answered on this port.
+	// Report nothing rather than a hollow entry.
+	if !matched {
+		return nil
+	}
+	return stat
+}
+
+// fetch GETs the engine's /metrics endpoint on loopback and parses it.
+func (s *engineScraper) fetch(ctx context.Context) ([]promSample, error) {
+	url := fmt.Sprintf("http://127.0.0.1:%d/metrics", s.port)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("metrics endpoint returned %d", resp.StatusCode)
+	}
+	return parsePromText(resp.Body), nil
+}
+
+// sumGauges sums every series of the first metric family (in listed priority
+// order) that is present. Summing across label sets is correct both for
+// per-label counter fan-out and for single-series gauges.
+func sumGauges(byName map[string][]promSample, names []string) (float64, bool) {
+	for _, name := range names {
+		samples, ok := byName[name]
+		if !ok || len(samples) == 0 {
+			continue
+		}
+		var sum float64
+		for _, s := range samples {
+			sum += s.value
+		}
+		return sum, true
+	}
+	return 0, false
+}
+
+// findModelName returns the model_name label from the first dialect series
+// that carries one, or "".
+func findModelName(byName map[string][]promSample, d engineDialect) string {
+	families := make([]string, 0, 16)
+	families = append(families, d.runningGauges...)
+	families = append(families, d.waitingGauges...)
+	families = append(families, d.kvCacheFractionGauges...)
+	families = append(families, d.genTokenCounters...)
+	families = append(families, d.promptTokenCounters...)
+	families = append(families, d.genTPSGauges...)
+	families = append(families, d.promptTPSGauges...)
+	for _, name := range families {
+		for _, s := range byName[name] {
+			if m := s.labels[modelNameLabel]; m != "" {
+				return m
+			}
+		}
+	}
+	return ""
+}
+
+// snapshotHistogram folds a histogram family's _bucket/_count series into a
+// cumulative snapshot, summing across label sets per bucket bound.
+func snapshotHistogram(byName map[string][]promSample, base string) histSnapshot {
+	if base == "" {
+		return histSnapshot{}
+	}
+	snap := histSnapshot{buckets: make(map[float64]float64)}
+	for _, s := range byName[base+"_bucket"] {
+		le, err := parseLe(s.labels["le"])
+		if err != nil {
+			continue
+		}
+		snap.buckets[le] += s.value
+		snap.has = true
+	}
+	for _, s := range byName[base+"_count"] {
+		snap.count += s.value
+	}
+	// Some expositions omit _count; fall back to the +Inf bucket.
+	if snap.has && snap.count == 0 {
+		snap.count = snap.buckets[math.Inf(1)]
+	}
+	return snap
+}
+
+func parseLe(v string) (float64, error) {
+	if v == "+Inf" {
+		return math.Inf(1), nil
+	}
+	var f float64
+	_, err := fmt.Sscanf(v, "%g", &f)
+	return f, err
+}
+
+// counterRate computes a per-second rate from two monotonic counter readings.
+// A negative delta (engine restart / counter reset) or non-positive window
+// yields no rate.
+func counterRate(prev, cur, dtSeconds float64) (float64, bool) {
+	if dtSeconds <= 0 || cur < prev {
+		return 0, false
+	}
+	return round1((cur - prev) / dtSeconds), true
+}
+
+// histogramP50Delta computes the median over the window between two cumulative
+// histogram snapshots, using standard Prometheus-style linear interpolation
+// within the median bucket. Returns ok=false when either snapshot is missing,
+// no request finished in the window, or the counters went backwards (reset).
+func histogramP50Delta(prev, cur histSnapshot) (float64, bool) {
+	if !prev.has || !cur.has {
+		return 0, false
+	}
+	totalDelta := cur.count - prev.count
+	if totalDelta <= 0 {
+		return 0, false
+	}
+
+	les := make([]float64, 0, len(cur.buckets))
+	for le := range cur.buckets {
+		les = append(les, le)
+	}
+	sort.Float64s(les)
+
+	target := totalDelta / 2
+	prevBound := 0.0
+	prevCum := 0.0
+	for _, le := range les {
+		cum := cur.buckets[le] - prev.buckets[le]
+		if cum < prevCum {
+			// Bucket counts went backwards: counter reset mid-window.
+			return 0, false
+		}
+		if cum >= target {
+			if math.IsInf(le, 1) {
+				// Median falls in the overflow bucket: report the highest
+				// finite bound as the best available estimate (matches
+				// histogram_quantile's behavior).
+				return prevBound, true
+			}
+			bucketCount := cum - prevCum
+			if bucketCount <= 0 {
+				return le, true
+			}
+			return prevBound + (le-prevBound)*(target-prevCum)/bucketCount, true
+		}
+		prevBound = le
+		prevCum = cum
+	}
+	return 0, false
+}
+
+// round1 rounds to one decimal place to keep the on-wire block compact.
+func round1(v float64) float64 {
+	return math.Round(v*10) / 10
+}

--- a/internal/pulse/inference_test.go
+++ b/internal/pulse/inference_test.go
@@ -1,0 +1,324 @@
+package pulse
+
+import (
+	"context"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// vllmMetricsT0 / vllmMetricsT1 are canned vLLM /metrics expositions 10s
+// apart. The modern dialect: no throughput gauges, so tokens/s must come from
+// counter deltas, and latency medians from histogram bucket deltas.
+//
+// Windowed math the test asserts (t0 -> t1):
+//   - generation_tokens_total 50000 -> 52520 over 10s  => gen_tps 252.0
+//   - prompt_tokens_total     10000 -> 10000 over 10s  => prompt_tps 0.0
+//   - TTFT bucket deltas: le=1:+0, le=2:+1, le=3:+3, +Inf:+4 (count +4)
+//     median target 2 falls in le=3: 2 + (3-2)*(2-1)/2 = 2.5s => 2500ms
+//   - e2e bucket deltas: le=10:+0, le=20:+2, le=30:+4, +Inf:+4
+//     median target 2 falls in le=20: 10 + (20-10)*(2-0)/2 = 20s => 20000ms
+const vllmMetricsT0 = `# HELP vllm:num_requests_running Number of requests currently running on GPU.
+# TYPE vllm:num_requests_running gauge
+vllm:num_requests_running{model_name="Qwen/Qwen3-9B"} 4.0
+vllm:num_requests_waiting{model_name="Qwen/Qwen3-9B"} 0.0
+vllm:gpu_cache_usage_perc{model_name="Qwen/Qwen3-9B"} 0.777
+vllm:prompt_tokens_total{model_name="Qwen/Qwen3-9B"} 10000.0
+vllm:generation_tokens_total{model_name="Qwen/Qwen3-9B"} 50000.0
+vllm:time_to_first_token_seconds_bucket{le="1",model_name="Qwen/Qwen3-9B"} 100
+vllm:time_to_first_token_seconds_bucket{le="2",model_name="Qwen/Qwen3-9B"} 150
+vllm:time_to_first_token_seconds_bucket{le="3",model_name="Qwen/Qwen3-9B"} 190
+vllm:time_to_first_token_seconds_bucket{le="+Inf",model_name="Qwen/Qwen3-9B"} 200
+vllm:time_to_first_token_seconds_count{model_name="Qwen/Qwen3-9B"} 200
+vllm:e2e_request_latency_seconds_bucket{le="10",model_name="Qwen/Qwen3-9B"} 40
+vllm:e2e_request_latency_seconds_bucket{le="20",model_name="Qwen/Qwen3-9B"} 120
+vllm:e2e_request_latency_seconds_bucket{le="30",model_name="Qwen/Qwen3-9B"} 195
+vllm:e2e_request_latency_seconds_bucket{le="+Inf",model_name="Qwen/Qwen3-9B"} 200
+vllm:e2e_request_latency_seconds_count{model_name="Qwen/Qwen3-9B"} 200
+`
+
+const vllmMetricsT1 = `vllm:num_requests_running{model_name="Qwen/Qwen3-9B"} 4.0
+vllm:num_requests_waiting{model_name="Qwen/Qwen3-9B"} 0.0
+vllm:gpu_cache_usage_perc{model_name="Qwen/Qwen3-9B"} 0.777
+vllm:prompt_tokens_total{model_name="Qwen/Qwen3-9B"} 10000.0
+vllm:generation_tokens_total{model_name="Qwen/Qwen3-9B"} 52520.0
+vllm:time_to_first_token_seconds_bucket{le="1",model_name="Qwen/Qwen3-9B"} 100
+vllm:time_to_first_token_seconds_bucket{le="2",model_name="Qwen/Qwen3-9B"} 151
+vllm:time_to_first_token_seconds_bucket{le="3",model_name="Qwen/Qwen3-9B"} 193
+vllm:time_to_first_token_seconds_bucket{le="+Inf",model_name="Qwen/Qwen3-9B"} 204
+vllm:time_to_first_token_seconds_count{model_name="Qwen/Qwen3-9B"} 204
+vllm:e2e_request_latency_seconds_bucket{le="10",model_name="Qwen/Qwen3-9B"} 40
+vllm:e2e_request_latency_seconds_bucket{le="20",model_name="Qwen/Qwen3-9B"} 122
+vllm:e2e_request_latency_seconds_bucket{le="30",model_name="Qwen/Qwen3-9B"} 199
+vllm:e2e_request_latency_seconds_bucket{le="+Inf",model_name="Qwen/Qwen3-9B"} 204
+vllm:e2e_request_latency_seconds_count{model_name="Qwen/Qwen3-9B"} 204
+`
+
+// vllmLegacyMetrics is the older vLLM dialect that still exposed throughput
+// gauges directly.
+const vllmLegacyMetrics = `vllm:avg_generation_throughput_toks_per_s{model_name="mistral-7b"} 252.0
+vllm:avg_prompt_throughput_toks_per_s{model_name="mistral-7b"} 0.0
+vllm:gpu_cache_usage_perc{model_name="mistral-7b"} 0.5
+vllm:num_requests_running{model_name="mistral-7b"} 2.0
+vllm:num_requests_waiting{model_name="mistral-7b"} 1.0
+`
+
+// sglangMetrics is a canned SGLang exposition: gen throughput gauge,
+// token_usage fraction, running/queued gauges.
+const sglangMetrics = `# TYPE sglang:gen_throughput gauge
+sglang:gen_throughput{model_name="meta-llama/Llama-3.1-8B-Instruct"} 117.3
+sglang:token_usage{model_name="meta-llama/Llama-3.1-8B-Instruct"} 0.284
+sglang:num_running_reqs{model_name="meta-llama/Llama-3.1-8B-Instruct"} 3.0
+sglang:num_queue_reqs{model_name="meta-llama/Llama-3.1-8B-Instruct"} 0.0
+sglang:prompt_tokens_total{model_name="meta-llama/Llama-3.1-8B-Instruct"} 5000.0
+sglang:generation_tokens_total{model_name="meta-llama/Llama-3.1-8B-Instruct"} 20000.0
+`
+
+// metricsServer serves a swappable metrics body and returns a scraper aimed
+// at it.
+func metricsServer(t *testing.T, engine string) (*httptest.Server, *engineScraper, *string) {
+	t.Helper()
+	body := ""
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if body == "" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("test server port: %v", err)
+	}
+	return srv, newEngineScraper(engine, port, time.Second), &body
+}
+
+func TestVLLMCounterRateAndHistogramP50(t *testing.T) {
+	_, scraper, body := metricsServer(t, "vllm")
+
+	t0 := time.Unix(1753142400, 0)
+	scraper.now = func() time.Time { return t0 }
+
+	*body = vllmMetricsT0
+	stat := scraper.Observe(context.Background())
+	if stat == nil {
+		t.Fatal("first scrape returned nil")
+	}
+	// First scrape has no baseline: gauges present, rates/percentiles omitted.
+	if stat.Engine != "vllm" {
+		t.Errorf("engine: got %q", stat.Engine)
+	}
+	if stat.Model != "Qwen/Qwen3-9B" {
+		t.Errorf("model: got %q", stat.Model)
+	}
+	if stat.Running == nil || *stat.Running != 4 {
+		t.Errorf("running: got %v", stat.Running)
+	}
+	if stat.Waiting == nil || *stat.Waiting != 0 {
+		t.Errorf("waiting: got %v", stat.Waiting)
+	}
+	if stat.KVCachePct == nil || *stat.KVCachePct != 77.7 {
+		t.Errorf("kv_cache_pct: got %v", stat.KVCachePct)
+	}
+	if stat.GenTPS != nil || stat.PromptTPS != nil {
+		t.Errorf("first scrape must omit counter-derived tps, got gen=%v prompt=%v", stat.GenTPS, stat.PromptTPS)
+	}
+	if stat.TTFTMsP50 != nil || stat.E2EMsP50 != nil {
+		t.Errorf("first scrape must omit windowed p50s, got ttft=%v e2e=%v", stat.TTFTMsP50, stat.E2EMsP50)
+	}
+
+	// Second scrape, 10s later: rates and windowed medians appear.
+	scraper.now = func() time.Time { return t0.Add(10 * time.Second) }
+	*body = vllmMetricsT1
+	stat = scraper.Observe(context.Background())
+	if stat == nil {
+		t.Fatal("second scrape returned nil")
+	}
+	if stat.GenTPS == nil || *stat.GenTPS != 252.0 {
+		t.Errorf("gen_tps: got %v, want 252.0", deref(stat.GenTPS))
+	}
+	if stat.PromptTPS == nil || *stat.PromptTPS != 0.0 {
+		t.Errorf("prompt_tps: got %v, want 0.0", deref(stat.PromptTPS))
+	}
+	if stat.TTFTMsP50 == nil || *stat.TTFTMsP50 != 2500 {
+		t.Errorf("ttft_ms_p50: got %v, want 2500", deref(stat.TTFTMsP50))
+	}
+	if stat.E2EMsP50 == nil || *stat.E2EMsP50 != 20000 {
+		t.Errorf("e2e_ms_p50: got %v, want 20000", deref(stat.E2EMsP50))
+	}
+}
+
+func TestVLLMLegacyThroughputGauges(t *testing.T) {
+	_, scraper, body := metricsServer(t, "vllm")
+	*body = vllmLegacyMetrics
+
+	stat := scraper.Observe(context.Background())
+	if stat == nil {
+		t.Fatal("scrape returned nil")
+	}
+	// Gauges are direct: available on the very first scrape, no baseline needed.
+	if stat.GenTPS == nil || *stat.GenTPS != 252.0 {
+		t.Errorf("gen_tps: got %v, want 252.0", deref(stat.GenTPS))
+	}
+	if stat.PromptTPS == nil || *stat.PromptTPS != 0.0 {
+		t.Errorf("prompt_tps: got %v, want 0.0", deref(stat.PromptTPS))
+	}
+	if stat.KVCachePct == nil || *stat.KVCachePct != 50.0 {
+		t.Errorf("kv_cache_pct: got %v, want 50.0", deref(stat.KVCachePct))
+	}
+	if stat.Running == nil || *stat.Running != 2 || stat.Waiting == nil || *stat.Waiting != 1 {
+		t.Errorf("queues: running=%v waiting=%v", stat.Running, stat.Waiting)
+	}
+	if stat.Model != "mistral-7b" {
+		t.Errorf("model: got %q", stat.Model)
+	}
+	// Latency histograms absent from this exposition: fields omitted.
+	if stat.TTFTMsP50 != nil || stat.E2EMsP50 != nil {
+		t.Errorf("expected omitted p50s, got ttft=%v e2e=%v", stat.TTFTMsP50, stat.E2EMsP50)
+	}
+}
+
+func TestSGLangDialect(t *testing.T) {
+	_, scraper, body := metricsServer(t, "sglang")
+	*body = sglangMetrics
+
+	stat := scraper.Observe(context.Background())
+	if stat == nil {
+		t.Fatal("scrape returned nil")
+	}
+	if stat.Engine != "sglang" {
+		t.Errorf("engine: got %q", stat.Engine)
+	}
+	if stat.Model != "meta-llama/Llama-3.1-8B-Instruct" {
+		t.Errorf("model: got %q", stat.Model)
+	}
+	if stat.GenTPS == nil || *stat.GenTPS != 117.3 {
+		t.Errorf("gen_tps: got %v, want 117.3", deref(stat.GenTPS))
+	}
+	if stat.KVCachePct == nil || *stat.KVCachePct != 28.4 {
+		t.Errorf("kv_cache_pct: got %v, want 28.4", deref(stat.KVCachePct))
+	}
+	if stat.Running == nil || *stat.Running != 3 || stat.Waiting == nil || *stat.Waiting != 0 {
+		t.Errorf("queues: running=%v waiting=%v", stat.Running, stat.Waiting)
+	}
+	// SGLang has no prompt throughput gauge and this is the first scrape:
+	// prompt_tps omitted, not zero-filled.
+	if stat.PromptTPS != nil {
+		t.Errorf("prompt_tps must be omitted on first scrape, got %v", *stat.PromptTPS)
+	}
+}
+
+func TestScrapeFailuresReturnNil(t *testing.T) {
+	t.Run("endpoint absent", func(t *testing.T) {
+		// A port with nothing listening: connection refused, silently nil.
+		scraper := newEngineScraper("vllm", 1, 200*time.Millisecond)
+		if stat := scraper.Observe(context.Background()); stat != nil {
+			t.Errorf("expected nil for absent endpoint, got %+v", stat)
+		}
+	})
+
+	t.Run("non-200 response", func(t *testing.T) {
+		_, scraper, body := metricsServer(t, "vllm")
+		*body = "" // server 404s on empty body
+		if stat := scraper.Observe(context.Background()); stat != nil {
+			t.Errorf("expected nil for 404, got %+v", stat)
+		}
+	})
+
+	t.Run("wrong service on port", func(t *testing.T) {
+		_, scraper, body := metricsServer(t, "vllm")
+		*body = "some_other_service_metric 1.0\n"
+		if stat := scraper.Observe(context.Background()); stat != nil {
+			t.Errorf("expected nil when no dialect series match, got %+v", stat)
+		}
+	})
+
+	t.Run("failure drops the rate baseline", func(t *testing.T) {
+		_, scraper, body := metricsServer(t, "vllm")
+		*body = vllmMetricsT0
+		if stat := scraper.Observe(context.Background()); stat == nil {
+			t.Fatal("seed scrape failed")
+		}
+		*body = "" // engine goes away (404)
+		if stat := scraper.Observe(context.Background()); stat != nil {
+			t.Fatalf("expected nil during outage, got %+v", stat)
+		}
+		// Engine comes back: no rates on the first post-outage scrape.
+		*body = vllmMetricsT1
+		stat := scraper.Observe(context.Background())
+		if stat == nil {
+			t.Fatal("post-outage scrape failed")
+		}
+		if stat.GenTPS != nil || stat.TTFTMsP50 != nil {
+			t.Errorf("baseline must reset across an outage, got gen_tps=%v ttft=%v", deref(stat.GenTPS), deref(stat.TTFTMsP50))
+		}
+	})
+}
+
+func TestCounterRate(t *testing.T) {
+	if v, ok := counterRate(100, 350, 10); !ok || v != 25.0 {
+		t.Errorf("got %v, %v", v, ok)
+	}
+	if _, ok := counterRate(350, 100, 10); ok {
+		t.Error("counter reset must yield no rate")
+	}
+	if _, ok := counterRate(100, 200, 0); ok {
+		t.Error("zero window must yield no rate")
+	}
+}
+
+func TestHistogramP50Delta(t *testing.T) {
+	inf := math.Inf(1)
+	snap := func(count float64, b map[float64]float64) histSnapshot {
+		return histSnapshot{buckets: b, count: count, has: true}
+	}
+
+	t.Run("no new samples", func(t *testing.T) {
+		s := snap(10, map[float64]float64{1: 5, inf: 10})
+		if _, ok := histogramP50Delta(s, s); ok {
+			t.Error("identical snapshots must yield no p50")
+		}
+	})
+
+	t.Run("median in overflow bucket reports highest finite bound", func(t *testing.T) {
+		prev := snap(0, map[float64]float64{1: 0, 2: 0, inf: 0})
+		cur := snap(10, map[float64]float64{1: 1, 2: 2, inf: 10})
+		p50, ok := histogramP50Delta(prev, cur)
+		if !ok || p50 != 2 {
+			t.Errorf("got %v, %v; want 2, true", p50, ok)
+		}
+	})
+
+	t.Run("counter reset yields no p50", func(t *testing.T) {
+		prev := snap(100, map[float64]float64{1: 50, inf: 100})
+		cur := snap(110, map[float64]float64{1: 3, inf: 110})
+		if _, ok := histogramP50Delta(prev, cur); ok {
+			t.Error("bucket going backwards must yield no p50")
+		}
+	})
+
+	t.Run("missing snapshot", func(t *testing.T) {
+		cur := snap(10, map[float64]float64{1: 10, inf: 10})
+		if _, ok := histogramP50Delta(histSnapshot{}, cur); ok {
+			t.Error("missing prev must yield no p50")
+		}
+	})
+}
+
+// deref formats a *float64 for error messages without nil panics.
+func deref(v *float64) any {
+	if v == nil {
+		return nil
+	}
+	return *v
+}

--- a/internal/pulse/promparse.go
+++ b/internal/pulse/promparse.go
@@ -1,0 +1,130 @@
+package pulse
+
+import (
+	"bufio"
+	"io"
+	"strconv"
+	"strings"
+)
+
+// promSample is one parsed Prometheus exposition sample: bare metric name,
+// label set, and value.
+//
+// The status package's idle tracker (internal/status/idle.go) already has a
+// minimal exposition parser, but it deliberately discards labels. Pulse needs
+// them — histogram buckets are keyed by the "le" label and the served model
+// rides the "model_name" label — so this file carries its own label-aware
+// parser instead of widening that one.
+type promSample struct {
+	name   string
+	labels map[string]string
+	value  float64
+}
+
+// parsePromText reads a Prometheus text-format exposition and returns all
+// samples it can parse, skipping comments, blanks, and malformed lines. It is
+// tolerant by design: a partially garbled exposition yields the parseable
+// subset rather than an error, matching the "absent/partial metrics are not an
+// error" contract.
+func parsePromText(r io.Reader) []promSample {
+	var out []promSample
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if s, ok := parsePromLine(line); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// parsePromLine parses a single exposition sample line:
+//
+//	metric_name{label="value",...} value [timestamp]
+//
+// Label values may contain escaped quotes (\") and any byte except an
+// unescaped quote, including spaces, commas, and braces.
+func parsePromLine(line string) (promSample, bool) {
+	name, rest, labels, ok := splitSeries(line)
+	if !ok {
+		return promSample{}, false
+	}
+	fields := strings.Fields(rest)
+	if len(fields) == 0 {
+		return promSample{}, false
+	}
+	value, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		return promSample{}, false
+	}
+	return promSample{name: name, labels: labels, value: value}, true
+}
+
+// splitSeries splits "name{labels} rest" into the bare name, the remainder
+// after the series token, and the parsed label map (nil when unlabeled).
+func splitSeries(line string) (name, rest string, labels map[string]string, ok bool) {
+	brace := strings.IndexByte(line, '{')
+	// Unlabeled series: name and value split on whitespace.
+	if brace < 0 || strings.IndexFunc(line[:brace], isSpace) >= 0 {
+		sp := strings.IndexFunc(line, isSpace)
+		if sp <= 0 {
+			return "", "", nil, false
+		}
+		return line[:sp], line[sp:], nil, true
+	}
+
+	name = line[:brace]
+	labels = make(map[string]string)
+	i := brace + 1
+	for i < len(line) {
+		// Closing brace ends the label set.
+		if line[i] == '}' {
+			return name, line[i+1:], labels, true
+		}
+		// Parse label name up to '='.
+		eq := strings.IndexByte(line[i:], '=')
+		if eq < 0 {
+			return "", "", nil, false
+		}
+		key := strings.TrimSpace(line[i : i+eq])
+		i += eq + 1
+		if i >= len(line) || line[i] != '"' {
+			return "", "", nil, false
+		}
+		i++ // past opening quote
+		var val strings.Builder
+		for i < len(line) {
+			c := line[i]
+			if c == '\\' && i+1 < len(line) {
+				// Prometheus escapes: \" \\ \n
+				next := line[i+1]
+				switch next {
+				case 'n':
+					val.WriteByte('\n')
+				default:
+					val.WriteByte(next)
+				}
+				i += 2
+				continue
+			}
+			if c == '"' {
+				i++
+				break
+			}
+			val.WriteByte(c)
+			i++
+		}
+		labels[key] = val.String()
+		// Skip a separating comma (and any spaces).
+		for i < len(line) && (line[i] == ',' || line[i] == ' ') {
+			i++
+		}
+	}
+	return "", "", nil, false
+}
+
+func isSpace(r rune) bool { return r == ' ' || r == '\t' }

--- a/internal/pulse/promparse_test.go
+++ b/internal/pulse/promparse_test.go
@@ -1,0 +1,71 @@
+package pulse
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+func TestParsePromText(t *testing.T) {
+	text := `
+# HELP vllm:num_requests_running Number of requests currently running.
+# TYPE vllm:num_requests_running gauge
+vllm:num_requests_running{model_name="Qwen/Qwen3-9B"} 4.0
+plain_gauge 1.5
+vllm:time_to_first_token_seconds_bucket{le="0.5",model_name="Qwen/Qwen3-9B"} 10
+vllm:time_to_first_token_seconds_bucket{le="+Inf",model_name="Qwen/Qwen3-9B"} 12
+escaped{name="he said \"hi\", twice"} 2
+with_timestamp{a="b"} 3.14 1753142400000
+malformed_no_value{
+garbage line
+`
+	samples := parsePromText(strings.NewReader(text))
+	if len(samples) != 6 {
+		t.Fatalf("expected 6 samples, got %d: %+v", len(samples), samples)
+	}
+
+	byName := make(map[string][]promSample)
+	for _, s := range samples {
+		byName[s.name] = append(byName[s.name], s)
+	}
+
+	running := byName["vllm:num_requests_running"]
+	if len(running) != 1 || running[0].value != 4.0 {
+		t.Errorf("running: got %+v", running)
+	}
+	if running[0].labels["model_name"] != "Qwen/Qwen3-9B" {
+		t.Errorf("model_name label: got %q", running[0].labels["model_name"])
+	}
+
+	if v := byName["plain_gauge"]; len(v) != 1 || v[0].value != 1.5 || v[0].labels != nil {
+		t.Errorf("plain_gauge: got %+v", v)
+	}
+
+	buckets := byName["vllm:time_to_first_token_seconds_bucket"]
+	if len(buckets) != 2 {
+		t.Fatalf("buckets: got %+v", buckets)
+	}
+	if buckets[0].labels["le"] != "0.5" || buckets[1].labels["le"] != "+Inf" {
+		t.Errorf("le labels: got %q, %q", buckets[0].labels["le"], buckets[1].labels["le"])
+	}
+
+	if v := byName["escaped"]; len(v) != 1 || v[0].labels["name"] != `he said "hi", twice` {
+		t.Errorf("escaped label: got %+v", v)
+	}
+
+	if v := byName["with_timestamp"]; len(v) != 1 || v[0].value != 3.14 {
+		t.Errorf("with_timestamp: got %+v", v)
+	}
+}
+
+func TestParseLe(t *testing.T) {
+	if v, err := parseLe("+Inf"); err != nil || !math.IsInf(v, 1) {
+		t.Errorf("+Inf: got %v, %v", v, err)
+	}
+	if v, err := parseLe("0.5"); err != nil || v != 0.5 {
+		t.Errorf("0.5: got %v, %v", v, err)
+	}
+	if _, err := parseLe("bogus"); err == nil {
+		t.Error("bogus le should error")
+	}
+}

--- a/services/ports.go
+++ b/services/ports.go
@@ -179,6 +179,26 @@ func ManagedServiceHostPort(name string) (int, bool) {
 	return port, ok
 }
 
+// SGLangHostPort is sglang's native host port (services/compose/sglang.yml).
+// It never collided with anything, so it is not env-var-managed like the 8200
+// block; the constant exists so consumers (the heartbeat stats scraper,
+// internal/jobs/llm_inference.go) share one spelling instead of hardcoding
+// 30000.
+const SGLangHostPort = 30000
+
+// InferenceMetricsPorts maps the inference engines that expose a Prometheus
+// /metrics endpoint on their serving port to the host port citadel publishes
+// them on. This is the discovery source for the heartbeat stats scraper
+// (internal/pulse, citadel-cli#587): scrape targets come from this registry,
+// never from hardcoded literals. Engines without a Prometheus endpoint
+// (ollama, llamacpp, lmstudio) are deliberately absent.
+func InferenceMetricsPorts() map[string]int {
+	return map[string]int{
+		"vllm":   VLLMHostPort,
+		"sglang": SGLangHostPort,
+	}
+}
+
 // Citadel's own listeners. These are NOT module ports; they belong to
 // citadel-internal processes and must never be handed to a module compose file
 // or dynamically allocated to an app.


### PR DESCRIPTION
## Context

Fabric Pulse (aceteam-ai/aceteam#6334) needs live inference internals from every node on the mesh — tokens/s, KV-cache utilization, request queues, latency medians, GPU util/VRAM/temp/power. The sovereign path is node-local collection: Citadel scrapes its own engines and ships a compact block on the heartbeat it already sends. The backend never opens a socket into a node (Railway userspace-tailscaled can't anyway; see the fabric-vpn-relay docs).

Closes #587.

## Wire contract

The aceteam backend/web are being built against this exact shape; field names are load-bearing and pinned by a golden test:

```json
"stats": {
  "v": 1,
  "ts": 1753142400,
  "gpus": [{"i": 0, "util_pct": 85, "mem_used_mb": 22528, "mem_total_mb": 24576, "temp_c": 68, "power_w": 259}],
  "inference": [{"engine": "vllm", "model": "Qwen3-9B", "port": 8201, "gen_tps": 252.0, "prompt_tps": 0.0, "kv_cache_pct": 77.7, "running": 4, "waiting": 0, "ttft_ms_p50": 2500, "e2e_ms_p50": 20000}]
}
```

- `v`/`ts` always present; `gpus`/`inference` arrays omitted entirely when the node has no GPU / no reachable engine.
- Every field inside an entry is optional-when-unavailable: a metric an engine doesn't expose is omitted, never zero-filled. A present zero (`waiting: 0`) is real and shipped.
- The whole `stats` field is optional on the heartbeat — old backends ignore it, old nodes omit it (proven by a marshal test: no provider ⇒ no `stats` key).

## Summary

**`internal/pulse` (new)** — the collector:

- `collector.go` — background goroutine on its own interval (default 10s, `--heartbeat-stats-interval` / `CITADEL_HEARTBEAT_STATS_INTERVAL`) writing a cached latest-block. `Latest()` is a lock-guarded cache read that returns nil before first collection and after 3 missed intervals (a wedged collector degrades to a stats-less heartbeat, not a late one). Collection panics are swallowed — telemetry can never take down the node. Kill switch: `CITADEL_HEARTBEAT_STATS=false` (same pattern as `CITADEL_RECONCILE_PULL`), ON by default.
- `inference.go` — per-engine Prometheus scrape with a dialect table (metric-name drift handled by listing known spellings), counter-delta rates and windowed histogram medians using the previous scrape as baseline. Scrape failure drops the baseline so a restarted engine never yields rates computed across the gap. A non-engine answering the port yields nothing (no hollow entries).
- `promparse.go` — label-aware Prometheus text parser (the idle tracker's parser discards labels; pulse needs `le` for buckets and `model_name` for the model).
- `gpu.go` — `nvidia-smi --query-gpu=index,utilization.gpu,memory.used,memory.total,temperature.gpu,power.draw --format=csv,noheader,nounits`, 3s subprocess timeout; absent binary / error / `[N/A]` fields ⇒ omit.

**Metric mapping** (contract field ← engine series):

| Field | vLLM | SGLang |
|---|---|---|
| `gen_tps` | `vllm:avg_generation_throughput_toks_per_s` gauge (legacy) else rate of `vllm:generation_tokens_total` | `sglang:gen_throughput` gauge, else rate of `sglang:generation_tokens_total` |
| `prompt_tps` | `vllm:avg_prompt_throughput_toks_per_s` gauge (legacy) else rate of `vllm:prompt_tokens_total` | rate of `sglang:prompt_tokens_total` (no gauge exists) |
| `kv_cache_pct` | `vllm:gpu_cache_usage_perc` (V0) / `vllm:kv_cache_usage_perc` (V1), 0-1 fraction ×100 | `sglang:token_usage` ×100 |
| `running` | `vllm:num_requests_running` | `sglang:num_running_reqs` |
| `waiting` | `vllm:num_requests_waiting` | `sglang:num_queue_reqs` |
| `ttft_ms_p50` | `vllm:time_to_first_token_seconds` histogram, windowed bucket-delta median | `sglang:time_to_first_token_seconds` |
| `e2e_ms_p50` | `vllm:e2e_request_latency_seconds` histogram | `sglang:e2e_request_latency_seconds` |
| `model` | `model_name` label on any dialect series | same |

**`services/ports.go`** — scrape targets come from the host-port registry, not literals: new `InferenceMetricsPorts()` (vllm → 8201, sglang → new `SGLangHostPort = 30000` constant). Engines with no Prometheus endpoint (ollama, llamacpp, lmstudio) are deliberately absent.

**`internal/heartbeat`** — `StatusMessage.Stats *pulse.StatsBlock` (`json:"stats,omitempty"`) plus `SetStatsProvider()` on both publishers (`api.go`, `redis.go`). The provider is `pulse.Collector.Latest` — a pure cache read, so the heartbeat path never blocks on or fails because of collection.

**Wiring** — `cmd/work.go` starts the collector inside the heartbeat block and registers it on whichever publisher runs (API or legacy Redis). `cmd/controlcenter.go` mirrors it, but only when the control center is the node's heartbeat publisher (worker-held nodes already collect there), so a node never runs two collectors.

## Test plan

All green: `go build ./...` + full `go test ./...` on the branch.

| Group | Coverage |
|---|---|
| Contract golden (`block_test.go`) | Exact wire JSON for the full contract sample; empty-array omission; entry with only index; present-zero vs absent |
| vLLM scrape (`inference_test.go`) | Canned two-scrape fixture: counter-delta tps (252.0/0.0), windowed histogram p50s (2500ms/20000ms), first-scrape omission; legacy gauge dialect |
| SGLang scrape | Canned fixture: gen_throughput, token_usage ×100, queues, model label, prompt_tps omitted without baseline |
| Failure tolerance | Absent endpoint, 404 (warming), non-engine on port ⇒ nil; outage drops the rate baseline |
| Histogram/rate math | Counter reset, zero window, overflow-bucket median, missing snapshots |
| nvidia-smi CSV (`gpu_test.go`) | Two-GPU parse, `[N/A]`/`[Not Supported]` omission golden, garbage/empty input, index fallback |
| Collector (`collector_test.go`) | Empty collections ⇒ omitted arrays; nil before first collect; staleness bound (3 intervals); panic containment; kill-switch + interval resolution |
| Heartbeat (`stats_test.go`) | No provider / nil provider ⇒ no `stats` key on the wire; block rides under exactly `stats`; publisher seam defaults |

Not verifiable here (coordinator's job post-merge): live-node smoke against a real vLLM/SGLang + GPU node, and backend ingestion of the block.

## Related

- aceteam-ai/aceteam#6334 — Fabric Pulse (consumer)
- #587 — this issue
- `services/ports.go` host-port registry; `internal/status/idle.go` (existing vLLM idle scrape this deliberately does not disturb)
