### PR TITLE
fix(catalog): node-generated module secrets — unbreak nvr assignment/update (#637)

### DIFF
--- a/cmd/module_ops.go
+++ b/cmd/module_ops.go
@@ -151,16 +151,25 @@ func (o *liveModuleOps) Install(ctx context.Context, m reconcile.ModuleAssignmen
 	// Residual (interim, acceptable): if this Uninstall succeeds but the
 	// InstallFromManifest below then fails, the module is left down until the
 	// job retries and reinstalls it.
+	// Node-generated secrets must survive the teardown below: Uninstall deletes
+	// <name>.env, so without carrying them forward here the re-install would mint
+	// a NEW value on every re-assignment -- and compose would then recreate only
+	// the container whose env changed, leaving its consumer running with the old
+	// credential in memory. Read BEFORE the uninstall; anything the assignment
+	// supplies still wins, so an explicit rotation is still possible.
+	installConfig := m.Config
 	if hasService(nodeManifest, manifest.Name) {
+		installConfig = catalog.CarryGeneratedConfig(manifest, servicesDir, m.Config)
 		o.log("MODULE_SET: %q already installed; updating in place", manifest.Name)
 		if err := o.Uninstall(ctx, manifest.Name); err != nil {
 			return fmt.Errorf("update %q: uninstall existing: %w", manifest.Name, err)
 		}
 	}
 
-	// Non-interactive install: m.Config supplies the overrides; a missing REQUIRED
-	// config var is a returned error (never a stdin prompt on a headless node).
-	result, err := catalog.InstallFromManifest(manifest, composeSrc, servicesDir, m.Config, false, allowPrivileged, untrusted, false)
+	// Non-interactive install: installConfig supplies the overrides; a missing
+	// REQUIRED config var is a returned error (never a stdin prompt on a headless
+	// node).
+	result, err := catalog.InstallFromManifest(manifest, composeSrc, servicesDir, installConfig, false, allowPrivileged, untrusted, false)
 	if err != nil {
 		return fmt.Errorf("install %q: %w", manifest.Name, err)
 	}

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -236,7 +236,27 @@ type ConfigVar struct {
 	Description string `yaml:"description"`
 	Default     string `yaml:"default"`
 	Required    bool   `yaml:"required"`
+	// Generate names a value the NODE mints for itself when the operator supplies
+	// none, instead of failing or prompting. The only kind is "secret": a random
+	// 256-bit URL-safe token.
+	//
+	// This exists for credentials that exist purely BETWEEN a module's own
+	// containers -- a broker password, an internal API key -- which nobody
+	// outside the node ever needs to know or type. Without it such a var has no
+	// good option: `required: true` hard-fails the non-interactive assignment and
+	// update paths (a fabric MODULE_SET carries no value for it), while a static
+	// `default:` would ship the same well-known credential to every node.
+	//
+	// A generated value is STICKY: install reuses whatever is already in the
+	// module's .env, so reconciles and updates do not rotate a secret out from
+	// under a running container. Combine with `required: true` -- generation
+	// satisfies the requirement, and the requirement keeps a mis-typed
+	// `generate:` from silently yielding an empty credential.
+	Generate string `yaml:"generate"`
 }
+
+// GenerateSecret is the ConfigVar.Generate kind that mints a random token.
+const GenerateSecret = "secret"
 
 // HealthCheck describes how to probe the service for readiness.
 type HealthCheck struct {

--- a/internal/catalog/generate_test.go
+++ b/internal/catalog/generate_test.go
@@ -1,0 +1,149 @@
+package catalog
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A `generate:` var must satisfy `required:` without an override, an operator
+// prompt, or a shared default. This is the whole point: a fabric MODULE_SET
+// assignment and `citadel module update` both resolve config NON-INTERACTIVELY
+// with no value for such a var, and before generation existed that was a hard
+// "required config X has no value" failure -- i.e. the module became
+// undeployable the moment it declared an internal credential.
+func TestGeneratedSecretSatisfiesRequiredNonInteractively(t *testing.T) {
+	vars := []ConfigVar{{Name: "BROKER_PASSWORD", Required: true, Generate: GenerateSecret}}
+
+	got, err := resolveConfig(vars, nil, nil, false)
+	if err != nil {
+		t.Fatalf("resolveConfig: %v", err)
+	}
+	if got["BROKER_PASSWORD"] == "" {
+		t.Fatal("BROKER_PASSWORD is empty; a generated var must never yield a blank credential")
+	}
+	// Shell/compose safety: the value is interpolated into compose env and a
+	// quoted entrypoint, so it must carry no separator or metacharacter.
+	if strings.ContainsAny(got["BROKER_PASSWORD"], "=\"'$` \t\n") {
+		t.Errorf("generated secret %q contains a character unsafe for compose/shell interpolation", got["BROKER_PASSWORD"])
+	}
+	if len(got["BROKER_PASSWORD"]) < 32 {
+		t.Errorf("generated secret is only %d chars; want a high-entropy value", len(got["BROKER_PASSWORD"]))
+	}
+}
+
+// Two independent nodes must not end up with the same credential -- the failure
+// mode a static `default:` would have.
+func TestGeneratedSecretDiffersPerInstall(t *testing.T) {
+	vars := []ConfigVar{{Name: "S", Generate: GenerateSecret}}
+
+	a, err := resolveConfig(vars, nil, nil, false)
+	if err != nil {
+		t.Fatalf("resolveConfig: %v", err)
+	}
+	b, err := resolveConfig(vars, nil, nil, false)
+	if err != nil {
+		t.Fatalf("resolveConfig: %v", err)
+	}
+	if a["S"] == b["S"] {
+		t.Error("two installs produced the same secret; every node must mint its own")
+	}
+}
+
+// Stickiness. A reconcile or `citadel module update` re-runs install; if that
+// re-minted the secret, the .env would disagree with the credential the running
+// broker container was started with, and Frigate would silently fail to connect
+// until the whole stack was recreated.
+func TestGeneratedSecretIsReusedFromExistingEnv(t *testing.T) {
+	vars := []ConfigVar{{Name: "S", Required: true, Generate: GenerateSecret}}
+
+	first, err := resolveConfig(vars, nil, nil, false)
+	if err != nil {
+		t.Fatalf("resolveConfig: %v", err)
+	}
+	second, err := resolveConfig(vars, nil, first, false)
+	if err != nil {
+		t.Fatalf("resolveConfig: %v", err)
+	}
+	if second["S"] != first["S"] {
+		t.Errorf("secret rotated across installs: %q -> %q", first["S"], second["S"])
+	}
+}
+
+// An explicit value still wins over both generation and any persisted value --
+// that is how an operator points the module at an external broker.
+func TestOverrideBeatsGenerateAndExisting(t *testing.T) {
+	vars := []ConfigVar{{Name: "S", Generate: GenerateSecret}}
+
+	got, err := resolveConfig(vars,
+		map[string]string{"S": "operator-supplied"},
+		map[string]string{"S": "previously-generated"},
+		false)
+	if err != nil {
+		t.Fatalf("resolveConfig: %v", err)
+	}
+	if got["S"] != "operator-supplied" {
+		t.Errorf("S = %q, want the operator override to win", got["S"])
+	}
+}
+
+// A typo'd kind must fail loudly. Silently returning "" would hand the module an
+// empty password and, for a broker, that is an unauthenticated listener.
+func TestUnknownGenerateKindIsAnError(t *testing.T) {
+	vars := []ConfigVar{{Name: "S", Generate: "sekret"}}
+
+	if _, err := resolveConfig(vars, nil, nil, false); err == nil {
+		t.Fatal("resolveConfig accepted an unknown generate kind; want an error")
+	}
+}
+
+// Round-trip through the real .env file, since stickiness depends on install
+// being able to READ BACK what writeEnvFile produced.
+func TestEnvFileRoundTripPreservesGeneratedSecret(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nvr.env")
+
+	vars := []ConfigVar{{Name: "S", Required: true, Generate: GenerateSecret}}
+	first, err := resolveConfig(vars, nil, readEnvFile(path), false)
+	if err != nil {
+		t.Fatalf("resolveConfig: %v", err)
+	}
+	if err := writeEnvFile(path, first); err != nil {
+		t.Fatalf("writeEnvFile: %v", err)
+	}
+
+	second, err := resolveConfig(vars, nil, readEnvFile(path), false)
+	if err != nil {
+		t.Fatalf("resolveConfig: %v", err)
+	}
+	if second["S"] != first["S"] {
+		t.Errorf("secret did not survive the .env round trip: %q -> %q", first["S"], second["S"])
+	}
+}
+
+// readEnvFile must not choke on the shapes a real .env grows: comments, blanks,
+// and values that legitimately contain '=' (base64 padding, query strings).
+func TestReadEnvFileTolerance(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x.env")
+	if err := os.WriteFile(path, []byte("# a comment\n\nA=1\nB=v=with=equals\nnot-a-pair\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := readEnvFile(path)
+	if got["A"] != "1" {
+		t.Errorf("A = %q, want 1", got["A"])
+	}
+	if got["B"] != "v=with=equals" {
+		t.Errorf("B = %q, want the full value after the FIRST = only", got["B"])
+	}
+	if len(got) != 2 {
+		t.Errorf("parsed %d entries (%v), want 2", len(got), got)
+	}
+
+	// A missing file is "nothing persisted yet", not a failure.
+	if len(readEnvFile(filepath.Join(dir, "absent.env"))) != 0 {
+		t.Error("a missing .env must parse as empty, not error")
+	}
+}

--- a/internal/catalog/generate_test.go
+++ b/internal/catalog/generate_test.go
@@ -122,6 +122,80 @@ func TestEnvFileRoundTripPreservesGeneratedSecret(t *testing.T) {
 	}
 }
 
+// The fabric MODULE_SET update-in-place path UNINSTALLS before it installs, and
+// uninstall deletes <name>.env. Stickiness therefore cannot rely on install
+// reading the file itself on that path -- the value must be carried across the
+// teardown, or every re-assignment mints a new secret.
+func TestCarryGeneratedConfigSurvivesTeardown(t *testing.T) {
+	dir := t.TempDir()
+	m := &ServiceManifest{
+		Name: "nvr",
+		Config: []ConfigVar{
+			{Name: "NVR_MQTT_PASSWORD", Required: true, Generate: GenerateSecret},
+			{Name: "NVR_CAMERAS", Required: true},
+		},
+	}
+	path := filepath.Join(dir, "nvr.env")
+	if err := writeEnvFile(path, map[string]string{
+		"NVR_MQTT_PASSWORD": "already-minted",
+		"NVR_CAMERAS":       "lab,garage",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The assignment carries the operator's config but has no value for the
+	// generated var -- that is the whole point of generating it.
+	assigned := map[string]string{"NVR_CAMERAS": "lab,garage,driveway"}
+	got := CarryGeneratedConfig(m, dir, assigned)
+
+	if got["NVR_MQTT_PASSWORD"] != "already-minted" {
+		t.Errorf("NVR_MQTT_PASSWORD = %q, want the persisted value carried across the teardown", got["NVR_MQTT_PASSWORD"])
+	}
+	// A non-generated var must NOT be resurrected from the old .env: the
+	// assignment is authoritative for those, and reviving a stale camera list
+	// would silently undo a config change.
+	if got["NVR_CAMERAS"] != "lab,garage,driveway" {
+		t.Errorf("NVR_CAMERAS = %q, want the assignment's value, not the persisted one", got["NVR_CAMERAS"])
+	}
+	// The caller's map must not be mutated -- it is also what gets recorded in
+	// the lockfile for drift detection.
+	if _, leaked := assigned["NVR_MQTT_PASSWORD"]; leaked {
+		t.Error("CarryGeneratedConfig mutated the caller's config map; the lockfile would then record a secret and see drift forever")
+	}
+}
+
+// An explicitly assigned value must beat the persisted one -- that is how a
+// credential gets rotated on purpose.
+func TestCarryGeneratedConfigYieldsToExplicitAssignment(t *testing.T) {
+	dir := t.TempDir()
+	m := &ServiceManifest{
+		Name:   "nvr",
+		Config: []ConfigVar{{Name: "S", Generate: GenerateSecret}},
+	}
+	if err := writeEnvFile(filepath.Join(dir, "nvr.env"), map[string]string{"S": "old"}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := CarryGeneratedConfig(m, dir, map[string]string{"S": "rotated"})
+	if got["S"] != "rotated" {
+		t.Errorf("S = %q, want the explicit assignment to win", got["S"])
+	}
+}
+
+// A first install has no .env; carrying must be a clean no-op.
+func TestCarryGeneratedConfigOnFirstInstall(t *testing.T) {
+	m := &ServiceManifest{Name: "nvr", Config: []ConfigVar{{Name: "S", Generate: GenerateSecret}}}
+	assigned := map[string]string{"NVR_CAMERAS": "lab"}
+
+	got := CarryGeneratedConfig(m, t.TempDir(), assigned)
+	if _, ok := got["S"]; ok {
+		t.Error("carried a value for S with no .env present; install must mint it instead")
+	}
+	if got["NVR_CAMERAS"] != "lab" {
+		t.Errorf("assignment config was dropped: %v", got)
+	}
+}
+
 // readEnvFile must not choke on the shapes a real .env grows: comments, blanks,
 // and values that legitimately contain '=' (base64 padding, query strings).
 func TestReadEnvFileTolerance(t *testing.T) {

--- a/internal/catalog/install.go
+++ b/internal/catalog/install.go
@@ -2,6 +2,8 @@ package catalog
 
 import (
 	"bufio"
+	"crypto/rand"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"os"
@@ -203,8 +205,12 @@ func InstallFromManifest(manifest *ServiceManifest, composeSrcPath, servicesDir 
 	}
 
 	// 5. Resolve config values (prompt for required ones without defaults only
-	//    when interactive).
-	configValues, err := resolveConfig(manifest.Config, configOverrides, interactive)
+	//    when interactive). Any already-persisted values are passed in so a
+	//    `generate:` secret is minted ONCE and then reused: reconciles, module
+	//    updates and re-runs must not rotate a credential the module's running
+	//    containers were started with.
+	envDest := filepath.Join(servicesDir, name+".env")
+	configValues, err := resolveConfig(manifest.Config, configOverrides, readEnvFile(envDest), interactive)
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +269,6 @@ func InstallFromManifest(manifest *ServiceManifest, composeSrcPath, servicesDir 
 
 	// 7. Write .env file if there are config values.
 	if len(configValues) > 0 {
-		envDest := filepath.Join(servicesDir, name+".env")
 		if err := writeEnvFile(envDest, configValues); err != nil {
 			return nil, fmt.Errorf("failed to write env file: %w", err)
 		}
@@ -277,12 +282,33 @@ func InstallFromManifest(manifest *ServiceManifest, composeSrcPath, servicesDir 
 // prompts the user (os.Stdin) for any required config vars that have no default
 // and no override. When interactive is false, such a var is a returned error and
 // stdin is never read (the TUI path collects all config up front as overrides).
-func resolveConfig(configVars []ConfigVar, overrides map[string]string, interactive bool) (map[string]string, error) {
+//
+// existing holds the values already persisted in the module's .env (nil on a
+// first install). It is consulted ONLY for `generate:` vars, so that a minted
+// secret survives reconciles/updates; every other var still resolves purely from
+// the override/default/prompt chain, keeping the operator's input authoritative.
+func resolveConfig(configVars []ConfigVar, overrides, existing map[string]string, interactive bool) (map[string]string, error) {
 	values := make(map[string]string)
 
 	for _, cv := range configVars {
 		// Check override first.
 		if v, ok := overrides[cv.Name]; ok {
+			values[cv.Name] = v
+			continue
+		}
+
+		// A generated var mints its own value rather than failing or prompting --
+		// but only after reusing what a previous install already persisted, so the
+		// credential a running container holds is never rotated underneath it.
+		if cv.Generate != "" {
+			if v := existing[cv.Name]; v != "" {
+				values[cv.Name] = v
+				continue
+			}
+			v, err := generateConfigValue(cv.Generate)
+			if err != nil {
+				return nil, fmt.Errorf("config '%s': %w", cv.Name, err)
+			}
 			values[cv.Name] = v
 			continue
 		}
@@ -321,6 +347,49 @@ func resolveConfig(configVars []ConfigVar, overrides map[string]string, interact
 	}
 
 	return values, nil
+}
+
+// generateConfigValue mints a value for a ConfigVar declaring `generate:`.
+// An unknown kind is an error, not a silent empty string: a typo in a manifest
+// must not hand a module a blank credential.
+func generateConfigValue(kind string) (string, error) {
+	switch kind {
+	case GenerateSecret:
+		buf := make([]byte, 32)
+		if _, err := rand.Read(buf); err != nil {
+			return "", fmt.Errorf("generate secret: %w", err)
+		}
+		// URL-safe, unpadded: the value is interpolated into compose env and
+		// shell-quoted entrypoints, so it must contain no '=', quote or shell
+		// metacharacter.
+		return base64.RawURLEncoding.EncodeToString(buf), nil
+	default:
+		return "", fmt.Errorf("unknown generate kind %q (only %q is supported)", kind, GenerateSecret)
+	}
+}
+
+// readEnvFile parses a previously written module .env into a map. A missing or
+// unreadable file yields an empty map -- callers use it to REUSE prior values,
+// so "nothing persisted yet" and "cannot read it" both correctly mean "mint a
+// fresh one" rather than failing the install.
+func readEnvFile(path string) map[string]string {
+	values := make(map[string]string)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return values
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		values[strings.TrimSpace(k)] = v
+	}
+	return values
 }
 
 // copyFile copies src to dst, preserving content but using 0600 permissions.

--- a/internal/catalog/install.go
+++ b/internal/catalog/install.go
@@ -349,6 +349,46 @@ func resolveConfig(configVars []ConfigVar, overrides, existing map[string]string
 	return values, nil
 }
 
+// CarryGeneratedConfig returns assigned augmented with any `generate:` values
+// already persisted in the module's .env, for callers that TEAR DOWN a module
+// before re-installing it.
+//
+// The fabric MODULE_SET update-in-place path uninstalls before it installs, and
+// uninstall deletes <name>.env -- so by the time InstallFromManifest reads the
+// persisted values they are gone, and the node would mint a NEW secret on every
+// re-assignment. That is not merely churn: compose recreates only the containers
+// whose env changed (the broker), leaving the consumer running with the OLD
+// credential in memory until someone restarts it by hand.
+//
+// Call this BEFORE the teardown. Values the caller already supplies win, so an
+// operator can still rotate a credential by assigning one explicitly.
+func CarryGeneratedConfig(manifest *ServiceManifest, servicesDir string, assigned map[string]string) map[string]string {
+	if manifest == nil {
+		return assigned
+	}
+	persisted := readEnvFile(filepath.Join(servicesDir, manifest.Name+".env"))
+	if len(persisted) == 0 {
+		return assigned
+	}
+
+	merged := make(map[string]string, len(assigned)+len(manifest.Config))
+	for k, v := range assigned {
+		merged[k] = v
+	}
+	for _, cv := range manifest.Config {
+		if cv.Generate == "" {
+			continue
+		}
+		if _, ok := merged[cv.Name]; ok {
+			continue
+		}
+		if v := persisted[cv.Name]; v != "" {
+			merged[cv.Name] = v
+		}
+	}
+	return merged
+}
+
 // generateConfigValue mints a value for a ConfigVar declaring `generate:`.
 // An unknown kind is an error, not a silent empty string: a typo in a manifest
 // must not hand a module a blank credential.

--- a/services/nvr-service/service.yaml
+++ b/services/nvr-service/service.yaml
@@ -106,11 +106,17 @@ config:
     default: frigate
   - name: NVR_MQTT_PASSWORD
     description: >-
-      Password for the node-local MQTT broker (SECRET; never logged). REQUIRED:
-      mosquitto permits anonymous connections by default, and wyze-bridge runs
-      host-networked in this module, so an unauthenticated broker must never be
-      started.
+      Password for the node-local MQTT broker (SECRET; never logged). GENERATED
+      per node: this credential is used only BETWEEN this module's own containers
+      (frigate -> mosquitto, both on the module's private compose network), so no
+      operator ever needs to know or type it, and a shared default would ship the
+      same password to every node. Required as well as generated, so the compose
+      `:?` guard still fails closed -- mosquitto permits anonymous connections by
+      default and wyze-bridge runs host-networked here, so an unauthenticated
+      broker must never start. Set explicitly only to point Frigate at an
+      external broker.
     required: true
+    generate: secret
   - name: NVR_CAMERAS
     description: >-
       Comma-separated camera stream names (e.g. "front-door,garage=garage-cam";

--- a/services/nvr_manifest_test.go
+++ b/services/nvr_manifest_test.go
@@ -271,6 +271,42 @@ func TestNVRMosquittoRequiresCredentials(t *testing.T) {
 	}
 }
 
+// TestNVRMqttPasswordIsNodeGenerated pins that the broker credential the module
+// requires is one the NODE mints for itself. It is purely internal (frigate ->
+// mosquitto on the module's private network), so nothing upstream has a value to
+// send: a fabric MODULE_SET assignment and `citadel module update` both resolve
+// config non-interactively, and a required-but-ungenerated var makes BOTH paths
+// hard-fail — the module becomes undeployable. A static default is equally wrong
+// (same password on every node), which is why this asserts `generate:` and not
+// merely "has some value".
+func TestNVRMqttPasswordIsNodeGenerated(t *testing.T) {
+	var m catalog.ServiceManifest
+	if err := yaml.Unmarshal(nvrServiceYAML, &m); err != nil {
+		t.Fatalf("parse nvr service.yaml: %v", err)
+	}
+
+	var found bool
+	for _, cv := range m.Config {
+		if cv.Name != "NVR_MQTT_PASSWORD" {
+			continue
+		}
+		found = true
+		if cv.Generate != catalog.GenerateSecret {
+			t.Errorf("NVR_MQTT_PASSWORD generate = %q, want %q — otherwise assignment and update fail with "+
+				"'required config has no value'", cv.Generate, catalog.GenerateSecret)
+		}
+		if !cv.Required {
+			t.Error("NVR_MQTT_PASSWORD must stay required so the compose `:?` guard keeps failing closed")
+		}
+		if cv.Default != "" {
+			t.Errorf("NVR_MQTT_PASSWORD must have no default (%q) — a shared default ships one password to every node", cv.Default)
+		}
+	}
+	if !found {
+		t.Fatal("NVR_MQTT_PASSWORD missing from the nvr manifest config")
+	}
+}
+
 // readNVRCompose returns the nvr module compose file body.
 func readNVRCompose(t *testing.T) string {
 	t.Helper()


### PR DESCRIPTION
## Context

#639 gave the nvr module a node-local MQTT broker and made `NVR_MQTT_PASSWORD`
a required config var so mosquitto could never start anonymously. The compose
`:?` guard was right; making the operator the only possible SOURCE of the value
was not.

Nothing produces that value. Grep on main finds only consumers
(`cmd/nvrconfig`, the compose) and the test that asserts the `:?`. So
`cmd/module_ops.go:163` — the fabric MODULE_SET assignment path — resolves
config with `interactive=false` and the assignment's own config map, which has
no `NVR_MQTT_PASSWORD`, and fails with `required config 'NVR_MQTT_PASSWORD'
has no value`. **Assigning nvr to any node now fails.**

Confirmed on node 1314, which is recording 3 cameras today: its
`~/citadel-node/services/nvr.env` has 9 keys and no `NVR_MQTT_PASSWORD`, so the
merged module cannot be redeployed there at all.

## Root cause

`ConfigVar` offers exactly three ways to get a value: an override, a static
`default:`, or an interactive prompt. A credential used only BETWEEN a module's
own containers fits none of them — no operator has a value to type, no upstream
has one to send, and a `default:` would ship one shared password to every node
in the fleet.

## Changes

- `internal/catalog/catalog.go`: `ConfigVar.Generate` (`generate: secret`) — the
  node mints a random 256-bit URL-safe token for itself. URL-safe and unpadded
  so the value carries no `=`, quote, or shell metacharacter into compose env
  and quoted entrypoints.
- `internal/catalog/install.go`: generation slots between the override and
  default checks, so an explicit value still wins (that is how you point the
  module at an external broker). Generated values are **sticky**: install reads
  the module's existing `.env` first and reuses what is there. An unknown
  `generate:` kind is a loud error — silently returning `""` would hand a broker
  an empty password.
- `internal/catalog/install.go` + `cmd/module_ops.go`: `CarryGeneratedConfig`.
  The assignment path updates in place by uninstalling first, and uninstall
  deletes `<name>.env` — so read-back alone is not enough there and the secret
  would rotate on every re-assignment. The persisted value is now carried across
  the teardown. See "why rotation is not benign" below.
- `services/nvr-service/service.yaml`: `NVR_MQTT_PASSWORD` gains
  `generate: secret`, keeping `required: true` so the compose `:?` still fails
  closed.

Generic, not nvr-specific: any module with an internal credential can use it.

## Why rotation is not benign

Compose recreates only the containers whose env changed. `NVR_MQTT_PASSWORD` is
env for `mosquitto` and `nvr-config`, but **not** for `frigate` — Frigate reads
the regenerated `config.yml`. So a rotation recreates the broker and leaves
Frigate running with the old credential in memory; it goes quiet until it is
restarted explicitly. Observed for real on node 1314 while rotating by hand.
Sticky reuse is what keeps ordinary reconciles from tripping this.

## Scope — what this does NOT fix

`cmd/module_update.go:169` (`citadel module update`) passes `nil` overrides
non-interactively, and `existing` is consulted only for `generate:` vars. So
`WYZE_EMAIL` / `WYZE_PASSWORD` / `API_ID` / `API_KEY` / `NVR_CAMERAS` — required,
no default, no generate — still fail there. `citadel module update nvr` remains
broken. That is pre-existing (it predates #639) and out of scope here.

Nothing in this chain is released: `v2.96.0` predates #638, #639, #644 and this
PR. A release is needed before any node other than 1314 (running a dev build)
can deploy nvr.

## Testing

`go test ./internal/catalog/ ./services/ ./cmd/` — new coverage for:
required-is-satisfied non-interactively (the exact regression), per-node
uniqueness, stickiness across installs, stickiness through a real `.env` round
trip, carry-across-teardown (including that non-generated vars are NOT revived
from a stale `.env`, and that the caller's config map is not mutated — it is
what the lockfile records for drift detection), override precedence,
unknown-kind error, and `.env` parse tolerance.

Pre-existing macOS-local failures in `internal/jobs` / semantic search are
unrelated and reproduce on a clean `main` worktree.

Deploy verification on node 1314 in a PR comment below.