### PR TITLE
feat: model hotswap phase 1 (pilot, #632)

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -2026,6 +2026,10 @@ func runTUIWorker(ctx context.Context, activityFn func(level, msg string)) error
 	})
 
 	_, ccConfigDir, _ := findAndReadManifest()
+	var ccPinnedServices []string
+	if m, _, err := findAndReadManifest(); err == nil {
+		ccPinnedServices = manifestPinnedServices(m)
+	}
 	nodeJobOpts := nodeJobHandlerOpts{
 		LogFn:                     activity,
 		WorkspaceDir:              wsDir,
@@ -2038,6 +2042,7 @@ func runTUIWorker(ctx context.Context, activityFn func(level, msg string)) error
 		FilesDisabled:             !ccPerms.Files,
 		WorkflowExec:              ccWfExec,
 		HandlerLog:                func(format string, args ...any) { activity("info", fmt.Sprintf(format, args...)) },
+		PinnedServices:            ccPinnedServices,
 	}
 	handlers := buildNodeJobHandlers(nodeJobOpts)
 

--- a/cmd/hotswap.go
+++ b/cmd/hotswap.go
@@ -1,0 +1,194 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/aceteam-ai/citadel-cli/internal/jobs"
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+	"github.com/aceteam-ai/citadel-cli/internal/status"
+	"github.com/aceteam-ai/citadel-cli/internal/worker"
+)
+
+// hotswap.go wires the model-hotswap swap manager (citadel-cli#632) to this
+// node's real side-effects: a jobs.ServiceHandler for start/stop and a status
+// collector for live VRAM/footprint. It is constructed ONLY when
+// CITADEL_MODEL_HOTSWAP is on (see buildNodeJobHandlers), so nothing here runs on
+// a default node.
+
+// swapController implements worker.SwapController against the live node.
+type swapController struct {
+	svc            *jobs.ServiceHandler
+	configDir      string
+	pinnedServices map[string]bool
+	logf           func(format string, args ...any)
+}
+
+// newSwapController builds the live controller rooted at the node's config +
+// workspace dir, honoring the manifest's pinned_services (a pinned engine is
+// never swapped out — the #577 allowlist still applies here).
+func newSwapController(configDir, workspaceDir string, pinned []string, logf func(string, ...any)) *swapController {
+	set := make(map[string]bool, len(pinned))
+	for _, p := range pinned {
+		if p != "" {
+			set[p] = true
+		}
+	}
+	if logf == nil {
+		logf = func(string, ...any) {}
+	}
+	return &swapController{
+		svc:            jobs.NewServiceHandlerWithWorkspace(configDir, workspaceDir),
+		configDir:      configDir,
+		pinnedServices: set,
+		logf:           logf,
+	}
+}
+
+// Resident reports whether the engine's container is currently running.
+func (c *swapController) Resident(ctx context.Context, backend string) bool {
+	for _, e := range status.DiscoverLocalEngines(ctx) {
+		if e.Name == backend {
+			return true
+		}
+	}
+	return false
+}
+
+// PreemptInputs collects the live preemption inputs: running managed serving
+// engines other than `exclude` as candidates (VRAM footprint + instantaneous
+// idle + pinned flag) and the node's free VRAM. Mirrors the #577 executor's
+// buildPreemptCandidates/freeVRAMBytes, but reused here for the NON-durable swap
+// path.
+func (c *swapController) PreemptInputs(ctx context.Context, exclude string) ([]status.PreemptCandidate, uint64, bool) {
+	collector := status.NewCollector(status.CollectorConfig{ConfigDir: c.configDir})
+	st, err := collector.Collect()
+	if err != nil {
+		c.logf("[hotswap] status collect failed; skipping preemption: %v", err)
+		return nil, 0, false
+	}
+
+	freeVRAM, haveVRAM := freeVRAMBytesFromGPU(st.GPU)
+
+	var candidates []status.PreemptCandidate
+	for i := range st.Services {
+		s := &st.Services[i]
+		if s.Name == exclude || s.Status != status.ServiceStatusRunning {
+			continue
+		}
+		if status.EngineTypeFromName(s.Name) == "" {
+			continue // only serving engines are swap candidates
+		}
+		var vram uint64
+		if s.Footprint != nil {
+			vram = s.Footprint.VRAMBytes
+		}
+		candidates = append(candidates, status.PreemptCandidate{
+			Name:      s.Name,
+			VRAMBytes: vram,
+			Idle:      !status.FootprintActive(s.Footprint),
+			Pinned:    c.pinnedServices[s.Name],
+		})
+	}
+	return candidates, freeVRAM, haveVRAM
+}
+
+// StopNonDurable stops an engine WITHOUT marking desired_status:stopped, so it
+// remains eligible to swap back in (StopServiceByName is marker-free — the
+// durable marker is set only by the SERVICE_STOP job path).
+func (c *swapController) StopNonDurable(name string) error {
+	c.logf("[hotswap] evicting %s (non-durable) to free VRAM", name)
+	return c.svc.StopServiceByName(name)
+}
+
+// Start starts the target engine serving `model` via an internal SERVICE_START
+// carrying ONLY {service, model} — deliberately no vram_mb, so #577's DURABLE
+// preemptForVRAM stays inert (the swap did its own non-durable preemption). The
+// engine's compose-up runs to completion here (may build/load for minutes); the
+// caller runs this on a background context, not a job context.
+func (c *swapController) Start(ctx context.Context, backend, model string) error {
+	c.logf("[hotswap] starting %s (model=%s)", backend, model)
+	payload := map[string]string{"service": backend}
+	if model != "" {
+		payload["model"] = model
+	}
+	job := &nexus.Job{
+		ID:      "hotswap-" + backend,
+		Type:    "SERVICE_START",
+		Payload: payload,
+	}
+	jctx := jobs.JobContext{
+		Ctx:   ctx,
+		LogFn: func(level, msg string) { c.logf("[hotswap] %s", msg) },
+	}
+	if _, err := c.svc.Execute(jctx, job); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Ready reports whether the engine has actually LOADED a model and can serve —
+// deliberately stronger than Resident (which is merely "container up"). A vLLM/
+// llama.cpp/bonsai/OCR engine only reports a model on /v1/models once its weights
+// are loaded and the API is serving, so requiring a non-empty model set here
+// avoids the swap declaring "ready" the instant the container exists but before
+// the model is loaded (which would route a request into a not-yet-serving engine
+// — a hard failure on the bonsai/llama.cpp chat path, which has no readiness
+// wait). Ollama is the exception: it lists pulled models before loading any, but
+// it auto-loads on the first request, so a listed model is still servable.
+func (c *swapController) Ready(ctx context.Context, backend string) bool {
+	for _, e := range status.DiscoverLocalEngines(ctx) {
+		if e.Name == backend {
+			return len(e.Models) > 0
+		}
+	}
+	return false
+}
+
+// freeVRAMBytesFromGPU sums currently-free VRAM (total-used) across all GPUs that
+// report a total. The bool is false when NO GPU reports memory, so the caller
+// skips the VRAM fit check rather than treat "unknown" as "zero free" (fail-safe,
+// mirrors the #577 executor).
+func freeVRAMBytesFromGPU(gpus []status.GPUMetrics) (uint64, bool) {
+	var free uint64
+	found := false
+	for _, g := range gpus {
+		if g.MemoryTotalMB <= 0 {
+			continue
+		}
+		found = true
+		f := g.MemoryTotalMB - g.MemoryUsedMB
+		if f < 0 {
+			f = 0
+		}
+		free += uint64(f) * 1024 * 1024
+	}
+	return free, found
+}
+
+// newModelSwapManager builds the swap manager for the node, or nil when hotswap
+// is disabled. Returned as worker's swapper so cmd/nodejobs.go can attach it to
+// the llm_inference handler only when enabled.
+func newModelSwapManager(configDir, workspaceDir string, pinned []string, logf func(string, ...any)) *worker.SwapManager {
+	if !status.ModelHotswapEnabled() || configDir == "" {
+		return nil
+	}
+	if logf != nil {
+		logf("[hotswap] model hotswap ENABLED (CITADEL_MODEL_HOTSWAP); configDir=%s", configDir)
+	}
+	return worker.NewSwapManager(newSwapController(configDir, workspaceDir, pinned, logf))
+}
+
+// hotswapConfigDir returns configDir when model hotswap is enabled, else "".
+// The heartbeat collector runs with ConfigDir="" by default (engines are probed,
+// not read from the manifest); hotswap needs the config dir to enumerate
+// installed-but-stopped engines, so this passes it through only when enabled —
+// leaving the flag-off heartbeat path exactly as it was.
+func hotswapConfigDir(configDir string) string {
+	if status.ModelHotswapEnabled() {
+		return configDir
+	}
+	return ""
+}
+
+// ensure the controller satisfies the interface at compile time.
+var _ worker.SwapController = (*swapController)(nil)

--- a/cmd/nodejobs.go
+++ b/cmd/nodejobs.go
@@ -47,6 +47,10 @@ type nodeJobHandlerOpts struct {
 	// HandlerLog is the plain logger the privileged handlers (AGENT_UPDATE,
 	// WHATSAPP_PROVISION) use for their own progress lines. Required.
 	HandlerLog func(format string, args ...any)
+	// PinnedServices is the node's pinned_services allowlist (citadel #577). Used
+	// by the model-hotswap swap manager (#632) so a pinned engine is never
+	// evicted to swap in another. Optional.
+	PinnedServices []string
 }
 
 // buildNodeJobHandlers returns the base node-job handler set: the legacy Nexus
@@ -77,7 +81,15 @@ func buildNodeJobHandlers(opts nodeJobHandlerOpts) []worker.JobHandler {
 	// control-center worker route it to the node-local engine (vllm/sglang/
 	// ollama/llamacpp/bonsai). Without it every inference job failed with
 	// "unsupported job type \"llm_inference\": node X has no handler for it".
-	handlers = append(handlers, worker.NewLLMInferenceHandler())
+	llmHandler := worker.NewLLMInferenceHandler()
+	// Model hotswap (citadel-cli#632, default OFF): when CITADEL_MODEL_HOTSWAP is
+	// on and this node has a config dir, attach a swap manager so an
+	// installed-but-not-resident target engine is swapped in on demand. Returns nil
+	// (no swapper) when disabled, so the handler is byte-for-byte the pre-#632 one.
+	if swapper := newModelSwapManager(opts.ConfigDir, opts.WorkspaceDir, opts.PinnedServices, opts.HandlerLog); swapper != nil {
+		llmHandler = llmHandler.WithSwapper(swapper)
+	}
+	handlers = append(handlers, llmHandler)
 	return handlers
 }
 

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1172,12 +1172,16 @@ func runWork(cmd *cobra.Command, args []string) {
 	var collector *status.Collector
 	if workStatusPort > 0 {
 		collector = status.NewCollector(status.CollectorConfig{
-			NodeName:       nodeName,
-			ConfigDir:      "",
+			NodeName: nodeName,
+			// ConfigDir is normally "" on the heartbeat path (engines are probed,
+			// not read from the manifest). Model hotswap (#632) needs it to
+			// enumerate installed-but-stopped engines, so pass it only when enabled.
+			ConfigDir:      hotswapConfigDir(workConfigDir),
 			Services:       nil,
 			Capabilities:   statusCaps,
 			WorkerLiveness: workerLivenessFn,
 			PinnedServices: manifestPinnedServices(workManifest),
+			ModelHotswap:   status.ModelHotswapEnabled(),
 		})
 	}
 
@@ -1445,11 +1449,12 @@ func runWork(cmd *cobra.Command, args []string) {
 		if collector == nil {
 			collector = status.NewCollector(status.CollectorConfig{
 				NodeName:       nodeName,
-				ConfigDir:      "",
+				ConfigDir:      hotswapConfigDir(workConfigDir),
 				Services:       nil,
 				Capabilities:   statusCaps,
 				WorkerLiveness: workerLivenessFn,
 				PinnedServices: manifestPinnedServices(workManifest),
+				ModelHotswap:   status.ModelHotswapEnabled(),
 			})
 		}
 
@@ -2037,6 +2042,7 @@ func runWork(cmd *cobra.Command, args []string) {
 		FilesDisabled:             !workPerms.Files,
 		WorkflowExec:              wfExec,
 		HandlerLog:                func(format string, args ...any) { Log(format, args...) },
+		PinnedServices:            manifestPinnedServices(workManifest),
 	}
 	handlers := buildNodeJobHandlers(nodeJobOpts)
 

--- a/internal/status/collector.go
+++ b/internal/status/collector.go
@@ -33,6 +33,7 @@ type Collector struct {
 	fpIdleTracker  *FootprintIdleTracker  // footprint-derived idle for engines #416 can't scrape (citadel #421)
 	netIdleTracker *IdleTracker           // network-activity idle for non-vLLM services (citadel #433)
 	pinnedServices map[string]bool        // node pinned_services allowlist -> ServiceInfo.Pinned (citadel #577)
+	modelHotswap   bool                   // advertise installed-vs-resident models (citadel #632)
 }
 
 // ServiceConfig holds the configuration for a service from the manifest.
@@ -57,6 +58,12 @@ type CollectorConfig struct {
 	// running service whose name is listed is marked ServiceInfo.Pinned=true so
 	// the heartbeat and `citadel services` show pinned vs preemptible. Optional.
 	PinnedServices []string
+	// ModelHotswap enables installed-vs-resident model advertising in the
+	// heartbeat (citadel #632): running engines are marked resident and installed-
+	// but-stopped engines are additively advertised as swap-in candidates. Off by
+	// default; wired from CITADEL_MODEL_HOTSWAP. Requires ConfigDir to enumerate
+	// installed engines. When false the heartbeat output is unchanged.
+	ModelHotswap bool
 }
 
 // NewCollector creates a new status collector.
@@ -73,6 +80,7 @@ func NewCollector(cfg CollectorConfig) *Collector {
 		fpIdleTracker:  NewFootprintIdleTracker(),
 		netIdleTracker: NewIdleTracker(IdleThresholdSeconds()),
 		pinnedServices: toStringSet(cfg.PinnedServices),
+		modelHotswap:   cfg.ModelHotswap,
 	}
 }
 
@@ -165,6 +173,16 @@ func (c *Collector) Collect() (*NodeStatus, error) {
 	// holding GPU/RAM is now visible instead of a bare "running" with no
 	// footprint. One stats call + one nvidia-smi pair for the whole set.
 	c.attachFootprints(status)
+
+	// Model hotswap (#632, default OFF): mark running engines resident and
+	// additively advertise installed-but-stopped engines as swap-in candidates.
+	// Runs after footprints so a resident engine's VRAM estimate can use its live
+	// footprint. `reported` still holds the names already in status.Services, so a
+	// running engine is never duplicated by the installed-engine pass. Flag-off:
+	// never called, heartbeat unchanged.
+	if c.modelHotswap {
+		c.applyModelHotswap(status, reported)
+	}
 
 	// Include cached capabilities if available. Copy the cached struct rather
 	// than aliasing it, so populating the per-heartbeat capability flags below

--- a/internal/status/hotswap.go
+++ b/internal/status/hotswap.go
@@ -1,0 +1,214 @@
+package status
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+
+	embeddedservices "github.com/aceteam-ai/citadel-cli/services"
+)
+
+// hotswap.go — installed-vs-resident model advertising for VRAM-aware on-demand
+// model hotswap (citadel-cli#632, Phase 1 PILOT).
+//
+// Everything here is gated behind CITADEL_MODEL_HOTSWAP (default OFF). When the
+// flag is off, ModelHotswapEnabled() returns false and the collector never calls
+// applyModelHotswap, so the heartbeat output is byte-identical to today's.
+
+// ModelHotswapEnabled reports whether VRAM-aware on-demand model hotswap is
+// enabled on this node via the CITADEL_MODEL_HOTSWAP env var (truthy:
+// 1/true/yes/on). Default OFF — the pilot is enabled per-node (node 1297). Kept
+// in the leaf status package so both the collector and the worker's swap path can
+// read the same gate without an import cycle.
+func ModelHotswapEnabled() bool {
+	return isTruthyEnv(os.Getenv("CITADEL_MODEL_HOTSWAP"))
+}
+
+// isTruthyEnv reports whether an env value is one of the accepted truthy tokens.
+func isTruthyEnv(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
+}
+
+// engineModelEnvVars maps a managed serving engine to the <name>.env variable(s)
+// (in preference order) that select its served model. Mirrors the compose files'
+// ${VAR:-default} interpolation so a stopped engine advertises the same model id
+// it would serve on start. Engines absent here have no serve-time model env.
+var engineModelEnvVars = map[string][]string{
+	"vllm":          {"VLLM_MODEL"},
+	"unlimited-ocr": {"OCR_SERVED_NAME", "OCR_MODEL"},
+	"bonsai":        {"BONSAI_MODEL"},
+}
+
+// engineDefaultModel is the served model id an engine falls back to when its
+// <name>.env sets no override — the same value the compose ${VAR:-default}
+// carries. This is what lets a freshly-installed bonsai/unlimited-ocr advertise a
+// concrete model while stopped (the pilot case on node 1297). Engines with no
+// stable default (vllm serves whatever weights the deploy selected) are absent,
+// so they are advertised only when a model was persisted.
+var engineDefaultModel = map[string]string{
+	"unlimited-ocr": "baidu/Unlimited-OCR",
+	"bonsai":        "Bonsai-27B-Q1_0.gguf",
+}
+
+// engineVRAMEstimateMB is a per-engine VRAM PROVISIONING BUDGET (MB): the VRAM
+// the node should have FREE before it is safe to start the engine, NOT its
+// steady-state footprint. This is what the swap planner feeds PlanPreemption as
+// requiredVRAM, and what a STOPPED installed engine advertises as VRAMEstimateMB.
+//
+// Why provisioning budgets, not steady-state: on the RTX 3090 pilot (24GB) with
+// Unlimited-OCR resident (~13.5GB), ~10.5GB is free. If bonsai's budget were its
+// bounded-context steady-state (~6-8GB) the planner would see "fits, no evict"
+// and start bonsai into a card that then can't safely hold both — a no-op swap
+// followed by an OOM. Sizing the big engines above half the card forces the
+// intended single-big-model-at-a-time swap: starting one evicts the other. A
+// RUNNING engine advertises its live footprint instead (applyModelHotswap), so
+// these conservative numbers only gate the swap decision. Refined per model in
+// Phase 3.
+var engineVRAMEstimateMB = map[string]int{
+	"vllm":          22000,
+	"sglang":        22000,
+	"unlimited-ocr": 20000,
+	"bonsai":        22000,
+	"llamacpp":      8000,
+	"ollama":        8000,
+}
+
+// EngineVRAMEstimateMB returns the coarse VRAM estimate (MB) for a managed
+// engine, or 0 when unknown. Exported so the worker swap planner can size its
+// required-VRAM budget from the same table the heartbeat advertises.
+func EngineVRAMEstimateMB(engine string) int {
+	return engineVRAMEstimateMB[engine]
+}
+
+// applyModelHotswap annotates the collected status for model hotswap (#632):
+//  1. marks every RUNNING managed serving engine Resident=true and attaches its
+//     VRAM estimate (live footprint VRAM when known, else the coarse table), and
+//  2. additively advertises INSTALLED-but-STOPPED engines (compose materialized
+//     on disk, a served model resolvable) as Resident=false swap-in candidates.
+//
+// reported is the set of service names already present in status.Services (so a
+// running engine is not duplicated). Called only when the flag is on.
+func (c *Collector) applyModelHotswap(st *NodeStatus, reported map[string]struct{}) {
+	// 1. Mark residency + VRAM estimate on already-reported serving engines.
+	for i := range st.Services {
+		s := &st.Services[i]
+		if EngineTypeFromName(s.Name) == "" {
+			continue // not a serving engine (db, embedding, misc)
+		}
+		if s.Status != ServiceStatusRunning {
+			continue
+		}
+		resident := true
+		s.Resident = &resident
+		if s.VRAMEstimateMB == 0 {
+			if s.Footprint != nil && s.Footprint.VRAMBytes > 0 {
+				s.VRAMEstimateMB = int(s.Footprint.VRAMBytes / (1024 * 1024))
+			} else {
+				s.VRAMEstimateMB = engineVRAMEstimateMB[s.Name]
+			}
+		}
+	}
+
+	// 2. Advertise installed-but-stopped engines as swap-in candidates.
+	for _, eng := range c.collectInstalledEngines(reported) {
+		st.Services = append(st.Services, eng)
+	}
+}
+
+// collectInstalledEngines returns installed-but-stopped managed serving engines
+// as Resident=false ServiceInfo entries so the platform can route a request to a
+// swappable model. An engine is "installed" here when its compose file has been
+// materialized on disk (<configDir>/services/<name>.yml) — i.e. it was deployed
+// at least once — AND a served model id resolves (persisted <name>.env override
+// or the compose default). Engines already in reported (running) are skipped.
+// Returns nil when the collector has no configDir (the model source is unknown).
+func (c *Collector) collectInstalledEngines(reported map[string]struct{}) []ServiceInfo {
+	if c.configDir == "" {
+		return nil
+	}
+	var out []ServiceInfo
+	for name := range embeddedservices.ServiceMap {
+		if EngineTypeFromName(name) == "" {
+			continue // only serving engines are swappable
+		}
+		if _, dup := reported[name]; dup {
+			continue // already reported (running)
+		}
+		if !c.engineComposeMaterialized(name) {
+			continue // not installed on this node
+		}
+		model := c.resolveInstalledModel(name)
+		if model == "" {
+			continue // no advertisable model (e.g. vllm with none persisted)
+		}
+		notResident := false
+		out = append(out, ServiceInfo{
+			Name:           name,
+			Type:           ServiceTypeLLM,
+			Status:         ServiceStatusStopped,
+			Port:           managedEngineHostPort(name),
+			Health:         HealthStatusUnknown,
+			Models:         []string{model},
+			Resident:       &notResident,
+			VRAMEstimateMB: engineVRAMEstimateMB[name],
+		})
+	}
+	return out
+}
+
+// engineComposeMaterialized reports whether the engine's compose file exists on
+// disk under the collector's config dir (the marker that it was deployed here).
+func (c *Collector) engineComposeMaterialized(name string) bool {
+	path := filepath.Join(c.configDir, "services", name+".yml")
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+// resolveInstalledModel returns the served model id a stopped engine would serve:
+// the first present <name>.env override for the engine's model env var(s), else
+// the compose default. Empty when neither resolves.
+func (c *Collector) resolveInstalledModel(name string) string {
+	envPath := filepath.Join(c.configDir, "services", name+".env")
+	env := readEnvFile(envPath)
+	for _, key := range engineModelEnvVars[name] {
+		if v := strings.TrimSpace(env[key]); v != "" {
+			return v
+		}
+	}
+	return engineDefaultModel[name]
+}
+
+// readEnvFile parses a simple KEY=VALUE .env file into a map. Blank lines,
+// comments, and malformed lines are skipped. Surrounding quotes on the value are
+// stripped. Returns an empty map when the file is absent or unreadable.
+func readEnvFile(path string) map[string]string {
+	out := map[string]string{}
+	f, err := os.Open(path)
+	if err != nil {
+		return out
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		k = strings.TrimSpace(k)
+		v = strings.TrimSpace(v)
+		v = strings.Trim(v, `"'`)
+		if k != "" {
+			out[k] = v
+		}
+	}
+	return out
+}

--- a/internal/status/hotswap_test.go
+++ b/internal/status/hotswap_test.go
@@ -1,0 +1,156 @@
+package status
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeInstalledEngine materializes an engine's compose (and optional env) under
+// a temp config dir so collectInstalledEngines treats it as installed.
+func writeInstalledEngine(t *testing.T, dir, name, envContents string) {
+	t.Helper()
+	svcDir := filepath.Join(dir, "services")
+	if err := os.MkdirAll(svcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(svcDir, name+".yml"), []byte("services: {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if envContents != "" {
+		if err := os.WriteFile(filepath.Join(svcDir, name+".env"), []byte(envContents), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestCollectInstalledEngines_AdvertisesStoppedWithDefaultModel(t *testing.T) {
+	dir := t.TempDir()
+	writeInstalledEngine(t, dir, "bonsai", "") // no env -> compose default model
+
+	c := NewCollector(CollectorConfig{ConfigDir: dir, ModelHotswap: true})
+	engines := c.collectInstalledEngines(map[string]struct{}{})
+
+	var bonsai *ServiceInfo
+	for i := range engines {
+		if engines[i].Name == "bonsai" {
+			bonsai = &engines[i]
+		}
+	}
+	if bonsai == nil {
+		t.Fatalf("expected bonsai advertised as installed, got %+v", engines)
+	}
+	if bonsai.Status != ServiceStatusStopped {
+		t.Errorf("status = %q, want stopped", bonsai.Status)
+	}
+	if bonsai.Resident == nil || *bonsai.Resident {
+		t.Errorf("Resident = %v, want non-nil false", bonsai.Resident)
+	}
+	if len(bonsai.Models) != 1 || bonsai.Models[0] != "Bonsai-27B-Q1_0.gguf" {
+		t.Errorf("Models = %v, want [Bonsai-27B-Q1_0.gguf]", bonsai.Models)
+	}
+	if bonsai.VRAMEstimateMB == 0 {
+		t.Errorf("expected a non-zero VRAM estimate for bonsai")
+	}
+}
+
+func TestResolveInstalledModel_EnvOverrideWins(t *testing.T) {
+	dir := t.TempDir()
+	writeInstalledEngine(t, dir, "vllm", "VLLM_MODEL=my-org/my-model\n# a comment\n")
+
+	c := NewCollector(CollectorConfig{ConfigDir: dir, ModelHotswap: true})
+	engines := c.collectInstalledEngines(map[string]struct{}{})
+
+	var found bool
+	for _, e := range engines {
+		if e.Name == "vllm" {
+			found = true
+			if len(e.Models) != 1 || e.Models[0] != "my-org/my-model" {
+				t.Errorf("vllm Models = %v, want [my-org/my-model]", e.Models)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected vllm advertised from persisted VLLM_MODEL")
+	}
+}
+
+func TestCollectInstalledEngines_SkipsAlreadyReported(t *testing.T) {
+	dir := t.TempDir()
+	writeInstalledEngine(t, dir, "bonsai", "")
+
+	c := NewCollector(CollectorConfig{ConfigDir: dir, ModelHotswap: true})
+	// bonsai already reported (running) => must not be duplicated as stopped.
+	engines := c.collectInstalledEngines(map[string]struct{}{"bonsai": {}})
+	for _, e := range engines {
+		if e.Name == "bonsai" {
+			t.Fatalf("bonsai should be skipped when already reported")
+		}
+	}
+}
+
+func TestCollectInstalledEngines_NoConfigDirReturnsNil(t *testing.T) {
+	c := NewCollector(CollectorConfig{ModelHotswap: true}) // ConfigDir empty
+	if got := c.collectInstalledEngines(map[string]struct{}{}); got != nil {
+		t.Fatalf("expected nil with no configDir, got %v", got)
+	}
+}
+
+func TestApplyModelHotswap_MarksRunningEngineResident(t *testing.T) {
+	dir := t.TempDir()
+	c := NewCollector(CollectorConfig{ConfigDir: dir, ModelHotswap: true})
+
+	st := &NodeStatus{Services: []ServiceInfo{
+		{Name: "vllm", Type: ServiceTypeLLM, Status: ServiceStatusRunning},
+		{Name: "postgres", Type: ServiceTypeDatabase, Status: ServiceStatusRunning},
+	}}
+	reported := map[string]struct{}{"vllm": {}, "postgres": {}}
+
+	c.applyModelHotswap(st, reported)
+
+	byName := map[string]ServiceInfo{}
+	for _, s := range st.Services {
+		byName[s.Name] = s
+	}
+	if r := byName["vllm"].Resident; r == nil || !*r {
+		t.Errorf("vllm Resident = %v, want non-nil true", byName["vllm"].Resident)
+	}
+	if byName["vllm"].VRAMEstimateMB == 0 {
+		t.Errorf("expected a VRAM estimate on the resident vllm engine")
+	}
+	// A non-engine service must NOT get a residency flag.
+	if byName["postgres"].Resident != nil {
+		t.Errorf("postgres Resident = %v, want nil (not a serving engine)", byName["postgres"].Resident)
+	}
+}
+
+// TestServiceInfo_FlagOffOmitsResidentKey asserts the omitempty on the *bool and
+// int keeps a flag-off heartbeat byte-identical: no `resident`/`vram_estimate_mb`.
+func TestServiceInfo_FlagOffOmitsResidentKey(t *testing.T) {
+	b, err := json.Marshal(ServiceInfo{Name: "vllm", Type: ServiceTypeLLM, Status: ServiceStatusRunning})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	if strings.Contains(s, "resident") {
+		t.Errorf("flag-off JSON must not contain a resident key: %s", s)
+	}
+	if strings.Contains(s, "vram_estimate_mb") {
+		t.Errorf("flag-off JSON must not contain vram_estimate_mb: %s", s)
+	}
+}
+
+func TestModelHotswapEnabled_TruthyParsing(t *testing.T) {
+	cases := map[string]bool{
+		"1": true, "true": true, "YES": true, "on": true, "On": true,
+		"": false, "0": false, "false": false, "no": false, "off": false, "nope": false,
+	}
+	for v, want := range cases {
+		t.Setenv("CITADEL_MODEL_HOTSWAP", v)
+		if got := ModelHotswapEnabled(); got != want {
+			t.Errorf("ModelHotswapEnabled(%q) = %v, want %v", v, got, want)
+		}
+	}
+}

--- a/internal/status/types.go
+++ b/internal/status/types.go
@@ -213,6 +213,22 @@ type ServiceInfo struct {
 	// (citadel-cli#577). Omitted (false) for preemptible services — the default.
 	// The platform reads this to show pinned vs preemptible per node.
 	Pinned bool `json:"pinned,omitempty"`
+
+	// Resident reports whether an installed serving engine's model is currently
+	// loaded and serving (container up) as opposed to merely installed-and-
+	// swappable (container stopped). Populated ONLY when model hotswap is enabled
+	// (CITADEL_MODEL_HOTSWAP, citadel-cli#632); nil otherwise, so the omitempty on
+	// this *bool keeps the flag-off heartbeat byte-identical. nil = residency not
+	// tracked; true = resident; false = installed but not resident (a swap-in
+	// candidate resolve_fabric_target may route to and let the node swap in).
+	Resident *bool `json:"resident,omitempty"`
+
+	// VRAMEstimateMB is the approximate GPU memory (MB) this engine's model
+	// occupies (running) or would occupy (stopped) when resident. Populated only
+	// under model hotswap (citadel-cli#632) so the platform can reason about swap
+	// fit: the live footprint VRAM for a running engine, else a coarse per-engine
+	// estimate. Omitted (0) when unknown or hotswap off.
+	VRAMEstimateMB int `json:"vram_estimate_mb,omitempty"`
 }
 
 // HealthResponse is the response for /health endpoint.

--- a/internal/worker/llm_inference.go
+++ b/internal/worker/llm_inference.go
@@ -51,6 +51,18 @@ type LLMInferenceHandler struct {
 	// httpClient issues the outbound engine requests. Defaults to
 	// http.DefaultClient; overridable in tests.
 	httpClient *http.Client
+
+	// swapper, when non-nil, enables VRAM-aware on-demand model hotswap
+	// (citadel-cli#632): before routing to the engine, an installed-but-not-
+	// resident target is swapped in. Injected ONLY when CITADEL_MODEL_HOTSWAP is
+	// on (cmd/nodejobs.go), so a nil swapper == today's behavior exactly.
+	swapper modelSwapper
+}
+
+// modelSwapper is the swap surface the handler needs. Satisfied by *SwapManager;
+// an interface so the handler is unit-testable with a mock. See swap.go.
+type modelSwapper interface {
+	EnsureResident(ctx context.Context, backend, model string) (SwapOutcome, error)
 }
 
 // NewLLMInferenceHandler constructs the llm_inference handler with the default
@@ -79,6 +91,14 @@ func NewLLMInferenceHandler() *LLMInferenceHandler {
 	}
 }
 
+// WithSwapper attaches a model-hotswap swapper (citadel-cli#632). Called from
+// cmd/nodejobs.go ONLY when CITADEL_MODEL_HOTSWAP is on; leaving it unset keeps
+// the handler's behavior identical to before hotswap.
+func (h *LLMInferenceHandler) WithSwapper(s modelSwapper) *LLMInferenceHandler {
+	h.swapper = s
+	return h
+}
+
 // CanHandle reports whether this handler processes the given job type.
 func (h *LLMInferenceHandler) CanHandle(jobType string) bool {
 	return jobType == JobTypeLLMInference
@@ -96,6 +116,22 @@ func (h *LLMInferenceHandler) Execute(ctx context.Context, job *Job, stream Stre
 	payload, err := parseLLMInferencePayload(job.Payload)
 	if err != nil {
 		return h.failure(fmt.Errorf("invalid payload: %w", err)), nil
+	}
+
+	// Model hotswap (citadel-cli#632): when enabled (swapper injected), an
+	// installed-but-not-resident target engine is swapped in before routing. If it
+	// becomes ready within the wait budget (≤15s) we fall through and serve
+	// normally; otherwise we return a structured model_warming result (a normal
+	// success JobResult carrying no content) for the platform to relay + retry. A
+	// nil swapper (flag off) skips this block entirely — unchanged behavior.
+	if h.swapper != nil {
+		outcome, swapErr := h.swapper.EnsureResident(ctx, payload.Backend, payload.Model)
+		if swapErr != nil {
+			return h.failure(fmt.Errorf("model hotswap failed: %w", swapErr)), nil
+		}
+		if !outcome.Ready {
+			return h.warming(payload.Model, outcome.ETASeconds), nil
+		}
 	}
 
 	switch payload.Backend {
@@ -872,6 +908,27 @@ func writeSingleChunk(stream StreamWriter, content string) {
 
 func (h *LLMInferenceHandler) success(output map[string]any) *JobResult {
 	return &JobResult{Status: JobStatusSuccess, Output: output}
+}
+
+// warming returns the structured model_warming result (citadel-cli#632) for a
+// swap that did not become ready within the wait budget. It is a SUCCESS result
+// (so the runner WriteEnds + Acks it) carrying a control payload rather than
+// assistant content — deliberately no WriteChunk, so the platform relays the
+// warming signal instead of streaming it as a reply. The platform inspects
+// output.status == "model_warming" and retries after retry_after seconds.
+func (h *LLMInferenceHandler) warming(model string, etaSeconds int) *JobResult {
+	if etaSeconds < 0 {
+		etaSeconds = 0
+	}
+	return &JobResult{
+		Status: JobStatusSuccess,
+		Output: map[string]any{
+			"status":      "model_warming",
+			"model":       model,
+			"eta_seconds": etaSeconds,
+			"retry_after": warmingRetryAfter,
+		},
+	}
 }
 
 func (h *LLMInferenceHandler) failure(err error) *JobResult {

--- a/internal/worker/llm_inference_hotswap_test.go
+++ b/internal/worker/llm_inference_hotswap_test.go
@@ -1,0 +1,141 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// fakeSwapper is a scriptable modelSwapper for the handler's hotswap path.
+type fakeSwapper struct {
+	outcome SwapOutcome
+	err     error
+	calls   int
+	backend string
+}
+
+func (f *fakeSwapper) EnsureResident(_ context.Context, backend, _ string) (SwapOutcome, error) {
+	f.calls++
+	f.backend = backend
+	return f.outcome, f.err
+}
+
+func hotswapJob() *Job {
+	return &Job{
+		ID:   "job-hs",
+		Type: JobTypeLLMInference,
+		Payload: map[string]any{
+			"model":    "bonsai-27b",
+			"backend":  "bonsai",
+			"messages": []map[string]any{{"role": "user", "content": "hi"}},
+		},
+	}
+}
+
+// TestHotswap_FlagOff_NoSwapperIsPassthrough asserts that with no swapper
+// injected (CITADEL_MODEL_HOTSWAP off), Execute routes straight to the engine —
+// byte-for-byte the pre-#632 behavior, never touching a swap path.
+func TestHotswap_FlagOff_NoSwapperIsPassthrough(t *testing.T) {
+	body := `{"choices":[{"message":{"content":"served"},"finish_reason":"stop"}],` +
+		`"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer ts.Close()
+
+	h := NewLLMInferenceHandler()
+	h.baseURLs["bonsai"] = ts.URL
+	if h.swapper != nil {
+		t.Fatalf("expected nil swapper by default")
+	}
+
+	result, err := h.Execute(context.Background(), hotswapJob(), &MockStreamWriter{})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if result.Status != JobStatusSuccess {
+		t.Fatalf("status = %v, want success", result.Status)
+	}
+	if got, _ := result.Output["content"].(string); got != "served" {
+		t.Fatalf("content = %q, want served", got)
+	}
+	if s, _ := result.Output["status"].(string); s == "model_warming" {
+		t.Fatalf("flag-off path must never emit a warming result")
+	}
+}
+
+// TestHotswap_NotReady_ReturnsWarmingShape asserts the exact model_warming JSON
+// shape and that NO content chunk is emitted (the platform relays warming, it is
+// not assistant content).
+func TestHotswap_NotReady_ReturnsWarmingShape(t *testing.T) {
+	h := NewLLMInferenceHandler().WithSwapper(&fakeSwapper{
+		outcome: SwapOutcome{Ready: false, ETASeconds: 42},
+	})
+
+	stream := &MockStreamWriter{}
+	result, err := h.Execute(context.Background(), hotswapJob(), stream)
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if result.Status != JobStatusSuccess {
+		t.Fatalf("warming must be a SUCCESS result, got %v", result.Status)
+	}
+	if len(stream.chunks) != 0 {
+		t.Fatalf("warming must emit no content chunks, got %v", stream.chunks)
+	}
+	if got, _ := result.Output["status"].(string); got != "model_warming" {
+		t.Fatalf("status = %q, want model_warming", got)
+	}
+	if got, _ := result.Output["model"].(string); got != "bonsai-27b" {
+		t.Fatalf("model = %q, want bonsai-27b", got)
+	}
+	if got, _ := result.Output["eta_seconds"].(int); got != 42 {
+		t.Fatalf("eta_seconds = %v, want 42", got)
+	}
+	if got, _ := result.Output["retry_after"].(int); got != warmingRetryAfter {
+		t.Fatalf("retry_after = %v, want %d", got, warmingRetryAfter)
+	}
+}
+
+// TestHotswap_Ready_RoutesToEngine asserts that when the swap reports Ready the
+// handler proceeds to the normal engine path and serves the reply.
+func TestHotswap_Ready_RoutesToEngine(t *testing.T) {
+	body := `{"choices":[{"message":{"content":"served-after-swap"},"finish_reason":"stop"}],` +
+		`"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer ts.Close()
+
+	sw := &fakeSwapper{outcome: SwapOutcome{Ready: true}}
+	h := NewLLMInferenceHandler().WithSwapper(sw)
+	h.baseURLs["bonsai"] = ts.URL
+
+	result, err := h.Execute(context.Background(), hotswapJob(), &MockStreamWriter{})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if sw.calls != 1 || sw.backend != "bonsai" {
+		t.Fatalf("expected EnsureResident called once for bonsai, got calls=%d backend=%q", sw.calls, sw.backend)
+	}
+	if got, _ := result.Output["content"].(string); got != "served-after-swap" {
+		t.Fatalf("content = %q, want served-after-swap", got)
+	}
+}
+
+// TestHotswap_SwapError_FailsJob asserts a hard swap error fails the job.
+func TestHotswap_SwapError_FailsJob(t *testing.T) {
+	h := NewLLMInferenceHandler().WithSwapper(&fakeSwapper{
+		err: errors.New("cannot swap in bonsai: pinned services hold VRAM"),
+	})
+
+	result, err := h.Execute(context.Background(), hotswapJob(), &MockStreamWriter{})
+	if err != nil {
+		t.Fatalf("Execute returned transport error: %v", err)
+	}
+	if result.Status != JobStatusFailure {
+		t.Fatalf("status = %v, want failure on hard swap error", result.Status)
+	}
+}

--- a/internal/worker/swap.go
+++ b/internal/worker/swap.go
@@ -1,0 +1,384 @@
+// internal/worker/swap.go
+//
+// VRAM-aware on-demand model hotswap — swap manager (citadel-cli#632, Phase 1).
+//
+// When CITADEL_MODEL_HOTSWAP is on, an llm_inference job for an installed-but-
+// not-resident engine triggers a swap: preempt idle/LRU non-pinned resident
+// engines to free VRAM, start the target engine, and wait ≤15s for it to become
+// ready. If it becomes ready in time the request is served normally; otherwise
+// the handler returns a structured `model_warming` result and the platform
+// retries.
+//
+// Design constraints (all enforced here):
+//   - Cold-start is minutes (bonsai's first start even builds an image). So the
+//     actual compose-up + load runs in a BACKGROUND goroutine with its own
+//     context, NOT on the job's context (which the runner cancels). EnsureResident
+//     starts-or-joins that background swap and only OBSERVES it for ≤15s.
+//   - Single-flight: at most ONE swap runs per node. A miss for the SAME model
+//     while a swap is in flight attaches to it; a miss for a DIFFERENT model
+//     returns warming immediately and starts NO second swap (no GPU thrash).
+//   - Non-durable eviction: peers are stopped WITHOUT desired_status:stopped
+//     (StopNonDurable), so an evicted model stays eligible to swap back in — the
+//     opposite of #577's sticky operator stop. The internal SERVICE_START also
+//     carries only {service, model} (no vram_mb), so #577's DURABLE preemptForVRAM
+//     stays inert; the swap does its own non-durable PlanPreemption here.
+//   - Min-residency floor: an engine that became ready within minResidency is
+//     never evicted (filtered out of the candidate set before planning).
+//   - LRU: candidates are pre-sorted least-recently-used first so PlanPreemption's
+//     stable idle-then-largest-VRAM ordering breaks ties by LRU.
+package worker
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/status"
+)
+
+// Default swap timing knobs. The 15s wait budget and 60s min-residency floor are
+// fixed by the #632 design; the background load ceiling bounds a wedged compose-up
+// so the single-flight lock is eventually released.
+const (
+	swapWaitBudget       = 15 * time.Second
+	swapMinResidency     = 60 * time.Second
+	swapBackgroundMaxDur = 15 * time.Minute
+	swapReadyPollEvery   = 1 * time.Second
+	warmingRetryAfter    = 10 // seconds; the platform's retry_after hint
+)
+
+// SwapController abstracts the node side-effects a swap performs, so the swap
+// manager's decision logic (single-flight, LRU, min-residency, planning) is
+// unit-testable against a mock. The real implementation (cmd/hotswap.go) wraps a
+// jobs.ServiceHandler + a status collector.
+type SwapController interface {
+	// Resident reports whether the engine `backend` is currently running (its
+	// container is up). Residency, not readiness: a running-but-loading engine is
+	// resident (the normal inference path then waits for readiness).
+	Resident(ctx context.Context, backend string) bool
+
+	// PreemptInputs returns the live preemption inputs: the running managed
+	// serving engines other than `exclude` as PlanPreemption candidates (with
+	// VRAM footprint + instantaneous idle), and the node's currently-free VRAM in
+	// bytes. haveVRAM is false when free VRAM cannot be determined (no GPU /
+	// nvidia-smi absent), in which case the swap skips preemption (fail-safe).
+	PreemptInputs(ctx context.Context, exclude string) (candidates []status.PreemptCandidate, freeVRAM uint64, haveVRAM bool)
+
+	// StopNonDurable stops an engine WITHOUT marking it durably stopped, so it
+	// stays eligible to swap back in (the #632 non-durable eviction path).
+	StopNonDurable(name string) error
+
+	// Start starts the target engine serving `model` (an internal SERVICE_START
+	// with {service, model} only — no vram_mb, so #577 preemption stays inert).
+	Start(ctx context.Context, backend, model string) error
+
+	// Ready reports whether the engine's HTTP API answers (loaded and serving).
+	Ready(ctx context.Context, backend string) bool
+}
+
+// SwapOutcome is what EnsureResident reports to the inference handler.
+type SwapOutcome struct {
+	// Ready is true when the target engine is resident and serving; the handler
+	// then proceeds to the normal inference path.
+	Ready bool
+	// ETASeconds is the estimated remaining seconds until the model is ready,
+	// surfaced in the model_warming result when Ready is false.
+	ETASeconds int
+}
+
+// swapOp is a single in-flight background swap. done is closed when the swap
+// finishes; ready/err record its terminal state. transient marks a swap that
+// could not proceed right now (e.g. min-residency blocked every candidate) but
+// is not a hard failure — the caller should warm and retry.
+type swapOp struct {
+	backend   string
+	model     string
+	startedAt time.Time
+	loadEst   time.Duration
+	done      chan struct{}
+	ready     bool
+	transient bool
+	err       error
+}
+
+// SwapManager serializes and observes model swaps on a node.
+type SwapManager struct {
+	ctrl SwapController
+
+	// requiredVRAM returns the VRAM budget (bytes) a swap-in of `backend` needs.
+	requiredVRAM func(backend string) uint64
+	// loadEstimate returns the expected cold-start time for `backend`, used for
+	// the warming ETA.
+	loadEstimate func(backend string) time.Duration
+	now          func() time.Time
+
+	waitBudget    time.Duration
+	minResidency  time.Duration
+	backgroundMax time.Duration // ceiling on a background swap (releases the lock)
+	readyPoll     time.Duration // readiness poll interval
+
+	mu       sync.Mutex
+	inflight *swapOp              // the single in-flight swap, or nil
+	lastUsed map[string]time.Time // per-engine last request time (LRU)
+	readyAt  map[string]time.Time // per-engine last became-ready time (min-residency)
+}
+
+// NewSwapManager builds a swap manager with default timing and VRAM/load
+// estimates sourced from the shared status tables. ctrl supplies the node
+// side-effects.
+func NewSwapManager(ctrl SwapController) *SwapManager {
+	return &SwapManager{
+		ctrl:          ctrl,
+		requiredVRAM:  func(b string) uint64 { return uint64(status.EngineVRAMEstimateMB(b)) * 1024 * 1024 },
+		loadEstimate:  defaultLoadEstimate,
+		now:           time.Now,
+		waitBudget:    swapWaitBudget,
+		minResidency:  swapMinResidency,
+		backgroundMax: swapBackgroundMaxDur,
+		readyPoll:     swapReadyPollEvery,
+		lastUsed:      map[string]time.Time{},
+		readyAt:       map[string]time.Time{},
+	}
+}
+
+// defaultLoadEstimate is a coarse per-engine cold-start estimate for the warming
+// ETA. Bonsai can build its image on first start (~7min per CLAUDE.md); the
+// others are cached-image loads of tens of seconds to a couple minutes.
+func defaultLoadEstimate(backend string) time.Duration {
+	switch backend {
+	case "bonsai":
+		return 3 * time.Minute
+	case "vllm", "sglang", "unlimited-ocr":
+		return 90 * time.Second
+	default:
+		return 60 * time.Second
+	}
+}
+
+// EnsureResident makes the engine for `backend` (serving `model`) resident, or
+// reports that a swap is in progress. It never blocks longer than the wait
+// budget. The returned error is a hard failure (e.g. the swap cannot fit without
+// evicting a min-residency/pinned holder) that the handler should surface as a
+// job failure; a nil error with Ready=false means "warming, retry".
+func (m *SwapManager) EnsureResident(ctx context.Context, backend, model string) (SwapOutcome, error) {
+	m.touch(backend)
+
+	// Already resident: nothing to do (fast path, no lock contention with swaps).
+	if m.ctrl.Resident(ctx, backend) {
+		return SwapOutcome{Ready: true}, nil
+	}
+
+	op := m.startOrJoin(backend, model)
+	if op == nil {
+		// A different swap is in flight — do not start a second one. Warm.
+		return SwapOutcome{Ready: false, ETASeconds: int(m.loadEstimate(backend).Seconds())}, nil
+	}
+
+	// Observe the (possibly background) swap for the remaining wait budget.
+	elapsed := m.now().Sub(op.startedAt)
+	remaining := m.waitBudget - elapsed
+	if remaining < 0 {
+		remaining = 0
+	}
+
+	timer := time.NewTimer(remaining)
+	defer timer.Stop()
+
+	select {
+	case <-op.done:
+		if op.err != nil {
+			return SwapOutcome{}, op.err
+		}
+		if op.ready {
+			return SwapOutcome{Ready: true}, nil
+		}
+		// Completed but not ready (transient block, e.g. min-residency): warm.
+		return SwapOutcome{Ready: false, ETASeconds: m.etaSeconds(op)}, nil
+	case <-timer.C:
+		return SwapOutcome{Ready: false, ETASeconds: m.etaSeconds(op)}, nil
+	case <-ctx.Done():
+		// The job context was cancelled; the background swap keeps running so a
+		// retry can pick up the now-resident model. Report warming.
+		return SwapOutcome{Ready: false, ETASeconds: m.etaSeconds(op)}, nil
+	}
+}
+
+// startOrJoin returns the in-flight op to observe: a freshly started swap, the
+// existing swap for the SAME backend (joined), or nil when a swap for a DIFFERENT
+// backend is already in flight (the caller must not start a second one — the
+// single-flight guarantee that stops concurrent misses thrashing the GPU).
+func (m *SwapManager) startOrJoin(backend, model string) *swapOp {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.inflight != nil {
+		if m.inflight.backend == backend {
+			return m.inflight // join the same-model swap
+		}
+		return nil // different model in flight: refuse
+	}
+
+	op := &swapOp{
+		backend:   backend,
+		model:     model,
+		startedAt: m.now(),
+		loadEst:   m.loadEstimate(backend),
+		done:      make(chan struct{}),
+	}
+	m.inflight = op
+	go m.runSwap(op)
+	return op
+}
+
+// runSwap performs the actual eviction + start + wait-ready in the background,
+// with its own bounded context (independent of any job context). It closes
+// op.done when finished and clears the single-flight slot.
+func (m *SwapManager) runSwap(op *swapOp) {
+	defer func() {
+		close(op.done)
+		m.mu.Lock()
+		if m.inflight == op {
+			m.inflight = nil
+		}
+		m.mu.Unlock()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), m.backgroundMax)
+	defer cancel()
+
+	// Plan and execute non-durable preemption to free VRAM.
+	if err := m.preempt(ctx, op); err != nil {
+		op.err = err
+		return
+	}
+	if op.transient {
+		return // could not proceed now; caller warms and retries
+	}
+
+	// Start the target engine (SERVICE_START {service, model}; no vram_mb).
+	if err := m.ctrl.Start(ctx, op.backend, op.model); err != nil {
+		op.err = fmt.Errorf("failed to start %s for swap: %w", op.backend, err)
+		return
+	}
+
+	// Wait for readiness up to the background ceiling.
+	for {
+		if m.ctrl.Ready(ctx, op.backend) {
+			op.ready = true
+			m.markReady(op.backend)
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return // ceiling hit; op.ready stays false (warming)
+		case <-time.After(m.readyPoll):
+		}
+	}
+}
+
+// preempt runs PlanPreemption over the min-residency-filtered, LRU-ordered
+// candidate set and executes the resulting non-durable stops. It sets
+// op.transient (not op.err) when the deploy cannot fit ONLY because min-residency
+// is currently protecting an otherwise-evictable engine — a retryable condition.
+// A genuine inability to fit (pinned / not enough VRAM even ignoring
+// min-residency) is a hard error.
+func (m *SwapManager) preempt(ctx context.Context, op *swapOp) error {
+	required := m.requiredVRAM(op.backend)
+	if required == 0 {
+		return nil // no budget known: skip preemption (fail-safe)
+	}
+	candidates, freeVRAM, haveVRAM := m.ctrl.PreemptInputs(ctx, op.backend)
+	if !haveVRAM {
+		return nil // free VRAM unknown: never evict on an absent signal
+	}
+
+	// LRU order: least-recently-used first so PlanPreemption's stable
+	// idle-then-largest-VRAM sort breaks ties toward the coldest engine.
+	m.sortByLRU(candidates)
+
+	// Would it fit if min-residency did not protect anyone? Distinguishes a hard
+	// "can never fit" from a transient "can't fit yet".
+	fullPlan := status.PlanPreemption(candidates, required, freeVRAM)
+	if !fullPlan.Fits {
+		return fmt.Errorf("cannot swap in %s: %s", op.backend, fullPlan.Reason)
+	}
+
+	// Now apply the min-residency floor: an engine that became ready within the
+	// floor is not a candidate right now.
+	eligible := m.filterMinResidency(candidates)
+	plan := status.PlanPreemption(eligible, required, freeVRAM)
+	if !plan.Fits {
+		op.transient = true // blocked only by min-residency; retry soon
+		return nil
+	}
+
+	for _, name := range plan.Stop {
+		if err := m.ctrl.StopNonDurable(name); err != nil {
+			return fmt.Errorf("cannot swap in %s: failed to evict %s: %w", op.backend, name, err)
+		}
+		m.forget(name)
+	}
+	return nil
+}
+
+// filterMinResidency drops candidates that became ready within the min-residency
+// floor (they must not be evicted yet).
+func (m *SwapManager) filterMinResidency(candidates []status.PreemptCandidate) []status.PreemptCandidate {
+	now := m.now()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]status.PreemptCandidate, 0, len(candidates))
+	for _, c := range candidates {
+		if t, ok := m.readyAt[c.Name]; ok && now.Sub(t) < m.minResidency {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+// sortByLRU orders candidates least-recently-used first (unknown = oldest).
+func (m *SwapManager) sortByLRU(candidates []status.PreemptCandidate) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return m.lastUsed[candidates[i].Name].Before(m.lastUsed[candidates[j].Name])
+	})
+}
+
+// touch records that `backend` was just requested (LRU freshness).
+func (m *SwapManager) touch(backend string) {
+	m.mu.Lock()
+	m.lastUsed[backend] = m.now()
+	m.mu.Unlock()
+}
+
+// markReady records that `backend` just became ready (starts its min-residency
+// window and refreshes its LRU stamp).
+func (m *SwapManager) markReady(backend string) {
+	now := m.now()
+	m.mu.Lock()
+	m.readyAt[backend] = now
+	m.lastUsed[backend] = now
+	m.mu.Unlock()
+}
+
+// forget clears the residency window of an evicted engine.
+func (m *SwapManager) forget(name string) {
+	m.mu.Lock()
+	delete(m.readyAt, name)
+	m.mu.Unlock()
+}
+
+// etaSeconds estimates remaining seconds until the in-flight swap is ready,
+// floored at the retry_after hint so the platform never busy-retries.
+func (m *SwapManager) etaSeconds(op *swapOp) int {
+	remaining := op.loadEst - m.now().Sub(op.startedAt)
+	secs := int(remaining.Seconds())
+	if secs < warmingRetryAfter {
+		secs = warmingRetryAfter
+	}
+	return secs
+}

--- a/internal/worker/swap_test.go
+++ b/internal/worker/swap_test.go
@@ -1,0 +1,283 @@
+package worker
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/status"
+)
+
+// mockSwapController is a scriptable SwapController for unit tests.
+type mockSwapController struct {
+	mu sync.Mutex
+
+	resident   map[string]bool // backend -> currently running
+	candidates []status.PreemptCandidate
+	freeVRAM   uint64
+	haveVRAM   bool
+
+	startGate chan struct{} // if non-nil, Start blocks until closed
+	startErr  error
+
+	startCount int
+	started    []string // backends passed to Start (in order)
+	stopped    []string // names passed to StopNonDurable
+
+	readyAfterStart bool // Ready returns true once the backend has been started
+}
+
+func newMockController() *mockSwapController {
+	return &mockSwapController{
+		resident: map[string]bool{},
+		haveVRAM: true,
+		freeVRAM: 1 << 40, // 1TiB free by default => fits without eviction
+	}
+}
+
+func (m *mockSwapController) Resident(_ context.Context, backend string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.resident[backend]
+}
+
+func (m *mockSwapController) PreemptInputs(_ context.Context, exclude string) ([]status.PreemptCandidate, uint64, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]status.PreemptCandidate, 0, len(m.candidates))
+	for _, c := range m.candidates {
+		if c.Name != exclude {
+			out = append(out, c)
+		}
+	}
+	return out, m.freeVRAM, m.haveVRAM
+}
+
+func (m *mockSwapController) StopNonDurable(name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stopped = append(m.stopped, name)
+	// Freeing a candidate's VRAM: remove it and credit its bytes.
+	for i, c := range m.candidates {
+		if c.Name == name {
+			m.freeVRAM += c.VRAMBytes
+			m.candidates = append(m.candidates[:i], m.candidates[i+1:]...)
+			break
+		}
+	}
+	return nil
+}
+
+func (m *mockSwapController) Start(_ context.Context, backend, _ string) error {
+	// Count the ATTEMPT before any gate, so an in-flight (blocked) swap is still
+	// observable as a started swap.
+	m.mu.Lock()
+	m.startCount++
+	m.started = append(m.started, backend)
+	gate := m.startGate
+	startErr := m.startErr
+	m.mu.Unlock()
+
+	if gate != nil {
+		<-gate
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if startErr != nil {
+		return startErr
+	}
+	if m.readyAfterStart {
+		m.resident[backend] = true
+	}
+	return nil
+}
+
+func (m *mockSwapController) Ready(_ context.Context, backend string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.resident[backend]
+}
+
+// newTestManager builds a manager with fast, deterministic timing.
+func newTestManager(ctrl SwapController) *SwapManager {
+	m := NewSwapManager(ctrl)
+	m.waitBudget = 40 * time.Millisecond
+	m.minResidency = time.Minute
+	m.backgroundMax = 2 * time.Second
+	m.readyPoll = 2 * time.Millisecond
+	return m
+}
+
+func (m *mockSwapController) startCountVal() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.startCount
+}
+
+func (m *mockSwapController) stoppedNames() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.stopped...)
+}
+
+// --- tests ---
+
+func TestEnsureResident_AlreadyResident_ServesImmediately(t *testing.T) {
+	ctrl := newMockController()
+	ctrl.resident["bonsai"] = true
+	m := newTestManager(ctrl)
+
+	out, err := m.EnsureResident(context.Background(), "bonsai", "Bonsai-27B")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !out.Ready {
+		t.Fatalf("expected Ready=true when engine already resident")
+	}
+	if ctrl.startCountVal() != 0 {
+		t.Fatalf("expected no Start call for a resident engine, got %d", ctrl.startCountVal())
+	}
+}
+
+func TestEnsureResident_SwapCompletesInBudget_Serves(t *testing.T) {
+	ctrl := newMockController()
+	ctrl.readyAfterStart = true // becomes ready as soon as Start runs
+	m := newTestManager(ctrl)
+	m.waitBudget = 2 * time.Second // generous so the fast swap finishes in budget
+
+	out, err := m.EnsureResident(context.Background(), "bonsai", "Bonsai-27B")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !out.Ready {
+		t.Fatalf("expected Ready=true after a fast swap")
+	}
+}
+
+func TestEnsureResident_SwapTooSlow_ReturnsWarming(t *testing.T) {
+	ctrl := newMockController()
+	ctrl.readyAfterStart = false // never becomes ready
+	m := newTestManager(ctrl)
+
+	out, err := m.EnsureResident(context.Background(), "bonsai", "Bonsai-27B")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Ready {
+		t.Fatalf("expected Ready=false (warming) when swap exceeds budget")
+	}
+	if out.ETASeconds < warmingRetryAfter {
+		t.Fatalf("expected ETA >= retry_after floor, got %d", out.ETASeconds)
+	}
+}
+
+func TestEnsureResident_DifferentModelInFlight_WarmsAndStartsNoSecondSwap(t *testing.T) {
+	ctrl := newMockController()
+	ctrl.startGate = make(chan struct{}) // hold the first swap open
+	m := newTestManager(ctrl)
+	m.backgroundMax = 5 * time.Second
+
+	// First miss: starts a swap that blocks in Start, so inflight stays set.
+	out1, err := m.EnsureResident(context.Background(), "bonsai", "Bonsai-27B")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out1.Ready {
+		t.Fatalf("expected first miss to warm while swap is in flight")
+	}
+
+	// Second miss for a DIFFERENT model while the first is in flight.
+	out2, err := m.EnsureResident(context.Background(), "unlimited-ocr", "baidu/Unlimited-OCR")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out2.Ready {
+		t.Fatalf("expected second (different-model) miss to warm, not serve")
+	}
+	if got := ctrl.startCountVal(); got != 1 {
+		t.Fatalf("expected exactly ONE swap started (no thrash), got %d", got)
+	}
+
+	close(ctrl.startGate) // let the first swap proceed and exit
+}
+
+func TestSwap_MinResidencyFloor_DoesNotEvictRecentlyReady(t *testing.T) {
+	ctrl := newMockController()
+	ctrl.haveVRAM = true
+	ctrl.freeVRAM = 0 // full GPU: a swap MUST evict to fit
+	// A candidate large enough that evicting it WOULD free enough for bonsai's
+	// provisioning budget (~21.5GB) — so the only thing blocking the swap is the
+	// min-residency floor, not a genuine VRAM shortfall.
+	ctrl.candidates = []status.PreemptCandidate{
+		{Name: "unlimited-ocr", VRAMBytes: 23 << 30, Idle: true},
+	}
+	m := newTestManager(ctrl)
+	// unlimited-ocr became ready 5s ago; the 60s floor protects it.
+	m.readyAt["unlimited-ocr"] = m.now().Add(-5 * time.Second)
+
+	out, err := m.EnsureResident(context.Background(), "bonsai", "Bonsai-27B")
+	if err != nil {
+		t.Fatalf("expected no hard error (transient min-residency block), got %v", err)
+	}
+	if out.Ready {
+		t.Fatalf("expected warming while the only candidate is within min-residency")
+	}
+	// Give the background op a moment to finish its (no-op) plan.
+	time.Sleep(50 * time.Millisecond)
+	if names := ctrl.stoppedNames(); len(names) != 0 {
+		t.Fatalf("expected NO eviction within min-residency, got %v", names)
+	}
+}
+
+func TestSwap_CannotFitPinned_HardError(t *testing.T) {
+	ctrl := newMockController()
+	ctrl.haveVRAM = true
+	ctrl.freeVRAM = 0
+	ctrl.candidates = []status.PreemptCandidate{
+		{Name: "unlimited-ocr", VRAMBytes: 12 << 30, Idle: true, Pinned: true},
+	}
+	m := newTestManager(ctrl)
+	m.waitBudget = 2 * time.Second // let the swap finish so the error surfaces
+
+	_, err := m.EnsureResident(context.Background(), "bonsai", "Bonsai-27B")
+	if err == nil {
+		t.Fatalf("expected a hard error when the only VRAM holder is pinned")
+	}
+}
+
+func TestEnsureResident_BackgroundSwapSurvivesJobCancellation(t *testing.T) {
+	ctrl := newMockController()
+	ctrl.readyAfterStart = true
+	ctrl.startGate = make(chan struct{}) // hold Start until we cancel the job ctx
+	m := newTestManager(ctrl)
+	m.backgroundMax = 5 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel the job context shortly after the call begins observing.
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+
+	out, err := m.EnsureResident(ctx, "bonsai", "Bonsai-27B")
+	if err != nil {
+		t.Fatalf("cancellation must not be a hard error, got %v", err)
+	}
+	if out.Ready {
+		t.Fatalf("expected warming when the job ctx is cancelled mid-swap")
+	}
+
+	// The background swap keeps running: let Start proceed, then it should finish.
+	close(ctrl.startGate)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if ctrl.Resident(context.Background(), "bonsai") {
+			return // background swap completed despite the cancelled job ctx
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("background swap did not complete after job-context cancellation")
+}


### PR DESCRIPTION
## Context
Phase 1 of #632 — VRAM-aware on-demand model hotswap, so a single-GPU node can present multiple installed models as available and swap them in on demand instead of an operator pinning one resident model. **Pilot, default OFF** behind `CITADEL_MODEL_HOTSWAP` (truthy `1/true/yes/on`); flag-off behavior is byte-identical to today. We'll enable it only on node 1297.

## What's here
**Heartbeat installed-vs-resident** (`internal/status`)
- `ServiceInfo` gains `Resident *bool` + `VRAMEstimateMB int` (both `omitempty`; a flag-off heartbeat contains neither key — asserted by a test).
- Collector (gated on flag + `ConfigDir`) marks running engines `resident:true` and additively advertises installed-but-stopped engines (compose materialized on disk + a served model resolvable from `<name>.env` or the compose default) as `resident:false` swap-in candidates. Dedicated `collectInstalledEngines()` pass so a running engine's richer probe entry is never shadowed.

**Swap manager** (`internal/worker/swap.go`)
- Single-flight lock: one swap per node; a same-model miss joins, a **different-model miss returns warming and starts no second swap** (no GPU thrash).
- Runs the (minutes-long) compose-up/build in a **background goroutine with its own context** — never the job ctx — so cancellation can't kill a swap; `EnsureResident` only *observes* for ≤15s.
- **Non-durable eviction**: `PlanPreemption` (#577) + `StopServiceByName` **without** the durable `desired_status:stopped` marker, so an evicted model stays swap-eligible.
- Min-residency floor (60s) filters recently-ready engines out of the candidate set before planning; LRU pre-sort breaks `PlanPreemption` ties.

**Wired into `llm_inference`**: flag on → an installed-but-not-resident target is swapped in before routing. Ready within budget → serve normally. Not ready → structured warming result (a SUCCESS `JobResult` carrying **no** content chunk):
```json
{"status":"model_warming","model":"<id>","eta_seconds":<n>,"retry_after":10}
```

## Note on the VRAM budget (shared contract)
The companion aceteam PR forwards `vram_mb` on `SERVICE_START`, which lights up **#577's durable** `preemptForVRAM`. The hotswap path here **deliberately does NOT consume `vram_mb`** and its internal `SERVICE_START` carries only `{service, model}` — the swap runs its **own non-durable** `PlanPreemption` (sized from a per-engine provisioning-budget table) so an LRU eviction stays reversible. Passing `vram_mb` on the internal start would make #577 evict *durably* and turn the LRU one-way.

The provisioning-budget table sizes the big engines above half the RTX 3090 (verified: OCR resident leaves ~10.5GB free) so a big-model swap-in forces evicting the other big model — the intended one-big-model-at-a-time behavior — rather than a no-op "fits" followed by an OOM.

## Testing
`go test ./...` + `go vet ./...` green (unit tests run with `-race`). New tests: swap serialization/join, different-model-in-flight starts no second swap, min-residency floor, warming-vs-serve, background swap survives job-context cancellation, pinned hard-error, installed enumeration + env override, resident marking, flag-off omits `resident` key, truthy parsing.

Live swap timing on node 1297 (bonsai↔OCR) is a documented human follow-up (issue #1's "pin the number").

Closes #632 (Phase 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)