### PR TITLE
fix(heartbeat): report ollama available models + route inference to non-GPU (Apple) nodes (#606)

### DIFF
--- a/cmd/work.go
+++ b/cmd/work.go
@@ -674,16 +674,25 @@ func runWork(cmd *cobra.Command, args []string) {
 			Debug("shell queue: %s", shellQueue)
 		}
 
-		// GPU nodes must also consume the GPU inference queues. In API mode the
-		// server's worker-config returns only the CPU base queue today (#6315),
-		// so gateway inference dispatched to jobs:v1:gpu-general (+ gpu tag
-		// queues) with a target_node would never reach this node. Self-subscribe
-		// from locally-detected GPU capabilities, mirroring direct-Redis mode.
-		// Additive to whatever worker-config returned; a CPU-only node adds
-		// nothing (GPUInferenceQueues returns nil without a GPU).
-		if gpuQueues := capabilities.GPUInferenceQueues(nodeCaps); len(gpuQueues) > 0 {
-			apiQueueNames = appendUniqueQueues(apiQueueNames, gpuQueues)
-			Debug("gpu node: also subscribing to GPU inference queues %v", gpuQueues)
+		// Inference-capable nodes must also consume the GPU inference queues. In
+		// API mode the server's worker-config returns only the CPU base queue
+		// today (#6315), so platform inference dispatched to jobs:v1:gpu-general
+		// (+ gpu tag queues) with a target_node would never reach this node.
+		// Self-subscribe from locally-detected capabilities, mirroring
+		// direct-Redis mode. Additive to whatever worker-config returned.
+		//
+		// A GPU node subscribes to gpu-general + its tag queues. A node with NO
+		// discrete GPU but a running serving engine (the Apple Silicon + native
+		// ollama case) also subscribes to gpu-general so a target_node-pinned
+		// inference job arrives instead of timing out (citadel-cli#606 /
+		// aceteam#6634). Serving is detected live (native + docker engines) so it
+		// works for a natively run ollama, which the docker-only Engines snapshot
+		// misses. A node serving nothing adds nothing.
+		serving := nodeIsServingModels(ctx)
+		if infQueues := capabilities.InferenceQueues(nodeCaps, serving); len(infQueues) > 0 {
+			apiQueueNames = appendUniqueQueues(apiQueueNames, infQueues)
+			Debug("inference node (gpu=%t serving=%t): also subscribing to inference queues %v",
+				nodeCaps != nil && nodeCaps.GPU != nil && len(nodeCaps.GPU.Devices) > 0, serving, infQueues)
 		}
 
 		apiSource = worker.NewAPISource(worker.APISourceConfig{
@@ -2456,6 +2465,20 @@ func resolveAllowReadOutsideWorkspace() bool {
 
 // resolveConsumerGroup returns the consumer group name to use.
 // Priority: explicit flag > Headscale node ID > hostname > fallback "citadel-workers".
+// nodeIsServingModels reports whether this node is currently running a managed
+// serving engine (vllm / ollama / llamacpp / bonsai), including a natively run
+// ollama. It drives the non-GPU inference-queue subscription (citadel-cli#606):
+// an Apple Silicon node running ollama has no discrete GPU but CAN serve, so it
+// must consume jobs:v1:gpu-general. status.DiscoverLocalEngines does the same
+// docker + native running-check the heartbeat uses, so this sees exactly what
+// the fabric sees. Bounded so a slow/hung engine can never stall worker startup;
+// on timeout it reports false (fail-safe: no extra queue subscription).
+func nodeIsServingModels(ctx context.Context) bool {
+	probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	return len(status.DiscoverLocalEngines(probeCtx)) > 0
+}
+
 func resolveConsumerGroup(explicit, headscaleNodeID, hostname string) string {
 	if explicit != "" {
 		return explicit

--- a/internal/capabilities/detector.go
+++ b/internal/capabilities/detector.go
@@ -388,6 +388,36 @@ func GPUInferenceQueues(caps *NodeCapabilities) []string {
 	return ResolveQueues(tagCaps, "jobs:v1:gpu-general")
 }
 
+// InferenceQueues returns the inference queues an API-mode worker should
+// self-subscribe to so platform inference actually reaches it. Platform
+// inference (aceteam routes/inference.py) always dispatches an llm_inference
+// job to the shared jobs:v1:gpu-general queue with a target_node pin; a node
+// that does not consume that queue never receives the job (it times out at the
+// platform as a 504; see aceteam#6634).
+//
+//   - A node with a GPU returns GPUInferenceQueues (gpu-general + its
+//     gpu/engine/vram tag queues), unchanged from #6315.
+//   - A node with NO GPU but a running serving engine (serving == true) still
+//     returns the gpu-general base queue. This is the Apple Silicon case: a
+//     Mac runs ollama natively over unified memory and reports no discrete GPU,
+//     so GPUInferenceQueues is empty, yet it CAN serve inference and must
+//     consume the queue for a target_node-pinned job to arrive (citadel-cli#606).
+//   - Otherwise returns nil: a node that serves no models has no reason to join
+//     the inference queue.
+//
+// serving must reflect a live check that includes NATIVE engines (e.g.
+// status.DiscoverLocalEngines), not the docker-only detectRunningEngines()
+// snapshot in NodeCapabilities.Engines, which misses a natively run ollama.
+func InferenceQueues(caps *NodeCapabilities, serving bool) []string {
+	if q := GPUInferenceQueues(caps); len(q) > 0 {
+		return q
+	}
+	if serving {
+		return []string{"jobs:v1:gpu-general"}
+	}
+	return nil
+}
+
 func detectGPU() []Capability {
 	ctx, cancel := context.WithTimeout(context.Background(), detectionTimeout)
 	defer cancel()

--- a/internal/capabilities/detector_test.go
+++ b/internal/capabilities/detector_test.go
@@ -167,6 +167,46 @@ func TestGPUInferenceQueues(t *testing.T) {
 	}
 }
 
+func TestInferenceQueues(t *testing.T) {
+	// GPU node: same as GPUInferenceQueues regardless of the serving flag.
+	gpu := &NodeCapabilities{
+		GPU:  &GPUCapabilities{Count: 1, Devices: []GPUDevice{{Name: "NVIDIA GeForce RTX 3090", Tag: "rtx3090", VRAMTag: "24gb"}}},
+		Tags: []string{"gpu:rtx3090", "vram:24gb"},
+	}
+	for _, serving := range []bool{false, true} {
+		q := InferenceQueues(gpu, serving)
+		found := false
+		for _, name := range q {
+			if name == "jobs:v1:gpu-general" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("GPU node (serving=%t) must consume jobs:v1:gpu-general; got %v", serving, q)
+		}
+	}
+
+	// No-GPU node that IS serving (Apple Silicon + native ollama): must join the
+	// gpu-general base queue so a target_node-pinned inference job arrives.
+	noGPU := &NodeCapabilities{Tags: []string{"cpu:general"}}
+	if q := InferenceQueues(noGPU, true); len(q) != 1 || q[0] != "jobs:v1:gpu-general" {
+		t.Errorf("non-GPU serving node must subscribe to exactly [jobs:v1:gpu-general]; got %v", q)
+	}
+
+	// No-GPU node serving nothing: no inference queue.
+	if q := InferenceQueues(noGPU, false); q != nil {
+		t.Errorf("non-GPU non-serving node must not subscribe to any inference queue; got %v", q)
+	}
+
+	// nil caps: serving still governs the base-queue subscription.
+	if q := InferenceQueues(nil, true); len(q) != 1 || q[0] != "jobs:v1:gpu-general" {
+		t.Errorf("nil caps serving node must subscribe to [jobs:v1:gpu-general]; got %v", q)
+	}
+	if q := InferenceQueues(nil, false); q != nil {
+		t.Errorf("nil caps non-serving node must return nil; got %v", q)
+	}
+}
+
 func TestTagsHelper(t *testing.T) {
 	caps := []Capability{
 		{Tag: "gpu:rtx4090"},

--- a/internal/status/engines.go
+++ b/internal/status/engines.go
@@ -36,14 +36,15 @@ var managedProbeEngines = []string{"vllm", "ollama", "llamacpp", "bonsai"}
 // when no manifest-driven service config was passed to the collector (the
 // common heartbeat case, where c.services is nil). Each entry carries the
 // per-service idle signal when the engine's metrics are scrapeable (citadel
-// #416) and the currently LOADED model(s) discovered from the engine's local
-// API (citadel #529) — e.g. vLLM/llama.cpp `GET /v1/models`, ollama
-// `GET /api/ps`.
+// #416) and the model(s) the engine can serve, discovered from the engine's
+// local API (citadel #529): e.g. vLLM/llama.cpp `GET /v1/models` (the loaded
+// model), ollama `GET /api/tags` (every pulled model, all auto-loadable on
+// request; citadel-cli#606).
 //
 // It only emits an entry for an engine that is actually running AND answered
 // at least one probe (idle scrape or model discovery). An engine that answers
 // model discovery with an empty list (llama.cpp up with no model loaded,
-// ollama with nothing resident) IS emitted — running with no models is real,
+// ollama with nothing pulled) IS emitted: running with no models is real,
 // reportable state. A running-but-unresponsive engine (e.g. still loading its
 // model, HTTP not yet up) is skipped rather than reported with a misleading
 // "idle since startup" — the existing manifest-driven collectServiceStatus

--- a/internal/status/models.go
+++ b/internal/status/models.go
@@ -54,10 +54,20 @@ func EngineTypeFromName(name string) string {
 	return ""
 }
 
-// DiscoverModels queries an LLM service for LOADED models (the model(s)
-// currently being served, not merely downloaded). It automatically detects the
-// service type and uses the appropriate API. A running engine with no model
-// loaded returns an empty slice and nil error.
+// DiscoverModels queries an LLM service for the model(s) it can serve right
+// now. It automatically detects the service type and uses the appropriate API.
+// A running engine with nothing to serve returns an empty slice and nil error.
+//
+// "Can serve right now" differs by engine. vLLM, llama.cpp, and bonsai each
+// serve exactly the one model they were started with, so their loaded model
+// (GET /v1/models) IS the servable set. Ollama is different: it auto-loads any
+// pulled model on first request, so every pulled/cached model is immediately
+// servable. Ollama therefore reports its available models (GET /api/tags, the
+// same set `ollama list` shows), not just the models resident in memory
+// (GET /api/ps). Reporting only resident models left a node that had pulled a
+// model but not yet served a request advertising an empty model set, so the
+// platform registry stayed empty and inference could not route to it
+// (citadel-cli#606 / aceteam#6634).
 func (m *ModelDiscovery) DiscoverModels(ctx context.Context, serviceType string, port int) ([]string, error) {
 	switch serviceType {
 	case "vllm":
@@ -118,11 +128,16 @@ func (m *ModelDiscovery) discoverOpenAIModels(ctx context.Context, engineLabel s
 	return models, nil
 }
 
-// discoverOllamaModels queries Ollama's API for LOADED (running) models.
-// Ollama exposes: GET /api/ps — the models currently loaded into memory.
-// (/api/tags lists DOWNLOADED models, which is not what the heartbeat needs.)
+// discoverOllamaModels queries Ollama's API for AVAILABLE (pulled) models.
+// Ollama exposes: GET /api/tags, every model pulled to the node, which is the
+// same set `ollama list` shows. Because Ollama auto-loads a pulled model on the
+// first request, every pulled model is immediately servable, so /api/tags is the
+// correct notion of "what this node can serve" for routing. (GET /api/ps lists
+// only models currently resident in memory, which is empty right after a pull
+// and before the first request: the gap that made a freshly deployed model
+// unroutable, citadel-cli#606.)
 func (m *ModelDiscovery) discoverOllamaModels(ctx context.Context, port int) ([]string, error) {
-	url := fmt.Sprintf("http://%s:%d/api/ps", m.host, port)
+	url := fmt.Sprintf("http://%s:%d/api/tags", m.host, port)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {

--- a/internal/status/models_test.go
+++ b/internal/status/models_test.go
@@ -83,20 +83,23 @@ func TestDiscoverModels_LlamacppNoModelLoaded(t *testing.T) {
 	}
 }
 
-// TestDiscoverModels_OllamaLoaded verifies ollama discovery uses /api/ps
-// (LOADED models), not /api/tags (downloaded models).
-func TestDiscoverModels_OllamaLoaded(t *testing.T) {
+// TestDiscoverModels_OllamaAvailable verifies ollama discovery reports the
+// AVAILABLE (pulled) models from /api/tags (the servable set, since ollama
+// auto-loads any pulled model on request) and does NOT depend on /api/ps
+// (resident models), which is empty right after a pull (citadel-cli#606).
+func TestDiscoverModels_OllamaAvailable(t *testing.T) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/ps", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/tags", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{
 			"models": []map[string]any{
+				{"name": "phi3:mini", "model": "phi3:mini", "size": 2176178913},
 				{"name": "llama3:8b", "model": "llama3:8b", "size": 5137025024},
 			},
 		})
 	})
-	mux.HandleFunc("/api/tags", func(w http.ResponseWriter, r *http.Request) {
-		t.Error("discovery must query /api/ps (loaded), not /api/tags (downloaded)")
+	mux.HandleFunc("/api/ps", func(w http.ResponseWriter, r *http.Request) {
+		t.Error("discovery must query /api/tags (available/servable), not /api/ps (resident)")
 		http.NotFound(w, r)
 	})
 	discovery, port := newTestDiscovery(t, mux)
@@ -105,16 +108,16 @@ func TestDiscoverModels_OllamaLoaded(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !reflect.DeepEqual(models, []string{"llama3:8b"}) {
-		t.Fatalf("expected [llama3:8b], got %v", models)
+	if !reflect.DeepEqual(models, []string{"phi3:mini", "llama3:8b"}) {
+		t.Fatalf("expected [phi3:mini llama3:8b], got %v", models)
 	}
 }
 
-// TestDiscoverModels_OllamaNothingLoaded covers a running ollama with no
-// models resident in memory: empty result, no error.
-func TestDiscoverModels_OllamaNothingLoaded(t *testing.T) {
+// TestDiscoverModels_OllamaNothingPulled covers a running ollama with no
+// models pulled to the node: empty result, no error.
+func TestDiscoverModels_OllamaNothingPulled(t *testing.T) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/ps", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/tags", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{"models": []any{}})
 	})
@@ -122,7 +125,7 @@ func TestDiscoverModels_OllamaNothingLoaded(t *testing.T) {
 
 	models, err := discovery.DiscoverModels(context.Background(), "ollama", port)
 	if err != nil {
-		t.Fatalf("expected no error for empty /api/ps, got: %v", err)
+		t.Fatalf("expected no error for empty /api/tags, got: %v", err)
 	}
 	if len(models) != 0 {
 		t.Fatalf("expected no models, got %v", models)


### PR DESCRIPTION
Closes #606. Companion to aceteam-ai/aceteam#6634.

## Context
On a live darwin/M1 Pro node (citadel v2.88.0) running ollama natively, a platform Deploy (`MODEL_CACHE_PULL` + `SERVICE_START`) succeeds and the model serves locally (`curl localhost:11434/api/generate` works), but the platform reports `Cached Models: none` and org inference 504s. The node's worker log also emits `reconcile pass error: reconcile: refusing empty desired state ...`.

Investigation found **two independent node-side root causes**, both fixed here.

## Root cause A: heartbeat under-reports ollama models
`internal/status/models.go` `discoverOllamaModels` queried ollama `GET /api/ps` (models **resident in memory**). Right after `MODEL_CACHE_PULL` and before the first inference request, nothing is resident, so `/api/ps` returns empty. The node therefore advertised an empty `services[].models` for ollama on every heartbeat.

The platform inference router (aceteam `routes/inference.py`, #5927) builds a node's servable model set from `services[].models` (heartbeat -> `worker/node_status/worker.py` writes `node:service_usage:{id}` -> `_get_served_models_map` -> merged into candidate `models`). Empty models means the router has nothing to match, and `inference_models` shows nothing.

**Fix:** ollama reports `GET /api/tags` (every pulled model, the set `ollama list` shows). Ollama auto-loads any pulled model on first request, so a pulled model IS immediately servable; `/api/tags` is the correct "what can this node serve" notion for routing. vLLM/llama.cpp/bonsai are unchanged (`GET /v1/models`): they serve exactly the one loaded model, so loaded == servable there. Query failures still leave models empty (resilient, per #529).

## Root cause B: non-GPU serving nodes never consume the inference queue
Platform inference (streaming, buffered, and the `inference_chat` MCP tool) always dispatches `llm_inference` to the shared `jobs:v1:gpu-general` queue with a `target_node` pin. In API mode a node only self-subscribes to that queue when it has a discrete GPU (`capabilities.GPUInferenceQueues`, #6315). An Apple Silicon node reports **no discrete GPU**, so it never consumed `jobs:v1:gpu-general` and the target_node-pinned job **never arrived** (the "inference job never received by the node" symptom in aceteam#6634; surfaces as a 504).

**Fix:** new pure helper `capabilities.InferenceQueues(caps, serving)` returns `jobs:v1:gpu-general` for a non-GPU node that is running a serving engine, in addition to the existing GPU behavior. `serving` is detected live via `status.DiscoverLocalEngines` (docker **and native**, so a natively run ollama counts, unlike the docker-only `Engines` snapshot). The probe is bounded (5s) and fail-safe (false on timeout, so it never blocks worker startup or over-subscribes).

**Safety (shared-queue misrouting):** widening `jobs:v1:gpu-general` to more nodes is safe because the worker already ACK-skips any job whose `target_node` != this node's Headscale ID, in the general (job-type-agnostic) runner path: `internal/worker/runner.go:369-374`, gated on `RunnerConfig.NodeID` which is wired from the Headscale node ID (`cmd/work.go:2078`). This is the identical mechanism GPU nodes already rely on for gpu-general (#6315/#5086); B adds no new safety property, it just reuses it for serving nodes on the same per-node consumer group (`citadel-node-<id>`).

## Is a platform-side change ALSO required?
**No for routing. The routing loop closes fully node-side with A + B.**
- `pick_best_node` / `collect_available_models` (aceteam `routes/inference.py`) gate only on `is_online` + `_candidate_serves(model)`. `_scan_inference_nodes` appends candidates regardless of `gpu_count`. The `node:service_usage` writer (`utils/service_usage.py`) copies `services[].models` with no GPU gate, and `worker/node_status/worker.py` populates it from the heartbeat. So **there is no discovery/routing filter that excludes non-GPU (Apple) nodes.** The hypothesis in #606/#6634 that "discovery excludes nodes with no discrete GPU" is not borne out by the code: `inference_models`' "No online GPU nodes serving models" is cosmetic copy shown whenever the model list is empty (which was caused by A), not an actual GPU filter.
- **Caveat (cosmetic, not blocking):** the `Cached Models:` line in `fabric_node_status` reads a separate platform registry (Redis `node:model_cache:{node_id}`, `get_cached_models_for_nodes`), written by the deploy/cache-pull dispatch, **not** the heartbeat. After A+B the model becomes routable, but that specific display line may still read `none` until the platform populates `node:model_cache` on deploy. Populating/repairing that is platform-side (aceteam#6634) and does not affect routability.

## Reconcile "refusing empty desired state" (investigated, not a bug here)
`RefuseFullWipe` (`internal/reconcile`) **refuses** to converge to an empty desired MODULE_SET (it applies nothing, protecting installed modules) and operates on catalog/lockfile modules, entirely independent of the status collector. It **cannot** gate model/service reporting. The warning means the control plane has no desired-module rows for this node while services are installed: a platform-config observation, not a citadel defect. Left as-is.

## Known limitation (important for onboarding, needs a follow-up)
The inference-queue subscription is decided **once at `citadel work` startup**. The verified repro works because ollama runs as a persistent native service on darwin, so it is already serving when the worker starts. But a **cold first-time node** where `SERVICE_START` starts the engine *after* the worker is running will NOT join `jobs:v1:gpu-general` until the worker restarts. That is the standard "install citadel, then deploy your first model" flow, so end-to-end routing for a cold onboarding is **not** fully closed by this PR alone. The durable fix is dynamic re-subscription (worker `AddQueue` when a serving engine starts). Tracking as a follow-up; flagging here so the platform team does not read this as "cold onboarding routes end-to-end."

## Architectural note for reviewers
B chooses the node-side complement (a non-GPU serving node joins `gpu-general`) over the platform-side alternative (route non-GPU inference to the node's per-node stream). It mirrors #6315 exactly. If reviewers prefer the platform-routing approach, the B commit can be dropped independently; A stands on its own.

## Tests
- `internal/status/models_test.go`: ollama reports `/api/tags` available models (asserts `/api/ps` is NOT queried); empty-pull returns empty, no error.
- `internal/capabilities/detector_test.go`: `InferenceQueues` for GPU (any serving flag), non-GPU-serving (joins gpu-general), and non-GPU-non-serving (nil).
- `go build ./...`, `go vet ./...`, `go test ./...` all green.

*Generated by Claude Opus 4.8*