### PR TITLE
fix: route ollama chat requests to /api/chat (empty content, aceteam#6641)

### DIFF
--- a/internal/worker/llm_inference.go
+++ b/internal/worker/llm_inference.go
@@ -278,6 +278,18 @@ func (h *LLMInferenceHandler) bufferedCompletions(stream StreamWriter, body io.R
 
 // executeOllama handles inference via Ollama's native /api/generate API.
 func (h *LLMInferenceHandler) executeOllama(ctx context.Context, stream StreamWriter, payload *jobs.LLMInferencePayload) (*JobResult, error) {
+	// Chat-style requests (the OpenAI gateway and MCP inference_chat send
+	// `messages`, not `prompt`) route to Ollama's native /api/chat, which applies
+	// the model's chat template and returns the reply in message.content.
+	// /api/generate has no messages support: sending it an empty prompt made
+	// Ollama merely load the model and return an empty `response`
+	// (done_reason "load"), which surfaced as "No response content returned from
+	// the inference node" on the platform (issue #6641). The /api/generate prompt
+	// path is preserved for prompt-style jobs.
+	if len(payload.Messages) > 0 {
+		return h.executeOllamaChat(ctx, stream, payload)
+	}
+
 	reqPayload := map[string]any{
 		"model":  payload.Model,
 		"prompt": payload.Prompt,
@@ -357,6 +369,146 @@ func (h *LLMInferenceHandler) bufferedOllama(stream StreamWriter, body io.Reader
 		"content":       response.Response,
 		"finish_reason": "stop",
 	}), nil
+}
+
+// executeOllamaChat handles chat-style inference via Ollama's native /api/chat
+// API. Unlike /api/generate (prompt in, `response` out), /api/chat takes
+// `messages` and returns the assistant turn in `message.content`, applying the
+// served model's chat template. Used whenever an llm_inference job carries
+// `messages` (the shape the OpenAI gateway and MCP inference_chat dispatch).
+func (h *LLMInferenceHandler) executeOllamaChat(ctx context.Context, stream StreamWriter, payload *jobs.LLMInferencePayload) (*JobResult, error) {
+	messages := make([]map[string]string, 0, len(payload.Messages))
+	for _, m := range payload.Messages {
+		messages = append(messages, map[string]string{"role": m.Role, "content": m.Content})
+	}
+
+	reqPayload := map[string]any{
+		"model":    payload.Model,
+		"messages": messages,
+		"stream":   payload.Stream,
+	}
+	// Ollama takes sampling controls under `options` (not top-level like the
+	// OpenAI shape). Only send the ones the job set so an unset field keeps the
+	// model default rather than pinning greedy/zero.
+	options := map[string]any{}
+	if payload.MaxTokens > 0 {
+		options["num_predict"] = payload.MaxTokens
+	}
+	if payload.Temperature > 0 {
+		options["temperature"] = payload.Temperature
+	}
+	if payload.TopP > 0 {
+		options["top_p"] = payload.TopP
+	}
+	if len(payload.Stop) > 0 {
+		options["stop"] = payload.Stop
+	}
+	if len(options) > 0 {
+		reqPayload["options"] = options
+	}
+
+	resp, err := h.postJSON(ctx, h.baseURL("ollama")+"/api/chat", reqPayload)
+	if err != nil {
+		return h.failure(fmt.Errorf("failed to connect to Ollama: %w", err)), nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return h.failure(fmt.Errorf("Ollama returned status %d: %s", resp.StatusCode, string(body))), nil
+	}
+
+	if payload.Stream {
+		return h.streamOllamaChat(stream, resp.Body)
+	}
+	return h.bufferedOllamaChat(stream, resp.Body)
+}
+
+// streamOllamaChat forwards Ollama's /api/chat newline-delimited JSON stream as
+// chunks. Each frame carries an incremental message.content; the final frame has
+// done=true plus token counts.
+func (h *LLMInferenceHandler) streamOllamaChat(stream StreamWriter, body io.Reader) (*JobResult, error) {
+	scanner := bufio.NewScanner(body)
+	// Allow long JSON lines (large deltas) beyond bufio's default 64KiB cap.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	chunkIndex := 0
+	var fullContent strings.Builder
+	var promptTokens, completionTokens int
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		var chunk struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+			Done            bool `json:"done"`
+			PromptEvalCount int  `json:"prompt_eval_count"`
+			EvalCount       int  `json:"eval_count"`
+		}
+		if err := json.Unmarshal([]byte(line), &chunk); err != nil {
+			continue
+		}
+		if chunk.Message.Content != "" {
+			fullContent.WriteString(chunk.Message.Content)
+			stream.WriteChunk(chunk.Message.Content, chunkIndex)
+			chunkIndex++
+		}
+		if chunk.PromptEvalCount > 0 {
+			promptTokens = chunk.PromptEvalCount
+		}
+		if chunk.EvalCount > 0 {
+			completionTokens = chunk.EvalCount
+		}
+		if chunk.Done {
+			break
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return h.failure(err), nil
+	}
+	return h.success(map[string]any{
+		"content":       fullContent.String(),
+		"finish_reason": "stop",
+		"usage":         ollamaUsage(promptTokens, completionTokens),
+	}), nil
+}
+
+// bufferedOllamaChat parses a non-streamed Ollama /api/chat response.
+func (h *LLMInferenceHandler) bufferedOllamaChat(stream StreamWriter, body io.Reader) (*JobResult, error) {
+	bodyBytes, err := io.ReadAll(body)
+	if err != nil {
+		return h.failure(err), nil
+	}
+	var response struct {
+		Message struct {
+			Content string `json:"content"`
+		} `json:"message"`
+		PromptEvalCount int `json:"prompt_eval_count"`
+		EvalCount       int `json:"eval_count"`
+	}
+	if err := json.Unmarshal(bodyBytes, &response); err != nil {
+		return h.failure(fmt.Errorf("failed to parse Ollama response: %w", err)), nil
+	}
+	writeSingleChunk(stream, response.Message.Content)
+	return h.success(map[string]any{
+		"content":       response.Message.Content,
+		"finish_reason": "stop",
+		"usage":         ollamaUsage(response.PromptEvalCount, response.EvalCount),
+	}), nil
+}
+
+// ollamaUsage maps Ollama's prompt_eval_count/eval_count onto the platform's
+// usage shape (prompt_tokens/completion_tokens/total_tokens) so the token footer
+// works for the ollama chat path like the vLLM/llama.cpp chat path.
+func ollamaUsage(promptTokens, completionTokens int) map[string]any {
+	return map[string]any{
+		"prompt_tokens":     promptTokens,
+		"completion_tokens": completionTokens,
+		"total_tokens":      promptTokens + completionTokens,
+	}
 }
 
 // executeLlamaCppAt runs a llama.cpp-server inference against an explicit base

--- a/internal/worker/llm_inference_test.go
+++ b/internal/worker/llm_inference_test.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -195,6 +196,172 @@ func TestLLMInferenceHandler_BackendRouting(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("ollama messages route to /api/chat", func(t *testing.T) {
+		// Regression for issue #6641: a chat request (messages, no prompt) to the
+		// ollama backend previously hit /api/generate with an empty prompt, so
+		// Ollama loaded the model and returned an empty response -> "No response
+		// content" on the platform. It must route to /api/chat and return
+		// message.content instead.
+		body := `{"model":"llama3.2:1b","message":{"role":"assistant","content":"OK"},` +
+			`"done":true,"prompt_eval_count":15,"eval_count":3}`
+		var gotPath, gotPrompt string
+		var sawMessages bool
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			var req map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			if _, ok := req["messages"]; ok {
+				sawMessages = true
+			}
+			if p, ok := req["prompt"].(string); ok {
+				gotPrompt = p
+			}
+			if r.URL.Path != "/api/chat" {
+				http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+				return
+			}
+			_, _ = w.Write([]byte(body))
+		}))
+		defer ts.Close()
+
+		h := NewLLMInferenceHandler()
+		h.baseURLs["ollama"] = ts.URL
+
+		job := &Job{
+			ID:   "job-ollama-chat",
+			Type: JobTypeLLMInference,
+			Payload: map[string]any{
+				"model":    "llama3.2:1b",
+				"backend":  "ollama",
+				"messages": []map[string]any{{"role": "user", "content": "Reply with exactly: OK"}},
+			},
+		}
+		stream := &MockStreamWriter{}
+		result, err := h.Execute(context.Background(), job, stream)
+		if err != nil {
+			t.Fatalf("Execute error: %v", err)
+		}
+		if result == nil || result.Status != JobStatusSuccess {
+			t.Fatalf("result = %+v, want success", result)
+		}
+		if gotPath != "/api/chat" {
+			t.Errorf("routed to %q, want /api/chat", gotPath)
+		}
+		if !sawMessages {
+			t.Errorf("request did not carry messages")
+		}
+		if gotPrompt != "" {
+			t.Errorf("request carried a prompt %q, want none", gotPrompt)
+		}
+		if got, _ := result.Output["content"].(string); got != "OK" {
+			t.Errorf("content = %q, want OK", got)
+		}
+		if len(stream.chunks) != 1 || stream.chunks[0] != "OK" {
+			t.Errorf("chunks = %v, want [OK]", stream.chunks)
+		}
+		usage, _ := result.Output["usage"].(map[string]any)
+		if usage == nil {
+			t.Fatalf("usage missing, want token counts")
+		}
+		if usage["prompt_tokens"] != 15 || usage["completion_tokens"] != 3 || usage["total_tokens"] != 18 {
+			t.Errorf("usage = %v, want prompt=15 completion=3 total=18", usage)
+		}
+	})
+
+	t.Run("ollama streaming chat routes to /api/chat", func(t *testing.T) {
+		frames := []string{
+			`{"message":{"role":"assistant","content":"Hel"},"done":false}`,
+			`{"message":{"role":"assistant","content":"lo"},"done":false}`,
+			`{"message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":9,"eval_count":2}`,
+		}
+		var gotPath string
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			if r.URL.Path != "/api/chat" {
+				http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+				return
+			}
+			for _, f := range frames {
+				_, _ = w.Write([]byte(f + "\n"))
+			}
+		}))
+		defer ts.Close()
+
+		h := NewLLMInferenceHandler()
+		h.baseURLs["ollama"] = ts.URL
+
+		job := &Job{
+			ID:   "job-ollama-chat-stream",
+			Type: JobTypeLLMInference,
+			Payload: map[string]any{
+				"model":    "llama3.2:1b",
+				"backend":  "ollama",
+				"stream":   true,
+				"messages": []map[string]any{{"role": "user", "content": "hi"}},
+			},
+		}
+		stream := &MockStreamWriter{}
+		result, err := h.Execute(context.Background(), job, stream)
+		if err != nil {
+			t.Fatalf("Execute error: %v", err)
+		}
+		if result == nil || result.Status != JobStatusSuccess {
+			t.Fatalf("result = %+v, want success", result)
+		}
+		if gotPath != "/api/chat" {
+			t.Errorf("routed to %q, want /api/chat", gotPath)
+		}
+		if strings.Join(stream.chunks, "|") != "Hel|lo" {
+			t.Errorf("chunks = %v, want [Hel lo]", stream.chunks)
+		}
+		if got, _ := result.Output["content"].(string); got != "Hello" {
+			t.Errorf("content = %q, want Hello", got)
+		}
+		usage, _ := result.Output["usage"].(map[string]any)
+		if usage == nil || usage["prompt_tokens"] != 9 || usage["completion_tokens"] != 2 {
+			t.Errorf("usage = %v, want prompt=9 completion=2", usage)
+		}
+	})
+
+	t.Run("ollama prompt still routes to /api/generate", func(t *testing.T) {
+		var gotPath string
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			if r.URL.Path != "/api/generate" {
+				http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+				return
+			}
+			_, _ = w.Write([]byte(`{"response":"generated"}`))
+		}))
+		defer ts.Close()
+
+		h := NewLLMInferenceHandler()
+		h.baseURLs["ollama"] = ts.URL
+
+		job := &Job{
+			ID:   "job-ollama-generate",
+			Type: JobTypeLLMInference,
+			Payload: map[string]any{
+				"model":   "llama3.2:1b",
+				"backend": "ollama",
+				"prompt":  "hi",
+			},
+		}
+		result, err := h.Execute(context.Background(), job, &MockStreamWriter{})
+		if err != nil {
+			t.Fatalf("Execute error: %v", err)
+		}
+		if result == nil || result.Status != JobStatusSuccess {
+			t.Fatalf("result = %+v, want success", result)
+		}
+		if gotPath != "/api/generate" {
+			t.Errorf("routed to %q, want /api/generate", gotPath)
+		}
+		if got, _ := result.Output["content"].(string); got != "generated" {
+			t.Errorf("content = %q, want generated", got)
+		}
+	})
 
 	t.Run("unknown backend fails", func(t *testing.T) {
 		h := NewLLMInferenceHandler()


### PR DESCRIPTION
## Context

Follow-up to citadel-cli#611 (v2.90.0). Fixes aceteam-ai/aceteam#6641: inference on a non-GPU Apple Silicon / ollama node now routes and executes, but the platform returns **"No response content returned from the inference node."** for every request.

## Root Cause

`LLMInferenceHandler.executeOllama` (`internal/worker/llm_inference.go`) only read `payload.Prompt` and posted to ollama's `/api/generate`. But the OpenAI-compatible gateway and the MCP `inference_chat` tool build the `llm_inference` payload with `messages` and **no** `prompt` (`build_dispatch_payload` in `python-backend/routes/gateway_citadel.py`). So ollama received an empty prompt: it loaded the model and returned an empty `response` with `done_reason: "load"` (HTTP 200, model resident, zero content). The platform reads `result.content`, finds it empty, and returns the error.

The vLLM and llama.cpp/bonsai paths already branch on `len(payload.Messages) > 0` and use `/v1/chat/completions`. The ollama path had no such branch.

Confirmed live on node 1083:
```
# empty prompt -> /api/generate
{"response":"","done":true,"done_reason":"load"}
# messages -> /api/chat
{"message":{"role":"assistant","content":"OK."},"done":true,...}
```

## Changes

- `internal/worker/llm_inference.go`: `executeOllama` now routes message-carrying jobs to ollama's native `/api/chat` (via new `executeOllamaChat` + `streamOllamaChat` / `bufferedOllamaChat`). Both buffered and streaming variants are covered, so the SSE gateway path (`stream=true`) is fixed too, not just the buffered MCP path. `prompt_eval_count`/`eval_count` are mapped onto the platform `usage` shape (`ollamaUsage`). The `/api/generate` prompt path is preserved unchanged for prompt-style jobs.
- `internal/worker/llm_inference_test.go`: tests that messages route to `/api/chat` with content + usage (buffered), streaming chat accumulates deltas from `message.content`, and a prompt-only job still routes to `/api/generate`.

## Testing

- `go build ./...`, `go vet ./...`, `go test ./...` all green.
- **Live-verified on node 1083** (Apple M1 Pro, ollama native): built darwin/arm64 from this branch, deployed, restarted the worker. `inference_chat(model="phi3:mini", "Reply with exactly: OK")` now returns `"OK. How can I assist you further?"` with `Tokens: 15 in / 10 out | Node: 1083`, where before it returned the empty-content error. This exercises the buffered chat path (MCP is non-streaming); the streaming path is unit-tested only.

## Note on the "nothing logged in the worker loop" observation

Expected, not a wrong-path symptom. The `worker/llm_inference.go` handler emits no `ctx.Log` lines on any backend path. The empty-content result (not the legacy handler's "missing prompt" error) already proved this handler was the live consumer. A logging pass is a possible follow-up but is out of scope here.

*Generated by Claude Opus 4.8*