### PR TITLE
fix(instance): reattach to running TUI cleanly — no surprise shell, no Ctrl-D freeze

### DIFF
--- a/cmd/attach.go
+++ b/cmd/attach.go
@@ -37,7 +37,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aceteam-ai/citadel-cli/internal/instance"
 	"github.com/aceteam-ai/citadel-cli/internal/network"
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
 	"github.com/aceteam-ai/citadel-cli/internal/worklock"
 	"github.com/spf13/cobra"
 )
@@ -54,7 +56,10 @@ client of it. 'citadel attach' names the running instance (PID, version, uptime)
 and shows its live node identity, health, and managed services, read from the
 worker's local status server.
 
-If no worker is running, it says so and points you at 'citadel work'.`,
+If no worker is running, it says so and points you at 'citadel work'.
+
+Use --shell to instead open an interactive shell on the running control center
+(the TUI you launched with 'citadel'). Ctrl+] detaches; Ctrl-D exits the shell.`,
 	RunE:         runAttach,
 	SilenceUsage: true,
 	// The no-worker path prints its own friendly guidance and returns
@@ -68,13 +73,39 @@ If no worker is running, it says so and points you at 'citadel work'.`,
 // scripts while keeping the message clean.
 var errNoRunningWorker = fmt.Errorf("no citadel worker is running on this node")
 
+// errNoRunningInstance is the --shell counterpart: returned (exit 1) when no
+// control-center TUI (the citadel.sock instance) is running to open a shell on.
+var errNoRunningInstance = fmt.Errorf("no citadel control center is running on this node")
+
+// attachShell, when set, opens an interactive shell on the running control-center
+// instance (the citadel.sock/instance mechanism) instead of printing the worker
+// status banner. NOTE: this targets the INSTANCE (TUI) mechanism, distinct from
+// the default banner which reads the WORKER lock — two independent "is citadel
+// running?" surfaces on a node.
+var attachShell bool
+
 func init() {
+	attachCmd.Flags().BoolVar(&attachShell, "shell", false,
+		"Open an interactive shell on the running control center (instead of printing status). Ctrl+] detaches; Ctrl-D exits the shell.")
 	rootCmd.AddCommand(attachCmd)
 }
 
 // runAttach discovers the running worker via the single-instance lock and prints
 // the attach view, or a "nothing to attach to" message when none is running.
 func runAttach(_ *cobra.Command, _ []string) error {
+	// --shell: open an interactive shell on the running control-center instance
+	// (the citadel.sock mechanism, distinct from the worker lock below). This is
+	// the explicit opt-in escape hatch for the behavior bare `citadel` used to do
+	// by default — now bare `citadel` just names the running TUI and exits.
+	if attachShell {
+		configDir := platform.ConfigDir()
+		if !instance.IsRunning(configDir) {
+			fmt.Fprintln(os.Stdout, "No Citadel control center is running on this node. Start one with:  citadel")
+			return errNoRunningInstance
+		}
+		return instance.Attach(configDir)
+	}
+
 	stateDir := network.GetStateDir()
 
 	// IsHeld is the authoritative liveness check (flock probe + PID liveness +

--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -176,13 +176,20 @@ func runControlCenter() {
 		os.Exit(1)
 	}
 
-	// Single-instance detection: if another TUI is running, attach to it
+	// Single-instance detection: a control-center TUI is already running (it holds
+	// citadel.sock) in another terminal. Two terminals cannot share one bubbletea
+	// TUI, so name the running instance and exit cleanly rather than silently
+	// dropping the user into a surprise shell on the node (the reported confusion:
+	// "this should've reattached to the TUI but went to a console"). An explicit
+	// shell into the node remains available via `citadel attach --shell`.
 	configDir := platform.ConfigDir()
 	if instance.IsRunning(configDir) {
-		if err := instance.Attach(configDir); err != nil {
-			fmt.Fprintf(os.Stderr, "Attach failed: %v\n", err)
-			os.Exit(1)
+		if pid := instance.PID(configDir); pid > 0 {
+			fmt.Fprintf(os.Stderr, "Citadel control center is already running (PID %d) in another terminal.\n", pid)
+		} else {
+			fmt.Fprintln(os.Stderr, "Citadel control center is already running in another terminal.")
 		}
+		fmt.Fprintln(os.Stderr, "Switch to that terminal to use it, or run `citadel attach --shell` for a shell on this node.")
 		return
 	}
 

--- a/internal/instance/instance_test.go
+++ b/internal/instance/instance_test.go
@@ -3,12 +3,117 @@
 package instance
 
 import (
+	"io"
 	"net"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 )
+
+// fakePTY is a ptyIO whose Read blocks until released, so relaySession's
+// teardown can be tested deterministically without a real PTY/shell. Releasing
+// it (or closing the conn) simulates the shell exiting.
+type fakePTY struct {
+	mu        sync.Mutex
+	writes    [][]byte
+	resizedTo [2]uint16
+	release   chan struct{} // Read returns io.EOF once closed (shell "exits")
+}
+
+func newFakePTY() *fakePTY { return &fakePTY{release: make(chan struct{})} }
+
+func (f *fakePTY) Read(p []byte) (int, error) {
+	<-f.release
+	return 0, io.EOF
+}
+
+func (f *fakePTY) exit() { close(f.release) }
+
+func (f *fakePTY) Write(p []byte) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.writes = append(f.writes, append([]byte(nil), p...))
+	return len(p), nil
+}
+
+func (f *fakePTY) Resize(cols, rows uint16) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.resizedTo = [2]uint16{cols, rows}
+	return nil
+}
+
+// TestRelaySession_ShellExitClosesConn is the regression test for the reported
+// freeze: when the shell exits (session.Read returns EOF), relaySession must
+// close the conn so BOTH the relay loop and the attached client detach, instead
+// of hanging on their respective conn.Read.
+func TestRelaySession_ShellExitClosesConn(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	session := newFakePTY()
+
+	done := make(chan struct{})
+	go func() {
+		relaySession(serverConn, session)
+		close(done)
+	}()
+
+	session.exit() // the shell exits
+
+	// The attached client must observe the connection close (EOF), not hang.
+	_ = clientConn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 16)
+	if _, err := clientConn.Read(buf); err == nil {
+		t.Fatal("client Read returned nil error after shell exit; expected the conn to be closed")
+	}
+
+	// relaySession itself must return (its client->PTY loop unblocked by the close).
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("relaySession did not return after shell exit — teardown hung (the freeze regression)")
+	}
+	_ = clientConn.Close()
+}
+
+// TestRelaySession_ResizeMessage verifies a 5-byte resize frame is applied to
+// the session and not forwarded as shell input.
+func TestRelaySession_ResizeMessage(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	session := newFakePTY() // Read blocks (shell alive) so the relay stays up
+	defer session.exit()    // release the PTY->client goroutine at the end
+
+	done := make(chan struct{})
+	go func() {
+		relaySession(serverConn, session)
+		close(done)
+	}()
+
+	// Send a resize frame: 0x00, cols=120 (LE), rows=40 (LE).
+	frame := []byte{0x00, 120, 0, 40, 0}
+	_ = clientConn.SetWriteDeadline(time.Now().Add(time.Second))
+	if _, err := clientConn.Write(frame); err != nil {
+		t.Fatalf("write resize frame: %v", err)
+	}
+	_ = clientConn.Close() // ends the relay's client->PTY loop
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("relaySession did not return after client close")
+	}
+
+	session.mu.Lock()
+	got := session.resizedTo
+	sawWrite := len(session.writes)
+	session.mu.Unlock()
+	if got != [2]uint16{120, 40} {
+		t.Errorf("resize not applied: got %v, want [120 40]", got)
+	}
+	if sawWrite != 0 {
+		t.Errorf("resize frame must not be written to the shell as input, got %d writes", sawWrite)
+	}
+}
 
 func TestListenAndIsRunning(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/instance/server.go
+++ b/internal/instance/server.go
@@ -151,8 +151,31 @@ func (s *Server) handleClient(conn net.Conn) {
 	}
 	defer session.Close()
 
-	// PTY → client
+	relaySession(conn, session)
+}
+
+// ptyIO is the subset of *console.PTYSession that relaySession needs. It exists
+// so the relay teardown (the part that had the Ctrl-D-hang bug) is unit-testable
+// with a fake session and a net.Pipe, without spawning a real shell/PTY.
+type ptyIO interface {
+	Read(p []byte) (int, error)
+	Write(p []byte) (int, error)
+	Resize(cols, rows uint16) error
+}
+
+// relaySession pipes conn<->session bidirectionally until either side ends.
+//
+// CRITICAL teardown invariant: when the shell exits (session.Read returns EOF),
+// the PTY->client goroutine MUST close conn. The client->PTY loop below is
+// blocked on conn.Read, and the attached client is blocked on its own conn.Read;
+// nothing else closes conn. Without this, a Ctrl-D that exits the shell left the
+// attach session hung forever (the reported freeze). Closing conn unblocks both
+// this loop and the client, so both detach cleanly. Double-close is harmless.
+func relaySession(conn net.Conn, session ptyIO) {
+	// PTY -> client. On exit (shell died / PTY EOF, or a write to a detached
+	// client), close conn so the client->PTY loop and the remote client tear down.
 	go func() {
+		defer conn.Close()
 		buf := make([]byte, 4096)
 		for {
 			n, err := session.Read(buf)
@@ -167,7 +190,7 @@ func (s *Server) handleClient(conn net.Conn) {
 		}
 	}()
 
-	// client → PTY (with resize detection)
+	// client -> PTY (with resize detection).
 	buf := make([]byte, 4096)
 	for {
 		n, err := conn.Read(buf)


### PR DESCRIPTION
## Context
Reported live on ubuntu-gpu: running bare `citadel` while a control-center TUI was already running printed *"Citadel is already running (PID 2685359). Starting a new shell on the running instance… Press Ctrl+] to detach."* and dropped into a **plain shell** instead of reattaching to the TUI — then **froze on Ctrl-D**.

## Root cause
Two problems in the single-instance attach path (`internal/instance`, from #276):

1. **Freeze (server.go):** on shell exit the PTY→client goroutine `return`ed *without closing `conn`*. Both the server's client→PTY loop and the attached client were blocked on `conn.Read`, and nothing else closed the connection — so Ctrl-D exited the shell but the attach session hung forever.
2. **Surprise shell (controlcenter.go):** `runControlCenter` detected the running instance and silently opened a *fresh* shell (exec-style), which is not what "reattach to the TUI" implies. Two terminals genuinely can't share one bubbletea TUI.

## Changes
- `internal/instance/server.go`: extract the relay into a testable `relaySession()`; its PTY→client goroutine now `defer conn.Close()` so shell-exit tears down both directions (symmetric with the client-detach direction). Double-close is harmless.
- `internal/instance/instance_test.go`: race-tested teardown regression test (fake PTY + `net.Pipe`) that **hangs without the fix**; plus a resize-frame test.
- `cmd/controlcenter.go`: bare `citadel` when a TUI is already running now **names the running instance (PID) and exits cleanly** instead of opening a shell.
- `cmd/attach.go`: the explicit shell escape hatch moves to **`citadel attach --shell`**, sourced from the **instance** socket/PID (NOT the `worklock` worker mechanism — a separate "is citadel running?" surface that must not be conflated).

## Testing
`go build/vet/test ./...` green; the teardown test passes under `-race` (and times out without the fix). Behavior change is a clean message + exit.

## Note
The live node runs v2.87.0 and auto-updates from releases, so this reaches it only after a release lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)