### PR TITLE
fix(status,worker): route unlimited-ocr end-to-end (discovery + inference)

### DIFF
--- a/internal/status/models.go
+++ b/internal/status/models.go
@@ -83,6 +83,12 @@ func (m *ModelDiscovery) DiscoverModels(ctx context.Context, serviceType string,
 		// bonsai (PrismML Bonsai-27B) is served by the llama.cpp fork, so it
 		// exposes the identical OpenAI-compatible /v1/models endpoint.
 		return m.discoverOpenAIModels(ctx, "bonsai", port)
+	case "unlimited-ocr":
+		// Baidu Unlimited-OCR is served by vLLM, exposing the identical
+		// OpenAI-compatible /v1/models endpoint. Without this case the heartbeat
+		// never surfaces the model (the engine is dropped from
+		// collectManagedEngineStatus), so the gateway/fabric can't route to it.
+		return m.discoverOpenAIModels(ctx, "Unlimited-OCR", port)
 	case "ollama":
 		return m.discoverOllamaModels(ctx, port)
 	default:
@@ -179,8 +185,9 @@ func (m *ModelDiscovery) discoverOllamaModels(ctx context.Context, port int) ([]
 // CheckServiceHealth performs a health check on an LLM service.
 func (m *ModelDiscovery) CheckServiceHealth(ctx context.Context, serviceType string, port int) (string, error) {
 	switch serviceType {
-	case "vllm", "llamacpp", "bonsai":
-		// vLLM, llama.cpp, and the bonsai llama.cpp fork all expose GET /health.
+	case "vllm", "llamacpp", "bonsai", "unlimited-ocr":
+		// vLLM, llama.cpp, the bonsai fork, and the vLLM-served Unlimited-OCR all
+		// expose GET /health.
 		return m.checkHTTPHealth(ctx, port)
 	case "ollama":
 		return m.checkOllamaHealth(ctx, port)

--- a/internal/status/ocr_engine_routing_test.go
+++ b/internal/status/ocr_engine_routing_test.go
@@ -1,0 +1,30 @@
+package status
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestDiscoverModelsHandlesEveryProbeEngine guards the gap that kept
+// baidu/Unlimited-OCR off the heartbeat: an engine in managedProbeEngines whose
+// serviceType has no DiscoverModels case falls through to the "unsupported
+// service type" default, which makes collectManagedEngineStatus drop it (it is
+// only reported when a probe responds). A new managed engine MUST add a
+// DiscoverModels case; this test fails loudly if it doesn't.
+func TestDiscoverModelsHandlesEveryProbeEngine(t *testing.T) {
+	d := NewModelDiscovery()
+	for _, engine := range managedProbeEngines {
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		// Probe a port with nothing listening: a HANDLED engine returns a
+		// connection error (or empty list); an UNHANDLED one returns the
+		// "unsupported service type" sentinel from the switch default.
+		_, err := d.DiscoverModels(ctx, engine, 1)
+		cancel()
+		if err != nil && strings.Contains(err.Error(), "unsupported service type") {
+			t.Errorf("DiscoverModels has no case for managedProbeEngine %q "+
+				"(engine would be dropped from the heartbeat / not routable)", engine)
+		}
+	}
+}

--- a/internal/worker/llm_inference.go
+++ b/internal/worker/llm_inference.go
@@ -66,6 +66,10 @@ func NewLLMInferenceHandler() *LLMInferenceHandler {
 			"vllm":     fmt.Sprintf("http://localhost:%d", services.VLLMHostPort),
 			"llamacpp": fmt.Sprintf("http://localhost:%d", services.LlamacppHostPort),
 			"bonsai":   fmt.Sprintf("http://localhost:%d", services.BonsaiHostPort),
+			// unlimited-ocr (Baidu Unlimited-OCR) is served by vLLM on its own
+			// registry host port; route inference there (multimodal image content
+			// is carried by executeChatCompletionsAt via #625).
+			"unlimited-ocr": fmt.Sprintf("http://localhost:%d", services.UnlimitedOCRHostPort),
 			// sglang/ollama sit on their native, well-known host ports (not part of
 			// the collision-managed 8200 block — see services/ports.go).
 			"sglang": "http://localhost:30000",
@@ -107,6 +111,10 @@ func (h *LLMInferenceHandler) Execute(ctx context.Context, job *Job, stream Stre
 		// Bonsai serves the identical llama.cpp-server API on its own host port
 		// (PrismML fork). Reuse the llama.cpp request/stream path pointed at it.
 		return h.executeLlamaCppAt(ctx, stream, payload, h.baseURL("bonsai"))
+	case "unlimited-ocr":
+		// Baidu Unlimited-OCR is a vLLM OpenAI engine on its own host port; use the
+		// chat-completions path so multimodal image_url content (#625) reaches it.
+		return h.executeChatCompletionsAt(ctx, stream, payload, h.baseURL("unlimited-ocr"))
 	default:
 		return h.failure(fmt.Errorf("unsupported backend: %s", payload.Backend)), nil
 	}


### PR DESCRIPTION
## Root cause
#623 added `unlimited-ocr` to `managedProbeEngines` but not to the engine-type switches that make an engine usable. So on a node serving Baidu Unlimited-OCR:
- **Discovery:** `DiscoverModels` hit the `default: unsupported service type` branch → `collectManagedEngineStatus` only reports engines whose probe responds → the engine was **dropped from the heartbeat** → never advertised → the platform's `run_fabric_chat` couldn't resolve the model on the node.
- **Inference:** even if advertised, the worker's `llm_inference` backend switch had no `unlimited-ocr` case (→ "unsupported backend") and no `baseURLs` entry for :8213.

Found while running the live OCR-through-flow test after v2.94.0 shipped: the node served `baidu/Unlimited-OCR` on :8213 but `inference_nodes` / `/status` never listed it.

## Fix
- `internal/status/models.go`: `DiscoverModels` + `CheckServiceHealth` handle `unlimited-ocr` (vLLM-style OpenAI `/v1/models` + `/health`).
- `internal/worker/llm_inference.go`: `baseURLs["unlimited-ocr"] = UnlimitedOCRHostPort` and the backend switch routes `unlimited-ocr` → `executeChatCompletionsAt` (carries multimodal `image_url` via #625).
- Regression guard `TestDiscoverModelsHandlesEveryProbeEngine` so a future managed engine can't silently miss a `DiscoverModels` case.

## Testing
`go test ./...` green (67 pkgs). Completes the OCR-on-fabric path: flow → FabricInference (aceteam #6752) → node → Unlimited-OCR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)