### PR TITLE
Default-off + passcode for console/screen/file capabilities (#6524)

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -2005,6 +2005,8 @@ func runTUIWorker(ctx context.Context, activityFn func(level, msg string)) error
 		ConfigDir:                 ccConfigDir,
 		AllowReadOutsideWorkspace: resolveAllowReadOutsideWorkspace(),
 		ShellDisabled:             !ccPerms.Shell,
+		DesktopDisabled:           !ccPerms.Desktop,
+		FilesDisabled:             !ccPerms.Files,
 		WorkflowExec:              ccWfExec,
 		HandlerLog:                func(format string, args ...any) { activity("info", fmt.Sprintf(format, args...)) },
 	}

--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -517,10 +517,20 @@ func ccOnNetworkConnect(activityFn func(level, msg string)) {
 			stopTerminalServer()
 		}
 
-		if err := startTerminalServer(orgID, activityFn); err != nil {
-			activityFn("warning", fmt.Sprintf("Terminal server failed: %v", err))
+		// Console permission gate (aceteam#6524): the control-center node stands up
+		// its own terminal server with a VPN listener, so — exactly like `citadel
+		// work` — starting it must be gated on the operator opting `console` in, not
+		// just on being connected. A fresh node has `console` default-DENY, so no
+		// terminal listener goes on the org mesh. When enabled, the passcode
+		// verifier wired in startTerminalServer gates every connection.
+		if config.LoadPermissions(platform.ConfigDir()).Console {
+			if err := startTerminalServer(orgID, activityFn); err != nil {
+				activityFn("warning", fmt.Sprintf("Terminal server failed: %v", err))
+			} else {
+				activityFn("info", fmt.Sprintf("Terminal server listening on port %d", ccTerminalPort))
+			}
 		} else {
-			activityFn("info", fmt.Sprintf("Terminal server listening on port %d", ccTerminalPort))
+			activityFn("info", "Console (terminal) disabled — enable the 'console' permission + set a node passcode to allow remote terminal access")
 		}
 	}
 
@@ -562,10 +572,20 @@ func startTerminalServer(orgID string, activityFn func(level, msg string)) error
 	}
 
 	// Build configuration
-	config := terminal.DefaultConfig()
-	config.OrgID = orgID
-	config.AuthServiceURL = authServiceURL
-	config.Port = ccTerminalPort
+	termCfg := terminal.DefaultConfig()
+	termCfg.OrgID = orgID
+	termCfg.AuthServiceURL = authServiceURL
+	termCfg.Port = ccTerminalPort
+
+	// Per-node passcode gate (aceteam#6524), same as the `citadel work` terminal
+	// server: even after a valid token or same-owner mesh identity, a connection
+	// must present the node passcode. Loaded fresh per connection so a rotated
+	// passcode is honored without restarting the control center; fails closed.
+	// (config is the internal/config package; the local terminal config is
+	// termCfg to avoid shadowing it here.)
+	termCfg.PasscodeVerifier = func(pin string) bool {
+		return config.LoadPermissions(platform.ConfigDir()).VerifyPasscode(pin)
+	}
 
 	// Create the caching token validator
 	apiToken := ""
@@ -573,10 +593,10 @@ func startTerminalServer(orgID string, activityFn func(level, msg string)) error
 		apiToken = cfg.DeviceAPIToken
 	}
 	ccTerminalAuth = terminal.NewCachingTokenValidator(
-		config.AuthServiceURL,
-		config.OrgID,
+		termCfg.AuthServiceURL,
+		termCfg.OrgID,
 		apiToken,
-		config.TokenRefreshInterval,
+		termCfg.TokenRefreshInterval,
 	)
 
 	// Route validator log messages through the TUI activity log so token
@@ -594,7 +614,7 @@ func startTerminalServer(orgID string, activityFn func(level, msg string)) error
 	// Create and start the server. Operate on a local until fully started, then
 	// publish the pointer atomically so concurrent readers (the supervisor)
 	// never observe a half-initialized server.
-	srv := terminal.NewServer(config, ccTerminalAuth)
+	srv := terminal.NewServer(termCfg, ccTerminalAuth)
 
 	// Trust verified mesh peers on the VPN listener so `citadel connect <name>`
 	// works with no platform-minted token (citadel #585). Additive: token path

--- a/cmd/nodejobs.go
+++ b/cmd/nodejobs.go
@@ -23,6 +23,14 @@ type nodeJobHandlerOpts struct {
 	AllowReadOutsideWorkspace bool
 	// ShellDisabled registers SHELL_COMMAND in a refusing state (still dispatchable).
 	ShellDisabled bool
+	// DesktopDisabled skips registration of the screen/VNC/desktop handlers
+	// (aceteam#6524). Wired from the persisted `desktop` node permission
+	// (default-DENY on a fresh node).
+	DesktopDisabled bool
+	// FilesDisabled skips registration of the file browse/host handlers
+	// (aceteam#6524). Wired from the persisted `files` node permission
+	// (default-DENY on a fresh node).
+	FilesDisabled bool
 	// LogFn routes legacy handler job output through a callback instead of stdout.
 	LogFn func(level, msg string)
 	// WorkflowExec backs the WORKFLOW_RUN handler. Required.
@@ -45,6 +53,8 @@ func buildNodeJobHandlers(opts nodeJobHandlerOpts) []worker.JobHandler {
 		ConfigDir:                 opts.ConfigDir,
 		AllowReadOutsideWorkspace: opts.AllowReadOutsideWorkspace,
 		ShellDisabled:             opts.ShellDisabled,
+		DesktopDisabled:           opts.DesktopDisabled,
+		FilesDisabled:             opts.FilesDisabled,
 	})
 	if opts.WorkflowExec != nil {
 		handlers = append(handlers, workflow.NewHandler(opts.WorkflowExec))

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1240,6 +1240,12 @@ func runWork(cmd *cobra.Command, args []string) {
 		if permsForDesktop.Desktop {
 			if serverCfg.TokenValidator != nil {
 				serverCfg.EnableDesktop = true
+				// Per-node passcode gate for the direct-mesh desktop endpoints
+				// (aceteam#6524). Loaded fresh per request so a rotated passcode is
+				// honored without a worker restart; fails closed when unset.
+				serverCfg.PasscodeVerifier = func(pin string) bool {
+					return config.LoadPermissions(platform.ConfigDir()).VerifyPasscode(pin)
+				}
 				Debug("desktop API enabled (per-request VNC readiness checks)")
 				// Bundle VNC startup so the shared desktop works with zero
 				// manual `citadel vnc enable` (#483). Idempotent, headless-safe,
@@ -1638,6 +1644,17 @@ func runWork(cmd *cobra.Command, args []string) {
 	}
 
 	// Start terminal server if enabled
+	// Console permission gate (aceteam#6524): the terminal server's own VPN
+	// listener is directly dialable by any mesh peer, so starting it must be
+	// gated on the operator opting the `console` permission in — not just the
+	// --terminal flag. A fresh node has `console` default-DENY, so it does NOT
+	// stand up a terminal listener on the org mesh. When enabled, the passcode
+	// verifier below additionally gates every connection.
+	terminalPerms := config.LoadPermissions(platform.ConfigDir())
+	if workTerminal && !terminalPerms.Console {
+		fmt.Fprintln(os.Stderr, "   - Terminal (console) disabled: enable the 'console' permission + set a node passcode to allow remote terminal access")
+		workTerminal = false
+	}
 	if workTerminal {
 		// Check platform support
 		if runtime.GOOS == "windows" {
@@ -1664,6 +1681,14 @@ func runWork(cmd *cobra.Command, args []string) {
 				termConfig.OrgID = orgID
 				termConfig.AuthServiceURL = baseURL
 				termConfig.Version = Version
+
+				// Per-node passcode gate (aceteam#6524). Loaded fresh via the
+				// closure on each connection so a passcode rotated at runtime (via
+				// APPLY_DEVICE_CONFIG or the Control Center) is honored without a
+				// worker restart. Fails closed when no passcode is set.
+				termConfig.PasscodeVerifier = func(pin string) bool {
+					return config.LoadPermissions(platform.ConfigDir()).VerifyPasscode(pin)
+				}
 
 				// Best-effort: provision a Citadel-managed tmux binary so persistent
 				// terminal sessions "just work" on nodes without a system tmux. This
@@ -1986,6 +2011,8 @@ func runWork(cmd *cobra.Command, args []string) {
 		ConfigDir:                 workConfigDir,
 		AllowReadOutsideWorkspace: resolveAllowReadOutsideWorkspace(),
 		ShellDisabled:             !workPerms.Shell,
+		DesktopDisabled:           !workPerms.Desktop,
+		FilesDisabled:             !workPerms.Files,
 		WorkflowExec:              wfExec,
 		HandlerLog:                func(format string, args ...any) { Log(format, args...) },
 	}

--- a/docs/capability-toggles.md
+++ b/docs/capability-toggles.md
@@ -1,17 +1,30 @@
 # Capability Toggles
 
-Node capabilities in Citadel are **config toggles, default opted-in**. A node
-that has the dependencies for a capability advertises it (and registers the
-matching job handler) out of the box; the operator may **opt out** from the
-Control Center, and the platform may set the same value **programmatically** via
-`APPLY_DEVICE_CONFIG`. This mirrors the opt-out model already used for anonymous
-telemetry (`internal/config/telemetry.go`).
+Citadel node capabilities are **config toggles**, but they come in two postures
+depending on risk:
 
-## The pattern
+- **Default-ON (opt-out)** — low-stakes capabilities (meeting notetaker,
+  telemetry, keep-awake, services/ssh/provision). A node that *can* do the thing
+  advertises it and registers the handler out of the box; the operator may **opt
+  out** from the Control Center, and the platform may set the same value
+  programmatically via `APPLY_DEVICE_CONFIG`.
+- **Default-OFF (opt-in) + passcode** — sensitive remote-access surfaces
+  (**console/terminal**, **screen/VNC/desktop**, **file hosting/browsing**, and
+  **shell**). A freshly joined node does **not** expose these: it neither
+  advertises them nor serves the corresponding jobs until the operator explicitly
+  enables each one, and even then a **per-node passcode** gates actual access.
+
+The default-ON pattern mirrors the opt-out model used for anonymous telemetry
+(`internal/config/telemetry.go`) and the meeting capability
+(`internal/config/meeting.go`). The rest of this doc first describes that pattern,
+then the sensitive default-OFF + passcode posture (aceteam#6524) and **why they
+differ**.
+
+## The default-ON (opt-out) pattern
 
 Each capability toggle is a small per-concern config file in
 `platform.ConfigDir()` with a default-true value, following the
-Telemetry/KeepAwake shape:
+Telemetry/Meeting shape:
 
 - **Config** (`internal/config/<cap>.go`): a struct with one bool, a
   `Default<Cap>()` returning **enabled**, and `Load<Cap>` / `Save<Cap>`. Absent
@@ -38,7 +51,7 @@ and `APPLY_DEVICE_CONFIG` write that one file, so the effective value is
 org owns the node config, so a device-config push re-applying an opt-out over a
 local change is intentional — same as VNC/SSH.)
 
-## Concrete instance: the `meeting` capability (aceteam#5098)
+### Concrete instance: the `meeting` capability (aceteam#5098)
 
 The auto-join meeting notetaker is the first capability wired this way:
 
@@ -50,3 +63,95 @@ The auto-join meeting notetaker is the first capability wired this way:
 - Programmatic: `DeviceConfig.MeetingEnabled *bool` (`meetingEnabled` in the
   APPLY_DEVICE_CONFIG payload), driven by the platform's `citadel_config` MCP
   tool.
+
+## The default-OFF (opt-in) + passcode posture (aceteam#6524)
+
+The sensitive remote-access surfaces live in a single per-node config,
+`internal/config/permissions.go` (`permissions.yaml`), which the HTTPS gateway
+and the mesh listeners read:
+
+| Permission  | Surface                                  | Default |
+|-------------|------------------------------------------|---------|
+| `console`   | Terminal/shell WebSocket access          | **OFF** |
+| `desktop`   | Screen/VNC, screenshots, remote actions  | **OFF** |
+| `files`     | Filesystem browse/host (FILE_* jobs)     | **OFF** |
+| `shell`     | `SHELL_COMMAND` (arbitrary code as root)  | **OFF** |
+| `services`  | Service list/management                  | ON      |
+| `ssh`       | SSH authorized_keys sync                 | ON      |
+| `provision` | Container provisioning API               | ON      |
+
+`DefaultPermissions()` returns the console/desktop/files/shell surfaces
+**disabled**. This flips the previous default-on model.
+
+### Why these three differ from meeting/telemetry
+
+Telemetry is anonymous debug data; the meeting notetaker joins a call the org
+already scheduled. Neither exposes the operator's own machine. Console, desktop,
+and files are categorically different: the moment a node joins the fabric,
+default-on put the operator's **terminal, screen, and filesystem** on the org
+mesh before they decided to expose them. For a privacy-first operator ("your data
+stays in this box") that is a trust-breaking surprise (the White Whale onboarding
+incident). So these surfaces are **default-deny, opt-in** — joining to serve a
+model must never, by itself, expose remote access. Inference/model-serving is
+**not** a permission and is unaffected: a node serves models with all three
+surfaces off.
+
+### The passcode gate — "enabled" is not "open"
+
+Enabling a surface is not the same as opening it to anyone on the org mesh. A
+**per-node passcode** (bcrypt hash in `permissions.yaml`, never plaintext) gates
+actual access:
+
+- Set/verified via `Permissions.SetPasscode` / `Permissions.VerifyPasscode`
+  (bcrypt, salt embedded in the hash).
+- **Scope:** one passcode **per node**, with **per-capability enablement**
+  (enable console and desktop independently; one passcode unlocks whatever is
+  enabled). This matches the issue's recommended scope.
+- **Fail-closed:** a surface that is enabled but has **no passcode set** stays
+  denied. Enablement without a passcode never silently opens the surface.
+
+### Enforcement points (all must hold; each fails closed)
+
+1. **Advertisement** (`internal/status/capabilities_flags.go`): the heartbeat
+   capability flags for console/desktop/files report available only when the
+   node is capable **and** the permission is enabled. A fresh node reports them
+   false, so the web console does not present a live surface. (Enablement stays
+   separately visible via the `PermissionState` heartbeat block, so the web can
+   still render an "enable + set passcode" call to action.)
+2. **Redis fabric handlers** (`internal/worker/handler_adapter.go`): the
+   VNC/screenshot/actions handlers and the FILE_* browse/host handlers are
+   registered **only** when `desktop` / `files` are enabled (`DesktopDisabled` /
+   `FilesDisabled` opts). A fresh node refuses those jobs. `TRANSCRIBE_AUDIO` and
+   `MEETING_JOIN` share the workspace but belong to the default-ON meeting
+   capability and are deliberately **not** gated.
+3. **HTTPS gateway** (`internal/gateway/gateway.go`): `permissionMiddleware`
+   blocks a disabled category, and for an enabled sensitive category additionally
+   requires the passcode (`X-Citadel-Passcode` header, or `?passcode=` for
+   WebSocket clients).
+4. **Direct mesh listeners** — because a mesh peer can dial these listeners
+   directly (not only through the gateway):
+   - **Terminal server** (`internal/terminal/`): started only when `console` is
+     enabled (`cmd/work.go`), and every connection additionally requires the
+     passcode (`Config.PasscodeVerifier`) on top of token/mesh-identity auth.
+   - **Desktop endpoints** on the status server (`internal/status/server.go`
+     `/api/screenshot`, `/api/actions`): gated on `desktop`, and `requireAuth`
+     additionally requires the passcode (`ServerConfig.PasscodeVerifier`).
+
+### Enabling a surface
+
+- **Control Center:** the Built-in Services modal toggles console/desktop/files.
+  Enabling one with no passcode set warns that access stays denied until a
+  passcode is set.
+- **Programmatic (`APPLY_DEVICE_CONFIG`):** `DeviceConfig` carries
+  `consoleEnabled` / `desktopEnabled` / `filesEnabled` (`*bool`, nil = untouched)
+  and `nodePasscode` (`*string`, bcrypt-hashed before persist; empty clears it).
+  This writes the same `permissions.yaml` the gates read.
+
+### Cross-repo follow-up (aceteam web console, not in this repo)
+
+The web console should render console/desktop/files as **opt-in** (an "enable +
+set passcode" call to action) rather than presenting a live console for a node
+that has not enabled the surface, and must send the passcode on the
+`X-Citadel-Passcode` header (or `?passcode=` for the WebSocket terminal/VNC).
+Track alongside the mesh-ACL / cross-org work ([[citadel-mesh-security]] #5028):
+that work is about cross-org exposure, this is per-node owner consent.

--- a/internal/config/permissions.go
+++ b/internal/config/permissions.go
@@ -5,36 +5,73 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
+	"golang.org/x/crypto/bcrypt"
 	"gopkg.in/yaml.v3"
 )
 
-// Permissions controls which capabilities are exposed through the HTTPS gateway.
-// Most fields default to true (opt-out model). The exception is Shell, which is
-// default-deny (opt-in): SHELL_COMMAND runs arbitrary code as root on the node,
-// so a node must explicitly enable it before commands are accepted
-// (aceteam #6149, Phase 0).
+// Permissions controls which capabilities are exposed through the HTTPS gateway
+// and the mesh remote-access listeners.
+//
+// Posture is split by risk (aceteam#6524):
+//
+//   - Sensitive remote-access surfaces — Console (terminal/shell), Desktop
+//     (VNC/screenshot/actions), and Files (filesystem browse/host) — are
+//     **default-DENY, opt-in**. A freshly joined node does NOT expose them: it
+//     neither advertises them nor serves the corresponding jobs until the
+//     operator explicitly enables each one. This flips the previous default-on
+//     model, which put a machine's console/screen/files on the org mesh the
+//     moment it joined (the White Whale onboarding landmine). Shell (arbitrary
+//     code as root) was already default-deny (#6149, Phase 0).
+//   - Lower-stakes surfaces — Services, SSH, Provision — keep the default-on
+//     (opt-out) model. They mediate node operation the org already owns and do
+//     not expose the operator's interactive machine surface the way
+//     console/desktop/files do.
+//
+// Enabling a sensitive surface is NOT the same as opening it to anyone on the
+// org mesh: a per-node passcode (PasscodeHash) gates actual access. "Enabled"
+// means "reachable IF you also present the node passcode." A capability that is
+// enabled but has no passcode set fails CLOSED (access denied) — enablement
+// without a passcode never silently opens the surface.
 type Permissions struct {
-	Console   bool `yaml:"console" json:"console"`     // Terminal WebSocket access
-	Desktop   bool `yaml:"desktop" json:"desktop"`     // VNC, screenshots, actions
-	Files     bool `yaml:"files" json:"files"`         // File browser API
-	Services  bool `yaml:"services" json:"services"`   // Service list/management
-	SSH       bool `yaml:"ssh" json:"ssh"`             // SSH authorized_keys sync
-	Provision bool `yaml:"provision" json:"provision"` // Container provisioning API
+	Console   bool `yaml:"console" json:"console"`     // Terminal WebSocket access (default-deny, opt-in)
+	Desktop   bool `yaml:"desktop" json:"desktop"`     // VNC, screenshots, actions (default-deny, opt-in)
+	Files     bool `yaml:"files" json:"files"`         // File browser API (default-deny, opt-in)
+	Services  bool `yaml:"services" json:"services"`   // Service list/management (default-on, opt-out)
+	SSH       bool `yaml:"ssh" json:"ssh"`             // SSH authorized_keys sync (default-on, opt-out)
+	Provision bool `yaml:"provision" json:"provision"` // Container provisioning API (default-on, opt-out)
 	Shell     bool `yaml:"shell" json:"shell"`         // SHELL_COMMAND job execution (default-deny, opt-in)
+
+	// PasscodeHash is the bcrypt hash of the per-node passcode that gates the
+	// sensitive remote-access surfaces (console/desktop/files). It is never the
+	// plaintext PIN — bcrypt embeds its own salt, so no separate salt field is
+	// stored. Empty means no passcode is set, in which case every sensitive
+	// surface fails closed even if its bool is true (see VerifyPasscode).
+	PasscodeHash string `yaml:"passcode_hash,omitempty" json:"passcode_hash,omitempty"`
 }
 
 const permissionsFile = "permissions.yaml"
 
-// DefaultPermissions returns a Permissions struct with capabilities enabled
-// except Shell. Shell is default-deny (opt-in): SHELL_COMMAND executes arbitrary
-// code as root, so a node must explicitly set `shell: true` to accept it
-// (aceteam #6149, Phase 0).
+// bcryptPasscodeCost is deliberately the library default. The passcode is a
+// short interactive PIN, not a password database, and verification runs on the
+// node's access path; the default cost keeps that check fast while still salting
+// + stretching so a leaked permissions.yaml does not reveal the PIN.
+const bcryptPasscodeCost = bcrypt.DefaultCost
+
+// DefaultPermissions returns the default node posture: the sensitive
+// remote-access surfaces (Console, Desktop, Files, Shell) are DISABLED, and the
+// lower-stakes operational surfaces (Services, SSH, Provision) are enabled.
+//
+// Default-deny for console/desktop/files is intentional (aceteam#6524): joining
+// the fabric to serve a model must never, by itself, put the operator's
+// terminal, screen, or filesystem on the org mesh. The operator opts each one in
+// explicitly (Control Center or APPLY_DEVICE_CONFIG) and sets a passcode.
 func DefaultPermissions() *Permissions {
 	return &Permissions{
-		Console:   true,
-		Desktop:   true,
-		Files:     true,
+		Console:   false,
+		Desktop:   false,
+		Files:     false,
 		Services:  true,
 		SSH:       true,
 		Provision: true,
@@ -43,10 +80,10 @@ func DefaultPermissions() *Permissions {
 }
 
 // LoadPermissions reads permissions from the config directory.
-// If the file doesn't exist, returns defaults (all capabilities enabled except
-// Shell, which is default-deny; see DefaultPermissions).
-// Partial files preserve defaults for absent keys (unmarshal into pre-initialized
-// struct), so a config that predates the `shell` key leaves Shell disabled.
+// If the file doesn't exist, returns defaults (see DefaultPermissions:
+// console/desktop/files/shell disabled, services/ssh/provision enabled).
+// Partial files preserve defaults for absent keys (unmarshal into a
+// pre-initialized struct), so a config that predates a key keeps its default.
 func LoadPermissions(configDir string) *Permissions {
 	p := DefaultPermissions()
 
@@ -55,13 +92,16 @@ func LoadPermissions(configDir string) *Permissions {
 		return p
 	}
 
-	// yaml.Unmarshal only overwrites keys present in the file,
-	// so absent keys keep their default (true) value.
+	// yaml.Unmarshal only overwrites keys present in the file, so absent keys
+	// keep their default value.
 	_ = yaml.Unmarshal(data, p)
 	return p
 }
 
-// SavePermissions writes permissions to the config directory.
+// SavePermissions writes permissions to the config directory. The file is
+// written 0600 because it now carries the node passcode hash (a credential):
+// even though bcrypt makes the hash non-reversible cheaply, there is no reason
+// to leave it group/world-readable.
 func SavePermissions(configDir string, p *Permissions) error {
 	if err := os.MkdirAll(configDir, 0755); err != nil {
 		return fmt.Errorf("create config dir: %w", err)
@@ -72,5 +112,50 @@ func SavePermissions(configDir string, p *Permissions) error {
 		return fmt.Errorf("marshal permissions: %w", err)
 	}
 
-	return os.WriteFile(filepath.Join(configDir, permissionsFile), data, 0644)
+	return os.WriteFile(filepath.Join(configDir, permissionsFile), data, 0600)
+}
+
+// SetPasscode hashes pin with bcrypt and stores it in PasscodeHash. An empty pin
+// clears the passcode (HasPasscode becomes false), which — combined with the
+// fail-closed VerifyPasscode — re-locks every sensitive surface. The caller is
+// responsible for persisting via SavePermissions.
+func (p *Permissions) SetPasscode(pin string) error {
+	if strings.TrimSpace(pin) == "" {
+		p.PasscodeHash = ""
+		return nil
+	}
+	hash, err := bcrypt.GenerateFromPassword([]byte(pin), bcryptPasscodeCost)
+	if err != nil {
+		return fmt.Errorf("hash passcode: %w", err)
+	}
+	p.PasscodeHash = string(hash)
+	return nil
+}
+
+// HasPasscode reports whether a node passcode is set.
+func (p *Permissions) HasPasscode() bool {
+	return p.PasscodeHash != ""
+}
+
+// VerifyPasscode reports whether pin matches the stored node passcode. It fails
+// CLOSED: an unset passcode (no hash) or an empty pin returns false, so a
+// sensitive surface that was enabled but never given a passcode stays locked
+// rather than silently opening to anyone on the org mesh.
+func (p *Permissions) VerifyPasscode(pin string) bool {
+	if p.PasscodeHash == "" || pin == "" {
+		return false
+	}
+	return bcrypt.CompareHashAndPassword([]byte(p.PasscodeHash), []byte(pin)) == nil
+}
+
+// IsSensitiveCategory reports whether a permission category is a passcode-gated
+// sensitive remote-access surface. Kept as a package function so the gateway and
+// listener paths agree on the set without duplicating the string literals.
+func IsSensitiveCategory(category string) bool {
+	switch category {
+	case "console", "desktop", "files":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/config/permissions_test.go
+++ b/internal/config/permissions_test.go
@@ -6,137 +6,196 @@ import (
 	"testing"
 )
 
-func TestDefaultPermissions(t *testing.T) {
+// TestDefaultPermissions_SensitiveSurfacesOff is the core aceteam#6524 guarantee:
+// a freshly joined node (no permissions.yaml) does NOT expose the sensitive
+// remote-access surfaces (console/desktop/files) or shell, while the lower-stakes
+// operational surfaces (services/ssh/provision) stay on.
+func TestDefaultPermissions_SensitiveSurfacesOff(t *testing.T) {
 	p := DefaultPermissions()
-	if !p.Console || !p.Desktop || !p.Files || !p.Services || !p.SSH || !p.Provision {
-		t.Errorf("DefaultPermissions should enable non-shell capabilities, got %+v", p)
+	if p.Console || p.Desktop || p.Files || p.Shell {
+		t.Errorf("console/desktop/files/shell must be default-DENY on a fresh node, got %+v", p)
 	}
-	// Shell is default-deny (opt-in): a fresh node must not accept SHELL_COMMAND
-	// until an operator explicitly enables it (aceteam #6149, Phase 0).
-	if p.Shell {
-		t.Errorf("DefaultPermissions should leave Shell disabled (default-deny), got %+v", p)
+	if !p.Services || !p.SSH || !p.Provision {
+		t.Errorf("services/ssh/provision should stay default-on (opt-out), got %+v", p)
+	}
+	if p.HasPasscode() {
+		t.Error("a fresh node must not have a passcode set")
 	}
 }
 
-func TestLoadPermissions_ShellDefaultsDisabled(t *testing.T) {
-	// Shell is default-deny (opt-in). A config that omits the `shell` key (e.g.
-	// one written before the field existed) must leave shell DISABLED so the
-	// kill-switch fails closed (aceteam #6149, Phase 0).
+// TestLoadPermissions_NoFile_FreshNode asserts the on-disk-absent path returns the
+// same locked-down posture (the actual code path a just-joined node hits).
+func TestLoadPermissions_NoFile_FreshNode(t *testing.T) {
 	dir := t.TempDir()
-	data := []byte("console: true\nssh: false\n")
-	if err := os.WriteFile(filepath.Join(dir, "permissions.yaml"), data, 0644); err != nil {
+	p := LoadPermissions(dir)
+	if p.Console || p.Desktop || p.Files || p.Shell {
+		t.Errorf("no-file load must leave sensitive surfaces disabled, got %+v", p)
+	}
+	if !p.Services || !p.SSH || !p.Provision {
+		t.Errorf("no-file load should keep services/ssh/provision on, got %+v", p)
+	}
+}
+
+// TestLoadPermissions_AbsentKeysStayDisabled verifies a partial/legacy config
+// that omits console/desktop/files leaves them DISABLED (fail closed), so a
+// permissions.yaml written before this change does not silently re-open them.
+func TestLoadPermissions_AbsentKeysStayDisabled(t *testing.T) {
+	dir := t.TempDir()
+	// Legacy-shaped file that only sets ssh; the sensitive keys are absent.
+	data := []byte("ssh: true\n")
+	if err := os.WriteFile(filepath.Join(dir, "permissions.yaml"), data, 0600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 	p := LoadPermissions(dir)
-	if p.Shell {
-		t.Error("shell should default to DISABLED when absent from a config file")
-	}
-
-	// Explicit opt-in must round-trip.
-	data = []byte("shell: true\n")
-	if err := os.WriteFile(filepath.Join(dir, "permissions.yaml"), data, 0644); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-	p = LoadPermissions(dir)
-	if !p.Shell {
-		t.Error("shell should be true when explicitly enabled in config")
-	}
-
-	// Explicit opt-out must round-trip.
-	data = []byte("shell: false\n")
-	if err := os.WriteFile(filepath.Join(dir, "permissions.yaml"), data, 0644); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-	p = LoadPermissions(dir)
-	if p.Shell {
-		t.Error("shell should be false when explicitly disabled in config")
+	if p.Console || p.Desktop || p.Files {
+		t.Errorf("absent sensitive keys must default to DISABLED, got %+v", p)
 	}
 }
 
-func TestLoadPermissions_NoFile(t *testing.T) {
+// TestLoadPermissions_ExplicitOptInRoundTrips confirms an operator's opt-in
+// persists and reloads.
+func TestLoadPermissions_ExplicitOptInRoundTrips(t *testing.T) {
 	dir := t.TempDir()
+	data := []byte("console: true\ndesktop: true\nfiles: true\n")
+	if err := os.WriteFile(filepath.Join(dir, "permissions.yaml"), data, 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
 	p := LoadPermissions(dir)
-	if !p.Console || !p.Desktop || !p.Files || !p.Services || !p.SSH {
-		t.Errorf("LoadPermissions with no file should return defaults, got %+v", p)
+	if !p.Console || !p.Desktop || !p.Files {
+		t.Errorf("explicit opt-in should round-trip true, got %+v", p)
 	}
 }
 
-func TestSaveAndLoadRoundTrip(t *testing.T) {
-	dir := t.TempDir()
-	original := &Permissions{
-		Console:  false,
-		Desktop:  true,
-		Files:    false,
-		Services: true,
-		SSH:      false,
+// TestPasscode_SetVerifyHashesNotPlaintext verifies the passcode is stored
+// hashed (never plaintext) and verifies correctly.
+func TestPasscode_SetVerifyHashesNotPlaintext(t *testing.T) {
+	p := DefaultPermissions()
+	if err := p.SetPasscode("1379"); err != nil {
+		t.Fatalf("SetPasscode: %v", err)
 	}
+	if p.PasscodeHash == "" {
+		t.Fatal("passcode hash should be set")
+	}
+	if p.PasscodeHash == "1379" {
+		t.Fatal("passcode must NOT be stored in plaintext")
+	}
+	if !p.HasPasscode() {
+		t.Error("HasPasscode should be true after SetPasscode")
+	}
+	if !p.VerifyPasscode("1379") {
+		t.Error("correct passcode should verify")
+	}
+	if p.VerifyPasscode("0000") {
+		t.Error("wrong passcode must be rejected")
+	}
+}
 
-	if err := SavePermissions(dir, original); err != nil {
+// TestPasscode_FailsClosed is the "enabled != open" guarantee: verification with
+// no passcode set, or an empty pin, must fail — so an enabled-but-passcode-less
+// surface stays locked.
+func TestPasscode_FailsClosed(t *testing.T) {
+	p := DefaultPermissions() // no passcode
+	if p.VerifyPasscode("anything") {
+		t.Error("verify must fail closed when no passcode is set")
+	}
+	if err := p.SetPasscode("1379"); err != nil {
+		t.Fatalf("SetPasscode: %v", err)
+	}
+	if p.VerifyPasscode("") {
+		t.Error("an empty pin must never verify")
+	}
+	// Clearing the passcode re-locks.
+	if err := p.SetPasscode(""); err != nil {
+		t.Fatalf("clear passcode: %v", err)
+	}
+	if p.HasPasscode() || p.VerifyPasscode("1379") {
+		t.Error("clearing the passcode should re-lock (HasPasscode false, verify fails)")
+	}
+}
+
+// TestPasscode_RoundTripsThroughSaveLoad confirms the hash persists and still
+// verifies after a save/load cycle, and that a leaked file never carries the PIN.
+func TestPasscode_RoundTripsThroughSaveLoad(t *testing.T) {
+	dir := t.TempDir()
+	p := DefaultPermissions()
+	p.Console = true
+	if err := p.SetPasscode("2468"); err != nil {
+		t.Fatalf("SetPasscode: %v", err)
+	}
+	if err := SavePermissions(dir, p); err != nil {
 		t.Fatalf("SavePermissions: %v", err)
 	}
 
+	raw, err := os.ReadFile(filepath.Join(dir, "permissions.yaml"))
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if containsPlaintextPIN(string(raw), "2468") {
+		t.Error("persisted permissions.yaml must not contain the plaintext PIN")
+	}
+
 	loaded := LoadPermissions(dir)
-	if loaded.Console != original.Console ||
-		loaded.Desktop != original.Desktop ||
-		loaded.Files != original.Files ||
-		loaded.Services != original.Services ||
-		loaded.SSH != original.SSH {
-		t.Errorf("round trip mismatch: saved %+v, loaded %+v", original, loaded)
+	if !loaded.Console {
+		t.Error("console opt-in should persist")
+	}
+	if !loaded.VerifyPasscode("2468") {
+		t.Error("passcode should verify after save/load round-trip")
 	}
 }
 
-func TestLoadPermissions_PartialConfig(t *testing.T) {
+// TestIsSensitiveCategory pins the set of passcode-gated surfaces the gateway and
+// listener paths agree on.
+func TestIsSensitiveCategory(t *testing.T) {
+	for _, c := range []string{"console", "desktop", "files"} {
+		if !IsSensitiveCategory(c) {
+			t.Errorf("%q should be a sensitive category", c)
+		}
+	}
+	for _, c := range []string{"services", "ssh", "provision", "shell", ""} {
+		if IsSensitiveCategory(c) {
+			t.Errorf("%q should NOT be a sensitive category", c)
+		}
+	}
+}
+
+// TestSavePermissions_FileMode0600 confirms the file carrying the passcode hash
+// is not group/world-readable.
+func TestSavePermissions_FileMode0600(t *testing.T) {
 	dir := t.TempDir()
-
-	// Write a partial file that only disables console
-	data := []byte("console: false\n")
-	if err := os.WriteFile(filepath.Join(dir, "permissions.yaml"), data, 0644); err != nil {
-		t.Fatalf("write partial config: %v", err)
-	}
-
-	p := LoadPermissions(dir)
-	if p.Console {
-		t.Error("console should be false from partial config")
-	}
-	// All other fields should remain true (defaults)
-	if !p.Desktop {
-		t.Error("desktop should be true (default, not in partial config)")
-	}
-	if !p.Files {
-		t.Error("files should be true (default, not in partial config)")
-	}
-	if !p.Services {
-		t.Error("services should be true (default, not in partial config)")
-	}
-	if !p.SSH {
-		t.Error("ssh should be true (default, not in partial config)")
-	}
-}
-
-func TestSavePermissions_CreatesDir(t *testing.T) {
-	dir := filepath.Join(t.TempDir(), "nested", "dir")
 	p := DefaultPermissions()
-
+	_ = p.SetPasscode("1379")
 	if err := SavePermissions(dir, p); err != nil {
-		t.Fatalf("SavePermissions should create nested dirs: %v", err)
+		t.Fatalf("SavePermissions: %v", err)
 	}
-
-	// Verify file exists
-	if _, err := os.Stat(filepath.Join(dir, "permissions.yaml")); err != nil {
-		t.Errorf("permissions file should exist after save: %v", err)
+	info, err := os.Stat(filepath.Join(dir, "permissions.yaml"))
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Errorf("permissions.yaml should be 0600 (holds a credential), got %o", perm)
 	}
 }
 
 func TestLoadPermissions_InvalidYAML(t *testing.T) {
 	dir := t.TempDir()
 	data := []byte("not: [valid: yaml: {{{")
-	if err := os.WriteFile(filepath.Join(dir, "permissions.yaml"), data, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "permissions.yaml"), data, 0600); err != nil {
 		t.Fatalf("write invalid yaml: %v", err)
 	}
-
 	p := LoadPermissions(dir)
-	// Should still return defaults on parse error
-	if !p.Console || !p.Desktop || !p.Files || !p.Services || !p.SSH {
-		t.Errorf("invalid YAML should return defaults, got %+v", p)
+	// Should still return the (locked-down) defaults on parse error.
+	if p.Console || p.Desktop || p.Files {
+		t.Errorf("invalid YAML should return locked-down defaults, got %+v", p)
 	}
+}
+
+// containsPlaintextPIN reports whether s contains the raw pin (used to prove the
+// stored bcrypt hash is not the plaintext).
+func containsPlaintextPIN(s, pin string) bool {
+	for i := 0; i+len(pin) <= len(s); i++ {
+		if s[i:i+len(pin)] == pin {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -369,6 +369,17 @@ func categoryForPath(path string) string {
 	return ""
 }
 
+// passcodeFromRequest extracts the per-node passcode a caller presents for a
+// sensitive surface. The header is the primary channel; the query parameter is
+// the fallback for WebSocket clients (e.g. the browser terminal/VNC), which
+// cannot set custom headers on the upgrade request.
+func passcodeFromRequest(r *http.Request) string {
+	if h := r.Header.Get("X-Citadel-Passcode"); h != "" {
+		return h
+	}
+	return r.URL.Query().Get("passcode")
+}
+
 // permissionMiddleware checks permissions before passing requests to the next handler.
 // If permissions are nil, all requests pass through.
 func (s *Server) permissionMiddleware(next http.Handler) http.Handler {
@@ -402,6 +413,22 @@ func (s *Server) permissionMiddleware(next http.Handler) http.Handler {
 				w.WriteHeader(http.StatusForbidden)
 				fmt.Fprint(w, `{"error":"capability disabled by node operator"}`)
 				return
+			}
+
+			// Passcode gate (aceteam#6524): an ENABLED sensitive surface
+			// (console/desktop/files) additionally requires the per-node passcode,
+			// so "enabled" is not "open to anyone on the org mesh". The caller
+			// presents it via the X-Citadel-Passcode header (or ?passcode= for
+			// WebSocket clients that cannot set headers). Fails CLOSED: a node with
+			// no passcode set, or a wrong/absent passcode, is denied — enabling a
+			// surface without a passcode never silently opens it.
+			if config.IsSensitiveCategory(category) {
+				if !perms.VerifyPasscode(passcodeFromRequest(r)) {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusUnauthorized)
+					fmt.Fprint(w, `{"error":"node passcode required"}`)
+					return
+				}
 			}
 		}
 		next.ServeHTTP(w, r)

--- a/internal/gateway/passcode_test.go
+++ b/internal/gateway/passcode_test.go
@@ -1,0 +1,91 @@
+package gateway
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/config"
+)
+
+// TestPermissionMiddleware_SensitivePasscodeGate verifies the aceteam#6524
+// gateway behavior for a sensitive surface (/api/screenshot -> desktop):
+//   - disabled: blocked (403) regardless of passcode
+//   - enabled + no passcode set: fails closed (401)
+//   - enabled + wrong passcode: 401
+//   - enabled + correct passcode: passes through
+func TestPermissionMiddleware_SensitivePasscodeGate(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	newGateway := func(p *config.Permissions) http.Handler {
+		s := NewServer(Config{NodeName: "test-node"})
+		s.SetPermissions(p)
+		return s.permissionMiddleware(next)
+	}
+
+	call := func(h http.Handler, passcode string) int {
+		req := httptest.NewRequest(http.MethodGet, "/api/screenshot", nil)
+		if passcode != "" {
+			req.Header.Set("X-Citadel-Passcode", passcode)
+		}
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	t.Run("disabled surface is blocked", func(t *testing.T) {
+		p := config.DefaultPermissions() // desktop=false
+		_ = p.SetPasscode("1379")
+		if code := call(newGateway(p), "1379"); code != http.StatusForbidden {
+			t.Errorf("disabled desktop should be 403, got %d", code)
+		}
+	})
+
+	t.Run("enabled but no passcode fails closed", func(t *testing.T) {
+		p := config.DefaultPermissions()
+		p.Desktop = true // enabled, but no passcode
+		if code := call(newGateway(p), ""); code != http.StatusUnauthorized {
+			t.Errorf("enabled-no-passcode should be 401, got %d", code)
+		}
+	})
+
+	t.Run("enabled + wrong passcode is denied", func(t *testing.T) {
+		p := config.DefaultPermissions()
+		p.Desktop = true
+		_ = p.SetPasscode("1379")
+		if code := call(newGateway(p), "0000"); code != http.StatusUnauthorized {
+			t.Errorf("wrong passcode should be 401, got %d", code)
+		}
+	})
+
+	t.Run("enabled + correct passcode passes", func(t *testing.T) {
+		p := config.DefaultPermissions()
+		p.Desktop = true
+		_ = p.SetPasscode("1379")
+		if code := call(newGateway(p), "1379"); code != http.StatusOK {
+			t.Errorf("correct passcode should pass (200), got %d", code)
+		}
+	})
+}
+
+// TestPermissionMiddleware_NonSensitiveNoPasscode confirms a non-sensitive,
+// default-on surface (services) is NOT passcode-gated: it passes with no
+// passcode, so the passcode change does not regress ordinary operation.
+func TestPermissionMiddleware_NonSensitiveNoPasscode(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	p := config.DefaultPermissions() // services=true, no passcode
+	s := NewServer(Config{NodeName: "test-node"})
+	s.SetPermissions(p)
+	h := s.permissionMiddleware(next)
+
+	req := httptest.NewRequest(http.MethodGet, "/services", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("non-sensitive services route should pass without a passcode, got %d", w.Code)
+	}
+}

--- a/internal/jobs/config_handler.go
+++ b/internal/jobs/config_handler.go
@@ -58,6 +58,26 @@ type DeviceConfig struct {
 	// (aceteam#5097). Pointer so nil leaves the persisted value untouched; a
 	// non-positive value is clamped to the default by the config accessor.
 	MeetingRetentionDays *int `json:"meetingRetentionDays,omitempty"`
+
+	// ConsoleEnabled/DesktopEnabled/FilesEnabled are the programmatic opt-IN path
+	// for the sensitive remote-access surfaces (aceteam#6524). They are pointers
+	// so an omitted field (nil) leaves the node's persisted permission untouched —
+	// a plain bool would default to false and silently disable a surface the
+	// moment any device config is applied. A non-nil value writes the same
+	// permissions.yaml the Control Center toggle and the gateway/listener gates
+	// read. These are default-DENY on a fresh node, so the platform must send
+	// `true` here (together with a NodePasscode) to actually enable a surface.
+	ConsoleEnabled *bool `json:"consoleEnabled,omitempty"`
+	DesktopEnabled *bool `json:"desktopEnabled,omitempty"`
+	FilesEnabled   *bool `json:"filesEnabled,omitempty"`
+
+	// NodePasscode sets (or, when empty, clears) the per-node passcode that gates
+	// the sensitive surfaces (aceteam#6524). Pointer so nil leaves the stored
+	// passcode untouched; a non-nil value is bcrypt-hashed before it is persisted
+	// (the plaintext PIN is never written to disk). Enabling a surface without a
+	// passcode leaves it fail-closed, so the platform should set this alongside
+	// the *Enabled flags.
+	NodePasscode *string `json:"nodePasscode,omitempty"`
 }
 
 // ConfigHandler handles APPLY_DEVICE_CONFIG jobs.
@@ -138,6 +158,57 @@ func (h *ConfigHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) 
 			}
 			if config.MeetingRetentionDays != nil {
 				result += fmt.Sprintf("\nMeeting recording retention set to %d days", *config.MeetingRetentionDays)
+			}
+		}
+	}
+
+	// Apply the sensitive-surface permissions + passcode (aceteam#6524) when the
+	// platform pushed any of them. Load-modify-save the same permissions.yaml the
+	// gateway, terminal/desktop listeners, and Redis handlers read, so the
+	// programmatic path and the Control Center converge on one persisted value.
+	// Written to platform.ConfigDir() (the per-concern config location the gates
+	// read), not h.ConfigDir (the manifest dir). Only the fields the platform set
+	// are touched; nil pointers leave the persisted value intact.
+	if config.ConsoleEnabled != nil || config.DesktopEnabled != nil || config.FilesEnabled != nil || config.NodePasscode != nil {
+		perms := citadelconfig.LoadPermissions(platform.ConfigDir())
+		if config.ConsoleEnabled != nil {
+			perms.Console = *config.ConsoleEnabled
+		}
+		if config.DesktopEnabled != nil {
+			perms.Desktop = *config.DesktopEnabled
+		}
+		if config.FilesEnabled != nil {
+			perms.Files = *config.FilesEnabled
+		}
+		if config.NodePasscode != nil {
+			if err := perms.SetPasscode(*config.NodePasscode); err != nil {
+				result += fmt.Sprintf("\nWarning: failed to set node passcode: %v", err)
+			}
+		}
+		if err := citadelconfig.SavePermissions(platform.ConfigDir(), perms); err != nil {
+			result += fmt.Sprintf("\nWarning: failed to persist permissions: %v", err)
+		} else {
+			if config.ConsoleEnabled != nil {
+				result += fmt.Sprintf("\nConsole (terminal) access %s", enabledLabel(*config.ConsoleEnabled))
+			}
+			if config.DesktopEnabled != nil {
+				result += fmt.Sprintf("\nDesktop (screen/VNC) access %s", enabledLabel(*config.DesktopEnabled))
+			}
+			if config.FilesEnabled != nil {
+				result += fmt.Sprintf("\nFiles (browse/host) access %s", enabledLabel(*config.FilesEnabled))
+			}
+			if config.NodePasscode != nil {
+				if perms.HasPasscode() {
+					result += "\nNode passcode set"
+				} else {
+					result += "\nNode passcode cleared (sensitive surfaces re-locked)"
+				}
+			}
+			// Guardrail: an enabled surface with no passcode fails closed. Surface
+			// that in the job result so an operator who enabled without a passcode
+			// understands why access is still denied.
+			if (perms.Console || perms.Desktop || perms.Files) && !perms.HasPasscode() {
+				result += "\nNote: a sensitive surface is enabled but no passcode is set — access stays denied until a passcode is set"
 			}
 		}
 	}

--- a/internal/jobs/config_handler_passcode_test.go
+++ b/internal/jobs/config_handler_passcode_test.go
@@ -1,0 +1,108 @@
+package jobs
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	citadelconfig "github.com/aceteam-ai/citadel-cli/internal/config"
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
+)
+
+// TestDeviceConfig_SensitivePermsUnmarshal verifies the new sensitive-surface
+// fields carry absent(nil)-vs-explicit pointer semantics, matching the meeting
+// fields — so applying a device config that omits them never silently flips a
+// surface.
+func TestDeviceConfig_SensitivePermsUnmarshal(t *testing.T) {
+	var c DeviceConfig
+	if err := json.Unmarshal([]byte(`{"deviceName":"n"}`), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if c.ConsoleEnabled != nil || c.DesktopEnabled != nil || c.FilesEnabled != nil || c.NodePasscode != nil {
+		t.Errorf("absent sensitive fields must be nil, got %+v", c)
+	}
+
+	if err := json.Unmarshal([]byte(`{"consoleEnabled":true,"nodePasscode":"1379"}`), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if c.ConsoleEnabled == nil || !*c.ConsoleEnabled {
+		t.Error("explicit consoleEnabled:true should be non-nil true")
+	}
+	if c.NodePasscode == nil || *c.NodePasscode != "1379" {
+		t.Error("nodePasscode should round-trip")
+	}
+}
+
+// TestApplyDeviceConfig_EnablesConsoleAndSetsPasscode is the programmatic opt-in
+// path (aceteam#6524): APPLY_DEVICE_CONFIG with consoleEnabled + nodePasscode
+// must write permissions.yaml so console is enabled and the passcode verifies —
+// without storing the plaintext PIN.
+func TestApplyDeviceConfig_EnablesConsoleAndSetsPasscode(t *testing.T) {
+	dir := t.TempDir()
+	// platform.ConfigDir() (where permissions.yaml is written) resolves via HOME.
+	t.Setenv("HOME", dir)
+	t.Setenv("SUDO_USER", "")
+	cfgDir := filepath.Join(dir, ".citadel-cli")
+	if err := os.MkdirAll(cfgDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.yaml"), []byte("node:\n  name: t\n"), 0600); err != nil {
+		t.Fatalf("marker: %v", err)
+	}
+
+	// Sanity: a fresh node starts locked down.
+	if p := citadelconfig.LoadPermissions(platform.ConfigDir()); p.Console || p.HasPasscode() {
+		t.Fatalf("precondition: fresh node should be locked down, got %+v", p)
+	}
+
+	// Manifest dir for the handler (separate from the per-concern config dir).
+	manifestDir := filepath.Join(dir, "citadel-node")
+	if err := os.MkdirAll(manifestDir, 0755); err != nil {
+		t.Fatalf("mkdir manifest: %v", err)
+	}
+
+	h := NewConfigHandler(manifestDir)
+	payload, _ := json.Marshal(map[string]any{
+		"deviceName":     "peters-macbook",
+		"consoleEnabled": true,
+		"nodePasscode":   "1379",
+	})
+	job := &nexus.Job{
+		Type:    "APPLY_DEVICE_CONFIG",
+		Payload: map[string]string{"config": string(payload)},
+	}
+	if _, err := h.Execute(JobContext{}, job); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	p := citadelconfig.LoadPermissions(platform.ConfigDir())
+	if !p.Console {
+		t.Error("console should be enabled after APPLY_DEVICE_CONFIG")
+	}
+	if !p.VerifyPasscode("1379") {
+		t.Error("passcode should verify after APPLY_DEVICE_CONFIG")
+	}
+	if p.Desktop || p.Files {
+		t.Error("desktop/files should remain disabled (only console was pushed)")
+	}
+
+	// The plaintext PIN must never be written to disk.
+	raw, err := os.ReadFile(filepath.Join(cfgDir, "permissions.yaml"))
+	if err != nil {
+		t.Fatalf("read perms: %v", err)
+	}
+	if containsSub(string(raw), "1379") {
+		t.Error("permissions.yaml must not contain the plaintext PIN")
+	}
+}
+
+func containsSub(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/status/advertisement_gate_test.go
+++ b/internal/status/advertisement_gate_test.go
@@ -1,0 +1,85 @@
+package status
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestAdvertisement_DisabledSurfacesNotAdvertised is the White Whale fix
+// (aceteam#6524): even when the node is physically capable, the heartbeat
+// capability flags for console/desktop/files must read FALSE while the operator
+// has those permissions disabled — so the Fabric web console does not present a
+// live terminal/screen/file browser for a freshly joined node. GPU is not gated.
+func TestAdvertisement_DisabledSurfacesNotAdvertised(t *testing.T) {
+	dir := t.TempDir()
+	// Point ConfigDir and the workspace resolver at the temp HOME. The config.yaml
+	// marker makes the root code path of resolveConfigDir also resolve here.
+	t.Setenv("HOME", dir)
+	t.Setenv("SUDO_USER", "")
+	t.Setenv("CITADEL_WORKSPACE", "")
+	cfgDir := filepath.Join(dir, ".citadel-cli")
+	if err := os.MkdirAll(cfgDir, 0755); err != nil {
+		t.Fatalf("mkdir cfg: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.yaml"), []byte("node:\n  name: t\n"), 0600); err != nil {
+		t.Fatalf("write config marker: %v", err)
+	}
+	// Make the files hardware-signal TRUE by creating the workspace, so the gate
+	// (not the absence of a workspace) is what suppresses the files flag.
+	if err := os.MkdirAll(filepath.Join(dir, "citadel-node", "workspace"), 0755); err != nil {
+		t.Fatalf("mkdir workspace: %v", err)
+	}
+
+	// permissions.yaml with the sensitive surfaces DISABLED.
+	perms := []byte("console: false\ndesktop: false\nfiles: false\nservices: true\n")
+	if err := os.WriteFile(filepath.Join(cfgDir, "permissions.yaml"), perms, 0600); err != nil {
+		t.Fatalf("write perms: %v", err)
+	}
+
+	caps := &NodeCapabilities{}
+	// vncPort > 0 would otherwise make desktop capable; pass a live port to prove
+	// the permission gate — not the absence of hardware — is what suppresses it.
+	populateCapabilityFlags(caps, 5901)
+
+	if caps.Console == nil || *caps.Console {
+		t.Errorf("console must not advertise while disabled, got %v", caps.Console)
+	}
+	if caps.Desktop == nil || *caps.Desktop {
+		t.Errorf("desktop must not advertise while disabled, got %v", caps.Desktop)
+	}
+	if caps.Files == nil || *caps.Files {
+		t.Errorf("files must not advertise while disabled (workspace present), got %v", caps.Files)
+	}
+}
+
+// TestAdvertisement_EnabledFilesAdvertised confirms opting in restores the
+// advertisement: with files enabled AND a workspace present, the files flag is
+// true. (Files is the deterministic one — its hardware signal is a dir stat.)
+func TestAdvertisement_EnabledFilesAdvertised(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("SUDO_USER", "")
+	t.Setenv("CITADEL_WORKSPACE", "")
+	cfgDir := filepath.Join(dir, ".citadel-cli")
+	if err := os.MkdirAll(cfgDir, 0755); err != nil {
+		t.Fatalf("mkdir cfg: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.yaml"), []byte("node:\n  name: t\n"), 0600); err != nil {
+		t.Fatalf("write config marker: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "citadel-node", "workspace"), 0755); err != nil {
+		t.Fatalf("mkdir workspace: %v", err)
+	}
+	perms := []byte("files: true\n")
+	if err := os.WriteFile(filepath.Join(cfgDir, "permissions.yaml"), perms, 0600); err != nil {
+		t.Fatalf("write perms: %v", err)
+	}
+
+	caps := &NodeCapabilities{}
+	populateCapabilityFlags(caps, 0)
+
+	if caps.Files == nil || !*caps.Files {
+		t.Errorf("files should advertise when enabled with a workspace present, got %v", caps.Files)
+	}
+}

--- a/internal/status/capabilities_flags.go
+++ b/internal/status/capabilities_flags.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aceteam-ai/citadel-cli/internal/config"
 	"github.com/aceteam-ai/citadel-cli/internal/deskstream"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
 )
@@ -47,14 +48,27 @@ func detectStaticCaps() {
 // flag is derived from vncPort (already computed by Collect, so we avoid a
 // second VNC probe). console/gpu come from the cached static detection; files
 // is a cheap stat of the workspace directory.
+//
+// Sensitive-surface gate (aceteam#6524): console/desktop/files report as
+// available ONLY when the node has BOTH the underlying capability AND the
+// operator has opted the matching permission in. This is what stops the Fabric
+// web console from presenting a live terminal/screen/file browser for a freshly
+// joined node that never opted in (the White Whale landmine) — a fresh node has
+// these permissions default-DENY, so the flags read false. The operator's
+// enable/disable choice remains separately visible on the heartbeat via the
+// PermissionState block (permissionsToHeartbeat), so the web can still render an
+// "enable + set passcode" call to action from that signal. GPU/H264 are
+// hardware-only and never gated (inference must advertise regardless).
 func populateCapabilityFlags(caps *NodeCapabilities, vncPort int) {
 	detectStaticCaps()
 
-	console := cachedConsole
+	perms := config.LoadPermissions(platform.ConfigDir())
+
+	console := cachedConsole && perms.Console
 	gpu := cachedGPU
 	h264 := cachedH264
-	desktop := vncPort > 0 || probeVNCPort(platform.DefaultVNCPort)
-	files := detectFiles()
+	desktop := (vncPort > 0 || probeVNCPort(platform.DefaultVNCPort)) && perms.Desktop
+	files := detectFiles() && perms.Files
 
 	caps.Console = &console
 	caps.Desktop = &desktop

--- a/internal/status/capabilities_flags_test.go
+++ b/internal/status/capabilities_flags_test.go
@@ -2,6 +2,8 @@ package status
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -30,14 +32,56 @@ func TestPopulateCapabilityFlagsAlwaysSetsAll(t *testing.T) {
 	}
 }
 
-// TestCapabilityFlagsDesktopDerivedFromVNCPort verifies the desktop flag is true
-// when a VNC port was already detected, without dialing.
-func TestCapabilityFlagsDesktopDerivedFromVNCPort(t *testing.T) {
-	caps := &NodeCapabilities{}
-	populateCapabilityFlags(caps, 5900)
-	if caps.Desktop == nil || !*caps.Desktop {
-		t.Errorf("Desktop should be true when vncPort > 0, got %v", caps.Desktop)
+// writeDesktopPerm points ConfigDir at a temp HOME carrying a permissions.yaml
+// with the given desktop value, and returns nothing (the env is restored by
+// t.Setenv). The config.yaml marker makes the root code path of resolveConfigDir
+// also resolve here. Used to exercise the aceteam#6524 gate deterministically.
+func writeDesktopPerm(t *testing.T, desktopEnabled bool) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("SUDO_USER", "")
+	cfgDir := filepath.Join(dir, ".citadel-cli")
+	if err := os.MkdirAll(cfgDir, 0755); err != nil {
+		t.Fatalf("mkdir cfg: %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.yaml"), []byte("node:\n  name: t\n"), 0600); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+	perms := "desktop: false\n"
+	if desktopEnabled {
+		perms = "desktop: true\n"
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "permissions.yaml"), []byte(perms), 0600); err != nil {
+		t.Fatalf("write perms: %v", err)
+	}
+}
+
+// TestCapabilityFlagsDesktopDerivedFromVNCPort verifies the desktop flag under
+// the aceteam#6524 opt-in posture: a detected VNC port advertises desktop ONLY
+// when the operator has enabled the `desktop` permission. The VNC port is the
+// hardware signal; the permission is the consent gate — both must hold. This
+// replaces the old assertion that a VNC port alone advertised desktop (which put
+// a node's screen on the mesh before the operator opted in — the White Whale
+// landmine).
+func TestCapabilityFlagsDesktopDerivedFromVNCPort(t *testing.T) {
+	t.Run("enabled: vnc port advertises desktop", func(t *testing.T) {
+		writeDesktopPerm(t, true)
+		caps := &NodeCapabilities{}
+		populateCapabilityFlags(caps, 5900)
+		if caps.Desktop == nil || !*caps.Desktop {
+			t.Errorf("Desktop should be true when vncPort > 0 AND desktop is enabled, got %v", caps.Desktop)
+		}
+	})
+
+	t.Run("disabled: vnc port does NOT advertise desktop", func(t *testing.T) {
+		writeDesktopPerm(t, false)
+		caps := &NodeCapabilities{}
+		populateCapabilityFlags(caps, 5900)
+		if caps.Desktop == nil || *caps.Desktop {
+			t.Errorf("Desktop must stay false when desktop is disabled, even with vncPort > 0, got %v", caps.Desktop)
+		}
+	})
 }
 
 // TestCapabilityFlagsJSONContract verifies the wire format matches the backend

--- a/internal/status/server.go
+++ b/internal/status/server.go
@@ -34,6 +34,12 @@ type Server struct {
 	tokenValidator terminal.TokenValidator
 	orgID          string
 	enableDesktop  bool
+	// passcodeVerifier, when non-nil, adds the per-node passcode gate on top of
+	// the token check for the desktop endpoints (/api/screenshot, /api/actions)
+	// (aceteam#6524). These serve the operator's screen/input directly over the
+	// mesh, so a valid org token is not sufficient: the caller must also hold the
+	// node passcode. Nil leaves behavior unchanged (token-only). Fails closed.
+	passcodeVerifier func(pin string) bool
 
 	// gatewayCertPath is the on-disk path to the gateway's self-signed leaf cert
 	// PEM. When set, the status server serves it unauthenticated at
@@ -88,6 +94,11 @@ type ServerConfig struct {
 	TokenValidator terminal.TokenValidator // Optional: enables authenticated desktop endpoints
 	OrgID          string                  // Required when TokenValidator is set
 	EnableDesktop  bool                    // When true AND TokenValidator is set, registers /api/screenshot and /api/actions
+
+	// PasscodeVerifier, when non-nil, adds the per-node passcode gate to the
+	// desktop endpoints on top of the token check (aceteam#6524). See the
+	// Server.passcodeVerifier field. Nil leaves behavior token-only.
+	PasscodeVerifier func(pin string) bool
 
 	// Agent, when set, registers the /agent/* introspection & control
 	// endpoints (issue #236). These are served over the same dual (LAN+VPN)
@@ -145,6 +156,7 @@ func NewServer(cfg ServerConfig, collector *Collector) *Server {
 		tokenValidator:    cfg.TokenValidator,
 		orgID:             cfg.OrgID,
 		enableDesktop:     cfg.EnableDesktop,
+		passcodeVerifier:  cfg.PasscodeVerifier,
 		agent:             cfg.Agent,
 		extraRoutes:       cfg.ExtraRoutes,
 		gatewayCertPath:   cfg.GatewayCertPath,
@@ -515,6 +527,21 @@ func (s *Server) requireAuth(next http.HandlerFunc) http.HandlerFunc {
 		if _, err := s.tokenValidator.ValidateToken(token, s.orgID); err != nil {
 			http.Error(w, `{"error":"invalid token"}`, http.StatusUnauthorized)
 			return
+		}
+		// Per-node passcode gate (aceteam#6524): the desktop endpoints expose the
+		// operator's screen/input directly over the mesh, so a valid org token is
+		// not sufficient — the caller must also present the node passcode via the
+		// X-Citadel-Passcode header (or ?passcode= for parity with the WS paths).
+		// Fails closed. Skipped only when no verifier is wired.
+		if s.passcodeVerifier != nil {
+			passcode := r.Header.Get("X-Citadel-Passcode")
+			if passcode == "" {
+				passcode = r.URL.Query().Get("passcode")
+			}
+			if !s.passcodeVerifier(passcode) {
+				http.Error(w, `{"error":"node passcode required"}`, http.StatusUnauthorized)
+				return
+			}
 		}
 		next(w, r)
 	}

--- a/internal/terminal/config.go
+++ b/internal/terminal/config.go
@@ -96,6 +96,16 @@ type Config struct {
 
 	// Debug enables verbose debug logging
 	Debug bool
+
+	// PasscodeVerifier, when non-nil, adds the per-node passcode gate on top of
+	// the existing auth (aceteam#6524). After a connection authenticates (token
+	// or same-owner mesh identity), it must ALSO present the node passcode, which
+	// is checked here. This is what makes "console enabled" different from "any
+	// org mesh peer can open a shell" — a valid org device token or a same-owner
+	// mesh peer is not enough; the caller must also hold the node passcode. When
+	// nil (e.g. the localhost test server), no passcode is required and behavior
+	// is unchanged. The verifier fails closed (see config.Permissions.VerifyPasscode).
+	PasscodeVerifier func(pin string) bool
 }
 
 // DefaultConfig returns a Config with sensible defaults

--- a/internal/terminal/server.go
+++ b/internal/terminal/server.go
@@ -488,6 +488,27 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 	s.logger.Debugf("authorized user %s from %s via %s", tokenInfo.UserID, ip, authVia)
 
+	// Passcode gate (aceteam#6524): even after a valid token or same-owner mesh
+	// identity, the caller must present the per-node passcode to open a shell.
+	// This is the owner-consent factor that makes "console enabled" different
+	// from "any org mesh peer can dial :7860 and get a shell". Presented via the
+	// ?passcode= query param (a browser WebSocket cannot set request headers on
+	// the upgrade), with the X-Citadel-Passcode header honored for non-browser
+	// clients. Fails closed. Skipped only when no verifier is wired (e.g. the
+	// localhost test server), preserving existing behavior there.
+	if s.config.PasscodeVerifier != nil {
+		passcode := r.URL.Query().Get("passcode")
+		if passcode == "" {
+			passcode = r.Header.Get("X-Citadel-Passcode")
+		}
+		if !s.config.PasscodeVerifier(passcode) {
+			s.logger.Printf("passcode gate rejected connection from %s (user %s, via %s)", ip, tokenInfo.UserID, authVia)
+			atomic.AddInt64(&s.failedConnections, 1)
+			writeJSONError(w, "node passcode required", http.StatusUnauthorized)
+			return
+		}
+	}
+
 	// Check connection limit
 	if s.sessions.Count() >= s.config.MaxConnections {
 		s.logger.Printf("max connections reached (%d), rejecting %s", s.config.MaxConnections, ip)

--- a/internal/tui/controlcenter/actions.go
+++ b/internal/tui/controlcenter/actions.go
@@ -1944,20 +1944,20 @@ func (cc *ControlCenter) showBuiltinServicesModal() {
 	services := []builtinServiceDef{
 		{
 			name:    "Console",
-			desc:    "Remote terminal access",
-			detail:  "Provides WebSocket-based terminal access to this machine.\nRemote users can open a shell session through the AceTeam web UI.\nGateway route: /terminal",
+			desc:    "Remote terminal access (default OFF)",
+			detail:  "Provides WebSocket-based terminal access to this machine.\nRemote users can open a shell session through the AceTeam web UI.\n\n[red]Default OFF (opt-in) + passcode-gated (aceteam#6524):[-] a fresh node\ndoes not expose a terminal. When enabled it still requires the node\npasscode, so enabling is not the same as opening it to the org mesh.\nGateway route: /terminal",
 			enabled: &perms.Console,
 		},
 		{
 			name:    "Desktop",
-			desc:    "VNC, screenshots, remote actions",
-			detail:  "Enables remote desktop access via VNC and screenshot capture.\nIncludes remote keyboard/mouse actions.\nGateway routes: /vnc, /api/screenshot, /api/actions",
+			desc:    "VNC, screenshots, remote actions (default OFF)",
+			detail:  "Enables remote desktop access via VNC and screenshot capture.\nIncludes remote keyboard/mouse actions.\n\n[red]Default OFF (opt-in) + passcode-gated (aceteam#6524):[-] a fresh node\ndoes not expose its screen. When enabled it still requires the node\npasscode.\nGateway routes: /vnc, /api/screenshot, /api/actions",
 			enabled: &perms.Desktop,
 		},
 		{
 			name:    "Files",
-			desc:    "File browser API",
-			detail:  "Exposes a file browser API for remote file access.\nAllows reading, writing, and searching files on this machine.\nGateway routes: /api/files/*",
+			desc:    "File browser API (default OFF)",
+			detail:  "Exposes a file browser API for remote file access.\nAllows reading, writing, and searching files on this machine.\n\n[red]Default OFF (opt-in) + passcode-gated (aceteam#6524):[-] a fresh node\ndoes not expose its filesystem. When enabled it still requires the\nnode passcode.\nGateway routes: /api/files/*",
 			enabled: &perms.Files,
 		},
 		{
@@ -2051,6 +2051,16 @@ func (cc *ControlCenter) showBuiltinServicesModal() {
 				state = "disabled"
 			}
 			cc.AddActivity("info", fmt.Sprintf("%s %s (applies on restart)", services[row].name, state))
+
+			// Passcode reminder (aceteam#6524): a sensitive surface
+			// (Console/Desktop/Files) that is enabled without a node passcode
+			// fails CLOSED — enabling it does not open it. Warn so the operator
+			// knows to set a passcode (via the web console / APPLY_DEVICE_CONFIG)
+			// before the surface is actually reachable.
+			name := services[row].name
+			if *services[row].enabled && (name == "Console" || name == "Desktop" || name == "Files") && !perms.HasPasscode() {
+				cc.AddActivity("warning", fmt.Sprintf("%s enabled but no node passcode is set — access stays denied until you set a passcode", name))
+			}
 		}
 	}
 

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -130,6 +130,21 @@ type LegacyHandlerOpts struct {
 	// "disabled" error rather than "unsupported job type"), but every command
 	// is rejected. Wired from the persisted `shell` node permission.
 	ShellDisabled bool
+	// DesktopDisabled, when true, SKIPS registration of the screen/VNC/desktop
+	// job handlers (FILE_SCREENSHOT, VNC_SCREENSHOT, VNC_TYPE, VNC_KEYS,
+	// VNC_ACTIONS). A fresh node has `desktop` default-DENY (aceteam#6524), so it
+	// does not serve these — a dispatched desktop job is refused ("unsupported
+	// job type") until the operator opts in. Wired from the persisted `desktop`
+	// node permission.
+	DesktopDisabled bool
+	// FilesDisabled, when true, SKIPS registration of the file browse/host job
+	// handlers (FILE_READ/READ_BYTES/WRITE/WRITE_BYTES/EDIT/LIST/SEARCH/INDEX/
+	// SEMANTIC_SEARCH). A fresh node has `files` default-DENY (aceteam#6524).
+	// Note this gates ONLY the file-browser surface: TRANSCRIBE_AUDIO and
+	// MEETING_JOIN share the workspace but belong to the default-ON meeting
+	// capability and are NOT gated here. Wired from the persisted `files`
+	// node permission.
+	FilesDisabled bool
 	// MeetingProfileDir overrides the persistent, signed-in bot Chrome profile
 	// directory used by MEETING_JOIN (issue #5122). If empty, the handler falls
 	// back to platform.EnvMeetingProfileDir, then platform's ConfigDir()-rooted
@@ -183,23 +198,6 @@ func CreateLegacyHandlersWithOpts(opts LegacyHandlerOpts) []JobHandler {
 		NewLegacyHandlerAdapter(JobTypeIOSBuild, jobs.NewIOSBuildHandler(opts.WorkspaceDir)),
 		NewLegacyHandlerAdapter(JobTypeAndroidBuild, jobs.NewAndroidBuildHandler(opts.WorkspaceDir)),
 		NewLegacyHandlerAdapter(JobTypeGomobileBuild, jobs.NewGomobileBuildHandler(opts.WorkspaceDir)),
-		// Desktop capture/input handlers (issue #4179). Registered
-		// unconditionally: screenshot/type/keys need no workspace sandbox, and
-		// gating them behind WorkspaceDir would leave the desktop_screenshot /
-		// vnc_* MCP tools timing out on any node without a configured workspace.
-		// FILE_SCREENSHOT and VNC_SCREENSHOT share one capture path (the
-		// existing internal/desktop X11 capture); there is no separate VNC
-		// framebuffer source.
-		NewLegacyHandlerAdapter(JobTypeFileScreenshot, &jobs.ScreenshotHandler{}),
-		NewLegacyHandlerAdapter(JobTypeVNCScreenshot, &jobs.ScreenshotHandler{}),
-		NewLegacyHandlerAdapter(JobTypeVNCType, &jobs.TypeHandler{}),
-		NewLegacyHandlerAdapter(JobTypeVNCKeys, &jobs.KeysHandler{}),
-		// VNC_ACTIONS exposes the pointer/keyboard primitives shipped in #314
-		// (move/click/mousedown/mouseup/scroll, including the drag sequence) over
-		// the fabric Redis transport so the aceteam desktop_click / desktop_drag
-		// MCP tools can drive a node end to end (issue #4180). Same unconditional
-		// registration rationale as the screenshot/type/keys handlers above.
-		NewLegacyHandlerAdapter(JobTypeVNCActions, &jobs.ActionsHandler{}),
 		NewLegacyHandlerAdapter(JobTypeCobrowse, jobs.NewCobrowseHandler()),
 		// Resource snapshot (issue #427): returns the node's full GPU/host
 		// resource-consumer picture over the fabric. Registered unconditionally
@@ -226,44 +224,73 @@ func CreateLegacyHandlersWithOpts(opts LegacyHandlerOpts) []JobHandler {
 		NewLegacyHandlerAdapter(JobTypeInstanceMessage, jobs.NewInstanceMessageHandler()),
 	}
 
+	// Screen/VNC/desktop handlers (issue #4179, #4180) — the screen-share
+	// surface. Default-DENY (aceteam#6524): registered ONLY when the operator has
+	// opted the node's `desktop` permission in. A fresh node does not register
+	// them, so a dispatched desktop_screenshot / vnc_* / desktop_click fabric job
+	// is refused ("unsupported job type") rather than silently capturing the
+	// operator's screen. FILE_SCREENSHOT and VNC_SCREENSHOT share one capture
+	// path (the internal/desktop X11 capture); there is no separate VNC
+	// framebuffer source.
+	if !opts.DesktopDisabled {
+		handlers = append(handlers,
+			NewLegacyHandlerAdapter(JobTypeFileScreenshot, &jobs.ScreenshotHandler{}),
+			NewLegacyHandlerAdapter(JobTypeVNCScreenshot, &jobs.ScreenshotHandler{}),
+			NewLegacyHandlerAdapter(JobTypeVNCType, &jobs.TypeHandler{}),
+			NewLegacyHandlerAdapter(JobTypeVNCKeys, &jobs.KeysHandler{}),
+			NewLegacyHandlerAdapter(JobTypeVNCActions, &jobs.ActionsHandler{}),
+		)
+	}
+
 	// Register file-operation handlers when a workspace is configured.
 	if opts.WorkspaceDir != "" {
-		readHandler := jobs.NewFileReadHandler(opts.WorkspaceDir)
-		readHandler.AllowOutsideWorkspace = opts.AllowReadOutsideWorkspace
+		// File browse/host handlers — the node-filesystem surface. Default-DENY
+		// (aceteam#6524): registered ONLY when the operator has opted the node's
+		// `files` permission in. A fresh node does not register them, so a
+		// dispatched FILE_* fabric job is refused rather than serving the
+		// operator's filesystem. NOTE: TRANSCRIBE_AUDIO and MEETING_JOIN below
+		// also use the workspace but belong to the default-ON meeting capability,
+		// so they are deliberately OUTSIDE this gate.
+		if !opts.FilesDisabled {
+			readHandler := jobs.NewFileReadHandler(opts.WorkspaceDir)
+			readHandler.AllowOutsideWorkspace = opts.AllowReadOutsideWorkspace
 
-		readBytesHandler := jobs.NewFileReadBytesHandler(opts.WorkspaceDir)
-		readBytesHandler.AllowOutsideWorkspace = opts.AllowReadOutsideWorkspace
+			readBytesHandler := jobs.NewFileReadBytesHandler(opts.WorkspaceDir)
+			readBytesHandler.AllowOutsideWorkspace = opts.AllowReadOutsideWorkspace
 
-		listHandler := jobs.NewFileListHandler(opts.WorkspaceDir)
-		listHandler.AllowOutsideWorkspace = opts.AllowReadOutsideWorkspace
+			listHandler := jobs.NewFileListHandler(opts.WorkspaceDir)
+			listHandler.AllowOutsideWorkspace = opts.AllowReadOutsideWorkspace
 
-		searchHandler := jobs.NewFileSearchHandler(opts.WorkspaceDir)
-		searchHandler.AllowOutsideWorkspace = opts.AllowReadOutsideWorkspace
+			searchHandler := jobs.NewFileSearchHandler(opts.WorkspaceDir)
+			searchHandler.AllowOutsideWorkspace = opts.AllowReadOutsideWorkspace
 
-		// Node-local semantic index (aceteam#6087). FILE_INDEX walks the
-		// workspace and (re)embeds changed files via the node's TEI service;
-		// FILE_SEMANTIC_SEARCH runs a KNN over that index. The DB path is
-		// resolved by the handler (CITADEL_INDEX_DB or index.db beside the
-		// workspace). FILE_INDEX honors the read-outside-workspace relaxation
-		// like the other read handlers.
-		indexHandler := jobs.NewFileIndexHandler(opts.WorkspaceDir, "")
-		indexHandler.AllowOutsideWorkspace = opts.AllowReadOutsideWorkspace
+			// Node-local semantic index (aceteam#6087). FILE_INDEX walks the
+			// workspace and (re)embeds changed files via the node's TEI service;
+			// FILE_SEMANTIC_SEARCH runs a KNN over that index. The DB path is
+			// resolved by the handler (CITADEL_INDEX_DB or index.db beside the
+			// workspace). FILE_INDEX honors the read-outside-workspace relaxation
+			// like the other read handlers.
+			indexHandler := jobs.NewFileIndexHandler(opts.WorkspaceDir, "")
+			indexHandler.AllowOutsideWorkspace = opts.AllowReadOutsideWorkspace
 
+			handlers = append(handlers,
+				NewLegacyHandlerAdapter(JobTypeFileRead, readHandler),
+				NewLegacyHandlerAdapter(JobTypeFileReadBytes, readBytesHandler),
+				NewLegacyHandlerAdapter(JobTypeFileWrite, jobs.NewFileWriteHandler(opts.WorkspaceDir)),
+				NewLegacyHandlerAdapter(JobTypeFileWriteBytes, jobs.NewFileWriteBytesHandler(opts.WorkspaceDir)),
+				NewLegacyHandlerAdapter(JobTypeFileEdit, jobs.NewFileEditHandler(opts.WorkspaceDir)),
+				NewLegacyHandlerAdapter(JobTypeFileList, listHandler),
+				NewLegacyHandlerAdapter(JobTypeFileSearch, searchHandler),
+				NewLegacyHandlerAdapter(JobTypeFileIndex, indexHandler),
+				NewLegacyHandlerAdapter(JobTypeFileSemanticSearch, jobs.NewFileSemanticSearchHandler(opts.WorkspaceDir, "")),
+			)
+		}
+
+		// Node-local meeting transcription (faster-whisper sidecar). Part of the
+		// default-ON meeting capability, NOT the files surface — registered with
+		// the workspace (so it can validate audio paths the way file handlers do)
+		// but OUTSIDE the FilesDisabled gate.
 		handlers = append(handlers,
-			NewLegacyHandlerAdapter(JobTypeFileRead, readHandler),
-			NewLegacyHandlerAdapter(JobTypeFileReadBytes, readBytesHandler),
-			NewLegacyHandlerAdapter(JobTypeFileWrite, jobs.NewFileWriteHandler(opts.WorkspaceDir)),
-			NewLegacyHandlerAdapter(JobTypeFileWriteBytes, jobs.NewFileWriteBytesHandler(opts.WorkspaceDir)),
-			NewLegacyHandlerAdapter(JobTypeFileEdit, jobs.NewFileEditHandler(opts.WorkspaceDir)),
-			NewLegacyHandlerAdapter(JobTypeFileList, listHandler),
-			NewLegacyHandlerAdapter(JobTypeFileSearch, searchHandler),
-			NewLegacyHandlerAdapter(JobTypeFileList, jobs.NewFileListHandler(opts.WorkspaceDir)),
-			NewLegacyHandlerAdapter(JobTypeFileSearch, jobs.NewFileSearchHandler(opts.WorkspaceDir)),
-			NewLegacyHandlerAdapter(JobTypeFileIndex, indexHandler),
-			NewLegacyHandlerAdapter(JobTypeFileSemanticSearch, jobs.NewFileSemanticSearchHandler(opts.WorkspaceDir, "")),
-			// Node-local meeting transcription (faster-whisper sidecar). Registered
-			// with the workspace so it can validate audio paths the same way the
-			// file handlers do.
 			NewLegacyHandlerAdapter(JobTypeTranscribeAudio, jobs.NewTranscribeAudioHandler(opts.WorkspaceDir)),
 		)
 

--- a/internal/worker/handler_gating_test.go
+++ b/internal/worker/handler_gating_test.go
@@ -1,0 +1,89 @@
+package worker
+
+import "testing"
+
+// anyHandles reports whether the built handler set registers a handler for the
+// given job type.
+func anyHandles(handlers []JobHandler, jobType string) bool {
+	for _, h := range handlers {
+		if h.CanHandle(jobType) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestFreshNode_RefusesSensitiveJobs is the aceteam#6524 teeth: a fresh node
+// (sensitive surfaces default-DENY, wired as DesktopDisabled/FilesDisabled) must
+// NOT register the screen/VNC or file-browse handlers, so those fabric jobs are
+// refused ("unsupported job type") rather than silently executed.
+func TestFreshNode_RefusesSensitiveJobs(t *testing.T) {
+	handlers := CreateLegacyHandlersWithOpts(LegacyHandlerOpts{
+		WorkspaceDir:    t.TempDir(), // a workspace IS configured...
+		DesktopDisabled: true,        // ...but desktop is off
+		FilesDisabled:   true,        // ...and files is off
+	})
+
+	desktopJobs := []string{
+		JobTypeFileScreenshot, JobTypeVNCScreenshot,
+		JobTypeVNCType, JobTypeVNCKeys, JobTypeVNCActions,
+	}
+	for _, jt := range desktopJobs {
+		if anyHandles(handlers, jt) {
+			t.Errorf("fresh node must NOT register desktop job %q", jt)
+		}
+	}
+
+	fileJobs := []string{
+		JobTypeFileRead, JobTypeFileReadBytes, JobTypeFileWrite,
+		JobTypeFileWriteBytes, JobTypeFileEdit, JobTypeFileList,
+		JobTypeFileSearch, JobTypeFileIndex, JobTypeFileSemanticSearch,
+	}
+	for _, jt := range fileJobs {
+		if anyHandles(handlers, jt) {
+			t.Errorf("fresh node must NOT register file-browse job %q", jt)
+		}
+	}
+}
+
+// TestFreshNode_StillServesInferenceAndMeeting proves the gate did not
+// over-reach: inference and the default-ON meeting/transcribe/TTS surfaces stay
+// available even with console/desktop/files disabled. Joining to serve a model
+// must never require enabling remote access.
+func TestFreshNode_StillServesInferenceAndMeeting(t *testing.T) {
+	handlers := CreateLegacyHandlersWithOpts(LegacyHandlerOpts{
+		WorkspaceDir:    t.TempDir(),
+		DesktopDisabled: true,
+		FilesDisabled:   true,
+	})
+
+	mustHandle := []string{
+		JobTypeVLLMInference,
+		JobTypeOllamaInference,
+		JobTypeLlamaCppInference,
+		JobTypeEmbedding,
+		JobTypeSynthesizeSpeech,
+		JobTypeTranscribeAudio, // meeting capability, shares the workspace but not gated
+	}
+	for _, jt := range mustHandle {
+		if !anyHandles(handlers, jt) {
+			t.Errorf("inference/meeting job %q must be served regardless of console/desktop/files", jt)
+		}
+	}
+}
+
+// TestEnabledNode_RegistersSensitiveHandlers confirms opting in (Desktop/Files
+// enabled) restores the handlers.
+func TestEnabledNode_RegistersSensitiveHandlers(t *testing.T) {
+	handlers := CreateLegacyHandlersWithOpts(LegacyHandlerOpts{
+		WorkspaceDir:    t.TempDir(),
+		DesktopDisabled: false,
+		FilesDisabled:   false,
+	})
+	if !anyHandles(handlers, JobTypeVNCScreenshot) {
+		t.Error("enabled node should register VNC_SCREENSHOT")
+	}
+	if !anyHandles(handlers, JobTypeFileRead) {
+		t.Error("enabled node should register FILE_READ")
+	}
+}


### PR DESCRIPTION
## Context

Part of aceteam-ai/aceteam#6524. On the White Whale onboarding call, Peter saw the web console showing his MacBook's terminal/screen/files as a live node the moment it joined the fabric — a trust-breaking default for a privacy-first customer. Node console/desktop/file surfaces were **default-ON**; this flips the three sensitive remote-access surfaces to **default-OFF opt-in + a per-node passcode** (Jason's decision: both layers), while inference/model-serving stays available with zero remote access enabled.

These three already existed as `Permissions{Console, Desktop, Files}` (default `true`), gated at the HTTPS gateway. Rather than add parallel `console.go`/`desktop.go`/`files.go` files, this flips those defaults and adds the passcode to the existing struct — the `Default<Cap>()`-returns-DISABLED shape the issue asked for.

## Summary

**Default-OFF (`internal/config/permissions.go`)**
- `DefaultPermissions()` now returns `console/desktop/files` (and pre-existing `shell`) **disabled**; `services/ssh/provision` stay on. Absent keys in a legacy `permissions.yaml` stay disabled (fail closed).

**Per-node passcode (bcrypt, `golang.org/x/crypto`)**
- `PasscodeHash` (bcrypt, salt embedded — no plaintext, no separate salt) with `SetPasscode` / `VerifyPasscode` / `HasPasscode`. `permissions.yaml` written `0600` (now holds a credential). Fail-closed: an enabled surface with no passcode set stays denied.

**Enforcement at every path a fresh node could leak from (each fails closed):**
1. **Advertisement** (`internal/status/capabilities_flags.go`) — heartbeat console/desktop/files flags now require capability AND permission, so the web console stops presenting a live surface for a fresh node. Enablement stays separately visible via the `PermissionState` heartbeat block so the web can render an enable-CTA. GPU/H264 not gated (inference advertises regardless).
2. **Redis fabric handlers** (`internal/worker/handler_adapter.go`) — VNC/screenshot/actions and FILE_* browse/host handlers register only when `desktop`/`files` are enabled (`DesktopDisabled`/`FilesDisabled`). A fresh node refuses those jobs. `TRANSCRIBE_AUDIO`/`MEETING_JOIN` share the workspace but are the default-ON meeting capability and are deliberately **not** gated.
3. **HTTPS gateway** (`internal/gateway/gateway.go`) — `permissionMiddleware` blocks a disabled category and, for an enabled sensitive category, additionally requires the passcode (`X-Citadel-Passcode` header / `?passcode=`).
4. **Direct mesh listeners** (the key non-gateway threat — a mesh peer can dial these directly):
   - Terminal server started only when `console` is enabled (`cmd/work.go`), and every connection additionally requires the passcode (`terminal.Config.PasscodeVerifier`) on top of token/mesh-identity auth.
   - Status-server desktop endpoints (`/api/screenshot`, `/api/actions`) require the passcode in `requireAuth` (`status.ServerConfig.PasscodeVerifier`).

**Opt-in paths**
- `APPLY_DEVICE_CONFIG` (`internal/jobs/config_handler.go`): new `consoleEnabled`/`desktopEnabled`/`filesEnabled` (`*bool`, nil = untouched) and `nodePasscode` (`*string`, bcrypt-hashed before persist). Writes the same `permissions.yaml` the gates read.
- Control Center Built-in Services modal: detail copy updated to the new posture; enabling a surface with no passcode set warns that access stays denied until a passcode is set.

**Docs:** `docs/capability-toggles.md` rewritten to document the default-OFF + passcode posture and contrast it with default-ON meeting/telemetry and **why** they differ.

## Test plan

`go build ./...`, `go vet`, and `go test ./...` all pass. New tests:
- `internal/config/permissions_test.go` — fresh node has the three surfaces off; absent keys stay disabled; passcode hashes (not plaintext), verifies, fails closed on unset/empty/cleared; `0600` file mode; round-trips through save/load.
- `internal/worker/handler_gating_test.go` — fresh node refuses VNC/FILE jobs; **inference + meeting/transcribe/TTS served regardless** (proves inference isn't gated); enabling restores the handlers.
- `internal/gateway/passcode_test.go` — disabled→403; enabled-no-passcode→401; wrong→401; correct→200; non-sensitive route needs no passcode.
- `internal/status/advertisement_gate_test.go` — capable-but-disabled node does not advertise (even with a live VNC port + workspace); enabling files re-advertises.
- `internal/jobs/config_handler_passcode_test.go` — APPLY_DEVICE_CONFIG enables console + sets passcode without writing plaintext.

## Design decisions to confirm (@sunapi386)

1. **Passcode scope = per-node, per-capability enablement** (the issue's recommendation): enable console/desktop independently; one node passcode unlocks whatever is enabled. Change if you want per-capability passcodes.
2. **Files has no direct-mesh HTTP surface** — file browse/host is only the Redis FILE_* path (org-backend-authenticated) plus the (routeless) gateway `files` category. So files is enforced by **default-OFF enablement + org-backend auth**, not a per-request passcode (there's no node HTTP file listener to attach one to). Console and desktop, which DO have direct mesh listeners, get the full passcode gate. Flag if you want files to also require a passcode on a future file HTTP surface.
3. **Breaking change for deployed nodes:** flipping the defaults means any already-deployed node relying on default-on console/desktop/files (including the computer-use / shared-desktop fleet) stops responding to those until re-enabled + a passcode is set. Intended per the issue, but calling it out.
4. **Applies-on-restart for the gateway path:** the gateway snapshots permissions at startup (existing model), so a passcode/enable pushed via APPLY_DEVICE_CONFIG takes effect for the gateway on next worker start. The terminal/desktop verifiers load fresh per request (honor rotation live). Both directions fail closed.

**Cross-repo follow-up (aceteam, NOT in this PR):** the web console should render these as opt-in ("enable + set passcode") instead of a live console, and send the passcode via `X-Citadel-Passcode` (or `?passcode=` for the WS terminal/VNC). Coordinate with mesh-ACL work (#5028): that's cross-org exposure, this is per-node owner consent.

*Generated by Claude Opus 4.8*
