### PR TITLE
fix(nvr): make nvr-config image build (patches/ + buildvcs)

### DIFF
--- a/services/nvr-service/Dockerfile
+++ b/services/nvr-service/Dockerfile
@@ -10,9 +10,10 @@
 FROM golang:1.26 AS build
 WORKDIR /src
 COPY go.mod go.sum ./
+COPY patches/ ./patches/
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -o /out/nvrconfig ./cmd/nvrconfig
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -buildvcs=false -o /out/nvrconfig ./cmd/nvrconfig
 
 FROM alpine:3.20
 RUN adduser -D -u 10001 nvr


### PR DESCRIPTION
## Why
`build-nvr-service` is **red on main** (run 30059248662) — it runs post-merge, not as a required check, so #600 merged with a broken image build. Result: `ghcr.io/aceteam-ai/nvr-config` was never pushed (404), and `fabric_node_module_set module=nvr` cannot come up — Frigate blocks forever on the missing init container.

## Two bugs (both proven by a local `docker build` on ubuntu-gpu)
1. **`patches/` missing before `go mod download`.** `go.mod` has `replace github.com/gdamore/tcell/v2 => ./patches/tcell/v2`; only `go.mod`/`go.sum` were copied, so download can't read the replaced module. → `COPY patches/ ./patches/` before the download layer (kept split so the module layer still caches).
2. **`go build` VCS stamping fails** (`error obtaining VCS status: exit status 128`) — needs a usable `.git` in-context. → `-buildvcs=false`, standard for containerized Go builds.

## Verified
Image builds (11.2MB); binary runs and fails loudly on missing `NVR_CAMERAS` as designed. Once merged, CI publishes the image and `module=nvr` can deploy to node 1314.

Refs #597, #600