### PR TITLE
Add shellEnabled device-config toggle (default-off + passcode) for remote node-management

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -2032,6 +2032,7 @@ func runTUIWorker(ctx context.Context, activityFn func(level, msg string)) error
 		ConfigDir:                 ccConfigDir,
 		AllowReadOutsideWorkspace: resolveAllowReadOutsideWorkspace(),
 		ShellDisabled:             !ccPerms.Shell,
+		ShellVerifyPasscode:       nodePasscodeVerifier,
 		DesktopDisabled:           !ccPerms.Desktop,
 		FilesDisabled:             !ccPerms.Files,
 		WorkflowExec:              ccWfExec,

--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -2032,6 +2032,7 @@ func runTUIWorker(ctx context.Context, activityFn func(level, msg string)) error
 		ConfigDir:                 ccConfigDir,
 		AllowReadOutsideWorkspace: resolveAllowReadOutsideWorkspace(),
 		ShellDisabled:             !ccPerms.Shell,
+		ShellHasPasscode:          nodeHasPasscode,
 		ShellVerifyPasscode:       nodePasscodeVerifier,
 		DesktopDisabled:           !ccPerms.Desktop,
 		FilesDisabled:             !ccPerms.Files,

--- a/cmd/job_handlers.go
+++ b/cmd/job_handlers.go
@@ -15,6 +15,17 @@ import (
 // A map to hold all our registered job handlers.
 var jobHandlers map[string]jobs.JobHandler
 
+// nodePasscodeVerifier verifies a presented passcode against the node's persisted
+// bcrypt passcode (aceteam#6524). It reloads permissions on every call so a
+// passcode set/rotated via APPLY_DEVICE_CONFIG or the control center takes effect
+// without a worker restart, mirroring the gateway's per-request passcode gate.
+// Wired into the SHELL_COMMAND handler so an ENABLED shell still fails closed
+// unless the correct node passcode is presented. VerifyPasscode itself fails
+// closed (no passcode set, or empty/wrong pin, returns false).
+func nodePasscodeVerifier(pin string) bool {
+	return config.LoadPermissions(platform.ConfigDir()).VerifyPasscode(pin)
+}
+
 // executeJob finds the right handler and runs a job.
 func executeJob(client *nexus.Client, job *nexus.Job) (string, error) {
 	var output []byte
@@ -61,6 +72,10 @@ func init() {
 	// run commands as root regardless of the permission (aceteam #6149, Phase 0).
 	shellHandler := jobs.NewShellCommandHandler("")
 	shellHandler.Disabled = !config.LoadPermissions(platform.ConfigDir()).Shell
+	// Even on this legacy Nexus/diagnostic path an enabled shell is passcode-gated
+	// (aceteam#6524): executeJob polls remote jobs and reports back, so leaving the
+	// verifier nil here would run enabled shell with no passcode. Fail closed.
+	shellHandler.VerifyPasscode = nodePasscodeVerifier
 
 	// Register all job handlers for test command
 	jobHandlers = map[string]jobs.JobHandler{

--- a/cmd/job_handlers.go
+++ b/cmd/job_handlers.go
@@ -26,6 +26,15 @@ func nodePasscodeVerifier(pin string) bool {
 	return config.LoadPermissions(platform.ConfigDir()).VerifyPasscode(pin)
 }
 
+// nodeHasPasscode reports whether a node passcode is configured (aceteam#6524).
+// It reloads permissions on every call, mirroring nodePasscodeVerifier, so the
+// SHELL_COMMAND handler can distinguish "no passcode set" (passcode_not_set)
+// from "wrong passcode presented" (passcode_invalid) without a worker restart.
+// HasPasscode reports only presence, never the hash.
+func nodeHasPasscode() bool {
+	return config.LoadPermissions(platform.ConfigDir()).HasPasscode()
+}
+
 // executeJob finds the right handler and runs a job.
 func executeJob(client *nexus.Client, job *nexus.Job) (string, error) {
 	var output []byte
@@ -75,6 +84,8 @@ func init() {
 	// Even on this legacy Nexus/diagnostic path an enabled shell is passcode-gated
 	// (aceteam#6524): executeJob polls remote jobs and reports back, so leaving the
 	// verifier nil here would run enabled shell with no passcode. Fail closed.
+	// HasPasscode lets the handler distinguish passcode_not_set from passcode_invalid.
+	shellHandler.HasPasscode = nodeHasPasscode
 	shellHandler.VerifyPasscode = nodePasscodeVerifier
 
 	// Register all job handlers for test command

--- a/cmd/job_handlers_shell_test.go
+++ b/cmd/job_handlers_shell_test.go
@@ -31,6 +31,17 @@ func TestLegacyShellHandlerHonorsKillSwitch(t *testing.T) {
 		t.Errorf("legacy SHELL_COMMAND handler Disabled=%v, want %v (from persisted shell permission)",
 			shell.Disabled, wantDisabled)
 	}
+
+	// Both passcode signals must be wired so an ENABLED shell fails closed and can
+	// distinguish passcode_not_set from passcode_invalid (aceteam#6524). A nil
+	// HasPasscode would refuse every command as passcode_not_set even when the
+	// operator set a correct passcode (a silent functional regression).
+	if shell.HasPasscode == nil {
+		t.Error("legacy SHELL_COMMAND handler HasPasscode is nil; must be wired from the persisted node passcode")
+	}
+	if shell.VerifyPasscode == nil {
+		t.Error("legacy SHELL_COMMAND handler VerifyPasscode is nil; must be wired from the persisted node passcode")
+	}
 }
 
 // TestLegacyShellHandlerDefaultDeny confirms that, absent an explicit opt-in

--- a/cmd/nodejobs.go
+++ b/cmd/nodejobs.go
@@ -23,6 +23,10 @@ type nodeJobHandlerOpts struct {
 	AllowReadOutsideWorkspace bool
 	// ShellDisabled registers SHELL_COMMAND in a refusing state (still dispatchable).
 	ShellDisabled bool
+	// ShellVerifyPasscode gates an ENABLED SHELL_COMMAND handler on the per-node
+	// passcode (aceteam#6524). Required whenever ShellDisabled is false: a nil
+	// verifier makes shell fail closed. Wired from the persisted node passcode.
+	ShellVerifyPasscode func(pin string) bool
 	// DesktopDisabled skips registration of the screen/VNC/desktop handlers
 	// (aceteam#6524). Wired from the persisted `desktop` node permission
 	// (default-DENY on a fresh node).
@@ -53,6 +57,7 @@ func buildNodeJobHandlers(opts nodeJobHandlerOpts) []worker.JobHandler {
 		ConfigDir:                 opts.ConfigDir,
 		AllowReadOutsideWorkspace: opts.AllowReadOutsideWorkspace,
 		ShellDisabled:             opts.ShellDisabled,
+		ShellVerifyPasscode:       opts.ShellVerifyPasscode,
 		DesktopDisabled:           opts.DesktopDisabled,
 		FilesDisabled:             opts.FilesDisabled,
 	})

--- a/cmd/nodejobs.go
+++ b/cmd/nodejobs.go
@@ -23,6 +23,11 @@ type nodeJobHandlerOpts struct {
 	AllowReadOutsideWorkspace bool
 	// ShellDisabled registers SHELL_COMMAND in a refusing state (still dispatchable).
 	ShellDisabled bool
+	// ShellHasPasscode reports whether a node passcode is configured, so an enabled
+	// shell can distinguish passcode_not_set from passcode_invalid. Required whenever
+	// ShellDisabled is false: a nil signal makes shell fail closed. Wired from the
+	// persisted node passcode.
+	ShellHasPasscode func() bool
 	// ShellVerifyPasscode gates an ENABLED SHELL_COMMAND handler on the per-node
 	// passcode (aceteam#6524). Required whenever ShellDisabled is false: a nil
 	// verifier makes shell fail closed. Wired from the persisted node passcode.
@@ -57,6 +62,7 @@ func buildNodeJobHandlers(opts nodeJobHandlerOpts) []worker.JobHandler {
 		ConfigDir:                 opts.ConfigDir,
 		AllowReadOutsideWorkspace: opts.AllowReadOutsideWorkspace,
 		ShellDisabled:             opts.ShellDisabled,
+		ShellHasPasscode:          opts.ShellHasPasscode,
 		ShellVerifyPasscode:       opts.ShellVerifyPasscode,
 		DesktopDisabled:           opts.DesktopDisabled,
 		FilesDisabled:             opts.FilesDisabled,

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -2022,6 +2022,7 @@ func runWork(cmd *cobra.Command, args []string) {
 		ConfigDir:                 workConfigDir,
 		AllowReadOutsideWorkspace: resolveAllowReadOutsideWorkspace(),
 		ShellDisabled:             !workPerms.Shell,
+		ShellVerifyPasscode:       nodePasscodeVerifier,
 		DesktopDisabled:           !workPerms.Desktop,
 		FilesDisabled:             !workPerms.Files,
 		WorkflowExec:              wfExec,

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -2022,6 +2022,7 @@ func runWork(cmd *cobra.Command, args []string) {
 		ConfigDir:                 workConfigDir,
 		AllowReadOutsideWorkspace: resolveAllowReadOutsideWorkspace(),
 		ShellDisabled:             !workPerms.Shell,
+		ShellHasPasscode:          nodeHasPasscode,
 		ShellVerifyPasscode:       nodePasscodeVerifier,
 		DesktopDisabled:           !workPerms.Desktop,
 		FilesDisabled:             !workPerms.Files,

--- a/docs/capability-toggles.md
+++ b/docs/capability-toggles.md
@@ -124,6 +124,16 @@ actual access:
    `FilesDisabled` opts). A fresh node refuses those jobs. `TRANSCRIBE_AUDIO` and
    `MEETING_JOIN` share the workspace but belong to the default-ON meeting
    capability and are deliberately **not** gated.
+   - **Shell** (`SHELL_COMMAND`) is the odd one out: it has **no gateway/HTTP
+     route** (`categoryForPath` never returns `shell`), so it is gated entirely on
+     the Redis job path. The handler is always registered (so a disabled node
+     returns the "disabled" refusal rather than "unsupported job type"), but it
+     refuses unless `shell` is enabled **and** the job presents the correct node
+     passcode. The passcode travels in the `SHELL_COMMAND` payload's `passcode`
+     field (there is no header, unlike console/desktop/files). Fail-closed: an
+     enabled handler whose passcode verifier was never wired, or a wrong/absent
+     payload passcode, refuses every command. This governs the platform's
+     node-management tabs (logs/services/docker), which run shell commands.
 3. **HTTPS gateway** (`internal/gateway/gateway.go`): `permissionMiddleware`
    blocks a disabled category, and for an enabled sensitive category additionally
    requires the passcode (`X-Citadel-Passcode` header, or `?passcode=` for
@@ -139,19 +149,28 @@ actual access:
 
 ### Enabling a surface
 
-- **Control Center:** the Built-in Services modal toggles console/desktop/files.
-  Enabling one with no passcode set warns that access stays denied until a
-  passcode is set.
+- **Control Center:** the Built-in Services modal toggles
+  console/desktop/files/shell. Enabling one with no passcode set warns that
+  access stays denied until a passcode is set.
 - **Programmatic (`APPLY_DEVICE_CONFIG`):** `DeviceConfig` carries
-  `consoleEnabled` / `desktopEnabled` / `filesEnabled` (`*bool`, nil = untouched)
-  and `nodePasscode` (`*string`, bcrypt-hashed before persist; empty clears it).
-  This writes the same `permissions.yaml` the gates read.
+  `consoleEnabled` / `desktopEnabled` / `filesEnabled` / `shellEnabled` (`*bool`,
+  nil = untouched) and `nodePasscode` (`*string`, bcrypt-hashed before persist;
+  empty clears it). This writes the same `permissions.yaml` the gates read. To
+  enable remote shell for the node-management tabs, send
+  `{"shellEnabled": true, "nodePasscode": "<pin>"}`; the tabs must then present
+  that same `<pin>` in each `SHELL_COMMAND` payload's `passcode` field.
 
 ### Cross-repo follow-up (aceteam web console, not in this repo)
 
-The web console should render console/desktop/files as **opt-in** (an "enable +
-set passcode" call to action) rather than presenting a live console for a node
-that has not enabled the surface, and must send the passcode on the
-`X-Citadel-Passcode` header (or `?passcode=` for the WebSocket terminal/VNC).
-Track alongside the mesh-ACL / cross-org work ([[citadel-mesh-security]] #5028):
-that work is about cross-org exposure, this is per-node owner consent.
+The web console should render console/desktop/files/shell as **opt-in** (an
+"enable + set passcode" call to action) rather than presenting a live surface for
+a node that has not enabled it, and must send the passcode on the
+`X-Citadel-Passcode` header (or `?passcode=` for the WebSocket terminal/VNC). For
+**shell** specifically (the node-management logs/services/docker tabs, aceteam
+#6559), the enable call is `APPLY_DEVICE_CONFIG {"shellEnabled": true,
+"nodePasscode": "<pin>"}` and each dispatched `SHELL_COMMAND` must carry the pin
+in its `passcode` payload field (shell has no HTTP header path). How the web
+attaches that pin per dispatch (human-entered once vs stored for the session) is
+the web side's decision. Track alongside the mesh-ACL / cross-org work
+([[citadel-mesh-security]] #5028): that work is about cross-org exposure, this is
+per-node owner consent.

--- a/docs/capability-toggles.md
+++ b/docs/capability-toggles.md
@@ -131,9 +131,35 @@ actual access:
      refuses unless `shell` is enabled **and** the job presents the correct node
      passcode. The passcode travels in the `SHELL_COMMAND` payload's `passcode`
      field (there is no header, unlike console/desktop/files). Fail-closed: an
-     enabled handler whose passcode verifier was never wired, or a wrong/absent
-     payload passcode, refuses every command. This governs the platform's
-     node-management tabs (logs/services/docker), which run shell commands.
+     enabled handler whose passcode signals were never wired, a node with no
+     passcode set, or a wrong/absent payload passcode, refuses every command. This
+     governs the platform's node-management tabs (logs/services/docker), which run
+     shell commands.
+
+     **Machine-readable refusal (aceteam#6559/#6597/#6598).** A refused
+     `SHELL_COMMAND` returns a typed error (`jobs.ShellRefusal`) whose message is a
+     JSON object so the platform frontend can prompt the operator precisely instead
+     of surfacing a raw string:
+
+     ```json
+     {"reason":"<code>","message":"<human readable>"}
+     ```
+
+     `reason` is exactly one of three codes, checked in this order:
+
+     | `reason` | When | Frontend prompt |
+     |----------|------|-----------------|
+     | `shell_disabled` | The shell surface is off (`shell: false`). | Offer "enable Shell". |
+     | `passcode_not_set` | Shell is enabled but **no** node passcode is configured, so there is nothing to check against. | Offer "set a node passcode". |
+     | `passcode_invalid` | A passcode **is** configured but the payload passcode is absent or wrong. | Re-prompt for the correct passcode. |
+
+     The node distinguishes `passcode_not_set` from `passcode_invalid` via a
+     `HasPasscode` signal (reports only whether a passcode exists, never the hash)
+     alongside `VerifyPasscode`. Both are wired from `permissions.yaml` at every
+     construction site (`worker.CreateLegacyHandlersWithOpts`, the `citadel work`
+     and control-center worker builds, and the legacy `cmd/job_handlers` map). The
+     JSON is produced with `encoding/json` (not string concatenation), so a
+     `message` containing quotes stays valid JSON.
 3. **HTTPS gateway** (`internal/gateway/gateway.go`): `permissionMiddleware`
    blocks a disabled category, and for an enabled sensitive category additionally
    requires the passcode (`X-Citadel-Passcode` header, or `?passcode=` for

--- a/internal/jobs/config_handler.go
+++ b/internal/jobs/config_handler.go
@@ -71,6 +71,17 @@ type DeviceConfig struct {
 	DesktopEnabled *bool `json:"desktopEnabled,omitempty"`
 	FilesEnabled   *bool `json:"filesEnabled,omitempty"`
 
+	// ShellEnabled is the programmatic opt-IN for remote shell command execution
+	// (SHELL_COMMAND jobs) — the surface behind the platform's node-management tabs
+	// (logs/services/docker), which run shell commands. Pointer for the same
+	// absent(nil)-vs-explicit reason as the other *Enabled flags: an omitted field
+	// leaves the node's persisted `shell` permission untouched. Default-DENY on a
+	// fresh node (aceteam#6524 / #6149), so the platform must send `true` here
+	// (together with a NodePasscode) to enable it. Even enabled, shell stays
+	// fail-closed until a passcode is set AND presented per SHELL_COMMAND, exactly
+	// like console/desktop/files.
+	ShellEnabled *bool `json:"shellEnabled,omitempty"`
+
 	// NodePasscode sets (or, when empty, clears) the per-node passcode that gates
 	// the sensitive surfaces (aceteam#6524). Pointer so nil leaves the stored
 	// passcode untouched; a non-nil value is bcrypt-hashed before it is persisted
@@ -169,7 +180,7 @@ func (h *ConfigHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) 
 	// Written to platform.ConfigDir() (the per-concern config location the gates
 	// read), not h.ConfigDir (the manifest dir). Only the fields the platform set
 	// are touched; nil pointers leave the persisted value intact.
-	if config.ConsoleEnabled != nil || config.DesktopEnabled != nil || config.FilesEnabled != nil || config.NodePasscode != nil {
+	if config.ConsoleEnabled != nil || config.DesktopEnabled != nil || config.FilesEnabled != nil || config.ShellEnabled != nil || config.NodePasscode != nil {
 		perms := citadelconfig.LoadPermissions(platform.ConfigDir())
 		if config.ConsoleEnabled != nil {
 			perms.Console = *config.ConsoleEnabled
@@ -179,6 +190,9 @@ func (h *ConfigHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) 
 		}
 		if config.FilesEnabled != nil {
 			perms.Files = *config.FilesEnabled
+		}
+		if config.ShellEnabled != nil {
+			perms.Shell = *config.ShellEnabled
 		}
 		if config.NodePasscode != nil {
 			if err := perms.SetPasscode(*config.NodePasscode); err != nil {
@@ -197,6 +211,9 @@ func (h *ConfigHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) 
 			if config.FilesEnabled != nil {
 				result += fmt.Sprintf("\nFiles (browse/host) access %s", enabledLabel(*config.FilesEnabled))
 			}
+			if config.ShellEnabled != nil {
+				result += fmt.Sprintf("\nShell (remote command) access %s", enabledLabel(*config.ShellEnabled))
+			}
 			if config.NodePasscode != nil {
 				if perms.HasPasscode() {
 					result += "\nNode passcode set"
@@ -207,7 +224,7 @@ func (h *ConfigHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) 
 			// Guardrail: an enabled surface with no passcode fails closed. Surface
 			// that in the job result so an operator who enabled without a passcode
 			// understands why access is still denied.
-			if (perms.Console || perms.Desktop || perms.Files) && !perms.HasPasscode() {
+			if (perms.Console || perms.Desktop || perms.Files || perms.Shell) && !perms.HasPasscode() {
 				result += "\nNote: a sensitive surface is enabled but no passcode is set — access stays denied until a passcode is set"
 			}
 		}

--- a/internal/jobs/config_handler.go
+++ b/internal/jobs/config_handler.go
@@ -72,7 +72,7 @@ type DeviceConfig struct {
 	FilesEnabled   *bool `json:"filesEnabled,omitempty"`
 
 	// ShellEnabled is the programmatic opt-IN for remote shell command execution
-	// (SHELL_COMMAND jobs) — the surface behind the platform's node-management tabs
+	// (SHELL_COMMAND jobs), the surface behind the platform's node-management tabs
 	// (logs/services/docker), which run shell commands. Pointer for the same
 	// absent(nil)-vs-explicit reason as the other *Enabled flags: an omitted field
 	// leaves the node's persisted `shell` permission untouched. Default-DENY on a

--- a/internal/jobs/config_handler_passcode_test.go
+++ b/internal/jobs/config_handler_passcode_test.go
@@ -98,6 +98,130 @@ func TestApplyDeviceConfig_EnablesConsoleAndSetsPasscode(t *testing.T) {
 	}
 }
 
+// TestDeviceConfig_ShellEnabledUnmarshal verifies shellEnabled carries the same
+// absent(nil)-vs-explicit pointer semantics as the other sensitive-surface flags,
+// so applying a device config that omits it never silently flips the shell
+// permission.
+func TestDeviceConfig_ShellEnabledUnmarshal(t *testing.T) {
+	var c DeviceConfig
+	if err := json.Unmarshal([]byte(`{"deviceName":"n"}`), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if c.ShellEnabled != nil {
+		t.Errorf("absent shellEnabled must be nil, got %+v", c.ShellEnabled)
+	}
+	if err := json.Unmarshal([]byte(`{"shellEnabled":true,"nodePasscode":"1379"}`), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if c.ShellEnabled == nil || !*c.ShellEnabled {
+		t.Error("explicit shellEnabled:true should be non-nil true")
+	}
+}
+
+// TestApplyDeviceConfig_EnablesShellAndSetsPasscode is the programmatic opt-in
+// for remote shell (aceteam#6524): APPLY_DEVICE_CONFIG with shellEnabled +
+// nodePasscode must persist the `shell` permission and a verifying passcode,
+// while leaving console/desktop/files untouched.
+func TestApplyDeviceConfig_EnablesShellAndSetsPasscode(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("SUDO_USER", "")
+	cfgDir := filepath.Join(dir, ".citadel-cli")
+	if err := os.MkdirAll(cfgDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.yaml"), []byte("node:\n  name: t\n"), 0600); err != nil {
+		t.Fatalf("marker: %v", err)
+	}
+
+	// Sanity: a fresh node refuses shell (default-deny) and has no passcode.
+	if p := citadelconfig.LoadPermissions(platform.ConfigDir()); p.Shell || p.HasPasscode() {
+		t.Fatalf("precondition: fresh node should refuse shell + have no passcode, got %+v", p)
+	}
+
+	manifestDir := filepath.Join(dir, "citadel-node")
+	if err := os.MkdirAll(manifestDir, 0755); err != nil {
+		t.Fatalf("mkdir manifest: %v", err)
+	}
+
+	h := NewConfigHandler(manifestDir)
+	payload, _ := json.Marshal(map[string]any{
+		"deviceName":   "peters-macbook",
+		"shellEnabled": true,
+		"nodePasscode": "2468",
+	})
+	job := &nexus.Job{
+		Type:    "APPLY_DEVICE_CONFIG",
+		Payload: map[string]string{"config": string(payload)},
+	}
+	if _, err := h.Execute(JobContext{}, job); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	p := citadelconfig.LoadPermissions(platform.ConfigDir())
+	if !p.Shell {
+		t.Error("shell should be enabled after APPLY_DEVICE_CONFIG")
+	}
+	if !p.VerifyPasscode("2468") {
+		t.Error("passcode should verify after APPLY_DEVICE_CONFIG")
+	}
+	if p.Console || p.Desktop || p.Files {
+		t.Error("console/desktop/files should remain disabled (only shell was pushed)")
+	}
+
+	// The plaintext PIN must never be written to disk.
+	raw, err := os.ReadFile(filepath.Join(cfgDir, "permissions.yaml"))
+	if err != nil {
+		t.Fatalf("read perms: %v", err)
+	}
+	if containsSub(string(raw), "2468") {
+		t.Error("permissions.yaml must not contain the plaintext PIN")
+	}
+}
+
+// TestApplyDeviceConfig_ShellOmittedLeavesPermissionUntouched confirms a device
+// config that does not mention shellEnabled preserves an already-enabled shell
+// permission (nil pointer = no-op), matching the other *Enabled flags.
+func TestApplyDeviceConfig_ShellOmittedLeavesPermissionUntouched(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("SUDO_USER", "")
+	cfgDir := filepath.Join(dir, ".citadel-cli")
+	if err := os.MkdirAll(cfgDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.yaml"), []byte("node:\n  name: t\n"), 0600); err != nil {
+		t.Fatalf("marker: %v", err)
+	}
+
+	// Pre-enable shell + set a passcode.
+	perms := citadelconfig.LoadPermissions(platform.ConfigDir())
+	perms.Shell = true
+	if err := perms.SetPasscode("2468"); err != nil {
+		t.Fatalf("set passcode: %v", err)
+	}
+	if err := citadelconfig.SavePermissions(platform.ConfigDir(), perms); err != nil {
+		t.Fatalf("save perms: %v", err)
+	}
+
+	manifestDir := filepath.Join(dir, "citadel-node")
+	if err := os.MkdirAll(manifestDir, 0755); err != nil {
+		t.Fatalf("mkdir manifest: %v", err)
+	}
+
+	// A config that only renames the device must not touch shell.
+	h := NewConfigHandler(manifestDir)
+	payload, _ := json.Marshal(map[string]any{"deviceName": "renamed"})
+	job := &nexus.Job{Type: "APPLY_DEVICE_CONFIG", Payload: map[string]string{"config": string(payload)}}
+	if _, err := h.Execute(JobContext{}, job); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if p := citadelconfig.LoadPermissions(platform.ConfigDir()); !p.Shell || !p.VerifyPasscode("2468") {
+		t.Errorf("shell/passcode must survive a config that omits shellEnabled, got %+v", p)
+	}
+}
+
 func containsSub(s, sub string) bool {
 	for i := 0; i+len(sub) <= len(s); i++ {
 		if s[i:i+len(sub)] == sub {

--- a/internal/jobs/shell_command.go
+++ b/internal/jobs/shell_command.go
@@ -22,6 +22,22 @@ import (
 // tests, so keep it stable.
 const ShellDisabledError = "shell command execution is not enabled on this node; enable the `shell` permission (set `shell: true` in permissions.yaml or toggle Shell in the AceTeam control center, then restart the worker)"
 
+// ShellPasscodeRequiredError is the exact message returned when SHELL_COMMAND
+// execution is enabled but the job did not present the correct per-node
+// passcode. Shell is a sensitive surface (aceteam#6524): enabling it is not the
+// same as opening it to anyone who can dispatch a job, so an enabled node
+// additionally requires the node passcode (the SAME bcrypt passcode that gates
+// console/desktop/files). Fails CLOSED: a node with no passcode set, a passcode
+// gate that was never wired, or a wrong/absent payload passcode is refused. The
+// wording is part of the handler's contract and is asserted in tests, so keep it
+// stable.
+const ShellPasscodeRequiredError = "shell command execution requires the node passcode; set a node passcode and present it in the SHELL_COMMAND payload `passcode` field"
+
+// ShellPasscodePayloadKey is the SHELL_COMMAND payload field carrying the
+// per-node passcode. The platform (aceteam#6559) must set this on every shell
+// dispatch once the node has Shell enabled, or the command is refused.
+const ShellPasscodePayloadKey = "passcode"
+
 // standardPATHDirs are directories ensured on PATH when the inherited process
 // environment is restricted (e.g. citadel running via systemd or nohup with a
 // minimal PATH). They are merged into the command environment so /bin/sh can
@@ -208,6 +224,16 @@ type ShellCommandHandler struct {
 	// `shell` node permission, which is default-deny (opt-in): unless a node
 	// explicitly enables Shell, callers set Disabled=true (aceteam #6149).
 	Disabled bool
+	// VerifyPasscode gates an ENABLED shell handler on the per-node passcode
+	// (aceteam#6524), mirroring how the gateway gates console/desktop/files: it
+	// checks the passcode presented in the SHELL_COMMAND payload (see
+	// ShellPasscodePayloadKey) against the node's bcrypt passcode. Fail-CLOSED
+	// contract: whenever the handler is enabled (Disabled==false) this MUST be
+	// wired; a nil verifier refuses every command, so a forgotten gate never
+	// silently opens root shell to anyone who can dispatch a job. The construction
+	// sites (worker.CreateLegacyHandlersWithOpts and the legacy cmd/job_handlers
+	// map) wire it from config.LoadPermissions(...).VerifyPasscode.
+	VerifyPasscode func(pin string) bool
 }
 
 // NewShellCommandHandler constructs a handler bound to a workspace directory.
@@ -220,6 +246,16 @@ func (h *ShellCommandHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, e
 	if h.Disabled {
 		ctx.Log("warn", "     - [Job %s] Refusing shell command: %s", job.ID, ShellDisabledError)
 		return nil, fmt.Errorf("%s", ShellDisabledError)
+	}
+
+	// Passcode gate (aceteam#6524): an ENABLED shell surface additionally requires
+	// the per-node passcode, so "enabled" is not "open to anyone who can dispatch a
+	// job". Fail CLOSED: a nil verifier (gate not wired) or a wrong/absent payload
+	// passcode refuses before any command runs. The passcode is read from a
+	// dedicated payload field and is never forwarded into the command environment.
+	if h.VerifyPasscode == nil || !h.VerifyPasscode(job.Payload[ShellPasscodePayloadKey]) {
+		ctx.Log("warn", "     - [Job %s] Refusing shell command: %s", job.ID, ShellPasscodeRequiredError)
+		return nil, fmt.Errorf("%s", ShellPasscodeRequiredError)
 	}
 
 	cmdString, ok := job.Payload["command"]

--- a/internal/jobs/shell_command.go
+++ b/internal/jobs/shell_command.go
@@ -13,25 +13,57 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
 )
 
-// ShellDisabledError is the exact message returned when SHELL_COMMAND execution
-// is not enabled on this node. Shell is default-deny (opt-in) as of aceteam #6149
-// Phase 0: a node accepts remote commands only after an operator explicitly
-// enables the `shell` permission (set `shell: true` in the node's
-// permissions.yaml, or toggle Shell in the AceTeam control center, then restart
-// the worker). The wording is part of the handler's contract and is asserted in
-// tests, so keep it stable.
-const ShellDisabledError = "shell command execution is not enabled on this node; enable the `shell` permission (set `shell: true` in permissions.yaml or toggle Shell in the AceTeam control center, then restart the worker)"
+// Shell refusal reason codes. A SHELL_COMMAND refusal returns a *ShellRefusal
+// whose Error() is a JSON object {"reason":"<code>","message":"<human>"} so the
+// platform frontend (aceteam#6559/#6597/#6598) can prompt the operator precisely
+// (enable shell, set a passcode, or fix the presented passcode) instead of
+// surfacing a raw error string. The codes are part of the handler's contract and
+// are asserted in tests, so keep them stable.
+const (
+	// ReasonShellDisabled means the shell surface is turned off entirely
+	// (h.Disabled==true). Shell is default-deny (opt-in) as of aceteam #6149
+	// Phase 0: a node accepts remote commands only after an operator explicitly
+	// enables the `shell` permission.
+	ReasonShellDisabled = "shell_disabled"
+	// ReasonPasscodeNotSet means shell is ENABLED but no node passcode is
+	// configured, so there is nothing to check the presented passcode against.
+	// Fails CLOSED: the operator must set a passcode before shell can run.
+	ReasonPasscodeNotSet = "passcode_not_set"
+	// ReasonPasscodeInvalid means a passcode IS configured but the presented
+	// payload passcode is absent or wrong.
+	ReasonPasscodeInvalid = "passcode_invalid"
+)
 
-// ShellPasscodeRequiredError is the exact message returned when SHELL_COMMAND
-// execution is enabled but the job did not present the correct per-node
-// passcode. Shell is a sensitive surface (aceteam#6524): enabling it is not the
-// same as opening it to anyone who can dispatch a job, so an enabled node
-// additionally requires the node passcode (the SAME bcrypt passcode that gates
-// console/desktop/files). Fails CLOSED: a node with no passcode set, a passcode
-// gate that was never wired, or a wrong/absent payload passcode is refused. The
-// wording is part of the handler's contract and is asserted in tests, so keep it
-// stable.
-const ShellPasscodeRequiredError = "shell command execution requires the node passcode; set a node passcode and present it in the SHELL_COMMAND payload `passcode` field"
+// Human-readable messages carried in a ShellRefusal.Message. Kept as constants
+// so the handler and its tests agree on the wording without duplicating the
+// literals.
+const (
+	msgShellDisabled   = "shell command execution is not enabled on this node; enable the `shell` permission (set `shell: true` in permissions.yaml or toggle Shell in the AceTeam control center, then restart the worker)"
+	msgPasscodeNotSet  = "shell command execution requires a node passcode, but none is set; set a node passcode (APPLY_DEVICE_CONFIG `nodePasscode` or the AceTeam control center) before dispatching shell commands"
+	msgPasscodeInvalid = "shell command execution requires the node passcode; present the correct passcode in the SHELL_COMMAND payload `passcode` field"
+)
+
+// ShellRefusal is the typed error returned when a SHELL_COMMAND is refused. Its
+// Error() renders a machine-readable JSON object
+// {"reason":"<code>","message":"<human>"} (marshaled via encoding/json, never
+// hand-concatenated, so a message containing quotes stays valid JSON). Reason is
+// one of the Reason* codes above. Callers should inspect the typed error via
+// errors.As and switch on Reason rather than string-matching the message.
+type ShellRefusal struct {
+	Reason  string `json:"reason"`
+	Message string `json:"message"`
+}
+
+// Error renders the refusal as a JSON object. Reason and Message are plain
+// strings so json.Marshal cannot fail here; the concatenated fallback exists
+// only to satisfy the error contract defensively and is never expected to run.
+func (e *ShellRefusal) Error() string {
+	b, err := json.Marshal(e)
+	if err != nil {
+		return `{"reason":"` + e.Reason + `","message":"shell command refused"}`
+	}
+	return string(b)
+}
 
 // ShellPasscodePayloadKey is the SHELL_COMMAND payload field carrying the
 // per-node passcode. The platform (aceteam#6559) must set this on every shell
@@ -219,11 +251,20 @@ type ShellCommandHandler struct {
 	// WorkspaceDir, when non-empty, is set as the command's working directory so
 	// relative paths resolve consistently with the file-operation handlers.
 	WorkspaceDir string
-	// Disabled, when true, makes Execute refuse every command with
-	// ShellDisabledError instead of running it. Wired from the persisted
+	// Disabled, when true, makes Execute refuse every command with a
+	// ReasonShellDisabled refusal instead of running it. Wired from the persisted
 	// `shell` node permission, which is default-deny (opt-in): unless a node
 	// explicitly enables Shell, callers set Disabled=true (aceteam #6149).
 	Disabled bool
+	// HasPasscode reports whether a node passcode is configured at all, WITHOUT
+	// leaking the hash. It lets Execute distinguish "no passcode set"
+	// (ReasonPasscodeNotSet: the operator must set one) from "wrong passcode
+	// presented" (ReasonPasscodeInvalid), which VerifyPasscode alone cannot do
+	// (both cases make VerifyPasscode return false). Fail-CLOSED contract: a nil
+	// HasPasscode, or HasPasscode()==false, is treated as "no passcode set" and
+	// refuses every command. The construction sites wire it from
+	// config.LoadPermissions(...).HasPasscode.
+	HasPasscode func() bool
 	// VerifyPasscode gates an ENABLED shell handler on the per-node passcode
 	// (aceteam#6524), mirroring how the gateway gates console/desktop/files: it
 	// checks the passcode presented in the SHELL_COMMAND payload (see
@@ -243,19 +284,34 @@ func NewShellCommandHandler(workspace string) *ShellCommandHandler {
 }
 
 func (h *ShellCommandHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	// Refusal decision order (aceteam#6524, #6559): shell_disabled beats
+	// passcode_not_set beats passcode_invalid. Each returns a typed *ShellRefusal
+	// carrying a machine-readable reason code so the platform can prompt the
+	// operator precisely. Fail CLOSED throughout: a nil HasPasscode or a nil
+	// VerifyPasscode still refuses, so a forgotten gate never silently opens root
+	// shell to anyone who can dispatch a job.
 	if h.Disabled {
-		ctx.Log("warn", "     - [Job %s] Refusing shell command: %s", job.ID, ShellDisabledError)
-		return nil, fmt.Errorf("%s", ShellDisabledError)
+		refusal := &ShellRefusal{Reason: ReasonShellDisabled, Message: msgShellDisabled}
+		ctx.Log("warn", "     - [Job %s] Refusing shell command: %s", job.ID, refusal.Message)
+		return nil, refusal
 	}
 
-	// Passcode gate (aceteam#6524): an ENABLED shell surface additionally requires
-	// the per-node passcode, so "enabled" is not "open to anyone who can dispatch a
-	// job". Fail CLOSED: a nil verifier (gate not wired) or a wrong/absent payload
-	// passcode refuses before any command runs. The passcode is read from a
-	// dedicated payload field and is never forwarded into the command environment.
+	// No passcode configured: nothing to check against, so the operator must set
+	// one before shell can run. A nil HasPasscode is treated as "not set".
+	if h.HasPasscode == nil || !h.HasPasscode() {
+		refusal := &ShellRefusal{Reason: ReasonPasscodeNotSet, Message: msgPasscodeNotSet}
+		ctx.Log("warn", "     - [Job %s] Refusing shell command: %s", job.ID, refusal.Message)
+		return nil, refusal
+	}
+
+	// A passcode IS configured: the job must present the correct one. The passcode
+	// is read from a dedicated payload field and is never forwarded into the
+	// command environment. A nil verifier (gate not wired) or a wrong/absent
+	// payload passcode refuses before any command runs.
 	if h.VerifyPasscode == nil || !h.VerifyPasscode(job.Payload[ShellPasscodePayloadKey]) {
-		ctx.Log("warn", "     - [Job %s] Refusing shell command: %s", job.ID, ShellPasscodeRequiredError)
-		return nil, fmt.Errorf("%s", ShellPasscodeRequiredError)
+		refusal := &ShellRefusal{Reason: ReasonPasscodeInvalid, Message: msgPasscodeInvalid}
+		ctx.Log("warn", "     - [Job %s] Refusing shell command: %s", job.ID, refusal.Message)
+		return nil, refusal
 	}
 
 	cmdString, ok := job.Payload["command"]

--- a/internal/jobs/shell_command_test.go
+++ b/internal/jobs/shell_command_test.go
@@ -9,6 +9,12 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
 )
 
+// allowPasscode is a test verifier that accepts any presented passcode. It lets
+// the pre-existing shell tests exercise the ENABLED execution path without
+// threading a real node passcode through each case; the passcode gate itself is
+// covered by the dedicated TestShellCommand_Passcode* cases below.
+func allowPasscode(string) bool { return true }
+
 func runShell(t *testing.T, h *ShellCommandHandler, command string) ([]byte, error) {
 	t.Helper()
 	return h.Execute(JobContext{}, &nexus.Job{
@@ -21,7 +27,7 @@ func runShell(t *testing.T, h *ShellCommandHandler, command string) ([]byte, err
 }
 
 func TestShellCommand_MissingCommand(t *testing.T) {
-	h := &ShellCommandHandler{}
+	h := &ShellCommandHandler{VerifyPasscode: allowPasscode}
 	_, err := h.Execute(JobContext{}, &nexus.Job{
 		ID:      "test-1",
 		Type:    "SHELL_COMMAND",
@@ -33,7 +39,7 @@ func TestShellCommand_MissingCommand(t *testing.T) {
 }
 
 func TestShellCommand_EmptyCommand(t *testing.T) {
-	h := &ShellCommandHandler{}
+	h := &ShellCommandHandler{VerifyPasscode: allowPasscode}
 	// Whitespace-only command must be rejected.
 	_, err := runShell(t, h, "   ")
 	if err == nil {
@@ -42,7 +48,7 @@ func TestShellCommand_EmptyCommand(t *testing.T) {
 }
 
 func TestShellCommand_BasicExecution(t *testing.T) {
-	h := &ShellCommandHandler{}
+	h := &ShellCommandHandler{VerifyPasscode: allowPasscode}
 	out, err := runShell(t, h, "echo hello")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -53,7 +59,7 @@ func TestShellCommand_BasicExecution(t *testing.T) {
 }
 
 func TestShellCommand_Pipe(t *testing.T) {
-	h := &ShellCommandHandler{}
+	h := &ShellCommandHandler{VerifyPasscode: allowPasscode}
 	out, err := runShell(t, h, "echo hello | cat")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -64,7 +70,7 @@ func TestShellCommand_Pipe(t *testing.T) {
 }
 
 func TestShellCommand_AndAnd(t *testing.T) {
-	h := &ShellCommandHandler{}
+	h := &ShellCommandHandler{VerifyPasscode: allowPasscode}
 	out, err := runShell(t, h, "true && echo ok")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -75,7 +81,7 @@ func TestShellCommand_AndAnd(t *testing.T) {
 }
 
 func TestShellCommand_QuotedArgs(t *testing.T) {
-	h := &ShellCommandHandler{}
+	h := &ShellCommandHandler{VerifyPasscode: allowPasscode}
 	out, err := runShell(t, h, `echo "a b c"`)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -86,7 +92,7 @@ func TestShellCommand_QuotedArgs(t *testing.T) {
 }
 
 func TestShellCommand_MultiLineScript(t *testing.T) {
-	h := &ShellCommandHandler{}
+	h := &ShellCommandHandler{VerifyPasscode: allowPasscode}
 	out, err := runShell(t, h, "set -e\necho one\necho two")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -97,7 +103,7 @@ func TestShellCommand_MultiLineScript(t *testing.T) {
 }
 
 func TestShellCommand_NonZeroExit(t *testing.T) {
-	h := &ShellCommandHandler{}
+	h := &ShellCommandHandler{VerifyPasscode: allowPasscode}
 	_, err := runShell(t, h, "exit 3")
 	if err == nil {
 		t.Fatal("expected error for non-zero exit, got nil")
@@ -110,6 +116,7 @@ func TestShellCommand_WorkspaceCwd(t *testing.T) {
 		t.Fatalf("setup: %v", err)
 	}
 	h := NewShellCommandHandler(dir)
+	h.VerifyPasscode = allowPasscode
 	// Relative path resolves against the configured workspace directory.
 	out, err := runShell(t, h, "cat foo.txt")
 	if err != nil {
@@ -231,8 +238,9 @@ func TestShellCommand_DisabledRefusesAndDoesNotExec(t *testing.T) {
 }
 
 func TestShellCommand_EnabledByDefault(t *testing.T) {
-	// A zero-value handler (Disabled=false) must still execute normally.
-	h := &ShellCommandHandler{}
+	// An enabled handler (Disabled=false) with a satisfied passcode gate executes
+	// normally.
+	h := &ShellCommandHandler{VerifyPasscode: allowPasscode}
 	out, err := runShell(t, h, "echo ok")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -248,13 +256,116 @@ func TestShellCommand_ScrubsSecretsFromChildEnv(t *testing.T) {
 	t.Setenv("FOO_TOKEN", "leak-me")
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "leak-me-too")
 
-	h := &ShellCommandHandler{}
+	h := &ShellCommandHandler{VerifyPasscode: allowPasscode}
 	out, err := runShell(t, h, "echo \"[$FOO_TOKEN][$AWS_SECRET_ACCESS_KEY]\"")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if strings.TrimSpace(string(out)) != "[][]" {
 		t.Errorf("secrets leaked into child env: output = %q", string(out))
+	}
+}
+
+// runShellWithPasscode dispatches a SHELL_COMMAND carrying a passcode payload
+// field, exercising the aceteam#6524 per-job passcode gate.
+func runShellWithPasscode(t *testing.T, h *ShellCommandHandler, command, passcode string) ([]byte, error) {
+	t.Helper()
+	return h.Execute(JobContext{}, &nexus.Job{
+		ID:   "test",
+		Type: "SHELL_COMMAND",
+		Payload: map[string]string{
+			"command":               command,
+			ShellPasscodePayloadKey: passcode,
+		},
+	})
+}
+
+// TestShellCommand_EnabledNilVerifierFailsClosed proves the fail-closed contract
+// at the type level: an ENABLED handler (Disabled=false) whose passcode verifier
+// was never wired refuses every command, so a forgotten gate never silently opens
+// root shell.
+func TestShellCommand_EnabledNilVerifierFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	sentinel := filepath.Join(dir, "executed.marker")
+
+	h := &ShellCommandHandler{} // enabled, VerifyPasscode nil
+	out, err := runShell(t, h, "touch "+sentinel)
+
+	if err == nil {
+		t.Fatal("expected refusal when the passcode gate is not wired, got nil")
+	}
+	if err.Error() != ShellPasscodeRequiredError {
+		t.Errorf("error = %q, want %q", err.Error(), ShellPasscodeRequiredError)
+	}
+	if len(out) != 0 {
+		t.Errorf("expected no output, got %q", string(out))
+	}
+	if _, statErr := os.Stat(sentinel); statErr == nil {
+		t.Error("command executed despite a nil passcode verifier")
+	}
+}
+
+// TestShellCommand_EnabledWrongPasscodeRefused proves that an enabled handler
+// with a real verifier still refuses a command that presents the wrong (or no)
+// passcode, and does not execute it.
+func TestShellCommand_EnabledWrongPasscodeRefused(t *testing.T) {
+	dir := t.TempDir()
+	sentinel := filepath.Join(dir, "executed.marker")
+
+	// Verifier that only accepts the correct PIN.
+	h := &ShellCommandHandler{VerifyPasscode: func(pin string) bool { return pin == "2468" }}
+
+	// Wrong passcode.
+	out, err := runShellWithPasscode(t, h, "touch "+sentinel, "0000")
+	if err == nil || err.Error() != ShellPasscodeRequiredError {
+		t.Fatalf("wrong passcode: err = %v, want %q", err, ShellPasscodeRequiredError)
+	}
+	// Absent passcode.
+	if _, err := runShell(t, h, "touch "+sentinel); err == nil || err.Error() != ShellPasscodeRequiredError {
+		t.Fatalf("absent passcode: err = %v, want %q", err, ShellPasscodeRequiredError)
+	}
+	if len(out) != 0 {
+		t.Errorf("expected no output, got %q", string(out))
+	}
+	if _, statErr := os.Stat(sentinel); statErr == nil {
+		t.Error("command executed despite a wrong/absent passcode")
+	}
+}
+
+// TestShellCommand_EnabledCorrectPasscodeRuns proves the allow path: an enabled
+// handler runs the command when the correct passcode is presented.
+func TestShellCommand_EnabledCorrectPasscodeRuns(t *testing.T) {
+	h := &ShellCommandHandler{VerifyPasscode: func(pin string) bool { return pin == "2468" }}
+	out, err := runShellWithPasscode(t, h, "echo ok", "2468")
+	if err != nil {
+		t.Fatalf("correct passcode should run: %v", err)
+	}
+	if string(out) != "ok\n" {
+		t.Errorf("output = %q, want %q", string(out), "ok\n")
+	}
+}
+
+// TestShellCommand_DisabledBeatsPasscode confirms the Disabled kill-switch is
+// checked first: a disabled handler refuses with ShellDisabledError even when a
+// correct passcode is presented.
+func TestShellCommand_DisabledBeatsPasscode(t *testing.T) {
+	h := &ShellCommandHandler{Disabled: true, VerifyPasscode: allowPasscode}
+	_, err := runShellWithPasscode(t, h, "echo ok", "2468")
+	if err == nil || err.Error() != ShellDisabledError {
+		t.Fatalf("disabled handler: err = %v, want %q", err, ShellDisabledError)
+	}
+}
+
+// TestShellCommand_PasscodeNotForwardedToChildEnv confirms the passcode payload
+// field never leaks into the executed command's environment.
+func TestShellCommand_PasscodeNotForwardedToChildEnv(t *testing.T) {
+	h := &ShellCommandHandler{VerifyPasscode: allowPasscode}
+	out, err := runShellWithPasscode(t, h, "env", "super-secret-pin")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(string(out), "super-secret-pin") {
+		t.Errorf("passcode leaked into child environment: %q", string(out))
 	}
 }
 
@@ -265,7 +376,7 @@ func TestShellCommand_RestrictedPATH(t *testing.T) {
 	t.Cleanup(func() { os.Setenv("PATH", origPATH) })
 	os.Setenv("PATH", "/nonexistent_dir_only")
 
-	h := &ShellCommandHandler{}
+	h := &ShellCommandHandler{VerifyPasscode: allowPasscode}
 	out, err := runShell(t, h, "uname")
 	if err != nil {
 		t.Fatalf("shell command with restricted PATH should work via augmented env: %v", err)

--- a/internal/jobs/shell_command_test.go
+++ b/internal/jobs/shell_command_test.go
@@ -1,6 +1,8 @@
 package jobs
 
 import (
+	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,6 +17,22 @@ import (
 // covered by the dedicated TestShellCommand_Passcode* cases below.
 func allowPasscode(string) bool { return true }
 
+// passcodeIsSet is a test HasPasscode signal reporting that a node passcode is
+// configured. Enabled handlers that expect to reach the verifier (or run) must
+// wire it, otherwise the new decision order refuses with passcode_not_set before
+// the verifier is consulted.
+func passcodeIsSet() bool { return true }
+
+// refusalReason asserts err is a *ShellRefusal and returns its reason code.
+func refusalReason(t *testing.T, err error) string {
+	t.Helper()
+	var r *ShellRefusal
+	if !errors.As(err, &r) {
+		t.Fatalf("error %v (%T) is not a *ShellRefusal", err, err)
+	}
+	return r.Reason
+}
+
 func runShell(t *testing.T, h *ShellCommandHandler, command string) ([]byte, error) {
 	t.Helper()
 	return h.Execute(JobContext{}, &nexus.Job{
@@ -27,7 +45,7 @@ func runShell(t *testing.T, h *ShellCommandHandler, command string) ([]byte, err
 }
 
 func TestShellCommand_MissingCommand(t *testing.T) {
-	h := &ShellCommandHandler{VerifyPasscode: allowPasscode}
+	h := &ShellCommandHandler{HasPasscode: passcodeIsSet, VerifyPasscode: allowPasscode}
 	_, err := h.Execute(JobContext{}, &nexus.Job{
 		ID:      "test-1",
 		Type:    "SHELL_COMMAND",
@@ -39,7 +57,7 @@ func TestShellCommand_MissingCommand(t *testing.T) {
 }
 
 func TestShellCommand_EmptyCommand(t *testing.T) {
-	h := &ShellCommandHandler{VerifyPasscode: allowPasscode}
+	h := &ShellCommandHandler{HasPasscode: passcodeIsSet, VerifyPasscode: allowPasscode}
 	// Whitespace-only command must be rejected.
 	_, err := runShell(t, h, "   ")
 	if err == nil {
@@ -48,7 +66,7 @@ func TestShellCommand_EmptyCommand(t *testing.T) {
 }
 
 func TestShellCommand_BasicExecution(t *testing.T) {
-	h := &ShellCommandHandler{VerifyPasscode: allowPasscode}
+	h := &ShellCommandHandler{HasPasscode: passcodeIsSet, VerifyPasscode: allowPasscode}
 	out, err := runShell(t, h, "echo hello")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -59,7 +77,7 @@ func TestShellCommand_BasicExecution(t *testing.T) {
 }
 
 func TestShellCommand_Pipe(t *testing.T) {
-	h := &ShellCommandHandler{VerifyPasscode: allowPasscode}
+	h := &ShellCommandHandler{HasPasscode: passcodeIsSet, VerifyPasscode: allowPasscode}
 	out, err := runShell(t, h, "echo hello | cat")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -70,7 +88,7 @@ func TestShellCommand_Pipe(t *testing.T) {
 }
 
 func TestShellCommand_AndAnd(t *testing.T) {
-	h := &ShellCommandHandler{VerifyPasscode: allowPasscode}
+	h := &ShellCommandHandler{HasPasscode: passcodeIsSet, VerifyPasscode: allowPasscode}
 	out, err := runShell(t, h, "true && echo ok")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -81,7 +99,7 @@ func TestShellCommand_AndAnd(t *testing.T) {
 }
 
 func TestShellCommand_QuotedArgs(t *testing.T) {
-	h := &ShellCommandHandler{VerifyPasscode: allowPasscode}
+	h := &ShellCommandHandler{HasPasscode: passcodeIsSet, VerifyPasscode: allowPasscode}
 	out, err := runShell(t, h, `echo "a b c"`)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -92,7 +110,7 @@ func TestShellCommand_QuotedArgs(t *testing.T) {
 }
 
 func TestShellCommand_MultiLineScript(t *testing.T) {
-	h := &ShellCommandHandler{VerifyPasscode: allowPasscode}
+	h := &ShellCommandHandler{HasPasscode: passcodeIsSet, VerifyPasscode: allowPasscode}
 	out, err := runShell(t, h, "set -e\necho one\necho two")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -103,7 +121,7 @@ func TestShellCommand_MultiLineScript(t *testing.T) {
 }
 
 func TestShellCommand_NonZeroExit(t *testing.T) {
-	h := &ShellCommandHandler{VerifyPasscode: allowPasscode}
+	h := &ShellCommandHandler{HasPasscode: passcodeIsSet, VerifyPasscode: allowPasscode}
 	_, err := runShell(t, h, "exit 3")
 	if err == nil {
 		t.Fatal("expected error for non-zero exit, got nil")
@@ -116,6 +134,7 @@ func TestShellCommand_WorkspaceCwd(t *testing.T) {
 		t.Fatalf("setup: %v", err)
 	}
 	h := NewShellCommandHandler(dir)
+	h.HasPasscode = passcodeIsSet
 	h.VerifyPasscode = allowPasscode
 	// Relative path resolves against the configured workspace directory.
 	out, err := runShell(t, h, "cat foo.txt")
@@ -225,8 +244,8 @@ func TestShellCommand_DisabledRefusesAndDoesNotExec(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected refusal error when shell is disabled, got nil")
 	}
-	if err.Error() != ShellDisabledError {
-		t.Errorf("error = %q, want %q", err.Error(), ShellDisabledError)
+	if reason := refusalReason(t, err); reason != ReasonShellDisabled {
+		t.Errorf("reason = %q, want %q", reason, ReasonShellDisabled)
 	}
 	if len(out) != 0 {
 		t.Errorf("expected no output when disabled, got %q", string(out))
@@ -240,7 +259,7 @@ func TestShellCommand_DisabledRefusesAndDoesNotExec(t *testing.T) {
 func TestShellCommand_EnabledByDefault(t *testing.T) {
 	// An enabled handler (Disabled=false) with a satisfied passcode gate executes
 	// normally.
-	h := &ShellCommandHandler{VerifyPasscode: allowPasscode}
+	h := &ShellCommandHandler{HasPasscode: passcodeIsSet, VerifyPasscode: allowPasscode}
 	out, err := runShell(t, h, "echo ok")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -256,7 +275,7 @@ func TestShellCommand_ScrubsSecretsFromChildEnv(t *testing.T) {
 	t.Setenv("FOO_TOKEN", "leak-me")
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "leak-me-too")
 
-	h := &ShellCommandHandler{VerifyPasscode: allowPasscode}
+	h := &ShellCommandHandler{HasPasscode: passcodeIsSet, VerifyPasscode: allowPasscode}
 	out, err := runShell(t, h, "echo \"[$FOO_TOKEN][$AWS_SECRET_ACCESS_KEY]\"")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -280,49 +299,69 @@ func runShellWithPasscode(t *testing.T, h *ShellCommandHandler, command, passcod
 	})
 }
 
-// TestShellCommand_EnabledNilVerifierFailsClosed proves the fail-closed contract
-// at the type level: an ENABLED handler (Disabled=false) whose passcode verifier
-// was never wired refuses every command, so a forgotten gate never silently opens
-// root shell.
-func TestShellCommand_EnabledNilVerifierFailsClosed(t *testing.T) {
+// TestShellCommand_EnabledNoPasscodeSetFailsClosed proves the fail-closed
+// contract for the "no passcode configured" case: an ENABLED handler
+// (Disabled=false) with no HasPasscode signal (or one that reports false) refuses
+// every command with reason passcode_not_set, so a forgotten gate never silently
+// opens root shell. This holds even when a VerifyPasscode IS wired: with no
+// passcode set there is nothing to verify against, and HasPasscode is checked
+// first.
+func TestShellCommand_EnabledNoPasscodeSetFailsClosed(t *testing.T) {
 	dir := t.TempDir()
 	sentinel := filepath.Join(dir, "executed.marker")
 
-	h := &ShellCommandHandler{} // enabled, VerifyPasscode nil
-	out, err := runShell(t, h, "touch "+sentinel)
-
-	if err == nil {
-		t.Fatal("expected refusal when the passcode gate is not wired, got nil")
+	cases := map[string]*ShellCommandHandler{
+		"nil HasPasscode and nil VerifyPasscode":   {},
+		"nil HasPasscode but VerifyPasscode wired": {VerifyPasscode: allowPasscode},
+		"HasPasscode reports false":                {HasPasscode: func() bool { return false }, VerifyPasscode: allowPasscode},
 	}
-	if err.Error() != ShellPasscodeRequiredError {
-		t.Errorf("error = %q, want %q", err.Error(), ShellPasscodeRequiredError)
-	}
-	if len(out) != 0 {
-		t.Errorf("expected no output, got %q", string(out))
-	}
-	if _, statErr := os.Stat(sentinel); statErr == nil {
-		t.Error("command executed despite a nil passcode verifier")
+	for name, h := range cases {
+		t.Run(name, func(t *testing.T) {
+			out, err := runShellWithPasscode(t, h, "touch "+sentinel, "2468")
+			if err == nil {
+				t.Fatal("expected refusal when no node passcode is set, got nil")
+			}
+			if reason := refusalReason(t, err); reason != ReasonPasscodeNotSet {
+				t.Errorf("reason = %q, want %q", reason, ReasonPasscodeNotSet)
+			}
+			if len(out) != 0 {
+				t.Errorf("expected no output, got %q", string(out))
+			}
+			if _, statErr := os.Stat(sentinel); statErr == nil {
+				t.Error("command executed despite no passcode being set")
+			}
+		})
 	}
 }
 
-// TestShellCommand_EnabledWrongPasscodeRefused proves that an enabled handler
-// with a real verifier still refuses a command that presents the wrong (or no)
-// passcode, and does not execute it.
+// TestShellCommand_EnabledWrongPasscodeRefused proves that when a passcode IS
+// configured (HasPasscode true), an enabled handler still refuses a command that
+// presents the wrong (or no) passcode with reason passcode_invalid, and does not
+// execute it. A nil verifier alongside a configured passcode also fails closed as
+// passcode_invalid.
 func TestShellCommand_EnabledWrongPasscodeRefused(t *testing.T) {
 	dir := t.TempDir()
 	sentinel := filepath.Join(dir, "executed.marker")
 
-	// Verifier that only accepts the correct PIN.
-	h := &ShellCommandHandler{VerifyPasscode: func(pin string) bool { return pin == "2468" }}
+	// Passcode configured; verifier accepts only the correct PIN.
+	h := &ShellCommandHandler{
+		HasPasscode:    passcodeIsSet,
+		VerifyPasscode: func(pin string) bool { return pin == "2468" },
+	}
 
 	// Wrong passcode.
 	out, err := runShellWithPasscode(t, h, "touch "+sentinel, "0000")
-	if err == nil || err.Error() != ShellPasscodeRequiredError {
-		t.Fatalf("wrong passcode: err = %v, want %q", err, ShellPasscodeRequiredError)
+	if err == nil || refusalReason(t, err) != ReasonPasscodeInvalid {
+		t.Fatalf("wrong passcode: err = %v, want reason %q", err, ReasonPasscodeInvalid)
 	}
 	// Absent passcode.
-	if _, err := runShell(t, h, "touch "+sentinel); err == nil || err.Error() != ShellPasscodeRequiredError {
-		t.Fatalf("absent passcode: err = %v, want %q", err, ShellPasscodeRequiredError)
+	if _, err := runShell(t, h, "touch "+sentinel); err == nil || refusalReason(t, err) != ReasonPasscodeInvalid {
+		t.Fatalf("absent passcode: err = %v, want reason %q", err, ReasonPasscodeInvalid)
+	}
+	// Passcode configured but verifier never wired: still passcode_invalid (fail closed).
+	nilVerifier := &ShellCommandHandler{HasPasscode: passcodeIsSet}
+	if _, err := runShellWithPasscode(t, nilVerifier, "touch "+sentinel, "2468"); err == nil || refusalReason(t, err) != ReasonPasscodeInvalid {
+		t.Fatalf("nil verifier with passcode set: err = %v, want reason %q", err, ReasonPasscodeInvalid)
 	}
 	if len(out) != 0 {
 		t.Errorf("expected no output, got %q", string(out))
@@ -333,9 +372,13 @@ func TestShellCommand_EnabledWrongPasscodeRefused(t *testing.T) {
 }
 
 // TestShellCommand_EnabledCorrectPasscodeRuns proves the allow path: an enabled
-// handler runs the command when the correct passcode is presented.
+// handler with a configured passcode runs the command when the correct passcode
+// is presented.
 func TestShellCommand_EnabledCorrectPasscodeRuns(t *testing.T) {
-	h := &ShellCommandHandler{VerifyPasscode: func(pin string) bool { return pin == "2468" }}
+	h := &ShellCommandHandler{
+		HasPasscode:    passcodeIsSet,
+		VerifyPasscode: func(pin string) bool { return pin == "2468" },
+	}
 	out, err := runShellWithPasscode(t, h, "echo ok", "2468")
 	if err != nil {
 		t.Fatalf("correct passcode should run: %v", err)
@@ -345,21 +388,38 @@ func TestShellCommand_EnabledCorrectPasscodeRuns(t *testing.T) {
 	}
 }
 
+// TestShellRefusal_ErrorIsValidJSON pins the machine-readable contract: Error()
+// is a JSON object with reason + message keys, and stays valid JSON even when the
+// message contains a double quote (proving it is marshaled, not concatenated).
+func TestShellRefusal_ErrorIsValidJSON(t *testing.T) {
+	r := &ShellRefusal{Reason: ReasonPasscodeInvalid, Message: `needs a "quoted" passcode`}
+	var decoded map[string]string
+	if err := json.Unmarshal([]byte(r.Error()), &decoded); err != nil {
+		t.Fatalf("Error() is not valid JSON: %v (got %q)", err, r.Error())
+	}
+	if decoded["reason"] != ReasonPasscodeInvalid {
+		t.Errorf("reason = %q, want %q", decoded["reason"], ReasonPasscodeInvalid)
+	}
+	if decoded["message"] != `needs a "quoted" passcode` {
+		t.Errorf("message = %q, want the quoted message round-tripped", decoded["message"])
+	}
+}
+
 // TestShellCommand_DisabledBeatsPasscode confirms the Disabled kill-switch is
-// checked first: a disabled handler refuses with ShellDisabledError even when a
-// correct passcode is presented.
+// checked first: a disabled handler refuses with reason shell_disabled even when
+// a passcode is configured and the correct passcode is presented.
 func TestShellCommand_DisabledBeatsPasscode(t *testing.T) {
-	h := &ShellCommandHandler{Disabled: true, VerifyPasscode: allowPasscode}
+	h := &ShellCommandHandler{Disabled: true, HasPasscode: passcodeIsSet, VerifyPasscode: allowPasscode}
 	_, err := runShellWithPasscode(t, h, "echo ok", "2468")
-	if err == nil || err.Error() != ShellDisabledError {
-		t.Fatalf("disabled handler: err = %v, want %q", err, ShellDisabledError)
+	if err == nil || refusalReason(t, err) != ReasonShellDisabled {
+		t.Fatalf("disabled handler: err = %v, want reason %q", err, ReasonShellDisabled)
 	}
 }
 
 // TestShellCommand_PasscodeNotForwardedToChildEnv confirms the passcode payload
 // field never leaks into the executed command's environment.
 func TestShellCommand_PasscodeNotForwardedToChildEnv(t *testing.T) {
-	h := &ShellCommandHandler{VerifyPasscode: allowPasscode}
+	h := &ShellCommandHandler{HasPasscode: passcodeIsSet, VerifyPasscode: allowPasscode}
 	out, err := runShellWithPasscode(t, h, "env", "super-secret-pin")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -376,7 +436,7 @@ func TestShellCommand_RestrictedPATH(t *testing.T) {
 	t.Cleanup(func() { os.Setenv("PATH", origPATH) })
 	os.Setenv("PATH", "/nonexistent_dir_only")
 
-	h := &ShellCommandHandler{VerifyPasscode: allowPasscode}
+	h := &ShellCommandHandler{HasPasscode: passcodeIsSet, VerifyPasscode: allowPasscode}
 	out, err := runShell(t, h, "uname")
 	if err != nil {
 		t.Fatalf("shell command with restricted PATH should work via augmented env: %v", err)

--- a/internal/tui/controlcenter/actions.go
+++ b/internal/tui/controlcenter/actions.go
@@ -1975,7 +1975,7 @@ func (cc *ControlCenter) showBuiltinServicesModal() {
 		{
 			name:    "Shell",
 			desc:    "Remote shell command execution",
-			detail:  "Allows dispatched SHELL_COMMAND jobs to run through /bin/sh on this node.\nDisable to make the node refuse all remote shell execution.\nInherited secrets are always scrubbed from the command environment.",
+			detail:  "Allows dispatched SHELL_COMMAND jobs to run through /bin/sh on this node.\nGoverns the platform node-management tabs (logs/services/docker).\nDisable to make the node refuse all remote shell execution.\n\n[red]Default OFF (opt-in) + passcode-gated (aceteam#6524):[-] a fresh node\nrefuses shell. When enabled it still requires the node passcode\npresented per command, so enabling alone does not open it.\nInherited secrets are always scrubbed from the command environment.",
 			enabled: &perms.Shell,
 		},
 	}

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -130,6 +130,13 @@ type LegacyHandlerOpts struct {
 	// "disabled" error rather than "unsupported job type"), but every command
 	// is rejected. Wired from the persisted `shell` node permission.
 	ShellDisabled bool
+	// ShellVerifyPasscode gates an ENABLED SHELL_COMMAND handler on the per-node
+	// passcode (aceteam#6524), mirroring the console/desktop/files gate. Wired from
+	// config.LoadPermissions(...).VerifyPasscode so an enabled shell still refuses
+	// a command that does not present the correct node passcode. REQUIRED whenever
+	// ShellDisabled is false: a nil verifier makes the handler fail closed (refuse
+	// every command). See jobs.ShellCommandHandler.VerifyPasscode.
+	ShellVerifyPasscode func(pin string) bool
 	// DesktopDisabled, when true, SKIPS registration of the screen/VNC/desktop
 	// job handlers (FILE_SCREENSHOT, VNC_SCREENSHOT, VNC_TYPE, VNC_KEYS,
 	// VNC_ACTIONS). A fresh node has `desktop` default-DENY (aceteam#6524), so it
@@ -169,6 +176,7 @@ func CreateLegacyHandlers(logFn ...func(level, msg string)) []JobHandler {
 func CreateLegacyHandlersWithOpts(opts LegacyHandlerOpts) []JobHandler {
 	shellHandler := jobs.NewShellCommandHandler(opts.WorkspaceDir)
 	shellHandler.Disabled = opts.ShellDisabled
+	shellHandler.VerifyPasscode = opts.ShellVerifyPasscode
 
 	handlers := []*LegacyHandlerAdapter{
 		NewLegacyHandlerAdapter(JobTypeShellCommand, shellHandler),

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -130,6 +130,13 @@ type LegacyHandlerOpts struct {
 	// "disabled" error rather than "unsupported job type"), but every command
 	// is rejected. Wired from the persisted `shell` node permission.
 	ShellDisabled bool
+	// ShellHasPasscode reports whether a node passcode is configured, letting the
+	// handler distinguish "no passcode set" (passcode_not_set) from "wrong passcode
+	// presented" (passcode_invalid). Wired from config.LoadPermissions(...).HasPasscode.
+	// REQUIRED whenever ShellDisabled is false: a nil signal makes the handler treat
+	// the node as having no passcode and refuse every command (fail closed). See
+	// jobs.ShellCommandHandler.HasPasscode.
+	ShellHasPasscode func() bool
 	// ShellVerifyPasscode gates an ENABLED SHELL_COMMAND handler on the per-node
 	// passcode (aceteam#6524), mirroring the console/desktop/files gate. Wired from
 	// config.LoadPermissions(...).VerifyPasscode so an enabled shell still refuses
@@ -176,6 +183,7 @@ func CreateLegacyHandlers(logFn ...func(level, msg string)) []JobHandler {
 func CreateLegacyHandlersWithOpts(opts LegacyHandlerOpts) []JobHandler {
 	shellHandler := jobs.NewShellCommandHandler(opts.WorkspaceDir)
 	shellHandler.Disabled = opts.ShellDisabled
+	shellHandler.HasPasscode = opts.ShellHasPasscode
 	shellHandler.VerifyPasscode = opts.ShellVerifyPasscode
 
 	handlers := []*LegacyHandlerAdapter{

--- a/internal/worker/handler_adapter_test.go
+++ b/internal/worker/handler_adapter_test.go
@@ -276,10 +276,13 @@ func TestCreateLegacyHandlers_ShellDisabled(t *testing.T) {
 	}
 }
 
-// TestCreateLegacyHandlers_ShellEnabledByDefault confirms the default opt
-// (ShellDisabled=false) leaves shell execution working.
-func TestCreateLegacyHandlers_ShellEnabledByDefault(t *testing.T) {
-	handlers := CreateLegacyHandlersWithOpts(LegacyHandlerOpts{})
+// TestCreateLegacyHandlers_ShellEnabledWithPasscode confirms that an enabled
+// shell (ShellDisabled=false) whose passcode verifier is wired runs a command
+// that presents the correct passcode.
+func TestCreateLegacyHandlers_ShellEnabledWithPasscode(t *testing.T) {
+	handlers := CreateLegacyHandlersWithOpts(LegacyHandlerOpts{
+		ShellVerifyPasscode: func(pin string) bool { return pin == "2468" },
+	})
 
 	var shell JobHandler
 	for _, h := range handlers {
@@ -295,14 +298,49 @@ func TestCreateLegacyHandlers_ShellEnabledByDefault(t *testing.T) {
 	job := &Job{
 		ID:      "job-shell-enabled",
 		Type:    JobTypeShellCommand,
-		Payload: map[string]any{"command": "echo ok"},
+		Payload: map[string]any{"command": "echo ok", "passcode": "2468"},
 	}
 	result, err := shell.Execute(context.Background(), job, &NoOpStreamWriter{})
 	if err != nil {
-		t.Fatalf("enabled shell handler should run: %v", err)
+		t.Fatalf("enabled shell handler with correct passcode should run: %v", err)
 	}
 	if result.Status != JobStatusSuccess {
 		t.Errorf("result.Status = %v, want success", result.Status)
+	}
+}
+
+// TestCreateLegacyHandlers_ShellEnabledNoVerifierFailsClosed proves the
+// fail-closed contract at the construction layer: an enabled shell with no
+// passcode verifier wired refuses execution (a forgotten gate never opens root
+// shell).
+func TestCreateLegacyHandlers_ShellEnabledNoVerifierFailsClosed(t *testing.T) {
+	handlers := CreateLegacyHandlersWithOpts(LegacyHandlerOpts{}) // enabled, no verifier
+
+	var shell JobHandler
+	for _, h := range handlers {
+		if h.CanHandle(JobTypeShellCommand) {
+			shell = h
+			break
+		}
+	}
+	if shell == nil {
+		t.Fatal("SHELL_COMMAND handler must be registered")
+	}
+
+	job := &Job{
+		ID:      "job-shell-no-verifier",
+		Type:    JobTypeShellCommand,
+		Payload: map[string]any{"command": "echo should-not-run"},
+	}
+	result, err := shell.Execute(context.Background(), job, &NoOpStreamWriter{})
+	if err == nil {
+		t.Fatal("enabled shell with no passcode verifier should refuse")
+	}
+	if !strings.Contains(err.Error(), jobs.ShellPasscodeRequiredError) {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), jobs.ShellPasscodeRequiredError)
+	}
+	if result != nil && result.Status == JobStatusSuccess {
+		t.Error("shell handler without a passcode verifier must not report success")
 	}
 }
 

--- a/internal/worker/handler_adapter_test.go
+++ b/internal/worker/handler_adapter_test.go
@@ -4,12 +4,23 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"strings"
 	"testing"
 
 	"github.com/aceteam-ai/citadel-cli/internal/jobs"
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
 )
+
+// shellRefusalReason asserts err carries a *jobs.ShellRefusal and returns its
+// reason code. The legacy adapter returns the handler's typed error unwrapped, so
+// errors.As reaches it.
+func shellRefusalReason(t *testing.T, err error) string {
+	t.Helper()
+	var r *jobs.ShellRefusal
+	if !errors.As(err, &r) {
+		t.Fatalf("error %v (%T) is not a *jobs.ShellRefusal", err, err)
+	}
+	return r.Reason
+}
 
 // TestLegacyHandler is a mock jobs.JobHandler for testing.
 type TestLegacyHandler struct {
@@ -266,8 +277,8 @@ func TestCreateLegacyHandlers_ShellDisabled(t *testing.T) {
 	if err == nil {
 		t.Fatal("disabled SHELL_COMMAND handler should return an error")
 	}
-	if !strings.Contains(err.Error(), jobs.ShellDisabledError) {
-		t.Errorf("error = %q, want it to contain %q", err.Error(), jobs.ShellDisabledError)
+	if reason := shellRefusalReason(t, err); reason != jobs.ReasonShellDisabled {
+		t.Errorf("reason = %q, want %q", reason, jobs.ReasonShellDisabled)
 	}
 	// The adapter surfaces failures via the returned error; result should not
 	// report success.
@@ -277,10 +288,11 @@ func TestCreateLegacyHandlers_ShellDisabled(t *testing.T) {
 }
 
 // TestCreateLegacyHandlers_ShellEnabledWithPasscode confirms that an enabled
-// shell (ShellDisabled=false) whose passcode verifier is wired runs a command
-// that presents the correct passcode.
+// shell (ShellDisabled=false) whose HasPasscode + passcode verifier are wired
+// runs a command that presents the correct passcode.
 func TestCreateLegacyHandlers_ShellEnabledWithPasscode(t *testing.T) {
 	handlers := CreateLegacyHandlersWithOpts(LegacyHandlerOpts{
+		ShellHasPasscode:    func() bool { return true },
 		ShellVerifyPasscode: func(pin string) bool { return pin == "2468" },
 	})
 
@@ -309,12 +321,12 @@ func TestCreateLegacyHandlers_ShellEnabledWithPasscode(t *testing.T) {
 	}
 }
 
-// TestCreateLegacyHandlers_ShellEnabledNoVerifierFailsClosed proves the
+// TestCreateLegacyHandlers_ShellEnabledNoPasscodeFailsClosed proves the
 // fail-closed contract at the construction layer: an enabled shell with no
-// passcode verifier wired refuses execution (a forgotten gate never opens root
-// shell).
-func TestCreateLegacyHandlers_ShellEnabledNoVerifierFailsClosed(t *testing.T) {
-	handlers := CreateLegacyHandlersWithOpts(LegacyHandlerOpts{}) // enabled, no verifier
+// HasPasscode signal wired refuses execution with reason passcode_not_set (a
+// forgotten gate never opens root shell).
+func TestCreateLegacyHandlers_ShellEnabledNoPasscodeFailsClosed(t *testing.T) {
+	handlers := CreateLegacyHandlersWithOpts(LegacyHandlerOpts{}) // enabled, no signals
 
 	var shell JobHandler
 	for _, h := range handlers {
@@ -328,19 +340,56 @@ func TestCreateLegacyHandlers_ShellEnabledNoVerifierFailsClosed(t *testing.T) {
 	}
 
 	job := &Job{
-		ID:      "job-shell-no-verifier",
+		ID:      "job-shell-no-passcode",
 		Type:    JobTypeShellCommand,
 		Payload: map[string]any{"command": "echo should-not-run"},
 	}
 	result, err := shell.Execute(context.Background(), job, &NoOpStreamWriter{})
 	if err == nil {
-		t.Fatal("enabled shell with no passcode verifier should refuse")
+		t.Fatal("enabled shell with no passcode signal should refuse")
 	}
-	if !strings.Contains(err.Error(), jobs.ShellPasscodeRequiredError) {
-		t.Errorf("error = %q, want it to contain %q", err.Error(), jobs.ShellPasscodeRequiredError)
+	if reason := shellRefusalReason(t, err); reason != jobs.ReasonPasscodeNotSet {
+		t.Errorf("reason = %q, want %q", reason, jobs.ReasonPasscodeNotSet)
 	}
 	if result != nil && result.Status == JobStatusSuccess {
-		t.Error("shell handler without a passcode verifier must not report success")
+		t.Error("shell handler without a passcode must not report success")
+	}
+}
+
+// TestCreateLegacyHandlers_ShellEnabledWrongPasscode proves the distinct
+// passcode_invalid code at the construction layer: a passcode IS configured
+// (HasPasscode true) but the presented payload passcode is wrong.
+func TestCreateLegacyHandlers_ShellEnabledWrongPasscode(t *testing.T) {
+	handlers := CreateLegacyHandlersWithOpts(LegacyHandlerOpts{
+		ShellHasPasscode:    func() bool { return true },
+		ShellVerifyPasscode: func(pin string) bool { return pin == "2468" },
+	})
+
+	var shell JobHandler
+	for _, h := range handlers {
+		if h.CanHandle(JobTypeShellCommand) {
+			shell = h
+			break
+		}
+	}
+	if shell == nil {
+		t.Fatal("SHELL_COMMAND handler must be registered")
+	}
+
+	job := &Job{
+		ID:      "job-shell-wrong-passcode",
+		Type:    JobTypeShellCommand,
+		Payload: map[string]any{"command": "echo should-not-run", "passcode": "0000"},
+	}
+	result, err := shell.Execute(context.Background(), job, &NoOpStreamWriter{})
+	if err == nil {
+		t.Fatal("enabled shell with a wrong passcode should refuse")
+	}
+	if reason := shellRefusalReason(t, err); reason != jobs.ReasonPasscodeInvalid {
+		t.Errorf("reason = %q, want %q", reason, jobs.ReasonPasscodeInvalid)
+	}
+	if result != nil && result.Status == JobStatusSuccess {
+		t.Error("shell handler with a wrong passcode must not report success")
 	}
 }
 


### PR DESCRIPTION
## Context

PR #596 made the sensitive remote-access surfaces (console/desktop/files) **default-OFF opt-in + bcrypt passcode**, enabled remotely via `APPLY_DEVICE_CONFIG` fields `consoleEnabled`/`desktopEnabled`/`filesEnabled` + `nodePasscode`. Shell (`SHELL_COMMAND`, arbitrary code as root) was already **default-deny** (#6149), but there was **no way to enable it remotely**: the platform's node-management tabs (logs/services/docker) run shell commands, so they could not be turned on from the web. This adds the missing toggle, mirroring #596.

aceteam #6559 currently shows Control-Center guidance for the shell tabs and will call this once released.

## Summary

- **`shellEnabled` on `APPLY_DEVICE_CONFIG`** (`internal/jobs/config_handler.go`): new `DeviceConfig.ShellEnabled *bool` (pointer, so omitted = no-op). When non-nil it persists the `shell` permission to the same `permissions.yaml` the detector/handlers read. `Default` for Shell stays **DISABLED** (unchanged default-deny).
- **Per-job passcode gate on shell execution** (`internal/jobs/shell_command.go`): an enabled `ShellCommandHandler` now verifies the node passcode presented in the `SHELL_COMMAND` payload against the existing bcrypt `nodePasscode` (reused, no second passcode). Shell has **no gateway/HTTP route** (`categoryForPath` never returns `shell`), so unlike console/desktop/files the gate lives on the Redis job path, not the HTTPS middleware. **Fail-closed:** refuses when disabled, when the passcode verifier is not wired, or when the payload passcode is wrong/absent. Wired at **every** construction site including the legacy Nexus/diagnostic path (`cmd/job_handlers.go`), plus the worker (`cmd/work.go`) and Control-Center worker (`cmd/controlcenter.go`) via `LegacyHandlerOpts.ShellVerifyPasscode` / `nodeJobHandlerOpts.ShellVerifyPasscode`.
- **Control Center parity** (`internal/tui/controlcenter/actions.go`): the existing Shell toggle's detail text now notes default-OFF + passcode gating and that it governs the logs/services/docker tabs (no second toggle added).
- **Docs** (`docs/capability-toggles.md`): documents `shellEnabled` alongside console/desktop/files, the default-off + passcode posture, and the shell-specific per-job passcode path.
- `IsSensitiveCategory` deliberately **unchanged** (shell stays out of the gateway's sensitive set; a pinned test asserts this and no gateway path maps to `shell`).

## Payload contracts (for the aceteam web wiring, #6559)

Two contracts are needed; wiring only the first will make every command 401-equivalent (refused).

1. **Enable shell** via `APPLY_DEVICE_CONFIG`:
   ```json
   { "shellEnabled": true, "nodePasscode": "<pin>" }
   ```
   (`nodePasscode` is the same bcrypt passcode used by console/desktop/files; empty clears it.)

2. **Each `SHELL_COMMAND` dispatch** must carry the same pin in a dedicated payload field:
   ```json
   { "command": "docker ps", "passcode": "<pin>" }
   ```
   Field name: **`passcode`** (top-level in the `SHELL_COMMAND` payload). The pin is never forwarded into the executed command's environment.

**Open question the web side owns:** how to attach the pin per dispatch (human-entered once vs stored for the session).

## Test plan

`gofmt -l .` clean, `go vet ./...` clean, `go test ./...` fully green (67 packages).

New/updated tests:
- Fresh node refuses shell (default-deny) — existing behavior preserved.
- `APPLY_DEVICE_CONFIG{shellEnabled:true, nodePasscode}` enables shell and the passcode verifies; plaintext PIN never written to disk; console/desktop/files stay disabled.
- Omitting `shellEnabled` leaves an already-enabled shell untouched (nil pointer = no-op).
- Enabled + **wrong/absent** passcode still refused (command never runs); enabled + **correct** passcode runs.
- Enabled + **nil verifier** fails closed (both at the handler and the `CreateLegacyHandlersWithOpts` layer).
- Disabled kill-switch beats the passcode check; passcode never leaks into the child env.
- Inference unaffected; console/desktop/files behavior unchanged.

## Design decision to confirm

Shell execution is now **fail-closed on a per-job passcode**: an enabled node refuses any `SHELL_COMMAND` that does not present the correct node passcode. This is the shell analogue of #596's console/desktop fail-closed posture. It does mean a node that manually set `shell: true` without a passcode will now refuse shell until a passcode is set. Flag if you'd prefer enable-without-passcode to remain passcode-free for shell (not recommended).

*Generated by Claude Opus 4.8*

## Scope / honest notes

- **`TMUX_SESSION` is not gated here (pre-existing).** Its `shell` payload field launches a command when a session is created, without the `shell` permission or the node passcode. So this PR's "enabled shell refuses commands without the passcode" claim covers `SHELL_COMMAND` specifically, not `TMUX_SESSION`. The interactive surface (reading output / typing) still requires attaching via the terminal WebSocket, which #596 gates on `console` + passcode, but the create-time command is a passcode-free fire-and-forget path. Gating it is a follow-up, out of scope for this toggle.
- **Takes effect on worker restart.** `Disabled` is read at handler construction (like #596's console/desktop), so flipping `shellEnabled` applies on the next worker start; the passcode verifier itself reloads per-call. The `shell is not enabled` error already tells the operator to restart the worker. #6559's "one-click enable" should not expect instant effect without a restart.
- **No passcode in logs.** The passcode rides a dedicated payload field; the worker/redisapi receive paths do not log the payload map, and the handler logs only the command string, never the pin. Shell enablement is already exposed to the platform via the heartbeat `PermissionState` block (`Shell`), so #6559 can render enabled-vs-CTA.
