### PR TITLE
feat(nvr): raise shm_size to 512mb and add a node-local MQTT broker (#637)

### DIFF
--- a/cmd/nvrconfig/main.go
+++ b/cmd/nvrconfig/main.go
@@ -72,10 +72,28 @@ func run() error {
 		}
 	}
 
+	// MQTT is on by default: the module ships a node-local broker, and Frigate
+	// has no other real-time event egress (#637). NVR_MQTT=false opts out.
+	mqttEnabled := strings.ToLower(strings.TrimSpace(getenvDefault("NVR_MQTT", "true"))) != "false"
+	mqttPort := nvr.DefaultMQTTPort
+	if raw := strings.TrimSpace(os.Getenv("NVR_MQTT_PORT")); raw != "" {
+		if v, err := strconv.Atoi(raw); err == nil && v > 0 {
+			mqttPort = v
+		}
+	}
+
 	cfg := nvr.Config{
 		RetentionDays: retention,
 		Detector:      detector,
 		Storage:       nvr.StorageSpec{Mode: mode, Target: os.Getenv("NVR_STORAGE_TARGET")},
+		MQTT: nvr.MQTTSpec{
+			Enabled:     mqttEnabled,
+			Host:        getenvDefault("NVR_MQTT_HOST", "mosquitto"),
+			Port:        mqttPort,
+			User:        os.Getenv("NVR_MQTT_USER"),
+			Password:    os.Getenv("NVR_MQTT_PASSWORD"),
+			TopicPrefix: getenvDefault("NVR_MQTT_TOPIC_PREFIX", nvr.DefaultMQTTTopicPrefix),
+		},
 	}
 	yamlOut, err := nvr.GenerateFrigateConfig(cfg, cameras)
 	if err != nil {

--- a/internal/nvr/config.go
+++ b/internal/nvr/config.go
@@ -64,6 +64,11 @@ const (
 const (
 	OpenVINOModelPath    = "/openvino-model/ssdlite_mobilenet_v2.xml"
 	OpenVINOLabelmapPath = "/openvino-model/coco_91cl_bkgr.txt"
+
+	// DefaultMQTTPort is the broker's in-network port. Not published to the host.
+	DefaultMQTTPort = 1883
+	// DefaultMQTTTopicPrefix matches Frigate's own default topic namespace.
+	DefaultMQTTTopicPrefix = "frigate"
 )
 
 // wyzeBridgeRTSPHost is the address Frigate uses to pull camera RTSP streams from
@@ -107,6 +112,36 @@ type Config struct {
 	RetentionDays int
 	Detector      Detector
 	Storage       StorageSpec
+	// MQTT configures Frigate's event egress. Frigate 0.17 has NO generic
+	// outbound webhook (its config schema offers only mqtt, web-push
+	// notifications, and alerts), so MQTT is the only real-time event channel;
+	// the alternative is polling /api/events. The module ships a node-local
+	// broker for this (#637).
+	MQTT MQTTSpec
+}
+
+// MQTTSpec points Frigate at the module's broker. The broker is node-local and
+// publishes NO host port: it is reachable only on the module's compose network.
+// Binding it to 127.0.0.1 would NOT be sufficient, because wyze-bridge runs with
+// host networking in this module, which would make a bound port LAN-reachable.
+type MQTTSpec struct {
+	// Enabled turns on Frigate's MQTT client. When false the generated config
+	// keeps the explicit `enabled: false` Frigate requires to treat MQTT as
+	// optional.
+	Enabled bool
+	// Host is the broker hostname on the compose network (the compose service
+	// name), not an IP or a host port.
+	Host string
+	// Port is the broker's in-network port (1883 by default).
+	Port int
+	// User and Password authenticate to the broker. Mosquitto allows anonymous
+	// connections by default, so the module always sets credentials rather than
+	// relying on network isolation alone.
+	User     string
+	Password string
+	// TopicPrefix namespaces this node's topics so a future multi-node consumer
+	// can tell publishers apart. Defaults to "frigate".
+	TopicPrefix string
 }
 
 // ---- Frigate config.yml shape (only the fields we set) ----
@@ -172,6 +207,36 @@ type detectToggle struct {
 	Enabled bool `yaml:"enabled"`
 }
 
+// mqttBlock renders the frigate `mqtt:` section. Disabled is the zero value, so
+// a caller that never sets MQTTSpec keeps the previous behavior.
+func mqttBlock(m MQTTSpec) map[string]any {
+	if !m.Enabled {
+		return map[string]any{"enabled": false}
+	}
+	port := m.Port
+	if port == 0 {
+		port = DefaultMQTTPort
+	}
+	prefix := m.TopicPrefix
+	if prefix == "" {
+		prefix = DefaultMQTTTopicPrefix
+	}
+	block := map[string]any{
+		"enabled":      true,
+		"host":         m.Host,
+		"port":         port,
+		"topic_prefix": prefix,
+	}
+	// Only emit credentials when set: Frigate rejects empty user/password keys.
+	if m.User != "" {
+		block["user"] = m.User
+	}
+	if m.Password != "" {
+		block["password"] = m.Password
+	}
+	return block
+}
+
 // GenerateFrigateConfig renders a Frigate 0.17 config.yml from the assignment
 // config and the runtime-discovered camera list. It bakes in every scar from the
 // live SJC build:
@@ -191,9 +256,9 @@ func GenerateFrigateConfig(cfg Config, cameras []Camera) (string, error) {
 	}
 
 	fc := frigateConfig{
-		// The reference build has no MQTT broker; Frigate makes MQTT optional only
-		// when explicitly disabled.
-		MQTT: map[string]any{"enabled": false},
+		// Frigate treats MQTT as optional only when explicitly disabled, so this
+		// key is always emitted.
+		MQTT: mqttBlock(cfg.MQTT),
 		FFmpeg: ffmpegSpec{
 			HwaccelArgs: "preset-vaapi",
 		},

--- a/services/nvr-service/compose.yml
+++ b/services/nvr-service/compose.yml
@@ -62,9 +62,59 @@ services:
       - NVR_STORAGE_MODE=${NVR_STORAGE_MODE:-local}
       - NVR_STORAGE_TARGET=${NVR_STORAGE_TARGET:-}
       - NVR_CAMERAS=${NVR_CAMERAS:?nvr requires NVR_CAMERAS (comma-separated camera stream names)}
+      # MQTT is Frigate's only real-time event egress (it has no generic outbound
+      # webhook), so the module runs a broker and points Frigate at it by default.
+      # Set NVR_MQTT=false to opt out.
+      - NVR_MQTT=${NVR_MQTT:-true}
+      - NVR_MQTT_HOST=mosquitto
+      - NVR_MQTT_USER=${NVR_MQTT_USER:-frigate}
+      - NVR_MQTT_PASSWORD=${NVR_MQTT_PASSWORD:?nvr requires NVR_MQTT_PASSWORD (mosquitto allows anonymous access by default)}
     volumes:
       - ~/.citadel-cli/nvr/config:/config
       - ~/.citadel-cli/nvr/media:/media
+
+  mosquitto:
+    image: eclipse-mosquitto:2
+    container_name: citadel-nvr-mosquitto
+    # DELIBERATELY NO `ports:` BLOCK. The broker is reachable only on this
+    # module's compose network, never from the host, the LAN, or the fabric.
+    # Binding 127.0.0.1 would NOT be equivalent: wyze-bridge runs with host
+    # networking in this module, so a bound port would be LAN-reachable.
+    #
+    # Why node-local rather than one shared broker for the fabric (#637):
+    # Frigate publishes at QoS 0 (fire-and-forget), so a WAN broker blip drops
+    # events silently; a shared bus would be a second control plane to secure
+    # (TLS/credentials/ACLs) when the citadel worker already holds an
+    # authenticated outbound channel; and cross-tenant topic isolation would
+    # become security-critical on a tailnet that is currently flat across orgs.
+    entrypoint:
+      # Mosquitto allows ANONYMOUS access by default. Generate a password file
+      # from the assignment credentials at start, then run with it. Written to a
+      # tmpfs so the credential never lands on disk.
+      - /bin/sh
+      - -c
+      - |
+        set -e
+        mosquitto_passwd -c -b /mosquitto/secrets/passwd "$$NVR_MQTT_USER" "$$NVR_MQTT_PASSWORD"
+        cat > /mosquitto/config/mosquitto.conf <<CONF
+        listener 1883
+        allow_anonymous false
+        password_file /mosquitto/secrets/passwd
+        persistence false
+        CONF
+        # mosquitto drops to the unprivileged `mosquitto` user, so it cannot read
+        # the root-owned files we just wrote into the tmpfs -- without this it
+        # exits with 'Unable to open pwfile' and the module never starts.
+        chown -R mosquitto:mosquitto /mosquitto/secrets /mosquitto/config
+        chmod 0600 /mosquitto/secrets/passwd
+        exec mosquitto -c /mosquitto/config/mosquitto.conf
+    environment:
+      - NVR_MQTT_USER=${NVR_MQTT_USER:-frigate}
+      - NVR_MQTT_PASSWORD=${NVR_MQTT_PASSWORD:?nvr requires NVR_MQTT_PASSWORD (mosquitto allows anonymous access by default)}
+    tmpfs:
+      - /mosquitto/secrets
+      - /mosquitto/config
+    restart: unless-stopped
 
   frigate:
     image: ghcr.io/blakeblackshear/frigate:stable
@@ -72,12 +122,21 @@ services:
     depends_on:
       wyze-bridge:
         condition: service_started
+      mosquitto:
+        condition: service_started
       nvr-config:
         # Frigate must not start until config.yml exists and the nas mount (if any)
         # is verified.
         condition: service_completed_successfully
-    # Frigate decodes frames into /dev/shm; the 64MB default is too small.
-    shm_size: 256mb
+    # Frigate decodes frames into /dev/shm; the 64MB default is far too small.
+    # /dev/shm carries RAW DECODED frames between the capture and detect
+    # processes (a 1080p YUV420 frame is ~3MB, buffered ~9 deep per camera), so
+    # it scales with cameras x resolution, NOT with the compressed bitrate.
+    # 256mb was too small for 3x1080p: Frigate warned it needed >=306MB and
+    # measured steady-state use was 322MB (#637). Undersizing causes frame-write
+    # failures and capture-process restart loops, not merely slowness. This is a
+    # tmpfs CAP, not a reservation: unused headroom costs no RAM.
+    shm_size: 512mb
     devices:
       # Intel iGPU render node for hardware decode (preset-vaapi) + OpenVINO
       # detection. Matches sandbox.devices in service.yaml.

--- a/services/nvr-service/service.yaml
+++ b/services/nvr-service/service.yaml
@@ -92,6 +92,25 @@ config:
       uses this target to mount/retarget. NOTE: /config (Frigate's SQLite DB)
       ALWAYS stays on local disk regardless of this value — SQLite corrupts over
       NFS; only /media follows the target.
+  - name: NVR_MQTT
+    description: >-
+      Run the node-local MQTT broker and point Frigate at it (default true).
+      Frigate 0.17 has NO generic outbound webhook -- its schema offers only
+      mqtt, web-push notifications, and alerts -- so MQTT is the only real-time
+      event egress; the alternative is polling /api/events. The broker publishes
+      no host port and is reachable only on the module's compose network. Set to
+      false to skip event egress entirely.
+    default: "true"
+  - name: NVR_MQTT_USER
+    description: "Username for the node-local MQTT broker."
+    default: frigate
+  - name: NVR_MQTT_PASSWORD
+    description: >-
+      Password for the node-local MQTT broker (SECRET; never logged). REQUIRED:
+      mosquitto permits anonymous connections by default, and wyze-bridge runs
+      host-networked in this module, so an unauthenticated broker must never be
+      started.
+    required: true
   - name: NVR_CAMERAS
     description: >-
       Comma-separated camera stream names (e.g. "front-door,garage=garage-cam";

--- a/services/nvr_manifest_test.go
+++ b/services/nvr_manifest_test.go
@@ -2,6 +2,8 @@ package services
 
 import (
 	_ "embed"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -206,4 +208,75 @@ func TestNVRComposeInvariants(t *testing.T) {
 	if !ok || dep.Condition != "service_completed_successfully" {
 		t.Errorf("frigate must depend_on nvr-config with condition service_completed_successfully; got %+v", frigate.DependsOn)
 	}
+}
+
+// TestNVRComposeShmSize pins the /dev/shm cap. Frigate passes RAW DECODED frames
+// through /dev/shm (a 1080p YUV420 frame is ~3MB, buffered ~9 deep per camera),
+// so it scales with cameras x resolution, not with the compressed bitrate. At
+// 256mb with 3x1080p, Frigate warned it needed >=306MB and measured steady-state
+// use was 322MB (#637); undersizing causes frame-write failures and
+// capture-process restart loops.
+func TestNVRComposeShmSize(t *testing.T) {
+	body := readNVRCompose(t)
+	if strings.Contains(body, "shm_size: 256mb") {
+		t.Error("shm_size is back to 256mb, which is too small for 3x1080p cameras (#637)")
+	}
+	if !strings.Contains(body, "shm_size: 512mb") {
+		t.Error("expected frigate shm_size: 512mb")
+	}
+}
+
+// TestNVRMosquittoIsNotReachableOffTheComposeNetwork is the security-critical
+// property of the node-local broker: it must publish NO host port. Binding
+// 127.0.0.1 would NOT be equivalent, because wyze-bridge runs host-networked in
+// this module, which would make any bound port LAN-reachable.
+func TestNVRMosquittoIsNotReachableOffTheComposeNetwork(t *testing.T) {
+	var compose struct {
+		Services map[string]struct {
+			Ports       []any  `yaml:"ports"`
+			NetworkMode string `yaml:"network_mode"`
+		} `yaml:"services"`
+	}
+	if err := yaml.Unmarshal([]byte(readNVRCompose(t)), &compose); err != nil {
+		t.Fatalf("parse compose: %v", err)
+	}
+	mosq, ok := compose.Services["mosquitto"]
+	if !ok {
+		t.Fatal("mosquitto service missing from the nvr module compose")
+	}
+	if len(mosq.Ports) != 0 {
+		t.Errorf("mosquitto must publish no host port, got %v", mosq.Ports)
+	}
+	if mosq.NetworkMode == "host" {
+		t.Error("mosquitto must not use host networking")
+	}
+}
+
+// TestNVRMosquittoRequiresCredentials pins that the broker never starts
+// anonymously: mosquitto permits anonymous connections BY DEFAULT, so the
+// config must disable that and the password must be a required input.
+func TestNVRMosquittoRequiresCredentials(t *testing.T) {
+	body := readNVRCompose(t)
+	if !strings.Contains(body, "allow_anonymous false") {
+		t.Error("mosquitto config must set allow_anonymous false")
+	}
+	// `:?` makes compose fail loudly when the password is unset, rather than
+	// starting a broker with an empty credential.
+	if !strings.Contains(body, "NVR_MQTT_PASSWORD:?") {
+		t.Error("NVR_MQTT_PASSWORD must be a required compose variable")
+	}
+	// mosquitto drops privileges; without this it cannot read its own pwfile.
+	if !strings.Contains(body, "chown -R mosquitto:mosquitto") {
+		t.Error("the generated password file must be chowned to the mosquitto user")
+	}
+}
+
+// readNVRCompose returns the nvr module compose file body.
+func readNVRCompose(t *testing.T) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("nvr-service", "compose.yml"))
+	if err != nil {
+		t.Fatalf("read nvr compose: %v", err)
+	}
+	return string(b)
 }


### PR DESCRIPTION
Fixes #637. Found while running the nvr module for real on node 1314 (recording 3 cameras to a Synology NFS share).

## 1. shm_size 256mb -> 512mb
Frigate warned it needed `>=306MB` with 3x1080p; measured steady-state usage after the bump is **322MB — above the old cap**. `/dev/shm` carries **raw decoded frames** between capture and detect (a 1080p YUV420 frame is ~3MB, ~9 deep per camera), so it scales with cameras x resolution, not the compressed bitrate. Undersizing causes frame-write failures and capture-process restart loops. It is a tmpfs **cap, not a reservation** — headroom costs no RAM until used.

## 2. Node-local MQTT broker
Frigate 0.17 has **no generic outbound webhook** (schema offers only mqtt / web-push / alerts), so MQTT is the only real-time event egress; the alternative is polling `/api/events`.

**Why node-local and not one shared broker for the fabric:** Frigate publishes at **QoS 0** (fire-and-forget) so a WAN broker blip drops events silently; a shared bus is a second control plane to secure when the worker already holds an authenticated outbound channel; and cross-tenant topic isolation becomes security-critical on a tailnet that is [currently flat across orgs](https://github.com/aceteam-ai/nexus/issues/45).

Security properties, each pinned by a test:
- **No host port.** Reachable only on the module's compose network. Binding 127.0.0.1 would **not** be equivalent — wyze-bridge runs host-networked here, so a bound port would be LAN-reachable.
- **Credentials mandatory.** mosquitto allows anonymous connections by default; `NVR_MQTT_PASSWORD` is a required compose var (`:?`), so an unauthenticated broker cannot start.
- Password file lives in a **tmpfs** and is chowned to the `mosquitto` user — required after it drops privileges (without it the broker dies with `Unable to open pwfile`; caught during testing).

On by default; `NVR_MQTT=false` opts out.

## Test plan
- `go build ./...`, `go vet`, `gofmt` clean; **full `go test ./...` passes**.
- New manifest tests: `TestNVRComposeShmSize`, `TestNVRMosquittoIsNotReachableOffTheComposeNetwork`, `TestNVRMosquittoRequiresCredentials`.
- `docker compose config` renders: frigate `shm=536870912`; **mosquitto `ports=(none)`**.
- **Broker auth verified live** (running as the unprivileged mosquitto user): anonymous publish -> `Connection Refused: not authorised` (rc=5); correct credentials -> rc=0; wrong password -> rc=5.
- **Config generation verified** with the `nvr-config` image built from this branch: default renders `mqtt: enabled: true` with host/port/user/password/topic_prefix; `NVR_MQTT=false` renders `enabled: false`.
- Exercised on node 1314 in an isolated compose project; the live recording stack was untouched and stayed healthy throughout.

## Follow-ups (deliberately not here)
- The **fabric forwarder** relaying events over citadel's existing outbound channel (`internal/redisapi` pubsub/StreamAdd already provides the primitive).
- Both files must be **mirrored to `aceteam-ai/citadel-services`** as `services/nvr/{service.yaml,compose.yml}` before nodes install them — the citadel-cli copy is the source of truth but is not what nodes pull.
- The `nvr-config` image must be rebuilt+pushed for the MQTT block to take effect on nodes (the currently published image predates this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)