### PR TITLE
fix(release): write release state without GNU-only `sed -i`

### DIFF
--- a/scripts/release-engine.sh
+++ b/scripts/release-engine.sh
@@ -64,7 +64,15 @@ write_state() {
   local key=$1 value=$2
   ensure_state_dir
   if grep -q "^${key}=" "$STATE_FILE" 2>/dev/null; then
-    sed -i "s|^${key}=.*|${key}=${value}|" "$STATE_FILE"
+    # Rewrite through a temp file rather than `sed -i`. In-place sed is NOT
+    # portable: GNU takes `-i` with no argument, BSD/macOS requires a backup
+    # suffix and otherwise swallows the script as the suffix -- which made every
+    # release from a Mac die at the first state write with
+    # "sed: 1: ...: invalid command code j". Nothing here needs sed anyway.
+    local tmp="${STATE_FILE}.tmp.$$"
+    grep -v "^${key}=" "$STATE_FILE" > "$tmp" || true
+    echo "${key}=${value}" >> "$tmp"
+    mv "$tmp" "$STATE_FILE"
   else
     echo "${key}=${value}" >> "$STATE_FILE"
   fi


### PR DESCRIPTION
`write_state` used `sed -i "s|...|"` with no backup suffix. That is GNU
syntax: BSD/macOS sed requires a suffix argument and otherwise consumes the
script AS the suffix, then treats the state file path as the sed program —
so every release run from a Mac died at the first state write with

    sed: 1: "/Users/.../.release/state": invalid command code j

Hit while cutting v2.97.0. The step tracker had recorded nothing, so no
partial release state was left behind.

Rewrite through a temp file + mv instead. Nothing here needed sed, and this
also makes the update atomic, so an interrupted write can no longer leave a
truncated state file that would confuse a --resume.

## Testing

`./scripts/release.sh --dry-run` twice from a macOS worktree:
- 1st run (append branch) — state written, validation passes
- 2nd run (**replace** branch, the one that used to die) — state correct, no duplicate keys, no stray `.tmp` file

Before this, the first state write on macOS aborted the release outright.