### PR TITLE
install: ensure citadel is on PATH after curl install (#6522)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -285,23 +285,42 @@ main() {
 
   # Handle PATH configuration for user-local installs
   if [ "$INSTALL_MODE" = "user" ]; then
+    echo "  Location: ${INSTALL_DIR}/${BINARY_NAME}" >&2
+
     if is_in_path "$INSTALL_DIR"; then
-      echo "  Location: ${INSTALL_DIR}/${BINARY_NAME}" >&2
+      # Already on PATH: the bare `citadel` command works immediately.
+      echo "" >&2
+      echo "  Run 'citadel --help' to get started." >&2
+      echo "  To provision this node, run: citadel init" >&2
     else
-      # Add to PATH in shell profile
-      if add_to_path; then
-        echo "  Location: ${INSTALL_DIR}/${BINARY_NAME}" >&2
+      # Not on PATH. Persist to the shell profile for future terminals, but the
+      # CURRENT shell won't pick that up until it is reloaded — so also show the
+      # exact copy-pasteable command to fix this session, plus absolute-path
+      # invocations that work RIGHT NOW (before PATH is fixed). This is the
+      # "command not found in the first 30 seconds" onboarding trap (#6522).
+      add_to_path || true
+
+      local profile_file
+      profile_file=$(detect_shell_profile)
+      local shell_name
+      shell_name=$(basename "$SHELL")
+
+      echo "" >&2
+      warn "${INSTALL_DIR} is not on your PATH."
+      echo "  Added it to ${profile_file} for new terminals." >&2
+      echo "" >&2
+      echo "  To use 'citadel' in THIS terminal, run:" >&2
+      if [ "$shell_name" = "fish" ]; then
+        echo "      fish_add_path ${INSTALL_DIR}" >&2
       else
-        local profile_file
-        profile_file=$(detect_shell_profile)
-        echo "" >&2
-        warn "To use citadel, restart your terminal or run:"
-        echo "  source ${profile_file}" >&2
+        echo "      export PATH=\"${INSTALL_DIR}:\$PATH\"" >&2
       fi
+      echo "" >&2
+      echo "  Or run citadel now by its full path:" >&2
+      echo "      ${INSTALL_DIR}/citadel --help" >&2
+      echo "      ${INSTALL_DIR}/citadel init" >&2
     fi
-    echo "" >&2
-    echo "  Run 'citadel --help' to get started." >&2
-    echo "  To provision this node, run: citadel init" >&2
+
     echo "" >&2
     echo "  Note: Full provisioning (Docker, GPU toolkit) requires sudo." >&2
     echo "  You can run 'citadel init --network-only' for network setup without sudo." >&2


### PR DESCRIPTION
## Context

Part of aceteam-ai/aceteam#6522 (Part 2 only).

From the White Whale onboarding call: after the documented `curl … | sh` install, `citadel` was **command not found**. The user-local installer drops the binary in `~/.local/bin`, which is frequently not on `PATH`, and the success message told the user to run a bare `citadel init` that could not resolve. This is the first 30 seconds of every self-serve onboarding, so it reads as broken.

(Parts 1 — Models page discoverability — and 3 — device-approval bounce — are handled separately in the `aceteam` repo.)

## Root Cause

`scripts/install.sh` (the non-root, user-local path served at `get.aceteam.ai/citadel.sh`) already had PATH helpers (`detect_shell_profile`, `is_in_path`, `add_to_path`), but two gaps remained:

1. The "getting started" lines always printed the **bare** `citadel init` command, even when `~/.local/bin` was not on the current `PATH` → command not found.
2. The old `if add_to_path; then …` structure keyed the guidance on whether the profile line was *newly added* vs *already present*. When the line was already in the profile but not yet loaded into the current shell (return 0), the user got **no** actionable guidance at all and fell through to the bare command.

A piped `curl | sh` runs in a subshell and cannot mutate the parent interactive shell's `PATH`, so appending to the profile alone never fixes the current session — the user must be told explicitly.

## Changes

- `scripts/install.sh`: restructured the user-local success block to branch on `is_in_path "$INSTALL_DIR"` (the actual discriminator), not on whether the profile line was newly added:
  - **On PATH** → keep the simple bare-command guidance (works immediately).
  - **Not on PATH** → persist to the shell profile (idempotent, unchanged `add_to_path`), then additionally:
    - print a copy-pasteable, shell-appropriate current-session fix — `export PATH="…/.local/bin:$PATH"` for bash/zsh/sh, `fish_add_path …` for fish — naming the profile it was written to;
    - print **absolute-path** invocations (`${INSTALL_DIR}/citadel --help`, `${INSTALL_DIR}/citadel init`) that work right now, before PATH is fixed.

The root `install.sh` was intentionally left unchanged: it installs to `/usr/local/bin` (root-only, always on `PATH`), so it does not have this bug. `install.ps1` was also left unchanged — it already patches the User PATH and the current session's `$env:Path`.

## Test plan

No shell test harness exists for the installers, so the PATH logic was exercised in a scratch harness that sources the helpers + new success block against a fake `$HOME` with `INSTALL_DIR` deliberately off `$PATH`:

- **Detection**: off-PATH correctly takes the guidance branch; on-PATH takes the bare-command branch.
- **Shell dispatch**: `SHELL=/bin/bash` and `/usr/bin/zsh` emit `export PATH="…:$PATH"`; `SHELL=/usr/bin/fish` emits `fish_add_path …`.
- **Absolute-path invocation**: `${INSTALL_DIR}/citadel init` is printed in the not-on-PATH case.
- **Idempotency**: running `add_to_path` twice appends the line exactly once (`.local/bin` line count = 1) for bash, zsh, and fish profiles.
- `bash -n scripts/install.sh` — syntax clean.
- `go test ./...` — all pass (shell-only change; no Go affected).

*Generated by Claude Opus 4.8*