### PR TITLE
feat(nvr): package wyze-bridge + Frigate camera NVR as a catalog module (#597)

### DIFF
--- a/.github/workflows/build-nvr-service.yml
+++ b/.github/workflows/build-nvr-service.yml
@@ -1,0 +1,67 @@
+name: Build nvr-service image
+
+# Builds and publishes the nvr module's init-container to GHCR as
+# ghcr.io/aceteam-ai/nvr-config. The module compose
+# (services/nvr-service/compose.yml, and the catalog copy in
+# aceteam-ai/citadel-services) runs this image BEFORE Frigate to generate
+# /config/config.yml and verify a nas /media mount (aceteam-ai/citadel-cli#597), so
+# the image MUST exist in the registry -- the same failure mode that bit
+# whisper-service (image never published) is what this workflow prevents.
+#
+# The binary (cmd/nvrconfig) depends on the module go.mod + internal/nvr, so the
+# build context is the REPO ROOT (context: .), unlike meeting-service whose context
+# is its own dir. Triggers on changes to the nvr Go source, its Dockerfile, or this
+# workflow. Tags: `latest` on main plus the commit SHA for pinning/rollback.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "cmd/nvrconfig/**"
+      - "internal/nvr/**"
+      - "services/nvr-service/Dockerfile"
+      - ".github/workflows/build-nvr-service.yml"
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE: ghcr.io/aceteam-ai/nvr-config
+
+jobs:
+  build:
+    name: Build + push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          # Repo root: the nvrconfig binary needs go.mod + internal/nvr.
+          context: .
+          file: services/nvr-service/Dockerfile
+          # frigate:stable + the openvino runtime are amd64; service.yaml declares
+          # arch: [amd64] to match.
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/cmd/nvrconfig/main.go
+++ b/cmd/nvrconfig/main.go
@@ -1,0 +1,101 @@
+// Command nvrconfig is the init-container entrypoint for the nvr catalog module
+// (aceteam-ai/citadel-cli#597). It runs to completion BEFORE Frigate starts
+// (compose `depends_on: condition: service_completed_successfully`) and does the
+// two runtime jobs a stock Frigate image cannot:
+//
+//  1. Generate /config/config.yml from the assignment env vars + the camera list,
+//     using the SAME tested generator the rest of citadel uses
+//     (internal/nvr.GenerateFrigateConfig) — one implementation, compiled in, no
+//     drift with a parallel script.
+//  2. For storage.mode=nas, VERIFY /media is genuinely a network filesystem
+//     (statfs magic) and root-writable BEFORE Frigate writes a single recording —
+//     the shipped guard against the #1 storage scar (a failed NFS mount silently
+//     writing to the local disk). Inside this container /media is a bind mount, so
+//     this MUST check the filesystem type, not mountedness.
+//
+// It exits non-zero (failing the whole stack, loudly and actionably) on any bad
+// input — including zero cameras, which Frigate 0.17 otherwise turns into an
+// opaque crash-loop.
+//
+// Env inputs (from the module .env / assignment): NVR_DETECTOR (openvino|cpu),
+// NVR_RETENTION_DAYS, NVR_STORAGE_MODE (local|nas|volume), NVR_CAMERAS
+// (comma-separated `name` / `name=stream`). Wyze credentials are NOT read here —
+// only docker-wyze-bridge sees them.
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nvr"
+)
+
+const (
+	configPath = "/config/config.yml"
+	mediaPath  = "/media"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "nvrconfig: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	detector := nvr.Detector(strings.ToLower(strings.TrimSpace(getenvDefault("NVR_DETECTOR", "openvino"))))
+
+	retention := 12
+	if raw := strings.TrimSpace(os.Getenv("NVR_RETENTION_DAYS")); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			return fmt.Errorf("NVR_RETENTION_DAYS %q is not an integer", raw)
+		}
+		retention = n
+	}
+
+	mode := nvr.StorageMode(strings.ToLower(strings.TrimSpace(getenvDefault("NVR_STORAGE_MODE", "local"))))
+
+	cameras := nvr.ParseCameras(os.Getenv("NVR_CAMERAS"))
+	if len(cameras) == 0 {
+		return fmt.Errorf("no cameras: set NVR_CAMERAS to a comma-separated list of camera stream names " +
+			"(e.g. \"front-door,garage=garage-cam\"). Frigate 0.17 refuses to start with an empty cameras: block")
+	}
+
+	// nas: refuse to start unless /media is a real network mount (root-writable).
+	// This is the shipped guard against silently recording to the local disk.
+	if mode == nvr.StorageNAS {
+		if err := nvr.VerifyMediaIsNetworkFS(mediaPath, os.Getuid(), nvr.DefaultNetFSProbe()); err != nil {
+			return err
+		}
+	}
+
+	cfg := nvr.Config{
+		RetentionDays: retention,
+		Detector:      detector,
+		Storage:       nvr.StorageSpec{Mode: mode, Target: os.Getenv("NVR_STORAGE_TARGET")},
+	}
+	yamlOut, err := nvr.GenerateFrigateConfig(cfg, cameras)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll("/config", 0o755); err != nil {
+		return fmt.Errorf("create /config: %w", err)
+	}
+	if err := os.WriteFile(configPath, []byte(yamlOut), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", configPath, err)
+	}
+	fmt.Printf("nvrconfig: wrote %s (detector=%s retention=%dd storage=%s cameras=%v)\n",
+		configPath, detector, retention, mode, nvr.CameraNames(cameras))
+	return nil
+}
+
+func getenvDefault(key, def string) string {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		return v
+	}
+	return def
+}

--- a/internal/nvr/config.go
+++ b/internal/nvr/config.go
@@ -1,0 +1,270 @@
+// Package nvr holds the reconcile logic for the `nvr` catalog module
+// (aceteam-ai/citadel-cli#597): a self-hosted camera NVR built from
+// docker-wyze-bridge (Wyze TUTK P2P -> RTSP) + Frigate (recording + local
+// object detection).
+//
+// This package is the AUTHORITATIVE, unit-tested implementation of the two
+// node-side reconcile concerns that a container image cannot own:
+//
+//  1. Generating Frigate's config.yml from the assignment config (detector,
+//     retention, discovered cameras). Frigate reads /config/config.yml; the
+//     module ships no static config because the detector block, retention, and
+//     camera list are all assignment/runtime inputs. GenerateFrigateConfig bakes
+//     in every scar observed on the live SJC build (node 1314) — see below.
+//  2. Resolving + verifying the media storage target (local | nas | volume). The
+//     NAS mount + fstab persistence + writability check are HOST/root operations
+//     a container can't perform, and getting them wrong silently writes
+//     recordings to the local disk (the #597 scar).
+//
+// Wiring note (documented follow-up, mirrors meeting #514's "handler wired in a
+// later PR" and preempt #577's "currently INERT"): the fabric MODULE_SET
+// reconcile that calls these helpers to materialize config.yml + mount the media
+// target on the node is the remaining integration. It is kept out of this PR so
+// the pure logic can land tested; the container-independent behavior is fully
+// covered here. Secrets (wyze creds) are deliberately NOT an input to this
+// package — Frigate never sees them; docker-wyze-bridge authenticates to Wyze
+// via its own env and is the only container that handles credentials.
+package nvr
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Detector selects Frigate's object-detection backend.
+type Detector string
+
+const (
+	// DetectorOpenVINO uses the Intel iGPU via OpenVINO (device: GPU). The default
+	// for the target mini node (Intel iGPU present).
+	DetectorOpenVINO Detector = "openvino"
+	// DetectorCPU is the fallback for hardware without OpenVINO support (e.g. an
+	// AMD Vega iGPU, which has no OpenVINO runtime).
+	DetectorCPU Detector = "cpu"
+)
+
+// StorageMode selects where recordings (Frigate's /media) live.
+type StorageMode string
+
+const (
+	// StorageLocal points /media at a plain node path.
+	StorageLocal StorageMode = "local"
+	// StorageNAS mounts an NFS/SMB export and points /media at the mountpoint.
+	StorageNAS StorageMode = "nas"
+	// StorageVolume points /media at a citadel-provisioned volume.
+	StorageVolume StorageMode = "volume"
+)
+
+// Bundled OpenVINO model shipped inside the Frigate image. Frigate 0.17 crashes
+// at startup ("TypeError: stat() ... NoneType") when an openvino detector is used
+// without an explicit model: block, so we always emit these paths for openvino.
+const (
+	OpenVINOModelPath    = "/openvino-model/ssdlite_mobilenet_v2.xml"
+	OpenVINOLabelmapPath = "/openvino-model/coco_91cl_bkgr.txt"
+)
+
+// wyzeBridgeRTSPHost is the address Frigate uses to pull camera RTSP streams from
+// docker-wyze-bridge. Because wyze-bridge runs with host networking (mandatory —
+// TUTK P2P needs LAN broadcast + UDP hole-punching), its RTSP server binds the
+// HOST. Frigate runs on the default bridge network, so it reaches the host via
+// the docker host-gateway alias (compose `extra_hosts`). The port is
+// wyze-bridge's default RTSP port (8554).
+const (
+	WyzeBridgeRTSPHostname = "host.docker.internal"
+	WyzeBridgeRTSPPort     = 8554
+)
+
+// StorageSpec is the resolved media-storage configuration for one assignment.
+type StorageSpec struct {
+	Mode StorageMode
+	// Target is a node path (local), a `host:/export` (nas), or a volume id
+	// (volume). Interpreted per Mode.
+	Target string
+}
+
+// Camera is one camera discovered from docker-wyze-bridge at runtime. The camera
+// list is NOT part of the assignment config — wyze-bridge enumerates the Wyze
+// account and exposes one RTSP stream per camera. The reconcile passes the
+// discovered set here.
+type Camera struct {
+	// Name is the Frigate camera name (a slug; wyze-bridge uses the camera's
+	// nickname lowercased with dashes).
+	Name string
+	// StreamPath is the RTSP path wyze-bridge serves for this camera (e.g.
+	// "front-door"). Defaults to Name when empty.
+	StreamPath string
+}
+
+// Config is the assignment input this package turns into a Frigate config.yml.
+// It deliberately excludes wyze credentials (see package doc).
+type Config struct {
+	// RetentionDays bounds continuous recording. Sized by DAYS, never by free
+	// space: a Synology NFS quota is invisible to `df` on the client, so a
+	// free-space heuristic would never fire (the #597 scar).
+	RetentionDays int
+	Detector      Detector
+	Storage       StorageSpec
+}
+
+// ---- Frigate config.yml shape (only the fields we set) ----
+
+type frigateConfig struct {
+	MQTT      map[string]any          `yaml:"mqtt"`
+	Detectors map[string]detectorSpec `yaml:"detectors"`
+	Model     *modelSpec              `yaml:"model,omitempty"`
+	FFmpeg    ffmpegSpec              `yaml:"ffmpeg"`
+	Record    recordSpec              `yaml:"record"`
+	Cameras   map[string]cameraSpec   `yaml:"cameras"`
+}
+
+type detectorSpec struct {
+	Type       string `yaml:"type"`
+	Device     string `yaml:"device,omitempty"`
+	NumThreads int    `yaml:"num_threads,omitempty"`
+}
+
+type modelSpec struct {
+	Path             string `yaml:"path"`
+	LabelmapPath     string `yaml:"labelmap_path"`
+	Width            int    `yaml:"width"`
+	Height           int    `yaml:"height"`
+	InputTensor      string `yaml:"input_tensor"`
+	InputPixelFormat string `yaml:"input_pixel_format"`
+}
+
+type ffmpegSpec struct {
+	// HwaccelArgs uses Frigate's preset alias, not raw ffmpeg flags. preset-vaapi
+	// drives hardware decode via /dev/dri/renderD128.
+	HwaccelArgs string `yaml:"hwaccel_args"`
+}
+
+type recordSpec struct {
+	Enabled    bool           `yaml:"enabled"`
+	Continuous continuousSpec `yaml:"continuous"`
+}
+
+// continuousSpec writes the MIGRATED retention key. Frigate 0.17 moved
+// record.retain.days -> record.continuous.days; writing the old key is silently
+// ignored (recordings then use the default retention, not the assigned days).
+type continuousSpec struct {
+	Days int `yaml:"days"`
+}
+
+type cameraSpec struct {
+	FFmpeg cameraFFmpeg `yaml:"ffmpeg"`
+	Detect detectToggle `yaml:"detect"`
+	// record inherits the top-level record block; no per-camera override needed.
+}
+
+type cameraFFmpeg struct {
+	Inputs []cameraInput `yaml:"inputs"`
+}
+
+type cameraInput struct {
+	Path  string   `yaml:"path"`
+	Roles []string `yaml:"roles"`
+}
+
+type detectToggle struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+// GenerateFrigateConfig renders a Frigate 0.17 config.yml from the assignment
+// config and the runtime-discovered camera list. It bakes in every scar from the
+// live SJC build:
+//
+//   - openvino -> explicit model: block (bundled xml + coco labelmap) so Frigate
+//     0.17 does not crash on a missing model path; cpu -> a `type: cpu` detector
+//     (Frigate bundles the cpu model, so no model: block is required).
+//   - ffmpeg.hwaccel_args: preset-vaapi (hardware decode).
+//   - continuous recording with the MIGRATED record.continuous.days key.
+//   - cameras pull RTSP from host.docker.internal:8554 (host-net wyze-bridge).
+//
+// It does NOT transcode: each camera records the raw H.264 wyze-bridge already
+// emits (~1 Mbit/s). Retention is bounded by days only.
+func GenerateFrigateConfig(cfg Config, cameras []Camera) (string, error) {
+	if cfg.RetentionDays <= 0 {
+		return "", fmt.Errorf("nvr: retention_days must be positive, got %d", cfg.RetentionDays)
+	}
+
+	fc := frigateConfig{
+		// The reference build has no MQTT broker; Frigate makes MQTT optional only
+		// when explicitly disabled.
+		MQTT: map[string]any{"enabled": false},
+		FFmpeg: ffmpegSpec{
+			HwaccelArgs: "preset-vaapi",
+		},
+		Record: recordSpec{
+			Enabled:    true,
+			Continuous: continuousSpec{Days: cfg.RetentionDays},
+		},
+		Cameras: map[string]cameraSpec{},
+	}
+
+	switch cfg.Detector {
+	case DetectorOpenVINO:
+		fc.Detectors = map[string]detectorSpec{
+			"ov": {Type: "openvino", Device: "GPU"},
+		}
+		fc.Model = &modelSpec{
+			Path:             OpenVINOModelPath,
+			LabelmapPath:     OpenVINOLabelmapPath,
+			Width:            300,
+			Height:           300,
+			InputTensor:      "nhwc",
+			InputPixelFormat: "bgr",
+		}
+	case DetectorCPU:
+		fc.Detectors = map[string]detectorSpec{
+			"cpu1": {Type: "cpu", NumThreads: 3},
+		}
+		// No model: block — Frigate bundles the cpu tflite model.
+	default:
+		return "", fmt.Errorf("nvr: unknown detector %q (want %q or %q)", cfg.Detector, DetectorOpenVINO, DetectorCPU)
+	}
+
+	for _, cam := range cameras {
+		name := strings.TrimSpace(cam.Name)
+		if name == "" {
+			continue
+		}
+		streamPath := cam.StreamPath
+		if strings.TrimSpace(streamPath) == "" {
+			streamPath = name
+		}
+		fc.Cameras[name] = cameraSpec{
+			FFmpeg: cameraFFmpeg{
+				Inputs: []cameraInput{
+					{
+						Path:  fmt.Sprintf("rtsp://%s:%d/%s", WyzeBridgeRTSPHostname, WyzeBridgeRTSPPort, streamPath),
+						Roles: []string{"record", "detect"},
+					},
+				},
+			},
+			Detect: detectToggle{Enabled: true},
+		}
+	}
+
+	out, err := yaml.Marshal(fc)
+	if err != nil {
+		return "", fmt.Errorf("nvr: marshal frigate config: %w", err)
+	}
+	header := "# Generated by citadel nvr module (aceteam-ai/citadel-cli#597). DO NOT EDIT.\n" +
+		"# Regenerated from the module assignment config on every reconcile.\n"
+	return header + string(out), nil
+}
+
+// CameraNames returns the sorted camera names, for stable logging/tests.
+func CameraNames(cameras []Camera) []string {
+	names := make([]string, 0, len(cameras))
+	for _, c := range cameras {
+		if n := strings.TrimSpace(c.Name); n != "" {
+			names = append(names, n)
+		}
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/nvr/config.go
+++ b/internal/nvr/config.go
@@ -257,6 +257,33 @@ func GenerateFrigateConfig(cfg Config, cameras []Camera) (string, error) {
 	return header + string(out), nil
 }
 
+// ParseCameras parses the NVR_CAMERAS env value into a camera list. The format is
+// a comma-separated list of `name` or `name=stream-path` entries (stream-path
+// defaults to name), e.g. "front-door,garage=garage-cam". This is the explicit,
+// deterministic camera source the init container ships with; auto-discovery from
+// docker-wyze-bridge's API is a runtime enhancement validated at the node-1314
+// human acceptance step, not the shipped default.
+func ParseCameras(raw string) []Camera {
+	var out []Camera
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		name, stream, found := strings.Cut(part, "=")
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		cam := Camera{Name: name}
+		if found {
+			cam.StreamPath = strings.TrimSpace(stream)
+		}
+		out = append(out, cam)
+	}
+	return out
+}
+
 // CameraNames returns the sorted camera names, for stable logging/tests.
 func CameraNames(cameras []Camera) []string {
 	names := make([]string, 0, len(cameras))

--- a/internal/nvr/config_test.go
+++ b/internal/nvr/config_test.go
@@ -226,8 +226,8 @@ func TestVerifyMediaMountPropagatesProbeError(t *testing.T) {
 }
 
 // TestResolveMediaSource covers the three storage modes and the /config-stays-local
-// invariant (ResolveMediaSource only ever returns a MEDIA path; /config is a
-// separate constant that never follows the target).
+// invariant (ResolveMediaSource only ever returns a MEDIA path; ConfigDir is a
+// separate local path that never follows the target).
 func TestResolveMediaSource(t *testing.T) {
 	// local: path is the target, no mount needed.
 	p, needsMount, err := ResolveMediaSource(StorageSpec{Mode: StorageLocal, Target: "/srv/nvr"})
@@ -235,10 +235,14 @@ func TestResolveMediaSource(t *testing.T) {
 		t.Errorf("local: got (%q, %v, %v), want (/srv/nvr, false, nil)", p, needsMount, err)
 	}
 
-	// nas: media path is the citadel mountpoint and needsMount is true.
+	// nas: media path is the citadel MediaDir() and needsMount is true.
+	mediaDir, err := MediaDir()
+	if err != nil {
+		t.Fatalf("MediaDir: %v", err)
+	}
 	p, needsMount, err = ResolveMediaSource(StorageSpec{Mode: StorageNAS, Target: "nas.local:/volume2/surveillance"})
-	if err != nil || !needsMount || p != DefaultNASMountpoint {
-		t.Errorf("nas: got (%q, %v, %v), want (%s, true, nil)", p, needsMount, err, DefaultNASMountpoint)
+	if err != nil || !needsMount || p != mediaDir {
+		t.Errorf("nas: got (%q, %v, %v), want (%s, true, nil)", p, needsMount, err, mediaDir)
 	}
 
 	// nas without host:/export is rejected.
@@ -253,26 +257,85 @@ func TestResolveMediaSource(t *testing.T) {
 	}
 
 	// /config must NEVER equal the media source — SQLite stays local.
-	if LocalConfigDir == "" || strings.Contains(LocalConfigDir, DefaultNASMountpoint) {
-		t.Errorf("LocalConfigDir %q must be a local path independent of the NAS media mount", LocalConfigDir)
+	configDir, err := ConfigDir()
+	if err != nil {
+		t.Fatalf("ConfigDir: %v", err)
+	}
+	if configDir == "" || configDir == mediaDir {
+		t.Errorf("ConfigDir %q must be a local path independent of the media dir %q", configDir, mediaDir)
 	}
 }
 
 // TestFstabEntry pins the persisted NFSv3 mount line (Synology target has no v4).
 func TestFstabEntry(t *testing.T) {
-	line, err := FstabEntry("nas.local:/volume2/surveillance", DefaultNASMountpoint)
+	line, err := FstabEntry("nas.local:/volume2/surveillance", "/mnt/nvr-media")
 	if err != nil {
 		t.Fatalf("FstabEntry: %v", err)
 	}
-	for _, want := range []string{"nas.local:/volume2/surveillance", DefaultNASMountpoint, "nfs", "vers=3", "_netdev"} {
+	for _, want := range []string{"nas.local:/volume2/surveillance", "/mnt/nvr-media", "nfs", "vers=3", "_netdev"} {
 		if !strings.Contains(line, want) {
 			t.Errorf("fstab line %q missing %q", line, want)
 		}
 	}
-	if _, err := FstabEntry("/no-export", DefaultNASMountpoint); err == nil {
+	if _, err := FstabEntry("/no-export", "/mnt/nvr-media"); err == nil {
 		t.Errorf("expected error for export without host:")
 	}
 	if _, err := FstabEntry("nas:/x", "relative/mount"); err == nil {
 		t.Errorf("expected error for relative mountpoint")
+	}
+}
+
+// TestVerifyMediaIsNetworkFS is the SHIPPED in-container guard: inside frigate
+// /media is always a bind mount, so mountedness is a false pass — the check must
+// use the filesystem TYPE. A local fs (ext4) in nas mode must FAIL (the silent
+// local-disk leak); a real NFS/SMB mount that is root-writable passes.
+func TestVerifyMediaIsNetworkFS(t *testing.T) {
+	const magicEXT4 int64 = 0xEF53
+	cases := []struct {
+		name      string
+		fsType    int64
+		writable  bool
+		wantErr   bool
+		errSubstr string
+	}{
+		{"nfs+writable", MagicNFS, true, false, ""},
+		{"cifs+writable", MagicCIFS, true, false, ""},
+		{"local ext4 (the leak)", magicEXT4, true, true, "NOT a network filesystem"},
+		{"nfs but squashed", MagicNFS, false, true, "no_root_squash"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			probe := NetFSProbe{
+				FSType:   func(string) (int64, error) { return tc.fsType, nil },
+				Writable: func(string, int) (bool, error) { return tc.writable, nil },
+			}
+			err := VerifyMediaIsNetworkFS("/media", 0, probe)
+			if tc.wantErr && (err == nil || !strings.Contains(err.Error(), tc.errSubstr)) {
+				t.Fatalf("want error containing %q, got %v", tc.errSubstr, err)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("want no error, got %v", err)
+			}
+		})
+	}
+	if !IsNetworkFSMagic(MagicNFS) || IsNetworkFSMagic(magicEXT4) {
+		t.Errorf("IsNetworkFSMagic misclassified NFS/ext4")
+	}
+}
+
+// TestParseCameras covers the explicit NVR_CAMERAS format (name and name=stream).
+func TestParseCameras(t *testing.T) {
+	cams := ParseCameras("front-door, garage=garage-cam ,, back-yard")
+	if len(cams) != 3 {
+		t.Fatalf("want 3 cameras, got %d: %+v", len(cams), cams)
+	}
+	if cams[0].Name != "front-door" || cams[0].StreamPath != "" {
+		t.Errorf("cam0 = %+v", cams[0])
+	}
+	if cams[1].Name != "garage" || cams[1].StreamPath != "garage-cam" {
+		t.Errorf("cam1 = %+v (want garage=garage-cam)", cams[1])
+	}
+	if got := ParseCameras("   "); got != nil {
+		t.Errorf("blank NVR_CAMERAS should yield no cameras, got %+v", got)
 	}
 }

--- a/internal/nvr/config_test.go
+++ b/internal/nvr/config_test.go
@@ -1,0 +1,278 @@
+package nvr
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// parseGenerated renders a config and parses it back into a generic map so tests
+// can assert on the actual emitted structure (not just substrings).
+func parseGenerated(t *testing.T, cfg Config, cams []Camera) map[string]any {
+	t.Helper()
+	out, err := GenerateFrigateConfig(cfg, cams)
+	if err != nil {
+		t.Fatalf("GenerateFrigateConfig: %v", err)
+	}
+	var m map[string]any
+	if err := yaml.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatalf("generated config does not parse as YAML: %v\n%s", err, out)
+	}
+	return m
+}
+
+// TestDetectorOpenVINOEmitsExplicitModel pins the #1 Frigate 0.17 scar: an
+// openvino detector MUST come with an explicit model: block (bundled xml +
+// labelmap) or Frigate crashes at startup. It also asserts device: GPU (Intel
+// iGPU).
+func TestDetectorOpenVINOEmitsExplicitModel(t *testing.T) {
+	m := parseGenerated(t, Config{
+		RetentionDays: 12,
+		Detector:      DetectorOpenVINO,
+		Storage:       StorageSpec{Mode: StorageLocal, Target: "/srv/nvr"},
+	}, nil)
+
+	dets, ok := m["detectors"].(map[string]any)
+	if !ok {
+		t.Fatalf("detectors block missing/wrong type: %T", m["detectors"])
+	}
+	ov, ok := dets["ov"].(map[string]any)
+	if !ok {
+		t.Fatalf("openvino detector 'ov' missing: %v", dets)
+	}
+	if ov["type"] != "openvino" {
+		t.Errorf("detector type = %v, want openvino", ov["type"])
+	}
+	if ov["device"] != "GPU" {
+		t.Errorf("detector device = %v, want GPU (Intel iGPU)", ov["device"])
+	}
+
+	model, ok := m["model"].(map[string]any)
+	if !ok {
+		t.Fatalf("openvino requires an explicit model: block or Frigate 0.17 crashes; got %v", m["model"])
+	}
+	if model["path"] != OpenVINOModelPath {
+		t.Errorf("model.path = %v, want %s", model["path"], OpenVINOModelPath)
+	}
+	if model["labelmap_path"] != OpenVINOLabelmapPath {
+		t.Errorf("model.labelmap_path = %v, want %s", model["labelmap_path"], OpenVINOLabelmapPath)
+	}
+}
+
+// TestDetectorCPUEmitsCPUBlockNoModel pins the AMD/Vega fallback: a cpu detector
+// and NO model: block (Frigate bundles the cpu model).
+func TestDetectorCPUEmitsCPUBlockNoModel(t *testing.T) {
+	m := parseGenerated(t, Config{
+		RetentionDays: 7,
+		Detector:      DetectorCPU,
+		Storage:       StorageSpec{Mode: StorageLocal, Target: "/srv/nvr"},
+	}, nil)
+
+	dets, ok := m["detectors"].(map[string]any)
+	if !ok {
+		t.Fatalf("detectors block missing: %T", m["detectors"])
+	}
+	cpu, ok := dets["cpu1"].(map[string]any)
+	if !ok {
+		t.Fatalf("cpu detector 'cpu1' missing: %v", dets)
+	}
+	if cpu["type"] != "cpu" {
+		t.Errorf("detector type = %v, want cpu", cpu["type"])
+	}
+	if _, hasOV := dets["ov"]; hasOV {
+		t.Errorf("cpu config must not emit an openvino detector: %v", dets)
+	}
+	if _, hasModel := m["model"]; hasModel {
+		t.Errorf("cpu detector must NOT emit a model: block (Frigate bundles the cpu model); got %v", m["model"])
+	}
+}
+
+// TestRetentionUsesMigratedContinuousKey pins the Frigate 0.17 migration:
+// record.retain.days -> record.continuous.days. Writing the OLD key is silently
+// ignored, so recordings would use default retention instead of the assigned days.
+func TestRetentionUsesMigratedContinuousKey(t *testing.T) {
+	m := parseGenerated(t, Config{
+		RetentionDays: 12,
+		Detector:      DetectorOpenVINO,
+		Storage:       StorageSpec{Mode: StorageLocal, Target: "/srv/nvr"},
+	}, nil)
+
+	record, ok := m["record"].(map[string]any)
+	if !ok {
+		t.Fatalf("record block missing: %T", m["record"])
+	}
+	if _, hasRetain := record["retain"]; hasRetain {
+		t.Errorf("record.retain is the PRE-0.17 key and is silently ignored; must use record.continuous.days")
+	}
+	cont, ok := record["continuous"].(map[string]any)
+	if !ok {
+		t.Fatalf("record.continuous block missing (migrated key): %v", record)
+	}
+	if days, _ := cont["days"].(int); days != 12 {
+		t.Errorf("record.continuous.days = %v, want 12", cont["days"])
+	}
+	if record["enabled"] != true {
+		t.Errorf("record.enabled = %v, want true (continuous recording)", record["enabled"])
+	}
+}
+
+// TestFFmpegPresetVAAPI pins hardware decode via the preset alias.
+func TestFFmpegPresetVAAPI(t *testing.T) {
+	m := parseGenerated(t, Config{
+		RetentionDays: 12,
+		Detector:      DetectorCPU,
+		Storage:       StorageSpec{Mode: StorageLocal, Target: "/srv/nvr"},
+	}, nil)
+	ff, ok := m["ffmpeg"].(map[string]any)
+	if !ok {
+		t.Fatalf("ffmpeg block missing: %T", m["ffmpeg"])
+	}
+	if ff["hwaccel_args"] != "preset-vaapi" {
+		t.Errorf("ffmpeg.hwaccel_args = %v, want preset-vaapi", ff["hwaccel_args"])
+	}
+}
+
+// TestCamerasPullFromHostNetWyzeBridge pins that camera RTSP inputs target the
+// host-networked wyze-bridge via the docker host-gateway alias on 8554, and that
+// the config records raw H.264 (no transcode: role includes record+detect, no
+// re-encode args).
+func TestCamerasPullFromHostNetWyzeBridge(t *testing.T) {
+	out, err := GenerateFrigateConfig(Config{
+		RetentionDays: 12,
+		Detector:      DetectorOpenVINO,
+		Storage:       StorageSpec{Mode: StorageLocal, Target: "/srv/nvr"},
+	}, []Camera{{Name: "front-door"}, {Name: "garage", StreamPath: "garage-cam"}})
+	if err != nil {
+		t.Fatalf("GenerateFrigateConfig: %v", err)
+	}
+	wantFront := "rtsp://host.docker.internal:8554/front-door"
+	if !strings.Contains(out, wantFront) {
+		t.Errorf("expected camera input %q in:\n%s", wantFront, out)
+	}
+	wantGarage := "rtsp://host.docker.internal:8554/garage-cam"
+	if !strings.Contains(out, wantGarage) {
+		t.Errorf("expected camera stream-path override input %q in:\n%s", wantGarage, out)
+	}
+
+	var m map[string]any
+	if err := yaml.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	cams, ok := m["cameras"].(map[string]any)
+	if !ok || len(cams) != 2 {
+		t.Fatalf("expected 2 cameras, got %v", m["cameras"])
+	}
+}
+
+// TestGenerateRejectsBadInput guards the two hard errors.
+func TestGenerateRejectsBadInput(t *testing.T) {
+	if _, err := GenerateFrigateConfig(Config{RetentionDays: 0, Detector: DetectorCPU}, nil); err == nil {
+		t.Errorf("expected error for retention_days <= 0")
+	}
+	if _, err := GenerateFrigateConfig(Config{RetentionDays: 5, Detector: "gpu-nonsense"}, nil); err == nil {
+		t.Errorf("expected error for unknown detector")
+	}
+}
+
+// TestVerifyMediaMountSeparatesMountednessFromWritability is the core NAS scar
+// test: a path that is WRITABLE but NOT mounted must FAIL (that is the silent
+// local-disk leak). Only mounted AND writable passes.
+func TestVerifyMediaMountSeparatesMountednessFromWritability(t *testing.T) {
+	cases := []struct {
+		name      string
+		mounted   bool
+		writable  bool
+		wantErr   bool
+		errSubstr string
+	}{
+		{"mounted+writable", true, true, false, ""},
+		{"writable-but-not-mounted (the leak)", false, true, true, "NOT a mountpoint"},
+		{"mounted-but-not-writable (squashed export)", true, false, true, "no_root_squash"},
+		{"neither", false, false, true, "NOT a mountpoint"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			probe := MountProbe{
+				IsMountpoint:  func(string) (bool, error) { return tc.mounted, nil },
+				WritableAsUID: func(string, int) (bool, error) { return tc.writable, nil },
+			}
+			err := VerifyMediaMount("/mnt/citadel-nvr-media", 0, probe)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if tc.wantErr && !strings.Contains(err.Error(), tc.errSubstr) {
+				t.Errorf("error %q does not mention %q", err.Error(), tc.errSubstr)
+			}
+		})
+	}
+}
+
+// TestVerifyMediaMountPropagatesProbeError ensures a probe failure is not
+// mistaken for "mounted".
+func TestVerifyMediaMountPropagatesProbeError(t *testing.T) {
+	sentinel := errors.New("stat boom")
+	probe := MountProbe{
+		IsMountpoint:  func(string) (bool, error) { return false, sentinel },
+		WritableAsUID: func(string, int) (bool, error) { return true, nil },
+	}
+	if err := VerifyMediaMount("/mnt/x", 0, probe); err == nil || !strings.Contains(err.Error(), "stat boom") {
+		t.Errorf("expected wrapped probe error, got %v", err)
+	}
+}
+
+// TestResolveMediaSource covers the three storage modes and the /config-stays-local
+// invariant (ResolveMediaSource only ever returns a MEDIA path; /config is a
+// separate constant that never follows the target).
+func TestResolveMediaSource(t *testing.T) {
+	// local: path is the target, no mount needed.
+	p, needsMount, err := ResolveMediaSource(StorageSpec{Mode: StorageLocal, Target: "/srv/nvr"})
+	if err != nil || needsMount || p != "/srv/nvr" {
+		t.Errorf("local: got (%q, %v, %v), want (/srv/nvr, false, nil)", p, needsMount, err)
+	}
+
+	// nas: media path is the citadel mountpoint and needsMount is true.
+	p, needsMount, err = ResolveMediaSource(StorageSpec{Mode: StorageNAS, Target: "nas.local:/volume2/surveillance"})
+	if err != nil || !needsMount || p != DefaultNASMountpoint {
+		t.Errorf("nas: got (%q, %v, %v), want (%s, true, nil)", p, needsMount, err, DefaultNASMountpoint)
+	}
+
+	// nas without host:/export is rejected.
+	if _, _, err := ResolveMediaSource(StorageSpec{Mode: StorageNAS, Target: "/not-an-export"}); err == nil {
+		t.Errorf("nas: expected error for target without host:/export")
+	}
+
+	// volume: path is the resolved volume path.
+	p, needsMount, err = ResolveMediaSource(StorageSpec{Mode: StorageVolume, Target: "/var/lib/citadel/volumes/vol-123"})
+	if err != nil || needsMount || p == "" {
+		t.Errorf("volume: got (%q, %v, %v)", p, needsMount, err)
+	}
+
+	// /config must NEVER equal the media source — SQLite stays local.
+	if LocalConfigDir == "" || strings.Contains(LocalConfigDir, DefaultNASMountpoint) {
+		t.Errorf("LocalConfigDir %q must be a local path independent of the NAS media mount", LocalConfigDir)
+	}
+}
+
+// TestFstabEntry pins the persisted NFSv3 mount line (Synology target has no v4).
+func TestFstabEntry(t *testing.T) {
+	line, err := FstabEntry("nas.local:/volume2/surveillance", DefaultNASMountpoint)
+	if err != nil {
+		t.Fatalf("FstabEntry: %v", err)
+	}
+	for _, want := range []string{"nas.local:/volume2/surveillance", DefaultNASMountpoint, "nfs", "vers=3", "_netdev"} {
+		if !strings.Contains(line, want) {
+			t.Errorf("fstab line %q missing %q", line, want)
+		}
+	}
+	if _, err := FstabEntry("/no-export", DefaultNASMountpoint); err == nil {
+		t.Errorf("expected error for export without host:")
+	}
+	if _, err := FstabEntry("nas:/x", "relative/mount"); err == nil {
+		t.Errorf("expected error for relative mountpoint")
+	}
+}

--- a/internal/nvr/storage.go
+++ b/internal/nvr/storage.go
@@ -8,29 +8,47 @@ import (
 	"syscall"
 )
 
-// LocalConfigDir is the citadel-owned LOCAL path bind-mounted at Frigate's
-// /config. It holds Frigate's SQLite DB (frigate.db) and the generated
-// config.yml. It MUST stay on local disk regardless of the media storage mode:
-// SQLite corrupts over NFS (the #597 scar). Only /media follows the storage
-// target; /config never does.
+// Fixed, citadel-owned LOCAL paths (relative to the node owner's home) that the
+// nvr compose bind-mounts. Both are LOCAL disk:
 //
-// Relative to the node owner's home; the reconcile joins it with the home dir.
-const LocalConfigDir = ".citadel-cli/nvr/config"
-
-// DefaultNASMountpoint is the citadel-owned LOCAL mountpoint an `nas` target is
-// mounted at (and then bind-mounted into Frigate as /media). A dedicated,
-// citadel-owned path — never a shared/system dir — so the mount-verify check has
-// a stable place to assert against.
-const DefaultNASMountpoint = "/mnt/citadel-nvr-media"
-
-// ResolveMediaSource returns the HOST path to bind-mount at Frigate's /media for
-// the given storage spec, plus whether the caller must first mount an external
-// filesystem there (true only for nas). It does NOT itself mount anything.
+//   - config: Frigate's config.yml + SQLite DB. MUST stay local regardless of the
+//     media storage mode — SQLite corrupts over NFS (the #597 scar). /config NEVER
+//     follows the storage target.
+//   - media:  recordings. For local mode this local dir IS the target. For nas
+//     mode the operator/reconcile NFS-mounts the share ONTO this same path before
+//     assigning the module, so the compose bind source is stable and the init
+//     container's network-fs check runs against it.
 //
-//   - local:  Target is used directly as the media path.
-//   - nas:    the media path is the citadel-owned mountpoint (DefaultNASMountpoint);
-//     the caller must NFS/SMB-mount Storage.Target there first and then
-//     VerifyMediaMount before starting Frigate.
+// These mirror the `~/.citadel-cli/nvr/{config,media}` bind sources in
+// services/nvr-service/compose.yml (compose expands a leading ~).
+const (
+	localConfigRel = ".citadel-cli/nvr/config"
+	localMediaRel  = ".citadel-cli/nvr/media"
+)
+
+// ConfigDir returns the absolute local /config bind source on this node.
+func ConfigDir() (string, error) { return homeJoin(localConfigRel) }
+
+// MediaDir returns the absolute local /media bind source on this node. For nas
+// mode this is the path an NFS/SMB export is mounted onto.
+func MediaDir() (string, error) { return homeJoin(localMediaRel) }
+
+func homeJoin(rel string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("nvr: resolve home dir: %w", err)
+	}
+	return filepath.Join(home, rel), nil
+}
+
+// ResolveMediaSource returns the HOST path bound at Frigate's /media for the given
+// storage spec, plus whether the caller must first mount an external filesystem
+// there (true only for nas). It does NOT itself mount anything.
+//
+//   - local:  Target is the media path directly (a node path).
+//   - nas:    the media path is the citadel-owned MediaDir(); the caller must
+//     NFS/SMB-mount Storage.Target there first and then verify it before
+//     starting Frigate.
 //   - volume: Target is the resolved volume path (the volume subsystem provides it).
 func ResolveMediaSource(s StorageSpec) (path string, needsMount bool, err error) {
 	switch s.Mode {
@@ -43,7 +61,11 @@ func ResolveMediaSource(s StorageSpec) (path string, needsMount bool, err error)
 		if !strings.Contains(s.Target, ":") {
 			return "", false, fmt.Errorf("nvr: storage.target for mode %q must be host:/export, got %q", StorageNAS, s.Target)
 		}
-		return DefaultNASMountpoint, true, nil
+		mp, err := MediaDir()
+		if err != nil {
+			return "", false, err
+		}
+		return mp, true, nil
 	case StorageVolume:
 		if strings.TrimSpace(s.Target) == "" {
 			return "", false, fmt.Errorf("nvr: storage.target (volume id) is required for mode %q", StorageVolume)
@@ -55,10 +77,11 @@ func ResolveMediaSource(s StorageSpec) (path string, needsMount bool, err error)
 }
 
 // FstabEntry builds the /etc/fstab line that persists an NFS mount across reboots.
-// export is the `host:/export` target; mountpoint is the local mountpoint. The
-// options force NFSv3 (Synology does not support v4 on the target NAS) and mount
-// at boot. Persisting in fstab is a hard #597 requirement — a hand `mount` is lost
-// on reboot and recordings then silently write to the local mountpoint.
+// export is the `host:/export` target; mountpoint is the local mountpoint (an
+// absolute path — typically MediaDir()). Options force NFSv3 (Synology does not
+// support v4 on the target NAS) and mount at boot. Persisting in fstab is a hard
+// #597 requirement — a hand `mount` is lost on reboot and recordings then silently
+// write to the local mountpoint.
 func FstabEntry(export, mountpoint string) (string, error) {
 	if !strings.Contains(export, ":") {
 		return "", fmt.Errorf("nvr: nfs export must be host:/export, got %q", export)
@@ -69,28 +92,26 @@ func FstabEntry(export, mountpoint string) (string, error) {
 	return fmt.Sprintf("%s %s nfs vers=3,rw,hard,noatime,_netdev 0 0", export, mountpoint), nil
 }
 
-// MountProbe abstracts the two filesystem questions VerifyMediaMount asks, so the
-// verify logic is unit-testable without a real NFS mount.
+// ---- Host-side pre-bind mount check (st_dev) ----
+
+// MountProbe abstracts the two filesystem questions the HOST-side VerifyMediaMount
+// asks, so it is unit-testable without a real NFS mount.
 type MountProbe struct {
-	// IsMountpoint reports whether path is an actual mountpoint (a filesystem is
-	// mounted there), as distinct from a plain local directory.
+	// IsMountpoint reports whether path is an actual mountpoint on the HOST, as
+	// distinct from a plain local directory (st_dev differs from the parent).
 	IsMountpoint func(path string) (bool, error)
-	// WritableAsUID reports whether uid can create files under path. Frigate runs
-	// as root in-container, so the export must be root-writable (NFS
-	// no_root_squash); uid is the container UID that will write recordings.
+	// WritableAsUID reports whether uid can create files under path.
 	WritableAsUID func(path string, uid int) (bool, error)
 }
 
-// VerifyMediaMount is the guard against the single worst #597 failure mode: a
-// FAILED NFS mount leaves the mountpoint a plain local directory that is happily
-// writable, so recordings silently land on the small local disk instead of the
-// NAS and nobody notices until it fills. It therefore checks mountedness
-// SEPARATELY from writability — a writable-but-not-mounted path is the bug, and
-// must fail.
-//
-// Order matters: assert the path is genuinely a mountpoint FIRST (catches the
-// leak), then assert it is writable as the container UID (catches a missing
-// no_root_squash export option). Only call this for mode == nas.
+// VerifyMediaMount is the HOST-side pre-bind guard the reconcile/human runs on the
+// node BEFORE the compose bind: it confirms the mountpoint really has a filesystem
+// mounted (st_dev differs from parent) and is writable, catching the case where an
+// NFS mount silently failed and left a plain local dir. It is distinct from the
+// CONTAINER-side VerifyMediaIsNetworkFS below: inside the frigate container /media
+// is ALWAYS a bind mount (st_dev always differs from parent), so an st_dev check
+// there is a false pass — the shipped in-container guard must use the filesystem
+// TYPE (statfs), not st_dev.
 func VerifyMediaMount(path string, uid int, probe MountProbe) error {
 	if probe.IsMountpoint == nil || probe.WritableAsUID == nil {
 		return fmt.Errorf("nvr: MountProbe is not fully configured")
@@ -100,31 +121,23 @@ func VerifyMediaMount(path string, uid int, probe MountProbe) error {
 		return fmt.Errorf("nvr: checking whether %s is mounted: %w", path, err)
 	}
 	if !mounted {
-		return fmt.Errorf("nvr: %s is NOT a mountpoint — the NFS mount failed; refusing to start Frigate so recordings do not silently write to the local disk", path)
+		return fmt.Errorf("nvr: %s is NOT a mountpoint — the NFS mount failed; refusing so recordings do not silently write to the local disk", path)
 	}
 	writable, err := probe.WritableAsUID(path, uid)
 	if err != nil {
 		return fmt.Errorf("nvr: checking writability of %s: %w", path, err)
 	}
 	if !writable {
-		return fmt.Errorf("nvr: %s is mounted but not writable as uid %d — the NFS export likely needs no_root_squash (Frigate runs as root in-container)", path, uid)
+		return fmt.Errorf("nvr: %s is mounted but not writable — the NFS export likely needs no_root_squash (Frigate runs as root in-container)", path)
 	}
 	return nil
 }
 
-// DefaultMountProbe returns a MountProbe backed by the real filesystem. It is the
-// production probe; tests inject their own.
+// DefaultMountProbe returns a host-side MountProbe backed by the real filesystem.
 func DefaultMountProbe() MountProbe {
-	return MountProbe{
-		IsMountpoint:  isMountpoint,
-		WritableAsUID: writableAsUID,
-	}
+	return MountProbe{IsMountpoint: isMountpoint, WritableAsUID: writableAsUID}
 }
 
-// isMountpoint reports whether path is a mountpoint by comparing its device id to
-// its parent's: a mountpoint sits on a different underlying device than the
-// directory that contains it. This is the classic st_dev comparison and needs no
-// /proc/mounts parse.
 func isMountpoint(path string) (bool, error) {
 	var st, parent syscall.Stat_t
 	if err := syscall.Stat(path, &st); err != nil {
@@ -133,24 +146,10 @@ func isMountpoint(path string) (bool, error) {
 	if err := syscall.Stat(filepath.Dir(path), &parent); err != nil {
 		return false, err
 	}
-	// Different device id than the parent => a filesystem is mounted here.
-	// Same device id but the path IS the filesystem root (rare for a mountpoint
-	// dir) is also handled by the inode check.
-	if st.Dev != parent.Dev {
-		return true, nil
-	}
-	return false, nil
+	return st.Dev != parent.Dev, nil
 }
 
-// writableAsUID reports whether uid can create a file under dir. It attempts a
-// probe write of a temp file. Running as root (Frigate's in-container identity),
-// a create succeeding proves the NFS export granted root write (no_root_squash);
-// on a root-squashed export the create fails with EACCES/EROFS.
 func writableAsUID(dir string, uid int) (bool, error) {
-	// The citadel process performing the check runs as the node owner; the real
-	// runtime write happens as the container UID. When the checker IS that uid (the
-	// common single-user node) the probe is exact; otherwise it is a best-effort
-	// create in the same export, which still catches a squashed/read-only export.
 	_ = uid
 	f, err := os.CreateTemp(dir, ".citadel-nvr-writecheck-")
 	if err != nil {
@@ -163,4 +162,81 @@ func writableAsUID(dir string, uid int) (bool, error) {
 	f.Close()
 	_ = os.Remove(name)
 	return true, nil
+}
+
+// ---- Container-side network-filesystem check (statfs) ----
+//
+// Linux superblock magics for network filesystems. These are what a statfs on a
+// bind-mounted /media reports as the UNDERLYING filesystem type, which is the only
+// reliable way (inside the frigate container, where /media is always a bind mount)
+// to tell "the host path is really an NFS/SMB share" from "the NFS mount failed and
+// /media is a plain local dir".
+const (
+	MagicNFS  int64 = 0x6969     // NFS_SUPER_MAGIC
+	MagicCIFS int64 = 0xFF534D42 // CIFS_MAGIC_NUMBER
+	MagicSMB2 int64 = 0xFE534D42 // SMB2_MAGIC_NUMBER
+	MagicSMB  int64 = 0x517B     // SMB_SUPER_MAGIC (older)
+)
+
+// IsNetworkFSMagic reports whether a statfs f_type value is a known network
+// filesystem (NFS or SMB/CIFS).
+func IsNetworkFSMagic(t int64) bool {
+	switch t {
+	case MagicNFS, MagicCIFS, MagicSMB2, MagicSMB:
+		return true
+	}
+	return false
+}
+
+// NetFSProbe abstracts the two filesystem questions VerifyMediaIsNetworkFS asks,
+// so the container-side guard is unit-testable without a real network mount.
+type NetFSProbe struct {
+	// FSType returns the statfs f_type (superblock magic) of the filesystem
+	// backing path.
+	FSType func(path string) (int64, error)
+	// Writable reports whether uid can create files under path (Frigate runs as
+	// root in-container, so a squashed export fails here).
+	Writable func(path string, uid int) (bool, error)
+}
+
+// VerifyMediaIsNetworkFS is the SHIPPED, in-container guard against the #1 storage
+// scar for nas mode: recordings silently landing on the small local disk because
+// the NFS mount failed. Inside the frigate/init container /media is a bind mount,
+// so an st_dev/mountpoint check is a false pass; this checks the filesystem TYPE
+// (statfs magic) is genuinely NFS/SMB, THEN that it is root-writable
+// (no_root_squash). It must fail closed so Frigate never starts writing to a
+// non-network /media.
+func VerifyMediaIsNetworkFS(path string, uid int, probe NetFSProbe) error {
+	if probe.FSType == nil || probe.Writable == nil {
+		return fmt.Errorf("nvr: NetFSProbe is not fully configured")
+	}
+	t, err := probe.FSType(path)
+	if err != nil {
+		return fmt.Errorf("nvr: statfs %s: %w", path, err)
+	}
+	if !IsNetworkFSMagic(t) {
+		return fmt.Errorf("nvr: %s is NOT a network filesystem (statfs type 0x%x) — for storage.mode=nas the NFS/SMB export must be mounted here BEFORE start, or recordings silently write to the local disk", path, uint64(t))
+	}
+	writable, err := probe.Writable(path, uid)
+	if err != nil {
+		return fmt.Errorf("nvr: checking writability of %s: %w", path, err)
+	}
+	if !writable {
+		return fmt.Errorf("nvr: %s is a network mount but not writable as uid %d — the export likely needs no_root_squash (Frigate runs as root in-container)", path, uid)
+	}
+	return nil
+}
+
+// DefaultNetFSProbe returns a NetFSProbe backed by real statfs + a probe write.
+func DefaultNetFSProbe() NetFSProbe {
+	return NetFSProbe{
+		FSType: func(path string) (int64, error) {
+			var st syscall.Statfs_t
+			if err := syscall.Statfs(path, &st); err != nil {
+				return 0, err
+			}
+			return int64(st.Type), nil
+		},
+		Writable: writableAsUID,
+	}
 }

--- a/internal/nvr/storage.go
+++ b/internal/nvr/storage.go
@@ -1,0 +1,166 @@
+package nvr
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+// LocalConfigDir is the citadel-owned LOCAL path bind-mounted at Frigate's
+// /config. It holds Frigate's SQLite DB (frigate.db) and the generated
+// config.yml. It MUST stay on local disk regardless of the media storage mode:
+// SQLite corrupts over NFS (the #597 scar). Only /media follows the storage
+// target; /config never does.
+//
+// Relative to the node owner's home; the reconcile joins it with the home dir.
+const LocalConfigDir = ".citadel-cli/nvr/config"
+
+// DefaultNASMountpoint is the citadel-owned LOCAL mountpoint an `nas` target is
+// mounted at (and then bind-mounted into Frigate as /media). A dedicated,
+// citadel-owned path — never a shared/system dir — so the mount-verify check has
+// a stable place to assert against.
+const DefaultNASMountpoint = "/mnt/citadel-nvr-media"
+
+// ResolveMediaSource returns the HOST path to bind-mount at Frigate's /media for
+// the given storage spec, plus whether the caller must first mount an external
+// filesystem there (true only for nas). It does NOT itself mount anything.
+//
+//   - local:  Target is used directly as the media path.
+//   - nas:    the media path is the citadel-owned mountpoint (DefaultNASMountpoint);
+//     the caller must NFS/SMB-mount Storage.Target there first and then
+//     VerifyMediaMount before starting Frigate.
+//   - volume: Target is the resolved volume path (the volume subsystem provides it).
+func ResolveMediaSource(s StorageSpec) (path string, needsMount bool, err error) {
+	switch s.Mode {
+	case StorageLocal:
+		if strings.TrimSpace(s.Target) == "" {
+			return "", false, fmt.Errorf("nvr: storage.target is required for mode %q", StorageLocal)
+		}
+		return s.Target, false, nil
+	case StorageNAS:
+		if !strings.Contains(s.Target, ":") {
+			return "", false, fmt.Errorf("nvr: storage.target for mode %q must be host:/export, got %q", StorageNAS, s.Target)
+		}
+		return DefaultNASMountpoint, true, nil
+	case StorageVolume:
+		if strings.TrimSpace(s.Target) == "" {
+			return "", false, fmt.Errorf("nvr: storage.target (volume id) is required for mode %q", StorageVolume)
+		}
+		return s.Target, false, nil
+	default:
+		return "", false, fmt.Errorf("nvr: unknown storage mode %q", s.Mode)
+	}
+}
+
+// FstabEntry builds the /etc/fstab line that persists an NFS mount across reboots.
+// export is the `host:/export` target; mountpoint is the local mountpoint. The
+// options force NFSv3 (Synology does not support v4 on the target NAS) and mount
+// at boot. Persisting in fstab is a hard #597 requirement — a hand `mount` is lost
+// on reboot and recordings then silently write to the local mountpoint.
+func FstabEntry(export, mountpoint string) (string, error) {
+	if !strings.Contains(export, ":") {
+		return "", fmt.Errorf("nvr: nfs export must be host:/export, got %q", export)
+	}
+	if !filepath.IsAbs(mountpoint) {
+		return "", fmt.Errorf("nvr: mountpoint must be absolute, got %q", mountpoint)
+	}
+	return fmt.Sprintf("%s %s nfs vers=3,rw,hard,noatime,_netdev 0 0", export, mountpoint), nil
+}
+
+// MountProbe abstracts the two filesystem questions VerifyMediaMount asks, so the
+// verify logic is unit-testable without a real NFS mount.
+type MountProbe struct {
+	// IsMountpoint reports whether path is an actual mountpoint (a filesystem is
+	// mounted there), as distinct from a plain local directory.
+	IsMountpoint func(path string) (bool, error)
+	// WritableAsUID reports whether uid can create files under path. Frigate runs
+	// as root in-container, so the export must be root-writable (NFS
+	// no_root_squash); uid is the container UID that will write recordings.
+	WritableAsUID func(path string, uid int) (bool, error)
+}
+
+// VerifyMediaMount is the guard against the single worst #597 failure mode: a
+// FAILED NFS mount leaves the mountpoint a plain local directory that is happily
+// writable, so recordings silently land on the small local disk instead of the
+// NAS and nobody notices until it fills. It therefore checks mountedness
+// SEPARATELY from writability — a writable-but-not-mounted path is the bug, and
+// must fail.
+//
+// Order matters: assert the path is genuinely a mountpoint FIRST (catches the
+// leak), then assert it is writable as the container UID (catches a missing
+// no_root_squash export option). Only call this for mode == nas.
+func VerifyMediaMount(path string, uid int, probe MountProbe) error {
+	if probe.IsMountpoint == nil || probe.WritableAsUID == nil {
+		return fmt.Errorf("nvr: MountProbe is not fully configured")
+	}
+	mounted, err := probe.IsMountpoint(path)
+	if err != nil {
+		return fmt.Errorf("nvr: checking whether %s is mounted: %w", path, err)
+	}
+	if !mounted {
+		return fmt.Errorf("nvr: %s is NOT a mountpoint — the NFS mount failed; refusing to start Frigate so recordings do not silently write to the local disk", path)
+	}
+	writable, err := probe.WritableAsUID(path, uid)
+	if err != nil {
+		return fmt.Errorf("nvr: checking writability of %s: %w", path, err)
+	}
+	if !writable {
+		return fmt.Errorf("nvr: %s is mounted but not writable as uid %d — the NFS export likely needs no_root_squash (Frigate runs as root in-container)", path, uid)
+	}
+	return nil
+}
+
+// DefaultMountProbe returns a MountProbe backed by the real filesystem. It is the
+// production probe; tests inject their own.
+func DefaultMountProbe() MountProbe {
+	return MountProbe{
+		IsMountpoint:  isMountpoint,
+		WritableAsUID: writableAsUID,
+	}
+}
+
+// isMountpoint reports whether path is a mountpoint by comparing its device id to
+// its parent's: a mountpoint sits on a different underlying device than the
+// directory that contains it. This is the classic st_dev comparison and needs no
+// /proc/mounts parse.
+func isMountpoint(path string) (bool, error) {
+	var st, parent syscall.Stat_t
+	if err := syscall.Stat(path, &st); err != nil {
+		return false, err
+	}
+	if err := syscall.Stat(filepath.Dir(path), &parent); err != nil {
+		return false, err
+	}
+	// Different device id than the parent => a filesystem is mounted here.
+	// Same device id but the path IS the filesystem root (rare for a mountpoint
+	// dir) is also handled by the inode check.
+	if st.Dev != parent.Dev {
+		return true, nil
+	}
+	return false, nil
+}
+
+// writableAsUID reports whether uid can create a file under dir. It attempts a
+// probe write of a temp file. Running as root (Frigate's in-container identity),
+// a create succeeding proves the NFS export granted root write (no_root_squash);
+// on a root-squashed export the create fails with EACCES/EROFS.
+func writableAsUID(dir string, uid int) (bool, error) {
+	// The citadel process performing the check runs as the node owner; the real
+	// runtime write happens as the container UID. When the checker IS that uid (the
+	// common single-user node) the probe is exact; otherwise it is a best-effort
+	// create in the same export, which still catches a squashed/read-only export.
+	_ = uid
+	f, err := os.CreateTemp(dir, ".citadel-nvr-writecheck-")
+	if err != nil {
+		if os.IsPermission(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	name := f.Name()
+	f.Close()
+	_ = os.Remove(name)
+	return true, nil
+}

--- a/services/nvr-service/Dockerfile
+++ b/services/nvr-service/Dockerfile
@@ -1,0 +1,22 @@
+# Init-container image for the nvr catalog module (aceteam-ai/citadel-cli#597):
+# ghcr.io/aceteam-ai/nvr-config. It compiles the `nvrconfig` command
+# (cmd/nvrconfig) so the config.yml generation + nas network-fs verification run
+# from the SAME tested Go logic as the rest of citadel (internal/nvr) — no parallel
+# script to drift.
+#
+# IMPORTANT: the build context is the REPOSITORY ROOT (not services/nvr-service),
+# because the binary depends on the module's go.mod + internal/nvr. The CI
+# workflow (.github/workflows/build-nvr-service.yml) sets context: . accordingly.
+FROM golang:1.26 AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -o /out/nvrconfig ./cmd/nvrconfig
+
+FROM alpine:3.20
+RUN adduser -D -u 10001 nvr
+COPY --from=build /out/nvrconfig /usr/local/bin/nvrconfig
+# Runs as root: the nas write-check and writing into the (possibly root-squashed)
+# /config bind mount need it, matching Frigate's own in-container root identity.
+ENTRYPOINT ["/usr/local/bin/nvrconfig"]

--- a/services/nvr-service/compose.yml
+++ b/services/nvr-service/compose.yml
@@ -1,25 +1,27 @@
 # Module compose for the Citadel nvr camera-NVR stack (aceteam-ai/citadel-cli#597).
 #
-# Two containers:
-#   - wyze-bridge: Wyze TUTK P2P -> RTSP. MUST use host networking (see below).
-#   - frigate:     continuous recording + local object detection.
+# Three services:
+#   - wyze-bridge:  Wyze TUTK P2P -> RTSP. MUST use host networking (see below).
+#   - nvr-config:   init container (runs to completion first) that GENERATES
+#                   /config/config.yml and VERIFIES a nas /media mount.
+#   - frigate:      continuous recording + local object detection.
 #
 # Frigate's /config/config.yml is NOT static: its detector block, retention, and
-# camera list are assignment/runtime inputs, so citadel GENERATES it on the node
-# from the assignment config + the cameras docker-wyze-bridge discovers, and
-# writes it into the LOCAL config dir mounted below. That generator is the
-# authoritative, unit-tested implementation in internal/nvr (GenerateFrigateConfig)
-# — it bakes in every scar: the explicit openvino model: path (Frigate 0.17
-# crashes without it), ffmpeg preset-vaapi, and the MIGRATED record.continuous.days
-# key. The node-reconcile call that materializes it (and mounts/verifies the NAS
-# target) is the documented follow-up, mirroring meeting #514's "handler wired in
-# a later PR".
+# camera list are assignment/runtime inputs. The nvr-config init container
+# (ghcr.io/aceteam-ai/nvr-config, built from cmd/nvrconfig via
+# services/nvr-service/Dockerfile) generates it with the SAME tested Go logic
+# citadel uses (internal/nvr.GenerateFrigateConfig), baking in every scar: the
+# explicit openvino model: path (Frigate 0.17 crashes without it), ffmpeg
+# preset-vaapi, the MIGRATED record.continuous.days key, and no transcode.
 #
 # Host ports come from citadel's registry (services/ports.go): 8212 (host) -> 5000
-# (Frigate's native web port), injected as CITADEL_FRIGATE_HOST_PORT. NVR_MEDIA_DIR
-# is the host media path citadel resolves from NVR_STORAGE_MODE/TARGET (a local
-# path, the NAS mountpoint, or a volume path). /config is ALWAYS local — SQLite
-# corrupts over NFS, so only /media ever follows the storage target.
+# (Frigate's native web port), injected as CITADEL_FRIGATE_HOST_PORT. The config +
+# media host paths are FIXED at ~/.citadel-cli/nvr/{config,media} (compose expands
+# a leading ~). /config is ALWAYS local — SQLite corrupts over NFS. For
+# storage.mode=nas the operator/reconcile NFS-mounts the surveillance share ONTO
+# ~/.citadel-cli/nvr/media BEFORE assigning the module; nvr-config then statfs-
+# verifies /media is a real, root-writable network mount and REFUSES to start
+# otherwise, so recordings never silently land on the local disk.
 services:
   wyze-bridge:
     image: idisposablegithub365/wyze-bridge:latest
@@ -39,22 +41,41 @@ services:
       - WYZE_PASSWORD=${WYZE_PASSWORD:?nvr requires WYZE_PASSWORD}
       - API_ID=${API_ID:?nvr requires API_ID}
       - API_KEY=${API_KEY:?nvr requires API_KEY}
-      # Keep streams always-on so continuous recording never misses frames (the
-      # bridge otherwise tears an idle stream down on-demand).
+      # Keep streams always-on so continuous recording never misses frames.
       - ON_DEMAND=False
       # Record raw H.264 — do NOT transcode. The cameras already emit ~1 Mbit/s
       # H.264; re-encoding (even cheap iGPU HEVC) produces LARGER files.
       - WB_FFMPEG=False
     volumes:
-      # Persist the Wyze auth token cache so a restart does not re-authenticate.
       - ~/.citadel-cli/nvr/wyze-tokens:/tokens
     restart: unless-stopped
+
+  nvr-config:
+    image: ghcr.io/aceteam-ai/nvr-config:latest
+    container_name: citadel-nvr-config
+    # An init step, not a long-running service: it writes config.yml + verifies the
+    # nas mount, then exits. frigate waits for it to complete successfully.
+    restart: "no"
+    environment:
+      - NVR_DETECTOR=${NVR_DETECTOR:-openvino}
+      - NVR_RETENTION_DAYS=${NVR_RETENTION_DAYS:-12}
+      - NVR_STORAGE_MODE=${NVR_STORAGE_MODE:-local}
+      - NVR_STORAGE_TARGET=${NVR_STORAGE_TARGET:-}
+      - NVR_CAMERAS=${NVR_CAMERAS:?nvr requires NVR_CAMERAS (comma-separated camera stream names)}
+    volumes:
+      - ~/.citadel-cli/nvr/config:/config
+      - ~/.citadel-cli/nvr/media:/media
 
   frigate:
     image: ghcr.io/blakeblackshear/frigate:stable
     container_name: citadel-nvr-frigate
     depends_on:
-      - wyze-bridge
+      wyze-bridge:
+        condition: service_started
+      nvr-config:
+        # Frigate must not start until config.yml exists and the nas mount (if any)
+        # is verified.
+        condition: service_completed_successfully
     # Frigate decodes frames into /dev/shm; the 64MB default is too small.
     shm_size: 256mb
     devices:
@@ -71,13 +92,11 @@ services:
       - "${CITADEL_FRIGATE_HOST_PORT:?citadel must supply CITADEL_FRIGATE_HOST_PORT}:5000"
     volumes:
       # /config (config.yml + SQLite DB) is ALWAYS local disk — SQLite corrupts
-      # over NFS. citadel writes the generated config.yml here before start.
+      # over NFS. nvr-config wrote config.yml here before start.
       - ~/.citadel-cli/nvr/config:/config
-      # /media follows the storage target (local path / NAS mountpoint / volume
-      # path), resolved by citadel into NVR_MEDIA_DIR. For nas mode citadel mounts
-      # and VERIFIES this is a real, root-writable mountpoint BEFORE start, so a
-      # failed NFS mount never silently writes recordings to the local disk.
-      - ${NVR_MEDIA_DIR:?citadel must supply NVR_MEDIA_DIR (resolved from NVR_STORAGE_MODE/TARGET)}:/media
+      # /media follows the storage target. FIXED bind source; for nas mode the
+      # share is mounted onto this host path and nvr-config already verified it.
+      - ~/.citadel-cli/nvr/media:/media
       - /etc/localtime:/etc/localtime:ro
     environment:
       - TZ=${TZ:-UTC}

--- a/services/nvr-service/compose.yml
+++ b/services/nvr-service/compose.yml
@@ -1,0 +1,90 @@
+# Module compose for the Citadel nvr camera-NVR stack (aceteam-ai/citadel-cli#597).
+#
+# Two containers:
+#   - wyze-bridge: Wyze TUTK P2P -> RTSP. MUST use host networking (see below).
+#   - frigate:     continuous recording + local object detection.
+#
+# Frigate's /config/config.yml is NOT static: its detector block, retention, and
+# camera list are assignment/runtime inputs, so citadel GENERATES it on the node
+# from the assignment config + the cameras docker-wyze-bridge discovers, and
+# writes it into the LOCAL config dir mounted below. That generator is the
+# authoritative, unit-tested implementation in internal/nvr (GenerateFrigateConfig)
+# — it bakes in every scar: the explicit openvino model: path (Frigate 0.17
+# crashes without it), ffmpeg preset-vaapi, and the MIGRATED record.continuous.days
+# key. The node-reconcile call that materializes it (and mounts/verifies the NAS
+# target) is the documented follow-up, mirroring meeting #514's "handler wired in
+# a later PR".
+#
+# Host ports come from citadel's registry (services/ports.go): 8212 (host) -> 5000
+# (Frigate's native web port), injected as CITADEL_FRIGATE_HOST_PORT. NVR_MEDIA_DIR
+# is the host media path citadel resolves from NVR_STORAGE_MODE/TARGET (a local
+# path, the NAS mountpoint, or a volume path). /config is ALWAYS local — SQLite
+# corrupts over NFS, so only /media ever follows the storage target.
+services:
+  wyze-bridge:
+    image: idisposablegithub365/wyze-bridge:latest
+    container_name: citadel-nvr-wyze-bridge
+    # HOST NETWORKING IS MANDATORY AND NON-NEGOTIABLE. TUTK P2P needs LAN broadcast
+    # + UDP hole-punching; Docker bridge NAT breaks camera discovery and EVERY
+    # camera fails with "wyze: connect failed: discovery timeout". With host net,
+    # wyze-bridge binds its RTSP server on the host at :8554 (reserved in
+    # services/ports.go as WyzeBridgeRTSPPort); frigate pulls from there via the
+    # host-gateway alias. Because of host networking there is NO `ports:` block
+    # (host networking + published ports is a compose error).
+    network_mode: host
+    environment:
+      # Wyze credentials come from the assignment (SECRETS; never logged). Only
+      # this container ever sees them.
+      - WYZE_EMAIL=${WYZE_EMAIL:?nvr requires WYZE_EMAIL}
+      - WYZE_PASSWORD=${WYZE_PASSWORD:?nvr requires WYZE_PASSWORD}
+      - API_ID=${API_ID:?nvr requires API_ID}
+      - API_KEY=${API_KEY:?nvr requires API_KEY}
+      # Keep streams always-on so continuous recording never misses frames (the
+      # bridge otherwise tears an idle stream down on-demand).
+      - ON_DEMAND=False
+      # Record raw H.264 — do NOT transcode. The cameras already emit ~1 Mbit/s
+      # H.264; re-encoding (even cheap iGPU HEVC) produces LARGER files.
+      - WB_FFMPEG=False
+    volumes:
+      # Persist the Wyze auth token cache so a restart does not re-authenticate.
+      - ~/.citadel-cli/nvr/wyze-tokens:/tokens
+    restart: unless-stopped
+
+  frigate:
+    image: ghcr.io/blakeblackshear/frigate:stable
+    container_name: citadel-nvr-frigate
+    depends_on:
+      - wyze-bridge
+    # Frigate decodes frames into /dev/shm; the 64MB default is too small.
+    shm_size: 256mb
+    devices:
+      # Intel iGPU render node for hardware decode (preset-vaapi) + OpenVINO
+      # detection. Matches sandbox.devices in service.yaml.
+      - /dev/dri/renderD128:/dev/dri/renderD128
+    extra_hosts:
+      # Lets frigate (bridge network) reach the host-networked wyze-bridge RTSP
+      # server at host.docker.internal:8554.
+      - "host.docker.internal:host-gateway"
+    ports:
+      # host 8212 -> container 5000 (Frigate web UI/API). Host port owned by citadel
+      # (services/ports.go); the :? guard fails loudly if it was not injected.
+      - "${CITADEL_FRIGATE_HOST_PORT:?citadel must supply CITADEL_FRIGATE_HOST_PORT}:5000"
+    volumes:
+      # /config (config.yml + SQLite DB) is ALWAYS local disk — SQLite corrupts
+      # over NFS. citadel writes the generated config.yml here before start.
+      - ~/.citadel-cli/nvr/config:/config
+      # /media follows the storage target (local path / NAS mountpoint / volume
+      # path), resolved by citadel into NVR_MEDIA_DIR. For nas mode citadel mounts
+      # and VERIFIES this is a real, root-writable mountpoint BEFORE start, so a
+      # failed NFS mount never silently writes recordings to the local disk.
+      - ${NVR_MEDIA_DIR:?citadel must supply NVR_MEDIA_DIR (resolved from NVR_STORAGE_MODE/TARGET)}:/media
+      - /etc/localtime:/etc/localtime:ro
+    environment:
+      - TZ=${TZ:-UTC}
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:5000/api/version || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped

--- a/services/nvr-service/service.yaml
+++ b/services/nvr-service/service.yaml
@@ -77,15 +77,28 @@ config:
       does not crash.
     default: openvino
   - name: NVR_STORAGE_MODE
-    description: "Where recordings (/media) live: local | nas | volume."
+    description: >-
+      Where recordings (/media) live: local | nas | volume. For nas, the operator/
+      reconcile NFS-mounts the export onto the fixed media path (~/.citadel-cli/nvr/
+      media) BEFORE assignment; the nvr-config init container then statfs-verifies
+      /media is a real, root-writable network mount and refuses to start otherwise
+      (so a failed mount never silently writes to the local disk).
     default: local
   - name: NVR_STORAGE_TARGET
     description: >-
-      Interpreted per NVR_STORAGE_MODE: a node path (local), a host:/export
-      (nas — NFS/SMB, mounted + fstab-persisted + verified writable before Frigate
-      starts; the export needs no_root_squash), or a volume id (volume). NOTE:
-      /config (Frigate's SQLite DB) ALWAYS stays on local disk regardless of this
-      value — SQLite corrupts over NFS; only /media follows the target.
+      Informational per NVR_STORAGE_MODE: a node path (local), a host:/export
+      (nas — the export needs no_root_squash since Frigate runs as root), or a
+      volume id (volume). The compose binds a FIXED local media path; the reconcile
+      uses this target to mount/retarget. NOTE: /config (Frigate's SQLite DB)
+      ALWAYS stays on local disk regardless of this value — SQLite corrupts over
+      NFS; only /media follows the target.
+  - name: NVR_CAMERAS
+    description: >-
+      Comma-separated camera stream names (e.g. "front-door,garage=garage-cam";
+      `name` or `name=stream-path`). Frigate 0.17 refuses to start with an empty
+      cameras: block, so this is required and the nvr-config init container fails
+      loudly if it is empty. Auto-discovery from docker-wyze-bridge's API is a
+      runtime enhancement validated at node-1314 acceptance, not the default.
     required: true
 
 health_check:
@@ -105,12 +118,12 @@ volumes:
     host: ~/.citadel-cli/nvr/config
     container: /config
     description: Frigate config.yml + SQLite DB (must stay on local disk)
-  # Recordings. Host path resolved from NVR_STORAGE_MODE/TARGET (local path, the
-  # NAS mountpoint, or a volume path). Passed to compose via NVR_MEDIA_DIR.
+  # Recordings. FIXED local bind source; for nas mode the export is mounted onto
+  # this same host path before assignment (nvr-config verifies it is a network fs).
   - name: media
-    host: ${NVR_MEDIA_DIR}
+    host: ~/.citadel-cli/nvr/media
     container: /media
-    description: recordings (raw H.264); follows the storage target
+    description: recordings (raw H.264); for nas the share is mounted onto this path
   # docker-wyze-bridge token/cache dir so re-auth is not needed on every restart.
   - name: wyze-tokens
     host: ~/.citadel-cli/nvr/wyze-tokens

--- a/services/nvr-service/service.yaml
+++ b/services/nvr-service/service.yaml
@@ -1,0 +1,160 @@
+# Citadel module manifest for the nvr camera-NVR stack (aceteam-ai/citadel-cli#597).
+# Mirrors internal/catalog.ServiceManifest (schema v2). This is the module-install
+# path: `fabric_node_module_set node=<id> module=nvr` dispatches a MODULE_SET job
+# that resolves the module through the catalog (internal/catalog Source), NOT the
+# embedded services.ServiceMap (that is the SERVICE_START/inference-engine path:
+# vllm, bonsai, ollama). nvr is a MODULE, exactly like `meeting` and `gotenberg`.
+#
+# To ship as an installable module the fabric can resolve, this dir must be
+# published as services/nvr/{service.yaml,compose.yml} + a registry.yaml entry in
+# the SEPARATE catalog repo (aceteam-ai/citadel-services) — mirror how gotenberg
+# was added there (citadel-services#10). This citadel-cli copy is the source of
+# truth for the manifest/compose and registers the host ports in services/ports.go
+# so no other module can claim 8212 (Frigate UI) or the host-net 8554 (wyze RTSP).
+schema_version: 2
+name: nvr
+version: "0.1.0"
+description: >-
+  Self-hosted camera NVR: docker-wyze-bridge (Wyze TUTK P2P -> RTSP) + Frigate
+  (continuous recording + local object detection). One bridge per node/site.
+  Records raw H.264 to a configurable local / NAS / volume target; retention is
+  sized by days.
+category: media
+author: AceTeam
+license: Apache-2.0
+homepage: https://github.com/aceteam-ai/citadel-cli/issues/597
+
+requires:
+  # Frigate object detection runs on the INTEL iGPU via OpenVINO (device: GPU),
+  # reached through /dev/dri — NOT an NVIDIA GPU reservation. gpu: false keeps the
+  # NVIDIA-runtime requirement off; the iGPU device is granted via sandbox.devices.
+  # The cpu detector fallback needs no GPU at all.
+  gpu: false
+  # wyze-bridge + frigate:stable + the openvino runtime are amd64; the target is
+  # the SJC `mini` node (Intel iGPU, amd64).
+  arch: [amd64]
+
+ports:
+  # Frigate web UI + HTTP API. host 8212 (services/ports.go registry) -> container
+  # 5000 (Frigate's native web port). wyze-bridge publishes NO compose port — it
+  # runs with host networking and binds its RTSP/HLS/WebUI ports directly on the
+  # host (RTSP 8554 is reserved in services/ports.go). Frigate pulls camera RTSP
+  # from host.docker.internal:8554.
+  - host: 8212
+    container: 5000
+    protocol: tcp
+    description: Frigate web UI / HTTP API
+
+config:
+  # --- Wyze account credentials (SECRETS: supplied by the assignment, NEVER
+  # logged). Only docker-wyze-bridge consumes these; Frigate never sees them and
+  # the citadel-side config generator does not receive them. No defaults — an
+  # unset value must fail the assignment, not fall back.
+  - name: WYZE_EMAIL
+    description: "Wyze account email (SECRET; never logged)."
+    required: true
+  - name: WYZE_PASSWORD
+    description: "Wyze account password (SECRET; never logged)."
+    required: true
+  - name: API_ID
+    description: "Wyze developer API ID (SECRET; never logged)."
+    required: true
+  - name: API_KEY
+    description: "Wyze developer API key (SECRET; never logged)."
+    required: true
+  # --- NVR behavior (non-secret) ---
+  - name: NVR_RETENTION_DAYS
+    description: >-
+      Days of continuous recording to retain. Sized by DAYS, never by free space:
+      a Synology NFS quota is invisible to `df` on the client. Written to Frigate
+      as the migrated record.continuous.days key (0.17).
+    default: "12"
+  - name: NVR_DETECTOR
+    description: >-
+      Object detector: `openvino` (Intel iGPU, device GPU — the default) or `cpu`
+      (fallback for hardware without OpenVINO, e.g. an AMD Vega iGPU). openvino
+      emits an explicit model: path (bundled ssdlite_mobilenet_v2) so Frigate 0.17
+      does not crash.
+    default: openvino
+  - name: NVR_STORAGE_MODE
+    description: "Where recordings (/media) live: local | nas | volume."
+    default: local
+  - name: NVR_STORAGE_TARGET
+    description: >-
+      Interpreted per NVR_STORAGE_MODE: a node path (local), a host:/export
+      (nas — NFS/SMB, mounted + fstab-persisted + verified writable before Frigate
+      starts; the export needs no_root_squash), or a volume id (volume). NOTE:
+      /config (Frigate's SQLite DB) ALWAYS stays on local disk regardless of this
+      value — SQLite corrupts over NFS; only /media follows the target.
+    required: true
+
+health_check:
+  # catalog.ProbeHealth GETs http://127.0.0.1:<port><endpoint> ON THE HOST, so the
+  # port here is the PUBLISHED HOST port (8212), not the container port. Frigate's
+  # /api/version returns 200 once it has loaded config.yml and the detector.
+  endpoint: /api/version
+  port: 8212
+  interval: 30s
+  timeout: 10s
+  retries: 5
+
+volumes:
+  # Frigate config + SQLite DB. LOCAL disk always (SQLite corrupts over NFS), even
+  # in nas mode. Only /media follows the storage target.
+  - name: config
+    host: ~/.citadel-cli/nvr/config
+    container: /config
+    description: Frigate config.yml + SQLite DB (must stay on local disk)
+  # Recordings. Host path resolved from NVR_STORAGE_MODE/TARGET (local path, the
+  # NAS mountpoint, or a volume path). Passed to compose via NVR_MEDIA_DIR.
+  - name: media
+    host: ${NVR_MEDIA_DIR}
+    container: /media
+    description: recordings (raw H.264); follows the storage target
+  # docker-wyze-bridge token/cache dir so re-auth is not needed on every restart.
+  - name: wyze-tokens
+    host: ~/.citadel-cli/nvr/wyze-tokens
+    container: /tokens
+    description: wyze-bridge auth token cache
+
+# Gateway exposure DECLARATION (data only). Actually wiring Frigate's UI onto the
+# node gateway under /modules/nvr/ is the companion issue #598 — this block just
+# names the port env + gating capability so #598 needs zero manifest changes. No
+# exposure logic is implemented in #597.
+gateway:
+  prefix: nvr
+  port_env: CITADEL_FRIGATE_HOST_PORT
+  capability: console
+
+# Namespaced routing tag: install advertises the node as nvr-capable.
+node_tags:
+  - nvr
+
+tags:
+  - nvr
+  - camera
+  - frigate
+  - wyze
+  - surveillance
+  - media
+
+sandbox:
+  # wyze-bridge MANDATES host networking: TUTK P2P needs LAN broadcast + UDP
+  # hole-punching, and Docker bridge NAT breaks camera discovery (every camera
+  # then fails with "wyze: connect failed: discovery timeout"). This is the #1
+  # gotcha and is non-negotiable. It independently trips the #342 host-network
+  # risk scan (expected).
+  host_network: true
+  # Intel iGPU render node for Frigate hardware decode (preset-vaapi) + OpenVINO
+  # detection.
+  devices:
+    - /dev/dri/renderD128
+  writable_paths:
+    - /config
+    - /media
+    - /tokens
+    - /tmp
+  resources:
+    cpu: "4.0"
+    memory: 4g
+    pids: 4096

--- a/services/nvr-service/service.yaml
+++ b/services/nvr-service/service.yaml
@@ -157,6 +157,15 @@ sandbox:
   # then fails with "wyze: connect failed: discovery timeout"). This is the #1
   # gotcha and is non-negotiable. It independently trips the #342 host-network
   # risk scan (expected).
+  #
+  # INSTALL-AS-TRUSTED ONLY: nvr must be installed from the first-party catalog
+  # (a trusted Tier-0 source), so this sandbox block is IGNORED and the compose is
+  # authoritative — wyze-bridge on host net, frigate on bridge net (it needs the
+  # extra_hosts host-gateway alias + a published :5000, both broken under host
+  # net). The sandbox model is module-level (one network_mode for ALL services),
+  # so an UNTRUSTED install would wrongly force host networking onto frigate and
+  # break it. Per-service sandbox scoping is a documented follow-up; until then
+  # nvr is a trusted-catalog module only.
   host_network: true
   # Intel iGPU render node for Frigate hardware decode (preset-vaapi) + OpenVINO
   # detection.

--- a/services/nvr_manifest_test.go
+++ b/services/nvr_manifest_test.go
@@ -1,0 +1,192 @@
+package services
+
+import (
+	_ "embed"
+	"strings"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/catalog"
+	"gopkg.in/yaml.v3"
+)
+
+// nvrServiceYAML / nvrComposeYAML are the on-disk module manifest + compose the
+// installer will consume. Embedding them makes the test fail if a file is deleted
+// or renamed, and lets us parse the manifest through the REAL
+// catalog.ServiceManifest struct so a schema mismatch is caught at build time
+// rather than at install time on a node.
+//
+//go:embed nvr-service/service.yaml
+var nvrServiceYAML []byte
+
+//go:embed nvr-service/compose.yml
+var nvrComposeYAML []byte
+
+// TestNVRServiceManifest validates the nvr module manifest (#597) against the
+// catalog schema and the load-bearing invariants: host networking for
+// wyze-bridge, the iGPU render device for Frigate, the assignment config vars,
+// the published-host-port health check, and the (data-only) gateway block.
+func TestNVRServiceManifest(t *testing.T) {
+	var m catalog.ServiceManifest
+	if err := yaml.Unmarshal(nvrServiceYAML, &m); err != nil {
+		t.Fatalf("nvr service.yaml does not parse as a ServiceManifest: %v", err)
+	}
+
+	if m.Name != "nvr" {
+		t.Errorf("name = %q, want %q", m.Name, "nvr")
+	}
+	if m.SchemaVersion != catalog.CurrentSchemaVersion {
+		t.Errorf("schema_version = %d, want %d", m.SchemaVersion, catalog.CurrentSchemaVersion)
+	}
+
+	// Host networking is the #1 non-negotiable gotcha (TUTK discovery timeout
+	// otherwise). It must be declared in the sandbox block.
+	if !m.Sandbox.HostNetwork {
+		t.Errorf("sandbox.host_network must be true — wyze-bridge TUTK P2P needs it or every camera fails discovery")
+	}
+
+	// Frigate hardware decode + OpenVINO detection needs the iGPU render node.
+	foundDRI := false
+	for _, d := range m.Sandbox.Devices {
+		if strings.Contains(d, "renderD128") {
+			foundDRI = true
+		}
+	}
+	if !foundDRI {
+		t.Errorf("sandbox.devices must include /dev/dri/renderD128 for Frigate hw decode; got %v", m.Sandbox.Devices)
+	}
+
+	// The assignment config schema must be present. Secrets are required (no
+	// default) so an unset value fails the assignment instead of silently falling
+	// back.
+	cfg := map[string]catalog.ConfigVar{}
+	for _, c := range m.Config {
+		cfg[c.Name] = c
+	}
+	for _, secret := range []string{"WYZE_EMAIL", "WYZE_PASSWORD", "API_ID", "API_KEY"} {
+		c, ok := cfg[secret]
+		if !ok {
+			t.Errorf("config is missing required secret %q", secret)
+			continue
+		}
+		if !c.Required {
+			t.Errorf("secret %q must be required (no silent default)", secret)
+		}
+		if c.Default != "" {
+			t.Errorf("secret %q must not carry a default value", secret)
+		}
+	}
+	for _, name := range []string{"NVR_RETENTION_DAYS", "NVR_DETECTOR", "NVR_STORAGE_MODE", "NVR_STORAGE_TARGET"} {
+		if _, ok := cfg[name]; !ok {
+			t.Errorf("config is missing %q", name)
+		}
+	}
+
+	// Ports: Frigate host 8212 -> container 5000, matching the registry.
+	if len(m.Ports) != 1 {
+		t.Fatalf("expected exactly 1 published port (frigate), got %d", len(m.Ports))
+	}
+	if m.Ports[0].Host != FrigateHostPort || m.Ports[0].Container != 5000 {
+		t.Errorf("port = host %d -> container %d, want host %d -> container 5000", m.Ports[0].Host, m.Ports[0].Container, FrigateHostPort)
+	}
+
+	// Health check must target the PUBLISHED HOST port (ProbeHealth runs on the
+	// host), not the container port 5000.
+	if !catalog.HasHealthProbe(m.HealthCheck) {
+		t.Errorf("health_check is not probeable")
+	}
+	if m.HealthCheck.Port != FrigateHostPort {
+		t.Errorf("health_check.port = %d, want the published HOST port %d", m.HealthCheck.Port, FrigateHostPort)
+	}
+
+	// The gateway block is data-only (#598 owns exposure) but must be valid and
+	// name the registry's port env.
+	if m.Gateway == nil {
+		t.Errorf("expected a data-only gateway block (port env declaration for #598)")
+	} else {
+		if err := m.Gateway.Validate(); err != nil {
+			t.Errorf("gateway block does not validate: %v", err)
+		}
+		if m.Gateway.PortEnv != EnvFrigateHostPort {
+			t.Errorf("gateway.port_env = %q, want %q", m.Gateway.PortEnv, EnvFrigateHostPort)
+		}
+	}
+}
+
+// composeShape captures the compose fields the nvr invariants assert on.
+type composeShape struct {
+	Services map[string]struct {
+		NetworkMode string   `yaml:"network_mode"`
+		Ports       []string `yaml:"ports"`
+		Devices     []string `yaml:"devices"`
+		Volumes     []string `yaml:"volumes"`
+	} `yaml:"services"`
+}
+
+// TestNVRComposeInvariants pins the load-bearing compose scars: wyze-bridge on
+// host networking with NO published ports; frigate mapping the iGPU render node,
+// publishing the citadel-owned host port, and keeping /config on local disk while
+// /media follows the storage target.
+func TestNVRComposeInvariants(t *testing.T) {
+	var c composeShape
+	if err := yaml.Unmarshal(nvrComposeYAML, &c); err != nil {
+		t.Fatalf("nvr compose.yml does not parse: %v", err)
+	}
+
+	wyze, ok := c.Services["wyze-bridge"]
+	if !ok {
+		t.Fatalf("compose is missing the wyze-bridge service")
+	}
+	if wyze.NetworkMode != "host" {
+		t.Errorf("wyze-bridge network_mode = %q, want host (TUTK P2P discovery)", wyze.NetworkMode)
+	}
+	if len(wyze.Ports) != 0 {
+		t.Errorf("wyze-bridge must NOT publish ports under host networking; got %v", wyze.Ports)
+	}
+
+	frigate, ok := c.Services["frigate"]
+	if !ok {
+		t.Fatalf("compose is missing the frigate service")
+	}
+	foundDRI := false
+	for _, d := range frigate.Devices {
+		if strings.Contains(d, "renderD128") {
+			foundDRI = true
+		}
+	}
+	if !foundDRI {
+		t.Errorf("frigate must map /dev/dri/renderD128 for hw decode; got %v", frigate.Devices)
+	}
+	// Publishes the citadel-owned host port -> container 5000.
+	pubOK := false
+	for _, p := range frigate.Ports {
+		if strings.Contains(p, EnvFrigateHostPort) && strings.HasSuffix(p, ":5000") {
+			pubOK = true
+		}
+	}
+	if !pubOK {
+		t.Errorf("frigate must publish ${%s}:5000; got %v", EnvFrigateHostPort, frigate.Ports)
+	}
+
+	// /config must be a LOCAL path (the nvr config dir), never the media target;
+	// /media must be the resolved media dir. This is the SQLite-stays-local scar.
+	// Match by container-mount suffix: the HOST side may be a ${VAR:?msg}
+	// expansion that itself contains colons, so a naive split on ":" is wrong.
+	var configHost, mediaHost string
+	for _, v := range frigate.Volumes {
+		if h, ok := strings.CutSuffix(v, ":/config"); ok {
+			configHost = h
+		}
+		if h, ok := strings.CutSuffix(v, ":/media"); ok {
+			mediaHost = h
+		}
+	}
+	if !strings.Contains(configHost, "nvr/config") {
+		t.Errorf("/config host mount = %q, want the local nvr/config dir (SQLite must stay local)", configHost)
+	}
+	if strings.Contains(configHost, "NVR_MEDIA_DIR") {
+		t.Errorf("/config must NOT be on the media target (%q) — SQLite corrupts over NFS", configHost)
+	}
+	if !strings.Contains(mediaHost, "NVR_MEDIA_DIR") {
+		t.Errorf("/media host mount = %q, want the resolved ${NVR_MEDIA_DIR}", mediaHost)
+	}
+}

--- a/services/nvr_manifest_test.go
+++ b/services/nvr_manifest_test.go
@@ -75,7 +75,7 @@ func TestNVRServiceManifest(t *testing.T) {
 			t.Errorf("secret %q must not carry a default value", secret)
 		}
 	}
-	for _, name := range []string{"NVR_RETENTION_DAYS", "NVR_DETECTOR", "NVR_STORAGE_MODE", "NVR_STORAGE_TARGET"} {
+	for _, name := range []string{"NVR_RETENTION_DAYS", "NVR_DETECTOR", "NVR_STORAGE_MODE", "NVR_STORAGE_TARGET", "NVR_CAMERAS"} {
 		if _, ok := cfg[name]; !ok {
 			t.Errorf("config is missing %q", name)
 		}
@@ -115,10 +115,14 @@ func TestNVRServiceManifest(t *testing.T) {
 // composeShape captures the compose fields the nvr invariants assert on.
 type composeShape struct {
 	Services map[string]struct {
+		Image       string   `yaml:"image"`
 		NetworkMode string   `yaml:"network_mode"`
 		Ports       []string `yaml:"ports"`
 		Devices     []string `yaml:"devices"`
 		Volumes     []string `yaml:"volumes"`
+		DependsOn   map[string]struct {
+			Condition string `yaml:"condition"`
+		} `yaml:"depends_on"`
 	} `yaml:"services"`
 }
 
@@ -167,10 +171,9 @@ func TestNVRComposeInvariants(t *testing.T) {
 		t.Errorf("frigate must publish ${%s}:5000; got %v", EnvFrigateHostPort, frigate.Ports)
 	}
 
-	// /config must be a LOCAL path (the nvr config dir), never the media target;
-	// /media must be the resolved media dir. This is the SQLite-stays-local scar.
-	// Match by container-mount suffix: the HOST side may be a ${VAR:?msg}
-	// expansion that itself contains colons, so a naive split on ":" is wrong.
+	// /config must be a LOCAL path (the nvr config dir), never the media dir;
+	// /media is a separate local bind. This is the SQLite-stays-local scar.
+	// Match by container-mount suffix (the host side may contain colons).
 	var configHost, mediaHost string
 	for _, v := range frigate.Volumes {
 		if h, ok := strings.CutSuffix(v, ":/config"); ok {
@@ -183,10 +186,24 @@ func TestNVRComposeInvariants(t *testing.T) {
 	if !strings.Contains(configHost, "nvr/config") {
 		t.Errorf("/config host mount = %q, want the local nvr/config dir (SQLite must stay local)", configHost)
 	}
-	if strings.Contains(configHost, "NVR_MEDIA_DIR") {
-		t.Errorf("/config must NOT be on the media target (%q) — SQLite corrupts over NFS", configHost)
+	if !strings.Contains(mediaHost, "nvr/media") {
+		t.Errorf("/media host mount = %q, want the local nvr/media dir", mediaHost)
 	}
-	if !strings.Contains(mediaHost, "NVR_MEDIA_DIR") {
-		t.Errorf("/media host mount = %q, want the resolved ${NVR_MEDIA_DIR}", mediaHost)
+	if configHost == mediaHost {
+		t.Errorf("/config and /media must be distinct paths; both = %q", configHost)
+	}
+
+	// The nvr-config init container must exist and frigate must wait for it to
+	// complete successfully (config.yml generation + nas verify gate).
+	initSvc, ok := c.Services["nvr-config"]
+	if !ok {
+		t.Fatalf("compose is missing the nvr-config init container")
+	}
+	if !strings.Contains(initSvc.Image, "nvr-config") {
+		t.Errorf("nvr-config image = %q, want the ghcr nvr-config image", initSvc.Image)
+	}
+	dep, ok := frigate.DependsOn["nvr-config"]
+	if !ok || dep.Condition != "service_completed_successfully" {
+		t.Errorf("frigate must depend_on nvr-config with condition service_completed_successfully; got %+v", frigate.DependsOn)
 	}
 }

--- a/services/ports.go
+++ b/services/ports.go
@@ -73,6 +73,15 @@ const (
 	// name; the registry KEY stays "kokoro" (the implementation name), mirroring
 	// meeting's key/env-var split (key "meeting" / EnvMeetingdHostPort).
 	EnvTTSHostPort = "CITADEL_TTS_HOST_PORT"
+	// EnvFrigateHostPort carries the host port for Frigate's web UI/API in the nvr
+	// camera-NVR module (aceteam-ai/citadel-cli#597). Like claudecode/meeting/
+	// gotenberg, the nvr module's compose lives in the catalog repo
+	// (aceteam-ai/citadel-services), NOT the embedded ServiceMap, but the port is
+	// registered here so no other module can hardcode over it and so
+	// `citadel module install nvr` injects it via the same HostPortEnv() mechanism.
+	// The registry KEY is the module name "nvr" while the env var is spelled for the
+	// container it maps to (frigate) — the same key/env split as meeting.
+	EnvFrigateHostPort = "CITADEL_FRIGATE_HOST_PORT"
 )
 
 // Citadel-assigned host ports for the pre-packaged compose services. These are
@@ -143,7 +152,23 @@ const (
 	// injected host port; aligning citadel-services to 8211 is a follow-up in
 	// that repo.
 	TTSHostPort = 8211
+	// frigate: the Frigate web UI/API for the nvr camera-NVR module (#597). Next
+	// free slot in the 8200 block after kokoro's 8211. host 8212 -> container 5000
+	// (Frigate's native web port); this is the HOST publish. The nvr module's
+	// compose lives in citadel-services (like meeting/gotenberg), so this registry
+	// is the only thing stopping a future module from hardcoding over 8212.
+	FrigateHostPort = 8212
 )
+
+// WyzeBridgeRTSPPort is docker-wyze-bridge's RTSP server port in the nvr module
+// (#597). wyze-bridge MUST run with host networking (TUTK P2P needs LAN broadcast
+// + UDP hole-punching; Docker bridge NAT breaks camera discovery), so it binds
+// this port directly ON THE HOST — outside Docker's publish bookkeeping and
+// outside the env-var-substitution registry above, exactly like the LiveKit SFU.
+// It is reserved below (ReservedCitadelPorts) so no app allocation or module
+// publish can claim the port wyze-bridge will bind and that Frigate pulls RTSP
+// from (via host.docker.internal:8554).
+const WyzeBridgeRTSPPort = 8554
 
 // ServiceHostPorts maps service name -> citadel-assigned host port. Most entries
 // are compose services whose host publish citadel owns via env-var substitution;
@@ -163,6 +188,7 @@ var ServiceHostPorts = map[string]int{
 	"gotenberg":   GotenbergHostPort,
 	"bonsai":      BonsaiHostPort,
 	"kokoro":      TTSHostPort,
+	"nvr":         FrigateHostPort,
 }
 
 // serviceHostPortEnv maps each managed service to the compose env-var that
@@ -178,6 +204,7 @@ var serviceHostPortEnv = map[string]string{
 	"gotenberg":   EnvGotenbergHostPort,
 	"bonsai":      EnvBonsaiHostPort,
 	"kokoro":      EnvTTSHostPort,
+	"nvr":         EnvFrigateHostPort,
 }
 
 // HostPortEnv returns "KEY=value" entries for every citadel-managed host port,
@@ -282,17 +309,18 @@ const (
 // any of these. The collision guard test asserts the module registry, the apps
 // catalog, and the parsed compose files all avoid this set.
 var ReservedCitadelPorts = map[int]string{
-	GatewayPort:       "gateway/status-server",
-	GatewayHTTPSPort:  "gateway-https",
-	ControlMTLSPort:   "control-mtls",
-	TEIEmbeddingPort:  "tei-embeddings",
-	VNCWebsockifyPort: "vnc-websockify",
-	VNCPort:           "vnc-rfb",
-	DeskstreamPort:    "deskstream-h264",
-	TerminalPort:      "terminal-server",
-	LiveKitWSPort:     "livekit-signaling",
-	LiveKitICETCPPort: "livekit-ice-tcp",
-	LiveKitUDPMuxPort: "livekit-udp-mux",
+	GatewayPort:        "gateway/status-server",
+	GatewayHTTPSPort:   "gateway-https",
+	ControlMTLSPort:    "control-mtls",
+	TEIEmbeddingPort:   "tei-embeddings",
+	VNCWebsockifyPort:  "vnc-websockify",
+	VNCPort:            "vnc-rfb",
+	DeskstreamPort:     "deskstream-h264",
+	TerminalPort:       "terminal-server",
+	LiveKitWSPort:      "livekit-signaling",
+	LiveKitICETCPPort:  "livekit-ice-tcp",
+	LiveKitUDPMuxPort:  "livekit-udp-mux",
+	WyzeBridgeRTSPPort: "wyze-bridge-rtsp",
 }
 
 // AppsPortRange is the inclusive range apps auto-allocate host ports from

--- a/services/ports_test.go
+++ b/services/ports_test.go
@@ -119,17 +119,18 @@ func TestGotenbergHostPortRegistered(t *testing.T) {
 // two entries into one).
 func TestReservedCitadelPortsPairwiseDistinct(t *testing.T) {
 	wantEntries := map[int]string{
-		GatewayPort:       "gateway/status-server",
-		GatewayHTTPSPort:  "gateway-https",
-		ControlMTLSPort:   "control-mtls",
-		TEIEmbeddingPort:  "tei-embeddings",
-		VNCWebsockifyPort: "vnc-websockify",
-		VNCPort:           "vnc-rfb",
-		DeskstreamPort:    "deskstream-h264",
-		TerminalPort:      "terminal-server",
-		LiveKitWSPort:     "livekit-signaling",
-		LiveKitICETCPPort: "livekit-ice-tcp",
-		LiveKitUDPMuxPort: "livekit-udp-mux",
+		GatewayPort:        "gateway/status-server",
+		GatewayHTTPSPort:   "gateway-https",
+		ControlMTLSPort:    "control-mtls",
+		TEIEmbeddingPort:   "tei-embeddings",
+		VNCWebsockifyPort:  "vnc-websockify",
+		VNCPort:            "vnc-rfb",
+		DeskstreamPort:     "deskstream-h264",
+		TerminalPort:       "terminal-server",
+		LiveKitWSPort:      "livekit-signaling",
+		LiveKitICETCPPort:  "livekit-ice-tcp",
+		LiveKitUDPMuxPort:  "livekit-udp-mux",
+		WyzeBridgeRTSPPort: "wyze-bridge-rtsp",
 	}
 	if len(ReservedCitadelPorts) != len(wantEntries) {
 		t.Errorf("ReservedCitadelPorts has %d entries, want %d — a port constant collision collapses two listeners onto one port (see #504)",
@@ -195,6 +196,54 @@ func TestBonsaiHostPortRegistered(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("HostPortEnv() did not emit %q", want)
+	}
+}
+
+// TestFrigateHostPortRegistered pins the nvr camera-NVR module's Frigate web
+// UI/API host port (aceteam-ai/citadel-cli#597). Like claudecode/meeting/
+// gotenberg, the nvr module's compose lives in citadel-services (not the embedded
+// ServiceMap), so this registry -- and this test -- is the only thing that stops
+// a future module from hardcoding over 8212. The registry KEY is the module name
+// "nvr" while the env var is spelled CITADEL_FRIGATE_HOST_PORT (the container it
+// maps to), the same key/env split as meeting.
+func TestFrigateHostPortRegistered(t *testing.T) {
+	got, ok := ServiceHostPorts["nvr"]
+	if !ok || got != FrigateHostPort {
+		t.Errorf("ServiceHostPorts[%q] = %d (present=%v), want %d", "nvr", got, ok, FrigateHostPort)
+	}
+	if _, ok := serviceHostPortEnv["nvr"]; !ok {
+		t.Errorf("serviceHostPortEnv is missing %q; HostPortEnv() will not inject its host port", "nvr")
+	}
+	if FrigateHostPort >= AppsPortRangeStart && FrigateHostPort <= AppsPortRangeEnd {
+		t.Errorf("frigate host port %d sits inside the apps auto-allocation range %d-%d", FrigateHostPort, AppsPortRangeStart, AppsPortRangeEnd)
+	}
+	if name, taken := ReservedCitadelPorts[FrigateHostPort]; taken {
+		t.Errorf("frigate host port %d collides with reserved citadel port %q", FrigateHostPort, name)
+	}
+	// 8211 is kokoro's; frigate must be the distinct next slot.
+	if FrigateHostPort == TTSHostPort {
+		t.Errorf("FrigateHostPort %d collides with TTSHostPort; 8211 is taken, frigate must be the next free slot", FrigateHostPort)
+	}
+	for svc, port := range ServiceHostPorts {
+		if svc != "nvr" && port == FrigateHostPort {
+			t.Errorf("frigate host port %d collides with managed service %q", FrigateHostPort, svc)
+		}
+	}
+	// HostPortEnv must emit the frigate var so the module compose resolves.
+	want := EnvFrigateHostPort + "=8212"
+	found := false
+	for _, kv := range HostPortEnv() {
+		if kv == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("HostPortEnv() did not emit %q", want)
+	}
+	// The wyze-bridge host-net RTSP port must be reserved (frigate depends on it,
+	// and it is bound directly on the host like the LiveKit SFU ports).
+	if name, ok := ReservedCitadelPorts[WyzeBridgeRTSPPort]; !ok || name != "wyze-bridge-rtsp" {
+		t.Errorf("ReservedCitadelPorts[%d] = %q (present=%v), want wyze-bridge-rtsp", WyzeBridgeRTSPPort, name, ok)
 	}
 }
 


### PR DESCRIPTION
Closes #597 (node-side). Packages the hand-built SJC NVR stack (docker-wyze-bridge + Frigate) as an assignable Citadel **catalog module** (`nvr`).

## Context
A reference NVR is running by hand on node 1314 (mini, SJC) recording to Synology NFS. This turns it into a catalog SKU deployable via `fabric_node_module_set module=nvr`.

## Design (subsystem — important)
`nvr` is a **catalog module**, NOT a `services.ServiceMap` embedded engine. It deploys via `fabric_node_module_set` → `MODULE_SET` → catalog `InstallFromManifest` → `docker compose up`, exactly like `meeting`/`gotenberg`. (ServiceMap is the SERVICE_START/engine path — vllm/bonsai — and is deliberately untouched.)

## Changes
- `services/nvr-service/service.yaml` — `catalog.ServiceManifest` (schema v2): `sandbox.host_network` (wyze-bridge TUTK), `sandbox.devices [/dev/dri/renderD128]`, the assignment config schema, frigate host 8212→container 5000 + `/api/version` health check, a data-only `gateway:` block (exposure is #598's job).
- `services/nvr-service/compose.yml` — wyze-bridge (`network_mode: host`) + `nvr-config` init container + frigate (`/dev/dri`, `${CITADEL_FRIGATE_HOST_PORT}:5000`).
- `internal/nvr/{config.go,storage.go}` (+tests) — `GenerateFrigateConfig`, `VerifyMediaIsNetworkFS` (statfs), `ResolveMediaSource`, `FstabEntry`, `ParseCameras`.
- `cmd/nvrconfig/main.go` — init-container entrypoint (reuses `internal/nvr`, single source of truth).
- `services/nvr-service/Dockerfile` + `.github/workflows/build-nvr-service.yml` — build/publish `ghcr.io/aceteam-ai/nvr-config`.
- `services/ports.go` (+test) — frigate host port 8212, reserved wyze RTSP 8554.

## Scars baked in as requirements
Host networking (TUTK discovery timeout otherwise); explicit Frigate 0.17 detector `model:` path; migrated `record.continuous.days`; `/config` (SQLite) always local, only `/media` follows storage; `nas` mode statfs-verifies a real root-writable network mount before starting (a failed NFS mount silently writes local); no transcode, retention by days (Synology quota invisible to `df`).

## Testing
`go build/vet/test ./...` green. Unit tests cover config generation (openvino vs cpu, retention migration), the statfs NAS guard, camera parsing, port registration, and manifest shape.

## Required cross-repo follow-up (different repo — NOT in this PR)
For the fabric to resolve `module=nvr`, publish `services/nvr/{service.yaml,compose.yml}` + a `registry.yaml` entry to **`aceteam-ai/citadel-services`** (mirror gotenberg/citadel-services#10). Acceptance is then hardware-gated on node 1314 (real cameras + Synology `surveillance` NFS), both `storage.mode=nas` and `local` — steps in the manifest/PR discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)