### PR TITLE
fix: remove dead --daemon flag; skip GPU-only engines on macOS (#607, #608)

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -172,7 +172,7 @@ var (
 // runControlCenter launches the unified control center TUI
 func runControlCenter() {
 	if !tui.IsTTY() {
-		fmt.Fprintln(os.Stderr, "Control center requires a terminal. Use --daemon for background mode.")
+		fmt.Fprintln(os.Stderr, "Control center requires a terminal. Run 'citadel work' for headless/background operation.")
 		os.Exit(1)
 	}
 

--- a/cmd/darwin_engines.go
+++ b/cmd/darwin_engines.go
@@ -1,0 +1,52 @@
+// cmd/darwin_engines.go
+package cmd
+
+import (
+	"os"
+	"strings"
+)
+
+// nvidiaDockerOnlyEngines are containerized inference engines whose only images
+// require an NVIDIA GPU plus a running Docker daemon (vLLM and SGLang are
+// CUDA-only; the llamacpp image is the server-cuda build). On macOS none of
+// these can run, so auto-starting them only produces a "Cannot connect to the
+// Docker daemon" error that reads like a broken node (issue #608). The supported
+// local-inference path on macOS is native ollama.
+var nvidiaDockerOnlyEngines = map[string]bool{
+	"vllm":     true,
+	"sglang":   true,
+	"llamacpp": true,
+}
+
+// skipEngineOnDarwin reports whether auto-starting the named service should be
+// skipped because it is an NVIDIA/docker-only engine that cannot run on the
+// given OS. It only ever returns true on darwin: every other platform (Linux
+// with NVIDIA, Windows with WSL2) starts these engines as before. goos is passed
+// in (rather than read from runtime.GOOS) so the decision is a pure function and
+// can be unit-tested on any host. The force flag is an escape hatch to attempt
+// the start anyway.
+//
+// The caller additionally gates this on the service resolving to the docker
+// runtime, so a native llamacpp/ollama install on a Mac is never skipped: only
+// the CUDA-image docker fallback is suppressed.
+func skipEngineOnDarwin(goos, serviceName string, force bool) bool {
+	if force {
+		return false
+	}
+	if goos != "darwin" {
+		return false
+	}
+	return nvidiaDockerOnlyEngines[strings.ToLower(strings.TrimSpace(serviceName))]
+}
+
+// forceGPUEngines reports whether the operator has opted to attempt starting
+// NVIDIA/docker-only engines even on a platform where they normally cannot run
+// (kill switch for the darwin skip in skipEngineOnDarwin). Off by default.
+func forceGPUEngines() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("CITADEL_FORCE_GPU_ENGINES"))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}

--- a/cmd/darwin_engines_test.go
+++ b/cmd/darwin_engines_test.go
@@ -1,0 +1,69 @@
+// cmd/darwin_engines_test.go
+package cmd
+
+import "testing"
+
+func TestSkipEngineOnDarwin(t *testing.T) {
+	cases := []struct {
+		name    string
+		goos    string
+		service string
+		force   bool
+		want    bool
+	}{
+		// NVIDIA/docker-only engines are skipped on darwin.
+		{"vllm on darwin", "darwin", "vllm", false, true},
+		{"sglang on darwin", "darwin", "sglang", false, true},
+		{"llamacpp on darwin", "darwin", "llamacpp", false, true},
+		{"case-insensitive name", "darwin", "vLLM", false, true},
+		{"whitespace tolerated", "darwin", "  vllm  ", false, true},
+
+		// Non-GPU engines are never skipped, even on darwin.
+		{"ollama on darwin", "darwin", "ollama", false, false},
+		{"lmstudio on darwin", "darwin", "lmstudio", false, false},
+		{"unknown service on darwin", "darwin", "something-else", false, false},
+
+		// Other platforms always start these engines.
+		{"vllm on linux", "linux", "vllm", false, false},
+		{"llamacpp on linux", "linux", "llamacpp", false, false},
+		{"vllm on windows", "windows", "vllm", false, false},
+
+		// The force escape hatch overrides the darwin skip.
+		{"vllm on darwin forced", "darwin", "vllm", true, false},
+		{"llamacpp on darwin forced", "darwin", "llamacpp", true, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := skipEngineOnDarwin(tc.goos, tc.service, tc.force)
+			if got != tc.want {
+				t.Errorf("skipEngineOnDarwin(%q, %q, %v) = %v, want %v",
+					tc.goos, tc.service, tc.force, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestForceGPUEngines(t *testing.T) {
+	cases := []struct {
+		val  string
+		want bool
+	}{
+		{"1", true},
+		{"true", true},
+		{"YES", true},
+		{"On", true},
+		{"", false},
+		{"0", false},
+		{"false", false},
+		{"nonsense", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.val, func(t *testing.T) {
+			t.Setenv("CITADEL_FORCE_GPU_ENGINES", tc.val)
+			if got := forceGPUEngines(); got != tc.want {
+				t.Errorf("forceGPUEngines() with %q = %v, want %v", tc.val, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,7 +30,6 @@ var cfgFile string
 var nexusURL string
 var authServiceURL string
 var debugMode bool
-var daemonMode bool
 var noColorGlobal bool
 
 // noAutoUpdate, when set via the --no-auto-update persistent flag (or the
@@ -88,12 +87,9 @@ Just run 'citadel' — it handles login, network connection, and launches the
 control center. All other subcommands are for scripting and advanced use.`,
 	Version: Version,
 	Run: func(cmd *cobra.Command, args []string) {
-		// Default behavior: launch control center if TTY, otherwise show help
-		if daemonMode {
-			// TODO: Run in daemon mode (background worker)
-			fmt.Println("Daemon mode not yet implemented. Use 'citadel work' for now.")
-			return
-		}
+		// Default behavior: launch control center if TTY, otherwise show help.
+		// Headless/background operation is provided by 'citadel work' (run under
+		// systemd or another supervisor); there is deliberately no --daemon flag.
 		if tui.IsTTY() {
 			runControlCenter()
 		} else {
@@ -146,7 +142,7 @@ control center. All other subcommands are for scripting and advanced use.`,
 
 		// Detect if we're about to launch TUI control center
 		// In this case, suppress stdout printing and defer to TUI activity log
-		isTUIContext := cmdName == "citadel" && len(args) == 0 && !daemonMode && tui.IsTTY()
+		isTUIContext := cmdName == "citadel" && len(args) == 0 && tui.IsTTY()
 
 		// MCP uses stdout as transport -- suppress update print to stdout.
 		if cmdName == "mcp" {
@@ -243,7 +239,6 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&debugMode, "debug", false, "Enable debug output")
 	rootCmd.PersistentFlags().BoolVar(&noColorGlobal, "no-color", false, "Disable colorized output")
 	rootCmd.PersistentFlags().BoolVar(&noAutoUpdate, "no-auto-update", false, "Disable automatic update checks and installs for this run (or set CITADEL_NO_AUTO_UPDATE=1)")
-	rootCmd.Flags().BoolVar(&daemonMode, "daemon", false, "Run in background daemon mode (no TUI)")
 	rootCmd.Flags().BoolVar(&noMouse, "no-mouse", false, "Disable control-center mouse control (keeps terminal drag-to-copy)")
 
 	// Hide persistent flags that are only for dev/scripting

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -2187,6 +2187,18 @@ func startManagedServices(ctx context.Context) []startedService {
 
 		serviceType := determineServiceType(service)
 
+		// On macOS, skip NVIDIA/docker-only engines (vLLM, SGLang, llama.cpp-CUDA)
+		// instead of surfacing a "Cannot connect to the Docker daemon" error that
+		// reads like a broken node (issue #608). Gated on the service resolving to
+		// the docker runtime, so a native engine install is unaffected: only the
+		// unsupported CUDA-image docker fallback is suppressed. Native ollama is the
+		// supported local-inference path on macOS.
+		if serviceType == internalServices.ServiceTypeDocker &&
+			skipEngineOnDarwin(runtime.GOOS, service.Name, forceGPUEngines()) {
+			fmt.Printf("   - Skipping %s on macOS: needs an NVIDIA GPU and Docker (use native ollama for local inference)\n", service.Name)
+			continue
+		}
+
 		if serviceType == internalServices.ServiceTypeNative {
 			fmt.Printf("   - Starting %s (native)...\n", service.Name)
 			if err := startNativeService(service.Name, configDir); err != nil {

--- a/docs/man/citadel.1
+++ b/docs/man/citadel.1
@@ -18,10 +18,6 @@ control center. All other subcommands are for scripting and advanced use.
 
 
 .SH OPTIONS
-\fB--daemon\fP[=false]
-	Run in background daemon mode (no TUI)
-
-.PP
 \fB--debug\fP[=false]
 	Enable debug output
 


### PR DESCRIPTION
## Context

Two small onboarding papercuts reported on macOS (citadel v2.88.0/v2.89.0):

- **#607**: `citadel --help` advertised `--daemon` ("Run in background daemon mode (no TUI)"), but `citadel --daemon` only printed `Daemon mode not yet implemented. Use 'citadel work' for now.` and exited. An advertised flag that dead-ends is misleading for anyone scripting node startup.
- **#608**: On darwin, `citadel work` tried to auto-start vLLM and llama.cpp-CUDA. Both need an NVIDIA GPU and Docker, so on a Mac they failed with `Cannot connect to the Docker daemon at unix:///var/run/docker.sock`, which reads like the node is broken.

## Changes

### #607: remove the dead `--daemon` flag (chose removal over faking background mode)
Faking a "background daemon" by running the worker in the foreground would still contradict the "background" wording, so removing is the honest fix. True headless operation is already provided by `citadel work` (run under systemd or another supervisor).

- `cmd/root.go`: drop the `daemonMode` var, the "not yet implemented" branch, the flag registration, and the `!daemonMode` term in the TUI-context check.
- `cmd/controlcenter.go`: the non-TTY hint now points at `citadel work` instead of `--daemon`.
- `docs/man/citadel.1`: regenerated via `go run docs/gen-manpage.go docs/man` so the man page no longer lists `--daemon`.

### #608: skip NVIDIA/docker-only engines on macOS
- `cmd/darwin_engines.go` (new): pure `skipEngineOnDarwin(goos, serviceName, force)` decision plus a `forceGPUEngines()` env reader. The NVIDIA/docker-only set is `{vllm, sglang, llamacpp}`.
- `cmd/work.go`: in `startManagedServices`, skip those engines on darwin with a single informational line instead of the docker-connection error. Gated on the service resolving to the docker runtime, so a native engine install (e.g. native llamacpp/ollama) is never skipped: only the unsupported CUDA-image docker fallback is suppressed. `CITADEL_FORCE_GPU_ENGINES=1` is an opt-in escape hatch.
- `cmd/darwin_engines_test.go` (new): table tests for the pure decision (darwin skip, other platforms start, case/whitespace tolerance, force override) and the env reader.

A fresh Mac node now comes up clean using native ollama.

## Testing

- `go build ./...`, `go vet ./cmd/...`, and `GOOS=darwin go build ./...` all pass (the #608 path is darwin-specific).
- `go test ./cmd/...` passes, including the new `TestSkipEngineOnDarwin` / `TestForceGPUEngines`.
- Built binary: `citadel --help` no longer lists `--daemon`.

Closes #607
Closes #608

*Generated by Claude Opus 4.8*