### PR TITLE
fix(runtime): don't select podman when its API socket is dead (#636)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aceteam-ai/citadel-cli/internal/catalog"
 	"github.com/aceteam-ai/citadel-cli/internal/clilog"
 	"github.com/aceteam-ai/citadel-cli/internal/tui"
 	"github.com/aceteam-ai/citadel-cli/internal/update"
@@ -97,6 +98,12 @@ control center. All other subcommands are for scripting and advanced use.`,
 		}
 	},
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		// --runtime overrides container-runtime auto-detection (#636). Export it
+		// so the catalog selector sees it without threading a flag through the
+		// 13 call sites that resolve a runtime.
+		if containerRuntimeFlag != "" {
+			os.Setenv(catalog.RuntimeOverrideEnv, containerRuntimeFlag)
+		}
 		// MCP command uses stdout as JSON-RPC transport -- any non-protocol
 		// output there corrupts the stream. Redirect debug to stderr early,
 		// before the first Log() call.
@@ -228,6 +235,8 @@ func GetRootCmd() *cobra.Command {
 	return rootCmd
 }
 
+var containerRuntimeFlag string
+
 func init() {
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
@@ -238,6 +247,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&authServiceURL, "auth-service", getEnvOrDefault("CITADEL_AUTH_HOST", "https://aceteam.ai"), "The URL of the authentication service")
 	rootCmd.PersistentFlags().BoolVar(&debugMode, "debug", false, "Enable debug output")
 	rootCmd.PersistentFlags().BoolVar(&noColorGlobal, "no-color", false, "Disable colorized output")
+	rootCmd.PersistentFlags().StringVar(&containerRuntimeFlag, "runtime", "", "Container runtime for module containers: docker or podman (default: auto-detect)")
 	rootCmd.PersistentFlags().BoolVar(&noAutoUpdate, "no-auto-update", false, "Disable automatic update checks and installs for this run (or set CITADEL_NO_AUTO_UPDATE=1)")
 	rootCmd.Flags().BoolVar(&noMouse, "no-mouse", false, "Disable control-center mouse control (keeps terminal drag-to-copy)")
 

--- a/internal/catalog/runtime.go
+++ b/internal/catalog/runtime.go
@@ -1,6 +1,18 @@
 package catalog
 
-import "os/exec"
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+// RuntimeOverrideEnv is the environment variable that forces a container
+// runtime, bypassing auto-detection. Valid values: "docker", "podman". The
+// root command's --runtime flag sets it. An unrecognized value is ignored
+// (auto-detection proceeds) and reported via ContainerRuntime.FallbackReason.
+const RuntimeOverrideEnv = "CITADEL_CONTAINER_RUNTIME"
 
 // ContainerRuntime describes the container runtime (and its compose front-end)
 // that Citadel should drive for module containers. Module containment (#348)
@@ -29,6 +41,11 @@ type ContainerRuntime struct {
 	// Informational: callers may surface it; it does not change argument
 	// construction.
 	Rootless bool
+	// FallbackReason explains why selection could not honor the preferred
+	// runtime and downgraded to another one -- e.g. podman is installed but its
+	// API socket is not listening (#636). Empty when the preferred runtime was
+	// selected outright. SelectContainerRuntime logs it once per process.
+	FallbackReason string
 }
 
 // Label returns a short human-readable description of the selected runtime for
@@ -63,6 +80,15 @@ type runtimeProbes struct {
 	// podmanComposeSubcmd reports whether `podman compose` (the built-in compose
 	// subcommand) is usable, distinct from the separate `podman-compose` binary.
 	podmanComposeSubcmd func() bool
+	// podmanSocketLive reports whether podman's Docker-compatible API socket is
+	// actually listening. This is NOT implied by podmanComposeSubcmd: `podman
+	// compose version` succeeds by delegating to an external provider (usually
+	// docker-compose) that is present on PATH, even when the socket it would
+	// connect to is dead (#636).
+	podmanSocketLive func() bool
+	// override returns a forced runtime name ("docker"/"podman"), or "" to
+	// auto-detect.
+	override func() string
 }
 
 // defaultRuntimeProbes wires the probes to the real host.
@@ -73,6 +99,8 @@ func defaultRuntimeProbes() runtimeProbes {
 			return err == nil
 		},
 		podmanComposeSubcmd: hostPodmanComposeSubcmd,
+		podmanSocketLive:    hostPodmanSocketLive,
+		override:            func() string { return os.Getenv(RuntimeOverrideEnv) },
 	}
 }
 
@@ -89,43 +117,122 @@ func hostPodmanComposeSubcmd() bool {
 	return exec.Command("podman", "compose", "version").Run() == nil
 }
 
+// hostPodmanSocketLive reports whether podman's Docker-compatible API socket is
+// listening, which is what `podman compose` needs: it delegates to an external
+// compose provider that speaks the Docker API over that socket.
+//
+// podman itself reports this, so we do not depend on systemd being the thing
+// that manages the socket:
+//
+//	podman info --format {{.Host.RemoteSocket.Exists}}
+//
+// A node with podman installed but `podman.socket` inactive answers "false" --
+// exactly the state that made every module fail with "Cannot connect to the
+// Docker daemon at unix:///run/user/1000/podman/podman.sock" (#636).
+func hostPodmanSocketLive() bool {
+	if _, err := exec.LookPath("podman"); err != nil {
+		return false
+	}
+	out, err := exec.Command("podman", "info", "--format", "{{.Host.RemoteSocket.Exists}}").Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) == "true"
+}
+
+// warnOnce guards the fallback warning so repeatedly-called read paths (status,
+// resmon, footprint) do not spam it.
+var warnOnce sync.Once
+
 // SelectContainerRuntime resolves the container runtime to drive module
 // containers, preferring rootless podman over docker (#348). It uses the real
-// host probes.
+// host probes, and logs once if it had to fall back from the preferred runtime.
 func SelectContainerRuntime() ContainerRuntime {
-	return selectContainerRuntime(defaultRuntimeProbes())
+	rt := selectContainerRuntime(defaultRuntimeProbes())
+	if rt.FallbackReason != "" {
+		warnOnce.Do(func() {
+			fmt.Fprintf(os.Stderr, "warning: %s\n", rt.FallbackReason)
+		})
+	}
+	return rt
 }
 
 // selectContainerRuntime is the pure core (probes injected) so the selection
 // policy is table-testable without podman/docker installed.
 //
 // Policy, in order:
-//  1. podman present + `podman compose` subcommand usable -> podman with the
-//     "compose" prefix (rootless).
-//  2. podman present + `podman-compose` binary present     -> podman-compose
-//     (rootless), empty compose prefix.
-//  3. podman present, no compose front-end                 -> docker (podman
-//     alone cannot run a compose file; fall back rather than fail).
-//  4. podman absent                                        -> docker.
+//  0. An explicit override (--runtime / CITADEL_CONTAINER_RUNTIME) wins outright.
+//  1. podman present + `podman compose` usable + podman socket live -> podman
+//     with the "compose" prefix (rootless).
+//  2. podman present + `podman-compose` binary present -> podman-compose
+//     (rootless), empty compose prefix. This wrapper drives the podman CLI
+//     directly, so it does NOT need the API socket.
+//  3. podman present, no usable compose front-end (or a compose subcommand whose
+//     socket is dead) -> docker, with FallbackReason set.
+//  4. podman absent -> docker.
 //
 // When neither runtime is present we still return docker: the existing start
 // path already surfaces a clear docker-not-found error, and returning a concrete
 // runtime keeps callers simple. Selection never fails.
 func selectContainerRuntime(p runtimeProbes) ContainerRuntime {
 	docker := ContainerRuntime{EngineBin: "docker", Bin: "docker", ComposePrefix: []string{"compose"}}
+	podmanCompose := ContainerRuntime{EngineBin: "podman", Bin: "podman", ComposePrefix: []string{"compose"}, Rootless: true}
+	// Compose runs via the podman-compose wrapper, but engine sub-commands
+	// (inspect/rm) must still go to the podman CLI itself.
+	podmanWrapper := ContainerRuntime{EngineBin: "podman", Bin: "podman-compose", ComposePrefix: nil, Rootless: true}
+
+	var invalidOverride string
+	switch strings.ToLower(strings.TrimSpace(p.override())) {
+	case "docker":
+		return docker
+	case "podman":
+		// Forced: honor the operator's choice and pick the best available
+		// front-end. If neither is usable we still return podman so the failure
+		// is loud and attributable, rather than silently running docker.
+		if !p.podmanComposeSubcmd() && p.lookPath("podman-compose") {
+			return podmanWrapper
+		}
+		return podmanCompose
+	case "":
+		// auto-detect
+	default:
+		invalidOverride = fmt.Sprintf("ignoring unrecognized %s=%q (expected \"docker\" or \"podman\"); auto-detecting instead",
+			RuntimeOverrideEnv, p.override())
+	}
+
+	withReason := func(rt ContainerRuntime, reason string) ContainerRuntime {
+		switch {
+		case invalidOverride != "" && reason != "":
+			rt.FallbackReason = invalidOverride + "; " + reason
+		case invalidOverride != "":
+			rt.FallbackReason = invalidOverride
+		default:
+			rt.FallbackReason = reason
+		}
+		return rt
+	}
 
 	if !p.lookPath("podman") {
-		return docker
+		return withReason(docker, "")
 	}
 	if p.podmanComposeSubcmd() {
-		return ContainerRuntime{EngineBin: "podman", Bin: "podman", ComposePrefix: []string{"compose"}, Rootless: true}
+		if p.podmanSocketLive() {
+			return withReason(podmanCompose, "")
+		}
+		// `podman compose` exists but its API socket is dead, so every compose
+		// call would fail against a socket nobody is listening on. The
+		// podman-compose wrapper talks to the podman CLI directly and still
+		// works, so prefer it before giving up on podman entirely.
+		if p.lookPath("podman-compose") {
+			return withReason(podmanWrapper, "")
+		}
+		return withReason(docker, "podman is preferred on this node but its API socket is not responding "+
+			"(start podman.socket, or pass --runtime=podman to force it); falling back to docker")
 	}
 	if p.lookPath("podman-compose") {
-		// Compose runs via the podman-compose wrapper, but engine sub-commands
-		// (inspect/rm) must still go to the podman CLI itself.
-		return ContainerRuntime{EngineBin: "podman", Bin: "podman-compose", ComposePrefix: nil, Rootless: true}
+		return withReason(podmanWrapper, "")
 	}
 	// podman present but no compose front-end: docker can still drive the compose
 	// file, so prefer it over failing.
-	return docker
+	return withReason(docker, "")
 }

--- a/internal/catalog/runtime_test.go
+++ b/internal/catalog/runtime_test.go
@@ -2,15 +2,26 @@ package catalog
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
 // probeStub builds a runtimeProbes whose behavior is fully driven by the test,
 // so the selection policy is exercised without podman/docker installed.
 func probeStub(present map[string]bool, composeSubcmd bool) runtimeProbes {
+	// A live socket and no override keep these cases exercising the pre-#636
+	// policy unchanged; socket-dead and override behavior are covered below.
+	return probeStubFull(present, composeSubcmd, true, "")
+}
+
+// probeStubFull additionally drives the podman API-socket liveness probe and the
+// explicit runtime override (#636).
+func probeStubFull(present map[string]bool, composeSubcmd, socketLive bool, override string) runtimeProbes {
 	return runtimeProbes{
 		lookPath:            func(bin string) bool { return present[bin] },
 		podmanComposeSubcmd: func() bool { return composeSubcmd },
+		podmanSocketLive:    func() bool { return socketLive },
+		override:            func() string { return override },
 	}
 }
 
@@ -110,5 +121,65 @@ func TestContainerRuntime_ComposeArgs(t *testing.T) {
 	want = []string{"-f", "x.yml", "up", "-d"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("podman-compose ComposeArgs = %v, want %v", got, want)
+	}
+}
+
+// TestPodmanComposeSubcmdIsNotLiveness pins the #636 root cause: `podman compose
+// version` succeeds by delegating to an external provider (usually
+// docker-compose) that is merely present on PATH, so it says nothing about
+// whether podman's API socket is listening. Treating it as liveness selected a
+// runtime whose every command then failed with "Cannot connect to the Docker
+// daemon at unix:///run/user/1000/podman/podman.sock".
+func TestPodmanComposeSubcmdIsNotLiveness(t *testing.T) {
+	p := probeStubFull(map[string]bool{"podman": true, "docker": true}, true, false, "")
+	got := selectContainerRuntime(p)
+	if got.EngineBin != "docker" {
+		t.Fatalf("EngineBin = %q, want docker when podman's socket is dead", got.EngineBin)
+	}
+	if got.FallbackReason == "" {
+		t.Error("want a FallbackReason explaining the downgrade, got empty")
+	}
+}
+
+// A dead socket must not abandon podman when the podman-compose wrapper is
+// available: that wrapper drives the podman CLI directly and needs no socket.
+func TestPodmanSocketDeadPrefersWrapperOverDocker(t *testing.T) {
+	p := probeStubFull(map[string]bool{"podman": true, "podman-compose": true, "docker": true}, true, false, "")
+	got := selectContainerRuntime(p)
+	if got.EngineBin != "podman" || got.Bin != "podman-compose" {
+		t.Fatalf("got EngineBin=%q Bin=%q, want podman/podman-compose", got.EngineBin, got.Bin)
+	}
+	if got.FallbackReason != "" {
+		t.Errorf("the wrapper is a first-class front-end, not a downgrade; got reason %q", got.FallbackReason)
+	}
+}
+
+func TestRuntimeOverride(t *testing.T) {
+	full := map[string]bool{"podman": true, "docker": true}
+
+	// docker forced even though podman is fully usable.
+	if got := selectContainerRuntime(probeStubFull(full, true, true, "docker")); got.EngineBin != "docker" {
+		t.Errorf("override=docker: EngineBin = %q, want docker", got.EngineBin)
+	}
+
+	// podman forced even though its socket is dead: fail loudly ON PODMAN rather
+	// than silently running docker behind the operator's back.
+	if got := selectContainerRuntime(probeStubFull(full, true, false, "podman")); got.EngineBin != "podman" {
+		t.Errorf("override=podman: EngineBin = %q, want podman (forced)", got.EngineBin)
+	}
+
+	// Case and surrounding whitespace are tolerated.
+	if got := selectContainerRuntime(probeStubFull(full, true, true, "  DOCKER  ")); got.EngineBin != "docker" {
+		t.Errorf("override=\"  DOCKER  \": EngineBin = %q, want docker", got.EngineBin)
+	}
+
+	// An unrecognized value must not silently pin a runtime: auto-detect, but
+	// tell the operator their setting was ignored.
+	got := selectContainerRuntime(probeStubFull(full, true, true, "containerd"))
+	if got.EngineBin != "podman" {
+		t.Errorf("bad override: EngineBin = %q, want auto-detected podman", got.EngineBin)
+	}
+	if !strings.Contains(got.FallbackReason, "unrecognized") {
+		t.Errorf("bad override: FallbackReason = %q, want it to mention the ignored value", got.FallbackReason)
 	}
 }


### PR DESCRIPTION
Fixes #636.

## Problem
On a node where **docker works and podman is installed but its socket is inactive**, every module fails to start — `citadel run`, the worker's auto-start-from-manifest, and therefore the whole `fabric_node_module_set` → reconcile → run path:

```
Cannot connect to the Docker daemon at unix:///run/user/1000/podman/podman.sock
```

Not nvr-specific: the worker logged the identical failure for `transcribe`.

## Root cause
`hostPodmanComposeSubcmd()` (`podman compose version`) was used as though it proved podman was usable. It only proves a compose **provider** exists on PATH — podman delegates to an external one (usually docker-compose), so it succeeds **even when the socket that provider connects to is dead**. Selection picked podman; every command then failed.

## Changes
- **Real liveness probe** — `podman info --format {{.Host.RemoteSocket.Exists}}`, gating only the `podman compose` path. Verified on the affected node: returns `false`, with path `/run/user/1000/podman/podman.sock` — exactly the socket in the error.
- **Dead socket prefers the podman-compose wrapper** before falling back, since that wrapper drives the podman CLI directly and needs no socket. Podman isn't abandoned when it's still usable.
- **Fallback to docker + warning** naming the dead socket and the remedy; warned once per process so the repeatedly-called status/resmon/footprint paths don't spam.
- **Explicit override** — `--runtime` flag + `CITADEL_CONTAINER_RUNTIME`. Forcing `podman` stays on podman even with a dead socket, so failure is loud rather than a silent rootless→rootful downgrade. Unrecognized values auto-detect and say so.

Implemented in the selector (all 13 call sites resolve through `SelectContainerRuntime`), so no call-site churn.

## Test plan
- `go build ./...`, `go vet`, `gofmt` clean; **full `go test ./...` passes**.
- New unit tests: `TestPodmanComposeSubcmdIsNotLiveness` (pins the root cause), `TestPodmanSocketDeadPrefersWrapperOverDocker`, `TestRuntimeOverride` (force/case-insensitivity/bad-value). Existing `TestSelectContainerRuntime` cases unchanged and passing.
- **Verified on node 1314 (mini)** — the node where this was found, podman socket `false`:

```
$ citadel run nvr
warning: podman is preferred on this node but its API socket is not responding
         (start podman.socket, or pass --runtime=podman to force it); falling back to docker
   Container runtime: docker
✅ Service 'nvr' is running.
```

Camera recording stayed healthy throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)