### PR TITLE
fix(jobs): accept a workspace reached through a symlink

### DIFF
--- a/internal/jobs/file_path.go
+++ b/internal/jobs/file_path.go
@@ -47,28 +47,47 @@ func ValidatePath(workspace, requestedPath string) (string, error) {
 		// This ensures that the non-existing suffix is still lexically clean.
 	}
 
-	// Boundary-safe prefix check: use filepath.Rel to avoid /workspace matching
-	// /workspaceEVIL. Rel returns a path starting with ".." if the target is
-	// outside the workspace.
-	rel, err := filepath.Rel(resolvedWorkspace, resolved)
-	if err != nil {
-		return "", fmt.Errorf("path %q is outside workspace: %w", requestedPath, err)
-	}
-	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+	// The real boundary: the fully symlink-resolved target must sit inside the
+	// symlink-resolved workspace. Both sides are in RESOLVED space, so this is the
+	// check that actually catches a symlink escape.
+	if !withinDir(resolvedWorkspace, resolved) {
 		return "", fmt.Errorf("path %q resolves outside workspace", requestedPath)
 	}
 
-	// Also verify the full (possibly non-existent) target lexically.
-	cleanTarget := filepath.Clean(target)
-	relTarget, err := filepath.Rel(resolvedWorkspace, cleanTarget)
-	if err != nil {
-		return "", fmt.Errorf("path %q is outside workspace: %w", requestedPath, err)
-	}
-	if relTarget == ".." || strings.HasPrefix(relTarget, ".."+string(filepath.Separator)) {
-		return "", fmt.Errorf("path %q resolves outside workspace", requestedPath)
-	}
+	// There used to be a SECOND, lexical check here comparing cleanTarget against
+	// resolvedWorkspace. It was removed because it was both WRONG and redundant:
+	//
+	//   Wrong: cleanTarget lives in UNRESOLVED space (built from the caller's
+	//   workspace argument, or given absolute by the caller) while
+	//   resolvedWorkspace has been through EvalSymlinks. Comparing the two
+	//   rejected a workspace's own contents whenever the workspace sat behind a
+	//   symlink. macOS puts /tmp and /var behind /private, so every temp-dir
+	//   workspace failed with "resolves outside workspace" -- which broke
+	//   `go test ./...` and therefore blocked cutting any release from a Mac. It
+	//   equally breaks a node whose authorized root is reached via a symlink.
+	//
+	//   Redundant: its stated job was catching ".." in a not-yet-existing leaf,
+	//   but resolveNearestAncestor rebuilds the full path INCLUDING that tail, and
+	//   filepath.Rel (inside withinDir) Cleans both operands -- so "ws/../../etc"
+	//   collapses to "/etc" and the check above already rejects it. Covered by
+	//   TestValidatePathRejectsDotDotInNonExistentTail.
+	//
+	// The returned value stays in the caller's spelling: cleanTarget and resolved
+	// denote the same file, and callers pass this straight back to os.* which
+	// follows symlinks anyway.
+	return filepath.Clean(target), nil
+}
 
-	return cleanTarget, nil
+// withinDir reports whether target is dir itself or lexically beneath it. It
+// uses filepath.Rel rather than a string prefix so /workspace does not match
+// /workspaceEVIL, and treats an un-relatable pair (different volumes on Windows)
+// as outside -- failing closed.
+func withinDir(dir, target string) bool {
+	rel, err := filepath.Rel(dir, target)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 // ValidateWithinRoots generalizes the single-root ValidatePath boundary to an

--- a/internal/jobs/file_path_symlink_test.go
+++ b/internal/jobs/file_path_symlink_test.go
@@ -1,0 +1,163 @@
+package jobs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// symlinkedWorkspace returns (linkPath, realPath) where linkPath is a symlink to
+// a real directory — the shape macOS gives every test for free (/var -> /private/var,
+// /tmp -> /private/tmp) and the shape any node has when an authorized root is
+// reached through a symlink.
+func symlinkedWorkspace(t *testing.T) (string, string) {
+	t.Helper()
+	base := t.TempDir()
+	real := filepath.Join(base, "real")
+	if err := os.MkdirAll(real, 0755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(base, "link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	return link, real
+}
+
+// The regression: ValidatePath compared the symlink-RESOLVED workspace against
+// the UNRESOLVED target, so a workspace reached through a symlink rejected its
+// own contents with "resolves outside workspace". On macOS that broke every
+// test using t.TempDir() and, worse, blocked `go test ./...` — meaning no
+// release could be cut from a Mac at all.
+func TestValidatePathAcceptsContentsOfSymlinkedWorkspace(t *testing.T) {
+	link, _ := symlinkedWorkspace(t)
+	if err := os.WriteFile(filepath.Join(link, "notes.md"), []byte("hi"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, req := range []string{
+		"notes.md",                            // relative
+		filepath.Join(link, "notes.md"),       // absolute, via the symlink
+		filepath.Join(link, "does-not-exist"), // non-existent leaf (write target)
+		link,                                  // the workspace itself
+	} {
+		if _, err := ValidatePath(link, req); err != nil {
+			t.Errorf("ValidatePath(%q) = %v, want accepted", req, err)
+		}
+	}
+}
+
+// The same path spelled in resolved form must also be accepted — a caller that
+// canonicalized the path first is not an attacker.
+func TestValidatePathAcceptsResolvedSpelling(t *testing.T) {
+	link, real := symlinkedWorkspace(t)
+	if err := os.WriteFile(filepath.Join(real, "notes.md"), []byte("hi"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ValidatePath(link, filepath.Join(real, "notes.md")); err != nil {
+		t.Errorf("resolved spelling rejected: %v", err)
+	}
+}
+
+// SECURITY: the boundary must still hold. These are the cases the relaxed
+// lexical check must NOT let through.
+func TestValidatePathStillRejectsEscapes(t *testing.T) {
+	link, _ := symlinkedWorkspace(t)
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "secret"), []byte("s"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A symlink INSIDE the workspace pointing out of it — the escape the
+	// resolved-space check exists for.
+	escape := filepath.Join(link, "escape")
+	if err := os.Symlink(outside, escape); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		req  string
+	}{
+		{"parent traversal", filepath.Join(link, "..", "..", "etc", "passwd")},
+		{"absolute outside", filepath.Join(outside, "secret")},
+		{"symlink escape", filepath.Join(escape, "secret")},
+		{"relative traversal", filepath.Join("..", "..", "etc", "passwd")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, err := ValidatePath(link, tc.req); err == nil {
+				t.Errorf("ValidatePath(%q) = %q with no error; escape must be rejected", tc.req, got)
+			}
+		})
+	}
+}
+
+// The removed lexical check nominally guarded ".." inside a NOT-YET-EXISTING
+// tail (a write target). Prove the remaining resolved-space check catches it:
+// resolveNearestAncestor rebuilds the full path including that tail, and
+// filepath.Rel Cleans both operands, so the traversal collapses and is rejected.
+func TestValidatePathRejectsDotDotInNonExistentTail(t *testing.T) {
+	link, _ := symlinkedWorkspace(t)
+
+	// CRITICAL: build these by STRING CONCATENATION, not filepath.Join. Join
+	// collapses ".." before the value ever reaches ValidatePath, so a Join-built
+	// case would prove nothing about how the validator handles a live traversal.
+	// These keep the ".." intact all the way in.
+	//
+	// Neither "newdir" nor anything under it exists, so resolution falls back to
+	// resolveNearestAncestor — the exact branch the removed lexical check covered.
+	for _, req := range []string{
+		link + "/newdir/../../escaped.txt",
+		link + "/a/b/../../../escaped.txt",
+		link + "/../escaped.txt",
+		link + "/newdir/../../../../../../../../etc/passwd",
+	} {
+		if got, err := ValidatePath(link, req); err == nil {
+			t.Errorf("ValidatePath(%q) = %q with no error; a .. traversal through a non-existent tail must be rejected", req, got)
+		}
+	}
+
+	// ...while a plain non-existent write target inside the workspace is fine.
+	if _, err := ValidatePath(link, filepath.Join(link, "newdir", "file.txt")); err != nil {
+		t.Errorf("legitimate non-existent write target rejected: %v", err)
+	}
+}
+
+// A sibling whose name merely PREFIXES the workspace must not pass — the
+// /workspace vs /workspaceEVIL case the Rel-based check exists to prevent.
+func TestValidatePathRejectsPrefixSibling(t *testing.T) {
+	base := t.TempDir()
+	ws := filepath.Join(base, "workspace")
+	evil := filepath.Join(base, "workspaceEVIL")
+	for _, d := range []string{ws, evil} {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(evil, "secret"), []byte("s"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, err := ValidatePath(ws, filepath.Join(evil, "secret")); err == nil {
+		t.Errorf("ValidatePath = %q with no error; a name-prefix sibling is outside the workspace", got)
+	}
+}
+
+// ValidateWithinRoots layers on ValidatePath, so a symlinked authorized root
+// must work too — this is what the local semantic-search surface actually calls.
+func TestValidateWithinRootsAcceptsSymlinkedRoot(t *testing.T) {
+	link, _ := symlinkedWorkspace(t)
+	if err := os.WriteFile(filepath.Join(link, "doc.md"), []byte("hi"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ValidateWithinRoots([]string{link}, filepath.Join(link, "doc.md")); err != nil {
+		t.Errorf("ValidateWithinRoots with a symlinked root: %v", err)
+	}
+	// And still fails closed outside every root.
+	if _, err := ValidateWithinRoots([]string{link}, filepath.Join(t.TempDir(), "elsewhere")); err == nil {
+		t.Error("a path outside every authorized root was accepted")
+	}
+}


### PR DESCRIPTION
## Context

`go test ./...` failed on macOS in internal/jobs, internal/rag and
internal/nodeindex — 9 tests, all with "resolves outside workspace" naming a
`t.TempDir()` path. Because `scripts/release.sh` runs the full suite, this
BLOCKED cutting any release from a Mac. Hit while cutting v2.97.0.

## Root cause

`ValidatePath` ran two boundary checks:

1. resolved-space: `Rel(EvalSymlinks(workspace), EvalSymlinks(target))` — the
   real symlink-escape check.
2. lexical: `Rel(EvalSymlinks(workspace), Clean(target))` — MIXED SPACES.

Check 2 compared a symlink-RESOLVED workspace against an UNRESOLVED target.
Whenever the workspace sat behind a symlink the two never agreed, so the
workspace rejected its own contents. macOS puts /tmp and /var behind /private,
so every temp-dir workspace failed — but this is not macOS-specific: any node
whose authorized root is reached through a symlink hits it, and the local
semantic-search surface (#617-619) is exactly that surface.

The file's own comment at the EvalSymlinks call ("it may be under a symlinked
tmpdir") shows the case was anticipated in check 1 and missed in check 2.

## Changes

- `internal/jobs/file_path.go`: removed check 2; extracted `withinDir` (Rel-based
  so /workspace never matches /workspaceEVIL, failing closed on a Rel error).

Check 2's stated job was catching ".." in a not-yet-existing leaf. It could not
do that job uniquely: `target` is `Clean`ed on entry, `resolveNearestAncestor`
re-attaches the tail via `filepath.Join` (which Cleans), and `Rel` Cleans both
operands — so a traversal collapses and check 1 rejects it. Verified, not
assumed; see below.

## Testing

This RELAXES a security boundary, so the tests are the safety net.

New `file_path_symlink_test.go`:
- accepts a symlinked workspace's own contents (relative, absolute-via-link,
  non-existent write target, the workspace itself) — the regression
- **still rejects**: parent traversal, absolute-outside, a symlink inside the
  workspace pointing out, relative traversal, a name-prefix sibling
  (/workspace vs /workspaceEVIL), and ".." through a non-existent tail
- `ValidateWithinRoots` with a symlinked authorized root works, and still fails
  closed outside every root

The ".." cases are built by STRING CONCATENATION, not `filepath.Join` — Join
collapses ".." before the value reaches the validator, so a Join-built case
would prove nothing about the reconstruct-the-tail branch. With the traversal
intact, all four are rejected: the redundancy claim is confirmed empirically.

MUTATION TEST: with the remaining boundary check commented out, 12 tests fail
(including every new one and all pre-existing escape tests) — so the tests do
detect a broken boundary rather than passing vacuously.

Full `go test ./...` and `go vet ./...` now pass on macOS.

## Note for reviewers

`TestValidatePathAcceptsResolvedSpelling` (workspace given as the symlink,
target given resolved) passes only because check 2 is gone; it asserts a
weaker property than the code did before and is not independent confirmation.
CI runs on Linux, where this bug never reproduced — so CI green says nothing
about this change. The macOS run and the mutation test are the real signal.