### PR TITLE
chore(hotswap): default model hotswap ON (break-glass disable only)

### DIFF
--- a/cmd/nodejobs.go
+++ b/cmd/nodejobs.go
@@ -82,10 +82,11 @@ func buildNodeJobHandlers(opts nodeJobHandlerOpts) []worker.JobHandler {
 	// ollama/llamacpp/bonsai). Without it every inference job failed with
 	// "unsupported job type \"llm_inference\": node X has no handler for it".
 	llmHandler := worker.NewLLMInferenceHandler()
-	// Model hotswap (citadel-cli#632, default OFF): when CITADEL_MODEL_HOTSWAP is
-	// on and this node has a config dir, attach a swap manager so an
-	// installed-but-not-resident target engine is swapped in on demand. Returns nil
-	// (no swapper) when disabled, so the handler is byte-for-byte the pre-#632 one.
+	// Model hotswap (citadel-cli#632, default ON): unless CITADEL_MODEL_HOTSWAP is
+	// explicitly disabled (0/false/no/off) and this node has a config dir, attach a
+	// swap manager so an installed-but-not-resident target engine is swapped in on
+	// demand. Returns nil (no swapper) only under the break-glass disable, in which
+	// case the handler is byte-for-byte the pre-#632 one.
 	if swapper := newModelSwapManager(opts.ConfigDir, opts.WorkspaceDir, opts.PinnedServices, opts.HandlerLog); swapper != nil {
 		llmHandler = llmHandler.WithSwapper(swapper)
 	}

--- a/internal/status/hotswap.go
+++ b/internal/status/hotswap.go
@@ -10,28 +10,27 @@ import (
 )
 
 // hotswap.go — installed-vs-resident model advertising for VRAM-aware on-demand
-// model hotswap (citadel-cli#632, Phase 1 PILOT).
+// model hotswap (citadel-cli#632).
 //
-// Everything here is gated behind CITADEL_MODEL_HOTSWAP (default OFF). When the
-// flag is off, ModelHotswapEnabled() returns false and the collector never calls
-// applyModelHotswap, so the heartbeat output is byte-identical to today's.
+// Hotswap is ON by default. CITADEL_MODEL_HOTSWAP is retained ONLY as a
+// break-glass disable: set it to a falsey value (0/false/no/off) to turn the
+// swap path off on a node that misbehaves. When disabled, ModelHotswapEnabled()
+// returns false and the collector never calls applyModelHotswap, so the
+// heartbeat output is byte-identical to the pre-hotswap node.
 
 // ModelHotswapEnabled reports whether VRAM-aware on-demand model hotswap is
-// enabled on this node via the CITADEL_MODEL_HOTSWAP env var (truthy:
-// 1/true/yes/on). Default OFF — the pilot is enabled per-node (node 1297). Kept
-// in the leaf status package so both the collector and the worker's swap path can
-// read the same gate without an import cycle.
+// active on this node. Default ON; only an explicit falsey CITADEL_MODEL_HOTSWAP
+// (0/false/no/off) disables it (a garbage/unknown value stays ON, so a typo
+// can't silently kill the feature). Kept in the leaf status package so both the
+// collector and the worker's swap path read the same gate without an import
+// cycle.
 func ModelHotswapEnabled() bool {
-	return isTruthyEnv(os.Getenv("CITADEL_MODEL_HOTSWAP"))
-}
-
-// isTruthyEnv reports whether an env value is one of the accepted truthy tokens.
-func isTruthyEnv(v string) bool {
-	switch strings.ToLower(strings.TrimSpace(v)) {
-	case "1", "true", "yes", "on":
-		return true
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("CITADEL_MODEL_HOTSWAP"))) {
+	case "0", "false", "no", "off":
+		return false // break-glass disable
+	default:
+		return true // default ON (unset or any other value)
 	}
-	return false
 }
 
 // engineModelEnvVars maps a managed serving engine to the <name>.env variable(s)

--- a/internal/status/hotswap_test.go
+++ b/internal/status/hotswap_test.go
@@ -142,10 +142,16 @@ func TestServiceInfo_FlagOffOmitsResidentKey(t *testing.T) {
 	}
 }
 
-func TestModelHotswapEnabled_TruthyParsing(t *testing.T) {
+// TestModelHotswapEnabled_DefaultOnDisableParsing verifies hotswap is ON by
+// default (unset, empty, or any non-falsey value) and only an explicit falsey
+// CITADEL_MODEL_HOTSWAP acts as the break-glass disable. A garbage value ("nope")
+// stays ON so a typo can't silently kill the feature.
+func TestModelHotswapEnabled_DefaultOnDisableParsing(t *testing.T) {
 	cases := map[string]bool{
-		"1": true, "true": true, "YES": true, "on": true, "On": true,
-		"": false, "0": false, "false": false, "no": false, "off": false, "nope": false,
+		// default ON: unset/empty, truthy tokens, and unknown/garbage values.
+		"": true, "1": true, "true": true, "YES": true, "on": true, "On": true, "nope": true,
+		// break-glass disable: explicit falsey tokens only.
+		"0": false, "false": false, "no": false, "off": false, "OFF": false,
 	}
 	for v, want := range cases {
 		t.Setenv("CITADEL_MODEL_HOTSWAP", v)


### PR DESCRIPTION
## What
Flips VRAM-aware on-demand model hotswap (#632) from opt-in pilot to **default-ON**, per request to stop gating behind a feature flag.

`CITADEL_MODEL_HOTSWAP` is retained ONLY as a **break-glass disable**: an explicit falsey value (`0`/`false`/`no`/`off`) turns the swap path off on a misbehaving node. Unset / empty / any other value = ON. A garbage value stays ON so a typo can't silently kill the feature.

## Why keep a kill switch
Hotswap evicts/swaps GPU-resident models on demand — a brand-new subsystem. Default-ON gives the behavior we want; the disable env var is an operational off-ramp if a node thrashes, with zero effect on the default.

## Changes
- `internal/status/hotswap.go`: invert `ModelHotswapEnabled` default; drop the now-unused `isTruthyEnv`.
- `hotswap_test.go`: assert default-on + explicit-disable semantics.
- `cmd/nodejobs.go`: correct the stale default-OFF comment.

## Testing
`go test ./...` green (67 pkgs). Being validated with a live bonsai↔OCR swap on node 1297 via a local build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)