### PR TITLE
fix(nvr): fix nvr-config image build so it publishes to GHCR (#597)

### DIFF
--- a/services/nvr-service/Dockerfile
+++ b/services/nvr-service/Dockerfile
@@ -10,9 +10,18 @@
 FROM golang:1.26 AS build
 WORKDIR /src
 COPY go.mod go.sum ./
+# go.mod has `replace github.com/gdamore/tcell/v2 => ./patches/tcell/v2`, so the
+# patched module must be present BEFORE `go mod download` — otherwise the download
+# fails with "reading patches/tcell/v2/go.mod: no such file or directory" (the
+# original build-nvr-service.yml failure that left ghcr.io/aceteam-ai/nvr-config
+# unpublished).
+COPY patches/ ./patches/
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -o /out/nvrconfig ./cmd/nvrconfig
+# -buildvcs=false: `COPY . .` brings in .git, but the container user differs from
+# the checkout owner, so git stamping fails ("dubious ownership", exit 128) and
+# aborts the build. nvrconfig needs no VCS stamp.
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -buildvcs=false -o /out/nvrconfig ./cmd/nvrconfig
 
 FROM alpine:3.20
 RUN adduser -D -u 10001 nvr


### PR DESCRIPTION
## Context
The NVR module (#597, merged in #600) can't deploy: **`build-nvr-service.yml` failed on main**, so `ghcr.io/aceteam-ai/nvr-config` was never published (GHCR 404). `module=nvr` would fail at image pull — the exact whisper-service "image never published" failure mode that workflow was built to prevent.

## Root cause — two Dockerfile bugs
1. `go.mod` has `replace github.com/gdamore/tcell/v2 => ./patches/tcell/v2`, but the Dockerfile ran `go mod download` **before** copying `patches/` → *"reading patches/tcell/v2/go.mod: no such file or directory"* (the actual CI failure). The nvr Dockerfile is the only repo-root Go build, so it's the only one that hit this.
2. After fixing #1, `go build -trimpath` tried VCS stamping on the `COPY`'d `.git` as a different container user → git *"dubious ownership"* exit 128 (would've been the next CI failure).

## Fix
- `COPY patches/ ./patches/` before `go mod download`.
- `-buildvcs=false` on the build.

## Verified
Local `docker build -f services/nvr-service/Dockerfile .` **succeeds**, and `nvrconfig` runs (fails loud on missing `NVR_CAMERAS`, as designed). Merging re-triggers the workflow (Dockerfile path) to publish `ghcr.io/aceteam-ai/nvr-config:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)