### PR TITLE
feat(footprint): node-side energy estimate (watt-hours) for the sovereignty receipt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -707,6 +707,51 @@ shaped like:
 The `engine` must be `bonsai` so the node routes `MODEL_CACHE_PULL` to the
 single-file GGUF pull and `SERVICE_START` to `services/compose/bonsai.yml`.
 
+### Per-request Energy Receipt (footprint energy, aceteam#6635)
+
+The footprint sampler can record a per-interval node energy estimate so the
+sovereignty pitch has an auditable watt-hours signal. It is **opt-in, default
+OFF**: when off, the sampler runs exactly as before (no power probe, no energy
+columns), so a node with energy disabled produces byte-identical footprint CSVs.
+
+**Columns (appended AFTER the core schema, only when enabled):** `power_w`,
+`energy_wh`, `power_source`. Written on the node-level (`_node`) row only;
+per-service/per-request attribution is a deliberate next increment.
+
+**Estimation waterfall (`internal/footprint/energy.go`, pure + unit-tested).**
+Tiers are never combined, so a `measured` label always means a real sensor:
+1. GPU board power (`nvidia-smi power.draw`, summed) -> `measured`
+2. GPU `util% x TDP` (TDP = `nvidia-smi power.limit`, or `CITADEL_GPU_TDP_WATTS`) -> `estimated`
+3. CPU `util% x CPU_TDP` (`CITADEL_CPU_TDP_WATTS`, default 65W) -> `estimated`
+4. nothing usable -> blank
+
+`energy_wh = power_w x interval_hours`. Apple Silicon and CPU-only nodes fall to
+tier 3 (powermetrics needs sudo and is never invoked). The `nvidia-smi` power
+probe runs ONLY when energy is enabled and a GPU is present.
+
+**Enabling (per node, three ways):**
+- Env var: `CITADEL_ENERGY_SAMPLING=1` (truthy `1`/`true`/`yes`/`on`; wins when set).
+- Node config file: `energy.yaml` (`sampling_enabled: true`) in `platform.ConfigDir()`,
+  via `config.LoadEnergy` / `config.SaveEnergy` (mirrors telemetry.yaml).
+- Platform: `APPLY_DEVICE_CONFIG` with `DeviceConfig.EnergySampling *bool`
+  (`energySampling` in the JSON), which load-modify-saves the same energy.yaml
+  (default-DENY pointer semantics, like ShellEnabled).
+
+Resolution precedence (`cmd/work.go:resolveEnergySampling`): env var if set,
+else energy.yaml, else OFF.
+
+**Backward-compat:** `query.go` gates parsing on the core (pre-energy) column
+count, so both 9-column (energy-off) and 12-column (energy-on) CSVs read cleanly.
+A daily file can mix schemas if energy is toggled mid-day; the Go query path is
+index-based and fine. A direct DuckDB glob over both schemas needs
+`union_by_name=true`.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `CITADEL_ENERGY_SAMPLING` | unset (OFF) | Enable the energy estimate. Truthy: `1`/`true`/`yes`/`on`. Overrides energy.yaml when set. |
+| `CITADEL_GPU_TDP_WATTS` | unset (use `power.limit`) | Override TDP for the GPU util estimate (tier 2). |
+| `CITADEL_CPU_TDP_WATTS` | `65` | CPU package TDP for the coarse CPU floor (tier 3). Apple Silicon runs lower than 65W. |
+
 ### Service Idle Detection and Auto-Stop (citadel #416)
 
 Managed services carry a per-service usage/idle signal so a node can tell whether an engine is actually being used or is pinning VRAM/RAM while idle. This is surfaced on the heartbeat and to operators, and can optionally drive auto-eviction.

--- a/cmd/footprints.go
+++ b/cmd/footprints.go
@@ -37,9 +37,11 @@ ad-hoc analysis, e.g.:
     FROM '~/citadel-node/footprints/*.csv' GROUP BY 1 ORDER BY 2 DESC"
 
 The node-level row is recorded under the service name "_node" and carries
-host CPU/RAM plus total GPU utilisation and VRAM used, and a per-interval
-energy estimate: power_w, energy_wh, and power_source (measured when read
-from a GPU power sensor, else estimated from utilisation and a TDP budget).`,
+host CPU/RAM plus total GPU utilisation and VRAM used. When energy sampling is
+enabled (CITADEL_ENERGY_SAMPLING=1 or energy.yaml; default off), the node row
+also carries a per-interval energy estimate: power_w, energy_wh, and
+power_source (measured when read from a GPU power sensor, else estimated from
+utilisation and a TDP budget).`,
 	Example: `  # Summarize all services over the last hour
   citadel footprints --since 1h
 

--- a/cmd/footprints.go
+++ b/cmd/footprints.go
@@ -37,7 +37,9 @@ ad-hoc analysis, e.g.:
     FROM '~/citadel-node/footprints/*.csv' GROUP BY 1 ORDER BY 2 DESC"
 
 The node-level row is recorded under the service name "_node" and carries
-host CPU/RAM plus total GPU utilisation and VRAM used.`,
+host CPU/RAM plus total GPU utilisation and VRAM used, and a per-interval
+energy estimate: power_w, energy_wh, and power_source (measured when read
+from a GPU power sensor, else estimated from utilisation and a TDP budget).`,
 	Example: `  # Summarize all services over the last hour
   citadel footprints --since 1h
 

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -2245,17 +2245,35 @@ func startFootprintSampler(ctx context.Context, nodeName string, manifest *Citad
 		}
 	}
 
+	energy := resolveEnergySampling()
 	cfg := footprint.Config{
-		NodeID:        nodeName,
-		Services:      serviceNames,
-		EngineBin:     catalog.SelectContainerRuntime().EngineBin,
-		Dir:           footprint.DefaultDir(nodeDir),
-		Interval:      interval,
-		RetentionDays: footprint.RetentionFromEnv(),
-		Logf:          func(format string, args ...any) { Log(format, args...) },
+		NodeID:         nodeName,
+		Services:       serviceNames,
+		EngineBin:      catalog.SelectContainerRuntime().EngineBin,
+		Dir:            footprint.DefaultDir(nodeDir),
+		Interval:       interval,
+		RetentionDays:  footprint.RetentionFromEnv(),
+		EnergySampling: energy,
+		Logf:           func(format string, args ...any) { Log(format, args...) },
 	}
 	go footprint.Run(ctx, cfg)
-	fmt.Printf("   - Footprint sampler: every %s → %s\n", interval, cfg.Dir)
+	energyLabel := "off"
+	if energy {
+		energyLabel = "on"
+	}
+	fmt.Printf("   - Footprint sampler: every %s (energy %s) → %s\n", interval, energyLabel, cfg.Dir)
+}
+
+// resolveEnergySampling decides whether the footprint sampler records the
+// per-request energy estimate (aceteam#6635). Default OFF. Precedence: the
+// CITADEL_ENERGY_SAMPLING env var wins when set (truthy enables, anything else
+// disables); otherwise the node's persisted energy.yaml toggle applies, which the
+// platform can set via APPLY_DEVICE_CONFIG.
+func resolveEnergySampling() bool {
+	if raw := strings.TrimSpace(os.Getenv("CITADEL_ENERGY_SAMPLING")); raw != "" {
+		return update.IsTruthy(raw)
+	}
+	return config.LoadEnergy(platform.ConfigDir()).SamplingEnabled
 }
 
 // stopManagedServices tears down services this worker started, mirroring the

--- a/internal/config/energy.go
+++ b/internal/config/energy.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Energy controls the per-request energy receipt sampler (aceteam#6635). Unlike
+// the capability opt-OUT toggles (meeting, telemetry), energy sampling is
+// default-OFF: it adds an nvidia-smi power probe per footprint tick and three
+// extra CSV columns, so a node opts IN explicitly. The operator enables it here
+// (energy.yaml) or via the CITADEL_ENERGY_SAMPLING env var; the platform can push
+// the same persisted value through APPLY_DEVICE_CONFIG (DeviceConfig.EnergySampling).
+type Energy struct {
+	// SamplingEnabled turns the footprint energy estimate on. When false (the
+	// default) the footprint sampler runs exactly as before the energy feature
+	// existed: no power probe, no power_w / energy_wh / power_source columns. When
+	// true the node-level footprint row carries a per-interval watt-hours estimate
+	// labeled measured (a real GPU power sensor) or estimated (a modeled figure).
+	SamplingEnabled bool `yaml:"sampling_enabled" json:"sampling_enabled"`
+}
+
+const energyFile = "energy.yaml"
+
+// DefaultEnergy returns Energy with sampling disabled: the opt-in default. Energy
+// sampling is off until an operator or the platform turns it on.
+func DefaultEnergy() *Energy {
+	return &Energy{SamplingEnabled: false}
+}
+
+// LoadEnergy reads energy settings from the config directory. A missing file
+// returns defaults (disabled). Partial files preserve defaults for absent keys
+// (unmarshal into a pre-initialized struct), mirroring LoadTelemetry.
+func LoadEnergy(configDir string) *Energy {
+	e := DefaultEnergy()
+
+	data, err := os.ReadFile(filepath.Join(configDir, energyFile))
+	if err != nil {
+		return e
+	}
+
+	// yaml.Unmarshal only overwrites keys present in the file, so an absent key
+	// keeps its default (false) value.
+	_ = yaml.Unmarshal(data, e)
+	return e
+}
+
+// SaveEnergy writes energy settings to the config directory. The
+// APPLY_DEVICE_CONFIG handler calls this when the platform pushes the toggle.
+func SaveEnergy(configDir string, e *Energy) error {
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+
+	data, err := yaml.Marshal(e)
+	if err != nil {
+		return fmt.Errorf("marshal energy: %w", err)
+	}
+
+	return os.WriteFile(filepath.Join(configDir, energyFile), data, 0644)
+}

--- a/internal/config/energy_test.go
+++ b/internal/config/energy_test.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadEnergyDefaultsOff(t *testing.T) {
+	dir := t.TempDir()
+	// No file present: default is OFF (opt-in).
+	if e := LoadEnergy(dir); e.SamplingEnabled {
+		t.Fatal("energy sampling should default to disabled")
+	}
+}
+
+func TestSaveLoadEnergyRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	if err := SaveEnergy(dir, &Energy{SamplingEnabled: true}); err != nil {
+		t.Fatalf("SaveEnergy: %v", err)
+	}
+	if e := LoadEnergy(dir); !e.SamplingEnabled {
+		t.Fatal("expected sampling enabled after save")
+	}
+	// File is named energy.yaml.
+	if _, err := os.Stat(filepath.Join(dir, energyFile)); err != nil {
+		t.Fatalf("energy.yaml not written: %v", err)
+	}
+}
+
+func TestLoadEnergyPartialFileKeepsDefault(t *testing.T) {
+	dir := t.TempDir()
+	// A file that does not mention sampling_enabled leaves the default (false).
+	if err := os.WriteFile(filepath.Join(dir, energyFile), []byte("# empty\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if e := LoadEnergy(dir); e.SamplingEnabled {
+		t.Fatal("absent key should keep default disabled")
+	}
+}

--- a/internal/footprint/energy.go
+++ b/internal/footprint/energy.go
@@ -1,0 +1,176 @@
+package footprint
+
+import (
+	"os"
+	"strconv"
+	"time"
+)
+
+// PowerSource labels how a sample's power figure was obtained, so an auditor can
+// tell a real hardware measurement apart from a modeled estimate. It is written
+// verbatim into the power_source CSV column.
+type PowerSource string
+
+const (
+	// PowerSourceMeasured means the figure came from a hardware power sensor
+	// (nvidia-smi power.draw). This is the number the sovereignty receipt wants.
+	PowerSourceMeasured PowerSource = "measured"
+	// PowerSourceEstimated means the figure was modeled from utilisation and a
+	// thermal design / power-limit budget, not read from a sensor.
+	PowerSourceEstimated PowerSource = "estimated"
+	// PowerSourceUnknown (empty) means no defensible figure was available; the CSV
+	// leaves power_w / energy_wh / power_source blank rather than guessing.
+	PowerSourceUnknown PowerSource = ""
+)
+
+// DefaultCPUTDPWatts is the fallback CPU package power budget used for the coarse
+// CPU-utilisation floor when CITADEL_CPU_TDP_WATTS is unset. 65W is a typical
+// desktop x86 TDP; it over-estimates Apple Silicon (M-series package power runs
+// lower) and under-estimates a HEDT/server socket, so operators should set the
+// env var to their chip's rated TDP for a tighter figure. It is only ever used as
+// the last waterfall tier (see EstimateNodePower), so it never dilutes a node
+// that reports real GPU power.
+const DefaultCPUTDPWatts = 65.0
+
+// PowerConfig holds the resolved, per-node power-estimation knobs. It is resolved
+// once (from the environment) and reused every tick, so no env parsing happens on
+// the sampling hot path.
+type PowerConfig struct {
+	// GPUTDPWattsOverride, when > 0, forces the TDP used for the GPU
+	// utilisation-times-TDP estimate (waterfall tier 2), overriding the card's
+	// reported power.limit. From CITADEL_GPU_TDP_WATTS. Zero means "use the
+	// measured power.limit".
+	GPUTDPWattsOverride float64
+	// CPUTDPWatts is the CPU package power budget for the coarse CPU floor
+	// (waterfall tier 3). From CITADEL_CPU_TDP_WATTS, defaulting to
+	// DefaultCPUTDPWatts. A value <= 0 disables the CPU floor entirely.
+	CPUTDPWatts float64
+}
+
+// PowerConfigFromEnv resolves the power-estimation knobs from the environment.
+// Unset or unparseable values fall back to safe defaults; nothing here shells
+// out or requires privileges.
+func PowerConfigFromEnv() PowerConfig {
+	return PowerConfig{
+		GPUTDPWattsOverride: envFloat("CITADEL_GPU_TDP_WATTS", 0),
+		CPUTDPWatts:         envFloat("CITADEL_CPU_TDP_WATTS", DefaultCPUTDPWatts),
+	}
+}
+
+// envFloat reads a non-negative float from env, returning def when unset or
+// invalid. A negative value is treated as invalid (falls back to def).
+func envFloat(key string, def float64) float64 {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return def
+	}
+	v, err := strconv.ParseFloat(raw, 64)
+	if err != nil || v < 0 {
+		return def
+	}
+	return v
+}
+
+// PowerInputs is the set of signals feeding one node-level power decision. The
+// *Known flags distinguish a real zero reading (idle GPU, 0% CPU) from "no
+// signal", which the waterfall must not treat as a measurement.
+type PowerInputs struct {
+	// HasGPU reports whether a GPU is present at all.
+	HasGPU bool
+	// GPUPowerWatts is the summed measured board power (nvidia-smi power.draw).
+	// Only meaningful when GPUPowerMeasured is true.
+	GPUPowerWatts float64
+	// GPUPowerMeasured is true when at least one GPU reported power.draw.
+	GPUPowerMeasured bool
+	// GPUUtilKnown / GPUUtilPercent carry the aggregate GPU utilisation (0-100).
+	GPUUtilKnown   bool
+	GPUUtilPercent float64
+	// GPUTDPWatts is the TDP used for the util-based estimate (power.limit or the
+	// configured override). Zero means "unknown", which skips tier 2.
+	GPUTDPWatts float64
+	// CPUKnown / CPUPercent carry the host CPU utilisation (0-100).
+	CPUKnown   bool
+	CPUPercent float64
+	// CPUTDPWatts is the CPU package power budget for the coarse floor. Zero
+	// disables tier 3.
+	CPUTDPWatts float64
+}
+
+// PowerEstimate is the outcome of one node-level power decision.
+type PowerEstimate struct {
+	// Watts is the estimated instantaneous node power. Only meaningful when Known.
+	Watts float64
+	// Source labels how Watts was obtained (measured vs estimated).
+	Source PowerSource
+	// Known is false when no defensible figure was available at all.
+	Known bool
+}
+
+// EstimateNodePower selects the best available node power figure via a strict
+// fall-through waterfall. Each tier is tried only if it can produce a value; the
+// first that can, wins. Tiers are NEVER combined, so a "measured" label always
+// means a real sensor reading and is never diluted by a modeled term.
+//
+//  1. Measured GPU board power (nvidia-smi power.draw)  -> measured
+//  2. GPU utilisation x TDP (power.limit or override)   -> estimated
+//  3. CPU utilisation x CPU TDP (coarse floor)          -> estimated
+//  4. Nothing usable                                    -> unknown (blank)
+//
+// Tier 3 is what gives Apple Silicon and CPU-only nodes a conservative floor
+// without powermetrics (which needs sudo): they have no power.draw, no NVIDIA
+// power.limit, and no GPU util, so they fall cleanly to the CPU model.
+//
+// A fuller node model (GPU + CPU + PSU efficiency + idle baseline summed) is a
+// deliberate next increment; this first cut reports a single, clearly-labeled
+// dominant term.
+func EstimateNodePower(in PowerInputs) PowerEstimate {
+	if in.HasGPU && in.GPUPowerMeasured {
+		return PowerEstimate{Watts: in.GPUPowerWatts, Source: PowerSourceMeasured, Known: true}
+	}
+	if in.HasGPU && in.GPUUtilKnown && in.GPUTDPWatts > 0 {
+		return PowerEstimate{
+			Watts:  wattsFromUtilTDP(in.GPUUtilPercent, in.GPUTDPWatts),
+			Source: PowerSourceEstimated,
+			Known:  true,
+		}
+	}
+	if in.CPUKnown && in.CPUTDPWatts > 0 {
+		return PowerEstimate{
+			Watts:  wattsFromUtilTDP(in.CPUPercent, in.CPUTDPWatts),
+			Source: PowerSourceEstimated,
+			Known:  true,
+		}
+	}
+	return PowerEstimate{}
+}
+
+// wattsFromUtilTDP models power as a linear fraction of a TDP budget: a device at
+// util% of capacity draws util% of its TDP. This is a coarse first-order model
+// (real curves have an idle floor and are convex), but it is defensible, needs no
+// sensor, and is clearly labeled "estimated". The utilisation is clamped to
+// 0..100 so a bogus reading cannot produce a negative or super-TDP figure. A
+// non-positive TDP yields 0.
+func wattsFromUtilTDP(utilPercent, tdpWatts float64) float64 {
+	if tdpWatts <= 0 {
+		return 0
+	}
+	frac := utilPercent / 100
+	if frac < 0 {
+		frac = 0
+	}
+	if frac > 1 {
+		frac = 1
+	}
+	return frac * tdpWatts
+}
+
+// energyWh converts an average power over an interval into watt-hours. This is a
+// left-Riemann approximation: each sample is credited one full interval at its
+// sampled power, so summing energy_wh across a day's node rows yields the
+// auditable daily energy total. A non-positive power or interval yields 0.
+func energyWh(powerW float64, interval time.Duration) float64 {
+	if powerW <= 0 || interval <= 0 {
+		return 0
+	}
+	return powerW * interval.Hours()
+}

--- a/internal/footprint/energy_test.go
+++ b/internal/footprint/energy_test.go
@@ -1,0 +1,193 @@
+package footprint
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func approx(a, b float64) bool { return math.Abs(a-b) < 1e-9 }
+
+func TestWattsFromUtilTDP(t *testing.T) {
+	cases := []struct {
+		name string
+		util float64
+		tdp  float64
+		want float64
+	}{
+		{"half load", 50, 350, 175},
+		{"full load", 100, 450, 450},
+		{"idle", 0, 350, 0},
+		{"zero tdp yields zero", 80, 0, 0},
+		{"negative tdp yields zero", 80, -10, 0},
+		{"util clamped above 100", 150, 300, 300},
+		{"util clamped below 0", -20, 300, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := wattsFromUtilTDP(c.util, c.tdp); !approx(got, c.want) {
+				t.Errorf("wattsFromUtilTDP(%v, %v) = %v, want %v", c.util, c.tdp, got, c.want)
+			}
+		})
+	}
+}
+
+func TestEnergyWh(t *testing.T) {
+	cases := []struct {
+		name     string
+		powerW   float64
+		interval time.Duration
+		want     float64
+	}{
+		{"60s at 100W", 100, 60 * time.Second, 100.0 / 60.0},
+		{"one hour at 200W", 200, time.Hour, 200},
+		{"zero power", 0, time.Hour, 0},
+		{"negative power", -5, time.Hour, 0},
+		{"zero interval", 100, 0, 0},
+		{"negative interval", 100, -time.Second, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := energyWh(c.powerW, c.interval); !approx(got, c.want) {
+				t.Errorf("energyWh(%v, %v) = %v, want %v", c.powerW, c.interval, got, c.want)
+			}
+		})
+	}
+}
+
+func TestEstimateNodePowerWaterfall(t *testing.T) {
+	cases := []struct {
+		name       string
+		in         PowerInputs
+		wantKnown  bool
+		wantWatts  float64
+		wantSource PowerSource
+	}{
+		{
+			name: "tier1 measured GPU wins even when util+tdp present",
+			in: PowerInputs{
+				HasGPU: true, GPUPowerMeasured: true, GPUPowerWatts: 142.5,
+				GPUUtilKnown: true, GPUUtilPercent: 90, GPUTDPWatts: 350,
+				CPUKnown: true, CPUPercent: 50, CPUTDPWatts: 65,
+			},
+			wantKnown: true, wantWatts: 142.5, wantSource: PowerSourceMeasured,
+		},
+		{
+			name: "tier2 GPU util times TDP when no measured draw",
+			in: PowerInputs{
+				HasGPU: true, GPUPowerMeasured: false,
+				GPUUtilKnown: true, GPUUtilPercent: 40, GPUTDPWatts: 350,
+				CPUKnown: true, CPUPercent: 100, CPUTDPWatts: 65,
+			},
+			wantKnown: true, wantWatts: 140, wantSource: PowerSourceEstimated,
+		},
+		{
+			name: "tier2 skipped when TDP unknown, falls to CPU",
+			in: PowerInputs{
+				HasGPU: true, GPUPowerMeasured: false,
+				GPUUtilKnown: true, GPUUtilPercent: 40, GPUTDPWatts: 0,
+				CPUKnown: true, CPUPercent: 50, CPUTDPWatts: 65,
+			},
+			wantKnown: true, wantWatts: 32.5, wantSource: PowerSourceEstimated,
+		},
+		{
+			name: "tier3 CPU floor (Apple Silicon / CPU-only node, no GPU)",
+			in: PowerInputs{
+				HasGPU:   false,
+				CPUKnown: true, CPUPercent: 25, CPUTDPWatts: 60,
+			},
+			wantKnown: true, wantWatts: 15, wantSource: PowerSourceEstimated,
+		},
+		{
+			name: "tier4 nothing usable yields unknown",
+			in: PowerInputs{
+				HasGPU:   false,
+				CPUKnown: true, CPUPercent: 50, CPUTDPWatts: 0,
+			},
+			wantKnown: false,
+		},
+		{
+			name: "no GPU util reading and no CPU TDP yields unknown",
+			in: PowerInputs{
+				HasGPU: true, GPUPowerMeasured: false, GPUUtilKnown: false,
+				GPUTDPWatts: 350, CPUKnown: false, CPUTDPWatts: 65,
+			},
+			wantKnown: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := EstimateNodePower(c.in)
+			if got.Known != c.wantKnown {
+				t.Fatalf("Known = %v, want %v", got.Known, c.wantKnown)
+			}
+			if !c.wantKnown {
+				return
+			}
+			if !approx(got.Watts, c.wantWatts) {
+				t.Errorf("Watts = %v, want %v", got.Watts, c.wantWatts)
+			}
+			if got.Source != c.wantSource {
+				t.Errorf("Source = %q, want %q", got.Source, c.wantSource)
+			}
+		})
+	}
+}
+
+func TestPowerConfigFromEnv(t *testing.T) {
+	t.Run("defaults when unset", func(t *testing.T) {
+		t.Setenv("CITADEL_GPU_TDP_WATTS", "")
+		t.Setenv("CITADEL_CPU_TDP_WATTS", "")
+		cfg := PowerConfigFromEnv()
+		if cfg.GPUTDPWattsOverride != 0 {
+			t.Errorf("GPU override = %v, want 0", cfg.GPUTDPWattsOverride)
+		}
+		if !approx(cfg.CPUTDPWatts, DefaultCPUTDPWatts) {
+			t.Errorf("CPU TDP = %v, want %v", cfg.CPUTDPWatts, DefaultCPUTDPWatts)
+		}
+	})
+	t.Run("honors valid overrides", func(t *testing.T) {
+		t.Setenv("CITADEL_GPU_TDP_WATTS", "450")
+		t.Setenv("CITADEL_CPU_TDP_WATTS", "125")
+		cfg := PowerConfigFromEnv()
+		if !approx(cfg.GPUTDPWattsOverride, 450) || !approx(cfg.CPUTDPWatts, 125) {
+			t.Errorf("got %+v, want 450/125", cfg)
+		}
+	})
+	t.Run("invalid CPU value falls back to default", func(t *testing.T) {
+		t.Setenv("CITADEL_CPU_TDP_WATTS", "not-a-number")
+		cfg := PowerConfigFromEnv()
+		if !approx(cfg.CPUTDPWatts, DefaultCPUTDPWatts) {
+			t.Errorf("CPU TDP = %v, want default %v", cfg.CPUTDPWatts, DefaultCPUTDPWatts)
+		}
+	})
+	t.Run("negative value rejected", func(t *testing.T) {
+		t.Setenv("CITADEL_GPU_TDP_WATTS", "-100")
+		cfg := PowerConfigFromEnv()
+		if cfg.GPUTDPWattsOverride != 0 {
+			t.Errorf("negative GPU override should fall back to 0, got %v", cfg.GPUTDPWattsOverride)
+		}
+	})
+}
+
+func TestParseWattsField(t *testing.T) {
+	cases := []struct {
+		in     string
+		wantOK bool
+		want   float64
+	}{
+		{"142.35", true, 142.35},
+		{" 90.0 ", true, 90.0},
+		{"[N/A]", false, 0},
+		{"[Not Supported]", false, 0},
+		{"[Insufficient Permissions]", false, 0},
+		{"", false, 0},
+		{"-1", false, 0},
+	}
+	for _, c := range cases {
+		got, ok := parseWattsField(c.in)
+		if ok != c.wantOK || (ok && !approx(got, c.want)) {
+			t.Errorf("parseWattsField(%q) = (%v, %v), want (%v, %v)", c.in, got, ok, c.want, c.wantOK)
+		}
+	}
+}

--- a/internal/footprint/footprint.go
+++ b/internal/footprint/footprint.go
@@ -42,9 +42,21 @@ type Sample struct {
 	// GPUUtilPercent is aggregate GPU utilisation. Only set on the node-level row.
 	GPUUtilPercent *float64
 	// IdleSeconds is how long the node has been idle, when a readily-available
-	// idle signal is wired in (#420). Left empty otherwise — this package does
+	// idle signal is wired in (#420). Left empty otherwise: this package does
 	// NOT reimplement idle detection.
 	IdleSeconds *int
+
+	// PowerW is the estimated instantaneous node power in watts. Set only on the
+	// node-level row (per-service attribution is a deliberate next increment).
+	// Left empty when no defensible figure is available.
+	PowerW *float64
+	// EnergyWh is the energy attributed to this sample's interval in watt-hours
+	// (PowerW times the sampling interval). Summing this column across node rows
+	// over a window yields the auditable energy total. Set only on the node row.
+	EnergyWh *float64
+	// PowerSource labels PowerW as measured (a real power sensor) or estimated (a
+	// modeled figure). Empty when no power figure was recorded.
+	PowerSource PowerSource
 }
 
 // NodeService is the reserved Service value for the synthetic node-level row that

--- a/internal/footprint/query.go
+++ b/internal/footprint/query.go
@@ -125,7 +125,10 @@ func readFileRows(path string) ([]row, error) {
 				continue // header
 			}
 		}
-		if len(rec) < len(csvHeader) {
+		// Gate on the core (pre-energy) column count, not the full header, so a CSV
+		// written by an older node (before the energy columns existed) is still
+		// parsed rather than silently dropped after an upgrade.
+		if len(rec) < coreColumns {
 			continue
 		}
 		parsed, ok := parseRecord(rec)

--- a/internal/footprint/query_test.go
+++ b/internal/footprint/query_test.go
@@ -2,6 +2,8 @@ package footprint
 
 import (
 	"math"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -162,5 +164,28 @@ func TestSummarizeMissingDirIsEmpty(t *testing.T) {
 	}
 	if len(got) != 0 {
 		t.Fatalf("expected empty result, got %+v", got)
+	}
+}
+
+// TestSummarizeReadsLegacyNineColumnCSV guards the backward-compat contract: a
+// footprints CSV written by an older node (9 columns, before the energy columns
+// existed) must still be summarized after an upgrade, not silently dropped.
+func TestSummarizeReadsLegacyNineColumnCSV(t *testing.T) {
+	dir := t.TempDir()
+	legacy := "ts,node_id,service,running,cpu_pct,rss_mb,vram_mb,gpu_util_pct,idle_seconds\n" +
+		"2026-07-01T12:00:00Z,n,vllm,true,10.00,1000.00,,,\n" +
+		"2026-07-01T12:01:00Z,n,vllm,true,20.00,2000.00,,,\n"
+	if err := os.WriteFile(filepath.Join(dir, "footprints-2026-07-01.csv"), []byte(legacy), 0o644); err != nil {
+		t.Fatalf("write legacy csv: %v", err)
+	}
+	summaries, err := Summarize(dir, QueryOptions{Now: time.Date(2026, 7, 1, 12, 5, 0, 0, time.UTC)}, time.Minute)
+	if err != nil {
+		t.Fatalf("Summarize: %v", err)
+	}
+	if len(summaries) != 1 || summaries[0].Service != "vllm" {
+		t.Fatalf("legacy rows dropped: got %+v", summaries)
+	}
+	if summaries[0].Samples != 2 || math.Abs(summaries[0].AvgRSSMB-1500) > 1e-6 {
+		t.Errorf("legacy summary = %+v, want 2 samples avg RSS 1500", summaries[0])
 	}
 }

--- a/internal/footprint/query_test.go
+++ b/internal/footprint/query_test.go
@@ -12,7 +12,7 @@ import (
 // CSVs (exercising header-skipping + parsing), not in-memory structs.
 func writeSyntheticCSV(t *testing.T, dir string, samples []Sample) {
 	t.Helper()
-	store, err := NewStore(dir)
+	store, err := NewStore(dir, false)
 	if err != nil {
 		t.Fatalf("NewStore: %v", err)
 	}
@@ -187,5 +187,39 @@ func TestSummarizeReadsLegacyNineColumnCSV(t *testing.T) {
 	}
 	if summaries[0].Samples != 2 || math.Abs(summaries[0].AvgRSSMB-1500) > 1e-6 {
 		t.Errorf("legacy summary = %+v, want 2 samples avg RSS 1500", summaries[0])
+	}
+}
+
+// TestSummarizeReadsTwelveColumnEnergyCSV verifies the other backward-compat
+// direction: a CSV written WITH the energy columns (energy sampling on) is parsed
+// by the same reader, so a fleet mixing energy-on and energy-off nodes summarizes
+// cleanly. parseRecord reads only the core columns; the energy tail is ignored.
+func TestSummarizeReadsTwelveColumnEnergyCSV(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir, true) // energy on -> 12-column output
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	day := time.Date(2026, 7, 5, 12, 0, 0, 0, time.UTC)
+	batch := []Sample{
+		{Timestamp: day, NodeID: "n", Service: "vllm", Running: true, RSSMB: f64(1000), CPUPercent: f64(10)},
+		{Timestamp: day.Add(time.Minute), NodeID: "n", Service: "vllm", Running: true, RSSMB: f64(2000), CPUPercent: f64(20)},
+		{Timestamp: day, NodeID: "n", Service: NodeService, Running: true,
+			PowerW: f64(210), EnergyWh: f64(3.5), PowerSource: PowerSourceMeasured},
+	}
+	if err := store.Append(batch); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	summaries, err := Summarize(dir, QueryOptions{Now: day.Add(5 * time.Minute)}, time.Minute)
+	if err != nil {
+		t.Fatalf("Summarize: %v", err)
+	}
+	byService := map[string]ServiceSummary{}
+	for _, s := range summaries {
+		byService[s.Service] = s
+	}
+	vllm, ok := byService["vllm"]
+	if !ok || vllm.Samples != 2 || vllm.AvgRSSMB != 1500 {
+		t.Fatalf("12-column CSV not parsed correctly: %+v", byService)
 	}
 }

--- a/internal/footprint/runner.go
+++ b/internal/footprint/runner.go
@@ -99,7 +99,7 @@ func Run(ctx context.Context, cfg Config) {
 		return
 	}
 
-	sampler := NewSampler(cfg.NodeID, cfg.Services, cfg.EngineBin)
+	sampler := NewSampler(cfg.NodeID, cfg.Services, cfg.EngineBin, interval, PowerConfigFromEnv())
 
 	// Prune once at startup so a node that was offline past the retention window
 	// cleans up immediately rather than after the first tick.

--- a/internal/footprint/runner.go
+++ b/internal/footprint/runner.go
@@ -36,6 +36,11 @@ type Config struct {
 	// RetentionDays prunes files older than this many days. Zero uses
 	// DefaultRetentionDays; negative disables pruning.
 	RetentionDays int
+	// EnergySampling turns the per-interval energy estimate on. Default false
+	// (opt-in): the caller resolves it from CITADEL_ENERGY_SAMPLING or the node's
+	// persisted energy config. When false, no power probe runs and no energy
+	// columns are written.
+	EnergySampling bool
 	// Logf is an optional structured log sink (e.g. cmd.Log). May be nil.
 	Logf func(format string, args ...any)
 }
@@ -93,13 +98,13 @@ func Run(ctx context.Context, cfg Config) {
 		logf = func(string, ...any) {}
 	}
 
-	store, err := NewStore(cfg.Dir)
+	store, err := NewStore(cfg.Dir, cfg.EnergySampling)
 	if err != nil {
 		logf("footprint: sampler disabled: %v", err)
 		return
 	}
 
-	sampler := NewSampler(cfg.NodeID, cfg.Services, cfg.EngineBin, interval, PowerConfigFromEnv())
+	sampler := NewSampler(cfg.NodeID, cfg.Services, cfg.EngineBin, interval, PowerConfigFromEnv(), cfg.EnergySampling)
 
 	// Prune once at startup so a node that was offline past the retention window
 	// cleans up immediately rather than after the first tick.

--- a/internal/footprint/sampler.go
+++ b/internal/footprint/sampler.go
@@ -36,8 +36,16 @@ type GPUSnapshot struct {
 type statsFunc func(ctx context.Context, engineBin string) ([]containerStat, error)
 
 // gpuFunc reads the node-level GPU snapshot for a tick. Injected so the sampler
-// is testable without a GPU.
+// is testable without a GPU. It carries VRAM/util only; power is read separately
+// (gpuPowerFunc) and ONLY when energy sampling is enabled, so a plain footprint
+// tick runs no extra probe.
 type gpuFunc func() GPUSnapshot
+
+// gpuPowerFunc reads GPU board power draw and the enforced power limit for a
+// tick, summed across GPUs. Injected so the sampler is testable, and called ONLY
+// when energy sampling is enabled and a GPU is present (so the default footprint
+// path runs zero nvidia-smi power probes).
+type gpuPowerFunc func() (watts float64, measured bool, limitWatts float64)
 
 // idleFunc returns the node's current idle-seconds signal and whether it is
 // available. Injected; the default returns (0, false) because #420's idle signal
@@ -52,6 +60,9 @@ type Sampler struct {
 	services  []string
 	engineBin string
 
+	// energy gates the whole energy estimate. When false (the default), no power
+	// probe runs and the node row carries no power_w / energy_wh / power_source.
+	energy bool
 	// powerCfg holds the resolved power-estimation knobs (TDP overrides). Resolved
 	// once so no env parsing happens per tick.
 	powerCfg PowerConfig
@@ -59,22 +70,27 @@ type Sampler struct {
 	// per-interval energy_wh. Zero leaves energy_wh blank.
 	interval time.Duration
 
-	stats statsFunc
-	gpu   gpuFunc
-	idle  idleFunc
+	stats    statsFunc
+	gpu      gpuFunc
+	gpuPower gpuPowerFunc
+	idle     idleFunc
 }
 
 // NewSampler wires a Sampler to the real host probes. interval is the sampling
-// cadence (used for energy_wh); powerCfg carries the resolved TDP knobs.
-func NewSampler(nodeID string, services []string, engineBin string, interval time.Duration, powerCfg PowerConfig) *Sampler {
+// cadence (used for energy_wh); powerCfg carries the resolved TDP knobs; energy
+// turns the power estimate (and its nvidia-smi power probe) on. When energy is
+// false the sampler behaves exactly as before the energy feature existed.
+func NewSampler(nodeID string, services []string, engineBin string, interval time.Duration, powerCfg PowerConfig, energy bool) *Sampler {
 	return &Sampler{
 		nodeID:    nodeID,
 		services:  services,
 		engineBin: engineBin,
+		energy:    energy,
 		powerCfg:  powerCfg,
 		interval:  interval,
 		stats:     sampleContainerStats,
 		gpu:       sampleGPU,
+		gpuPower:  readGPUPowerReading,
 		idle:      func() (int, bool) { return 0, false },
 	}
 }
@@ -146,11 +162,18 @@ func (s *Sampler) Sample(ctx context.Context, ts time.Time) []Sample {
 		node.GPUUtilPercent = &util
 	}
 
-	// Node-level energy estimate: the auditable per-request receipt starts here as
-	// a per-interval node figure. Prefer a measured GPU sensor, fall back to a
-	// clearly-labeled model. This is the only row that carries power; per-service
-	// attribution is a deliberate next increment.
-	s.fillNodePower(&node, snap, cpuPct, cpuOK)
+	// Node-level energy estimate: opt-in (default OFF). Only when enabled do we run
+	// the GPU power probe and stamp power_w / energy_wh / power_source. When off,
+	// this is a no-op so the tick is byte-identical to the pre-energy footprint.
+	if s.energy {
+		if snap.HasGPU && s.gpuPower != nil {
+			watts, measured, limit := s.gpuPower()
+			snap.PowerWatts = watts
+			snap.PowerMeasured = measured
+			snap.PowerLimitWatts = limit
+		}
+		s.fillNodePower(&node, snap, cpuPct, cpuOK)
+	}
 
 	rows = append(rows, node)
 	return rows
@@ -221,19 +244,17 @@ func sampleGPU() GPUSnapshot {
 			snap.GPUUtilPercent = util
 		}
 	}
-	// Best-effort power read via nvidia-smi. On any error (macOS/Metal, no NVIDIA
-	// driver, older driver) the power fields stay zero and the estimator falls
-	// through to a util or CPU model. This never prompts for privileges.
-	readGPUPower(&snap)
 	return snap
 }
 
-// readGPUPower runs a single read-only nvidia-smi query for board power draw and
-// the enforced power limit, summing across GPUs into snap. It is intentionally
+// readGPUPowerReading runs a single read-only nvidia-smi query for board power
+// draw and the enforced power limit, summed across GPUs. It is intentionally
 // footprint-local (not a change to the shared internal/platform GPU detector) so
 // this package stays self-contained per its package doc. Any failure is silent:
-// power.draw / power.limit are simply left unset.
-func readGPUPower(snap *GPUSnapshot) {
+// it returns measured=false and zero watts, so the estimator falls through to a
+// util or CPU model. This never prompts for privileges. It is called ONLY when
+// energy sampling is enabled.
+func readGPUPowerReading() (watts float64, measured bool, limitWatts float64) {
 	cmd := exec.Command(
 		"nvidia-smi",
 		"--query-gpu=power.draw,power.limit",
@@ -241,7 +262,7 @@ func readGPUPower(snap *GPUSnapshot) {
 	)
 	out, err := cmd.Output()
 	if err != nil {
-		return
+		return 0, false, 0
 	}
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 		parts := strings.Split(line, ",")
@@ -249,13 +270,14 @@ func readGPUPower(snap *GPUSnapshot) {
 			continue
 		}
 		if w, ok := parseWattsField(parts[0]); ok {
-			snap.PowerWatts += w
-			snap.PowerMeasured = true
+			watts += w
+			measured = true
 		}
 		if l, ok := parseWattsField(parts[1]); ok {
-			snap.PowerLimitWatts += l
+			limitWatts += l
 		}
 	}
+	return watts, measured, limitWatts
 }
 
 // parseWattsField parses an nvidia-smi power field (already "nounits", e.g.

--- a/internal/footprint/sampler.go
+++ b/internal/footprint/sampler.go
@@ -2,6 +2,7 @@ package footprint
 
 import (
 	"context"
+	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -17,6 +18,17 @@ type GPUSnapshot struct {
 	// HasGPU is false on nodes without an NVIDIA/Metal GPU, in which case the
 	// node-level row leaves vram_mb / gpu_util_pct empty.
 	HasGPU bool
+
+	// PowerWatts is the summed measured board power across GPUs (nvidia-smi
+	// power.draw). Valid only when PowerMeasured is true.
+	PowerWatts float64
+	// PowerMeasured is true when at least one GPU reported a real power.draw
+	// reading (not "[N/A]" / "[Not Supported]").
+	PowerMeasured bool
+	// PowerLimitWatts is the summed enforced power cap across GPUs (nvidia-smi
+	// power.limit). Used as the TDP for the utilisation-based power estimate when
+	// power.draw is unavailable. Zero when unknown.
+	PowerLimitWatts float64
 }
 
 // statsFunc runs the single container-stats exec for a tick. Injected so the
@@ -34,23 +46,33 @@ type gpuFunc func() GPUSnapshot
 type idleFunc func() (int, bool)
 
 // Sampler builds one batch of footprint samples per tick: one row per managed
-// service (from stats) plus one node-level row (host CPU/RSS + GPU).
+// service (from stats) plus one node-level row (host CPU/RSS + GPU + energy).
 type Sampler struct {
 	nodeID    string
 	services  []string
 	engineBin string
+
+	// powerCfg holds the resolved power-estimation knobs (TDP overrides). Resolved
+	// once so no env parsing happens per tick.
+	powerCfg PowerConfig
+	// interval is the sampling cadence, used to convert instantaneous power_w into
+	// per-interval energy_wh. Zero leaves energy_wh blank.
+	interval time.Duration
 
 	stats statsFunc
 	gpu   gpuFunc
 	idle  idleFunc
 }
 
-// NewSampler wires a Sampler to the real host probes.
-func NewSampler(nodeID string, services []string, engineBin string) *Sampler {
+// NewSampler wires a Sampler to the real host probes. interval is the sampling
+// cadence (used for energy_wh); powerCfg carries the resolved TDP knobs.
+func NewSampler(nodeID string, services []string, engineBin string, interval time.Duration, powerCfg PowerConfig) *Sampler {
 	return &Sampler{
 		nodeID:    nodeID,
 		services:  services,
 		engineBin: engineBin,
+		powerCfg:  powerCfg,
+		interval:  interval,
 		stats:     sampleContainerStats,
 		gpu:       sampleGPU,
 		idle:      func() (int, bool) { return 0, false },
@@ -109,20 +131,59 @@ func (s *Sampler) Sample(ctx context.Context, ts time.Time) []Sample {
 		Running:     true,
 		IdleSeconds: idlePtr,
 	}
-	if cpu, ok := hostCPUPercent(); ok {
-		node.CPUPercent = &cpu
+	cpuPct, cpuOK := hostCPUPercent()
+	if cpuOK {
+		node.CPUPercent = &cpuPct
 	}
 	if rss, ok := hostRSSMB(); ok {
 		node.RSSMB = &rss
 	}
-	if snap := s.gpu(); snap.HasGPU {
+	snap := s.gpu()
+	if snap.HasGPU {
 		vram := snap.VRAMUsedMB
 		util := snap.GPUUtilPercent
 		node.VRAMMB = &vram
 		node.GPUUtilPercent = &util
 	}
+
+	// Node-level energy estimate: the auditable per-request receipt starts here as
+	// a per-interval node figure. Prefer a measured GPU sensor, fall back to a
+	// clearly-labeled model. This is the only row that carries power; per-service
+	// attribution is a deliberate next increment.
+	s.fillNodePower(&node, snap, cpuPct, cpuOK)
+
 	rows = append(rows, node)
 	return rows
+}
+
+// fillNodePower runs the power waterfall for the node row and, when a figure is
+// available, sets power_w / energy_wh / power_source. It never fails: an absent
+// signal simply leaves the fields blank.
+func (s *Sampler) fillNodePower(node *Sample, snap GPUSnapshot, cpuPct float64, cpuOK bool) {
+	gpuTDP := s.powerCfg.GPUTDPWattsOverride
+	if gpuTDP <= 0 {
+		gpuTDP = snap.PowerLimitWatts
+	}
+	est := EstimateNodePower(PowerInputs{
+		HasGPU:           snap.HasGPU,
+		GPUPowerWatts:    snap.PowerWatts,
+		GPUPowerMeasured: snap.PowerMeasured,
+		GPUUtilKnown:     snap.HasGPU,
+		GPUUtilPercent:   snap.GPUUtilPercent,
+		GPUTDPWatts:      gpuTDP,
+		CPUKnown:         cpuOK,
+		CPUPercent:       cpuPct,
+		CPUTDPWatts:      s.powerCfg.CPUTDPWatts,
+	})
+	if !est.Known {
+		return
+	}
+	watts := est.Watts
+	node.PowerW = &watts
+	node.PowerSource = est.Source
+	if wh := energyWh(watts, s.interval); wh > 0 {
+		node.EnergyWh = &wh
+	}
 }
 
 // matchContainer returns the first stats row whose container name contains the
@@ -160,7 +221,57 @@ func sampleGPU() GPUSnapshot {
 			snap.GPUUtilPercent = util
 		}
 	}
+	// Best-effort power read via nvidia-smi. On any error (macOS/Metal, no NVIDIA
+	// driver, older driver) the power fields stay zero and the estimator falls
+	// through to a util or CPU model. This never prompts for privileges.
+	readGPUPower(&snap)
 	return snap
+}
+
+// readGPUPower runs a single read-only nvidia-smi query for board power draw and
+// the enforced power limit, summing across GPUs into snap. It is intentionally
+// footprint-local (not a change to the shared internal/platform GPU detector) so
+// this package stays self-contained per its package doc. Any failure is silent:
+// power.draw / power.limit are simply left unset.
+func readGPUPower(snap *GPUSnapshot) {
+	cmd := exec.Command(
+		"nvidia-smi",
+		"--query-gpu=power.draw,power.limit",
+		"--format=csv,noheader,nounits",
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		return
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		parts := strings.Split(line, ",")
+		if len(parts) < 2 {
+			continue
+		}
+		if w, ok := parseWattsField(parts[0]); ok {
+			snap.PowerWatts += w
+			snap.PowerMeasured = true
+		}
+		if l, ok := parseWattsField(parts[1]); ok {
+			snap.PowerLimitWatts += l
+		}
+	}
+}
+
+// parseWattsField parses an nvidia-smi power field (already "nounits", e.g.
+// "142.35"). It rejects the sentinel values nvidia-smi emits when a sensor is
+// absent ("[N/A]", "[Not Supported]", "[Insufficient Permissions]"), returning
+// ok=false so the caller falls through to an estimate.
+func parseWattsField(s string) (float64, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" || strings.HasPrefix(s, "[") {
+		return 0, false
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil || v < 0 {
+		return 0, false
+	}
+	return v, true
 }
 
 // parseMBField parses a platform GPUInfo memory string like "8192 MB" into MB.

--- a/internal/footprint/sampler_test.go
+++ b/internal/footprint/sampler_test.go
@@ -103,6 +103,7 @@ func TestSamplerNodeRowCarriesMeasuredPower(t *testing.T) {
 		nodeID:    "n",
 		services:  []string{"vllm"},
 		engineBin: "docker",
+		energy:    true,
 		interval:  60 * time.Second,
 		powerCfg:  PowerConfig{CPUTDPWatts: 65},
 		stats:     func(ctx context.Context, _ string) ([]containerStat, error) { return nil, nil },
@@ -147,6 +148,7 @@ func TestSamplerNodeRowEstimatesFromUtilWhenNoDraw(t *testing.T) {
 		nodeID:    "n",
 		services:  nil,
 		engineBin: "docker",
+		energy:    true,
 		interval:  60 * time.Second,
 		powerCfg:  PowerConfig{CPUTDPWatts: 65},
 		stats:     func(ctx context.Context, _ string) ([]containerStat, error) { return nil, nil },
@@ -166,6 +168,79 @@ func TestSamplerNodeRowEstimatesFromUtilWhenNoDraw(t *testing.T) {
 	}
 	if node.PowerW == nil || math.Abs(*node.PowerW-140) > 1e-6 { // 40% of 350
 		t.Errorf("power_w = %v, want 140", node.PowerW)
+	}
+}
+
+// TestSamplerEnergyDisabledSkipsProbeAndColumns verifies the default-OFF contract:
+// with energy off, the GPU power probe is never invoked and the node row carries
+// no power_w / energy_wh / power_source, even though a GPU with power is present.
+func TestSamplerEnergyDisabledSkipsProbeAndColumns(t *testing.T) {
+	probeCalled := false
+	s := &Sampler{
+		nodeID:    "n",
+		services:  []string{"vllm"},
+		engineBin: "docker",
+		energy:    false, // disabled
+		interval:  60 * time.Second,
+		powerCfg:  PowerConfig{CPUTDPWatts: 65},
+		stats:     func(ctx context.Context, _ string) ([]containerStat, error) { return nil, nil },
+		gpu: func() GPUSnapshot {
+			return GPUSnapshot{HasGPU: true, VRAMUsedMB: 8000, GPUUtilPercent: 55}
+		},
+		gpuPower: func() (float64, bool, float64) {
+			probeCalled = true
+			return 210, true, 350
+		},
+		idle: func() (int, bool) { return 0, false },
+	}
+	rows := s.Sample(context.Background(), time.Now())
+	if probeCalled {
+		t.Error("GPU power probe must NOT be invoked when energy sampling is disabled")
+	}
+	node := rows[len(rows)-1]
+	if node.Service != NodeService {
+		t.Fatalf("last row should be node, got %q", node.Service)
+	}
+	// VRAM/util still recorded (unchanged behavior); power columns stay blank.
+	if node.VRAMMB == nil || *node.VRAMMB != 8000 {
+		t.Errorf("VRAM should still be recorded when energy off, got %v", node.VRAMMB)
+	}
+	if node.PowerW != nil || node.EnergyWh != nil || node.PowerSource != PowerSourceUnknown {
+		t.Errorf("no power fields when energy off, got power_w=%v energy_wh=%v source=%q", node.PowerW, node.EnergyWh, node.PowerSource)
+	}
+}
+
+// TestSamplerEnergyEnabledInvokesProbe verifies the enabled path calls the
+// injected power probe and stamps the resulting measured figure.
+func TestSamplerEnergyEnabledInvokesProbe(t *testing.T) {
+	probeCalled := false
+	s := &Sampler{
+		nodeID:    "n",
+		engineBin: "docker",
+		energy:    true,
+		interval:  time.Hour,
+		powerCfg:  PowerConfig{CPUTDPWatts: 65},
+		stats:     func(ctx context.Context, _ string) ([]containerStat, error) { return nil, nil },
+		gpu: func() GPUSnapshot {
+			return GPUSnapshot{HasGPU: true, GPUUtilPercent: 50}
+		},
+		gpuPower: func() (float64, bool, float64) {
+			probeCalled = true
+			return 300, true, 350
+		},
+		idle: func() (int, bool) { return 0, false },
+	}
+	rows := s.Sample(context.Background(), time.Now())
+	if !probeCalled {
+		t.Error("GPU power probe should be invoked when energy sampling is enabled")
+	}
+	node := rows[len(rows)-1]
+	if node.PowerW == nil || *node.PowerW != 300 || node.PowerSource != PowerSourceMeasured {
+		t.Errorf("expected measured 300W from probe, got power_w=%v source=%q", node.PowerW, node.PowerSource)
+	}
+	// 300W for 1h = 300 Wh.
+	if node.EnergyWh == nil || math.Abs(*node.EnergyWh-300) > 1e-6 {
+		t.Errorf("energy_wh = %v, want 300", node.EnergyWh)
 	}
 }
 

--- a/internal/footprint/sampler_test.go
+++ b/internal/footprint/sampler_test.go
@@ -98,6 +98,77 @@ func TestSamplerStatsErrorStillEmitsNodeRow(t *testing.T) {
 	}
 }
 
+func TestSamplerNodeRowCarriesMeasuredPower(t *testing.T) {
+	s := &Sampler{
+		nodeID:    "n",
+		services:  []string{"vllm"},
+		engineBin: "docker",
+		interval:  60 * time.Second,
+		powerCfg:  PowerConfig{CPUTDPWatts: 65},
+		stats:     func(ctx context.Context, _ string) ([]containerStat, error) { return nil, nil },
+		gpu: func() GPUSnapshot {
+			return GPUSnapshot{
+				HasGPU: true, VRAMUsedMB: 8000, GPUUtilPercent: 55,
+				PowerWatts: 210, PowerMeasured: true, PowerLimitWatts: 350,
+			}
+		},
+		idle: func() (int, bool) { return 0, false },
+	}
+	rows := s.Sample(context.Background(), time.Now())
+	var node *Sample
+	for i := range rows {
+		if rows[i].Service == NodeService {
+			node = &rows[i]
+		}
+		if rows[i].Service == "vllm" {
+			// Per-service rows never carry power in this increment.
+			if rows[i].PowerW != nil || rows[i].EnergyWh != nil || rows[i].PowerSource != PowerSourceUnknown {
+				t.Errorf("service row must not carry power, got %+v", rows[i])
+			}
+		}
+	}
+	if node == nil {
+		t.Fatal("no node row")
+	}
+	if node.PowerW == nil || *node.PowerW != 210 {
+		t.Errorf("node power_w = %v, want 210 (measured draw wins)", node.PowerW)
+	}
+	if node.PowerSource != PowerSourceMeasured {
+		t.Errorf("node power_source = %q, want measured", node.PowerSource)
+	}
+	// 210W for 60s = 210/60 Wh.
+	if node.EnergyWh == nil || math.Abs(*node.EnergyWh-210.0/60.0) > 1e-6 {
+		t.Errorf("node energy_wh = %v, want %v", node.EnergyWh, 210.0/60.0)
+	}
+}
+
+func TestSamplerNodeRowEstimatesFromUtilWhenNoDraw(t *testing.T) {
+	s := &Sampler{
+		nodeID:    "n",
+		services:  nil,
+		engineBin: "docker",
+		interval:  60 * time.Second,
+		powerCfg:  PowerConfig{CPUTDPWatts: 65},
+		stats:     func(ctx context.Context, _ string) ([]containerStat, error) { return nil, nil },
+		gpu: func() GPUSnapshot {
+			// No measured draw, but a power.limit is known -> tier 2 estimate.
+			return GPUSnapshot{HasGPU: true, GPUUtilPercent: 40, PowerLimitWatts: 350}
+		},
+		idle: func() (int, bool) { return 0, false },
+	}
+	rows := s.Sample(context.Background(), time.Now())
+	node := rows[len(rows)-1]
+	if node.Service != NodeService {
+		t.Fatalf("last row should be node, got %q", node.Service)
+	}
+	if node.PowerSource != PowerSourceEstimated {
+		t.Errorf("power_source = %q, want estimated", node.PowerSource)
+	}
+	if node.PowerW == nil || math.Abs(*node.PowerW-140) > 1e-6 { // 40% of 350
+		t.Errorf("power_w = %v, want 140", node.PowerW)
+	}
+}
+
 func TestSamplerIdleSignalWiredThrough(t *testing.T) {
 	s := &Sampler{
 		nodeID:    "n",

--- a/internal/footprint/store.go
+++ b/internal/footprint/store.go
@@ -36,17 +36,33 @@ var dailyFilePattern = regexp.MustCompile(`^footprints-\d{4}-\d{2}-\d{2}\.csv$`)
 // is only ever one sampler per node).
 type Store struct {
 	dir string
+	// energy controls whether the three energy columns are written. When false
+	// (energy sampling off) the store writes the original core schema only, so a
+	// node with energy disabled produces byte-identical CSVs to the pre-energy
+	// build.
+	energy bool
 }
 
-// NewStore returns a Store writing to dir, creating the directory if needed.
-func NewStore(dir string) (*Store, error) {
+// NewStore returns a Store writing to dir, creating the directory if needed. When
+// energy is false the store omits the power_w / energy_wh / power_source columns
+// entirely (header and rows).
+func NewStore(dir string, energy bool) (*Store, error) {
 	if dir == "" {
 		return nil, fmt.Errorf("footprint: empty store dir")
 	}
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, fmt.Errorf("footprint: create store dir: %w", err)
 	}
-	return &Store{dir: dir}, nil
+	return &Store{dir: dir, energy: energy}, nil
+}
+
+// header returns the CSV header for this store: the core (pre-energy) columns,
+// plus the energy columns when energy sampling is enabled.
+func (s *Store) header() []string {
+	if s.energy {
+		return csvHeader
+	}
+	return csvHeader[:coreColumns]
 }
 
 // Dir returns the store's directory (the footprints/ path).
@@ -89,12 +105,12 @@ func (s *Store) Append(samples []Sample) error {
 
 	w := csv.NewWriter(f)
 	if needHeader {
-		if err := w.Write(csvHeader); err != nil {
+		if err := w.Write(s.header()); err != nil {
 			return fmt.Errorf("footprint: write header: %w", err)
 		}
 	}
 	for _, sm := range samples {
-		if err := w.Write(sm.toRecord()); err != nil {
+		if err := w.Write(sm.toRecord(s.energy)); err != nil {
 			return fmt.Errorf("footprint: write row: %w", err)
 		}
 	}
@@ -107,9 +123,11 @@ func (s *Store) Append(samples []Sample) error {
 
 // toRecord renders a sample as a CSV record in csvHeader column order. Unset
 // optional metrics render as the empty string, so DuckDB reads them as NULL and
-// a human greps them as blank — distinct from a measured zero.
-func (sm Sample) toRecord() []string {
-	return []string{
+// a human greps them as blank, distinct from a measured zero. The three energy
+// columns are appended only when energy is true; when false the record is the
+// original core schema.
+func (sm Sample) toRecord(energy bool) []string {
+	rec := []string{
 		sm.Timestamp.UTC().Format(time.RFC3339),
 		sm.NodeID,
 		sm.Service,
@@ -119,10 +137,15 @@ func (sm Sample) toRecord() []string {
 		intField(sm.VRAMMB),
 		floatField(sm.GPUUtilPercent),
 		intField(sm.IdleSeconds),
-		floatField(sm.PowerW),
-		floatField(sm.EnergyWh),
-		string(sm.PowerSource),
 	}
+	if energy {
+		rec = append(rec,
+			floatField(sm.PowerW),
+			floatField(sm.EnergyWh),
+			string(sm.PowerSource),
+		)
+	}
+	return rec
 }
 
 func floatField(v *float64) string {

--- a/internal/footprint/store.go
+++ b/internal/footprint/store.go
@@ -13,10 +13,19 @@ import (
 // csvHeader is the fixed column order for footprint CSVs. It is written once as
 // the first line of each daily file. DuckDB / pandas read these headers directly
 // (e.g. `duckdb -c "SELECT service, avg(rss_mb) FROM 'footprints/*.csv' GROUP BY 1"`).
+// The first coreColumns are the original, pre-energy schema. The energy columns
+// (power_w, energy_wh, power_source) are appended AFTER them so a reader that
+// knows only the core schema still parses old and new files positionally.
 var csvHeader = []string{
 	"ts", "node_id", "service", "running",
 	"cpu_pct", "rss_mb", "vram_mb", "gpu_util_pct", "idle_seconds",
+	"power_w", "energy_wh", "power_source",
 }
+
+// coreColumns is the count of pre-energy columns. A row with at least this many
+// fields is parseable; the energy columns are optional so footprint CSVs written
+// by an older node (9 columns) remain readable after this schema grew.
+const coreColumns = 9
 
 // dailyFilePattern matches footprints-YYYY-MM-DD.csv so retention pruning only
 // ever touches this package's own rotated files.
@@ -110,6 +119,9 @@ func (sm Sample) toRecord() []string {
 		intField(sm.VRAMMB),
 		floatField(sm.GPUUtilPercent),
 		intField(sm.IdleSeconds),
+		floatField(sm.PowerW),
+		floatField(sm.EnergyWh),
+		string(sm.PowerSource),
 	}
 }
 

--- a/internal/footprint/store_test.go
+++ b/internal/footprint/store_test.go
@@ -52,6 +52,32 @@ func TestAppendWritesHeaderOnce(t *testing.T) {
 	}
 }
 
+func TestAppendWritesEnergyColumns(t *testing.T) {
+	dir := t.TempDir()
+	store, _ := NewStore(dir)
+
+	day := time.Date(2026, 7, 3, 10, 0, 0, 0, time.UTC)
+	node := Sample{
+		Timestamp: day, NodeID: "n", Service: NodeService, Running: true,
+		VRAMMB: ip(8000), GPUUtilPercent: f64(55),
+		PowerW: f64(210), EnergyWh: f64(3.5), PowerSource: PowerSourceMeasured,
+	}
+	if err := store.Append([]Sample{node}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "footprints-2026-07-03.csv"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if !strings.HasSuffix(lines[0], "power_w,energy_wh,power_source") {
+		t.Fatalf("header missing energy columns: %q", lines[0])
+	}
+	if !strings.HasSuffix(lines[1], "210.00,3.50,measured") {
+		t.Fatalf("node row missing energy values: %q", lines[1])
+	}
+}
+
 func TestAppendRotatesByDay(t *testing.T) {
 	dir := t.TempDir()
 	store, _ := NewStore(dir)

--- a/internal/footprint/store_test.go
+++ b/internal/footprint/store_test.go
@@ -13,7 +13,7 @@ func ip(v int) *int          { return &v }
 
 func TestAppendWritesHeaderOnce(t *testing.T) {
 	dir := t.TempDir()
-	store, err := NewStore(dir)
+	store, err := NewStore(dir, false)
 	if err != nil {
 		t.Fatalf("NewStore: %v", err)
 	}
@@ -54,7 +54,7 @@ func TestAppendWritesHeaderOnce(t *testing.T) {
 
 func TestAppendWritesEnergyColumns(t *testing.T) {
 	dir := t.TempDir()
-	store, _ := NewStore(dir)
+	store, _ := NewStore(dir, true)
 
 	day := time.Date(2026, 7, 3, 10, 0, 0, 0, time.UTC)
 	node := Sample{
@@ -80,7 +80,7 @@ func TestAppendWritesEnergyColumns(t *testing.T) {
 
 func TestAppendRotatesByDay(t *testing.T) {
 	dir := t.TempDir()
-	store, _ := NewStore(dir)
+	store, _ := NewStore(dir, false)
 
 	d1 := time.Date(2026, 7, 1, 23, 59, 0, 0, time.UTC)
 	d2 := time.Date(2026, 7, 2, 0, 1, 0, 0, time.UTC)
@@ -100,7 +100,7 @@ func TestAppendRotatesByDay(t *testing.T) {
 
 func TestAppendEmptyIsNoop(t *testing.T) {
 	dir := t.TempDir()
-	store, _ := NewStore(dir)
+	store, _ := NewStore(dir, false)
 	if err := store.Append(nil); err != nil {
 		t.Fatalf("Append(nil): %v", err)
 	}
@@ -112,7 +112,7 @@ func TestAppendEmptyIsNoop(t *testing.T) {
 
 func TestPruneRemovesOldKeepsRecent(t *testing.T) {
 	dir := t.TempDir()
-	store, _ := NewStore(dir)
+	store, _ := NewStore(dir, false)
 
 	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
 	// Create files spanning old and recent days plus an unrelated file.
@@ -163,7 +163,7 @@ func TestPruneRemovesOldKeepsRecent(t *testing.T) {
 
 func TestPruneDisabledWhenRetentionNonPositive(t *testing.T) {
 	dir := t.TempDir()
-	store, _ := NewStore(dir)
+	store, _ := NewStore(dir, false)
 	now := time.Now()
 	if err := store.Append([]Sample{{Timestamp: now.AddDate(0, 0, -100), NodeID: "n", Service: "svc"}}); err != nil {
 		t.Fatal(err)

--- a/internal/jobs/config_handler.go
+++ b/internal/jobs/config_handler.go
@@ -82,6 +82,15 @@ type DeviceConfig struct {
 	// like console/desktop/files.
 	ShellEnabled *bool `json:"shellEnabled,omitempty"`
 
+	// EnergySampling is the programmatic opt-IN for the per-request energy receipt
+	// (aceteam#6635). Pointer for the same absent(nil)-vs-explicit reason as the
+	// other *Enabled flags: an omitted field leaves the node's persisted energy
+	// toggle untouched. A non-nil value writes the same energy.yaml the operator's
+	// env var / settings and the footprint sampler read. Default-OFF on a fresh
+	// node (it adds an nvidia-smi power probe per tick), so the platform must send
+	// `true` here to turn it on.
+	EnergySampling *bool `json:"energySampling,omitempty"`
+
 	// NodePasscode sets (or, when empty, clears) the per-node passcode that gates
 	// the sensitive surfaces (aceteam#6524). Pointer so nil leaves the stored
 	// passcode untouched; a non-nil value is bcrypt-hashed before it is persisted
@@ -170,6 +179,21 @@ func (h *ConfigHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) 
 			if config.MeetingRetentionDays != nil {
 				result += fmt.Sprintf("\nMeeting recording retention set to %d days", *config.MeetingRetentionDays)
 			}
+		}
+	}
+
+	// Apply the energy-sampling opt-in (aceteam#6635) when the platform pushed an
+	// explicit value. Load-modify-save the same energy.yaml the footprint sampler
+	// and the CITADEL_ENERGY_SAMPLING resolution read, so the device-config path
+	// and the local toggle converge on one persisted value (default-off when
+	// neither wrote it). Written to platform.ConfigDir(), not h.ConfigDir.
+	if config.EnergySampling != nil {
+		energy := citadelconfig.LoadEnergy(platform.ConfigDir())
+		energy.SamplingEnabled = *config.EnergySampling
+		if err := citadelconfig.SaveEnergy(platform.ConfigDir(), energy); err != nil {
+			result += fmt.Sprintf("\nWarning: failed to persist energy config: %v", err)
+		} else {
+			result += fmt.Sprintf("\nEnergy sampling %s (takes effect on next worker start)", enabledLabel(*config.EnergySampling))
 		}
 	}
 


### PR DESCRIPTION
## Context

The sovereignty pitch rests on an auditable per-request energy receipt (watt-hours plus where it ran). Today the node writes a footprint CSV (`~/citadel-node/footprints/footprints-YYYY-MM-DD.csv`, one sample per ~60s) with `ts,node_id,service,running,cpu_pct,rss_mb,vram_mb,gpu_util_pct,idle_seconds`. It has NO energy field. This PR adds the first node-side increment of the energy receipt (cross-repo epic aceteam-ai/aceteam#6635).

## What power signals are realistically available per platform

- **Linux + NVIDIA:** `nvidia-smi --query-gpu=power.draw,power.limit`. `power.draw` is a real board-power sensor reading (our measured term); `power.limit` is the card's enforced power cap and is a defensible per-card TDP for the utilisation fallback (no hand-maintained TDP table to go stale). On the target RTX 3090 both are populated. Some consumer-card/driver combos blank `power.draw`; the code falls through in that case.
- **macOS (Apple Silicon):** `powermetrics` is the only per-SoC power source and it requires sudo. We never invoke it (no sudo in the default path). Apple Silicon therefore has no `power.draw`, no NVIDIA `power.limit`, no GPU util, so it falls to a conservative CPU-utilisation floor (tier 3 below).
- **CPU-only:** coarse `cpu_pct x CPU_TDP` estimate, TDP configurable via `CITADEL_CPU_TDP_WATTS` (default 65W).

## What this implements

Three CSV columns, appended after the existing schema (so old readers/files stay valid): **`power_w`**, **`energy_wh`**, **`power_source`**. They are set on the node-level (`_node`) row only.

Power is chosen by a strict fall-through waterfall. Tiers are never combined, so a `measured` label always means a real sensor reading and is never diluted by a modeled term:

| Tier | Signal | `power_source` |
|------|--------|----------------|
| 1 | GPU board power (`nvidia-smi power.draw`, summed) | `measured` |
| 2 | GPU `util% x TDP` (TDP = `power.limit`, or `CITADEL_GPU_TDP_WATTS` override) | `estimated` |
| 3 | CPU `util% x CPU_TDP` (`CITADEL_CPU_TDP_WATTS`, default 65W) | `estimated` |
| 4 | nothing usable | blank |

- `energy_wh = power_w x interval_hours` (left-Riemann: each sample credited one interval at its sampled power). Summing `energy_wh` across the node rows over a window yields the auditable energy total.
- Every path is resilient: a missing `nvidia-smi`, a `[N/A]`/`[Not Supported]` sensor value, or a non-NVIDIA host yields a blank or estimated value, never a crash and never a sudo prompt.
- Kept self-contained in `internal/footprint`: the power probe is a footprint-local `nvidia-smi` exec, not a change to the shared `internal/platform` GPU detector (per that package's design note).

## Environment knobs

| Variable | Default | Purpose |
|----------|---------|---------|
| `CITADEL_GPU_TDP_WATTS` | unset (use `power.limit`) | Override TDP for the GPU util estimate (tier 2). |
| `CITADEL_CPU_TDP_WATTS` | `65` | CPU package TDP for the coarse CPU floor (tier 3). Set to your chip's rated TDP; Apple Silicon runs lower than 65W. |

## Backward compatibility

`query.go` now gates row parsing on the core (pre-energy) 9-column count, not the full header, so footprint CSVs written by an older node are still summarized after upgrade instead of being silently dropped (covered by a test). One transition-day edge: a daily file created by the old binary keeps its 9-column header, then the new binary appends 12-column rows to it. The Go query path is index-based and fine. A direct DuckDB read is the caveat: a `header=true` read of that single transition-day file would misalign the new columns, and a `FROM 'footprints/*.csv'` glob spanning both pre- and post-upgrade day files mixes 9- and 12-column schemas, which DuckDB auto-detect can reject without `union_by_name=true`. New days written entirely by the new binary are clean.

## Configuration surface (energy sampling is opt-in, default OFF)

Per Jason's change request, energy measurement is **default OFF and configurable per node**. When off, the sampler runs exactly as before this PR: no `nvidia-smi` power probe (zero overhead) and no `power_w` / `energy_wh` / `power_source` columns (byte-identical CSVs to pre-PR). Readers handle both the 9-column (off) and 12-column (on) schemas.

Enable per node three ways (resolved once at `citadel work` start; precedence env > file > off):

| Surface | Value | Notes |
|---------|-------|-------|
| Env var | `CITADEL_ENERGY_SAMPLING=1` | Truthy `1`/`true`/`yes`/`on`; wins over the file when set. |
| Node config file | `energy.yaml` -> `sampling_enabled: true` | In `platform.ConfigDir()`, via `config.LoadEnergy` / `config.SaveEnergy` (mirrors `telemetry.yaml`). |
| Platform (`APPLY_DEVICE_CONFIG`) | `DeviceConfig.EnergySampling *bool` (`energySampling` JSON) | Load-modify-saves the same `energy.yaml`, default-DENY pointer semantics like `ShellEnabled` (#604). Wired. |

**Liveness:** the toggle is read once at `citadel work` startup. Pushing `EnergySampling` via `APPLY_DEVICE_CONFIG` persists `energy.yaml` immediately but **takes effect on the next worker start** (the job result says so). No hot-reload in this PR (deliberately out of scope).

`CITADEL_GPU_TDP_WATTS` (override tier-2 TDP) and `CITADEL_CPU_TDP_WATTS` (tier-3 CPU floor, default 65W) only matter when sampling is enabled.

## Next increment: per-request attribution + platform surfacing (not in this PR)

1. **Per-request attribution.** Integrate node power over each job's execution window and attribute it by the job's GPU-time share (job wall-clock x its fraction of GPU utilisation/VRAM during that window), rather than the node-wide instantaneous figure here. The per-service footprint rows are where a per-job energy column would live once the worker records job start/end against the sampler's time-series.
2. **Full node model.** Sum GPU + CPU + a PSU-efficiency factor + an idle baseline instead of reporting a single dominant term. Keep the `measured`/`estimated`/`mixed` label honest.
3. **Platform surfacing (AEP envelope).** Emit the per-request watt-hours plus `power_source` and node identity on the job-result cost/provenance envelope so the energy receipt rides the existing AEP response back to the platform and can be shown to the end user as an auditable receipt. This is the aceteam-side half of #6635.

## Testing

`go build ./...`, `go vet ./...`, `gofmt` clean. `go test ./internal/footprint/...` passes, including:
- Pure functions: `util+TDP -> watts` (with clamping and non-positive TDP), `watts x interval -> Wh` (zero/negative guards), the four-tier waterfall source selection, env config resolution, and `nvidia-smi` field parsing (`[N/A]` sentinels).
- Node-row wiring: measured draw wins over util; util+`power.limit` estimate when no draw; per-service rows carry no power.
- Store: the three new columns render correctly.
- Query: a legacy 9-column CSV is still parsed after the schema grew.

*Generated by Claude Opus 4.8*

