### PR TITLE
fix(worker): carry multimodal message content to the engine (#625)

### DIFF
--- a/internal/jobs/chatmessage_multimodal_test.go
+++ b/internal/jobs/chatmessage_multimodal_test.go
@@ -1,0 +1,72 @@
+package jobs
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestChatMessageMultimodal covers the #625 change: ChatMessage.Content is raw
+// JSON so it carries either a plain string or the OpenAI multimodal content-parts
+// array (needed for vision/OCR models like baidu/Unlimited-OCR).
+func TestChatMessageMultimodal(t *testing.T) {
+	t.Run("string content unmarshals and Text returns it", func(t *testing.T) {
+		var m ChatMessage
+		if err := json.Unmarshal([]byte(`{"role":"user","content":"hello world"}`), &m); err != nil {
+			t.Fatalf("unmarshal string content: %v", err)
+		}
+		if got := m.Text(); got != "hello world" {
+			t.Errorf("Text() = %q, want %q", got, "hello world")
+		}
+	})
+
+	t.Run("multimodal array unmarshals (was a hard error before #625)", func(t *testing.T) {
+		raw := `{"role":"user","content":[{"type":"text","text":"<image>document parsing."},{"type":"image_url","image_url":{"url":"data:image/png;base64,AAAA"}}]}`
+		var m ChatMessage
+		if err := json.Unmarshal([]byte(raw), &m); err != nil {
+			t.Fatalf("unmarshal multimodal content: %v", err)
+		}
+		if got := m.Text(); got != "<image>document parsing." {
+			t.Errorf("Text() = %q, want the concatenated text parts", got)
+		}
+	})
+
+	t.Run("empty content is safe", func(t *testing.T) {
+		var m ChatMessage
+		if m.Text() != "" {
+			t.Errorf("Text() on empty = %q, want empty", m.Text())
+		}
+		if string(m.ContentJSON()) != `""` {
+			t.Errorf("ContentJSON() on empty = %s, want empty JSON string", m.ContentJSON())
+		}
+	})
+
+	t.Run("ContentJSON forwards image parts verbatim into an outgoing request", func(t *testing.T) {
+		raw := `{"role":"user","content":[{"type":"text","text":"t"},{"type":"image_url","image_url":{"url":"data:image/png;base64,ZZ"}}]}`
+		var m ChatMessage
+		if err := json.Unmarshal([]byte(raw), &m); err != nil {
+			t.Fatal(err)
+		}
+		// Mirror executeChatCompletionsAt's forwarding shape.
+		out := map[string]any{"role": m.Role, "content": m.ContentJSON()}
+		b, err := json.Marshal(out)
+		if err != nil {
+			t.Fatalf("marshal forwarded message: %v", err)
+		}
+		s := string(b)
+		if !strings.Contains(s, `"image_url"`) || !strings.Contains(s, "data:image/png;base64,ZZ") {
+			t.Errorf("forwarded payload dropped the image part: %s", s)
+		}
+	})
+
+	t.Run("string content round-trips through the forward path as a string", func(t *testing.T) {
+		var m ChatMessage
+		if err := json.Unmarshal([]byte(`{"role":"user","content":"hi"}`), &m); err != nil {
+			t.Fatal(err)
+		}
+		b, _ := json.Marshal(map[string]any{"content": m.ContentJSON()})
+		if string(b) != `{"content":"hi"}` {
+			t.Errorf("string content forward = %s, want {\"content\":\"hi\"}", b)
+		}
+	})
+}

--- a/internal/jobs/queue_types.go
+++ b/internal/jobs/queue_types.go
@@ -1,6 +1,11 @@
 // Package jobs contains job type definitions and handlers for the Redis queue system.
 package jobs
 
+import (
+	"encoding/json"
+	"strings"
+)
+
 // Job types that citadel can handle
 const (
 	// JobTypeLLMInference handles local LLM completion requests
@@ -80,9 +85,53 @@ type LLMInferencePayload struct {
 }
 
 // ChatMessage represents a message in chat-style APIs.
+//
+// Content is stored as raw JSON because the OpenAI chat schema allows it to be
+// EITHER a plain string (the common case) OR the multimodal "content parts"
+// array — e.g. `[{"type":"text",...},{"type":"image_url","image_url":{"url":
+// "data:image/png;base64,..."}}]` — which a vision/OCR model like
+// baidu/Unlimited-OCR needs (#625). Keeping it raw lets the node forward either
+// shape verbatim to an OpenAI-compatible engine without lossy re-encoding; use
+// Text() when a plain-text view is required.
 type ChatMessage struct {
-	Role    string `json:"role"` // "system", "user", "assistant"
-	Content string `json:"content"`
+	Role    string          `json:"role"` // "system", "user", "assistant"
+	Content json.RawMessage `json:"content,omitempty"`
+}
+
+// Text returns the message content as plain text. Content may be a JSON string
+// (returned as-is) or the OpenAI multimodal array (its "text" parts are
+// concatenated; non-text parts such as image_url are ignored). Empty or
+// unparseable content yields "".
+func (m ChatMessage) Text() string {
+	if len(m.Content) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(m.Content, &s); err == nil {
+		return s
+	}
+	var parts []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(m.Content, &parts); err == nil {
+		var b strings.Builder
+		for _, p := range parts {
+			b.WriteString(p.Text)
+		}
+		return b.String()
+	}
+	return ""
+}
+
+// ContentJSON returns the raw content for forwarding verbatim to an
+// OpenAI-compatible engine, preserving multimodal parts. Empty content becomes
+// an empty JSON string so the outgoing request is always valid.
+func (m ChatMessage) ContentJSON() json.RawMessage {
+	if len(m.Content) == 0 {
+		return json.RawMessage(`""`)
+	}
+	return m.Content
 }
 
 // LLMInferenceResult represents the result of an llm_inference job.

--- a/internal/worker/llm_inference.go
+++ b/internal/worker/llm_inference.go
@@ -377,9 +377,13 @@ func (h *LLMInferenceHandler) bufferedOllama(stream StreamWriter, body io.Reader
 // served model's chat template. Used whenever an llm_inference job carries
 // `messages` (the shape the OpenAI gateway and MCP inference_chat dispatch).
 func (h *LLMInferenceHandler) executeOllamaChat(ctx context.Context, stream StreamWriter, payload *jobs.LLMInferencePayload) (*JobResult, error) {
+	// Ollama's /api/chat takes text content (images ride a separate `images`
+	// field we do not populate), so flatten any multimodal content to its text
+	// parts. OCR/vision fabric models run on vLLM (executeChatCompletionsAt), not
+	// this path.
 	messages := make([]map[string]string, 0, len(payload.Messages))
 	for _, m := range payload.Messages {
-		messages = append(messages, map[string]string{"role": m.Role, "content": m.Content})
+		messages = append(messages, map[string]string{"role": m.Role, "content": m.Text()})
 	}
 
 	reqPayload := map[string]any{
@@ -619,9 +623,13 @@ func (h *LLMInferenceHandler) bufferedLlamaCpp(stream StreamWriter, body io.Read
 // like Bonsai. Used whenever an llm_inference job carries `messages` (the shape
 // the OpenAI inference gateway dispatches).
 func (h *LLMInferenceHandler) executeChatCompletionsAt(ctx context.Context, stream StreamWriter, payload *jobs.LLMInferencePayload, baseURL string) (*JobResult, error) {
-	messages := make([]map[string]string, 0, len(payload.Messages))
+	// Forward content verbatim (map[string]any, not map[string]string) so the
+	// OpenAI multimodal "content parts" array — e.g. an image_url for a vision/OCR
+	// model like baidu/Unlimited-OCR (#625) — reaches the engine intact. A plain
+	// string content marshals back to a string unchanged.
+	messages := make([]map[string]any, 0, len(payload.Messages))
 	for _, m := range payload.Messages {
-		messages = append(messages, map[string]string{"role": m.Role, "content": m.Content})
+		messages = append(messages, map[string]any{"role": m.Role, "content": m.ContentJSON()})
 	}
 
 	reqPayload := map[string]any{


### PR DESCRIPTION
## Context
Node-side complement of the platform **FabricInference** node (aceteam #6752). Together they let a base64 image flow end-to-end: AceTeam flow → inference gateway → citadel node → vision/OCR engine (baidu/Unlimited-OCR, citadel #623).

## Root cause
The Redis `llm_inference` path typed `ChatMessage.Content` as a Go `string` and rebuilt outgoing messages as `map[string]string`. An OpenAI **multimodal content array** (`[{"type":"text",...},{"type":"image_url",...}]`) therefore either failed to JSON-unmarshal or was silently dropped — the image never reached the engine.

## Changes
- `internal/jobs/queue_types.go`: `ChatMessage.Content` → `json.RawMessage` (accepts a string **or** the multimodal array). New `Text()` (flatten to text parts) and `ContentJSON()` (forward-safe raw) helpers.
- `internal/worker/llm_inference.go`: `executeChatCompletionsAt` (vLLM/OpenAI) forwards content **verbatim** via `map[string]any` so `image_url` parts survive; `executeOllamaChat` flattens to text (Ollama carries images separately; OCR runs on vLLM).

## Testing
- New `chatmessage_multimodal_test.go`: multimodal unmarshal (a hard error before), `Text()` flattening, verbatim image forward, string round-trip.
- `go test ./...` green; `go vet` clean.

Closes #625.

🤖 Generated with [Claude Code](https://claude.com/claude-code)