### PR TITLE
feat(gateway): expose node services with private/org/link visibility (#598)

### DIFF
--- a/cmd/expose_ops.go
+++ b/cmd/expose_ops.go
@@ -1,0 +1,86 @@
+// cmd/expose_ops.go
+//
+// cmd-side live adapter for the EXPOSE_SET worker handler (issue #598). It
+// programs the in-process gateway to expose a local service, mints the `link`
+// token from the node's persistent signing key, and builds the managed mesh URL.
+// It lives here (not in internal/worker) because it needs the in-process gateway
+// ref, the node config dir, and the mesh IP — cmd-level edges the worker package
+// must not import. Keeping them here lets the worker handler stay unit-testable
+// behind the ExposeOps interface (mirrors newLiveModuleOps for MODULE_SET).
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/config"
+	"github.com/aceteam-ai/citadel-cli/internal/gateway"
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
+	"github.com/aceteam-ai/citadel-cli/internal/worker"
+)
+
+// defaultLinkTTL bounds a `link` exposure token when the request omits a TTL. A
+// day is long enough to be useful for a shared dashboard link without leaving an
+// unbounded credential outstanding.
+const defaultLinkTTL = 24 * time.Hour
+
+// liveExposeOps implements worker.ExposeOps against the live gateway.
+type liveExposeOps struct{}
+
+// Expose programs the in-process gateway to serve /expose/<name>/ -> the local
+// loopback port under the requested visibility, and returns the managed mesh URL
+// (plus a signed token for visibility=link). Requires the gateway to run in this
+// process (`citadel work --gateway` / `citadel serve`); otherwise it errors so
+// the job retries rather than silently no-oping.
+func (liveExposeOps) Expose(_ context.Context, req worker.ExposeRequest) (*worker.ExposeResult, error) {
+	ref := getProvisionedServiceGateway()
+	if ref == nil {
+		return nil, fmt.Errorf("no in-process gateway (expose requires the node gateway to be running)")
+	}
+
+	policy := &gateway.ExposePolicy{
+		Visibility: gateway.Visibility(req.Visibility),
+		Creator:    req.Creator,
+		TokenEpoch: req.Epoch,
+	}
+	addr := fmt.Sprintf("127.0.0.1:%d", req.Port)
+	if err := ref.gw.Expose(req.Name, addr, policy); err != nil {
+		return nil, err
+	}
+
+	res := &worker.ExposeResult{URL: exposeMeshURL(req.Name)}
+
+	if policy.Visibility == gateway.VisibilityLink {
+		key, err := config.LoadOrCreateExposeSigningKey(platform.ConfigDir())
+		if err != nil {
+			return nil, fmt.Errorf("load link signing key: %w", err)
+		}
+		ttl := time.Duration(req.TTLSeconds) * time.Second
+		if ttl <= 0 {
+			ttl = defaultLinkTTL
+		}
+		exp := time.Now().Add(ttl)
+		res.Token = gateway.MintLinkToken(key, req.Name, req.Epoch, exp)
+		res.ExpiresAt = exp.UTC().Format(time.RFC3339)
+	}
+	return res, nil
+}
+
+// exposeMeshURL builds the mesh URL an exposed service is reachable at:
+// <scheme>://<vpnIP>:<gatewayPort>/expose/<name>. Returns "" when off-mesh. It
+// mirrors gatewayRouteURL/moduleMeshAPIURL for the /expose/ namespace and reads
+// the persisted gateway facts so it is correct whether or not this process runs
+// the gateway.
+func exposeMeshURL(name string) string {
+	ip := meshIPv4()
+	if ip == "" {
+		return ""
+	}
+	f := gatewayFactsForURL()
+	scheme := "https"
+	if !f.UseTLS {
+		scheme = "http"
+	}
+	return fmt.Sprintf("%s://%s:%d%s", scheme, ip, f.Port, gateway.ExposeRoutePath(name))
+}

--- a/cmd/gateway_mesh_auth.go
+++ b/cmd/gateway_mesh_auth.go
@@ -1,0 +1,41 @@
+// cmd/gateway_mesh_auth.go
+//
+// cmd-side adapter that lets the gateway authorize a private/org exposure by
+// verified mesh-peer identity (issue #598). It bridges the network layer's
+// WhoIs to the gateway's MeshIdentityResolver interface. It lives here (not in
+// internal/gateway) because it depends on internal/network; keeping the
+// dependency on this side is what lets internal/gateway stay standalone and
+// unit-testable behind the interface (see cmd/terminal_mesh_auth.go, the same
+// pattern for the terminal endpoint).
+package cmd
+
+import (
+	"context"
+
+	"github.com/aceteam-ai/citadel-cli/internal/gateway"
+	"github.com/aceteam-ai/citadel-cli/internal/network"
+)
+
+// gatewayMeshResolver implements gateway.MeshIdentityResolver using the mesh
+// control plane. It is wired into the gateway via SetMeshResolver so an exposed
+// service with `private`/`org` visibility can authorize a caller arriving on the
+// VPN listener by its verified tailnet login + same-owner status — no
+// platform-minted token needed. `link` exposures do not use it (they verify a
+// signed token instead), so this only lights up private/org.
+type gatewayMeshResolver struct{}
+
+// ResolvePeer resolves an inbound connection's remote address to its verified
+// tailnet identity via network.WhoIsPeer. Any error is returned verbatim so the
+// gateway's exposure middleware fails the private/org check closed (an
+// unverifiable caller is never granted access).
+func (gatewayMeshResolver) ResolvePeer(ctx context.Context, remoteAddr string) (*gateway.MeshPeerIdentity, error) {
+	id, err := network.WhoIsPeer(ctx, remoteAddr)
+	if err != nil {
+		return nil, err
+	}
+	return &gateway.MeshPeerIdentity{
+		NodeName:  id.NodeName,
+		LoginName: id.LoginName,
+		SameOwner: id.SameOwner,
+	}, nil
+}

--- a/cmd/nodejobs.go
+++ b/cmd/nodejobs.go
@@ -108,6 +108,15 @@ func registerPrivilegedNodeJobHandlers(runner *worker.Runner, opts nodeJobHandle
 		Log: opts.HandlerLog,
 	}))
 
+	// EXPOSE_SET (issue #598): expose a local node service on the gateway with
+	// private/org/link visibility and return the managed mesh URL. The live ops
+	// adapter programs the in-process gateway; the node half of the `expose` MCP
+	// verb's contract.
+	runner.RegisterHandler(worker.NewExposeSetHandler(worker.ExposeSetConfig{
+		Ops: liveExposeOps{},
+		Log: opts.HandlerLog,
+	}))
+
 	// INSTANCE_* (aceteam#5963): fabric instance provisioning on this node's
 	// Proxmox hypervisor. Registered unconditionally so nodes without a proxmox
 	// provisioning config fail these jobs with a clear message; the lazy factory

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -202,6 +202,17 @@ func runServe(cmd *cobra.Command, args []string) error {
 	perms := config.LoadPermissions(platform.ConfigDir())
 	gw.SetPermissions(perms)
 
+	// Service ingress / exposure (issue #598): wire the identity resolver
+	// (private/org visibility) and the per-node link-token signing key so an
+	// exposed service under /expose/<name>/ can be gated by mesh identity or a
+	// signed link token. Harmless when nothing is exposed.
+	gw.SetMeshResolver(gatewayMeshResolver{})
+	if key, err := config.LoadOrCreateExposeSigningKey(platform.ConfigDir()); err != nil {
+		Log("warning: gateway link-token signing disabled: %v", err)
+	} else {
+		gw.SetExposeSigningKey(key)
+	}
+
 	// Register upstreams — status server endpoints
 	// These route to the status server started by 'citadel work --status-port'
 	gw.AddUpstream("/health", &gateway.Upstream{Address: statusAddr})

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1858,6 +1858,17 @@ func runWork(cmd *cobra.Command, args []string) {
 		perms := config.LoadPermissions(platform.ConfigDir())
 		gw.SetPermissions(perms)
 
+		// Service ingress / exposure (issue #598): wire the identity resolver
+		// (private/org visibility) and the per-node link-token signing key so an
+		// exposed service under /expose/<name>/ can be gated by mesh identity or a
+		// signed link token. Harmless when nothing is exposed.
+		gw.SetMeshResolver(gatewayMeshResolver{})
+		if key, err := config.LoadOrCreateExposeSigningKey(platform.ConfigDir()); err != nil {
+			Log("warning: gateway link-token signing disabled: %v", err)
+		} else {
+			gw.SetExposeSigningKey(key)
+		}
+
 		// Register upstreams (same routes as cmd/serve.go)
 		gw.AddUpstream("/health", &gateway.Upstream{Address: statusAddr})
 		gw.AddUpstream("/status", &gateway.Upstream{Address: statusAddr})

--- a/docs/gateway-ingress.md
+++ b/docs/gateway-ingress.md
@@ -79,6 +79,18 @@ the exposure's current `TokenEpoch`, and `exp` is in the future. Revocation is
 every prior token then fails the epoch check. Per-token (`jti`) revocation is a
 follow-up.
 
+**Shareable URL:** the MCP verb composes it as `url + "?access_token=" + token`.
+The bare `url` is not usable for a `link` exposure without the token.
+
+**Browser sessions (why one token works for a whole SPA):** a browser opens the
+shareable URL (token in the query), then fetches sub-resources (`/assets/app.js`,
+`/api/config`) that carry NO `?access_token=`. On a valid explicit token the
+middleware plants a path-scoped (`/expose/<name>/`), `Secure`, `HttpOnly`,
+`SameSite=Lax` session cookie whose value is the same signed token, so every
+subsequent request is re-verified (expiry included) and stays authorized. Without
+this, only the first request (curl) would work and the web UI would 401 on its
+first asset.
+
 ## Known scope / assumptions (v1)
 
 - **`private` is inert end-to-end until aceteam passes a `Creator`.** A locally
@@ -88,6 +100,21 @@ follow-up.
 - **`org` == same tailnet owner.** Mesh membership is treated as org membership,
   consistent with the #585 "TLS + mesh membership" posture. A finer org-membership
   check (beyond the tailnet owner) is a backend concern.
+- **`link` widens authorization, not network reachability.** The managed URL is a
+  `100.64.x` mesh address, reachable only by someone already on the mesh/LAN. A
+  link removes the org-identity requirement for that reachable audience; it does
+  not make the service publicly reachable.
+- **Subpath serving constraint (applies to ALL visibility levels).** The route is
+  served under `/expose/<name>/` with `StripPrefix`. An app that emits ABSOLUTE
+  asset paths (`<script src="/assets/...">`) will have the browser resolve them at
+  the gateway root → 404 — this is not auth, org/private hit it too. The exposed
+  app must be configured to serve under a base path matching the prefix (e.g.
+  Frigate's base-path config — the #597 nvr module is responsible for setting it
+  to `/expose/<name>/`). Apps using relative paths work unchanged. A generic
+  path-rewriting or per-service-subdomain answer is a follow-up if base-path
+  config is not available for a given app.
+- **WebSocket is enabled** on exposed routes, so live view / event streams
+  (Frigate) upgrade through the gateway.
 - **No tailnet HTTPS certs.** The gateway's own TLS on 8443 is the edge; nothing
   here depends on `tailscale cert` (which is disabled on the tailnet).
 - **On-ramp requires the in-process gateway.** `EXPOSE_SET` needs `citadel work

--- a/docs/gateway-ingress.md
+++ b/docs/gateway-ingress.md
@@ -1,0 +1,107 @@
+# Gateway ingress — expose node services with private/org/link visibility (#598)
+
+Status: node-side v1 implemented. The MCP `expose` verb + console action are the
+cross-repo (aceteam) follow-up that drives this.
+
+## What this adds
+
+A productized way to expose a node's **local** service (a dashboard, an engine
+UI, Frigate's web UI, any internal tool) on the fabric through the **existing
+Citadel gateway** — no parallel `tailscale serve` path. Every exposed service is
+served under a dedicated `/expose/<name>/` namespace and gated by a page-style
+**visibility ladder**:
+
+| Visibility | Who can reach it | How it is enforced |
+|------------|------------------|--------------------|
+| `private`  | the creator only | caller's tailnet login == recorded `Creator` |
+| `org`      | any same-owner mesh peer | `WhoIs(RemoteAddr).SameOwner == true` |
+| `link`     | anyone with a valid token | signed, expiring, revocable HMAC token |
+
+The verb is generic (`expose(service, visibility, ttl?)`) — the NVR/Frigate UI
+(#597) is the first consumer, but nothing here is camera-specific.
+
+## The layering that makes link/org work (read this)
+
+The gateway's capability layer (`permissionMiddleware` → `categoryForRequest`)
+gates builtin and `/modules/<prefix>/` routes and **fails closed**: a disabled
+capability returns 403 and a sensitive surface without the node passcode returns
+401 — *before* any later middleware runs. A `link` recipient has neither a
+capability nor the node passcode (that is the whole point of a shareable link),
+so exposed routes must **not** be gated by the capability switch.
+
+Therefore:
+
+- `categoryForPath` returns `""` (always-allowed) for `/expose/...`, so the
+  capability gate never rejects a link/org caller first.
+- `exposureMiddleware` (in `internal/gateway/exposure.go`) is the **sole** gate
+  for `/expose/`, and it **fails closed**: an `/expose/<name>` with no registered
+  policy is 404; any visibility check that cannot be affirmatively satisfied is
+  denied.
+
+This is verified through the **full `BuildHandler` chain** with maximally
+restrictive permissions (`config.Permissions{}` — every capability disabled, no
+passcode) in `exposure_test.go`: a valid link token must still reach the upstream.
+An isolated middleware test would pass while the real chain still 403'd — that gap
+is the reason the test drives the whole chain.
+
+## Components
+
+- `internal/gateway/exposure.go` — the primitive: `Visibility`, `ExposePolicy`,
+  the per-Server exposure registry (`SetExposure`/`Expose`/`RemoveExposure`),
+  `exposureMiddleware`, the `MeshIdentityResolver` interface (mirrors the #585
+  terminal resolver so the package stays standalone/testable), and the `link`
+  token mint/verify (`MintLinkToken`/`verifyLinkToken`, HMAC-SHA256).
+- `internal/gateway/gateway.go` — `categoryForPath` always-allows `/expose/`;
+  `BuildHandler` wraps `exposureMiddleware` closest to the mux; three `Server`
+  fields (`exposures`, `exposeSigningKey`, `meshResolver`).
+- `internal/config/expose_key.go` — `LoadOrCreateExposeSigningKey`: a dedicated
+  per-node 32-byte HMAC key, persisted `0600`. (The passcode hash is bcrypt, not
+  a raw HMAC key, and may be unset — so link tokens get their own key.)
+- `cmd/gateway_mesh_auth.go` — `gatewayMeshResolver`: wires `network.WhoIsPeer`
+  into the gateway's resolver interface (kept in cmd so the gateway package does
+  not depend on internal/network).
+- `cmd/serve.go`, `cmd/work.go` — wire the resolver + signing key into both
+  gateway construction sites.
+- `internal/worker/expose_set.go` — the `EXPOSE_SET` job handler (the node half
+  of the `expose` MCP verb's contract): per-node-stream gated, validates the
+  payload, calls the injected `ExposeOps`, returns `{url, token, expires_at}`.
+- `cmd/expose_ops.go` — `liveExposeOps`: programs the in-process gateway
+  (`gw.Expose`), mints the link token, and builds the managed mesh URL
+  (`https://<vpnIP>:<gatewayPort>/expose/<name>`).
+
+## `link` token model
+
+`MintLinkToken(key, name, epoch, exp)` → `base64url(payload).base64url(hmac)`,
+`payload = "<name>.<epoch>.<expUnix>"`. Verification (constant-time) requires:
+signature valid under the node key, `name` matches the exposure, `epoch` matches
+the exposure's current `TokenEpoch`, and `exp` is in the future. Revocation is
+**revoke-all-for-exposure** by bumping `TokenEpoch` (re-expose with `epoch+1`);
+every prior token then fails the epoch check. Per-token (`jti`) revocation is a
+follow-up.
+
+## Known scope / assumptions (v1)
+
+- **`private` is inert end-to-end until aceteam passes a `Creator`.** A locally
+  run expose cannot know a *remote* creator's tailnet login; it is an explicit
+  payload field. `link` and `org` function fully node-only. Empty `Creator` fails
+  closed.
+- **`org` == same tailnet owner.** Mesh membership is treated as org membership,
+  consistent with the #585 "TLS + mesh membership" posture. A finer org-membership
+  check (beyond the tailnet owner) is a backend concern.
+- **No tailnet HTTPS certs.** The gateway's own TLS on 8443 is the edge; nothing
+  here depends on `tailscale cert` (which is disabled on the tailnet).
+- **On-ramp requires the in-process gateway.** `EXPOSE_SET` needs `citadel work
+  --gateway` (or `citadel serve`); with no in-process gateway it fails (retryable)
+  rather than silently no-oping. Unlike modules, exposures are **not yet persisted**
+  to a registry+watcher, so they do not survive a gateway restart — durable
+  exposure state is a follow-up (mirror the provisioned-service registry).
+- **No metering.** Exposed-service egress is not metered/billed yet (the issue's
+  open question); the gateway does not wire `SetMetering` for `/expose/`.
+
+## Cross-repo follow-up (aceteam)
+
+Add the generic `expose(node, service, visibility, ttl?)` MCP verb + console
+action that dispatches an `EXPOSE_SET` job to the node's **per-node** stream and
+renders the returned `{url, token, expires_at}` (mirror `page_publish`
+ergonomics: create → returns URL; re-call to change visibility / rotate the link).
+The node side is ready for it.

--- a/internal/config/expose_key.go
+++ b/internal/config/expose_key.go
@@ -1,0 +1,53 @@
+// internal/config/expose_key.go
+//
+// Per-node signing key for gateway `link` access tokens (issue #598).
+//
+// The gateway signs shareable `link` exposure tokens with an HMAC key that must
+// (a) be stable across restarts so a token minted yesterday still verifies today
+// and (b) never leave the node. There is no existing per-node secret suited to
+// this: the passcode hash is a bcrypt digest (not a raw HMAC key) and may be
+// unset. So we mint a dedicated 32-byte random key on first use and persist it
+// 0600 alongside the other node config, exactly like the passcode hash.
+package config
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// exposeKeyFile is the filename (under the config dir) holding the hex-encoded
+// link-token signing key.
+const exposeKeyFile = "expose_signing_key"
+
+// exposeKeyLen is the length in bytes of a freshly-minted signing key.
+const exposeKeyLen = 32
+
+// LoadOrCreateExposeSigningKey returns the node's persistent link-token signing
+// key, generating and persisting one (0600) on first use. The key is stored
+// hex-encoded. A short/corrupt existing file is treated as absent and rotated
+// (which safely invalidates any outstanding link tokens — they fail closed).
+func LoadOrCreateExposeSigningKey(configDir string) ([]byte, error) {
+	path := filepath.Join(configDir, exposeKeyFile)
+	if data, err := os.ReadFile(path); err == nil {
+		if key, derr := hex.DecodeString(strings.TrimSpace(string(data))); derr == nil && len(key) >= exposeKeyLen {
+			return key, nil
+		}
+		// Fall through to regenerate a malformed/short key.
+	}
+
+	key := make([]byte, exposeKeyLen)
+	if _, err := rand.Read(key); err != nil {
+		return nil, fmt.Errorf("generate expose signing key: %w", err)
+	}
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return nil, fmt.Errorf("create config dir: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(hex.EncodeToString(key)), 0600); err != nil {
+		return nil, fmt.Errorf("persist expose signing key: %w", err)
+	}
+	return key, nil
+}

--- a/internal/gateway/exposure.go
+++ b/internal/gateway/exposure.go
@@ -224,22 +224,78 @@ func (s *Server) Expose(name, address string, policy *ExposePolicy) error {
 		return fmt.Errorf("gateway: Expose requires a valid visibility (private|org|link)")
 	}
 	// StripPrefix so the exposed app's own paths (/, /assets, ...) map through
-	// unchanged, exactly like a module route.
-	if err := s.WireModuleRoute(ExposeRoutePath(name), address, true); err != nil {
-		return err
-	}
+	// unchanged, exactly like a module route. WebSocket is enabled because a real
+	// web app (Frigate live view, dashboards) upgrades to WS; registerProxy routes
+	// plain HTTP and WS upgrades through the same handler.
+	//
+	// NOTE (subpath constraint): because the route is served under /expose/<name>/
+	// with StripPrefix, an exposed app that emits ABSOLUTE asset paths (<script
+	// src="/assets/...">) will have the browser resolve them at the gateway root
+	// (no /expose/<name> prefix) and 404 — for EVERY visibility level, this is not
+	// an auth issue. Such an app must be configured to serve under a base path
+	// matching the expose prefix (e.g. Frigate's base-path config, handled by the
+	// #597 nvr module). Apps that use relative paths work unchanged.
+	s.wireExposeRoute(ExposeRoutePath(name), address)
 	s.SetExposure(name, policy)
 	return nil
 }
 
-// accessTokenFromRequest extracts a `link` access token. The header is primary;
-// the query parameter is the fallback for plain browser navigation (a shared
-// link is opened in a browser, which cannot set a custom header).
-func accessTokenFromRequest(r *http.Request) string {
+// wireExposeRoute registers (or re-points) the /expose/<name> reverse-proxy
+// route with StripPrefix + WebSocket enabled. It mirrors WireModuleRoute's
+// re-wire-safe semantics (#449): a new route created after Start registers its
+// handler live; an existing route has its address mutated in place (never
+// replaced) so the running proxy keeps reading the current target.
+func (s *Server) wireExposeRoute(prefix, address string) {
+	s.mu.Lock()
+	up, ok := s.config.Upstreams[prefix]
+	if !ok {
+		up = &Upstream{StripPrefix: true, WebSocket: true}
+		up.setAddr(address)
+		s.config.Upstreams[prefix] = up
+		if s.started {
+			s.registerProxy(prefix, up)
+		}
+		s.mu.Unlock()
+		return
+	}
+	s.mu.Unlock()
+	up.setAddr(address)
+}
+
+// explicitLinkToken extracts a `link` access token presented EXPLICITLY (header
+// or query) — the shareable-link entry point. The header is primary; the query
+// parameter is the fallback for plain browser navigation (a shared link is
+// opened in a browser, which cannot set a custom header). The cookie fallback is
+// handled separately so the middleware can set the cookie on an explicit hit.
+func explicitLinkToken(r *http.Request) string {
 	if h := r.Header.Get("X-Citadel-Access"); h != "" {
 		return h
 	}
 	return r.URL.Query().Get("access_token")
+}
+
+// exposeCookieName is the per-exposure cookie that carries a validated link
+// token forward to sub-resource requests. It is per-name so one exposure's
+// session cannot authorize another, and it is path-scoped to /expose/<name>/.
+func exposeCookieName(name string) string {
+	return "citadel_expose_" + name
+}
+
+// setLinkCookie plants the validated token as a path-scoped session cookie so a
+// browser's subsequent sub-resource fetches (which carry no ?access_token=) stay
+// authorized. The cookie VALUE is the same signed token, so every subsequent
+// request is re-verified (including the token's own expiry) — the cookie widens
+// nothing. Secure + HttpOnly + SameSite=Lax; no Max-Age (session cookie), since
+// the token's embedded expiry is the real bound.
+func setLinkCookie(w http.ResponseWriter, name, token string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     exposeCookieName(name),
+		Value:    token,
+		Path:     ExposeRoutePath(name) + "/",
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	})
 }
 
 // MintLinkToken produces a signed access token for a `link` exposure that is
@@ -336,9 +392,28 @@ func (s *Server) exposureMiddleware(next http.Handler) http.Handler {
 
 		switch policy.Visibility {
 		case VisibilityLink:
-			if verifyLinkToken(key, name, policy.TokenEpoch, accessTokenFromRequest(r), time.Now()) {
-				next.ServeHTTP(w, r)
+			now := time.Now()
+			// 1. Explicit token (shareable link entry). On success, plant a
+			// path-scoped cookie so the browser's sub-resource fetches — which do
+			// NOT carry ?access_token= — stay authorized. Without this, the HTML
+			// loads but every /assets/* fetch 401s and the app is unusable in a
+			// browser (works only for curl).
+			if tok := explicitLinkToken(r); tok != "" {
+				if verifyLinkToken(key, name, policy.TokenEpoch, tok, now) {
+					setLinkCookie(w, name, tok)
+					next.ServeHTTP(w, r)
+					return
+				}
+				exposeDeny(w, http.StatusUnauthorized, "a valid access token is required")
 				return
+			}
+			// 2. Cookie (sub-resource requests after the first). Re-verified every
+			// time, so an expired/revoked token in the cookie still fails closed.
+			if c, err := r.Cookie(exposeCookieName(name)); err == nil {
+				if verifyLinkToken(key, name, policy.TokenEpoch, c.Value, now) {
+					next.ServeHTTP(w, r)
+					return
+				}
 			}
 			exposeDeny(w, http.StatusUnauthorized, "a valid access token is required")
 			return

--- a/internal/gateway/exposure.go
+++ b/internal/gateway/exposure.go
@@ -1,0 +1,395 @@
+// internal/gateway/exposure.go
+//
+// Service ingress / fabric exposure for the Citadel gateway (issue #598).
+//
+// This adds a productized way to expose a node's LOCAL service (a dashboard, an
+// engine UI, Frigate's web UI, ...) on the fabric through the SAME gateway that
+// already terminates TLS on 8443 and rides the tsnet VPN listener — no parallel
+// `tailscale serve` path. Every exposed service is served under the dedicated
+// /expose/<name>/ namespace and gated by a page-style VISIBILITY LADDER:
+//
+//	private — only the creator (by tailnet login).
+//	org     — any authenticated same-owner mesh peer (org == tailnet owner).
+//	link    — a signed, expiring, revocable access token (no mesh identity).
+//
+// # Why a dedicated namespace (the layering that makes link/org work)
+//
+// The capability layer (permissionMiddleware -> categoryForRequest) gates the
+// builtin and /modules/<prefix>/ routes and FAILS CLOSED (a disabled capability
+// or a missing node passcode returns 403/401 BEFORE any later middleware runs).
+// A `link` recipient has neither a capability nor the node passcode — that is the
+// whole point of a shareable link — so exposed routes must NOT be gated by the
+// capability switch. categoryForPath therefore returns "" (always-allowed) for
+// /expose/..., and this file's exposureMiddleware is the SOLE gate for it. It
+// fails closed for any /expose/<name> that has no registered policy (404), so
+// "always-allowed at the capability layer" never means "open".
+//
+// # Standalone by design
+//
+// Identity comes from an injected MeshIdentityResolver (mirroring the terminal
+// endpoint's #585 resolver), so this package stays decoupled from
+// internal/network and unit-testable with a mock. The cmd layer wires
+// network.WhoIsPeer. `private` needs the creator's tailnet login, which only the
+// backend/MCP caller knows (a locally-run `citadel expose` cannot know a REMOTE
+// creator's login) — it is an explicit input on ExposePolicy, and `private` is
+// inert end-to-end until aceteam passes it. `link` and `org` function fully in a
+// node-only v1.
+package gateway
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// exposeNamePattern matches a valid exposed-service name: lowercase alphanumeric
+// plus internal dashes, no slashes or dots, so a name can never inject a path
+// segment or traverse. Mirrors the catalog package's gateway-prefix rule (kept
+// local to avoid a gateway->catalog dependency).
+var exposeNamePattern = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+
+// ExposeRoutePrefix is the namespace under which EVERY exposed service is served
+// on the gateway. It is deliberately distinct from ModuleRoutePrefix
+// ("/modules/") so the capability layer can always-allow it (categoryForPath)
+// and hand sole gating to exposureMiddleware.
+const ExposeRoutePrefix = "/expose/"
+
+// ExposeRoutePath returns the gateway route path for an exposed service name:
+// "/expose/<name>". The convention lives here so the gateway (route
+// registration) and any out-of-process URL builder agree.
+func ExposeRoutePath(name string) string {
+	return ExposeRoutePrefix + name
+}
+
+// Visibility is the access level of an exposed service. It mirrors the pages
+// model exactly (private/org/link).
+type Visibility string
+
+const (
+	// VisibilityPrivate restricts access to the creator (by tailnet login).
+	VisibilityPrivate Visibility = "private"
+	// VisibilityOrg allows any authenticated same-owner mesh peer.
+	VisibilityOrg Visibility = "org"
+	// VisibilityLink allows any caller presenting a valid signed access token.
+	VisibilityLink Visibility = "link"
+)
+
+// Valid reports whether v is one of the three known visibility levels.
+func (v Visibility) Valid() bool {
+	switch v {
+	case VisibilityPrivate, VisibilityOrg, VisibilityLink:
+		return true
+	}
+	return false
+}
+
+// MeshPeerIdentity is the verified identity of a peer that connected over the
+// mesh/VPN listener, produced by a MeshIdentityResolver and consumed by
+// exposureMiddleware to authorize private/org access without a token.
+type MeshPeerIdentity struct {
+	// NodeName is the peer's node name (audit log).
+	NodeName string
+	// LoginName is the peer's tailnet user login (e.g. an email). It is the
+	// identity compared against a private exposure's Creator.
+	LoginName string
+	// SameOwner reports whether the peer belongs to the same tailnet owner/org as
+	// this node. It is the gate for `org` visibility.
+	SameOwner bool
+}
+
+// MeshIdentityResolver resolves an inbound connection's remote address to a
+// verified mesh peer identity. Injected via Server.SetMeshResolver so the
+// gateway stays standalone and unit-testable (tests pass a MockMeshResolver;
+// production wires network.WhoIsPeer through the cmd layer).
+type MeshIdentityResolver interface {
+	// ResolvePeer resolves remoteAddr ("ip:port") to a verified identity, or an
+	// error if the peer cannot be verified. An error is treated as unverified and
+	// fails the private/org check closed.
+	ResolvePeer(ctx context.Context, remoteAddr string) (*MeshPeerIdentity, error)
+}
+
+// MockMeshResolver is a MeshIdentityResolver for tests: it returns a fixed
+// identity (or error) regardless of the remote address.
+type MockMeshResolver struct {
+	Identity *MeshPeerIdentity
+	Err      error
+}
+
+// ResolvePeer implements MeshIdentityResolver for the mock.
+func (m *MockMeshResolver) ResolvePeer(context.Context, string) (*MeshPeerIdentity, error) {
+	if m.Err != nil {
+		return nil, m.Err
+	}
+	return m.Identity, nil
+}
+
+// ExposePolicy is the visibility policy recorded for one exposed service. It is
+// registered via Server.Expose and consulted per request by exposureMiddleware.
+type ExposePolicy struct {
+	// Visibility is the access level (private/org/link).
+	Visibility Visibility
+	// Creator is the tailnet login authorized for a `private` exposure. It is an
+	// explicit input (only the backend/MCP caller knows the remote creator's
+	// login); an empty Creator makes a `private` exposure inert (fails closed).
+	Creator string
+	// TokenEpoch is bound into every `link` token this exposure mints. Bumping it
+	// (re-exposing with an incremented epoch) invalidates all previously issued
+	// link tokens for this service — the revoke-all primitive behind "revocable".
+	TokenEpoch int
+}
+
+// exposePrefixFromPath extracts the exposed-service name from a /expose/<name>
+// (or /expose/<name>/...) request path, or "" if the path is not an exposure
+// route. Inverse of ExposeRoutePath.
+func exposePrefixFromPath(path string) string {
+	if !strings.HasPrefix(path, ExposeRoutePrefix) {
+		return ""
+	}
+	rest := strings.TrimPrefix(path, ExposeRoutePrefix)
+	if rest == "" {
+		return ""
+	}
+	if i := strings.IndexByte(rest, '/'); i >= 0 {
+		return rest[:i]
+	}
+	return rest
+}
+
+// SetMeshResolver injects the resolver used to verify a caller's mesh identity
+// for private/org exposures. A nil resolver makes every private/org exposure
+// fail closed (only `link` works without it). Safe to call before or after Start.
+func (s *Server) SetMeshResolver(r MeshIdentityResolver) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.meshResolver = r
+}
+
+// SetExposeSigningKey sets the per-node secret used to sign/verify `link` access
+// tokens. An empty key makes every link token fail verification (fail closed).
+// Safe to call before or after Start.
+func (s *Server) SetExposeSigningKey(key []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.exposeSigningKey = key
+}
+
+// SetExposure records (or replaces) the visibility policy for an exposed service.
+// It does NOT wire the reverse-proxy route — use Expose for that. Exposed under
+// s.mu so a running gateway can gain/lose exposures live.
+func (s *Server) SetExposure(name string, policy *ExposePolicy) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.exposures == nil {
+		s.exposures = make(map[string]*ExposePolicy)
+	}
+	s.exposures[name] = policy
+}
+
+// RemoveExposure deletes an exposure's policy. The middleware then fails closed
+// (404) for that name even if its proxy route object still exists.
+func (s *Server) RemoveExposure(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.exposures, name)
+}
+
+// getExposure returns the policy for name, or nil if not exposed.
+func (s *Server) getExposure(name string) *ExposePolicy {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.exposures[name]
+}
+
+// Expose wires the /expose/<name> reverse-proxy route to a loopback address AND
+// records its visibility policy, atomically from the caller's perspective. It is
+// the one call the EXPOSE control path (worker job / CLI) makes to program the
+// gateway. name must be a clean slug (lowercase alphanumeric + dash) so it can
+// never inject a path segment.
+func (s *Server) Expose(name, address string, policy *ExposePolicy) error {
+	if name == "" {
+		return fmt.Errorf("gateway: Expose requires a non-empty service name")
+	}
+	if !exposeNamePattern.MatchString(name) {
+		return fmt.Errorf("gateway: expose name %q must be lowercase alphanumeric and dashes only", name)
+	}
+	if policy == nil || !policy.Visibility.Valid() {
+		return fmt.Errorf("gateway: Expose requires a valid visibility (private|org|link)")
+	}
+	// StripPrefix so the exposed app's own paths (/, /assets, ...) map through
+	// unchanged, exactly like a module route.
+	if err := s.WireModuleRoute(ExposeRoutePath(name), address, true); err != nil {
+		return err
+	}
+	s.SetExposure(name, policy)
+	return nil
+}
+
+// accessTokenFromRequest extracts a `link` access token. The header is primary;
+// the query parameter is the fallback for plain browser navigation (a shared
+// link is opened in a browser, which cannot set a custom header).
+func accessTokenFromRequest(r *http.Request) string {
+	if h := r.Header.Get("X-Citadel-Access"); h != "" {
+		return h
+	}
+	return r.URL.Query().Get("access_token")
+}
+
+// MintLinkToken produces a signed access token for a `link` exposure that is
+// valid until exp. The token binds the service name and the exposure's TokenEpoch
+// so (a) a token for one service cannot open another and (b) bumping the epoch
+// revokes every outstanding token. Format: base64url(payload)"."base64url(hmac),
+// payload = "<name>.<epoch>.<expUnix>". Returns "" if key is empty (no signer).
+func MintLinkToken(key []byte, name string, epoch int, exp time.Time) string {
+	if len(key) == 0 {
+		return ""
+	}
+	payload := fmt.Sprintf("%s.%d.%d", name, epoch, exp.Unix())
+	sig := signPayload(key, payload)
+	return base64.RawURLEncoding.EncodeToString([]byte(payload)) + "." +
+		base64.RawURLEncoding.EncodeToString(sig)
+}
+
+// signPayload computes the HMAC-SHA256 of payload under key.
+func signPayload(key []byte, payload string) []byte {
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte(payload))
+	return mac.Sum(nil)
+}
+
+// verifyLinkToken reports whether token is a currently-valid link token for
+// (name, epoch) under key. It fails closed on every malformed/expired/tampered
+// input and uses a constant-time signature comparison. now is injected for
+// deterministic tests.
+func verifyLinkToken(key []byte, name string, epoch int, token string, now time.Time) bool {
+	if len(key) == 0 || token == "" {
+		return false
+	}
+	dot := strings.IndexByte(token, '.')
+	if dot <= 0 || dot == len(token)-1 {
+		return false
+	}
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(token[:dot])
+	if err != nil {
+		return false
+	}
+	gotSig, err := base64.RawURLEncoding.DecodeString(token[dot+1:])
+	if err != nil {
+		return false
+	}
+	payload := string(payloadBytes)
+	wantSig := signPayload(key, payload)
+	if subtle.ConstantTimeCompare(gotSig, wantSig) != 1 {
+		return false
+	}
+	// Signature verified — now the claims must match this exposure and be unexpired.
+	// Parse from the RIGHT: expUnix and epoch are numeric, but name may itself
+	// contain dots... it cannot (prefixPattern forbids dots), so a plain 3-way
+	// split is safe. Guard anyway.
+	parts := strings.Split(payload, ".")
+	if len(parts) != 3 {
+		return false
+	}
+	if parts[0] != name {
+		return false
+	}
+	gotEpoch, err := strconv.Atoi(parts[1])
+	if err != nil || gotEpoch != epoch {
+		return false
+	}
+	expUnix, err := strconv.ParseInt(parts[2], 10, 64)
+	if err != nil {
+		return false
+	}
+	return now.Before(time.Unix(expUnix, 0))
+}
+
+// exposureMiddleware is the SOLE access gate for /expose/<name>/ routes. It fails
+// closed: an unregistered name is 404, and any visibility check that cannot be
+// affirmatively satisfied is denied. Non-exposure paths pass straight through.
+func (s *Server) exposureMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		name := exposePrefixFromPath(r.URL.Path)
+		if name == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		policy := s.getExposure(name)
+		if policy == nil {
+			// Not exposed (or revoked): do not reveal, do not serve.
+			exposeDeny(w, http.StatusNotFound, "not found")
+			return
+		}
+
+		s.mu.RLock()
+		resolver := s.meshResolver
+		key := s.exposeSigningKey
+		s.mu.RUnlock()
+
+		switch policy.Visibility {
+		case VisibilityLink:
+			if verifyLinkToken(key, name, policy.TokenEpoch, accessTokenFromRequest(r), time.Now()) {
+				next.ServeHTTP(w, r)
+				return
+			}
+			exposeDeny(w, http.StatusUnauthorized, "a valid access token is required")
+			return
+
+		case VisibilityOrg:
+			if id, ok := resolvePeer(resolver, r); ok && id.SameOwner {
+				next.ServeHTTP(w, r)
+				return
+			}
+			exposeDeny(w, http.StatusForbidden, "org membership required")
+			return
+
+		case VisibilityPrivate:
+			// Inert until the creator login is provided by the backend/MCP caller.
+			if policy.Creator == "" {
+				exposeDeny(w, http.StatusForbidden, "private exposure has no creator set")
+				return
+			}
+			if id, ok := resolvePeer(resolver, r); ok && id.LoginName != "" && id.LoginName == policy.Creator {
+				next.ServeHTTP(w, r)
+				return
+			}
+			exposeDeny(w, http.StatusForbidden, "not the exposure creator")
+			return
+
+		default:
+			// Unknown visibility — fail closed.
+			exposeDeny(w, http.StatusForbidden, "access denied")
+			return
+		}
+	})
+}
+
+// resolvePeer runs the injected resolver against the request's RemoteAddr,
+// returning (identity, true) only on success. A nil resolver or any error yields
+// (nil, false) so the caller fails closed.
+func resolvePeer(resolver MeshIdentityResolver, r *http.Request) (*MeshPeerIdentity, bool) {
+	if resolver == nil {
+		return nil, false
+	}
+	id, err := resolver.ResolvePeer(r.Context(), r.RemoteAddr)
+	if err != nil || id == nil {
+		return nil, false
+	}
+	return id, true
+}
+
+// exposeDeny writes a JSON error with the given status for a denied exposure
+// request.
+func exposeDeny(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	fmt.Fprintf(w, `{"error":%q}`, msg)
+}

--- a/internal/gateway/exposure_test.go
+++ b/internal/gateway/exposure_test.go
@@ -96,6 +96,70 @@ func TestExposure_LinkReachesUpstreamThroughFullChain(t *testing.T) {
 	}
 }
 
+func TestExposure_LinkCookieCarriesSession(t *testing.T) {
+	key := []byte("cookie-key")
+	h, _ := buildExposedGateway(t, "frigate", &ExposePolicy{Visibility: VisibilityLink, TokenEpoch: 1}, nil, key)
+	tok := MintLinkToken(key, "frigate", 1, time.Now().Add(time.Hour))
+
+	// First request with the explicit token: 200 AND a Set-Cookie carrying the
+	// session forward.
+	req := httptest.NewRequest(http.MethodGet, "/expose/frigate/?access_token="+tok, nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("first (token) request: got %d, want 200", w.Code)
+	}
+	var session *http.Cookie
+	for _, c := range w.Result().Cookies() {
+		if c.Name == exposeCookieName("frigate") {
+			session = c
+		}
+	}
+	if session == nil {
+		t.Fatal("no session cookie was set on the token'd request")
+	}
+	if session.Path != "/expose/frigate/" {
+		t.Errorf("cookie path: got %q, want /expose/frigate/", session.Path)
+	}
+
+	// Sub-resource fetch carrying ONLY the cookie (no ?access_token=, as a browser
+	// would do for /assets/app.js): must be authorized. This is the case a
+	// per-request-only design silently 401s.
+	sub := httptest.NewRequest(http.MethodGet, "/expose/frigate/assets/app.js", nil)
+	sub.AddCookie(session)
+	w2 := httptest.NewRecorder()
+	h.ServeHTTP(w2, sub)
+	if w2.Code != http.StatusOK {
+		t.Errorf("cookie-only sub-resource: got %d, want 200", w2.Code)
+	}
+
+	// A tampered cookie must fail closed.
+	sub2 := httptest.NewRequest(http.MethodGet, "/expose/frigate/assets/app.js", nil)
+	sub2.AddCookie(&http.Cookie{Name: exposeCookieName("frigate"), Value: tok + "x"})
+	w3 := httptest.NewRecorder()
+	h.ServeHTTP(w3, sub2)
+	if w3.Code != http.StatusUnauthorized {
+		t.Errorf("tampered cookie: got %d, want 401", w3.Code)
+	}
+}
+
+func TestExpose_EnablesWebSocketAndStripPrefix(t *testing.T) {
+	gw := NewServer(Config{Port: 0})
+	if err := gw.Expose("frigate", "127.0.0.1:5000", &ExposePolicy{Visibility: VisibilityOrg}); err != nil {
+		t.Fatal(err)
+	}
+	up := gw.config.Upstreams[ExposeRoutePath("frigate")]
+	if up == nil {
+		t.Fatal("no upstream registered for the exposed route")
+	}
+	if !up.WebSocket {
+		t.Error("exposed upstream must have WebSocket enabled (live view / event streams)")
+	}
+	if !up.StripPrefix {
+		t.Error("exposed upstream must strip the /expose/<name> prefix")
+	}
+}
+
 func TestExposure_LinkTokenViaHeader(t *testing.T) {
 	key := []byte("hdr-key")
 	h, _ := buildExposedGateway(t, "svc", &ExposePolicy{Visibility: VisibilityLink, TokenEpoch: 3}, nil, key)

--- a/internal/gateway/exposure_test.go
+++ b/internal/gateway/exposure_test.go
@@ -1,0 +1,270 @@
+package gateway
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/config"
+)
+
+// buildExposedGateway wires a gateway that proxies /expose/<name> to a test
+// backend under the given policy, with MAXIMALLY RESTRICTIVE capability
+// permissions (every capability disabled, no node passcode) and the full
+// middleware chain built. This is the crux of the #598 test: it proves the
+// exposure gate is the SOLE authority for /expose/ routes — a link/org caller
+// must reach the backend even though the capability layer would 403/401 every
+// other sensitive route. An isolated middleware test would pass while the real
+// chain still rejected the caller.
+func buildExposedGateway(t *testing.T, name string, policy *ExposePolicy, resolver MeshIdentityResolver, key []byte) (http.Handler, *httptest.Server) {
+	t.Helper()
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("BACKEND-REACHED:" + r.URL.Path))
+	}))
+	t.Cleanup(backend.Close)
+
+	gw := NewServer(Config{Port: 0, NodeName: "test-node"})
+	// The zero-value Permissions disables every capability and sets no passcode:
+	// the harshest possible capability gate.
+	gw.SetPermissions(&config.Permissions{})
+	gw.SetMeshResolver(resolver)
+	gw.SetExposeSigningKey(key)
+
+	if err := gw.Expose(name, backendAddr(t, backend), policy); err != nil {
+		t.Fatalf("Expose: %v", err)
+	}
+	// Register proxy handlers on the mux (Start's loop is not run in tests), then
+	// build the full middleware chain.
+	for prefix, up := range gw.config.Upstreams {
+		gw.registerProxy(prefix, up)
+	}
+	return gw.BuildHandler(), backend
+}
+
+func backendAddr(t *testing.T, s *httptest.Server) string {
+	t.Helper()
+	// httptest URL is "http://127.0.0.1:PORT"; the upstream wants "host:port".
+	return s.Listener.Addr().String()
+}
+
+func doGet(h http.Handler, target string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	return w
+}
+
+func TestExposure_LinkReachesUpstreamThroughFullChain(t *testing.T) {
+	key := []byte("test-signing-key-0123456789")
+	policy := &ExposePolicy{Visibility: VisibilityLink, TokenEpoch: 1}
+	h, _ := buildExposedGateway(t, "frigate", policy, nil, key)
+
+	valid := MintLinkToken(key, "frigate", 1, time.Now().Add(time.Hour))
+	if valid == "" {
+		t.Fatal("MintLinkToken returned empty for a non-empty key")
+	}
+
+	// Valid token -> reaches the backend, despite every capability being disabled.
+	if w := doGet(h, "/expose/frigate/dashboard?access_token="+valid); w.Code != http.StatusOK {
+		t.Fatalf("valid link token: got %d, want 200 (chain body=%q)", w.Code, w.Body.String())
+	}
+
+	// No token -> 401, never reaches the backend.
+	if w := doGet(h, "/expose/frigate/dashboard"); w.Code != http.StatusUnauthorized {
+		t.Errorf("no token: got %d, want 401", w.Code)
+	}
+
+	// Expired token -> 401.
+	expired := MintLinkToken(key, "frigate", 1, time.Now().Add(-time.Minute))
+	if w := doGet(h, "/expose/frigate/?access_token="+expired); w.Code != http.StatusUnauthorized {
+		t.Errorf("expired token: got %d, want 401", w.Code)
+	}
+
+	// Wrong epoch (revoked) -> 401. A token minted at epoch 0 must not open an
+	// exposure now at epoch 1.
+	revoked := MintLinkToken(key, "frigate", 0, time.Now().Add(time.Hour))
+	if w := doGet(h, "/expose/frigate/?access_token="+revoked); w.Code != http.StatusUnauthorized {
+		t.Errorf("revoked (old-epoch) token: got %d, want 401", w.Code)
+	}
+
+	// A token for a DIFFERENT service name must not open this one.
+	other := MintLinkToken(key, "grafana", 1, time.Now().Add(time.Hour))
+	if w := doGet(h, "/expose/frigate/?access_token="+other); w.Code != http.StatusUnauthorized {
+		t.Errorf("cross-service token: got %d, want 401", w.Code)
+	}
+}
+
+func TestExposure_LinkTokenViaHeader(t *testing.T) {
+	key := []byte("hdr-key")
+	h, _ := buildExposedGateway(t, "svc", &ExposePolicy{Visibility: VisibilityLink, TokenEpoch: 3}, nil, key)
+	tok := MintLinkToken(key, "svc", 3, time.Now().Add(time.Hour))
+
+	req := httptest.NewRequest(http.MethodGet, "/expose/svc/", nil)
+	req.Header.Set("X-Citadel-Access", tok)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("header token: got %d, want 200", w.Code)
+	}
+}
+
+func TestExposure_OrgRequiresSameOwner(t *testing.T) {
+	policy := &ExposePolicy{Visibility: VisibilityOrg}
+
+	// Same-owner peer -> allowed.
+	sameOwner := &MockMeshResolver{Identity: &MeshPeerIdentity{LoginName: "a@b.co", SameOwner: true}}
+	h, _ := buildExposedGateway(t, "svc", policy, sameOwner, nil)
+	if w := doGet(h, "/expose/svc/"); w.Code != http.StatusOK {
+		t.Errorf("same-owner org: got %d, want 200", w.Code)
+	}
+
+	// Different-owner peer -> denied.
+	otherOwner := &MockMeshResolver{Identity: &MeshPeerIdentity{LoginName: "x@y.co", SameOwner: false}}
+	h2, _ := buildExposedGateway(t, "svc", policy, otherOwner, nil)
+	if w := doGet(h2, "/expose/svc/"); w.Code != http.StatusForbidden {
+		t.Errorf("different-owner org: got %d, want 403", w.Code)
+	}
+
+	// No resolver (e.g. LAN listener) -> fail closed.
+	h3, _ := buildExposedGateway(t, "svc", policy, nil, nil)
+	if w := doGet(h3, "/expose/svc/"); w.Code != http.StatusForbidden {
+		t.Errorf("org without resolver: got %d, want 403", w.Code)
+	}
+}
+
+func TestExposure_PrivateMatchesCreator(t *testing.T) {
+	// Creator match -> allowed.
+	creatorPeer := &MockMeshResolver{Identity: &MeshPeerIdentity{LoginName: "owner@team.co", SameOwner: true}}
+	h, _ := buildExposedGateway(t, "svc", &ExposePolicy{Visibility: VisibilityPrivate, Creator: "owner@team.co"}, creatorPeer, nil)
+	if w := doGet(h, "/expose/svc/"); w.Code != http.StatusOK {
+		t.Errorf("creator match: got %d, want 200", w.Code)
+	}
+
+	// Different login, same org -> denied (private is not org).
+	h2, _ := buildExposedGateway(t, "svc", &ExposePolicy{Visibility: VisibilityPrivate, Creator: "owner@team.co"}, creatorPeer, nil)
+	// re-point the same resolver at a different login by rebuilding
+	otherPeer := &MockMeshResolver{Identity: &MeshPeerIdentity{LoginName: "someone@team.co", SameOwner: true}}
+	h2, _ = buildExposedGateway(t, "svc", &ExposePolicy{Visibility: VisibilityPrivate, Creator: "owner@team.co"}, otherPeer, nil)
+	if w := doGet(h2, "/expose/svc/"); w.Code != http.StatusForbidden {
+		t.Errorf("non-creator same-org: got %d, want 403", w.Code)
+	}
+
+	// Empty creator -> inert, fail closed even for a valid peer.
+	h3, _ := buildExposedGateway(t, "svc", &ExposePolicy{Visibility: VisibilityPrivate, Creator: ""}, creatorPeer, nil)
+	if w := doGet(h3, "/expose/svc/"); w.Code != http.StatusForbidden {
+		t.Errorf("empty-creator private: got %d, want 403", w.Code)
+	}
+}
+
+func TestExposure_UnregisteredNameFailsClosed(t *testing.T) {
+	// Expose "known" but request "ghost": the middleware must 404 the unregistered
+	// name rather than fall through to the proxy/root.
+	h, _ := buildExposedGateway(t, "known", &ExposePolicy{Visibility: VisibilityOrg}, &MockMeshResolver{Identity: &MeshPeerIdentity{SameOwner: true}}, nil)
+	if w := doGet(h, "/expose/ghost/"); w.Code != http.StatusNotFound {
+		t.Errorf("unregistered exposure: got %d, want 404", w.Code)
+	}
+}
+
+func TestExposure_NonExposePathUnaffected(t *testing.T) {
+	// A non-/expose/ path must pass straight through the exposure middleware. With
+	// all capabilities disabled, /health (category "") is allowed; /terminal
+	// (category console, disabled) is 403 — proving exposure middleware does not
+	// interfere with the capability gate for builtin routes.
+	h, _ := buildExposedGateway(t, "svc", &ExposePolicy{Visibility: VisibilityOrg}, &MockMeshResolver{Identity: &MeshPeerIdentity{SameOwner: true}}, nil)
+	if w := doGet(h, "/terminal"); w.Code != http.StatusForbidden {
+		t.Errorf("/terminal with console disabled: got %d, want 403", w.Code)
+	}
+}
+
+func TestMintVerifyLinkToken(t *testing.T) {
+	key := []byte("k")
+	now := time.Unix(1_000_000, 0)
+
+	tok := MintLinkToken(key, "svc", 2, now.Add(time.Hour))
+	if !verifyLinkToken(key, "svc", 2, tok, now) {
+		t.Error("fresh token should verify")
+	}
+	// Expiry boundary.
+	if verifyLinkToken(key, "svc", 2, tok, now.Add(2*time.Hour)) {
+		t.Error("expired token must not verify")
+	}
+	// Epoch mismatch.
+	if verifyLinkToken(key, "svc", 3, tok, now) {
+		t.Error("epoch mismatch must not verify")
+	}
+	// Name mismatch.
+	if verifyLinkToken(key, "other", 2, tok, now) {
+		t.Error("name mismatch must not verify")
+	}
+	// Wrong key.
+	if verifyLinkToken([]byte("other-key"), "svc", 2, tok, now) {
+		t.Error("wrong key must not verify")
+	}
+	// Tampered token.
+	if verifyLinkToken(key, "svc", 2, tok+"x", now) {
+		t.Error("tampered token must not verify")
+	}
+	// Empty key mints nothing and verifies nothing.
+	if MintLinkToken(nil, "svc", 1, now.Add(time.Hour)) != "" {
+		t.Error("empty key should mint empty token")
+	}
+	if verifyLinkToken(nil, "svc", 2, tok, now) {
+		t.Error("empty key must not verify")
+	}
+	// Garbage token.
+	if verifyLinkToken(key, "svc", 2, "not-a-token", now) {
+		t.Error("garbage token must not verify")
+	}
+}
+
+func TestExpose_ValidatesName(t *testing.T) {
+	gw := NewServer(Config{Port: 0})
+	bad := []string{"", "Frigate", "a/b", "a..b", "a b", "-x", "x-"}
+	for _, name := range bad {
+		if err := gw.Expose(name, "127.0.0.1:5000", &ExposePolicy{Visibility: VisibilityOrg}); err == nil {
+			t.Errorf("Expose(%q) should have failed name validation", name)
+		}
+	}
+	// Invalid visibility rejected.
+	if err := gw.Expose("frigate", "127.0.0.1:5000", &ExposePolicy{Visibility: "public"}); err == nil {
+		t.Error("Expose with invalid visibility should fail")
+	}
+	// Valid name + visibility accepted.
+	if err := gw.Expose("frigate", "127.0.0.1:5000", &ExposePolicy{Visibility: VisibilityOrg}); err != nil {
+		t.Errorf("Expose(valid) unexpected error: %v", err)
+	}
+}
+
+func TestCategoryForPath_ExposeAlwaysAllowed(t *testing.T) {
+	for _, p := range []string{"/expose/frigate", "/expose/frigate/", "/expose/x/y/z"} {
+		if got := categoryForPath(p); got != "" {
+			t.Errorf("categoryForPath(%q) = %q, want \"\" (always-allowed)", p, got)
+		}
+	}
+}
+
+func TestRemoveExposure_FailsClosedAfterRevoke(t *testing.T) {
+	key := []byte("k")
+	gw := NewServer(Config{Port: 0, NodeName: "n"})
+	gw.SetPermissions(&config.Permissions{})
+	gw.SetExposeSigningKey(key)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
+	t.Cleanup(backend.Close)
+	if err := gw.Expose("svc", backend.Listener.Addr().String(), &ExposePolicy{Visibility: VisibilityLink, TokenEpoch: 1}); err != nil {
+		t.Fatal(err)
+	}
+	for prefix, up := range gw.config.Upstreams {
+		gw.registerProxy(prefix, up)
+	}
+	h := gw.BuildHandler()
+	tok := MintLinkToken(key, "svc", 1, time.Now().Add(time.Hour))
+	if w := doGet(h, "/expose/svc/?access_token="+tok); w.Code != http.StatusOK {
+		t.Fatalf("before revoke: got %d, want 200", w.Code)
+	}
+	gw.RemoveExposure("svc")
+	if w := doGet(h, "/expose/svc/?access_token="+tok); w.Code != http.StatusNotFound {
+		t.Errorf("after RemoveExposure: got %d, want 404", w.Code)
+	}
+}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -164,6 +164,22 @@ type Server struct {
 	// must have its proxy handler registered live (Start's registration loop has
 	// already run), whereas a route added before Start is picked up by that loop.
 	started bool
+
+	// exposures maps an exposed-service name (the <name> in /expose/<name>/) to
+	// its visibility policy. It is the SOLE gate for /expose/ routes
+	// (exposureMiddleware); an unregistered name fails closed (404). See
+	// exposure.go (issue #598). Set via SetExposure/Expose/RemoveExposure.
+	exposures map[string]*ExposePolicy
+
+	// exposeSigningKey is the per-node secret that signs/verifies `link` access
+	// tokens. Empty means no link token can verify (fail closed). Set via
+	// SetExposeSigningKey.
+	exposeSigningKey []byte
+
+	// meshResolver verifies a caller's mesh identity (tailnet login + same-owner)
+	// for private/org exposures. Nil makes private/org fail closed. Set via
+	// SetMeshResolver; the cmd layer wires network.WhoIsPeer.
+	meshResolver MeshIdentityResolver
 }
 
 // NewServer creates a new gateway server.
@@ -337,6 +353,16 @@ func categoryForRequest(path string, resolver CapabilityResolver) string {
 // routes (/modules/<prefix>/) are handled by categoryForRequest, which layers a
 // registry lookup on top of this.
 func categoryForPath(path string) string {
+	// Exposed-service routes (/expose/<name>/) are gated SOLELY by
+	// exposureMiddleware (identity/token visibility), never by the capability
+	// switch. Always-allow them here so a `link` recipient — who has no capability
+	// and no node passcode — is not rejected by the capability/passcode gate
+	// before the visibility middleware runs. exposureMiddleware fails closed for
+	// any unregistered /expose/<name>, so this is not an open door. See
+	// exposure.go (issue #598).
+	if strings.HasPrefix(path, ExposeRoutePrefix) {
+		return ""
+	}
 	// Terminal/console
 	if path == "/terminal" || strings.HasPrefix(path, "/terminal/") {
 		return "console"
@@ -704,6 +730,13 @@ func isWebSocketUpgrade(r *http.Request) bool {
 // middleware stack.
 func (s *Server) BuildHandler() http.Handler {
 	var handler http.Handler = s.mux
+	// exposureMiddleware wraps CLOSEST to the mux so it is the last gate before a
+	// request reaches the proxy. It gates ONLY /expose/<name>/ routes (identity/
+	// token visibility) and passes everything else through untouched. It sits
+	// inside the capability layer on purpose: categoryForPath always-allows
+	// /expose/, so the capability gate never rejects a link/org caller before this
+	// runs — this middleware is the sole authority for exposed routes.
+	handler = s.exposureMiddleware(handler)
 	if s.metering != nil {
 		handler = s.metering.WrapHandler(handler)
 	}

--- a/internal/worker/expose_set.go
+++ b/internal/worker/expose_set.go
@@ -1,0 +1,182 @@
+// internal/worker/expose_set.go
+//
+// EXPOSE_SET job handler (issue #598). Lets the `expose` MCP verb / console
+// action program THIS node's gateway to expose a local service on the fabric
+// with a page-style visibility ladder (private/org/link), and returns the
+// managed URL (plus a link token when visibility=link).
+//
+// # Privilege gating
+//
+// Exposing a node service mutates the node's gateway route table + exposure
+// policy, so — exactly like MODULE_SET, AGENT_UPDATE, and WHATSAPP_PROVISION —
+// it is honored ONLY when the job arrives on the per-node stream
+// (jobs:v1:shell:org_<id>:node:<nodeid>), never the shared org pool. It fails
+// closed.
+//
+// # Standalone by design
+//
+// The gateway wiring, link-token minting, and mesh-URL construction live in the
+// cmd layer (they need the in-process gateway ref, the node's signing key, and
+// the mesh IP), injected here as ExposeOps so this handler's routing/validation
+// is unit-testable with a fake — without a live gateway or mesh.
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// ExposeRequest is the parsed EXPOSE_SET payload: expose the local loopback
+// service at Port under the gateway name Name with the given Visibility.
+type ExposeRequest struct {
+	// Name is the exposed-service slug (the <name> in /expose/<name>/). Lowercase
+	// alphanumeric + dashes; validated by the gateway.
+	Name string `json:"name"`
+	// Port is the service's loopback host port (e.g. 5000 for Frigate).
+	Port int `json:"port"`
+	// Visibility is "private", "org", or "link".
+	Visibility string `json:"visibility"`
+	// TTLSeconds bounds a `link` token's lifetime. Ignored for private/org. A
+	// non-positive value lets the ops layer apply its default.
+	TTLSeconds int `json:"ttl_seconds"`
+	// Creator is the tailnet login authorized for a `private` exposure. Only the
+	// backend/MCP caller knows the remote creator's login; empty makes a private
+	// exposure inert (fails closed at the gateway).
+	Creator string `json:"creator"`
+	// Epoch, when >0, is bound into a `link` token so the backend can revoke all
+	// outstanding tokens for this exposure by bumping it. Defaults to 1.
+	Epoch int `json:"epoch"`
+}
+
+// ExposeResult is what the ops layer returns after programming the gateway.
+type ExposeResult struct {
+	// URL is the managed gateway URL the service is reachable at over the mesh,
+	// or "" when the node is off-mesh.
+	URL string `json:"url"`
+	// Token is the signed link access token (visibility=link only), else "".
+	Token string `json:"token,omitempty"`
+	// ExpiresAt is the link token's RFC3339 expiry (visibility=link only).
+	ExpiresAt string `json:"expires_at,omitempty"`
+}
+
+// ExposeOps is the live side-effect surface: program the gateway and return the
+// managed URL/token. The live adapter is wired in cmd; a nil Ops makes Execute
+// fail with a clear error rather than panic.
+type ExposeOps interface {
+	Expose(ctx context.Context, req ExposeRequest) (*ExposeResult, error)
+}
+
+// ExposeSetConfig configures an ExposeSetHandler.
+type ExposeSetConfig struct {
+	Ops ExposeOps
+	Log func(format string, args ...any)
+}
+
+// ExposeSetHandler processes EXPOSE_SET jobs.
+type ExposeSetHandler struct {
+	cfg ExposeSetConfig
+}
+
+// NewExposeSetHandler constructs an EXPOSE_SET handler.
+func NewExposeSetHandler(cfg ExposeSetConfig) *ExposeSetHandler {
+	if cfg.Log == nil {
+		cfg.Log = func(string, ...any) {}
+	}
+	return &ExposeSetHandler{cfg: cfg}
+}
+
+// CanHandle reports whether this handler processes the given job type.
+func (h *ExposeSetHandler) CanHandle(jobType string) bool {
+	return jobType == JobTypeExposeSet
+}
+
+// validVisibilities is the accepted visibility set (mirrors gateway.Visibility;
+// kept local to avoid a worker->gateway dependency).
+var validVisibilities = map[string]bool{"private": true, "org": true, "link": true}
+
+// Execute programs the gateway to expose one local service. See the package doc
+// for the privilege gate.
+func (h *ExposeSetHandler) Execute(ctx context.Context, job *Job, stream StreamWriter) (*JobResult, error) {
+	// Privilege gate: exposing a node service is privileged + node-targeted.
+	if !isPerNodeStream(job.SourceQueue) {
+		return h.failure(fmt.Errorf(
+			"EXPOSE_SET refused: must be dispatched to the per-node stream, got source queue %q", job.SourceQueue)), nil
+	}
+	if h.cfg.Ops == nil {
+		return h.failure(fmt.Errorf("EXPOSE_SET handler is misconfigured: no expose ops")), nil
+	}
+
+	req, err := parseExposeRequest(job.Payload)
+	if err != nil {
+		// A malformed request is terminal: retrying the same bad payload cannot help.
+		return h.failure(fmt.Errorf("EXPOSE_SET: %w", err)), nil
+	}
+
+	h.cfg.Log("EXPOSE_SET: name=%q port=%d visibility=%q", req.Name, req.Port, req.Visibility)
+
+	res, err := h.cfg.Ops.Expose(ctx, req)
+	if err != nil {
+		// Programming the gateway failed — transient (no in-process gateway yet,
+		// mesh not ready). Retry (DLQ-bounded by the runner).
+		return h.retry(fmt.Errorf("EXPOSE_SET: expose %q: %w", req.Name, err)), nil
+	}
+
+	out := map[string]any{
+		"name":       req.Name,
+		"visibility": req.Visibility,
+		"url":        res.URL,
+	}
+	if res.Token != "" {
+		out["token"] = res.Token
+	}
+	if res.ExpiresAt != "" {
+		out["expires_at"] = res.ExpiresAt
+	}
+	h.cfg.Log("EXPOSE_SET: exposed %q at %q", req.Name, res.URL)
+	return &JobResult{Status: JobStatusSuccess, Output: out}, nil
+}
+
+// parseExposeRequest reconstructs an ExposeRequest from the flattened job
+// payload (top-level fields, same convention as parseModuleAssignment) and
+// validates the required fields.
+func parseExposeRequest(payload map[string]any) (ExposeRequest, error) {
+	var req ExposeRequest
+	if payload == nil {
+		return req, fmt.Errorf("empty payload")
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return req, fmt.Errorf("marshal payload: %w", err)
+	}
+	if err := json.Unmarshal(raw, &req); err != nil {
+		return req, fmt.Errorf("decode expose request: %w", err)
+	}
+	req.Name = strings.TrimSpace(req.Name)
+	req.Visibility = strings.ToLower(strings.TrimSpace(req.Visibility))
+	if req.Name == "" {
+		return req, fmt.Errorf("expose request is missing a name")
+	}
+	if req.Port <= 0 {
+		return req, fmt.Errorf("expose request has an invalid port %d", req.Port)
+	}
+	if !validVisibilities[req.Visibility] {
+		return req, fmt.Errorf("unknown visibility %q (want private|org|link)", req.Visibility)
+	}
+	if req.Epoch <= 0 {
+		req.Epoch = 1
+	}
+	return req, nil
+}
+
+func (h *ExposeSetHandler) failure(err error) *JobResult {
+	return &JobResult{Status: JobStatusFailure, Error: err, Output: map[string]any{"error": err.Error()}}
+}
+
+func (h *ExposeSetHandler) retry(err error) *JobResult {
+	return &JobResult{Status: JobStatusRetry, Error: err, Output: map[string]any{"error": err.Error()}}
+}
+
+// Ensure ExposeSetHandler implements JobHandler.
+var _ JobHandler = (*ExposeSetHandler)(nil)

--- a/internal/worker/expose_set_test.go
+++ b/internal/worker/expose_set_test.go
@@ -1,0 +1,130 @@
+package worker
+
+import (
+	"context"
+	"testing"
+)
+
+// fakeExposeOps records the request it was given and returns a canned result (or
+// a forced error), so the handler's routing/validation is tested without a live
+// gateway.
+type fakeExposeOps struct {
+	got    ExposeRequest
+	called bool
+	result *ExposeResult
+	err    error
+}
+
+func (f *fakeExposeOps) Expose(_ context.Context, req ExposeRequest) (*ExposeResult, error) {
+	f.called = true
+	f.got = req
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.result != nil {
+		return f.result, nil
+	}
+	return &ExposeResult{URL: "https://100.64.0.9:8443/expose/" + req.Name}, nil
+}
+
+const exposePerNodeQueue = "jobs:v1:shell:org_test:node:1314"
+
+func newExposeJob(queue string, payload map[string]any) *Job {
+	return &Job{ID: "j1", Type: JobTypeExposeSet, SourceQueue: queue, Payload: payload}
+}
+
+func TestExposeSet_RejectsSharedPool(t *testing.T) {
+	ops := &fakeExposeOps{}
+	h := NewExposeSetHandler(ExposeSetConfig{Ops: ops})
+	job := newExposeJob("jobs:v1:tag:gpu:rtx3090", map[string]any{"name": "frigate", "port": 5000, "visibility": "org"})
+	res, _ := h.Execute(context.Background(), job, nil)
+	if res.Status != JobStatusFailure {
+		t.Fatalf("shared-pool EXPOSE_SET: got %s, want failure", res.Status)
+	}
+	if ops.called {
+		t.Error("ops must not be called for a shared-pool job")
+	}
+}
+
+func TestExposeSet_NilOps(t *testing.T) {
+	h := NewExposeSetHandler(ExposeSetConfig{})
+	job := newExposeJob(exposePerNodeQueue, map[string]any{"name": "frigate", "port": 5000, "visibility": "org"})
+	res, _ := h.Execute(context.Background(), job, nil)
+	if res.Status != JobStatusFailure {
+		t.Fatalf("nil ops: got %s, want failure", res.Status)
+	}
+}
+
+func TestExposeSet_ValidatesPayload(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload map[string]any
+	}{
+		{"missing name", map[string]any{"port": 5000, "visibility": "org"}},
+		{"missing port", map[string]any{"name": "frigate", "visibility": "org"}},
+		{"zero port", map[string]any{"name": "frigate", "port": 0, "visibility": "org"}},
+		{"bad visibility", map[string]any{"name": "frigate", "port": 5000, "visibility": "public"}},
+		{"empty payload", nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ops := &fakeExposeOps{}
+			h := NewExposeSetHandler(ExposeSetConfig{Ops: ops})
+			res, _ := h.Execute(context.Background(), newExposeJob(exposePerNodeQueue, c.payload), nil)
+			if res.Status != JobStatusFailure {
+				t.Errorf("%s: got %s, want failure", c.name, res.Status)
+			}
+			if ops.called {
+				t.Errorf("%s: ops must not be called on a bad payload", c.name)
+			}
+		})
+	}
+}
+
+func TestExposeSet_Success(t *testing.T) {
+	ops := &fakeExposeOps{result: &ExposeResult{URL: "https://100.64.0.9:8443/expose/frigate", Token: "tok", ExpiresAt: "2026-01-01T00:00:00Z"}}
+	h := NewExposeSetHandler(ExposeSetConfig{Ops: ops})
+	job := newExposeJob(exposePerNodeQueue, map[string]any{
+		"name": "frigate", "port": 5000, "visibility": "link", "ttl_seconds": 3600,
+	})
+	res, _ := h.Execute(context.Background(), job, nil)
+	if res.Status != JobStatusSuccess {
+		t.Fatalf("valid EXPOSE_SET: got %s (%v), want success", res.Status, res.Error)
+	}
+	if !ops.called {
+		t.Fatal("ops.Expose was not called")
+	}
+	// Epoch defaults to 1 when omitted.
+	if ops.got.Epoch != 1 {
+		t.Errorf("epoch: got %d, want default 1", ops.got.Epoch)
+	}
+	if ops.got.Name != "frigate" || ops.got.Port != 5000 || ops.got.Visibility != "link" {
+		t.Errorf("request passthrough wrong: %+v", ops.got)
+	}
+	if res.Output["url"] != "https://100.64.0.9:8443/expose/frigate" {
+		t.Errorf("url output: got %v", res.Output["url"])
+	}
+	if res.Output["token"] != "tok" {
+		t.Errorf("token output: got %v", res.Output["token"])
+	}
+}
+
+func TestExposeSet_OpsErrorRetries(t *testing.T) {
+	ops := &fakeExposeOps{err: context.DeadlineExceeded}
+	h := NewExposeSetHandler(ExposeSetConfig{Ops: ops})
+	job := newExposeJob(exposePerNodeQueue, map[string]any{"name": "frigate", "port": 5000, "visibility": "org"})
+	res, _ := h.Execute(context.Background(), job, nil)
+	if res.Status != JobStatusRetry {
+		t.Fatalf("ops error: got %s, want retry", res.Status)
+	}
+}
+
+func TestExposeSet_CanHandle(t *testing.T) {
+	h := NewExposeSetHandler(ExposeSetConfig{})
+	if !h.CanHandle(JobTypeExposeSet) {
+		t.Error("must handle EXPOSE_SET")
+	}
+	if h.CanHandle(JobTypeModuleSet) {
+		t.Error("must not handle MODULE_SET")
+	}
+}

--- a/internal/worker/job.go
+++ b/internal/worker/job.go
@@ -144,6 +144,7 @@ const (
 	JobTypeResourceSnapshot   = "RESOURCE_SNAPSHOT"    // Return the node's full GPU/host resource-consumer snapshot, managed and unmanaged (issue #427)
 	JobTypeInstanceMessage    = "INSTANCE_MESSAGE"     // Deliver a turn to a BYOC instance's loopback container (aceteam#5241)
 	JobTypeModuleSet          = "MODULE_SET"           // Set the desired state of a single module on this node (interim, aceteam#5280)
+	JobTypeExposeSet          = "EXPOSE_SET"           // Expose a local service on the gateway with private/org/link visibility (issue #598)
 	JobTypeMeetingJoin        = "MEETING_JOIN"         // Auto-join a video call, record + transcribe it node-locally (aceteam#5098)
 
 	// Fabric instance provisioning on a local hypervisor (aceteam#5963). These
@@ -207,6 +208,7 @@ var allKnownJobTypes = []string{
 	JobTypeResourceSnapshot,
 	JobTypeInstanceMessage,
 	JobTypeModuleSet,
+	JobTypeExposeSet,
 	JobTypeMeetingJoin,
 	JobTypeInstanceProvision,
 	JobTypeInstanceStart,


### PR DESCRIPTION
Closes #598. Node-side of the fabric service-ingress primitive. (Also subsumes the #581 unauthenticated-mesh-chat auth follow-up — the same identity-aware edge-auth layer.)

## Context
We need a productized way to expose a node's local service (Frigate's UI, dashboards, engines) on the fabric through the **existing** Citadel gateway — replacing the manual `tailscale serve` prototype — with a page-style **private / org / link** visibility ladder. Generic `expose(service, visibility)`; the NVR UI (#597) is the first consumer, nothing here is camera-specific.

## Design (the layering that makes link/org work)
The capability layer (`permissionMiddleware`) **fails closed** — a disabled capability → 403, a sensitive surface → passcode 401 — *before* later middleware. A `link` recipient has neither a capability nor the node passcode. So:
- `categoryForPath` **always-allows** `/expose/...` at the capability layer, and
- a new `exposureMiddleware` is the **sole** gate for `/expose/`, failing closed for any unregistered `/expose/<name>` (404).

Enforcement: `private` → caller's tailnet login == recorded creator; `org` → `WhoIs(RemoteAddr).SameOwner`; `link` → signed/expiring/revocable HMAC token. `link` also plants a path-scoped session **cookie** so a real browser SPA loads (not just curl), and exposed routes enable **WebSocket** (Frigate live view).

## Changes
- `internal/gateway/exposure.go` (+test): visibility ladder, per-Server exposure registry, `exposureMiddleware`, standalone `MeshIdentityResolver` (mirrors #585), HMAC link token mint/verify with epoch-based revoke-all, cookie sessions, WebSocket wiring.
- `internal/gateway/gateway.go`: `/expose/` always-allowed; `exposureMiddleware` wrapped closest to the mux; Server exposure fields.
- `internal/config/expose_key.go`: dedicated per-node 0600 HMAC signing key.
- `cmd/gateway_mesh_auth.go`: wire `network.WhoIsPeer` into the resolver.
- `cmd/serve.go`, `cmd/work.go`: wire resolver + key into both gateway sites.
- `internal/worker/expose_set.go` (+test): `EXPOSE_SET` handler (node half of the `expose` MCP verb) — per-node-stream gated.
- `cmd/expose_ops.go`: live ops — programs the gateway, mints the token, builds the managed mesh URL.
- `docs/gateway-ingress.md`: design, token model, v1 scope, follow-ups.

## Testing
`go build/vet/test ./...` green. Exposure is verified through the **full `BuildHandler` chain** under maximally-restrictive perms (`config.Permissions{}`): a valid link token still reaches the upstream; cookie-only sub-resource fetch authorizes; tampered/expired/wrong-epoch/cross-service tokens 401; unregistered exposure 404.

## Scope (documented, not silently implied)
`private` is inert until aceteam passes a `Creator`; `org` == same tailnet owner (the #585 posture). Remaining path to "watch Frigate through it": the `expose` **MCP verb + console** (aceteam repo), Frigate **base path = `/expose/<name>/`** in the #597 module (absolute-path assets constraint), and a live 2-node/browser verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)