### PR TITLE
feat(attach/tui): unify running-instance detection + warn on fabric-managed engine stops

### DIFF
--- a/cmd/attach.go
+++ b/cmd/attach.go
@@ -114,6 +114,14 @@ func runAttach(_ *cobra.Command, _ []string) error {
 	// ghost.
 	held, _ := worklock.IsHeld(stateDir)
 	if !held {
+		// No WORKER holds the lock — but a control-center TUI may still be running.
+		// That is a SEPARATE "is citadel running?" surface (the instance socket, not
+		// the worklock), so don't claim nothing is running when a TUI is up.
+		configDir := platform.ConfigDir()
+		if instance.IsRunning(configDir) {
+			fmt.Fprint(os.Stdout, tuiRunningNoWorkerMessage(instance.PID(configDir)))
+			return nil // something IS running; this is not the "nothing to attach to" error
+		}
 		fmt.Fprint(os.Stdout, noWorkerMessage())
 		return errNoRunningWorker
 	}
@@ -142,6 +150,23 @@ func noWorkerMessage() string {
 	var b strings.Builder
 	b.WriteString("No citadel worker is running on this node.\n\n")
 	b.WriteString("Start one with:  citadel work\n")
+	return b.String()
+}
+
+// tuiRunningNoWorkerMessage is shown when no WORKER holds the lock but a
+// control-center TUI (the instance socket — a separate "is citadel running?"
+// surface) IS running, so `citadel attach` never claims nothing is running when
+// a TUI is up. Pure so the copy is unit tested.
+func tuiRunningNoWorkerMessage(pid int) string {
+	var b strings.Builder
+	if pid > 0 {
+		fmt.Fprintf(&b, "Citadel control center is running (PID %d) — the TUI you launched with `citadel`.\n", pid)
+	} else {
+		b.WriteString("Citadel control center is running — the TUI you launched with `citadel`.\n")
+	}
+	b.WriteString("No worker is running yet.\n\n")
+	b.WriteString("  • open a shell on the running node:   citadel attach --shell\n")
+	b.WriteString("  • start a worker:                     citadel work\n")
 	return b.String()
 }
 

--- a/cmd/attach_test.go
+++ b/cmd/attach_test.go
@@ -21,6 +21,24 @@ func TestNoWorkerMessage(t *testing.T) {
 	}
 }
 
+func TestTUIRunningNoWorkerMessage(t *testing.T) {
+	// With a PID: names the running control center and points at the shell + worker.
+	out := tuiRunningNoWorkerMessage(4242)
+	for _, want := range []string{"control center is running", "PID 4242", "citadel attach --shell", "citadel work"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("message missing %q\n---\n%s", want, out)
+		}
+	}
+	// Must NOT claim nothing is running (the papercut this fixes).
+	if strings.Contains(out, "No citadel worker is running on this node") {
+		t.Errorf("should not claim nothing is running when a TUI is up\n---\n%s", out)
+	}
+	// Without a PID: still coherent, no "PID 0".
+	if strings.Contains(tuiRunningNoWorkerMessage(0), "PID 0") {
+		t.Error("zero PID should be omitted")
+	}
+}
+
 func TestRenderServicesSection_Empty(t *testing.T) {
 	if got := renderServicesSection(nil); got != "" {
 		t.Errorf("renderServicesSection(nil) = %q, want empty", got)

--- a/internal/tui/controlcenter/controlcenter.go
+++ b/internal/tui/controlcenter/controlcenter.go
@@ -1524,6 +1524,21 @@ func (cc *ControlCenter) startSelectedService() {
 	}()
 }
 
+// isFabricManagedEngine reports whether name is an inference engine the fabric
+// control plane may re-assert (re-dispatch SERVICE_START) when a model is
+// deployed to it — so a node-side stop of it can be silently overruled. Used to
+// warn on stop. Substring match mirrors status.EngineTypeFromName (kept local to
+// avoid a heavy import for one predicate).
+func isFabricManagedEngine(name string) bool {
+	n := strings.ToLower(name)
+	for _, e := range []string{"vllm", "ollama", "llamacpp", "llama.cpp", "llama-cpp", "bonsai", "sglang", "lmstudio"} {
+		if strings.Contains(n, e) {
+			return true
+		}
+	}
+	return false
+}
+
 // stopSelectedService stops the currently selected service
 func (cc *ControlCenter) stopSelectedService() {
 	svcName := cc.getSelectedServiceName()
@@ -1549,6 +1564,13 @@ func (cc *ControlCenter) stopSelectedService() {
 			delete(cc.serviceOverrides, svcName)
 			cc.serviceOverridesMu.Unlock()
 			cc.AddActivity("success", fmt.Sprintf("%s stopped", svcName))
+			// Inference engines are fabric-managed: if a model is deployed to one,
+			// the control plane re-asserts it (re-dispatches SERVICE_START), so a
+			// node-side stop can be overruled. Warn so the "I stopped it and it came
+			// right back" surprise is explained and the user knows where to manage it.
+			if isFabricManagedEngine(svcName) {
+				cc.AddActivity("warning", fmt.Sprintf("%s is a fabric-managed engine — if it comes back, a model is deployed to it. Manage it from the web console.", svcName))
+			}
 			cc.refresh()
 		}
 	}()

--- a/internal/tui/controlcenter/stop_test.go
+++ b/internal/tui/controlcenter/stop_test.go
@@ -2,6 +2,24 @@ package controlcenter
 
 import "testing"
 
+// TestIsFabricManagedEngine covers the predicate that gates the "fabric may
+// restart this" stop warning: inference engines match, plain media/tool services
+// do not.
+func TestIsFabricManagedEngine(t *testing.T) {
+	engines := []string{"vllm", "ollama", "llamacpp", "llama.cpp", "bonsai", "sglang", "lmstudio", "citadel-vllm", "VLLM"}
+	for _, n := range engines {
+		if !isFabricManagedEngine(n) {
+			t.Errorf("isFabricManagedEngine(%q) = false, want true", n)
+		}
+	}
+	nonEngines := []string{"kokoro", "meeting", "gotenberg", "transcribe", "nvr", "frigate", ""}
+	for _, n := range nonEngines {
+		if isFabricManagedEngine(n) {
+			t.Errorf("isFabricManagedEngine(%q) = true, want false", n)
+		}
+	}
+}
+
 // TestStopIdempotent verifies that Stop() can be called multiple times without
 // panicking on a double-close of stopChan. Stop() is reachable from three
 // concurrent paths during shutdown (the Ctrl+C key handler, the quit-confirm


### PR DESCRIPTION
Two node-side UX fixes from the post-batch interview.

## 1. `citadel attach` unified surfaces (#571 follow-up)
`citadel attach` keyed only off the **worklock** (worker) and printed *"No citadel worker is running"* even when a **control-center TUI** was up — two separate "is citadel running?" surfaces (worklock vs the instance socket). It now also checks `instance.IsRunning`, and when a TUI is running without a worker it **names it (PID)** and points at `citadel attach --shell` / `citadel work` instead of claiming nothing is running (exit 0, not the not-found error).

## 2. Fabric-managed-engine stop warning
Stopping an inference engine (`vllm`/`ollama`/`llamacpp`/`bonsai`/`sglang`/`lmstudio`) in the control center now adds a warning that the fabric may re-assert it if a model is deployed — explaining the reported *"I stopped it and it came right back"* surprise and pointing to the web console. (The root cause — the backend re-dispatching `SERVICE_START` — is fixed separately in the **aceteam** repo.)

## Testing
`go build/vet/test ./...` green. Added `TestTUIRunningNoWorkerMessage` and `TestIsFabricManagedEngine`; the pure message/predicate functions are unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)