### PR TITLE
feat(services): add Baidu Unlimited-OCR as an on-node document-OCR engine

### DIFF
--- a/docs/ocr-extraction-pipeline.md
+++ b/docs/ocr-extraction-pipeline.md
@@ -1,0 +1,89 @@
+# Sovereign Document-Extraction Pipeline (Unlimited-OCR)
+
+How to turn the `unlimited-ocr` engine (PR #623) into a document
+**routing + extraction** pipeline that runs on Citadel fabric, plus the
+persistence schema for what to store. Companion to `services/compose/unlimited-ocr.yml`.
+
+## Pipeline shape
+
+```
+document image ──▶ Unlimited-OCR (fabric)  ──▶ text + <|det|> regions + <table> HTML
+                          │
+                          ├──▶ embedding (fabric)  ──▶ vector  ──▶ ROUTE (classify doc_type)
+                          │
+                          └──▶ schema-constrained extraction (fabric) ──▶ fields + provenance ──▶ DB
+```
+
+This mirrors the prior-company (adanomad) extraction stack: **AdaExtract2**
+(GLiNER2 entity/relation extraction, which is citadel's own `extraction`/gliner2
+service), the **embedding** repo (image → 1024-dim vector → ANN for routing), and
+**AdaIE/ie-datasets** (schema-constrained IE with typed, normalized output).
+
+## OCR output grammar
+
+Unlimited-OCR emits an ordered region sequence:
+
+```
+<|det|>TYPE [x1, y1, x2, y2]<|/det|>CONTENT
+```
+
+- `TYPE` ∈ `title | text | table | …` (treat as an open set — only `title/text/table`
+  observed so far; do not add a DB CHECK constraint).
+- bbox is pixel coords `[x1,y1,x2,y2]`.
+- `CONTENT` is plain text, or reconstructed **HTML `<table>`** markup for tables.
+
+Request contract (Baidu recipe): prompt `"<image>document parsing."` + a base64
+`image_url`, with `skip_special_tokens:false` and
+`vllm_xargs:{ngram_size:35,window_size:128}`. Known quirk: `ngram_size:35`
+occasionally eats a repeated digit run (an invoice id `#2026-0729` OCR'd as
+`#2026-07`) — relevant for serial numbers / invoice ids.
+
+## Persistence schema
+
+See `docs/ocr-extraction-schema.sql`. Tables: `documents` (+ routing `doc_type`),
+`pages`, `blocks` (one row per OCR region: type + bbox + text/html), `doc_embeddings`
+(`vector(1024)` + HNSW, the routing signal), `extraction_schemas` / `extractions`
+/ `extraction_provenance` (field → source-region citations, the AdaExtract2 pattern).
+pgvector is greenfield wherever this lands (pronghorn has zero vector infra; AceTeam
+uses Supabase/pgvector).
+
+## AceTeam Flow (runs on fabric)
+
+A flow exists — **"Sovereign Document Extraction (OCR → Extract → Embed on Citadel
+Fabric)"** (flow id `0d065a4a-c08f-4caa-be92-db063ccda8ea`) — built from
+`APICall` (OCR + embed + extract, all hitting the fabric inference gateway) +
+`Jinja`/`ExpandJSON` glue. Design decisions:
+
+- All three model steps are `APICall` to the inference gateway (not `AgentMessage`),
+  because no AceTeam agent is bound to a fabric model — `APICall` is what makes a
+  node "run on fabric" with no invented `agent_id`.
+- `api_base`, `ocr_model`, `extract_model`, `embed_model` are **flow inputs**
+  (defaults: `https://api.aceteam.ai`, `baidu/Unlimited-OCR`, `bonsai-27b`,
+  `baai/bge-small-en-v1.5`). Auth is a **runtime** input (`api_token`), never
+  stored in the graph.
+- `APICall.response` is delivered as the raw response **string** — parse it
+  (`ExpandJSON` / a JSON step), don't feed it to a mapping-typed param directly.
+
+### ⚠️ Known blocker: internal vs public gateway URL
+
+Running the flow with `api_base=https://api.aceteam.ai` returns **HTTP 403 + a
+Cloudflare bot-challenge** — the AceTeam flow backend's egress is challenged on the
+public domain (a browser/trusted-IP client gets 200). `api.aceteam.ai/v1` is
+*served by* the backend (`routes/gateway.py`) and fabric routing happens over an
+**internal** Redis-dispatch / SOCKS5 path (`routes/inference.py`,
+`routes/fabric_relay.py`). So the flow's `api_base` must be the backend's
+**internal** inference URL, not the public one. This is a one-parameter fix once
+that internal host is known.
+
+Deeper fix (product gap): there is no first-class **Fabric Inference** flow node —
+`APICall`-to-a-URL is a workaround that also re-exposes the auth/URL plumbing. A
+native node that routes to fabric over the internal path (the same one chat uses)
+would remove the Cloudflare/auth/base-url footguns entirely.
+
+## Live status
+
+- `unlimited-ocr` engine e2e-proven on an RTX 3090 (direct OCR + gotenberg→PDF→OCR).
+- Gateway-routed OCR (`POST api.aceteam.ai/v1 {"model":"baidu/Unlimited-OCR"}`)
+  lights up once #623 ships (release + node auto-update) AND the model is deployed
+  on a fabric node — `managedProbeEngines` (this PR) is what makes the gateway
+  resolve the model to the node.

--- a/docs/ocr-extraction-schema.sql
+++ b/docs/ocr-extraction-schema.sql
@@ -1,0 +1,79 @@
+-- Proposed persistence schema for the OCR → route → extract pipeline.
+-- Postgres/pgvector flavor (AceTeam + pronghorn are Supabase/Postgres).
+-- adanomad `embedding` used ClickHouse for image-vector ANN; pgvector is the
+-- AceTeam-native equivalent. Reconcile table/column names with pronghorn's
+-- existing schema (docs/database-schema.md) before applying.
+
+-- 1. One row per ingested document.
+create table documents (
+  id            uuid primary key default gen_random_uuid(),
+  source_uri    text,                 -- where the original came from
+  sha256        text unique,          -- dedupe identical uploads
+  mime          text,                 -- application/pdf, image/png, ...
+  page_count    int,
+  node_id       text,                 -- which fabric node did the OCR (sovereignty)
+  ocr_model     text default 'baidu/Unlimited-OCR',
+  doc_type      text,                 -- ROUTING result: invoice | contract | report | ...
+  routing_score real,                 -- confidence of the routing decision
+  created_at    timestamptz default now()
+);
+
+-- 2. One row per page (Unlimited-OCR is single-image; PDFs rasterize per page).
+create table pages (
+  id           uuid primary key default gen_random_uuid(),
+  document_id  uuid references documents(id) on delete cascade,
+  page_no      int,
+  width_px     int,
+  height_px    int,
+  image_uri    text,                  -- rasterized page image (object store)
+  unique (document_id, page_no)
+);
+
+-- 3. The heart of it: one row per OCR-detected REGION.
+--    Mirrors the model's output grammar:  <|det|>TYPE [x1,y1,x2,y2]<|/det|>CONTENT
+create table blocks (
+  id           uuid primary key default gen_random_uuid(),
+  page_id      uuid references pages(id) on delete cascade,
+  seq          int,                   -- reading order within the page
+  block_type   text,                  -- title | text | table | list | figure | formula | ...
+  bbox         int[4],                -- [x1, y1, x2, y2] pixel coords (as emitted)
+  text         text,                  -- plain text content
+  html         text,                  -- table/list markup when block_type='table' (model emits <table>)
+  char_len     int
+);
+create index on blocks (page_id, seq);
+
+-- 4. Embeddings for ROUTING + similarity (the "embedding node").
+--    Doc-level for routing/classification; block-level optional for fine retrieval.
+create table doc_embeddings (
+  document_id  uuid references documents(id) on delete cascade,
+  model        text,                  -- image or text embedding model
+  embedding    vector(1024),          -- adanomad `embedding` produced 1024-dim
+  primary key (document_id, model)
+);
+create index on doc_embeddings using hnsw (embedding vector_cosine_ops);
+
+-- 5. Schema-constrained extraction (GLiNER2 / AdaExtract2 lineage).
+create table extraction_schemas (
+  id           uuid primary key default gen_random_uuid(),
+  name         text unique,           -- 'invoice_v1', 'contract_v1', ...
+  labels       jsonb                  -- entity/relation label set + field spec
+);
+
+create table extractions (
+  id           uuid primary key default gen_random_uuid(),
+  document_id  uuid references documents(id) on delete cascade,
+  schema_id    uuid references extraction_schemas(id),
+  fields       jsonb,                 -- the extracted structured record
+  created_at   timestamptz default now()
+);
+
+-- 6. Provenance: link each extracted field back to the source region + span.
+--    (AdaExtract2's "citations linking extracted entities back to source text".)
+create table extraction_provenance (
+  extraction_id uuid references extractions(id) on delete cascade,
+  field_path    text,                 -- e.g. 'total_due' or 'line_items[2].price'
+  block_id      uuid references blocks(id),
+  char_start    int,
+  char_end      int
+);

--- a/internal/apps/hostport_collision_test.go
+++ b/internal/apps/hostport_collision_test.go
@@ -109,13 +109,14 @@ func publishedHostPorts(composeYAML string) ([]int, error) {
 
 	// Map each ${VAR} spelling to its registry value.
 	envValue := map[string]int{
-		services.EnvLlamacppHostPort:   services.LlamacppHostPort,
-		services.EnvVLLMHostPort:       services.VLLMHostPort,
-		services.EnvExtractionHostPort: services.ExtractionHostPort,
-		services.EnvDiffusersHostPort:  services.DiffusersHostPort,
-		services.EnvClaudecodeHostPort: services.ClaudecodeHostPort,
-		services.EnvBonsaiHostPort:     services.BonsaiHostPort,
-		services.EnvTTSHostPort:        services.TTSHostPort,
+		services.EnvLlamacppHostPort:     services.LlamacppHostPort,
+		services.EnvVLLMHostPort:         services.VLLMHostPort,
+		services.EnvExtractionHostPort:   services.ExtractionHostPort,
+		services.EnvDiffusersHostPort:    services.DiffusersHostPort,
+		services.EnvClaudecodeHostPort:   services.ClaudecodeHostPort,
+		services.EnvBonsaiHostPort:       services.BonsaiHostPort,
+		services.EnvTTSHostPort:          services.TTSHostPort,
+		services.EnvUnlimitedOCRHostPort: services.UnlimitedOCRHostPort,
 	}
 
 	var out []int

--- a/internal/mesh/discovery.go
+++ b/internal/mesh/discovery.go
@@ -157,6 +157,8 @@ func EngineTypeFromName(name string) string {
 		return "ollama"
 	case strings.Contains(n, "bonsai"):
 		return "bonsai"
+	case strings.Contains(n, "unlimited-ocr"):
+		return "unlimited-ocr"
 	case strings.Contains(n, "llamacpp"), strings.Contains(n, "llama.cpp"), strings.Contains(n, "llama-cpp"):
 		return "llamacpp"
 	}

--- a/internal/status/engines.go
+++ b/internal/status/engines.go
@@ -32,7 +32,12 @@ var idleCapableEngines = []string{"vllm"}
 // same OpenAI-compatible /v1/models API as llama.cpp, so probing it surfaces the
 // served GGUF in the heartbeat's services[].models — which is how the inference
 // gateway learns a node is serving Bonsai and can route to it (backend=bonsai).
-var managedProbeEngines = []string{"vllm", "ollama", "llamacpp", "bonsai"}
+//
+// unlimited-ocr (Baidu Unlimited-OCR served by vLLM, host port 8213) is likewise
+// an OpenAI-compatible /v1 engine — it just takes image_url input on
+// /v1/chat/completions — so probing it surfaces baidu/Unlimited-OCR in the
+// heartbeat and lets the gateway/mesh route document-OCR requests to it by model.
+var managedProbeEngines = []string{"vllm", "ollama", "llamacpp", "bonsai", "unlimited-ocr"}
 
 // collectManagedEngineStatus reports running managed serving engines (from the
 // embedded services.ServiceMap) so their telemetry reaches the heartbeat even

--- a/internal/status/models.go
+++ b/internal/status/models.go
@@ -48,6 +48,8 @@ func EngineTypeFromName(name string) string {
 		return "ollama"
 	case strings.Contains(n, "bonsai"):
 		return "bonsai"
+	case strings.Contains(n, "unlimited-ocr"):
+		return "unlimited-ocr"
 	case strings.Contains(n, "llamacpp"), strings.Contains(n, "llama.cpp"), strings.Contains(n, "llama-cpp"):
 		return "llamacpp"
 	}

--- a/services/compose/unlimited-ocr.yml
+++ b/services/compose/unlimited-ocr.yml
@@ -1,0 +1,71 @@
+# services/compose/unlimited-ocr.yml
+#
+# Serves Baidu's Unlimited-OCR (a 3B vision-language OCR/document-parsing model,
+# https://huggingface.co/baidu/Unlimited-OCR, MIT) via an OpenAI-compatible
+# vLLM server. It exposes /v1/chat/completions with base64 `image_url` input and
+# returns document text (with optional structure/bbox markers), so it routes
+# through the SAME OpenAI surface as every other citadel engine.
+#
+# UNLIKE the generic vllm.yml (which pulls stock vllm/vllm-openai:latest), this
+# service uses Baidu's PURPOSE-BUILT image tag `vllm/vllm-openai:unlimited-ocr`.
+# The model is `trust_remote_code` (custom modeling code + a no-repeat n-gram
+# logits processor that ships INSIDE this image as
+# vllm.model_executor.models.unlimited_ocr:NGramPerReqLogitsProcessor), so stock
+# vLLM cannot serve it and there is no GGUF (llama.cpp/bonsai path is out). The
+# `cu130` default tag runs on Ampere (RTX 3090, SM86); the `-cu129` variant is
+# only for Hopper.
+#
+# The model resolves from the mounted HF cache on first start (like vllm.yml /
+# extraction.yml) — the WHOLE repo is needed (safetensors + the custom
+# modeling_unlimitedocr.py / deepencoder.py / conversation.py), so there is
+# deliberately NO single-file MODEL_CACHE_PULL branch for this engine.
+
+services:
+  unlimited-ocr:
+    image: vllm/vllm-openai:unlimited-ocr
+    container_name: citadel-unlimited-ocr
+    # Host port is owned by citadel (services/ports.go), supplied via
+    # CITADEL_UNLIMITED_OCR_HOST_PORT; the :? guard fails loudly if citadel forgot
+    # to supply it. Left on the default 0.0.0.0 bind because peers reach this
+    # engine directly over the mesh. The container serves the OpenAI API on :8000.
+    ports:
+      - "${CITADEL_UNLIMITED_OCR_HOST_PORT:?citadel must supply CITADEL_UNLIMITED_OCR_HOST_PORT}:8000"
+    volumes:
+      - ~/citadel-cache/huggingface:/root/.cache/huggingface
+    # The served model is interpolated from OCR_MODEL so a SERVICE_START job
+    # carrying a "model" payload could swap it (#530); the :- default keeps a
+    # standalone `docker compose up` working unchanged. --served-model-name pins
+    # the OpenAI id clients pass as "model".
+    #
+    # The four OCR-specific flags mirror Baidu's published vLLM recipe verbatim
+    # and are MANDATORY:
+    #   --trust-remote-code                loads the custom modeling code
+    #   --logits_processors ...            the no-repeat n-gram sampler the model needs
+    #   --no-enable-prefix-caching         the recipe disables it for this model
+    #   --mm-processor-cache-gb 0          the recipe disables the mm cache
+    #
+    # VRAM tuning (mirrors the bonsai #567 / vllm.yml lesson): the model's full
+    # 32768 context is unnecessary for page OCR, so --max-model-len defaults to
+    # 16384 and --gpu-memory-utilization to 0.60 (~14.5GB cap of a 24GB card),
+    # leaving the 3.3GB model + vision encoder + KV comfortable headroom. Override
+    # via OCR_MAX_MODEL_LEN / OCR_GPU_UTIL. --enforce-eager skips CUDA-graph
+    # capture (lower VRAM, faster cold start), matching vllm.yml.
+    command: >-
+      --host 0.0.0.0
+      --port 8000
+      --model ${OCR_MODEL:-baidu/Unlimited-OCR}
+      --served-model-name ${OCR_SERVED_NAME:-baidu/Unlimited-OCR}
+      --trust-remote-code
+      --logits_processors vllm.model_executor.models.unlimited_ocr:NGramPerReqLogitsProcessor
+      --no-enable-prefix-caching
+      --mm-processor-cache-gb 0
+      --max-model-len ${OCR_MAX_MODEL_LEN:-16384}
+      --gpu-memory-utilization ${OCR_GPU_UTIL:-0.60}
+      --enforce-eager
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/services/embed.go
+++ b/services/embed.go
@@ -42,6 +42,9 @@ var KokoroCompose string
 //go:embed compose/tei.yml
 var TEICompose string
 
+//go:embed compose/unlimited-ocr.yml
+var UnlimitedOCRCompose string
+
 // BonsaiDockerfile is the build-context Dockerfile for the bonsai service. It is
 // materialized to <config>/services/bonsai/Dockerfile (see WriteAuxFiles) so the
 // compose `build.context: ./bonsai` resolves on the node.
@@ -51,17 +54,18 @@ var BonsaiDockerfile string
 
 // ServiceMap provides a lookup for pre-packaged service compose files.
 var ServiceMap = map[string]string{
-	"ollama":     OllamaCompose,
-	"vllm":       VLLMCompose,
-	"llamacpp":   LlamacppCompose,
-	"lmstudio":   LMStudioCompose,
-	"sglang":     SGLangCompose,
-	"extraction": ExtractionCompose,
-	"transcribe": TranscribeCompose,
-	"diffusers":  DiffusersCompose,
-	"bonsai":     BonsaiCompose,
-	"kokoro":     KokoroCompose,
-	"tei":        TEICompose,
+	"ollama":        OllamaCompose,
+	"vllm":          VLLMCompose,
+	"llamacpp":      LlamacppCompose,
+	"lmstudio":      LMStudioCompose,
+	"sglang":        SGLangCompose,
+	"extraction":    ExtractionCompose,
+	"transcribe":    TranscribeCompose,
+	"diffusers":     DiffusersCompose,
+	"bonsai":        BonsaiCompose,
+	"kokoro":        KokoroCompose,
+	"tei":           TEICompose,
+	"unlimited-ocr": UnlimitedOCRCompose,
 }
 
 // ServiceAuxFiles maps a service name to auxiliary build-context files

--- a/services/known_hashes.go
+++ b/services/known_hashes.go
@@ -69,4 +69,7 @@ var KnownComposeHashes = map[string]map[string]bool{
 	"tei": {
 		"274a82d682918124ae2472413b3a2246cd99c706b225cd6c4806505a230d44ca": true,
 	},
+	"unlimited-ocr": {
+		"2f1e1f1ffae72db007b65d1b8d275f69c33c0c7e3207f8139ee8c2c1c8d2c9c0": true,
+	},
 }

--- a/services/ports.go
+++ b/services/ports.go
@@ -82,6 +82,12 @@ const (
 	// The registry KEY is the module name "nvr" while the env var is spelled for the
 	// container it maps to (frigate) — the same key/env split as meeting.
 	EnvFrigateHostPort = "CITADEL_FRIGATE_HOST_PORT"
+	// EnvUnlimitedOCRHostPort carries the host port for the unlimited-ocr service
+	// (Baidu Unlimited-OCR served by vLLM). Like vllm/bonsai it is an embedded
+	// ServiceMap compose whose container serves the OpenAI API on :8000; this env
+	// var supplies the HOST publish so `${CITADEL_UNLIMITED_OCR_HOST_PORT}`
+	// resolves at `docker compose up`.
+	EnvUnlimitedOCRHostPort = "CITADEL_UNLIMITED_OCR_HOST_PORT"
 )
 
 // Citadel-assigned host ports for the pre-packaged compose services. These are
@@ -158,6 +164,12 @@ const (
 	// compose lives in citadel-services (like meeting/gotenberg), so this registry
 	// is the only thing stopping a future module from hardcoding over 8212.
 	FrigateHostPort = 8212
+	// unlimited-ocr: Baidu Unlimited-OCR (a 3B vision-language OCR model) served by
+	// an OpenAI-compatible vLLM server (services/compose/unlimited-ocr.yml). Next
+	// free slot in the 8200 block after frigate's 8212 (8205 stays earmarked for
+	// Hermes/OpenClaw). It is an embedded ServiceMap compose, so its container
+	// serves on :8000 and this is the HOST publish.
+	UnlimitedOCRHostPort = 8213
 )
 
 // WyzeBridgeRTSPPort is docker-wyze-bridge's RTSP server port in the nvr module
@@ -177,34 +189,36 @@ const WyzeBridgeRTSPPort = 8554
 // unions this with the apps catalog and the parsed compose files to prove no two
 // host ports clash.
 var ServiceHostPorts = map[string]int{
-	"llamacpp":    LlamacppHostPort,
-	"vllm":        VLLMHostPort,
-	"extraction":  ExtractionHostPort,
-	"diffusers":   DiffusersHostPort,
-	"claudecode":  ClaudecodeHostPort,
-	"storage":     StorageHostPort,
-	"meeting":     MeetingdHostPort,
-	"meeting-cdp": MeetingCDPHostPort,
-	"gotenberg":   GotenbergHostPort,
-	"bonsai":      BonsaiHostPort,
-	"kokoro":      TTSHostPort,
-	"nvr":         FrigateHostPort,
+	"llamacpp":      LlamacppHostPort,
+	"vllm":          VLLMHostPort,
+	"extraction":    ExtractionHostPort,
+	"diffusers":     DiffusersHostPort,
+	"claudecode":    ClaudecodeHostPort,
+	"storage":       StorageHostPort,
+	"meeting":       MeetingdHostPort,
+	"meeting-cdp":   MeetingCDPHostPort,
+	"gotenberg":     GotenbergHostPort,
+	"bonsai":        BonsaiHostPort,
+	"kokoro":        TTSHostPort,
+	"nvr":           FrigateHostPort,
+	"unlimited-ocr": UnlimitedOCRHostPort,
 }
 
 // serviceHostPortEnv maps each managed service to the compose env-var that
 // carries its host port.
 var serviceHostPortEnv = map[string]string{
-	"llamacpp":    EnvLlamacppHostPort,
-	"vllm":        EnvVLLMHostPort,
-	"extraction":  EnvExtractionHostPort,
-	"diffusers":   EnvDiffusersHostPort,
-	"claudecode":  EnvClaudecodeHostPort,
-	"meeting":     EnvMeetingdHostPort,
-	"meeting-cdp": EnvMeetingCDPHostPort,
-	"gotenberg":   EnvGotenbergHostPort,
-	"bonsai":      EnvBonsaiHostPort,
-	"kokoro":      EnvTTSHostPort,
-	"nvr":         EnvFrigateHostPort,
+	"llamacpp":      EnvLlamacppHostPort,
+	"vllm":          EnvVLLMHostPort,
+	"extraction":    EnvExtractionHostPort,
+	"diffusers":     EnvDiffusersHostPort,
+	"claudecode":    EnvClaudecodeHostPort,
+	"meeting":       EnvMeetingdHostPort,
+	"meeting-cdp":   EnvMeetingCDPHostPort,
+	"gotenberg":     EnvGotenbergHostPort,
+	"bonsai":        EnvBonsaiHostPort,
+	"kokoro":        EnvTTSHostPort,
+	"nvr":           EnvFrigateHostPort,
+	"unlimited-ocr": EnvUnlimitedOCRHostPort,
 }
 
 // HostPortEnv returns "KEY=value" entries for every citadel-managed host port,


### PR DESCRIPTION
## Context
Request: get **baidu/Unlimited-OCR** (a 3B vision-language OCR / document-parsing model, MIT) listed as a citadel node/model offering, test it e2e, and prove it in a document-processing workflow. This is the sovereign-OCR building block — nodes can now OCR documents on their own GPU behind the same OpenAI `/v1` surface as every other engine.

## Why a dedicated service (not stock vllm/sglang)
- The model is `trust_remote_code` with a custom **no-repeat n-gram logits processor** that ships *inside* Baidu's purpose-built image `vllm/vllm-openai:unlimited-ocr` — stock vLLM can't serve it.
- **No GGUF exists**, so the lightweight llama.cpp/bonsai path is out.
- SGLang would need a custom wheel + `fa3` (Hopper-only) — messier and wrong for the 3090 fleet.
- The vLLM `cu130` image runs on Ampere (RTX 3090, SM86); it exposes `/v1/chat/completions` with base64 `image_url` input.

## Changes (citadel side)
- `services/compose/unlimited-ocr.yml` — new embedded compose. Prebuilt image (no build context). Mirrors Baidu's published vLLM recipe verbatim for the 4 mandatory OCR flags (`--trust-remote-code`, `--logits_processors …unlimited_ocr:NGramPerReqLogitsProcessor`, `--no-enable-prefix-caching`, `--mm-processor-cache-gb 0`). VRAM-tuned defaults (`--max-model-len 16384`, `--gpu-memory-utilization 0.60`) overridable via `OCR_*` env vars — same lesson as bonsai #567 / vllm.yml.
- `services/ports.go` — host port **8213** in the 8200 block (`CITADEL_UNLIMITED_OCR_HOST_PORT`) + both registry maps.
- `services/embed.go` — ServiceMap + `//go:embed` registration.
- `services/known_hashes.go` — template-hash allowlist entry (re-materialization safety net).
- `internal/status/engines.go` — added to `managedProbeEngines` so the heartbeat surfaces `baidu/Unlimited-OCR` and the gateway/mesh route document-OCR requests **by model**.
- `internal/status/models.go`, `internal/mesh/discovery.go` — `EngineTypeFromName` self-maps `unlimited-ocr`.
- `internal/apps/hostport_collision_test.go` — teach the collision guard's env resolver the new var.

## Testing
- **Unit/integration**: `go test ./...` green (67 packages), `go vet` clean, `docker compose config` renders port 8213 + all flags.
- **e2e on a live RTX 3090 node (ubuntu-gpu)**: pulled `vllm/vllm-openai:unlimited-ocr`, evicted bonsai to free VRAM, started via citadel's exact compose mechanism (`-p citadel-unlimited-ocr` + injected host-port env). Server came up serving `baidu/Unlimited-OCR` (~13.4 GB VRAM under the 0.60 cap).
  - **Direct OCR** on an invoice-with-table image (7 s): every line + table column + number extracted correctly, with `<|det|>` bbox structure markers.
  - **Full document pipeline** — `HTML → gotenberg(:8209) PDF → pdftoppm PNG → unlimited-ocr`: the table was reconstructed as correct HTML `<table>` markup; all text extracted. Proves two sovereign services chaining on-node.
  - Node restored to prior state afterward (bonsai brought back up).

## AceTeam-side follow-ups (different repo — NOT in this PR)
1. **Model catalog entry** in `aceteam` `data/model_catalog.json` / `fabric_catalog_models` so it's deployable from `/fabric/models`:
   ```json
   {
     "id": "baidu/Unlimited-OCR",
     "name": "Unlimited-OCR (document parsing)",
     "engine": "unlimited-ocr",
     "source": "baidu/Unlimited-OCR",
     "vram_gb": { "min": 6, "recommended": 14, "max_context": 16 },
     "context_length": 16384,
     "tags": ["ocr", "vision-language", "document", "vllm"]
   }
   ```
   `engine` must be `unlimited-ocr` so the node routes `SERVICE_START` to `services/compose/unlimited-ocr.yml`.
2. **Gateway `WriteTimeout` (120 s)** may be exceeded by very large multi-page OCR — worth a longer per-route budget for OCR.
3. **Dashboard idea (models page + Android TV app)**: show model → hosting machine → live traffic. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)