### PR TITLE
feat(gateway): expose /v1/chat/completions on the node gateway with model→engine routing (#581)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -558,20 +558,35 @@ provisioned gateway, which forces `:8080` + a VPN listener) does. Discovery
 therefore sees only gateway-enabled peers; the probe port is configurable via
 `--port` (`mesh.Options.Port`, default `services.GatewayPort` = 8080).
 
-**Chat reachability gap (KNOWN, tracked in #581):** `mesh chat` is wired but
-routing does NOT work end-to-end yet, because on **embedded-tsnet nodes the
-engine's host port is not reachable over the mesh**. Verified by self-dialing this
-node's own mesh IP:8210 via `network.Dial` while bonsai served fine on
-`localhost:8210` → `connection refused`: embedded tsnet's userspace netstack does
-not forward inbound mesh traffic to a host-bound port lacking a `srv.Listen()`
-(only ports citadel explicitly `ListenVPN`s — status 8080, gateway 8443, terminal,
-vnc, modules — answer over the mesh). The engine compose files bind `0.0.0.0` and
-carry a "peers reach this engine directly over the mesh" comment, but that
-reflects a full-Tailscale/kernel-TUN node, not embedded tsnet. Neither
-`citadel work --gateway` nor `citadel serve` proxies `/v1/chat/completions` (they
-proxy `/v1/embeddings` and control routes only). The node-side gateway chat route
-(model→engine, the complement of aceteam #6236) is the follow-up (#581); until
-then `mesh chat` fails gracefully with a message pointing there.
+**Chat reachability (was the #581 gap, now IMPLEMENTED):** on **embedded-tsnet
+nodes the engine's host port is not reachable over the mesh** — verified by
+self-dialing this node's own mesh IP:8210 via `network.Dial` while bonsai served
+fine on `localhost:8210` → `connection refused`: embedded tsnet's userspace
+netstack does not forward inbound mesh traffic to a host-bound port lacking a
+`srv.Listen()` (only ports citadel explicitly `ListenVPN`s — status 8080, gateway
+8443, terminal, vnc, modules — answer over the mesh). The engine compose files
+bind `0.0.0.0` and carry a "peers reach this engine directly over the mesh"
+comment, but that reflects a full-Tailscale/kernel-TUN node, not embedded tsnet.
+
+**Fix (#581, node-side complement of aceteam #6236):** the gateway now routes
+`/v1/chat/completions` (plus `/v1/completions` and `/v1/models`) by model. Both
+`citadel work --gateway` and `citadel serve` register a dynamic chat handler
+(`internal/gateway/chat_route.go`) that reads the request body's `model`,
+resolves it to the LOCAL serving engine's citadel-owned host port via
+`status.DiscoverLocalEngines` (behind a short TTL cache in `cmd/gateway_chat.go`),
+and reverse-proxies to `http://127.0.0.1:<port>/v1/chat/completions` — streaming
+SSE included (`ReverseProxy.FlushInterval=-1`). Model matching mirrors
+`mesh.FindModel` (exact case-insensitive → substring); an unknown model returns a
+404 OpenAI-shaped `model_not_found`. Because these routes sit on the same gateway
+mux, they ride the LAN listener AND the tsnet VPN listener, so `mesh.Client.
+ChatCompletion(ip, gatewayPort, body)` reaches them over the mesh. `mesh chat`
+now works end-to-end (target the node's gateway port, not the engine port).
+
+Auth posture: `categoryForPath` returns `""` for `/v1/chat/completions`, so it is
+always-allowed — same as `/v1/embeddings`. TLS + mesh membership are the only
+gate; the gateway does NOT currently wire `SetMetering`, so chat is neither
+metered nor authenticated per-request. A single chat response is bounded by the
+gateway `http.Server` `WriteTimeout` (120s), a pre-existing server-wide cap.
 
 ```bash
 citadel mesh models                 # list model -> node/engine/addr across the mesh

--- a/cmd/gateway_chat.go
+++ b/cmd/gateway_chat.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/gateway"
+	"github.com/aceteam-ai/citadel-cli/internal/status"
+)
+
+// gateway_chat.go wires the gateway's model->engine chat router (issue #581,
+// node-side complement of aceteam #6236) to this node's live engine discovery.
+// Shared by `citadel work --gateway` (cmd/work.go) and `citadel serve`
+// (cmd/serve.go) so both gateways expose /v1/chat/completions identically.
+
+// chatListerTTL bounds how long a discovered engine->model map is reused before
+// a fresh probe. status.DiscoverLocalEngines runs `docker inspect` + an engine
+// HTTP probe (bounded by status.ModelDiscoveryTimeout) per running engine, which
+// is too heavy to run on every chat request (it would add seconds of latency
+// before the first streamed token on a multi-engine node). A few seconds of
+// staleness is acceptable: the only failure modes are a transient 404 on a
+// just-loaded model or a transient 502 on a just-unloaded one, both of which
+// self-correct on the next refresh.
+const chatListerTTL = 5 * time.Second
+
+// newLocalChatLister builds a gateway.ChatModelLister backed by
+// status.DiscoverLocalEngines with a short TTL cache. The returned closure is
+// safe for concurrent use (the gateway calls it from request goroutines).
+func newLocalChatLister() gateway.ChatModelLister {
+	var (
+		mu     sync.Mutex
+		cached []gateway.ChatUpstream
+		expiry time.Time
+	)
+	return func() []gateway.ChatUpstream {
+		mu.Lock()
+		defer mu.Unlock()
+		if cached != nil && time.Now().Before(expiry) {
+			return cached
+		}
+		// Bound the probe a touch above ModelDiscoveryTimeout so a slow engine
+		// never stalls a chat request indefinitely.
+		ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+		defer cancel()
+		engines := status.DiscoverLocalEngines(ctx)
+		out := make([]gateway.ChatUpstream, 0, len(engines))
+		for _, e := range engines {
+			out = append(out, gateway.ChatUpstream{Engine: e.Name, Port: e.Port, Models: e.Models})
+		}
+		cached = out
+		expiry = time.Now().Add(chatListerTTL)
+		return out
+	}
+}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -219,6 +219,11 @@ func runServe(cmd *cobra.Command, args []string) error {
 	// stripping is needed.
 	gw.AddUpstream("/v1/embeddings", &gateway.Upstream{Address: embeddingAddr})
 
+	// Chat routing (issue #581): expose /v1/chat/completions (+ /v1/completions
+	// and /v1/models) with model->engine resolution so mesh-direct chat to this
+	// node reaches whichever local engine serves the requested model.
+	gw.SetChatRouter(newLocalChatLister())
+
 	// VNC WebSocket proxy (requires websockify running on vnc-port)
 	gw.AddUpstream("/vnc", &gateway.Upstream{
 		Address:     vncAddr,
@@ -250,6 +255,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	fmt.Printf("     /api/screenshot, /api/actions -> %s\n", statusAddr)
 	fmt.Printf("     /ssh/authorized-keys     -> %s (SSH key deploy)\n", statusAddr)
 	fmt.Printf("     /v1/embeddings           -> %s (TEI embeddings)\n", embeddingAddr)
+	fmt.Printf("     /v1/chat/completions     -> local engine by model (#581)\n")
 	fmt.Printf("     /vnc/...                 -> %s (websockify)\n", vncAddr)
 	fmt.Printf("     /terminal/...            -> %s (terminal)\n", termAddr)
 

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1833,6 +1833,11 @@ func runWork(cmd *cobra.Command, args []string) {
 		// /v1/embeddings path to the local TEI service (default 127.0.0.1:8102).
 		gw.AddUpstream("/v1/embeddings", &gateway.Upstream{Address: embeddingAddr})
 
+		// Chat routing (issue #581): expose /v1/chat/completions (+ /v1/completions
+		// and /v1/models) with model->engine resolution so mesh-direct chat to this
+		// node reaches whichever local engine serves the requested model.
+		gw.SetChatRouter(newLocalChatLister())
+
 		gw.AddUpstream("/vnc", &gateway.Upstream{
 			Address:     vncAddr,
 			StripPrefix: true,
@@ -1914,6 +1919,7 @@ func runWork(cmd *cobra.Command, args []string) {
 		fmt.Printf("     /ssh/authorized-keys     -> %s (SSH key deploy)\n", statusAddr)
 		fmt.Printf("     /workflow/...             -> %s (workflow API)\n", statusAddr)
 		fmt.Printf("     /v1/embeddings           -> %s (TEI embeddings)\n", embeddingAddr)
+		fmt.Printf("     /v1/chat/completions     -> local engine by model (#581)\n")
 		fmt.Printf("     /vnc/...                 -> %s (websockify)\n", vncAddr)
 		fmt.Printf("     /terminal/...            -> %s (terminal)\n", termAddr)
 		for _, e := range provisionedEntries {

--- a/internal/gateway/chat_route.go
+++ b/internal/gateway/chat_route.go
@@ -1,0 +1,280 @@
+package gateway
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// chat_route.go implements the node-side of served-engine chat routing
+// (issue #581), the complement of the backend served-engine routing
+// (aceteam #6236).
+//
+// WHY this exists: on embedded-tsnet nodes an engine's host port is NOT
+// reachable over the mesh — only ports citadel explicitly ListenVPN's (status,
+// gateway, terminal, vnc, modules) answer. So a peer that discovers this node
+// serves a model (via GET /status, internal/mesh) cannot dial the engine's
+// :8210/:8100 directly; it must go through the gateway. Before this, the gateway
+// proxied only /v1/embeddings (a single static upstream) and control routes, so
+// mesh-direct chat had no reachable endpoint (mesh chat failed gracefully,
+// pointing here).
+//
+// WHAT this adds: /v1/chat/completions, /v1/completions, and /v1/models on the
+// gateway mux, so they ride the same LAN + VPN listener as every other gateway
+// route. Chat/completions and completions resolve the requested model to the
+// LOCAL engine serving it (vllm/llamacpp/ollama/bonsai and their citadel-owned
+// host ports) and reverse-proxy to that engine's OpenAI-compatible endpoint,
+// streaming SSE included. Unlike the static Upstream map (one fixed address per
+// path), the backend here is chosen per request from the body's "model", so a
+// multi-engine node (e.g. vllm + bonsai) routes by model rather than to a single
+// upstream.
+
+// maxChatProbeBody bounds how much of a chat request body the router buffers to
+// read the "model" field. The full buffered body is still forwarded verbatim;
+// this only caps the peek so a hostile/buggy client cannot make the router hold
+// an unbounded body in memory.
+const maxChatProbeBody = 8 << 20 // 8 MiB
+
+// ChatUpstream is one local serving engine on THIS node that can answer
+// OpenAI-compatible chat/completions, plus the model(s) it currently serves.
+// Engine is informational (vllm/llamacpp/ollama/bonsai); Port is the
+// citadel-owned host port the engine's OpenAI-compatible API listens on
+// (localhost); Models are the loaded model id(s). It mirrors
+// status.LocalEngine, kept as a local type so the gateway package stays free of
+// the heavy internal/status transitive deps and the routing logic is
+// unit-testable with a hand-built lister.
+type ChatUpstream struct {
+	Engine string
+	Port   int
+	Models []string
+}
+
+// ChatModelLister returns the local serving engines and their models. The
+// gateway calls it per request (cmd wires a short-TTL-cached
+// status.DiscoverLocalEngines) so routing reflects live state — an engine that
+// loads or unloads a model changes where subsequent chat requests route.
+type ChatModelLister func() []ChatUpstream
+
+// SetChatRouter enables model->engine chat routing on the gateway. When set,
+// Start registers /v1/chat/completions, /v1/completions, and /v1/models. Passing
+// nil leaves those routes unregistered (the pre-#581 behavior). Must be called
+// before Start.
+func (s *Server) SetChatRouter(lister ChatModelLister) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.chatLister = lister
+}
+
+// registerChatRoutes wires the chat-routing handlers onto the mux. It is called
+// from Start (and directly from tests) so the test exercises the SAME
+// registration path as production rather than a hand-rolled parallel mux.
+func (s *Server) registerChatRoutes() {
+	chat := http.HandlerFunc(s.handleChatCompletions)
+	// Both paths route identically — resolve the model, proxy to its engine. The
+	// engines expose /v1/chat/completions and /v1/completions at the same
+	// (ip,port), so the router forwards the path unchanged.
+	s.mux.Handle("/v1/chat/completions", chat)
+	s.mux.Handle("/v1/completions", chat)
+	// /v1/models aggregates the models served locally (no model in the request,
+	// so it is a plain listing rather than a routed proxy).
+	s.mux.Handle("/v1/models", http.HandlerFunc(s.handleModels))
+}
+
+// handleChatCompletions reads the requested model from the body, resolves it to
+// a local engine's host port, and reverse-proxies the request (verbatim body,
+// streaming SSE included) to that engine's OpenAI-compatible endpoint. An
+// unknown model yields a 404 with an OpenAI-shaped error.
+func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
+	s.mu.RLock()
+	lister := s.chatLister
+	nodeName := s.config.NodeName
+	s.mu.RUnlock()
+
+	if lister == nil {
+		writeChatError(w, http.StatusNotFound, "model_not_found", "chat routing not enabled on this node")
+		return
+	}
+
+	// Buffer the body so we can read "model" and then forward it VERBATIM. The
+	// body is forwarded byte-for-byte (never re-marshalled from a parsed struct)
+	// so the metering middleware's stream_options.include_usage injection — and
+	// every client field — survives to the engine.
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxChatProbeBody))
+	_ = r.Body.Close()
+	if err != nil {
+		writeChatError(w, http.StatusBadRequest, "invalid_request_error", "failed to read request body")
+		return
+	}
+
+	var probe struct {
+		Model string `json:"model"`
+	}
+	// A malformed body still reaches the engine (which returns its own 4xx); we
+	// only need "model" to pick the route, so an unmarshal error is non-fatal.
+	_ = json.Unmarshal(body, &probe)
+	model := strings.TrimSpace(probe.Model)
+
+	port, engine, ok := resolveChatModel(model, lister())
+	if !ok {
+		writeChatError(w, http.StatusNotFound, "model_not_found",
+			fmt.Sprintf("model %q not served on this node", model))
+		return
+	}
+
+	// Restore the body for the proxy.
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	r.ContentLength = int64(len(body))
+
+	// Dial the engine on the loopback host port. 127.0.0.1 (not "localhost") to
+	// dodge an IPv6-first (::1) resolution against an IPv4-only engine bind.
+	target := &url.URL{Scheme: "http", Host: net.JoinHostPort("127.0.0.1", strconv.Itoa(port))}
+	proxy := &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL.Scheme = target.Scheme
+			req.URL.Host = target.Host
+			// Path (/v1/chat/completions or /v1/completions) is forwarded
+			// unchanged — the engine serves the identical path.
+			req.Header.Set("X-Forwarded-For", req.RemoteAddr)
+			req.Header.Set("X-Forwarded-Proto", "https")
+			if nodeName != "" {
+				req.Header.Set("X-Citadel-Node", nodeName)
+			}
+		},
+		// -1 flushes each write immediately so streaming (stream:true) SSE chunks
+		// reach the client as they arrive instead of being buffered.
+		FlushInterval: -1,
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			log.Printf("[Gateway] chat proxy error for %s -> %s (engine=%s): %v", r.URL.Path, target.Host, engine, err)
+			writeChatError(w, http.StatusBadGateway, "upstream_error", fmt.Sprintf("engine %q unavailable", engine))
+		},
+	}
+	proxy.ServeHTTP(w, r)
+}
+
+// handleModels returns the OpenAI-compatible /v1/models listing aggregated from
+// the local serving engines. Duplicate model ids (same model on two engines) are
+// de-duplicated; the first engine wins the owned_by field.
+func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
+	s.mu.RLock()
+	lister := s.chatLister
+	s.mu.RUnlock()
+
+	type modelObj struct {
+		ID      string `json:"id"`
+		Object  string `json:"object"`
+		OwnedBy string `json:"owned_by"`
+	}
+	data := []modelObj{}
+	if lister != nil {
+		seen := map[string]bool{}
+		for _, e := range lister() {
+			for _, m := range e.Models {
+				m = strings.TrimSpace(m)
+				if m == "" || seen[m] {
+					continue
+				}
+				seen[m] = true
+				data = append(data, modelObj{ID: m, Object: "model", OwnedBy: e.Engine})
+			}
+		}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"object": "list", "data": data})
+}
+
+// resolveChatModel picks the local engine host port that serves the requested
+// model. Matching mirrors internal/mesh.FindModel (the discovery-side selector)
+// so the gateway agrees with what a peer's `citadel mesh chat` discovered:
+//
+//   - exact, case-insensitive model-id match first (the load-bearing case —
+//     `mesh chat` forwards the exact discovered model id from the peer's
+//     /status), then
+//   - a case-insensitive substring match as a fallback (a human hitting the
+//     gateway with a short alias).
+//
+// Ordering is deterministic (sorted by model, then engine, then port) so a
+// substring that matches multiple engines resolves to a stable pick rather than
+// map-iteration-random. An empty model routes only when unambiguous — every
+// candidate resolves to the same port (a single engine); otherwise it is a miss
+// so the caller returns 404 rather than guessing. Returns ok=false when nothing
+// serves the model.
+func resolveChatModel(model string, engines []ChatUpstream) (port int, engine string, ok bool) {
+	type cand struct {
+		engine string
+		port   int
+		model  string
+	}
+	var all []cand
+	for _, e := range engines {
+		if e.Port <= 0 {
+			continue
+		}
+		if len(e.Models) == 0 {
+			// A running engine with no discovered model can still serve the
+			// empty-model case (a single-engine node), so record it with an empty
+			// model id.
+			all = append(all, cand{engine: e.Engine, port: e.Port})
+			continue
+		}
+		for _, m := range e.Models {
+			all = append(all, cand{engine: e.Engine, port: e.Port, model: strings.TrimSpace(m)})
+		}
+	}
+	if len(all) == 0 {
+		return 0, "", false
+	}
+	sort.Slice(all, func(i, j int) bool {
+		if all[i].model != all[j].model {
+			return all[i].model < all[j].model
+		}
+		if all[i].engine != all[j].engine {
+			return all[i].engine < all[j].engine
+		}
+		return all[i].port < all[j].port
+	})
+
+	model = strings.TrimSpace(model)
+	if model == "" {
+		// Route only when unambiguous: all candidates on one port (one engine).
+		firstPort := all[0].port
+		for _, c := range all {
+			if c.port != firstPort {
+				return 0, "", false
+			}
+		}
+		return all[0].port, all[0].engine, true
+	}
+
+	// Exact, case-insensitive id match.
+	for _, c := range all {
+		if c.model != "" && strings.EqualFold(c.model, model) {
+			return c.port, c.engine, true
+		}
+	}
+	// Substring fallback; deterministic first match (all is sorted).
+	needle := strings.ToLower(model)
+	for _, c := range all {
+		if c.model != "" && strings.Contains(strings.ToLower(c.model), needle) {
+			return c.port, c.engine, true
+		}
+	}
+	return 0, "", false
+}
+
+// writeChatError writes an OpenAI-shaped error object with the given HTTP status.
+func writeChatError(w http.ResponseWriter, status int, typ, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"error": map[string]string{"message": msg, "type": typ},
+	})
+}

--- a/internal/gateway/chat_route_test.go
+++ b/internal/gateway/chat_route_test.go
@@ -1,0 +1,213 @@
+package gateway
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// portOf extracts the numeric port from an httptest server URL (http://127.0.0.1:NNN).
+func portOf(t *testing.T, srv *httptest.Server) int {
+	t.Helper()
+	addr := strings.TrimPrefix(srv.URL, "http://")
+	_, portStr, ok := strings.Cut(addr, ":")
+	if !ok {
+		t.Fatalf("cannot parse port from %q", srv.URL)
+	}
+	p, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("bad port %q: %v", portStr, err)
+	}
+	return p
+}
+
+// newChatGateway builds a gateway whose chat routes are registered through the
+// SAME registerChatRoutes path Start uses (issue #581), backed by the given
+// lister. Returns the gateway ready for gw.mux.ServeHTTP.
+func newChatGateway(lister ChatModelLister) *Server {
+	gw := NewServer(Config{Port: 0, NodeName: "test-node"})
+	gw.SetChatRouter(lister)
+	gw.registerChatRoutes()
+	gw.mux.HandleFunc("/", gw.handleRoot)
+	return gw
+}
+
+// TestChatCompletionsRoutesToServingEngine verifies a chat request for a served
+// model is proxied (verbatim body) to that model's engine host port, and the
+// upstream status + body flow back through.
+func TestChatCompletionsRoutesToServingEngine(t *testing.T) {
+	engine := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("engine got path %q, want /v1/chat/completions", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		// Echo back the model the gateway forwarded so we can assert verbatim pass-through.
+		var req struct {
+			Model string `json:"model"`
+		}
+		_ = json.Unmarshal(body, &req)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"backend": "engine", "model": req.Model})
+	}))
+	defer engine.Close()
+
+	port := portOf(t, engine)
+	gw := newChatGateway(func() []ChatUpstream {
+		return []ChatUpstream{{Engine: "bonsai", Port: port, Models: []string{"Bonsai-27B-Q1_0.gguf"}}}
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"Bonsai-27B-Q1_0.gguf","messages":[{"role":"user","content":"hi"}]}`))
+	req.RemoteAddr = "1.2.3.4:5678"
+	w := httptest.NewRecorder()
+	gw.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("bad response: %v (body=%s)", err, w.Body.String())
+	}
+	if resp["backend"] != "engine" {
+		t.Errorf("routed to %q backend, want engine", resp["backend"])
+	}
+	if resp["model"] != "Bonsai-27B-Q1_0.gguf" {
+		t.Errorf("engine saw model %q, want verbatim Bonsai-27B-Q1_0.gguf", resp["model"])
+	}
+}
+
+// TestChatCompletionsSubstringMatch verifies a short alias resolves to the
+// serving engine via the case-insensitive substring fallback (mirroring
+// mesh.FindModel).
+func TestChatCompletionsSubstringMatch(t *testing.T) {
+	engine := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"backend": "engine"})
+	}))
+	defer engine.Close()
+
+	port := portOf(t, engine)
+	gw := newChatGateway(func() []ChatUpstream {
+		return []ChatUpstream{{Engine: "bonsai", Port: port, Models: []string{"Bonsai-27B-Q1_0.gguf"}}}
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"bonsai-27b"}`))
+	w := httptest.NewRecorder()
+	gw.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("substring alias should route: status = %d, body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestChatCompletionsStreamingForwardsSSE verifies streaming (stream:true) SSE
+// frames are forwarded through the gateway to the client.
+func TestChatCompletionsStreamingForwardsSSE(t *testing.T) {
+	engine := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fl, _ := w.(http.Flusher)
+		for _, chunk := range []string{
+			"data: {\"choices\":[{\"delta\":{\"content\":\"Hel\"}}]}\n\n",
+			"data: {\"choices\":[{\"delta\":{\"content\":\"lo\"}}]}\n\n",
+			"data: [DONE]\n\n",
+		} {
+			io.WriteString(w, chunk)
+			if fl != nil {
+				fl.Flush()
+			}
+		}
+	}))
+	defer engine.Close()
+
+	port := portOf(t, engine)
+	gw := newChatGateway(func() []ChatUpstream {
+		return []ChatUpstream{{Engine: "vllm", Port: port, Models: []string{"Qwen/Qwen2.5-7B"}}}
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"Qwen/Qwen2.5-7B","stream":true}`))
+	w := httptest.NewRecorder()
+	gw.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Errorf("content-type = %q, want text/event-stream (SSE preserved)", ct)
+	}
+	// Count forwarded SSE data frames.
+	var frames int
+	sc := bufio.NewScanner(strings.NewReader(w.Body.String()))
+	for sc.Scan() {
+		if strings.HasPrefix(sc.Text(), "data:") {
+			frames++
+		}
+	}
+	if frames != 3 {
+		t.Errorf("forwarded %d SSE data frames, want 3; body=%q", frames, w.Body.String())
+	}
+}
+
+// TestChatCompletionsUnknownModel404 verifies a request for a model no local
+// engine serves returns 404 with the OpenAI-shaped model_not_found error.
+func TestChatCompletionsUnknownModel404(t *testing.T) {
+	gw := newChatGateway(func() []ChatUpstream {
+		return []ChatUpstream{{Engine: "vllm", Port: 9999, Models: []string{"Qwen/Qwen2.5-7B"}}}
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"does-not-exist"}`))
+	w := httptest.NewRecorder()
+	gw.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+	var resp struct {
+		Error struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("bad error response: %v (body=%s)", err, w.Body.String())
+	}
+	if resp.Error.Type != "model_not_found" {
+		t.Errorf("error.type = %q, want model_not_found", resp.Error.Type)
+	}
+	if !strings.Contains(resp.Error.Message, "does-not-exist") {
+		t.Errorf("error.message = %q, want it to name the model", resp.Error.Message)
+	}
+}
+
+// TestResolveChatModel exercises the pure resolver: exact match, empty-model
+// single-engine routing, empty-model ambiguity, and miss.
+func TestResolveChatModel(t *testing.T) {
+	engines := []ChatUpstream{
+		{Engine: "vllm", Port: 8100, Models: []string{"Qwen/Qwen2.5-7B"}},
+		{Engine: "bonsai", Port: 8210, Models: []string{"Bonsai-27B-Q1_0.gguf"}},
+	}
+
+	if p, e, ok := resolveChatModel("bonsai-27b-q1_0.gguf", engines); !ok || p != 8210 || e != "bonsai" {
+		t.Errorf("exact (case-insensitive) = (%d,%q,%v), want (8210,bonsai,true)", p, e, ok)
+	}
+	if _, _, ok := resolveChatModel("nope", engines); ok {
+		t.Error("miss should return ok=false")
+	}
+	// Empty model with a single engine routes to it.
+	single := []ChatUpstream{{Engine: "vllm", Port: 8100, Models: []string{"Qwen/Qwen2.5-7B"}}}
+	if p, _, ok := resolveChatModel("", single); !ok || p != 8100 {
+		t.Errorf("empty-model single-engine = (%d,%v), want (8100,true)", p, ok)
+	}
+	// Empty model with two engines is ambiguous -> miss.
+	if _, _, ok := resolveChatModel("", engines); ok {
+		t.Error("empty-model multi-engine should be ambiguous (ok=false)")
+	}
+}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -152,6 +152,13 @@ type Server struct {
 	// SetProvisionedRegistry.
 	provisionedResolver CapabilityResolver
 
+	// chatLister, when non-nil, enables the model->engine chat-routing handlers
+	// (/v1/chat/completions, /v1/completions, /v1/models). It reports the local
+	// serving engines and their models so an incoming chat request is routed to
+	// whichever engine serves the requested model. Set via SetChatRouter; see
+	// chat_route.go (issue #581, node-side complement of aceteam #6236).
+	chatLister ChatModelLister
+
 	// started is set once Start has registered the proxy handlers for the routes
 	// present at that moment. It gates WireModuleRoute: a route added AFTER Start
 	// must have its proxy handler registered live (Start's registration loop has
@@ -408,6 +415,13 @@ func (s *Server) Start(ctx context.Context) error {
 	// Build the route table
 	for prefix, upstream := range s.config.Upstreams {
 		s.registerProxy(prefix, upstream)
+	}
+	// Model->engine chat routing (#581): unlike the static upstreams above, the
+	// chat routes resolve their backend per request from the requested model, so
+	// they are registered by a dedicated method rather than the upstream loop.
+	// Same mux, so they are reachable on both the LAN and the VPN listener.
+	if s.chatLister != nil {
+		s.registerChatRoutes()
 	}
 	// Any route added after this point (WireModuleRoute) must register its own
 	// proxy handler live, since this loop has already run.


### PR DESCRIPTION
Closes #581. Node-side complement of aceteam #6236 — closes the 'chat reachability gap' in CLAUDE.md. Exposes `POST /v1/chat/completions` (+ `/v1/completions`, `/v1/models`) on the gateway mux (LAN + VPN listeners), resolves model→local engine via `status.DiscoverLocalEngines`, reverse-proxies to the engine with SSE pass-through; unknown model → 404. New: `internal/gateway/chat_route.go`, `cmd/gateway_chat.go`, tests; wired in `cmd/work.go`+`cmd/serve.go`. `go build/vet/test ./...` green (65 pkgs).

**Caveat:** inherits `/v1/embeddings` posture — unauthenticated on the mesh (TLS + tailnet membership only, not metered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)