### PR TITLE
feat(embedding): ship TEI as a first-class module so sovereign embeddings route (#616)

### DIFF
--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -12,21 +12,21 @@ import (
 // accepts both embedded/catalog services (services.ServiceMap) and
 // module-installed services tracked in the manifest, while rejecting unknown
 // names. This is the regression guard for issue #358, where the gate only
-// consulted ServiceMap and rejected module-installed services like "tei".
+// consulted ServiceMap and rejected module-installed services not in the embedded ServiceMap.
 func TestServiceIsKnown(t *testing.T) {
-	// "tei" is a stand-in for a module-installed service: it is NOT in
+	// "custommod" is a stand-in for a module-installed service: it is NOT in
 	// services.ServiceMap but is present in the manifest after
-	// `citadel module install tei`.
+	// `citadel module install custommod`.
 	manifest := &CitadelManifest{
 		Services: []Service{
-			{Name: "tei", ComposeFile: "./services/tei.yml"},
+			{Name: "custommod", ComposeFile: "./services/custommod.yml"},
 		},
 	}
 
 	// Sanity check: the module-installed name must not be an embedded service,
 	// otherwise case (b) would not actually exercise the manifest fallback.
-	if _, ok := services.ServiceMap["tei"]; ok {
-		t.Fatal("test assumption broken: 'tei' should not be in services.ServiceMap")
+	if _, ok := services.ServiceMap["custommod"]; ok {
+		t.Fatal("test assumption broken: 'custommod' should not be in services.ServiceMap")
 	}
 
 	tests := []struct {
@@ -35,7 +35,7 @@ func TestServiceIsKnown(t *testing.T) {
 		want        bool
 	}{
 		{"embedded service only (ServiceMap)", "vllm", true},
-		{"module-installed service only (manifest)", "tei", true},
+		{"module-installed service only (manifest)", "custommod", true},
 		{"unknown service", "definitely-not-a-service", false},
 	}
 
@@ -54,7 +54,7 @@ func TestServiceIsKnown(t *testing.T) {
 func TestKnownServiceNames(t *testing.T) {
 	manifest := &CitadelManifest{
 		Services: []Service{
-			{Name: "tei", ComposeFile: "./services/tei.yml"},
+			{Name: "custommod", ComposeFile: "./services/custommod.yml"},
 			// vllm is also embedded; it must not be duplicated.
 			{Name: "vllm", ComposeFile: "./services/vllm.yml"},
 		},
@@ -65,7 +65,7 @@ func TestKnownServiceNames(t *testing.T) {
 	// Expect all embedded services (sorted) followed by the unique manifest-only
 	// names (sorted), with no duplicates.
 	want := append([]string{}, services.GetAvailableServices()...)
-	want = append(want, "tei")
+	want = append(want, "custommod")
 
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("knownServiceNames() = %v, want %v", got, want)

--- a/internal/status/collector.go
+++ b/internal/status/collector.go
@@ -129,7 +129,20 @@ func (c *Collector) Collect() (*NodeStatus, error) {
 		if _, dup := reported[eng.Name]; dup {
 			continue
 		}
+		reported[eng.Name] = struct{}{}
 		status.Services = append(status.Services, eng)
+	}
+
+	// Advertise running embedding services (e.g. TEI) with Type=embedding. This
+	// is the discovery signal the sovereign-RAG backend matches on to embed on
+	// the org's own node; like the engine probe it runs in the heartbeat path
+	// where c.services is nil, so a manifest entry is not required.
+	for _, emb := range c.collectEmbeddingServiceStatus() {
+		if _, dup := reported[emb.Name]; dup {
+			continue
+		}
+		reported[emb.Name] = struct{}{}
+		status.Services = append(status.Services, emb)
 	}
 
 	// Mark pinned services (citadel #577) so the heartbeat and `citadel services`

--- a/internal/status/engines.go
+++ b/internal/status/engines.go
@@ -2,10 +2,13 @@ package status
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/catalog"
 	nativesvc "github.com/aceteam-ai/citadel-cli/internal/services"
@@ -101,6 +104,62 @@ func (c *Collector) collectManagedEngineStatus() []ServiceInfo {
 		out = append(out, info)
 	}
 	return out
+}
+
+// embeddingProbeServices lists the OpenAI-compatible embedding services the
+// heartbeat probes on this node. Unlike LLM engines (managedProbeEngines), they
+// are advertised with Type=embedding and are NEVER offered to the gateway chat
+// router: the sovereign RAG path (aceteam) discovers them via the "tei"/
+// "embedding" service marker and reaches them through the gateway's
+// /v1/embeddings upstream, not /v1/chat/completions.
+var embeddingProbeServices = []string{"tei"}
+
+// collectEmbeddingServiceStatus reports running embedding services (container
+// "citadel-<name>") that answer a health check, as ServiceInfo with
+// Type=embedding. This is the discovery signal the sovereign-embeddings backend
+// (_find_tei_node) matches on: a node advertising a "tei" service becomes
+// eligible to embed on its own model. Kept separate from
+// collectManagedEngineStatus so an embedding server is never mistaken for a chat
+// LLM (whose model-discovery/idle probes and chat-router listing do not apply).
+func (c *Collector) collectEmbeddingServiceStatus() []ServiceInfo {
+	engineBin := catalog.SelectContainerRuntime().EngineBin
+	var out []ServiceInfo
+	for _, name := range embeddingProbeServices {
+		if !containerRunning(engineBin, "citadel-"+name) {
+			continue
+		}
+		port := managedEngineHostPort(name)
+		if port <= 0 {
+			continue
+		}
+		// Advertise only once the model is loaded (TEI /health is 200 only then),
+		// so the backend never discovers a still-warming node and then fails the
+		// embed with a 503.
+		if !embeddingServiceHealthy(port) {
+			continue
+		}
+		out = append(out, ServiceInfo{
+			Name:   name,
+			Type:   ServiceTypeEmbedding,
+			Status: ServiceStatusRunning,
+			Port:   port,
+			Health: HealthStatusOK,
+		})
+	}
+	return out
+}
+
+// embeddingServiceHealthy reports whether the embedding server on the loopback
+// host port answers TEI's /health endpoint with 200 (returned only after the
+// model has loaded).
+func embeddingServiceHealthy(port int) bool {
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/health", port))
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
 }
 
 // engineInList reports whether name is present in the given engine list.

--- a/internal/status/engines_test.go
+++ b/internal/status/engines_test.go
@@ -68,6 +68,24 @@ func TestManagedEngineHostPort_VLLM(t *testing.T) {
 	}
 }
 
+// TestEmbeddingProbeResolvesTEIPort guards that the embedding probe resolves
+// TEI's fixed host port (8102) from the embedded compose, so the advertised
+// ServiceInfo.Port matches the gateway's /v1/embeddings upstream. A drift here
+// would advertise a wrong port and break sovereign-embedding discovery.
+func TestEmbeddingProbeResolvesTEIPort(t *testing.T) {
+	if !engineInList(embeddingProbeServices, "tei") {
+		t.Fatal("tei missing from embeddingProbeServices; it would never advertise")
+	}
+	if got := managedEngineHostPort("tei"); got != services.TEIEmbeddingPort {
+		t.Fatalf("expected tei host port %d, got %d", services.TEIEmbeddingPort, got)
+	}
+	// TEI must be advertised as an embedding service, never as an LLM (which would
+	// wrongly feed the gateway chat router).
+	if ServiceTypeEmbedding == ServiceTypeLLM {
+		t.Fatal("ServiceTypeEmbedding must be distinct from ServiceTypeLLM")
+	}
+}
+
 // TestManagedProbeEnginesSupersetOfIdleCapable guards against the drift where
 // an engine added to the idle list is silently dropped from the heartbeat's
 // managed-engine sweep (which now iterates managedProbeEngines, #529).

--- a/internal/status/types.go
+++ b/internal/status/types.go
@@ -223,9 +223,10 @@ type HealthResponse struct {
 
 // ServiceType constants for service classification.
 const (
-	ServiceTypeLLM      = "llm"
-	ServiceTypeDatabase = "database"
-	ServiceTypeOther    = "other"
+	ServiceTypeLLM       = "llm"
+	ServiceTypeEmbedding = "embedding"
+	ServiceTypeDatabase  = "database"
+	ServiceTypeOther     = "other"
 )
 
 // ServiceStatus constants for service state.

--- a/internal/whatsapp/hostport.go
+++ b/internal/whatsapp/hostport.go
@@ -81,7 +81,11 @@ func SelectHostPort(preferred, floor int, probe func(int) bool) (int, error) {
 		start = floor
 	}
 
-	reserved := services.ReservedCitadelPorts
+	// Every port citadel claims -- its own listeners (gateway 8080, etc.) AND
+	// fixed-port compose services (transcribe 8101, tei 8102) -- so the bridge
+	// never races one of them for a port. ReservedCitadelPorts alone omits the
+	// compose-owned fixed ports, which sit inside this 8080+ scan range.
+	reserved := services.ClaimedHostPorts()
 	// 65535 is the max valid TCP port; stop there even if the scan limit would
 	// otherwise carry us past it.
 	for offset := 0; offset < hostPortScanLimit; offset++ {

--- a/services/compose/tei.yml
+++ b/services/compose/tei.yml
@@ -1,0 +1,44 @@
+# services/compose/tei.yml
+#
+# HuggingFace Text Embeddings Inference (TEI) serving
+# Alibaba-NLP/gte-multilingual-base (768-dim, CLS pooling) over the
+# OpenAI-compatible endpoint POST /v1/embeddings. This is the SOVEREIGN EMBEDDING
+# service: the platform resolves an org's embedding model and, for a TEI model,
+# embeds on the org's OWN node (no OpenAI in the loop, model provenance stored
+# with every vector). The backend reaches this through the node's mesh-exposed
+# citadel gateway (/v1/embeddings upstream), never this host port directly.
+#
+# CPU by default: gte-multilingual-base is ~600MB and runs comfortably on CPU,
+# leaving GPU VRAM for inference engines on shared nodes. `--dtype float32` is
+# DELIBERATE and load-bearing -- float16 on CPU segfaults through Intel MKL
+# (aceteam-ai/citadel-services#14); the single-thread MKL/OMP/RAYON env is the
+# segfault-safe combination proven on the cpu-1.6 image. A GPU variant
+# (float16, no MKL pinning) can follow as a separate compose.
+#
+# Host port: the container serves :80, published to the fixed host port 8102
+# (services/ports.go TEIEmbeddingPort), which the gateway's /v1/embeddings
+# upstream reverse-proxies to (cmd/serve.go --embedding-port, cmd/work.go
+# --gateway-embedding-port both default 8102). Like transcribe (8101), this is a
+# fixed well-known port, not a ${CITADEL_*_HOST_PORT}-managed one. Loopback-only
+# (127.0.0.1): the sole consumer is the co-located citadel gateway and TEI has
+# no auth of its own, so it must not be reachable off-host; the mesh reaches
+# embeddings through the gateway (TLS), never this port.
+services:
+  tei:
+    image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.6
+    container_name: citadel-tei
+    command: ["--model-id", "Alibaba-NLP/gte-multilingual-base", "--dtype", "float32"]
+    ports:
+      - "127.0.0.1:8102:80"
+    environment:
+      # Single-thread MKL/OMP/RAYON: float32-on-CPU is stable only when these are
+      # pinned to 1 (citadel-services#14). Do not remove.
+      - MKL_NUM_THREADS=1
+      - OMP_NUM_THREADS=1
+      - RAYON_NUM_THREADS=1
+      # HuggingFace cache: gte-multilingual-base (~600MB) downloads here once and
+      # persists across restarts (shared with other HF-based services).
+      - HUGGINGFACE_HUB_CACHE=/data
+    volumes:
+      - ~/citadel-cache/tei:/data
+    restart: unless-stopped

--- a/services/embed.go
+++ b/services/embed.go
@@ -39,6 +39,9 @@ var BonsaiCompose string
 //go:embed compose/kokoro.yml
 var KokoroCompose string
 
+//go:embed compose/tei.yml
+var TEICompose string
+
 // BonsaiDockerfile is the build-context Dockerfile for the bonsai service. It is
 // materialized to <config>/services/bonsai/Dockerfile (see WriteAuxFiles) so the
 // compose `build.context: ./bonsai` resolves on the node.
@@ -58,6 +61,7 @@ var ServiceMap = map[string]string{
 	"diffusers":  DiffusersCompose,
 	"bonsai":     BonsaiCompose,
 	"kokoro":     KokoroCompose,
+	"tei":        TEICompose,
 }
 
 // ServiceAuxFiles maps a service name to auxiliary build-context files

--- a/services/embed_test.go
+++ b/services/embed_test.go
@@ -75,6 +75,43 @@ func TestBonsaiComposeVRAMTuning(t *testing.T) {
 	}
 }
 
+// TestTEIComposeContract guards the sovereign-embedding TEI module. The
+// float32 + single-thread MKL/OMP/RAYON combination is load-bearing: float16 on
+// CPU segfaults through Intel MKL (citadel-services#14), so if these drift the
+// service crash-loops on start. The container serves :80 published to the fixed
+// host port 8102 (the gateway's /v1/embeddings upstream); a drift there silently
+// breaks discovery + the gateway proxy.
+func TestTEIComposeContract(t *testing.T) {
+	content, ok := ServiceMap["tei"]
+	if !ok {
+		t.Fatal("tei not found in ServiceMap")
+	}
+	for _, want := range []string{
+		"Alibaba-NLP/gte-multilingual-base",
+		"--dtype", "float32",
+		"MKL_NUM_THREADS=1",
+		"OMP_NUM_THREADS=1",
+		"RAYON_NUM_THREADS=1",
+		"127.0.0.1:8102:80",
+		"cpu-1.6",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("tei compose missing required contract fragment %q", want)
+		}
+	}
+}
+
+// TestGetAvailableServicesIncludesTEI ensures tei is advertised as a deployable
+// service so the fabric can schedule the sovereign-embedding module to a node.
+func TestGetAvailableServicesIncludesTEI(t *testing.T) {
+	for _, s := range GetAvailableServices() {
+		if s == "tei" {
+			return
+		}
+	}
+	t.Errorf("GetAvailableServices() = %v, want tei to be included", GetAvailableServices())
+}
+
 // TestDiffusersComposeRegistered ensures the diffusers service is in the
 // ServiceMap so `citadel init` writes services/diffusers.yml and a node can
 // enable it (aceteam #4468).

--- a/services/known_hashes.go
+++ b/services/known_hashes.go
@@ -66,4 +66,7 @@ var KnownComposeHashes = map[string]map[string]bool{
 	"kokoro": {
 		"3ce764e232b286c75f776872bb3554e15b2e03b229863abce271324a815ab777": true,
 	},
+	"tei": {
+		"274a82d682918124ae2472413b3a2246cd99c706b225cd6c4806505a230d44ca": true,
+	},
 }

--- a/services/ports.go
+++ b/services/ports.go
@@ -309,10 +309,14 @@ const (
 // any of these. The collision guard test asserts the module registry, the apps
 // catalog, and the parsed compose files all avoid this set.
 var ReservedCitadelPorts = map[int]string{
-	GatewayPort:        "gateway/status-server",
-	GatewayHTTPSPort:   "gateway-https",
-	ControlMTLSPort:    "control-mtls",
-	TEIEmbeddingPort:   "tei-embeddings",
+	GatewayPort:      "gateway/status-server",
+	GatewayHTTPSPort: "gateway-https",
+	ControlMTLSPort:  "control-mtls",
+	// TEIEmbeddingPort (8102) is intentionally NOT here: TEI is now a first-class
+	// embedded module (services/compose/tei.yml) that OWNS its host port via its
+	// compose, like the transcribe sidecar (8101). The collision guard forbids a
+	// module compose from publishing a ReservedCitadelPorts entry, so TEI's port
+	// protection lives in fixedComposeHostPorts / ClaimedHostPorts instead.
 	VNCWebsockifyPort:  "vnc-websockify",
 	VNCPort:            "vnc-rfb",
 	DeskstreamPort:     "deskstream-h264",
@@ -330,19 +334,44 @@ const (
 	AppsPortRangeEnd   = 8199
 )
 
-// InRangeReservedHostPorts returns the citadel-reserved host ports that fall
+// fixedComposeHostPorts are embedded compose services that publish a FIXED,
+// well-known host port NOT managed through the ${CITADEL_*_HOST_PORT} registry
+// and deliberately NOT listed in ReservedCitadelPorts -- they are owned by their
+// own compose file (which the collision guard validates), so listing them as
+// reserved would make the guard reject the very compose that publishes them.
+// They must nonetheless be treated as citadel-claimed so no dynamic host-port
+// allocator (apps, the whatsapp bridge) ever hands them out and races the
+// service for its port.
+var fixedComposeHostPorts = map[int]string{
+	TranscribePort:   "transcribe",
+	TEIEmbeddingPort: "tei",
+}
+
+// ClaimedHostPorts returns every host port citadel claims: its own process
+// listeners (ReservedCitadelPorts) plus fixed-port compose services
+// (fixedComposeHostPorts). Every dynamic host-port allocator must skip all of
+// these, whatever its scan range -- ReservedCitadelPorts alone is insufficient
+// because it deliberately omits compose-owned fixed ports like transcribe (8101)
+// and tei (8102).
+func ClaimedHostPorts() map[int]string {
+	out := make(map[int]string, len(ReservedCitadelPorts)+len(fixedComposeHostPorts))
+	for p, n := range ReservedCitadelPorts {
+		out[p] = n
+	}
+	for p, n := range fixedComposeHostPorts {
+		out[p] = n
+	}
+	return out
+}
+
+// InRangeReservedHostPorts returns the citadel-claimed host ports that fall
 // inside the apps auto-allocation range, so app allocation can skip them.
 func InRangeReservedHostPorts() map[int]bool {
 	reserved := make(map[int]bool)
-	for port := range ReservedCitadelPorts {
+	for port := range ClaimedHostPorts() {
 		if port >= AppsPortRangeStart && port <= AppsPortRangeEnd {
 			reserved[port] = true
 		}
-	}
-	// TranscribePort is a compose service (not in ReservedCitadelPorts) that
-	// nonetheless occupies a port inside the apps range.
-	if TranscribePort >= AppsPortRangeStart && TranscribePort <= AppsPortRangeEnd {
-		reserved[TranscribePort] = true
 	}
 	return reserved
 }

--- a/services/ports_test.go
+++ b/services/ports_test.go
@@ -117,12 +117,34 @@ func TestGotenbergHostPortRegistered(t *testing.T) {
 // membership: every citadel-owned listener port must be present as its own
 // entry (an accidental re-merge onto an existing port would silently collapse
 // two entries into one).
+// TestClaimedHostPortsCoversFixedComposePorts guards that fixed-port compose
+// services (transcribe 8101, tei 8102) -- which are intentionally NOT in
+// ReservedCitadelPorts so the collision guard lets their compose own them -- are
+// still surfaced as citadel-claimed to every dynamic host-port allocator, and
+// that tei's in-range port stays off-limits to app allocation. Without this a
+// dynamically allocated app or the whatsapp bridge could race TEI for 8102.
+func TestClaimedHostPortsCoversFixedComposePorts(t *testing.T) {
+	claimed := ClaimedHostPorts()
+	for port, name := range map[int]string{TranscribePort: "transcribe", TEIEmbeddingPort: "tei"} {
+		if _, ok := claimed[port]; !ok {
+			t.Errorf("ClaimedHostPorts missing fixed compose port %d (%s)", port, name)
+		}
+	}
+	if !InRangeReservedHostPorts()[TEIEmbeddingPort] {
+		t.Errorf("InRangeReservedHostPorts missing TEIEmbeddingPort %d; apps could allocate it", TEIEmbeddingPort)
+	}
+	// tei must NOT be in ReservedCitadelPorts (else the collision guard rejects
+	// its compose); it belongs only in the claimed union.
+	if _, ok := ReservedCitadelPorts[TEIEmbeddingPort]; ok {
+		t.Error("TEIEmbeddingPort must not be in ReservedCitadelPorts (its compose owns it)")
+	}
+}
+
 func TestReservedCitadelPortsPairwiseDistinct(t *testing.T) {
 	wantEntries := map[int]string{
 		GatewayPort:        "gateway/status-server",
 		GatewayHTTPSPort:   "gateway-https",
 		ControlMTLSPort:    "control-mtls",
-		TEIEmbeddingPort:   "tei-embeddings",
 		VNCWebsockifyPort:  "vnc-websockify",
 		VNCPort:            "vnc-rfb",
 		DeskstreamPort:     "deskstream-h264",


### PR DESCRIPTION
## Context

Closes the citadel half of **aceteam-ai/citadel-cli#616**. Sovereign RAG embeddings (aceteam #6339/#6495, live on prod) let an org embed on its **own** Citadel node's TEI instead of OpenAI. The backend was shipped but the path never routed. Root cause, proven on a live node:

- **Netns split:** a hand-run TEI container binds the *host-kernel* tailnet, but the backend resolves the node's *citadel userspace* tailnet IP — different network namespaces, so a dial to `:8102` is refused. (The paired backend PR fixes transport by routing through the gateway, which already mesh-proxies `/v1/embeddings`.)
- **Discovery gap:** the heartbeat collector advertises services via the **engine probe** (its manifest `c.services` is nil in the heartbeat path), so nothing surfaced a running TEI. `_find_tei_node` matched no node.

## Summary

- **`services/compose/tei.yml`** — embedded `tei` module: `text-embeddings-inference:cpu-1.6` serving `gte-multilingual-base` (768-dim) on the OpenAI-compatible `/v1/embeddings`, host-published on the fixed `8102` the gateway proxies to. `--dtype float32` + single-thread `MKL/OMP/RAYON` is **load-bearing** (float16-on-CPU segfaults, citadel-services#14) and pinned by a compose-contract test. Registered in `ServiceMap` (auto-materializes + advertised as deployable).
- **Embedding discovery probe** (`internal/status/engines.go`) — a purpose-built `collectEmbeddingServiceStatus` advertises a running `citadel-tei` container, gated on TEI `/health`, as `ServiceInfo{Type: "embedding"}`. Kept **separate from the LLM engine probe** so an embedding server is never fed to the gateway chat router. This is the signal `_find_tei_node` matches, and it survives the backend's heartbeat→`service_usage` pass-through unchanged (a model-less `type:"embedding"` entry).
- **Port ownership refactor** — TEI (`8102`) moves from a `ReservedCitadelPorts` standin (it predated TEI being a module) to a **compose-owned** port, mirroring the transcribe sidecar (8101). Because a fixed compose port is deliberately *not* in `ReservedCitadelPorts` (the collision guard forbids a module publishing a reserved port), a new **`ClaimedHostPorts()`** union (reserved + fixed compose ports) is now consulted by **both** dynamic allocators — app auto-allocation and the whatsapp bridge — so neither races transcribe/tei for their ports. (The whatsapp allocator previously read `ReservedCitadelPorts` directly and could have grabbed 8101/8102.)

## Test plan

- `go test ./services/... ./internal/status/... ./internal/apps/... ./internal/whatsapp/...` green; `go vet` clean.
- New guards: TEI compose contract (float32/MKL/port/image), `GetAvailableServices` includes tei, probe port resolution + `ServiceTypeEmbedding != ServiceTypeLLM`, `ClaimedHostPorts` covers transcribe+tei and keeps tei out of `ReservedCitadelPorts`.
- **Verified on a live node:** `citadel-tei` running + TEI `/health` 200 satisfy the probe's exact conditions.

**Draft** — final acceptance is deploy-gated: roll this binary to a node, confirm it advertises `tei`, and that the backend auto-discovers it (paired backend PR). Pairs with the aceteam backend PR for the transport half.