### PR TITLE
fix(gateway): persist exposures so they survive a worker restart (#647)

### DIFF
--- a/cmd/expose_ops.go
+++ b/cmd/expose_ops.go
@@ -12,6 +12,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"net"
 	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/config"
@@ -49,6 +50,22 @@ func (liveExposeOps) Expose(_ context.Context, req worker.ExposeRequest) (*worke
 		return nil, err
 	}
 
+	// Persist so the exposure survives a worker restart (#647). Every caller --
+	// the CLI, the MCP verb, the EXPOSE_SET job -- funnels through here, so this
+	// is the one place the durable set can be kept in step with the live one. A
+	// write failure is logged, not returned: the exposure IS live and the caller
+	// already has its URL, so failing the call would be a lie; the honest failure
+	// mode is "works now, gone after a restart", and it must be visible.
+	if err := config.SaveExposure(platform.ConfigDir(), config.ExposureRecord{
+		Name:       req.Name,
+		Port:       req.Port,
+		Visibility: req.Visibility,
+		Creator:    req.Creator,
+		TokenEpoch: req.Epoch,
+	}); err != nil {
+		Log("warning: exposure %q is live but was not persisted (it will not survive a restart): %v", req.Name, err)
+	}
+
 	res := &worker.ExposeResult{URL: exposeMeshURL(req.Name)}
 
 	if policy.Visibility == gateway.VisibilityLink {
@@ -65,6 +82,63 @@ func (liveExposeOps) Expose(_ context.Context, req worker.ExposeRequest) (*worke
 		res.ExpiresAt = exp.UTC().Format(time.RFC3339)
 	}
 	return res, nil
+}
+
+// restoreExposures re-wires the persisted exposure set onto a gateway that has
+// not started serving yet (#647). It MUST be called before Start: restoring
+// after the listener is up leaves a window in which a valid exposure 404s, which
+// is exactly the symptom this fixes.
+//
+// Every failure here is non-fatal and logged. A node whose exposure store is
+// unreadable must still come up serving its builtin routes; refusing to start
+// would turn a lost side-feature into an outage.
+func restoreExposures(gw *gateway.Server) {
+	recs, err := config.LoadExposures(platform.ConfigDir())
+	if err != nil {
+		Log("warning: could not restore gateway exposures: %v", err)
+		return
+	}
+	if len(recs) == 0 {
+		return
+	}
+
+	restored := 0
+	for _, r := range recs {
+		policy := &gateway.ExposePolicy{
+			Visibility: gateway.Visibility(r.Visibility),
+			Creator:    r.Creator,
+			TokenEpoch: r.TokenEpoch,
+		}
+		addr := fmt.Sprintf("127.0.0.1:%d", r.Port)
+		if err := gw.Expose(r.Name, addr, policy); err != nil {
+			// A record the gateway rejects (unknown visibility, bad name) is data
+			// we cannot honor -- skip it loudly rather than dropping the whole set.
+			Log("warning: skipping persisted exposure %q: %v", r.Name, err)
+			continue
+		}
+		// The upstream may be gone after a reboot (module removed, port changed).
+		// Say so now: otherwise the route restores fine and every request 502s
+		// with nothing explaining why.
+		if !localPortListening(r.Port) {
+			Log("warning: exposure %q restored but nothing is listening on 127.0.0.1:%d yet", r.Name, r.Port)
+		}
+		restored++
+	}
+	if restored > 0 {
+		Log("Restored %d gateway exposure(s)", restored)
+	}
+}
+
+// localPortListening reports whether something accepts TCP on the loopback port.
+// Short timeout: this runs once per exposure on the startup path, and a slow or
+// filtered probe must never delay the gateway coming up.
+func localPortListening(port int) bool {
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 300*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
 }
 
 // exposeMeshURL builds the mesh URL an exposed service is reachable at:

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -212,6 +212,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 	} else {
 		gw.SetExposeSigningKey(key)
 	}
+	// Re-wire exposures persisted by a previous run BEFORE the gateway serves,
+	// so there is no window in which a valid exposure 404s (#647).
+	restoreExposures(gw)
 
 	// Register upstreams — status server endpoints
 	// These route to the status server started by 'citadel work --status-port'

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1897,6 +1897,9 @@ func runWork(cmd *cobra.Command, args []string) {
 		} else {
 			gw.SetExposeSigningKey(key)
 		}
+		// Re-wire exposures persisted by a previous run BEFORE the gateway serves,
+		// so there is no window in which a valid exposure 404s (#647).
+		restoreExposures(gw)
 
 		// Register upstreams (same routes as cmd/serve.go)
 		gw.AddUpstream("/health", &gateway.Upstream{Address: statusAddr})

--- a/internal/config/exposures.go
+++ b/internal/config/exposures.go
@@ -1,0 +1,146 @@
+// internal/config/exposures.go
+//
+// Durable record of this node's gateway exposures (issue #647).
+//
+// The gateway's exposure table lives in the running `citadel work` process, so
+// before this every exposure vanished on restart — and a worker restart is
+// routine: auto-update, WORKER_SELF_HEAL (#548), `systemctl restart`, reboot. A
+// link shared from the iOS app or the MCP `expose` verb would therefore start
+// 404ing at an arbitrary later time, with no error anywhere and nothing off-node
+// aware the route was dropped.
+//
+// The tell that this was an oversight rather than a decision: the link-token
+// SIGNING KEY was already made durable (expose_key.go) so a token minted
+// yesterday still verifies today — but the routes those tokens authorize were
+// not, so the token outlived the thing it opened.
+//
+// Records are stored next to that key, 0600, and re-wired at gateway start.
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// exposuresFile is the filename (under the config dir) holding the exposure set.
+const exposuresFile = "exposures.json"
+
+// ExposureRecord is one persisted exposure: enough to rebuild both the
+// reverse-proxy route and its visibility policy verbatim after a restart.
+//
+// Deliberately NOT stored: the link TOKEN. Tokens are derived on demand from the
+// signing key and carry their own expiry, so persisting one would create a
+// credential with a longer life than the thing that minted it.
+type ExposureRecord struct {
+	// Name is the exposed-service slug (the <name> in /expose/<name>/).
+	Name string `json:"name"`
+	// Port is the loopback host port the route proxies to.
+	Port int `json:"port"`
+	// Visibility is "private", "org", or "link".
+	Visibility string `json:"visibility"`
+	// Creator is the tailnet login authorized for a `private` exposure. Empty
+	// makes a private exposure inert (fails closed), which is the correct
+	// restore behavior too: a private exposure whose creator was never recorded
+	// must not come back open.
+	Creator string `json:"creator,omitempty"`
+	// TokenEpoch is bound into every `link` token this exposure mints. It MUST
+	// survive a restart: if it reset to 0, tokens minted under the old epoch
+	// would stop verifying (breaking live links), and a later bump could not
+	// revoke anything it had already handed out.
+	TokenEpoch int `json:"token_epoch,omitempty"`
+}
+
+// LoadExposures returns the persisted exposure set, or an empty slice when
+// nothing has been exposed yet. A missing file is NOT an error (the common case
+// on a node that has never exposed anything); a corrupt one IS, so the caller
+// can say so loudly rather than silently starting with no routes.
+func LoadExposures(configDir string) ([]ExposureRecord, error) {
+	data, err := os.ReadFile(filepath.Join(configDir, exposuresFile))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read exposures: %w", err)
+	}
+	var recs []ExposureRecord
+	if err := json.Unmarshal(data, &recs); err != nil {
+		return nil, fmt.Errorf("parse exposures: %w", err)
+	}
+	return recs, nil
+}
+
+// SaveExposure records (or replaces, by name) one exposure. It is called on the
+// same path that programs the gateway, so the durable set and the live set are
+// written together and cannot diverge.
+func SaveExposure(configDir string, rec ExposureRecord) error {
+	if rec.Name == "" {
+		return fmt.Errorf("save exposure: empty name")
+	}
+	recs, err := LoadExposures(configDir)
+	if err != nil {
+		// A corrupt store must not make the node permanently unable to record new
+		// exposures; start a fresh set rather than failing every future expose.
+		recs = nil
+	}
+
+	replaced := false
+	for i := range recs {
+		if recs[i].Name == rec.Name {
+			recs[i] = rec
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		recs = append(recs, rec)
+	}
+	return writeExposures(configDir, recs)
+}
+
+// DeleteExposure drops one exposure from the durable set. Deleting an absent
+// name is a no-op, so an unexpose is idempotent.
+func DeleteExposure(configDir, name string) error {
+	recs, err := LoadExposures(configDir)
+	if err != nil || len(recs) == 0 {
+		return nil
+	}
+	out := recs[:0]
+	for _, r := range recs {
+		if r.Name != name {
+			out = append(out, r)
+		}
+	}
+	if len(out) == len(recs) {
+		return nil
+	}
+	return writeExposures(configDir, out)
+}
+
+// writeExposures persists recs 0600, sorted by name for a stable file, via a
+// temp file + rename so a crash mid-write cannot leave a truncated store that
+// would drop every exposure on the next start.
+func writeExposures(configDir string, recs []ExposureRecord) error {
+	sort.Slice(recs, func(i, j int) bool { return recs[i].Name < recs[j].Name })
+
+	data, err := json.MarshalIndent(recs, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode exposures: %w", err)
+	}
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+
+	path := filepath.Join(configDir, exposuresFile)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return fmt.Errorf("write exposures: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("persist exposures: %w", err)
+	}
+	return nil
+}

--- a/internal/config/exposures_test.go
+++ b/internal/config/exposures_test.go
@@ -1,0 +1,200 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The bug in #647: an exposure lived only in the running worker, so a restart
+// dropped it. Save -> Load must reproduce every field the gateway needs to
+// rebuild both the route and its access policy.
+func TestSaveLoadExposureRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	want := ExposureRecord{
+		Name:       "frigate",
+		Port:       8212,
+		Visibility: "link",
+		Creator:    "org_abc123",
+		TokenEpoch: 3,
+	}
+	if err := SaveExposure(dir, want); err != nil {
+		t.Fatalf("SaveExposure: %v", err)
+	}
+
+	got, err := LoadExposures(dir)
+	if err != nil {
+		t.Fatalf("LoadExposures: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("loaded %d records, want 1", len(got))
+	}
+	if got[0] != want {
+		t.Errorf("round trip = %+v, want %+v", got[0], want)
+	}
+}
+
+// TokenEpoch specifically must survive. If it reset to 0 on restart, every link
+// token minted under the old epoch would stop verifying — live shared links
+// would break — and a later epoch bump could no longer revoke them.
+func TestTokenEpochSurvivesRestart(t *testing.T) {
+	dir := t.TempDir()
+	if err := SaveExposure(dir, ExposureRecord{Name: "x", Port: 1, Visibility: "link", TokenEpoch: 7}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, _ := LoadExposures(dir)
+	if len(got) != 1 || got[0].TokenEpoch != 7 {
+		t.Errorf("TokenEpoch = %v, want 7 preserved across the store", got)
+	}
+}
+
+// Re-exposing the same name must REPLACE, not accumulate: the gateway keeps one
+// policy per name, so a duplicate record would make the restore order decide
+// which policy wins — and could silently reinstate an older, looser visibility.
+func TestSaveExposureReplacesByName(t *testing.T) {
+	dir := t.TempDir()
+	if err := SaveExposure(dir, ExposureRecord{Name: "frigate", Port: 8212, Visibility: "link"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveExposure(dir, ExposureRecord{Name: "frigate", Port: 9000, Visibility: "org"}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, _ := LoadExposures(dir)
+	if len(got) != 1 {
+		t.Fatalf("loaded %d records, want 1 (re-expose must replace)", len(got))
+	}
+	if got[0].Visibility != "org" || got[0].Port != 9000 {
+		t.Errorf("record = %+v, want the newer org/9000 policy to win", got[0])
+	}
+}
+
+func TestSaveExposureKeepsOtherNames(t *testing.T) {
+	dir := t.TempDir()
+	for _, r := range []ExposureRecord{
+		{Name: "frigate", Port: 8212, Visibility: "org"},
+		{Name: "grafana", Port: 3000, Visibility: "link"},
+	} {
+		if err := SaveExposure(dir, r); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, _ := LoadExposures(dir)
+	if len(got) != 2 {
+		t.Fatalf("loaded %d records, want 2", len(got))
+	}
+	// Sorted by name for a stable file.
+	if got[0].Name != "frigate" || got[1].Name != "grafana" {
+		t.Errorf("records not sorted by name: %+v", got)
+	}
+}
+
+// A node that has never exposed anything is the common case and must not look
+// like an error — otherwise every gateway start logs a spurious warning.
+func TestLoadExposuresMissingFileIsNotAnError(t *testing.T) {
+	got, err := LoadExposures(t.TempDir())
+	if err != nil {
+		t.Fatalf("missing store returned an error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %d records from an empty dir", len(got))
+	}
+}
+
+// A corrupt store must be reported, not silently treated as "no exposures" —
+// starting with zero routes and no message is exactly the invisible failure
+// this whole change exists to remove.
+func TestLoadExposuresCorruptIsAnError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, exposuresFile), []byte("{not json"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := LoadExposures(dir); err == nil {
+		t.Fatal("corrupt store parsed without error; the operator would never learn routes were lost")
+	}
+}
+
+// ...but a corrupt store must not permanently wedge the node: recording a new
+// exposure has to succeed by starting a fresh set.
+func TestSaveExposureRecoversFromCorruptStore(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, exposuresFile), []byte("garbage"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SaveExposure(dir, ExposureRecord{Name: "frigate", Port: 8212, Visibility: "org"}); err != nil {
+		t.Fatalf("SaveExposure over a corrupt store: %v", err)
+	}
+	got, err := LoadExposures(dir)
+	if err != nil || len(got) != 1 || got[0].Name != "frigate" {
+		t.Errorf("recovery failed: got %+v, err %v", got, err)
+	}
+}
+
+func TestDeleteExposure(t *testing.T) {
+	dir := t.TempDir()
+	for _, r := range []ExposureRecord{
+		{Name: "frigate", Port: 8212, Visibility: "org"},
+		{Name: "grafana", Port: 3000, Visibility: "org"},
+	} {
+		if err := SaveExposure(dir, r); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := DeleteExposure(dir, "frigate"); err != nil {
+		t.Fatalf("DeleteExposure: %v", err)
+	}
+	got, _ := LoadExposures(dir)
+	if len(got) != 1 || got[0].Name != "grafana" {
+		t.Errorf("after delete: %+v, want only grafana", got)
+	}
+
+	// Idempotent: unexposing something already gone is not an error.
+	if err := DeleteExposure(dir, "frigate"); err != nil {
+		t.Errorf("second DeleteExposure: %v", err)
+	}
+	if err := DeleteExposure(t.TempDir(), "anything"); err != nil {
+		t.Errorf("DeleteExposure with no store: %v", err)
+	}
+}
+
+// The store can name a private exposure's creator, so it must not be
+// world-readable — same posture as the signing key it sits beside.
+func TestExposureStorePermissions(t *testing.T) {
+	dir := t.TempDir()
+	if err := SaveExposure(dir, ExposureRecord{Name: "x", Port: 1, Visibility: "org"}); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(filepath.Join(dir, exposuresFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Errorf("exposures file mode = %o, want 600", perm)
+	}
+}
+
+// A crash mid-write must not leave a truncated store that drops every exposure,
+// so the write goes through a temp file + rename. Assert no stray temp file is
+// left behind on the happy path.
+func TestSaveExposureLeavesNoTempFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := SaveExposure(dir, ExposureRecord{Name: "x", Port: 1, Visibility: "org"}); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".tmp" {
+			t.Errorf("left a temp file behind: %s", e.Name())
+		}
+	}
+}


### PR DESCRIPTION
## Context

Exposures created via `citadel service expose`, the `/agent/expose` control
endpoint, or the MCP `expose` verb lived ONLY in the running `citadel work`
process. Restarting the worker silently dropped every one of them.

Found while deploying #646 to node 1314. Reproduced there:

```
GET https://100.64.0.97:8443/expose/frigate/   -> 200
# systemctl restart citadel-worker
GET https://100.64.0.97:8443/expose/frigate/   -> 404
GET https://100.64.0.97:8443/                  -> 200   # gateway itself fine
# citadel service expose frigate --port 8212 --visibility org
GET https://100.64.0.97:8443/expose/frigate/   -> 200
```

Worker restarts are routine — auto-update, WORKER_SELF_HEAL (#548),
`systemctl restart`, reboot — so a link shared from the iOS app (aceteam#6799)
or the MCP verb (aceteam#6650) stops working at an arbitrary later time, with
no error and nothing off-node aware the route was dropped.

## Root cause

The link-token SIGNING KEY was already made durable (`expose_key.go`) so a
token minted yesterday still verifies today — but the routes those tokens
authorize were not. The token outlived the thing it opened.

## Changes

- `internal/config/exposures.go`: `ExposureRecord` + Load/Save/Delete, stored
  0600 as `exposures.json` beside the signing key, written temp-file+rename so
  a crash mid-write cannot truncate the store and drop every exposure. The
  link TOKEN is deliberately NOT stored — tokens are derived from the key and
  carry their own expiry; persisting one would outlive its minter.
- `cmd/expose_ops.go`: `liveExposeOps.Expose` persists after programming the
  gateway. Every caller (CLI, MCP verb, EXPOSE_SET job) funnels through here,
  so live and durable sets cannot diverge. A write failure is LOGGED, not
  returned: the exposure is live and the caller already has its URL, so
  failing would be a lie — the honest failure is "works now, gone after a
  restart", and it must be visible.
- `cmd/expose_ops.go`: `restoreExposures` re-wires the set, called from
  `work.go` and `serve.go` BEFORE the gateway serves — restoring afterwards
  would leave a window in which a valid exposure 404s, the exact symptom being
  fixed. A record the gateway rejects is skipped loudly rather than dropping
  the whole set, and a restored route whose upstream is not listening logs a
  warning (otherwise it restores fine and every request 502s with nothing
  explaining why). All failures are non-fatal: a node with an unreadable
  exposure store must still come up serving its builtin routes.

`TokenEpoch` is preserved explicitly — resetting it to 0 would break every
live link token and make a later epoch bump unable to revoke what it had
already handed out.

## Testing

`go test ./internal/config/ ./cmd/ ./internal/gateway/` — round trip,
epoch preservation, replace-by-name (a duplicate would let restore order pick
the policy and could reinstate a looser visibility), missing store is not an
error, corrupt store IS an error but does not wedge future saves, delete is
idempotent, 0600 permissions, no stray temp file.

On-node verification on 1314 to follow in a PR comment.

## Known gap (unchanged by this PR)

There is still no unexpose path — `Server.RemoveExposure` has no caller
outside tests. `DeleteExposure` is here so that when one lands it has a
durable counterpart.