### PR TITLE
fix(controlcenter): correct the engine-stop warning to match reality

### DIFF
--- a/internal/tui/controlcenter/controlcenter.go
+++ b/internal/tui/controlcenter/controlcenter.go
@@ -1564,12 +1564,19 @@ func (cc *ControlCenter) stopSelectedService() {
 			delete(cc.serviceOverrides, svcName)
 			cc.serviceOverridesMu.Unlock()
 			cc.AddActivity("success", fmt.Sprintf("%s stopped", svcName))
-			// Inference engines are fabric-managed: if a model is deployed to one,
-			// the control plane re-asserts it (re-dispatches SERVICE_START), so a
-			// node-side stop can be overruled. Warn so the "I stopped it and it came
-			// right back" surprise is explained and the user knows where to manage it.
+			// This stop is durable: ccStopService persists desired_status: stopped,
+			// so the engine does NOT restart on its own. Nothing re-asserts a
+			// stopped engine: the desired-state reconcile is modules-only and does
+			// not manage engines, and inference traffic to a stopped engine is not a
+			// resume trigger (both verified by a live node trace). The pre-#528 "I
+			// stopped it and it came right back" surprise was a no-op stop (a
+			// `-p citadel-<name> down` that matched zero containers), fixed in #528.
+			// The real remaining caveat is routing, not restart: if a model was
+			// deployed to this engine from the platform, that model is now
+			// unavailable and the platform may keep routing to it until it
+			// reconciles the stop. Surface that so the user knows where to manage it.
 			if isFabricManagedEngine(svcName) {
-				cc.AddActivity("warning", fmt.Sprintf("%s is a fabric-managed engine — if it comes back, a model is deployed to it. Manage it from the web console.", svcName))
+				cc.AddActivity("warning", fmt.Sprintf("%s stopped durably (won't auto-restart). If a model was deployed to it, that model is now unavailable — redeploy or manage it from the web console.", svcName))
 			}
 			cc.refresh()
 		}


### PR DESCRIPTION
## Context

The `citadel services` (control center) engine-stop warning added in #614 told users a stopped inference engine "comes back" because "the control plane re-asserts it (re-dispatches SERVICE_START)." A live-node trace disproved that framing — and the wrong text shipped in **v2.91.0**, so it is actively misleading users right now.

## Root Cause (the actual bug, already fixed)

The original "I stopped a service and it came right back" symptom was **not** a re-assert. It was the pre-#528 no-op stop, per the #528 commit message: the TUI ran `docker compose -p citadel-<name> down`, but production containers run under the **default** compose project (`services`, the dir basename), so the `-p` down **matched zero containers, exited 0**, and the no-`-p` status read then showed the never-stopped container "running" again. *"Came right back" was "never left."*

**#528** (`15a782f`/#532) fixed it: drop `-p` everywhere + `ccStopService` persists `desired_status: stopped` (durable across worker restart/reboot). The node has since auto-updated to v2.91.0, which is why `vllm`/`llamacpp` now sit durably stopped.

## Evidence (live node trace)

- `Authorization: Bearer <key>` chat to `bonsai-27b` → 200 normally.
- Stopped `citadel-bonsai`, fired inference traffic: 1st request **502**, 2nd **404** (platform de-registers the model after the failed route).
- Watched 80s + `docker events`: **no auto-restart, no SERVICE_START, no container start/create** — only the manual stop/kill/die. Traffic to a stopped engine does **not** resume it.
- Code confirms: `CITADEL_RECONCILE_PULL` unset, and the desired-state reconcile is **modules-only** (`ModuleOps`/`ModuleAssignment`, no engine/SERVICE_START concept), so nothing re-asserts a stopped engine.

## Changes

- `internal/tui/controlcenter/controlcenter.go` — reword `stopSelectedService` comment + `AddActivity("warning", …)` from the disproven "control plane re-asserts it" to the true remaining caveat:
  > `<engine>` stopped durably (won't auto-restart). If a model was deployed to it, that model is now unavailable — redeploy or manage it from the web console.

No behavior change — text/comment only. The `isFabricManagedEngine` gate is unchanged.

## The real remaining caveat (B, not A)

Distinct from the fixed "comes back" symptom (A): the platform may keep **routing** to a node-stopped engine (the 502→404 above) until it reconciles the stop. That's addressed on the platform side by aceteam #6652 (down-only `inference:state` reconcile, merged). This PR just makes the node's user-facing text accurate.

## Testing

- `go build ./...` — clean
- `go test ./internal/tui/controlcenter/` — pass (`TestIsFabricManagedEngine`, `TestStopIdempotent`)
- `gofmt -l` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)