### PR TITLE
feat(gateway): make ingress usable end-to-end — X-Ingress-Path + an exposure driver (#598)

### DIFF
--- a/cmd/agent_tools.go
+++ b/cmd/agent_tools.go
@@ -75,6 +75,18 @@ func buildAgentProviders(ctx context.Context, d agentProviderDeps) *status.Agent
 		WorkerRestart: func() (any, error) {
 			return agentWorkerRestart()
 		},
+		Expose: func(spec status.ExposeSpec) (any, error) {
+			// Delegates to the same live adapter the EXPOSE_SET job uses, so the
+			// CLI/MCP path and the job path cannot drift.
+			return liveExposeOps{}.Expose(ctx, worker.ExposeRequest{
+				Name:       spec.Name,
+				Port:       spec.Port,
+				Visibility: spec.Visibility,
+				TTLSeconds: spec.TTLSeconds,
+				Creator:    spec.Creator,
+				Epoch:      spec.Epoch,
+			})
+		},
 	}
 }
 

--- a/cmd/provisioned_gateway.go
+++ b/cmd/provisioned_gateway.go
@@ -63,6 +63,12 @@ type gatewayFacts struct {
 	UseTLS     bool   `json:"use_tls"`
 	CertPath   string `json:"cert_path"`
 	StatusPort int    `json:"status_port,omitempty"`
+	// MeshIP is the node's AceTeam Network IPv4 that the gateway and status
+	// server bind. Persisted because an out-of-process CLI cannot ask the live
+	// tsnet for it: the network state is held by the running `citadel work`
+	// process, so meshIPv4() returns "" everywhere else. Without this a local
+	// command cannot address its own node's control surface (#598).
+	MeshIP string `json:"mesh_ip,omitempty"`
 }
 
 // provisionedStateDirOverride, when non-empty, replaces network.GetStateDir() as

--- a/cmd/service_expose.go
+++ b/cmd/service_expose.go
@@ -1,0 +1,149 @@
+// cmd/service_expose.go
+//
+// `citadel service expose` — the node-local driver for gateway ingress (#598).
+//
+// The gateway runs INSIDE the `citadel work` process, so a separate CLI process
+// cannot program it directly; it POSTs to that process's /agent/expose control
+// endpoint instead. The request goes to the node's own mesh IP (not loopback)
+// because the control surface authorizes VPN-origin callers — reusing the exact
+// posture of the other /agent/* control endpoints rather than widening it.
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/gateway"
+	"github.com/aceteam-ai/citadel-cli/internal/status"
+	"github.com/spf13/cobra"
+)
+
+var (
+	exposeSvcPort       int
+	exposeSvcVisibility string
+	exposeSvcTTL        time.Duration
+)
+
+var serviceExposeCmd = &cobra.Command{
+	Use:   "expose <name>",
+	Short: "Expose a local service on the AceTeam Network gateway",
+	Long: `Serves a local port on this node's gateway at /expose/<name>/, gated by a
+visibility level.
+
+  private  only the creator (requires a caller identity the backend supplies,
+           so a local CLI cannot grant it — use org or link)
+  org      any member of your organization on the network
+  link     anyone holding the signed, expiring link token
+
+Requires the node gateway to be running (citadel work).`,
+	Example: `  # Expose the nvr module's Frigate UI to your organization
+  citadel service expose frigate --port 8212 --visibility org
+
+  # Share a dashboard by link for 2 hours
+  citadel service expose grafana --port 3000 --visibility link --ttl 2h`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := args[0]
+		vis := gateway.Visibility(exposeSvcVisibility)
+		if !vis.Valid() {
+			return fmt.Errorf("invalid --visibility %q (want private, org, or link)", exposeSvcVisibility)
+		}
+		if exposeSvcPort <= 0 {
+			return fmt.Errorf("--port is required (the local port the service listens on)")
+		}
+		// A local caller cannot supply a remote tailnet identity, so `private`
+		// would be inert (fails closed at the gateway). Say so rather than
+		// creating an exposure nobody can reach.
+		if vis == gateway.VisibilityPrivate {
+			return fmt.Errorf("--visibility private needs a creator identity only the AceTeam backend can supply; use org or link from the CLI")
+		}
+
+		// meshIPv4() only answers inside the process that runs the network stack
+		// (`citadel work`); from a separate CLI process it is empty, so fall back
+		// to the facts that process persisted.
+		facts := gatewayFactsForURL()
+		ip := meshIPv4()
+		if ip == "" {
+			ip = facts.MeshIP
+		}
+		if ip == "" {
+			return fmt.Errorf("cannot determine this node's AceTeam Network IP; is `citadel work` running?")
+		}
+
+		body, err := json.Marshal(status.ExposeSpec{
+			Name:       name,
+			Port:       exposeSvcPort,
+			Visibility: string(vis),
+			TTLSeconds: int(exposeSvcTTL.Seconds()),
+		})
+		if err != nil {
+			return err
+		}
+
+		url := fmt.Sprintf("http://%s:%d/agent/expose", ip, statusPortFrom(facts))
+		req, err := http.NewRequestWithContext(cmd.Context(), http.MethodPost, url, bytes.NewReader(body))
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := (&http.Client{Timeout: 20 * time.Second}).Do(req)
+		if err != nil {
+			return fmt.Errorf("reach the node agent at %s: %w (is `citadel work` running?)", url, err)
+		}
+		defer resp.Body.Close()
+
+		var out struct {
+			URL       string `json:"url"`
+			Token     string `json:"token"`
+			ExpiresAt string `json:"expires_at"`
+			Error     string `json:"error"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			return fmt.Errorf("decode agent response (HTTP %d): %w", resp.StatusCode, err)
+		}
+		if resp.StatusCode != http.StatusOK || out.Error != "" {
+			msg := out.Error
+			if msg == "" {
+				msg = fmt.Sprintf("HTTP %d", resp.StatusCode)
+			}
+			return fmt.Errorf("expose failed: %s", msg)
+		}
+
+		fmt.Printf("\n✅ Exposed %q -> 127.0.0.1:%d\n", name, exposeSvcPort)
+		fmt.Printf("   URL:    %s\n", out.URL)
+		fmt.Printf("   Access: %s\n", vis)
+		if out.Token != "" {
+			fmt.Printf("   Link:   %s?access_token=%s\n", out.URL, out.Token)
+			fmt.Printf("   Expires: %s\n", out.ExpiresAt)
+		}
+		fmt.Println()
+		return nil
+	},
+}
+
+// statusPortFrom returns the port the agent control surface listens on, taking
+// the running gateway's own recorded port when available.
+func statusPortFrom(f gatewayFacts) int {
+	if f.StatusPort > 0 {
+		return f.StatusPort
+	}
+	if workStatusPort > 0 {
+		return workStatusPort
+	}
+	return defaultWorkStatusPort
+}
+
+func init() {
+	serviceExposeCmd.Flags().IntVar(&exposeSvcPort, "port", 0, "Local port the service listens on (required)")
+	serviceExposeCmd.Flags().StringVar(&exposeSvcVisibility, "visibility", "org", "Who may reach it: org or link")
+	serviceExposeCmd.Flags().DurationVar(&exposeSvcTTL, "ttl", 24*time.Hour, "Lifetime of a --visibility link token")
+	svcCmd.AddCommand(serviceExposeCmd)
+}
+
+// defaultWorkStatusPort mirrors the port `citadel work` binds the status/agent
+// server on when the gateway is enabled (cmd/work.go).
+const defaultWorkStatusPort = 8080

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1951,7 +1951,7 @@ func runWork(cmd *cobra.Command, args []string) {
 		// reachable mesh URL and verifies against the real cert (landmines a + b).
 		// StatusPort is persisted too so a separate process can build the plaintext
 		// cert_refresh_url (http://<ip>:<status-port>/gateway-cert.pem).
-		if err := writeGatewayFacts(gatewayFacts{Port: workGatewayPort, UseTLS: !workGatewayNoTLS, CertPath: gwCertPath, StatusPort: workStatusPort}); err != nil {
+		if err := writeGatewayFacts(gatewayFacts{Port: workGatewayPort, UseTLS: !workGatewayNoTLS, CertPath: gwCertPath, StatusPort: workStatusPort, MeshIP: meshIPv4()}); err != nil {
 			Log("could not persist gateway facts (out-of-process URL falls back to defaults): %v", err)
 		}
 		// Watch the registry so a module provisioned via the CLI while this gateway

--- a/internal/gateway/exposure.go
+++ b/internal/gateway/exposure.go
@@ -228,13 +228,15 @@ func (s *Server) Expose(name, address string, policy *ExposePolicy) error {
 	// web app (Frigate live view, dashboards) upgrades to WS; registerProxy routes
 	// plain HTTP and WS upgrades through the same handler.
 	//
-	// NOTE (subpath constraint): because the route is served under /expose/<name>/
-	// with StripPrefix, an exposed app that emits ABSOLUTE asset paths (<script
-	// src="/assets/...">) will have the browser resolve them at the gateway root
-	// (no /expose/<name> prefix) and 404 — for EVERY visibility level, this is not
-	// an auth issue. Such an app must be configured to serve under a base path
-	// matching the expose prefix (e.g. Frigate's base-path config, handled by the
-	// #597 nvr module). Apps that use relative paths work unchanged.
+	// NOTE (subpath): the route is served under /expose/<name>/ with StripPrefix,
+	// so an app that emits ABSOLUTE asset paths (<script src="/assets/...">) would
+	// have the browser resolve them at the gateway root and 404 — for EVERY
+	// visibility level; not an auth issue. wireExposeRoute therefore sends the
+	// external prefix as X-Ingress-Path (the Home Assistant ingress convention),
+	// which makes HA-ingress-aware apps (Frigate among them) rewrite their own
+	// emitted paths to include it. No app-side configuration is required. Apps
+	// that use relative paths work unchanged; an app that is neither
+	// ingress-aware nor relative still needs its own base-path setting.
 	s.wireExposeRoute(ExposeRoutePath(name), address)
 	s.SetExposure(name, policy)
 	return nil
@@ -249,7 +251,10 @@ func (s *Server) wireExposeRoute(prefix, address string) {
 	s.mu.Lock()
 	up, ok := s.config.Upstreams[prefix]
 	if !ok {
-		up = &Upstream{StripPrefix: true, WebSocket: true}
+		// IngressPath = the external prefix. Without it a subpath-mounted app's
+		// absolute asset URLs resolve at the gateway root and 404 (see
+		// Upstream.IngressPath).
+		up = &Upstream{StripPrefix: true, WebSocket: true, IngressPath: prefix}
 		up.setAddr(address)
 		s.config.Upstreams[prefix] = up
 		if s.started {

--- a/internal/gateway/exposure_test.go
+++ b/internal/gateway/exposure_test.go
@@ -332,3 +332,65 @@ func TestRemoveExposure_FailsClosedAfterRevoke(t *testing.T) {
 		t.Errorf("after RemoveExposure: got %d, want 404", w.Code)
 	}
 }
+
+// TestExposeSendsIngressPath pins the subpath fix: an exposed route must tell
+// the upstream which external prefix it is mounted under, via the Home Assistant
+// X-Ingress-Path convention. Without it, an app that emits absolute asset paths
+// (Frigate: src="/assets/main.js") has the browser resolve them at the gateway
+// ROOT, so every asset 404s under /expose/<name>/ — at every visibility level.
+func TestExposeSendsIngressPath(t *testing.T) {
+	var gotHeader, gotPath string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get("X-Ingress-Path")
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	gw := NewServer(Config{Port: 0, NodeName: "test-node"})
+	gw.SetPermissions(&config.Permissions{})
+	if err := gw.Expose("frigate", backendAddr(t, backend), &ExposePolicy{Visibility: VisibilityOrg}); err != nil {
+		t.Fatalf("Expose: %v", err)
+	}
+	gw.SetMeshResolver(&MockMeshResolver{Identity: &MeshPeerIdentity{SameOwner: true}})
+	for prefix, up := range gw.config.Upstreams {
+		gw.registerProxy(prefix, up)
+	}
+
+	// A CLIENT-SUPPLIED value must be overwritten: the header is the gateway's own
+	// statement about how it mounted this route, so it must never be steerable.
+	req := httptest.NewRequest(http.MethodGet, "/expose/frigate/assets/main.js", nil)
+	req.Header.Set("X-Ingress-Path", "/evil")
+	rec := httptest.NewRecorder()
+	gw.BuildHandler().ServeHTTP(rec, req)
+
+	if gotHeader != "/expose/frigate" {
+		t.Errorf("X-Ingress-Path = %q, want /expose/frigate (a client value must not survive)", gotHeader)
+	}
+	if gotPath != "/assets/main.js" {
+		t.Errorf("upstream path = %q, want /assets/main.js (prefix stripped)", gotPath)
+	}
+}
+
+// A route that is NOT subpath-mounted must not forward a client-supplied
+// X-Ingress-Path, or a caller could steer that upstream's generated URLs.
+func TestNonExposeRouteStripsClientIngressPath(t *testing.T) {
+	var got string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("X-Ingress-Path")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	up := &Upstream{Address: backendAddr(t, backend)}
+	gw := NewServer(Config{Port: 0, Upstreams: map[string]*Upstream{"/plain": up}})
+	gw.registerProxy("/plain", up)
+
+	req := httptest.NewRequest(http.MethodGet, "/plain/x", nil)
+	req.Header.Set("X-Ingress-Path", "/evil")
+	gw.mux.ServeHTTP(httptest.NewRecorder(), req)
+
+	if got != "" {
+		t.Errorf("X-Ingress-Path = %q, want it stripped on a non-subpath route", got)
+	}
+}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -100,6 +100,24 @@ type Upstream struct {
 	// WebSocket indicates this upstream handles WebSocket connections.
 	WebSocket bool
 
+	// IngressPath, when non-empty, is sent to the upstream as the X-Ingress-Path
+	// request header: the external prefix this app is served under.
+	//
+	// This is the Home Assistant "ingress" convention, and it is what makes a
+	// subpath-mounted web app work behind StripPrefix. Frigate (and every other
+	// HA-ingress-aware app) emits ABSOLUTE asset paths by default --
+	// `src="/assets/main.js"` -- which a browser resolves at the gateway ROOT,
+	// missing the /expose/<name> prefix entirely, so every asset 404s. Given the
+	// header, such an app rewrites its own emitted paths to
+	// `src="/expose/<name>/assets/main.js"` and the page loads.
+	//
+	// Verified against frigate:stable, whose nginx sub_filter rewrites on
+	// $http_x_ingress_path:
+	//
+	//	without header: src="/assets/main-CosNs8ey.js"
+	//	with header:    src="/expose/frigate/assets/main-CosNs8ey.js"
+	IngressPath string
+
 	// mu guards dynAddr for upstreams whose target is set after registration.
 	mu sync.RWMutex
 	// dynAddr, when non-empty, overrides Address. It is set via
@@ -570,6 +588,15 @@ func (s *Server) registerProxy(prefix string, upstream *Upstream) {
 			}
 			req.Header.Set("X-Forwarded-For", req.RemoteAddr)
 			req.Header.Set("X-Forwarded-Proto", "https")
+			// Set for subpath-mounted upstreams, DELETED otherwise: the value is
+			// a trusted statement about how the gateway mounted this route, so a
+			// client must never be able to supply its own and steer an upstream's
+			// generated URLs.
+			if upstream.IngressPath != "" {
+				req.Header.Set("X-Ingress-Path", upstream.IngressPath)
+			} else {
+				req.Header.Del("X-Ingress-Path")
+			}
 			if s.config.NodeName != "" {
 				req.Header.Set("X-Citadel-Node", s.config.NodeName)
 			}

--- a/internal/status/agent.go
+++ b/internal/status/agent.go
@@ -2,6 +2,7 @@ package status
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"strconv"
 )
@@ -52,6 +53,34 @@ type AgentProviders struct {
 
 	// WorkerRestart restarts the worker run loop in place. Returns a result.
 	WorkerRestart func() (any, error)
+
+	// Expose programs the in-process gateway to serve a local port under
+	// /expose/<name>/ with the given visibility, returning the managed URL (and,
+	// for visibility=link, a signed token). It lives here because the gateway
+	// runs in THIS process: an out-of-process caller (the CLI, the aceteam MCP)
+	// cannot reach it any other way (#598).
+	Expose func(ExposeSpec) (any, error)
+}
+
+// ExposeSpec is the /agent/expose request body. It mirrors the EXPOSE_SET job
+// payload so the CLI and the MCP verb drive the same contract.
+type ExposeSpec struct {
+	// Name is the exposed-service slug (the <name> in /expose/<name>/).
+	Name string `json:"name"`
+	// Port is the service's loopback host port (e.g. 8212 for the nvr module's
+	// Frigate UI).
+	Port int `json:"port"`
+	// Visibility is "private", "org", or "link".
+	Visibility string `json:"visibility"`
+	// TTLSeconds bounds a `link` token's lifetime; ignored for private/org.
+	TTLSeconds int `json:"ttl_seconds"`
+	// Creator is the tailnet login authorized for a `private` exposure. Only a
+	// remote caller (the backend/MCP) knows this; a local CLI leaves it empty,
+	// which makes a private exposure fail closed at the gateway.
+	Creator string `json:"creator"`
+	// Epoch, when >0, is bound into a `link` token so all outstanding tokens can
+	// be revoked by bumping it.
+	Epoch int `json:"epoch"`
 }
 
 // LogQuery describes a log tail/grep request.
@@ -116,6 +145,33 @@ func (s *Server) registerAgentRoutes(mux *http.ServeMux) {
 		}
 		return p.WorkerRestart()
 	})))
+	mux.HandleFunc("/agent/expose", s.requireVPNOrAuth(s.handleAgentExpose))
+}
+
+// handleAgentExpose programs an exposure on the in-process gateway. POST only,
+// with an ExposeSpec body. Same auth posture as the other control endpoints
+// (VPN origin or a valid org token), so a local operator drives it via the
+// node's own mesh IP and the backend drives it over the mesh.
+func (s *Server) handleAgentExpose(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.agent == nil || s.agent.Expose == nil {
+		writeAgentError(w, errUnavailable)
+		return
+	}
+	var spec ExposeSpec
+	if err := json.NewDecoder(io.LimitReader(r.Body, 64*1024)).Decode(&spec); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body: " + err.Error()})
+		return
+	}
+	res, err := s.agent.Expose(spec)
+	if err != nil {
+		writeAgentError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, res)
 }
 
 // errUnavailable is returned by providers that are not wired in this process.


### PR DESCRIPTION
Refs #598. Takes gateway ingress from *shipped but unreachable* to **working end-to-end**, verified on node 1314 with the nvr module's Frigate UI.

Two commits, each fixing one thing that blocked it.

## 1. Exposed subpath apps could never load their assets
Exposed routes are served under `/expose/<name>/` with StripPrefix, so an app emitting **absolute** asset paths has the browser resolve them at the gateway **root** — every asset 404s, at every visibility level. Frigate does exactly this (`src="/assets/main-CosNs8ey.js"`).

`Expose()`'s comment claimed apps "must be configured to serve under a base path … handled by the #597 nvr module". **Not true** — nvr sets no base path, and Frigate needs none. Frigate (like every Home Assistant *ingress*-aware app) rewrites its own paths from the **`X-Ingress-Path`** header, which the **proxy** supplies.

`Upstream.IngressPath` is now set for every `/expose/<name>` route; the Director **sets** the header when configured and **deletes** it otherwise, so a client can never supply one and steer an upstream's generated URLs.

## 2. Nothing could program an exposure
`EXPOSE_SET`, the handler, and `liveExposeOps` all shipped — but `citadel expose` is the older *discovery* command and the MCP verb is an unbuilt cross-repo follow-up. The gateway runs inside `citadel work`, so a separate CLI process cannot reach it.

- **`/agent/expose`** on the agent control surface (same process as the gateway), reusing the existing auth posture — VPN origin or a valid org token, **not widened**. It delegates to the *same* `liveExposeOps` the job path uses, so the two cannot drift.
- **`citadel service expose <name> --port --visibility [--ttl]`**, POSTing over the node's own mesh IP.
- **`gatewayFacts` records the mesh IP** — `meshIPv4()` only answers inside the process running the network stack, so out-of-process callers previously had no way to address their own node.
- `--visibility private` is **rejected from the CLI with an explanation** rather than silently creating an unreachable exposure (private needs a remote creator identity only the backend can supply).

## Verification (live, node 1314)
```
$ citadel service expose frigate --port 8212 --visibility org
✅ Exposed "frigate" -> 127.0.0.1:8212
   URL:    https://100.64.0.97:8443/expose/frigate
   Access: org
```
| From | Result |
|---|---|
| org peer | `/api/version` -> **200** (0.17.2) |
| org peer | HTML rewritten to `/expose/frigate/assets/main-*.js`, asset -> **200** |
| non-peer | **403** (fails closed) |

Plus `go build`/`vet`/`gofmt` clean, **full `go test ./...` passes**, and unit tests `TestExposeSendsIngressPath` (incl. rejecting a client-supplied `X-Ingress-Path: /evil`) and `TestNonExposeRouteStripsClientIngressPath`.

## Follow-up
The aceteam MCP `expose` verb remains the next step for remote/console use and for `private` (it can supply the creator identity). It should reuse this same contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)