### PR TITLE
feat(node): trust mesh peer identity for the terminal endpoint + default tmux sessions (#585)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -558,20 +558,35 @@ provisioned gateway, which forces `:8080` + a VPN listener) does. Discovery
 therefore sees only gateway-enabled peers; the probe port is configurable via
 `--port` (`mesh.Options.Port`, default `services.GatewayPort` = 8080).
 
-**Chat reachability gap (KNOWN, tracked in #581):** `mesh chat` is wired but
-routing does NOT work end-to-end yet, because on **embedded-tsnet nodes the
-engine's host port is not reachable over the mesh**. Verified by self-dialing this
-node's own mesh IP:8210 via `network.Dial` while bonsai served fine on
-`localhost:8210` → `connection refused`: embedded tsnet's userspace netstack does
-not forward inbound mesh traffic to a host-bound port lacking a `srv.Listen()`
-(only ports citadel explicitly `ListenVPN`s — status 8080, gateway 8443, terminal,
-vnc, modules — answer over the mesh). The engine compose files bind `0.0.0.0` and
-carry a "peers reach this engine directly over the mesh" comment, but that
-reflects a full-Tailscale/kernel-TUN node, not embedded tsnet. Neither
-`citadel work --gateway` nor `citadel serve` proxies `/v1/chat/completions` (they
-proxy `/v1/embeddings` and control routes only). The node-side gateway chat route
-(model→engine, the complement of aceteam #6236) is the follow-up (#581); until
-then `mesh chat` fails gracefully with a message pointing there.
+**Chat reachability (was the #581 gap, now IMPLEMENTED):** on **embedded-tsnet
+nodes the engine's host port is not reachable over the mesh** — verified by
+self-dialing this node's own mesh IP:8210 via `network.Dial` while bonsai served
+fine on `localhost:8210` → `connection refused`: embedded tsnet's userspace
+netstack does not forward inbound mesh traffic to a host-bound port lacking a
+`srv.Listen()` (only ports citadel explicitly `ListenVPN`s — status 8080, gateway
+8443, terminal, vnc, modules — answer over the mesh). The engine compose files
+bind `0.0.0.0` and carry a "peers reach this engine directly over the mesh"
+comment, but that reflects a full-Tailscale/kernel-TUN node, not embedded tsnet.
+
+**Fix (#581, node-side complement of aceteam #6236):** the gateway now routes
+`/v1/chat/completions` (plus `/v1/completions` and `/v1/models`) by model. Both
+`citadel work --gateway` and `citadel serve` register a dynamic chat handler
+(`internal/gateway/chat_route.go`) that reads the request body's `model`,
+resolves it to the LOCAL serving engine's citadel-owned host port via
+`status.DiscoverLocalEngines` (behind a short TTL cache in `cmd/gateway_chat.go`),
+and reverse-proxies to `http://127.0.0.1:<port>/v1/chat/completions` — streaming
+SSE included (`ReverseProxy.FlushInterval=-1`). Model matching mirrors
+`mesh.FindModel` (exact case-insensitive → substring); an unknown model returns a
+404 OpenAI-shaped `model_not_found`. Because these routes sit on the same gateway
+mux, they ride the LAN listener AND the tsnet VPN listener, so `mesh.Client.
+ChatCompletion(ip, gatewayPort, body)` reaches them over the mesh. `mesh chat`
+now works end-to-end (target the node's gateway port, not the engine port).
+
+Auth posture: `categoryForPath` returns `""` for `/v1/chat/completions`, so it is
+always-allowed — same as `/v1/embeddings`. TLS + mesh membership are the only
+gate; the gateway does NOT currently wire `SetMetering`, so chat is neither
+metered nor authenticated per-request. A single chat response is bounded by the
+gateway `http.Server` `WriteTimeout` (120s), a pre-existing server-wide cap.
 
 ```bash
 citadel mesh models                 # list model -> node/engine/addr across the mesh

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -36,8 +36,11 @@ REMOTE SHELL (no port):
   No host SSH config, no '.local' mDNS, no manual hops.
 
   The target node must be running its terminal endpoint, which 'citadel work'
-  starts by default (disable with --no-terminal). Authentication uses a terminal
-  token: pass --token or set CITADEL_TERMINAL_TOKEN.
+  starts by default (disable with --no-terminal). No token is needed: the node
+  trusts your verified mesh-peer identity over the VPN (citadel #585). Repeated
+  connects re-attach to the same live tmux-backed shell. A --token (or
+  CITADEL_TERMINAL_TOKEN) is still accepted for the platform terminal path or
+  when the target disables mesh trust.
 
 RAW TCP (with port):
   Establishes a raw TCP connection to a service on the target and pipes
@@ -281,5 +284,5 @@ func init() {
 	rootCmd.AddCommand(connectCmd)
 	connectCmd.Flags().IntVar(&connectTimeout, "timeout", 0, "Connection timeout in seconds (0 = no timeout, raw-TCP mode)")
 	connectCmd.Flags().IntVar(&connectTerminalPort, "terminal-port", 7860, "Terminal endpoint port on the target (remote-shell mode)")
-	connectCmd.Flags().StringVar(&connectToken, "token", "", "Terminal auth token (remote-shell mode; or set CITADEL_TERMINAL_TOKEN)")
+	connectCmd.Flags().StringVar(&connectToken, "token", "", "Terminal auth token (remote-shell mode; OPTIONAL — mesh identity is trusted by default; or set CITADEL_TERMINAL_TOKEN)")
 }

--- a/cmd/connect_shell.go
+++ b/cmd/connect_shell.go
@@ -27,16 +27,21 @@ import (
 
 // runRemoteShell opens an interactive shell on the target node over the mesh.
 //
+// Auth (citadel #585): no --token is required. The node authorizes a connection
+// arriving over its VPN listener by our verified mesh-peer identity, so dialing
+// <vpn_ip>:7860 over the mesh is sufficient. A token is still accepted for the
+// platform terminal path or when the target disables mesh trust.
+//
 // Idempotency (issue #582 / coordinate with #571): this client publishes no
 // heartbeat and holds no worklock, so repeated `citadel connect <target>` never
 // creates duplicate node state — each invocation is an independent view, and on
 // exit the terminal is always restored and the socket closed cleanly. Stateful
 // re-attach (reconnecting to the *same* live shell with its running command and
-// scrollback after a dropped connection) is provided by the node-side terminal
-// server when it backs sessions with a persistent per-user tmux session
-// (CITADEL_TERMINAL_SESSION). With the default (bare-shell) node config each
-// connection is a fresh shell. See the PR / follow-up for making tmux-backed
-// sessions the default so `connect` re-attach is seamless out of the box.
+// scrollback after a dropped connection) is now the default: the node-side
+// terminal server backs sessions with a persistent per-user tmux session by
+// default (citadel #585, DefaultSessionName="citadel"), so a repeated connect —
+// or a reconnect after a drop — re-attaches to the same live shell. Operators
+// can force a bare shell with CITADEL_TERMINAL_SESSION=none.
 func runRemoteShell(target string) error {
 	// Ensure the mesh is up before resolving/dialing.
 	netCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
@@ -52,25 +57,27 @@ func runRemoteShell(target string) error {
 		return fmt.Errorf("could not resolve '%s': %w", target, err)
 	}
 
-	// Auth token: --token flag or CITADEL_TERMINAL_TOKEN env.
+	// Auth token: OPTIONAL as of citadel #585. When we omit it, the target node
+	// authorizes this connection by our verified mesh-peer identity — dialing its
+	// <vpn_ip>:7860 over the mesh already proves we are an authenticated member
+	// of the org tailnet (auth happened at the WireGuard layer). A token is still
+	// accepted (and takes precedence node-side) for the platform terminal path or
+	// when mesh trust is disabled on the target (CITADEL_TERMINAL_TRUST_MESH=false).
 	token := connectToken
 	if token == "" {
 		token = os.Getenv("CITADEL_TERMINAL_TOKEN")
 	}
-	if token == "" {
-		return fmt.Errorf("no terminal token provided\n"+
-			"  A terminal token authenticates the remote shell. Provide one with:\n"+
-			"    --token <token>            or\n"+
-			"    CITADEL_TERMINAL_TOKEN=<token> citadel connect %s\n"+
-			"  (Tokens are issued by the AceTeam platform terminal feature.)", target)
-	}
 
 	addr := net.JoinHostPort(ip, fmt.Sprintf("%d", connectTerminalPort))
+	query := url.Values{}
+	if token != "" {
+		query.Set("token", token)
+	}
 	wsURL := url.URL{
 		Scheme:   "ws",
 		Host:     addr,
 		Path:     "/terminal",
-		RawQuery: url.Values{"token": {token}}.Encode(),
+		RawQuery: query.Encode(),
 	}
 
 	display := hostname
@@ -105,7 +112,7 @@ func remoteShellDialError(err error, resp *http.Response, display, addr string) 
 	if resp != nil {
 		switch resp.StatusCode {
 		case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
-			return fmt.Errorf("authentication rejected by %s (HTTP %d): the terminal token is invalid or not authorized for this node's org", display, resp.StatusCode)
+			return fmt.Errorf("authentication rejected by %s (HTTP %d): mesh-peer identity was not accepted (target may have mesh trust disabled, or we are not a same-owner tailnet peer) and no valid --token was supplied", display, resp.StatusCode)
 		case http.StatusServiceUnavailable:
 			return fmt.Errorf("%s is at capacity or its auth service is unavailable (HTTP %d)", display, resp.StatusCode)
 		default:

--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -596,6 +596,11 @@ func startTerminalServer(orgID string, activityFn func(level, msg string)) error
 	// never observe a half-initialized server.
 	srv := terminal.NewServer(config, ccTerminalAuth)
 
+	// Trust verified mesh peers on the VPN listener so `citadel connect <name>`
+	// works with no platform-minted token (citadel #585). Additive: token path
+	// preserved and takes precedence; localhost/LAN still requires a token.
+	srv.SetMeshResolver(meshIdentityResolver{})
+
 	// Suppress terminal server logging in TUI mode to prevent display corruption
 	srv.SetSilent()
 

--- a/cmd/gateway_chat.go
+++ b/cmd/gateway_chat.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/gateway"
+	"github.com/aceteam-ai/citadel-cli/internal/status"
+)
+
+// gateway_chat.go wires the gateway's model->engine chat router (issue #581,
+// node-side complement of aceteam #6236) to this node's live engine discovery.
+// Shared by `citadel work --gateway` (cmd/work.go) and `citadel serve`
+// (cmd/serve.go) so both gateways expose /v1/chat/completions identically.
+
+// chatListerTTL bounds how long a discovered engine->model map is reused before
+// a fresh probe. status.DiscoverLocalEngines runs `docker inspect` + an engine
+// HTTP probe (bounded by status.ModelDiscoveryTimeout) per running engine, which
+// is too heavy to run on every chat request (it would add seconds of latency
+// before the first streamed token on a multi-engine node). A few seconds of
+// staleness is acceptable: the only failure modes are a transient 404 on a
+// just-loaded model or a transient 502 on a just-unloaded one, both of which
+// self-correct on the next refresh.
+const chatListerTTL = 5 * time.Second
+
+// newLocalChatLister builds a gateway.ChatModelLister backed by
+// status.DiscoverLocalEngines with a short TTL cache. The returned closure is
+// safe for concurrent use (the gateway calls it from request goroutines).
+func newLocalChatLister() gateway.ChatModelLister {
+	var (
+		mu     sync.Mutex
+		cached []gateway.ChatUpstream
+		expiry time.Time
+	)
+	return func() []gateway.ChatUpstream {
+		mu.Lock()
+		defer mu.Unlock()
+		if cached != nil && time.Now().Before(expiry) {
+			return cached
+		}
+		// Bound the probe a touch above ModelDiscoveryTimeout so a slow engine
+		// never stalls a chat request indefinitely.
+		ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+		defer cancel()
+		engines := status.DiscoverLocalEngines(ctx)
+		out := make([]gateway.ChatUpstream, 0, len(engines))
+		for _, e := range engines {
+			out = append(out, gateway.ChatUpstream{Engine: e.Name, Port: e.Port, Models: e.Models})
+		}
+		cached = out
+		expiry = time.Now().Add(chatListerTTL)
+		return out
+	}
+}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -219,6 +219,11 @@ func runServe(cmd *cobra.Command, args []string) error {
 	// stripping is needed.
 	gw.AddUpstream("/v1/embeddings", &gateway.Upstream{Address: embeddingAddr})
 
+	// Chat routing (issue #581): expose /v1/chat/completions (+ /v1/completions
+	// and /v1/models) with model->engine resolution so mesh-direct chat to this
+	// node reaches whichever local engine serves the requested model.
+	gw.SetChatRouter(newLocalChatLister())
+
 	// VNC WebSocket proxy (requires websockify running on vnc-port)
 	gw.AddUpstream("/vnc", &gateway.Upstream{
 		Address:     vncAddr,
@@ -250,6 +255,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	fmt.Printf("     /api/screenshot, /api/actions -> %s\n", statusAddr)
 	fmt.Printf("     /ssh/authorized-keys     -> %s (SSH key deploy)\n", statusAddr)
 	fmt.Printf("     /v1/embeddings           -> %s (TEI embeddings)\n", embeddingAddr)
+	fmt.Printf("     /v1/chat/completions     -> local engine by model (#581)\n")
 	fmt.Printf("     /vnc/...                 -> %s (websockify)\n", vncAddr)
 	fmt.Printf("     /terminal/...            -> %s (terminal)\n", termAddr)
 

--- a/cmd/terminal_mesh_auth.go
+++ b/cmd/terminal_mesh_auth.go
@@ -1,0 +1,51 @@
+// cmd/terminal_mesh_auth.go
+//
+// cmd-side adapter that lets the terminal endpoint authorize a tokenless
+// connection by verified mesh-peer identity (citadel #585). It bridges the
+// network layer's WhoIs to the terminal server's MeshIdentityResolver
+// interface. It lives here (not in internal/terminal) because it depends on
+// internal/network; keeping the dependency on this side is what lets
+// internal/terminal stay standalone and unit-testable behind the interface.
+package cmd
+
+import (
+	"context"
+
+	"github.com/aceteam-ai/citadel-cli/internal/network"
+	"github.com/aceteam-ai/citadel-cli/internal/terminal"
+)
+
+// meshIdentityResolver implements terminal.MeshIdentityResolver using the mesh
+// control plane. It is wired into every terminal server via SetMeshResolver so
+// that connections arriving on the VPN listener from a verified same-owner
+// tailnet peer are trusted without a platform-minted token. The localhost/LAN
+// bind is unaffected and still requires a token (see terminal.resolveAuth).
+type meshIdentityResolver struct{}
+
+// ResolvePeer resolves an inbound connection's remote address to its verified
+// tailnet identity via network.WhoIsPeer. The peer's login becomes the terminal
+// session UserID, which drives the per-user tmux session name so a reconnecting
+// peer re-attaches to its own shell. Any error is returned verbatim so the
+// terminal server falls back to the token requirement (fail-safe: an
+// unverifiable peer is never granted an unauthenticated session).
+func (meshIdentityResolver) ResolvePeer(ctx context.Context, remoteAddr string) (*terminal.MeshPeerIdentity, error) {
+	id, err := network.WhoIsPeer(ctx, remoteAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	// Prefer the tailnet login as the stable per-user session key; fall back to
+	// the node name when no login is available so re-attach still works. Note:
+	// on a single-Headscale-user tailnet all peers share one login and therefore
+	// one per-user session — that matches the org-as-tailnet trust boundary.
+	userID := id.LoginName
+	if userID == "" {
+		userID = id.NodeName
+	}
+
+	return &terminal.MeshPeerIdentity{
+		NodeName:  id.NodeName,
+		UserID:    userID,
+		SameOwner: id.SameOwner,
+	}, nil
+}

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1833,6 +1833,11 @@ func runWork(cmd *cobra.Command, args []string) {
 		// /v1/embeddings path to the local TEI service (default 127.0.0.1:8102).
 		gw.AddUpstream("/v1/embeddings", &gateway.Upstream{Address: embeddingAddr})
 
+		// Chat routing (issue #581): expose /v1/chat/completions (+ /v1/completions
+		// and /v1/models) with model->engine resolution so mesh-direct chat to this
+		// node reaches whichever local engine serves the requested model.
+		gw.SetChatRouter(newLocalChatLister())
+
 		gw.AddUpstream("/vnc", &gateway.Upstream{
 			Address:     vncAddr,
 			StripPrefix: true,
@@ -1914,6 +1919,7 @@ func runWork(cmd *cobra.Command, args []string) {
 		fmt.Printf("     /ssh/authorized-keys     -> %s (SSH key deploy)\n", statusAddr)
 		fmt.Printf("     /workflow/...             -> %s (workflow API)\n", statusAddr)
 		fmt.Printf("     /v1/embeddings           -> %s (TEI embeddings)\n", embeddingAddr)
+		fmt.Printf("     /v1/chat/completions     -> local engine by model (#581)\n")
 		fmt.Printf("     /vnc/...                 -> %s (websockify)\n", vncAddr)
 		fmt.Printf("     /terminal/...            -> %s (terminal)\n", termAddr)
 		for _, e := range provisionedEntries {

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1686,6 +1686,12 @@ func runWork(cmd *cobra.Command, args []string) {
 
 				termServer := terminal.NewServer(termConfig, cachingAuth)
 
+				// Trust verified mesh peers on the VPN listener so `citadel connect
+				// <name>` works with no platform-minted token (citadel #585). This is
+				// additive: the token path is preserved and takes precedence, and the
+				// localhost/LAN bind still requires a token. See terminal.resolveAuth.
+				termServer.SetMeshResolver(meshIdentityResolver{})
+
 				// Add VPN listener so the terminal server is reachable over the tsnet VPN.
 				// Bind to the explicit assigned VPN IP (not ":port") so inbound
 				// connections from the platform relay (which dials ws://<vpn_ip>:7860)

--- a/internal/gateway/chat_route.go
+++ b/internal/gateway/chat_route.go
@@ -1,0 +1,280 @@
+package gateway
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// chat_route.go implements the node-side of served-engine chat routing
+// (issue #581), the complement of the backend served-engine routing
+// (aceteam #6236).
+//
+// WHY this exists: on embedded-tsnet nodes an engine's host port is NOT
+// reachable over the mesh — only ports citadel explicitly ListenVPN's (status,
+// gateway, terminal, vnc, modules) answer. So a peer that discovers this node
+// serves a model (via GET /status, internal/mesh) cannot dial the engine's
+// :8210/:8100 directly; it must go through the gateway. Before this, the gateway
+// proxied only /v1/embeddings (a single static upstream) and control routes, so
+// mesh-direct chat had no reachable endpoint (mesh chat failed gracefully,
+// pointing here).
+//
+// WHAT this adds: /v1/chat/completions, /v1/completions, and /v1/models on the
+// gateway mux, so they ride the same LAN + VPN listener as every other gateway
+// route. Chat/completions and completions resolve the requested model to the
+// LOCAL engine serving it (vllm/llamacpp/ollama/bonsai and their citadel-owned
+// host ports) and reverse-proxy to that engine's OpenAI-compatible endpoint,
+// streaming SSE included. Unlike the static Upstream map (one fixed address per
+// path), the backend here is chosen per request from the body's "model", so a
+// multi-engine node (e.g. vllm + bonsai) routes by model rather than to a single
+// upstream.
+
+// maxChatProbeBody bounds how much of a chat request body the router buffers to
+// read the "model" field. The full buffered body is still forwarded verbatim;
+// this only caps the peek so a hostile/buggy client cannot make the router hold
+// an unbounded body in memory.
+const maxChatProbeBody = 8 << 20 // 8 MiB
+
+// ChatUpstream is one local serving engine on THIS node that can answer
+// OpenAI-compatible chat/completions, plus the model(s) it currently serves.
+// Engine is informational (vllm/llamacpp/ollama/bonsai); Port is the
+// citadel-owned host port the engine's OpenAI-compatible API listens on
+// (localhost); Models are the loaded model id(s). It mirrors
+// status.LocalEngine, kept as a local type so the gateway package stays free of
+// the heavy internal/status transitive deps and the routing logic is
+// unit-testable with a hand-built lister.
+type ChatUpstream struct {
+	Engine string
+	Port   int
+	Models []string
+}
+
+// ChatModelLister returns the local serving engines and their models. The
+// gateway calls it per request (cmd wires a short-TTL-cached
+// status.DiscoverLocalEngines) so routing reflects live state — an engine that
+// loads or unloads a model changes where subsequent chat requests route.
+type ChatModelLister func() []ChatUpstream
+
+// SetChatRouter enables model->engine chat routing on the gateway. When set,
+// Start registers /v1/chat/completions, /v1/completions, and /v1/models. Passing
+// nil leaves those routes unregistered (the pre-#581 behavior). Must be called
+// before Start.
+func (s *Server) SetChatRouter(lister ChatModelLister) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.chatLister = lister
+}
+
+// registerChatRoutes wires the chat-routing handlers onto the mux. It is called
+// from Start (and directly from tests) so the test exercises the SAME
+// registration path as production rather than a hand-rolled parallel mux.
+func (s *Server) registerChatRoutes() {
+	chat := http.HandlerFunc(s.handleChatCompletions)
+	// Both paths route identically — resolve the model, proxy to its engine. The
+	// engines expose /v1/chat/completions and /v1/completions at the same
+	// (ip,port), so the router forwards the path unchanged.
+	s.mux.Handle("/v1/chat/completions", chat)
+	s.mux.Handle("/v1/completions", chat)
+	// /v1/models aggregates the models served locally (no model in the request,
+	// so it is a plain listing rather than a routed proxy).
+	s.mux.Handle("/v1/models", http.HandlerFunc(s.handleModels))
+}
+
+// handleChatCompletions reads the requested model from the body, resolves it to
+// a local engine's host port, and reverse-proxies the request (verbatim body,
+// streaming SSE included) to that engine's OpenAI-compatible endpoint. An
+// unknown model yields a 404 with an OpenAI-shaped error.
+func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
+	s.mu.RLock()
+	lister := s.chatLister
+	nodeName := s.config.NodeName
+	s.mu.RUnlock()
+
+	if lister == nil {
+		writeChatError(w, http.StatusNotFound, "model_not_found", "chat routing not enabled on this node")
+		return
+	}
+
+	// Buffer the body so we can read "model" and then forward it VERBATIM. The
+	// body is forwarded byte-for-byte (never re-marshalled from a parsed struct)
+	// so the metering middleware's stream_options.include_usage injection — and
+	// every client field — survives to the engine.
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxChatProbeBody))
+	_ = r.Body.Close()
+	if err != nil {
+		writeChatError(w, http.StatusBadRequest, "invalid_request_error", "failed to read request body")
+		return
+	}
+
+	var probe struct {
+		Model string `json:"model"`
+	}
+	// A malformed body still reaches the engine (which returns its own 4xx); we
+	// only need "model" to pick the route, so an unmarshal error is non-fatal.
+	_ = json.Unmarshal(body, &probe)
+	model := strings.TrimSpace(probe.Model)
+
+	port, engine, ok := resolveChatModel(model, lister())
+	if !ok {
+		writeChatError(w, http.StatusNotFound, "model_not_found",
+			fmt.Sprintf("model %q not served on this node", model))
+		return
+	}
+
+	// Restore the body for the proxy.
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	r.ContentLength = int64(len(body))
+
+	// Dial the engine on the loopback host port. 127.0.0.1 (not "localhost") to
+	// dodge an IPv6-first (::1) resolution against an IPv4-only engine bind.
+	target := &url.URL{Scheme: "http", Host: net.JoinHostPort("127.0.0.1", strconv.Itoa(port))}
+	proxy := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL.Scheme = target.Scheme
+			req.URL.Host = target.Host
+			// Path (/v1/chat/completions or /v1/completions) is forwarded
+			// unchanged — the engine serves the identical path.
+			req.Header.Set("X-Forwarded-For", req.RemoteAddr)
+			req.Header.Set("X-Forwarded-Proto", "https")
+			if nodeName != "" {
+				req.Header.Set("X-Citadel-Node", nodeName)
+			}
+		},
+		// -1 flushes each write immediately so streaming (stream:true) SSE chunks
+		// reach the client as they arrive instead of being buffered.
+		FlushInterval: -1,
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			log.Printf("[Gateway] chat proxy error for %s -> %s (engine=%s): %v", r.URL.Path, target.Host, engine, err)
+			writeChatError(w, http.StatusBadGateway, "upstream_error", fmt.Sprintf("engine %q unavailable", engine))
+		},
+	}
+	proxy.ServeHTTP(w, r)
+}
+
+// handleModels returns the OpenAI-compatible /v1/models listing aggregated from
+// the local serving engines. Duplicate model ids (same model on two engines) are
+// de-duplicated; the first engine wins the owned_by field.
+func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
+	s.mu.RLock()
+	lister := s.chatLister
+	s.mu.RUnlock()
+
+	type modelObj struct {
+		ID      string `json:"id"`
+		Object  string `json:"object"`
+		OwnedBy string `json:"owned_by"`
+	}
+	data := []modelObj{}
+	if lister != nil {
+		seen := map[string]bool{}
+		for _, e := range lister() {
+			for _, m := range e.Models {
+				m = strings.TrimSpace(m)
+				if m == "" || seen[m] {
+					continue
+				}
+				seen[m] = true
+				data = append(data, modelObj{ID: m, Object: "model", OwnedBy: e.Engine})
+			}
+		}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"object": "list", "data": data})
+}
+
+// resolveChatModel picks the local engine host port that serves the requested
+// model. Matching mirrors internal/mesh.FindModel (the discovery-side selector)
+// so the gateway agrees with what a peer's `citadel mesh chat` discovered:
+//
+//   - exact, case-insensitive model-id match first (the load-bearing case —
+//     `mesh chat` forwards the exact discovered model id from the peer's
+//     /status), then
+//   - a case-insensitive substring match as a fallback (a human hitting the
+//     gateway with a short alias).
+//
+// Ordering is deterministic (sorted by model, then engine, then port) so a
+// substring that matches multiple engines resolves to a stable pick rather than
+// map-iteration-random. An empty model routes only when unambiguous — every
+// candidate resolves to the same port (a single engine); otherwise it is a miss
+// so the caller returns 404 rather than guessing. Returns ok=false when nothing
+// serves the model.
+func resolveChatModel(model string, engines []ChatUpstream) (port int, engine string, ok bool) {
+	type cand struct {
+		engine string
+		port   int
+		model  string
+	}
+	var all []cand
+	for _, e := range engines {
+		if e.Port <= 0 {
+			continue
+		}
+		if len(e.Models) == 0 {
+			// A running engine with no discovered model can still serve the
+			// empty-model case (a single-engine node), so record it with an empty
+			// model id.
+			all = append(all, cand{engine: e.Engine, port: e.Port})
+			continue
+		}
+		for _, m := range e.Models {
+			all = append(all, cand{engine: e.Engine, port: e.Port, model: strings.TrimSpace(m)})
+		}
+	}
+	if len(all) == 0 {
+		return 0, "", false
+	}
+	sort.Slice(all, func(i, j int) bool {
+		if all[i].model != all[j].model {
+			return all[i].model < all[j].model
+		}
+		if all[i].engine != all[j].engine {
+			return all[i].engine < all[j].engine
+		}
+		return all[i].port < all[j].port
+	})
+
+	model = strings.TrimSpace(model)
+	if model == "" {
+		// Route only when unambiguous: all candidates on one port (one engine).
+		firstPort := all[0].port
+		for _, c := range all {
+			if c.port != firstPort {
+				return 0, "", false
+			}
+		}
+		return all[0].port, all[0].engine, true
+	}
+
+	// Exact, case-insensitive id match.
+	for _, c := range all {
+		if c.model != "" && strings.EqualFold(c.model, model) {
+			return c.port, c.engine, true
+		}
+	}
+	// Substring fallback; deterministic first match (all is sorted).
+	needle := strings.ToLower(model)
+	for _, c := range all {
+		if c.model != "" && strings.Contains(strings.ToLower(c.model), needle) {
+			return c.port, c.engine, true
+		}
+	}
+	return 0, "", false
+}
+
+// writeChatError writes an OpenAI-shaped error object with the given HTTP status.
+func writeChatError(w http.ResponseWriter, status int, typ, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"error": map[string]string{"message": msg, "type": typ},
+	})
+}

--- a/internal/gateway/chat_route_test.go
+++ b/internal/gateway/chat_route_test.go
@@ -1,0 +1,213 @@
+package gateway
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// portOf extracts the numeric port from an httptest server URL (http://127.0.0.1:NNN).
+func portOf(t *testing.T, srv *httptest.Server) int {
+	t.Helper()
+	addr := strings.TrimPrefix(srv.URL, "http://")
+	_, portStr, ok := strings.Cut(addr, ":")
+	if !ok {
+		t.Fatalf("cannot parse port from %q", srv.URL)
+	}
+	p, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("bad port %q: %v", portStr, err)
+	}
+	return p
+}
+
+// newChatGateway builds a gateway whose chat routes are registered through the
+// SAME registerChatRoutes path Start uses (issue #581), backed by the given
+// lister. Returns the gateway ready for gw.mux.ServeHTTP.
+func newChatGateway(lister ChatModelLister) *Server {
+	gw := NewServer(Config{Port: 0, NodeName: "test-node"})
+	gw.SetChatRouter(lister)
+	gw.registerChatRoutes()
+	gw.mux.HandleFunc("/", gw.handleRoot)
+	return gw
+}
+
+// TestChatCompletionsRoutesToServingEngine verifies a chat request for a served
+// model is proxied (verbatim body) to that model's engine host port, and the
+// upstream status + body flow back through.
+func TestChatCompletionsRoutesToServingEngine(t *testing.T) {
+	engine := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("engine got path %q, want /v1/chat/completions", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		// Echo back the model the gateway forwarded so we can assert verbatim pass-through.
+		var req struct {
+			Model string `json:"model"`
+		}
+		_ = json.Unmarshal(body, &req)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"backend": "engine", "model": req.Model})
+	}))
+	defer engine.Close()
+
+	port := portOf(t, engine)
+	gw := newChatGateway(func() []ChatUpstream {
+		return []ChatUpstream{{Engine: "bonsai", Port: port, Models: []string{"Bonsai-27B-Q1_0.gguf"}}}
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"Bonsai-27B-Q1_0.gguf","messages":[{"role":"user","content":"hi"}]}`))
+	req.RemoteAddr = "1.2.3.4:5678"
+	w := httptest.NewRecorder()
+	gw.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("bad response: %v (body=%s)", err, w.Body.String())
+	}
+	if resp["backend"] != "engine" {
+		t.Errorf("routed to %q backend, want engine", resp["backend"])
+	}
+	if resp["model"] != "Bonsai-27B-Q1_0.gguf" {
+		t.Errorf("engine saw model %q, want verbatim Bonsai-27B-Q1_0.gguf", resp["model"])
+	}
+}
+
+// TestChatCompletionsSubstringMatch verifies a short alias resolves to the
+// serving engine via the case-insensitive substring fallback (mirroring
+// mesh.FindModel).
+func TestChatCompletionsSubstringMatch(t *testing.T) {
+	engine := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"backend": "engine"})
+	}))
+	defer engine.Close()
+
+	port := portOf(t, engine)
+	gw := newChatGateway(func() []ChatUpstream {
+		return []ChatUpstream{{Engine: "bonsai", Port: port, Models: []string{"Bonsai-27B-Q1_0.gguf"}}}
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"bonsai-27b"}`))
+	w := httptest.NewRecorder()
+	gw.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("substring alias should route: status = %d, body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestChatCompletionsStreamingForwardsSSE verifies streaming (stream:true) SSE
+// frames are forwarded through the gateway to the client.
+func TestChatCompletionsStreamingForwardsSSE(t *testing.T) {
+	engine := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fl, _ := w.(http.Flusher)
+		for _, chunk := range []string{
+			"data: {\"choices\":[{\"delta\":{\"content\":\"Hel\"}}]}\n\n",
+			"data: {\"choices\":[{\"delta\":{\"content\":\"lo\"}}]}\n\n",
+			"data: [DONE]\n\n",
+		} {
+			io.WriteString(w, chunk)
+			if fl != nil {
+				fl.Flush()
+			}
+		}
+	}))
+	defer engine.Close()
+
+	port := portOf(t, engine)
+	gw := newChatGateway(func() []ChatUpstream {
+		return []ChatUpstream{{Engine: "vllm", Port: port, Models: []string{"Qwen/Qwen2.5-7B"}}}
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"Qwen/Qwen2.5-7B","stream":true}`))
+	w := httptest.NewRecorder()
+	gw.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Errorf("content-type = %q, want text/event-stream (SSE preserved)", ct)
+	}
+	// Count forwarded SSE data frames.
+	var frames int
+	sc := bufio.NewScanner(strings.NewReader(w.Body.String()))
+	for sc.Scan() {
+		if strings.HasPrefix(sc.Text(), "data:") {
+			frames++
+		}
+	}
+	if frames != 3 {
+		t.Errorf("forwarded %d SSE data frames, want 3; body=%q", frames, w.Body.String())
+	}
+}
+
+// TestChatCompletionsUnknownModel404 verifies a request for a model no local
+// engine serves returns 404 with the OpenAI-shaped model_not_found error.
+func TestChatCompletionsUnknownModel404(t *testing.T) {
+	gw := newChatGateway(func() []ChatUpstream {
+		return []ChatUpstream{{Engine: "vllm", Port: 9999, Models: []string{"Qwen/Qwen2.5-7B"}}}
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"does-not-exist"}`))
+	w := httptest.NewRecorder()
+	gw.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+	var resp struct {
+		Error struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("bad error response: %v (body=%s)", err, w.Body.String())
+	}
+	if resp.Error.Type != "model_not_found" {
+		t.Errorf("error.type = %q, want model_not_found", resp.Error.Type)
+	}
+	if !strings.Contains(resp.Error.Message, "does-not-exist") {
+		t.Errorf("error.message = %q, want it to name the model", resp.Error.Message)
+	}
+}
+
+// TestResolveChatModel exercises the pure resolver: exact match, empty-model
+// single-engine routing, empty-model ambiguity, and miss.
+func TestResolveChatModel(t *testing.T) {
+	engines := []ChatUpstream{
+		{Engine: "vllm", Port: 8100, Models: []string{"Qwen/Qwen2.5-7B"}},
+		{Engine: "bonsai", Port: 8210, Models: []string{"Bonsai-27B-Q1_0.gguf"}},
+	}
+
+	if p, e, ok := resolveChatModel("bonsai-27b-q1_0.gguf", engines); !ok || p != 8210 || e != "bonsai" {
+		t.Errorf("exact (case-insensitive) = (%d,%q,%v), want (8210,bonsai,true)", p, e, ok)
+	}
+	if _, _, ok := resolveChatModel("nope", engines); ok {
+		t.Error("miss should return ok=false")
+	}
+	// Empty model with a single engine routes to it.
+	single := []ChatUpstream{{Engine: "vllm", Port: 8100, Models: []string{"Qwen/Qwen2.5-7B"}}}
+	if p, _, ok := resolveChatModel("", single); !ok || p != 8100 {
+		t.Errorf("empty-model single-engine = (%d,%v), want (8100,true)", p, ok)
+	}
+	// Empty model with two engines is ambiguous -> miss.
+	if _, _, ok := resolveChatModel("", engines); ok {
+		t.Error("empty-model multi-engine should be ambiguous (ok=false)")
+	}
+}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -152,6 +152,13 @@ type Server struct {
 	// SetProvisionedRegistry.
 	provisionedResolver CapabilityResolver
 
+	// chatLister, when non-nil, enables the model->engine chat-routing handlers
+	// (/v1/chat/completions, /v1/completions, /v1/models). It reports the local
+	// serving engines and their models so an incoming chat request is routed to
+	// whichever engine serves the requested model. Set via SetChatRouter; see
+	// chat_route.go (issue #581, node-side complement of aceteam #6236).
+	chatLister ChatModelLister
+
 	// started is set once Start has registered the proxy handlers for the routes
 	// present at that moment. It gates WireModuleRoute: a route added AFTER Start
 	// must have its proxy handler registered live (Start's registration loop has
@@ -408,6 +415,13 @@ func (s *Server) Start(ctx context.Context) error {
 	// Build the route table
 	for prefix, upstream := range s.config.Upstreams {
 		s.registerProxy(prefix, upstream)
+	}
+	// Model->engine chat routing (#581): unlike the static upstreams above, the
+	// chat routes resolve their backend per request from the requested model, so
+	// they are registered by a dedicated method rather than the upstream loop.
+	// Same mux, so they are reachable on both the LAN and the VPN listener.
+	if s.chatLister != nil {
+		s.registerChatRoutes()
 	}
 	// Any route added after this point (WireModuleRoute) must register its own
 	// proxy handler live, since this loop has already run.

--- a/internal/network/server.go
+++ b/internal/network/server.go
@@ -308,6 +308,74 @@ func (s *NetworkServer) LocalClient() (*tailscale.LocalClient, error) {
 	return s.srv.LocalClient()
 }
 
+// PeerIdentity is the verified mesh identity of a connecting peer, resolved via
+// the tsnet/Tailscale control plane (WhoIs). It is the trust primitive behind
+// mesh-native authorization for the terminal endpoint (citadel #585): a peer
+// that can dial this node over the WireGuard mesh is already an authenticated
+// member of the tailnet, and WhoIs turns its source address into the node and
+// user the coordination server vouches for.
+type PeerIdentity struct {
+	// NodeName is the peer's MagicDNS/computed node name, for the audit log.
+	NodeName string
+
+	// LoginName is the tailnet user login the peer belongs to (e.g. an email).
+	// Used both for the audit log and to derive a stable per-user terminal
+	// session so a reconnecting peer re-attaches to its own shell.
+	LoginName string
+
+	// SameOwner reports whether the peer belongs to the same tailnet user/org as
+	// this node. This mirrors GetPeers' `peer.UserID == selfUserID` filter and is
+	// cheap defense-in-depth: a shared-in node or a different tailnet user that
+	// happens to be reachable is not treated as same-owner.
+	SameOwner bool
+}
+
+// WhoIs resolves a remote address ("ip" or "ip:port", typically an inbound
+// connection's RemoteAddr) to the verified mesh identity the coordination server
+// vouches for. It returns an error when the address does not map to a known
+// tailnet peer.
+//
+// Fail-safe contract (citadel #585): callers MUST treat any error as
+// "unverified" and fall back to token auth — never authorize a session just
+// because a connection looked like it arrived over the mesh.
+func (s *NetworkServer) WhoIs(ctx context.Context, remoteAddr string) (*PeerIdentity, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.srv == nil {
+		return nil, fmt.Errorf("not connected to network")
+	}
+
+	lc, err := s.srv.LocalClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get local client: %w", err)
+	}
+
+	who, err := lc.WhoIs(ctx, remoteAddr)
+	if err != nil {
+		return nil, fmt.Errorf("whois %s: %w", remoteAddr, err)
+	}
+	if who == nil || who.Node == nil {
+		return nil, fmt.Errorf("whois %s: no node in response", remoteAddr)
+	}
+
+	id := &PeerIdentity{
+		NodeName: who.Node.ComputedName,
+	}
+	if who.UserProfile != nil {
+		id.LoginName = who.UserProfile.LoginName
+	}
+
+	// Same-owner check mirrors GetPeers: compare the peer's owning user against
+	// self's, and require it is not a shared-in node (Sharer set). A best-effort
+	// Status() failure leaves SameOwner false (fail-closed on the extra check).
+	if status, serr := lc.Status(ctx); serr == nil && status.Self != nil {
+		id.SameOwner = who.Node.User == status.Self.UserID && who.Node.Sharer == 0
+	}
+
+	return id, nil
+}
+
 // Listen creates a listener on the network for the given address.
 // This allows exposing services to the AceTeam network.
 func (s *NetworkServer) Listen(network, addr string) (net.Listener, error) {

--- a/internal/network/singleton.go
+++ b/internal/network/singleton.go
@@ -195,6 +195,18 @@ func GetGlobalPeers(ctx context.Context) ([]PeerInfo, error) {
 	return s.GetPeers(ctx)
 }
 
+// WhoIsPeer resolves a remote address ("ip" or "ip:port") to its verified mesh
+// identity via the global server. See NetworkServer.WhoIs and citadel #585.
+// Returns an error when not connected or the peer cannot be verified; callers
+// must treat that as "unverified" and fall back to token auth.
+func WhoIsPeer(ctx context.Context, remoteAddr string) (*PeerIdentity, error) {
+	s := Global()
+	if s == nil {
+		return nil, fmt.Errorf("not connected to AceTeam Network")
+	}
+	return s.WhoIs(ctx, remoteAddr)
+}
+
 // PingPeer pings a peer via the global server.
 func PingPeer(ctx context.Context, ip string) (latencyMs float64, connType string, relay string, err error) {
 	s := Global()

--- a/internal/terminal/config.go
+++ b/internal/terminal/config.go
@@ -9,12 +9,21 @@ import (
 )
 
 // DefaultSessionName is the base tmux session name used when
-// CITADEL_TERMINAL_SESSION is not set. It defaults to empty, which turns tmux
-// backing OFF so terminals run a fresh bare shell. Operators opt in to
-// persistent tmux by setting CITADEL_TERMINAL_SESSION to a session name (e.g.
-// "citadel"), which must be a valid tmux session name per
-// tmux.ValidateSessionName.
-const DefaultSessionName = ""
+// CITADEL_TERMINAL_SESSION is not set.
+//
+// It defaults to "citadel", which turns persistent tmux backing ON by default
+// (citadel #585, Gap 2): each connection attaches to (or creates) a per-user
+// `tmux new-session -A -s <name>` session, so a repeated `citadel connect
+// <node>` — and a reconnect after a drop — re-attaches to the SAME live shell
+// (running command, scrollback, cwd preserved) instead of spawning a duplicate.
+//
+// This is a deliberate behavior change from the previous empty (tmux-off)
+// default: platform/token terminals that used to get a fresh bare shell now get
+// a resumable tmux session too. It stays safe because (a) when no tmux binary is
+// resolvable the server logs a warning and falls back to a bare shell, and
+// (b) operators can force a bare shell by setting CITADEL_TERMINAL_SESSION to a
+// disable sentinel ("none"/"off"/"disabled"/"false"/"0").
+const DefaultSessionName = "citadel"
 
 // Config holds the terminal server configuration
 type Config struct {
@@ -53,15 +62,22 @@ type Config struct {
 	// re-attaches to their own persistent terminal across reconnects while
 	// staying isolated from other users.
 	//
-	// It defaults to DefaultSessionName (empty), so tmux backing is OFF by
-	// default and terminals run a fresh, non-persistent bare shell. This keeps
-	// scripted/automated terminal use predictable (no state bleed across
-	// connections, consistent PTY/terminfo). To opt in to the persistent,
-	// reconnect-resilient tmux behavior, set CITADEL_TERMINAL_SESSION to a
-	// session name (e.g. "citadel"). The disable sentinels ("none"/"off"/
-	// "disabled"/"false"/"0") also force a bare shell and remain supported for
-	// explicit opt-out.
+	// It defaults to DefaultSessionName ("citadel"), so tmux backing is ON by
+	// default (citadel #585): terminals get a persistent, reconnect-resilient,
+	// per-user session so `citadel connect` re-attaches seamlessly. To force a
+	// fresh, non-persistent bare shell (e.g. for scripted/automated terminal use
+	// that wants no state bleed across connections), set CITADEL_TERMINAL_SESSION
+	// to a disable sentinel ("none"/"off"/"disabled"/"false"/"0").
 	SessionName string
+
+	// TrustMeshPeers enables mesh-peer identity trust for connections that
+	// arrive over the VPN listener (citadel #585). When true AND a
+	// MeshIdentityResolver is wired (SetMeshResolver), a tokenless VPN
+	// connection whose source resolves to a verified same-owner tailnet peer is
+	// authorized without a platform-minted token. It has NO effect on the
+	// localhost/LAN bind, which always requires a token. Defaults to true
+	// (CITADEL_TERMINAL_TRUST_MESH); set false to force tokens even on the mesh.
+	TrustMeshPeers bool
 
 	// AuthServiceURL is the URL of the AceTeam auth service for token validation
 	AuthServiceURL string
@@ -93,6 +109,7 @@ func DefaultConfig() *Config {
 		MaxConnections:       getEnvInt("CITADEL_TERMINAL_MAX_CONNECTIONS", 10),
 		Shell:                getEnvOrDefault("CITADEL_TERMINAL_SHELL", defaultShell()),
 		SessionName:          getEnvOrDefault("CITADEL_TERMINAL_SESSION", DefaultSessionName),
+		TrustMeshPeers:       getEnvBool("CITADEL_TERMINAL_TRUST_MESH", true),
 		AuthServiceURL:       getEnvOrDefault("CITADEL_AUTH_HOST", "https://aceteam.ai"),
 		RateLimitRPS:         1.0, // 1 connection attempt per second per IP
 		RateLimitBurst:       5,   // Allow bursts of 5

--- a/internal/terminal/config_test.go
+++ b/internal/terminal/config_test.go
@@ -3,6 +3,7 @@ package terminal
 
 import (
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -68,45 +69,77 @@ func TestConfigFromEnv(t *testing.T) {
 	}
 }
 
-// TestDefaultConfig_TmuxOffByDefault pins the off-by-default contract: with no
-// CITADEL_TERMINAL_SESSION set, no tmux session is configured, so the server
-// runs a bare shell (sessionCommand returns nil and sessionDisabled is true).
-func TestDefaultConfig_TmuxOffByDefault(t *testing.T) {
+// TestDefaultConfig_TmuxOnByDefault pins the on-by-default contract flipped by
+// citadel #585: with no CITADEL_TERMINAL_SESSION set the default is "citadel",
+// tmux backing is enabled, and (when a tmux binary is available) a persistent
+// attach-or-create command is produced so `citadel connect` re-attach works out
+// of the box.
+func TestDefaultConfig_TmuxOnByDefault(t *testing.T) {
 	// Empty simulates "unset": getEnvOrDefault treats "" as absent and falls
-	// back to DefaultSessionName, which is now empty.
+	// back to DefaultSessionName, which is now "citadel".
 	t.Setenv("CITADEL_TERMINAL_SESSION", "")
-
-	config := DefaultConfig()
-	if config.SessionName != "" {
-		t.Errorf("expected empty SessionName by default, got %q", config.SessionName)
-	}
-	if !sessionDisabled(config.SessionName) {
-		t.Error("expected tmux backing to be disabled by default")
-	}
-	// Even with a real tmux binary available, no command is produced.
-	makeFakeTmux(t)
-	if got := sessionCommand(config.SessionName, config.Shell); got != nil {
-		t.Errorf("expected nil session command by default, got %v", got)
-	}
-}
-
-// TestDefaultConfig_TmuxOptIn verifies operators restore persistent tmux by
-// setting CITADEL_TERMINAL_SESSION to a session name.
-func TestDefaultConfig_TmuxOptIn(t *testing.T) {
-	t.Setenv("CITADEL_TERMINAL_SESSION", "citadel")
 	bin := makeFakeTmux(t)
 
 	config := DefaultConfig()
 	if config.SessionName != "citadel" {
-		t.Errorf("expected SessionName %q from env, got %q", "citadel", config.SessionName)
+		t.Errorf("expected default SessionName %q, got %q", "citadel", config.SessionName)
 	}
 	if sessionDisabled(config.SessionName) {
-		t.Error("expected tmux backing to be enabled when opted in")
+		t.Error("expected tmux backing to be ENABLED by default (citadel #585)")
 	}
 	got := sessionCommand(config.SessionName, "/bin/bash")
 	want := []string{bin, "new-session", "-A", "-s", "citadel", "/bin/bash"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("sessionCommand = %v, want %v", got, want)
+	}
+}
+
+// TestDefaultConfig_TmuxOptOut verifies operators can force a bare, non-persistent
+// shell by setting CITADEL_TERMINAL_SESSION to a disable sentinel.
+func TestDefaultConfig_TmuxOptOut(t *testing.T) {
+	t.Setenv("CITADEL_TERMINAL_SESSION", "none")
+	makeFakeTmux(t) // even with tmux available, opt-out wins
+
+	config := DefaultConfig()
+	if config.SessionName != "none" {
+		t.Errorf("expected SessionName %q from env, got %q", "none", config.SessionName)
+	}
+	if !sessionDisabled(config.SessionName) {
+		t.Error("expected tmux backing to be disabled when opted out")
+	}
+	if got := sessionCommand(config.SessionName, config.Shell); got != nil {
+		t.Errorf("expected nil session command when opted out, got %v", got)
+	}
+}
+
+// TestDefaultConfig_TmuxMissingFallsBackToBareShell verifies the graceful
+// fallback: with tmux enabled (default) but no resolvable tmux binary,
+// sessionCommand returns nil so the server runs a bare shell (it logs a warning
+// and never fails the connection). The missing binary is mocked via
+// CITADEL_TMUX_BIN pointing at a nonexistent path.
+func TestDefaultConfig_TmuxMissingFallsBackToBareShell(t *testing.T) {
+	t.Setenv("CITADEL_TERMINAL_SESSION", "") // default -> "citadel" (enabled)
+	t.Setenv("CITADEL_TMUX_BIN", filepath.Join(t.TempDir(), "no-such-tmux"))
+
+	config := DefaultConfig()
+	if sessionDisabled(config.SessionName) {
+		t.Fatal("precondition: tmux should be enabled by default")
+	}
+	if got := sessionCommand(config.SessionName, config.Shell); got != nil {
+		t.Errorf("expected nil session command (bare-shell fallback) when tmux is missing, got %v", got)
+	}
+}
+
+// TestDefaultConfig_TrustMeshDefault pins the mesh-trust default (citadel #585):
+// on by default, opt-outable via CITADEL_TERMINAL_TRUST_MESH.
+func TestDefaultConfig_TrustMeshDefault(t *testing.T) {
+	t.Setenv("CITADEL_TERMINAL_TRUST_MESH", "")
+	if !DefaultConfig().TrustMeshPeers {
+		t.Error("expected TrustMeshPeers to default to true")
+	}
+	t.Setenv("CITADEL_TERMINAL_TRUST_MESH", "false")
+	if DefaultConfig().TrustMeshPeers {
+		t.Error("expected TrustMeshPeers=false from env opt-out")
 	}
 }
 

--- a/internal/terminal/meshauth.go
+++ b/internal/terminal/meshauth.go
@@ -1,0 +1,70 @@
+// internal/terminal/meshauth.go
+//
+// Mesh-peer identity trust for the terminal endpoint (citadel #585).
+//
+// The terminal server historically authenticated EVERY connection with a
+// platform-minted `?token=` (validated by TokenValidator). But any peer that
+// can dial this node's <vpn_ip>:7860 over the WireGuard mesh is *already* an
+// authenticated member of the org's tailnet — the authentication happened at
+// the mesh layer. This file defines the trust primitive that lets the server
+// accept such a connection based on its verified mesh identity instead of a
+// separately-provisioned token, so `citadel connect <name>` works with no
+// manual token.
+//
+// Security posture (READ THIS): mesh-identity trust is GATED to the VPN
+// listener. The localhost/LAN bind and any public exposure still require a
+// token (see Server.resolveAuth). The token path is preserved and takes
+// precedence; mesh identity is an ADDITIONAL authorizer used only when no token
+// is presented on a VPN connection. Resolution is fail-safe — an unresolvable
+// or same-owner-mismatched peer yields an error and the server falls back to
+// the token requirement, never an unauthenticated session.
+package terminal
+
+import "context"
+
+// MeshPeerIdentity is the verified identity of a peer that connected over the
+// mesh/VPN listener. It is produced by a MeshIdentityResolver (implemented in
+// the cmd layer against the tsnet control plane) and consumed by the terminal
+// server to authorize a connection WITHOUT a platform-minted token.
+type MeshPeerIdentity struct {
+	// NodeName is the peer's node name, included in the audit log.
+	NodeName string
+
+	// UserID identifies the peer for session ownership. It becomes the session
+	// TokenInfo.UserID, which drives the per-user tmux session name
+	// (sessionNameForUser) so a reconnecting peer re-attaches to its own shell
+	// rather than sharing one with every other peer.
+	UserID string
+
+	// SameOwner reports whether the peer belongs to the same tailnet owner/org
+	// as this node. The server rejects mesh trust when this is false.
+	SameOwner bool
+}
+
+// MeshIdentityResolver resolves an inbound connection's remote address to a
+// verified mesh peer identity. It is injected into the server (SetMeshResolver)
+// so the terminal package stays standalone and unit-testable without a live
+// mesh — tests pass a MockMeshResolver, production wires network.WhoIsPeer via
+// the cmd layer.
+type MeshIdentityResolver interface {
+	// ResolvePeer resolves remoteAddr ("ip:port") to a verified identity, or an
+	// error if the peer cannot be verified (the caller then falls back to token
+	// auth).
+	ResolvePeer(ctx context.Context, remoteAddr string) (*MeshPeerIdentity, error)
+}
+
+// MockMeshResolver is a MeshIdentityResolver for tests: it returns a fixed
+// identity (or error) regardless of the remote address, so auth-decision tests
+// need no live mesh.
+type MockMeshResolver struct {
+	Identity *MeshPeerIdentity
+	Err      error
+}
+
+// ResolvePeer implements MeshIdentityResolver for the mock.
+func (m *MockMeshResolver) ResolvePeer(ctx context.Context, remoteAddr string) (*MeshPeerIdentity, error) {
+	if m.Err != nil {
+		return nil, m.Err
+	}
+	return m.Identity, nil
+}

--- a/internal/terminal/meshauth_test.go
+++ b/internal/terminal/meshauth_test.go
@@ -1,0 +1,155 @@
+// internal/terminal/meshauth_test.go
+//
+// Tests for mesh-peer identity trust on the terminal endpoint (citadel #585).
+// These exercise Server.resolveAuth directly with an injected MockMeshResolver
+// so no live mesh is needed, pinning the security contract:
+//   - a verified same-owner peer on the VPN path is authorized WITHOUT a token,
+//   - an unverified/absent identity with no token is rejected,
+//   - the localhost/token path is unchanged (token still required off-VPN, and a
+//     valid token's identity is never discarded on a VPN connection).
+package terminal
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// newTestServer builds a server with a mock token validator and (optionally) a
+// mock mesh resolver, without starting any listeners.
+func newTestServer(mesh MeshIdentityResolver, trustMesh bool) (*Server, *MockTokenValidator) {
+	cfg := &Config{
+		Port:           7860,
+		MaxConnections: 10,
+		IdleTimeout:    30 * time.Minute,
+		OrgID:          "org-1",
+		Shell:          "/bin/sh",
+		RateLimitRPS:   1.0,
+		RateLimitBurst: 5,
+		TrustMeshPeers: trustMesh,
+	}
+	auth := NewMockTokenValidator()
+	s := NewServer(cfg, auth)
+	if mesh != nil {
+		s.SetMeshResolver(mesh)
+	}
+	return s, auth
+}
+
+// TestResolveAuth_MeshVerifiedOnVPN_NoToken: a verified same-owner peer on the
+// VPN listener is authorized with no token, and the session UserID comes from
+// the mesh login (per-user tmux re-attach key).
+func TestResolveAuth_MeshVerifiedOnVPN_NoToken(t *testing.T) {
+	mesh := &MockMeshResolver{Identity: &MeshPeerIdentity{
+		NodeName: "gpu-node-1", UserID: "alice@example.com", SameOwner: true,
+	}}
+	s, _ := newTestServer(mesh, true)
+
+	info, via, err := s.resolveAuth(context.Background(), "", true /*overVPN*/, "100.64.0.9:5000")
+	if err != nil {
+		t.Fatalf("expected mesh authorization, got error: %v", err)
+	}
+	if via != "mesh" {
+		t.Errorf("authVia = %q, want %q", via, "mesh")
+	}
+	if info == nil || info.UserID != "alice@example.com" {
+		t.Errorf("expected UserID from mesh login, got %+v", info)
+	}
+	if info.OrgID != "org-1" {
+		t.Errorf("expected OrgID from server config, got %q", info.OrgID)
+	}
+}
+
+// TestResolveAuth_NoTokenNoIdentity_Rejected: without a token and without a
+// verified identity the connection is rejected (fail-safe), whether the resolver
+// errors or is entirely absent.
+func TestResolveAuth_NoTokenNoIdentity_Rejected(t *testing.T) {
+	t.Run("resolver errors", func(t *testing.T) {
+		mesh := &MockMeshResolver{Err: errors.New("peer not found")}
+		s, _ := newTestServer(mesh, true)
+		if _, _, err := s.resolveAuth(context.Background(), "", true, "100.64.0.9:5000"); !errors.Is(err, ErrInvalidToken) {
+			t.Errorf("expected ErrInvalidToken, got %v", err)
+		}
+	})
+
+	t.Run("no resolver wired", func(t *testing.T) {
+		s, _ := newTestServer(nil, true)
+		if _, _, err := s.resolveAuth(context.Background(), "", true, "100.64.0.9:5000"); !errors.Is(err, ErrInvalidToken) {
+			t.Errorf("expected ErrInvalidToken, got %v", err)
+		}
+	})
+
+	t.Run("not same owner", func(t *testing.T) {
+		mesh := &MockMeshResolver{Identity: &MeshPeerIdentity{NodeName: "x", UserID: "eve", SameOwner: false}}
+		s, _ := newTestServer(mesh, true)
+		if _, _, err := s.resolveAuth(context.Background(), "", true, "100.64.0.9:5000"); !errors.Is(err, ErrInvalidToken) {
+			t.Errorf("expected ErrInvalidToken for non-same-owner peer, got %v", err)
+		}
+	})
+}
+
+// TestResolveAuth_MeshTrustGatedToVPN: even a verified peer is NOT trusted when
+// the connection did not arrive on the VPN listener (localhost/LAN), nor when
+// mesh trust is disabled. Both must require a token.
+func TestResolveAuth_MeshTrustGatedToVPN(t *testing.T) {
+	mesh := &MockMeshResolver{Identity: &MeshPeerIdentity{NodeName: "n", UserID: "alice", SameOwner: true}}
+
+	t.Run("not over VPN (localhost) -> token required", func(t *testing.T) {
+		s, _ := newTestServer(mesh, true)
+		if _, _, err := s.resolveAuth(context.Background(), "", false /*overVPN*/, "127.0.0.1:5000"); !errors.Is(err, ErrInvalidToken) {
+			t.Errorf("expected rejection off-VPN, got %v", err)
+		}
+	})
+
+	t.Run("mesh trust disabled -> token required even on VPN", func(t *testing.T) {
+		s, _ := newTestServer(mesh, false /*trustMesh*/)
+		if _, _, err := s.resolveAuth(context.Background(), "", true, "100.64.0.9:5000"); !errors.Is(err, ErrInvalidToken) {
+			t.Errorf("expected rejection with mesh trust off, got %v", err)
+		}
+	})
+}
+
+// TestResolveAuth_TokenPathUnchanged: the token path is preserved exactly. A
+// valid token authorizes on every listener; an invalid token is rejected with
+// its mapped error.
+func TestResolveAuth_TokenPathUnchanged(t *testing.T) {
+	s, auth := newTestServer(nil, true)
+	auth.AddValidToken("good", &TokenInfo{UserID: "u-token", OrgID: "org-1"})
+
+	// Valid token, localhost.
+	info, via, err := s.resolveAuth(context.Background(), "good", false, "127.0.0.1:5000")
+	if err != nil || via != "token" || info.UserID != "u-token" {
+		t.Fatalf("valid token off-VPN: info=%+v via=%q err=%v", info, via, err)
+	}
+
+	// Invalid token, over VPN, no resolver -> ErrInvalidToken (mesh cannot save
+	// a *present but bad* token; a bad token governs).
+	if _, _, err := s.resolveAuth(context.Background(), "bad", true, "100.64.0.9:5000"); !errors.Is(err, ErrInvalidToken) {
+		t.Errorf("invalid token: expected ErrInvalidToken, got %v", err)
+	}
+}
+
+// TestResolveAuth_TokenFirstOnVPN is the guard against reintroducing "mesh-first"
+// ordering: on a VPN connection carrying a VALID platform token, the token's own
+// UserID must win — the mesh login must NOT overwrite it. Mesh-first would
+// collapse every relayed user onto the relay's single mesh login (one shared
+// tmux session), a cross-user regression.
+func TestResolveAuth_TokenFirstOnVPN(t *testing.T) {
+	mesh := &MockMeshResolver{Identity: &MeshPeerIdentity{
+		NodeName: "backend-relay", UserID: "relay@aceteam.ai", SameOwner: true,
+	}}
+	s, auth := newTestServer(mesh, true)
+	auth.AddValidToken("user-tok", &TokenInfo{UserID: "per-user-42", OrgID: "org-1"})
+
+	info, via, err := s.resolveAuth(context.Background(), "user-tok", true /*overVPN*/, "100.64.0.2:5000")
+	if err != nil {
+		t.Fatalf("expected token authorization on VPN, got %v", err)
+	}
+	if via != "token" {
+		t.Errorf("authVia = %q, want token (token must take precedence over mesh)", via)
+	}
+	if info.UserID != "per-user-42" {
+		t.Errorf("UserID = %q, want per-user-42 (mesh login must NOT overwrite the token identity)", info.UserID)
+	}
+}

--- a/internal/terminal/server.go
+++ b/internal/terminal/server.go
@@ -3,6 +3,7 @@ package terminal
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -51,11 +52,43 @@ type noOpLogger struct{}
 func (l *noOpLogger) Printf(format string, v ...interface{}) {}
 func (l *noOpLogger) Debugf(format string, v ...interface{}) {}
 
+// ctxKey is the private type for request-context keys set by this server.
+type ctxKey int
+
+// vpnConnKey marks a request whose underlying connection arrived on a VPN
+// (mesh) listener rather than the localhost/LAN bind. It is the signal that
+// gates mesh-peer identity trust (citadel #585): only VPN connections may be
+// authorized by mesh identity; localhost and any public exposure still require
+// a token. It is set by the ConnContext hook installed in Start.
+const vpnConnKey ctxKey = iota
+
+// meshTaggedListener wraps a net.Listener whose accepted connections should be
+// treated as arriving over the mesh/VPN. Every listener registered via
+// AddListener is a tsnet VPN listener (the primary localhost bind in Start is
+// created separately and left unwrapped), so AddListener wraps them here. The
+// wrapping is what lets the ConnContext hook distinguish a mesh peer (eligible
+// for identity trust) from a localhost/LAN client (token required).
+type meshTaggedListener struct{ net.Listener }
+
+// Accept tags each accepted connection as mesh-originated.
+func (l *meshTaggedListener) Accept() (net.Conn, error) {
+	c, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	return &meshConn{Conn: c}, nil
+}
+
+// meshConn marks a connection accepted from a meshTaggedListener so the
+// ConnContext hook can flag its request context as mesh-originated.
+type meshConn struct{ net.Conn }
+
 // Server is the WebSocket terminal server
 type Server struct {
 	config   *Config
 	sessions *SessionManager
 	auth     TokenValidator
+	meshAuth MeshIdentityResolver // optional; gates mesh-identity trust (#585)
 	limiter  *RateLimiter
 	logger   Logger
 
@@ -106,6 +139,19 @@ func (s *Server) SetSilent() {
 	s.logger = &noOpLogger{}
 }
 
+// SetMeshResolver wires the mesh-peer identity resolver used to authorize
+// tokenless connections that arrive over the VPN listener (citadel #585). It is
+// optional and additive: when nil (the default), the server requires a token on
+// every listener exactly as before. When set AND config.TrustMeshPeers is true,
+// a tokenless VPN connection whose source resolves to a verified same-owner
+// tailnet peer is authorized without a platform-minted token. It never weakens
+// the localhost/LAN or token paths. Safe to call before Start.
+func (s *Server) SetMeshResolver(r MeshIdentityResolver) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.meshAuth = r
+}
+
 // AddListener registers an additional net.Listener that the server will also
 // serve on. This enables dual-listen on both LAN and VPN interfaces.
 //
@@ -114,16 +160,21 @@ func (s *Server) SetSilent() {
 // restarting the server (see issue #317). If the server is not yet running,
 // the listener is queued and served when Start is called.
 func (s *Server) AddListener(ln net.Listener) {
+	// Wrap so connections accepted here are tagged as mesh/VPN-originated, which
+	// is what makes them eligible for mesh-peer identity trust (citadel #585).
+	// The raw localhost bind in Start is intentionally NOT wrapped.
+	wrapped := &meshTaggedListener{Listener: ln}
+
 	s.mu.Lock()
-	s.extraListeners = append(s.extraListeners, ln)
+	s.extraListeners = append(s.extraListeners, wrapped)
 	running := s.running
 	httpServer := s.httpServer
 	s.mu.Unlock()
 
 	if running && httpServer != nil {
-		s.logger.Printf("also listening on %s (VPN, hot-attached)", ln.Addr().String())
+		s.logger.Printf("also listening on %s (VPN, hot-attached)", wrapped.Addr().String())
 		go func() {
-			if err := httpServer.Serve(ln); err != nil && err != http.ErrServerClosed {
+			if err := httpServer.Serve(wrapped); err != nil && err != http.ErrServerClosed {
 				s.logger.Printf("VPN listener error: %v", err)
 			}
 		}()
@@ -138,7 +189,14 @@ func (s *Server) RemoveListener(ln net.Listener) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for i, l := range s.extraListeners {
-		if l == ln {
+		// AddListener stores a meshTaggedListener wrapper, but callers pass the
+		// original (unwrapped) listener to RemoveListener, so match either the
+		// stored wrapper or its inner listener.
+		inner := l
+		if mt, ok := l.(*meshTaggedListener); ok {
+			inner = mt.Listener
+		}
+		if l == ln || inner == ln {
 			s.extraListeners = append(s.extraListeners[:i], s.extraListeners[i+1:]...)
 			return
 		}
@@ -199,6 +257,17 @@ func (s *Server) Start() error {
 		ReadTimeout:  15 * time.Second,
 		WriteTimeout: 15 * time.Second,
 		IdleTimeout:  60 * time.Second,
+		// Tag requests whose connection arrived on a VPN (mesh) listener. The
+		// same mux serves both the localhost bind and every AddListener'd VPN
+		// listener; this hook is the single, reliable place to distinguish them
+		// so handleWebSocket can gate mesh-peer identity trust to VPN
+		// connections only (citadel #585).
+		ConnContext: func(ctx context.Context, c net.Conn) context.Context {
+			if _, ok := c.(*meshConn); ok {
+				return context.WithValue(ctx, vpnConnKey, true)
+			}
+			return ctx
+		},
 	}
 
 	// Start idle session checker
@@ -309,6 +378,71 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 		s.limiter.Count())
 }
 
+// resolveAuth decides whether a connection is authorized WITHOUT touching the
+// ResponseWriter, so the decision is unit-testable with an injected mock mesh
+// resolver (no live mesh needed). It implements the citadel #585 auth order:
+//
+//  1. Token present -> validate it; its result GOVERNS. Valid -> authorize with
+//     the token's own UserID; invalid -> reject. This keeps the existing
+//     platform/token path completely unchanged, including on the VPN listener
+//     where the platform relay dials ws://<vpn_ip>:7860?token=... . Token-FIRST
+//     (not mesh-first) is essential: otherwise a relayed per-user token would be
+//     discarded in favor of the relay's single mesh login and every user would
+//     collapse onto one shared tmux session.
+//
+//  2. Token absent, connection arrived on the VPN listener, mesh trust is
+//     enabled (config.TrustMeshPeers) AND a resolver is wired -> authorize by
+//     verified mesh-peer identity, with NO token. This is what makes
+//     `citadel connect <name>` work tokenlessly: dialing <vpn_ip>:7860 already
+//     proves org tailnet membership. The peer must resolve and be same-owner.
+//
+//  3. Otherwise -> reject. Fail-safe: a connection is NEVER accepted merely
+//     because it looked like it arrived over the VPN (unresolved peer, wrong
+//     owner, mesh disabled, no resolver, or token-less on localhost/LAN all
+//     fall through to here).
+//
+// Security posture: mesh-identity trust is gated to the VPN listener; the
+// localhost/LAN bind and any public exposure still require a token. authVia is
+// "token" or "mesh" on success (for the audit log); on failure the returned
+// error is a sentinel suitable for HTTP status mapping.
+func (s *Server) resolveAuth(ctx context.Context, token string, overVPN bool, remoteAddr string) (*TokenInfo, string, error) {
+	// 1. Token path — preserved, and takes precedence on every listener.
+	if token != "" {
+		info, err := s.auth.ValidateToken(token, s.config.OrgID)
+		if err != nil {
+			return nil, "", err
+		}
+		return info, "token", nil
+	}
+
+	// 2. Mesh-identity path — tokenless, VPN-only, opt-outable, resolver-gated.
+	s.mu.RLock()
+	resolver := s.meshAuth
+	s.mu.RUnlock()
+	if overVPN && s.config.TrustMeshPeers && resolver != nil {
+		id, err := resolver.ResolvePeer(ctx, remoteAddr)
+		switch {
+		case err != nil:
+			// Fail-safe: an unverifiable peer falls through to rejection (it does
+			// NOT get an unauthenticated session). Logged at debug — a tokenless
+			// probe from a non-peer is expected noise.
+			s.logger.Debugf("mesh identity unverified for %s (rejecting tokenless): %v", remoteAddr, err)
+		case id == nil || !id.SameOwner:
+			s.logger.Printf("mesh peer %s rejected: not a same-owner tailnet member", remoteAddr)
+		default:
+			// Auditable: this connection was authorized purely on verified mesh
+			// identity, with no platform token. Log the peer at Printf so the
+			// mesh-trust path is always visible in node logs (citadel #585).
+			s.logger.Printf("authorized terminal via mesh-peer identity: node=%q login=%q addr=%s (no token; VPN listener, same-owner)",
+				id.NodeName, id.UserID, remoteAddr)
+			return &TokenInfo{UserID: id.UserID, OrgID: s.config.OrgID}, "mesh", nil
+		}
+	}
+
+	// 3. No valid credential — reject.
+	return nil, "", ErrInvalidToken
+}
+
 // handleWebSocket handles WebSocket upgrade and terminal session
 func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	// Get client IP for rate limiting
@@ -325,28 +459,26 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get and validate token
+	// Authorize the connection. resolveAuth implements the citadel #585 order:
+	// token first (preserves the platform/token path unchanged on every
+	// listener), then — only for a tokenless connection that arrived on the VPN
+	// listener — verified mesh-peer identity. See resolveAuth for the full
+	// contract and security posture.
 	token := r.URL.Query().Get("token")
-	if token == "" {
-		s.logger.Printf("missing token from %s", ip)
-		atomic.AddInt64(&s.failedConnections, 1)
-		writeJSONError(w, "missing token parameter", http.StatusUnauthorized)
-		return
-	}
+	overVPN, _ := r.Context().Value(vpnConnKey).(bool)
+	s.logger.Debugf("authorizing connection from %s (overVPN=%v, token=%v) for org %s",
+		ip, overVPN, token != "", s.config.OrgID)
 
-	// Log token validation attempt (don't log the actual token for security)
-	s.logger.Debugf("validating token for org %s from %s", s.config.OrgID, ip)
-
-	tokenInfo, err := s.auth.ValidateToken(token, s.config.OrgID)
+	tokenInfo, authVia, err := s.resolveAuth(r.Context(), token, overVPN, r.RemoteAddr)
 	if err != nil {
-		s.logger.Printf("token validation failed from %s: %v", ip, err)
+		s.logger.Printf("auth failed from %s (overVPN=%v): %v", ip, overVPN, err)
 		atomic.AddInt64(&s.failedConnections, 1)
-		switch err {
-		case ErrInvalidToken, ErrTokenExpired:
+		switch {
+		case errors.Is(err, ErrInvalidToken), errors.Is(err, ErrTokenExpired):
 			writeJSONError(w, err.Error(), http.StatusUnauthorized)
-		case ErrUnauthorized:
+		case errors.Is(err, ErrUnauthorized):
 			writeJSONError(w, err.Error(), http.StatusForbidden)
-		case ErrAuthServiceUnavailable:
+		case errors.Is(err, ErrAuthServiceUnavailable):
 			writeJSONError(w, err.Error(), http.StatusServiceUnavailable)
 		default:
 			writeJSONError(w, "authentication failed", http.StatusUnauthorized)
@@ -354,7 +486,7 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.logger.Debugf("token validated for user %s from %s", tokenInfo.UserID, ip)
+	s.logger.Debugf("authorized user %s from %s via %s", tokenInfo.UserID, ip, authVia)
 
 	// Check connection limit
 	if s.sessions.Count() >= s.config.MaxConnections {
@@ -396,6 +528,12 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		tmuxCommand = sessionCommand(tmuxSessionName, s.config.Shell)
 		if tmuxCommand != nil {
 			s.logger.Debugf("backing session %s with persistent tmux session %q", sessionID, tmuxSessionName)
+		} else {
+			// tmux backing is wanted (citadel #585 defaults it ON) but no usable
+			// tmux binary resolved. Fall back to a bare, non-persistent shell:
+			// the connection still succeeds, it just won't survive a reconnect.
+			// Warn (not silent) so the missing re-attach is diagnosable.
+			s.logger.Printf("tmux unavailable; session %s falls back to a bare (non-persistent) shell — reconnect re-attach disabled (install tmux, or set CITADEL_TERMINAL_SESSION=none to silence)", sessionID)
 		}
 	}
 

--- a/internal/terminal/server_meshconn_test.go
+++ b/internal/terminal/server_meshconn_test.go
@@ -1,0 +1,84 @@
+// internal/terminal/server_meshconn_test.go
+//go:build !windows
+
+// End-to-end check that the VPN-listener tagging (meshTaggedListener + the
+// ConnContext hook) actually threads the "arrived over the mesh" signal into
+// handleWebSocket, so mesh-peer identity trust is really gated to VPN
+// connections (citadel #585). Uses a real PTY (bare /bin/sh via
+// SessionName="none"), so it is Linux/macOS only, matching the PTY code.
+package terminal
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestMeshTrust_VPNvsLocalhost_EndToEnd(t *testing.T) {
+	const primaryPort = 17870
+
+	cfg := &Config{
+		Host:           "127.0.0.1",
+		Port:           primaryPort,
+		MaxConnections: 10,
+		IdleTimeout:    30 * time.Minute,
+		OrgID:          "org-1",
+		Shell:          "/bin/sh",
+		SessionName:    "none", // force a bare shell so the test needs no tmux
+		TrustMeshPeers: true,
+		RateLimitRPS:   100,
+		RateLimitBurst: 100,
+	}
+	s := NewServer(cfg, NewMockTokenValidator())
+	s.SetMeshResolver(&MockMeshResolver{Identity: &MeshPeerIdentity{
+		NodeName: "gpu-node-1", UserID: "alice@example.com", SameOwner: true,
+	}})
+
+	// Extra listener simulates the tsnet VPN listener; AddListener wraps it so
+	// its connections are tagged mesh-originated.
+	vpnLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("vpn listener: %v", err)
+	}
+	vpnAddr := vpnLn.Addr().(*net.TCPAddr)
+	s.AddListener(vpnLn)
+
+	if err := s.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer s.Stop(context.Background())
+	time.Sleep(100 * time.Millisecond)
+
+	dial := func(port int) (int, error) {
+		u := fmt.Sprintf("ws://127.0.0.1:%d/terminal", port) // no ?token=
+		conn, resp, err := websocket.DefaultDialer.Dial(u, nil)
+		status := 0
+		if resp != nil {
+			status = resp.StatusCode
+		}
+		if conn != nil {
+			conn.Close()
+		}
+		return status, err
+	}
+
+	// Over the VPN listener, no token -> authorized by mesh identity (101).
+	if _, err := dial(vpnAddr.Port); err != nil {
+		t.Errorf("VPN tokenless connect should succeed via mesh identity, got error: %v", err)
+	}
+
+	// Over the localhost (primary) listener, no token -> rejected (401). The
+	// mesh path must NOT engage off the VPN listener.
+	status, err := dial(primaryPort)
+	if err == nil {
+		t.Errorf("localhost tokenless connect should be rejected, but it succeeded")
+	}
+	if status != http.StatusUnauthorized {
+		t.Errorf("localhost tokenless connect: status = %d, want 401", status)
+	}
+}


### PR DESCRIPTION
Closes #585. Unblocks tokenless, idempotent `citadel connect` (v1 was #586).

## Changes
- **Mesh-peer identity trust (VPN-gated, token-first, fail-safe):** connections on the VPN listener are tagged (`meshTaggedListener` + `ConnContext`→`vpnConnKey`). `Server.resolveAuth`: a present token always governs (platform relay unchanged); only a *tokenless VPN* connection is authorized by verified mesh identity (`network.WhoIsPeer`→tsnet `WhoIs`, same-owner check). Off-VPN / mesh-disabled / unresolved / not-same-owner → token still required. Gated by `CITADEL_TERMINAL_TRUST_MESH` (default on). Mesh authorizations are logged.
- **Default tmux-backed sessions:** `DefaultSessionName` `""`→`"citadel"` (per-user re-attachable); graceful fallback to bare shell when tmux absent; opt-out `CITADEL_TERMINAL_SESSION=none`.
- `citadel connect --token` now optional. Wired into `citadel work` + control-center terminal servers.
- Files: `internal/network/{server,singleton}.go`, `internal/terminal/{meshauth.go(new),server.go,config.go}`, `cmd/{terminal_mesh_auth.go(new),work.go,controlcenter.go,connect.go,connect_shell.go}`, tests.

## Testing
`go build ./...`, `go vet ./...`, `go test ./...` green; `GOOS=windows go build ./...` compiles. Tests cover VPN-identity-authorized, tokenless-rejected, localhost/token-unchanged, token-first guard, tmux default/opt-out/fallback.

## Caveats
- Trust model: any same-owner tailnet node gets a tokenless shell over the mesh (deliberate; localhost/relay still token-gated).
- Same-`UserID` connections now share one tmux session (re-attach behavior).
- Needs a real 2-node live-verify (the one mocked path is `WhoIs(RemoteAddr)` with a real `100.64.x.x` addr).

🤖 Generated with [Claude Code](https://claude.com/claude-code)