### PR TITLE
feat(meetings): Teams join-flow scaffold for the Citadel bot (#7000)

### DIFF
--- a/internal/jobs/meeting_join.go
+++ b/internal/jobs/meeting_join.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -183,12 +184,129 @@ func clickButtonByTextOptionalJS(labels []string) string {
 		`return "";})()`
 }
 
+// meetingPlatform is the conferencing platform a meeting_url targets. It selects
+// which pre-join flow runJoinFlow drives (Meet vs Teams). Kept as a small string
+// enum so it can ride the result/logs legibly and so the aceteam backend's
+// meeting_platform column (issue #6997 owns the enum + gates) maps 1:1.
+type meetingPlatform string
+
+const (
+	// platformMeet is a meet.google.com meeting (the original, shipped flow).
+	platformMeet meetingPlatform = "meet"
+	// platformTeams is a Microsoft Teams web meeting (teams.microsoft.com /
+	// teams.live.com), both the /meet/<id>?p=<passcode> and /l/meetup-join/…
+	// link shapes. Handled by the Teams flow in meeting_join_teams.go.
+	platformTeams meetingPlatform = "teams"
+	// platformUnknown is any URL we do not recognize; parseMeetingJoinParams
+	// rejects it so an unsupported link fails fast with a clear error rather
+	// than launching a browser at a flow that cannot possibly work.
+	platformUnknown meetingPlatform = "unknown"
+)
+
+// parsedMeetingURL is the pure, statically-verifiable result of inspecting a
+// meeting_url: which platform it targets and (Teams /meet/<id>?p= links only)
+// the pre-join passcode. This is the main unit-tested deliverable of the Teams
+// scaffold — no browser, no network, just URL shape.
+type parsedMeetingURL struct {
+	Platform meetingPlatform
+	// Passcode is the Teams pre-join passcode extracted from the `p` query
+	// parameter of a teams.microsoft.com/meet/<id>?p=<passcode> link. Empty for
+	// Meet, for /l/meetup-join/… links (which embed auth in the path/query and
+	// need no separate passcode field), and when no `p` param is present.
+	Passcode string
+}
+
+// detectMeetingPlatform maps a meeting_url's host to a meetingPlatform. Pure and
+// host-based (not substring-based) so a lookalike path segment cannot spoof it:
+// it parses the URL and matches the hostname exactly or as a subdomain suffix.
+// A malformed URL or an unrecognized host returns platformUnknown. Case- and
+// scheme-insensitive; a bare host with no scheme is tolerated by prepending
+// https:// so operator-pasted "teams.microsoft.com/meet/…" still classifies.
+func detectMeetingPlatform(rawURL string) meetingPlatform {
+	host := meetingURLHost(rawURL)
+	if host == "" {
+		return platformUnknown
+	}
+	switch {
+	case hostMatches(host, "meet.google.com"):
+		return platformMeet
+	case hostMatches(host, "teams.microsoft.com"),
+		hostMatches(host, "teams.live.com"),
+		hostMatches(host, "teams.microsoft.us"): // GCC High / DoD cloud
+		return platformTeams
+	default:
+		return platformUnknown
+	}
+}
+
+// meetingURLHost extracts the lowercased hostname from rawURL, tolerating a
+// scheme-less host (prepends https://) so "teams.microsoft.com/meet/x" parses.
+// Returns "" for input that has no usable host.
+func meetingURLHost(rawURL string) string {
+	s := strings.TrimSpace(rawURL)
+	if s == "" {
+		return ""
+	}
+	if !strings.Contains(s, "://") {
+		s = "https://" + s
+	}
+	u, err := url.Parse(s)
+	if err != nil {
+		return ""
+	}
+	return strings.ToLower(u.Hostname())
+}
+
+// hostMatches reports whether host equals base or is a subdomain of base
+// (e.g. "gov.teams.microsoft.com" matches base "teams.microsoft.com"). Suffix
+// matching is anchored on a dot so "evilteams.microsoft.com" does NOT match
+// "teams.microsoft.com".
+func hostMatches(host, base string) bool {
+	return host == base || strings.HasSuffix(host, "."+base)
+}
+
+// parseTeamsPasscode returns the pre-join passcode from a Teams
+// /meet/<id>?p=<passcode> link (the `p` query parameter), or "" when the URL is
+// malformed or carries no `p` param. Pure and unit-tested.
+func parseTeamsPasscode(rawURL string) string {
+	s := strings.TrimSpace(rawURL)
+	if s == "" {
+		return ""
+	}
+	if !strings.Contains(s, "://") {
+		s = "https://" + s
+	}
+	u, err := url.Parse(s)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(u.Query().Get("p"))
+}
+
+// parseMeetingURL is the pure classifier used by parseMeetingJoinParams: it
+// detects the platform and (Teams only) extracts the pre-join passcode. Split
+// out so the whole URL-shape contract is unit-testable without a job payload.
+func parseMeetingURL(rawURL string) parsedMeetingURL {
+	plat := detectMeetingPlatform(rawURL)
+	out := parsedMeetingURL{Platform: plat}
+	if plat == platformTeams {
+		out.Passcode = parseTeamsPasscode(rawURL)
+	}
+	return out
+}
+
 // meetingJoinParams is the typed, validated job payload.
 type meetingJoinParams struct {
 	MeetingURL         string
 	MeetingID          string
 	BotDisplayName     string
 	MaxDurationSeconds int // 0 means "unset"; the handler applies defaultMeetingMaxDuration
+	// Platform is the conferencing platform detected from MeetingURL. Selects
+	// the pre-join flow in runJoinFlow.
+	Platform meetingPlatform
+	// Passcode is the Teams pre-join passcode (from a /meet/<id>?p=<passcode>
+	// link); empty for Meet and for passcode-less Teams links.
+	Passcode string
 }
 
 // parseMeetingJoinParams validates and normalizes the raw string payload. Payload
@@ -206,6 +324,15 @@ func parseMeetingJoinParams(payload map[string]string) (meetingJoinParams, error
 	if p.MeetingID == "" {
 		return meetingJoinParams{}, fmt.Errorf("job payload missing required 'meeting_id' field")
 	}
+	// Detect the platform from the URL shape and reject anything we cannot
+	// drive, so an unsupported link fails fast here rather than at a stale
+	// selector after the browser is up.
+	parsed := parseMeetingURL(p.MeetingURL)
+	if parsed.Platform == platformUnknown {
+		return meetingJoinParams{}, fmt.Errorf("unsupported meeting_url %q: only Google Meet (meet.google.com) and Microsoft Teams (teams.microsoft.com) links are supported", p.MeetingURL)
+	}
+	p.Platform = parsed.Platform
+	p.Passcode = parsed.Passcode
 	if p.BotDisplayName == "" {
 		p.BotDisplayName = defaultBotDisplayName
 	}
@@ -513,7 +640,13 @@ func (h *MeetingJoinHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, er
 // result shape is uniform (chat/recognized_commands come back empty). Splitting
 // here keeps Execute's happy path readable and the streaming gate in one place.
 func (h *MeetingJoinHandler) runMeetingLoop(ctx JobContext, br meetingBrowser, p meetingJoinParams, wavPath string) interactiveOutcome {
-	if !h.StreamingEnabled {
+	// The interactive during-call layer (announce / rolling `/ace` commands /
+	// chat capture) is Meet-coupled (issue #5435) and explicitly OUT of the Teams
+	// MVP scope (#7000: join + record + transcribe, no in-call chat). Route Teams
+	// through the plain record-until-end loop, which uses the Teams-aware
+	// end-detection (checkMeetingEndedFor). Wiring the interactive layer for Teams
+	// is a documented follow-up once its DOM is live-tuned.
+	if !h.StreamingEnabled || p.Platform == platformTeams {
 		return interactiveOutcome{endReason: h.waitForMeetingEnd(ctx, br, p)}
 	}
 
@@ -532,10 +665,28 @@ func (h *MeetingJoinHandler) runMeetingLoop(ctx JobContext, br meetingBrowser, p
 	return h.waitForMeetingEndInteractive(ctx, br, p, transcribe, meetingPollInterval, botMessages)
 }
 
-// runJoinFlow drives the Google Meet pre-join sequence (partially verified —
+// runJoinFlow dispatches to the platform-specific pre-join sequence based on the
+// platform detected from the meeting URL (parseMeetingJoinParams). Meet is the
+// original shipped flow; Teams (issue #7000) lives in meeting_join_teams.go and
+// is scaffolded/best-guess, pending live tuning. Both share the same downstream
+// record → transcribe path (nothing platform-specific past admission).
+func (h *MeetingJoinHandler) runJoinFlow(ctx JobContext, br meetingBrowser, p meetingJoinParams) error {
+	switch p.Platform {
+	case platformTeams:
+		return h.runTeamsJoinFlow(ctx, br, p)
+	case platformMeet:
+		return h.runMeetJoinFlow(ctx, br, p)
+	default:
+		// parseMeetingJoinParams rejects unknown platforms, so this is a
+		// defensive belt-and-braces for a caller that bypasses it.
+		return fmt.Errorf("cannot join meeting: unsupported platform %q for url %s", p.Platform, p.MeetingURL)
+	}
+}
+
+// runMeetJoinFlow drives the Google Meet pre-join sequence (partially verified —
 // see the LIVE-TUNING block). Non-fatal steps (permission dismissals, name entry
 // when signed in) log and continue; the join click and admission are fatal.
-func (h *MeetingJoinHandler) runJoinFlow(ctx JobContext, br meetingBrowser, p meetingJoinParams) error {
+func (h *MeetingJoinHandler) runMeetJoinFlow(ctx JobContext, br meetingBrowser, p meetingJoinParams) error {
 	if err := br.Navigate(p.MeetingURL); err != nil {
 		return fmt.Errorf("navigate to meeting url: %w", err)
 	}
@@ -657,13 +808,25 @@ func (h *MeetingJoinHandler) waitUntilAdmitted(ctx JobContext, br meetingBrowser
 func (h *MeetingJoinHandler) waitForMeetingEnd(ctx JobContext, br meetingBrowser, p meetingJoinParams) string {
 	deadline := time.Now().Add(p.maxDuration())
 	for time.Now().Before(deadline) {
-		if reason, ended := checkMeetingEnded(br); ended {
+		if reason, ended := checkMeetingEndedFor(p.Platform, br); ended {
 			return reason
 		}
 		time.Sleep(meetingPollInterval)
 	}
 	ctx.Log("info", "     - max meeting duration (%s) reached; leaving", p.maxDuration())
 	return "max_duration_reached"
+}
+
+// checkMeetingEndedFor dispatches the end heuristic by platform so a Teams call
+// ends on its own end/removed signal (best-guess, see meeting_join_teams.go)
+// rather than always running to the max_duration cap. Meet keeps the shared
+// checkMeetingEnded. The interactive (streaming) loop remains Meet-coupled and
+// out of Teams MVP scope — Teams runs the plain record→transcribe path.
+func checkMeetingEndedFor(plat meetingPlatform, page meetPage) (string, bool) {
+	if plat == platformTeams {
+		return checkTeamsMeetingEnded(page)
+	}
+	return checkMeetingEnded(page)
 }
 
 // syntheticTranscribeJob builds the in-process TRANSCRIBE_AUDIO job used to reuse

--- a/internal/jobs/meeting_join_teams.go
+++ b/internal/jobs/meeting_join_teams.go
@@ -1,0 +1,266 @@
+// internal/jobs/meeting_join_teams.go
+//
+// Microsoft Teams pre-join flow for the MEETING_JOIN handler (issue #7000 —
+// parallel to the Google Meet flow in meeting_join.go). It mirrors the Meet
+// flow's SHAPE exactly — navigate, dismiss the "Continue on this browser"
+// interstitial, enter a passcode (for /meet/<id>?p= links), type the guest
+// display name, mute cam/mic, click "Join now", wait in the lobby for admission,
+// then hand off to the SAME platform-agnostic record → transcribe path. Nothing
+// past admission is Teams-specific.
+//
+// ⚠️ EVERY SELECTOR / JS SNIPPET BELOW IS UNVERIFIED (best-guess). Unlike the
+// Meet flow — whose interstitial + host auto-admit path were confirmed against a
+// live call on 2026-07-11 — the Teams web DOM here has NOT been exercised against
+// a real Teams meeting. Teams renders its pre-join and in-call UI inside a heavy,
+// frequently-changing Fluent UI app; the class names, data-tid values, and button
+// labels WILL need live tuning against a real meeting before this can be trusted.
+// The statically-verifiable parts (URL → platform detection, passcode extraction)
+// live in meeting_join.go and are unit-tested; this file is the part a human must
+// tune. Everything is kept in this one file so tuning is a single-file edit.
+package jobs
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
+)
+
+// Teams-specific lifecycle timeouts. Deliberately generous (mirrors the Meet
+// flow) because Teams' web app is slow to hydrate: the pre-join screen commonly
+// takes several seconds to render its controls after navigation, and the
+// "Continue on this browser" interstitial can precede it.
+const (
+	// teamsPageSettle waits for the Teams web app shell to hydrate after
+	// navigation before we start poking at the DOM. Teams is heavier than Meet;
+	// give it a beat longer.
+	teamsPageSettle = 7 * time.Second
+	// teamsJoinButtonTimeout bounds the interstitial → passcode → name → mute →
+	// join poll loop. Teams routes through an extra "Continue on this browser"
+	// interstitial before the pre-join screen, so poll well past both renders.
+	teamsJoinButtonTimeout = 60 * time.Second
+)
+
+// ---------------------------------------------------------------------------
+// LIVE-TUNING REQUIRED — ALL UNVERIFIED (issue #7000)
+//
+// None of the selectors / JS below has been run against a real Teams meeting.
+// They are best-guess authored from Teams' publicly-documented web-join UX
+// (the "Continue on this browser" interstitial, a guest display-name field, the
+// mic/camera pre-join toggles, "Join now", and the "someone will let you in"
+// lobby). A human MUST open a real teams.microsoft.com meeting, drive this flow,
+// and confirm/replace each constant. Kept together so tuning is one place.
+//
+//	verified against real Microsoft Teams on: NEVER — pending a live meeting
+//
+// ---------------------------------------------------------------------------
+const (
+	// teamsNameInputSelector: the guest "Enter name" / "Type your name" field on
+	// the Teams web pre-join screen (anonymous join). UNVERIFIED best-guess:
+	// Teams has historically used data-tid="prejoin-display-name-input"; the
+	// aria/placeholder fallbacks hedge a rename.
+	teamsNameInputSelector = `input[data-tid="prejoin-display-name-input"],input[placeholder*="name" i],input[aria-label*="name" i]`
+
+	// teamsPasscodeInputSelector: the pre-join passcode field for a
+	// /meet/<id>?p=<passcode> link. UNVERIFIED best-guess — Teams "meet" links
+	// gate on a passcode entered on the pre-join screen. Placeholder/aria hedges.
+	teamsPasscodeInputSelector = `input[data-tid*="passcode" i],input[placeholder*="passcode" i],input[aria-label*="passcode" i],input[type="password"]`
+
+	// teamsIsAdmittedJS returns true once the in-call toolbar is present (the bot
+	// has been admitted from the lobby / joined directly). UNVERIFIED best-guess:
+	// Teams' hang-up/leave control has used data-tid="hangup-button"; the
+	// aria-label "Leave" and a call-duration timer are corroborating fallbacks.
+	teamsIsAdmittedJS = `(function(){` +
+		`return !!document.querySelector('button[data-tid="hangup-button"],button[aria-label*="Leave" i],button[title*="Leave" i],[data-tid="call-duration"]');` +
+		`})()`
+
+	// teamsIsEndedJS returns true when the call ended or the bot was removed —
+	// Teams swaps to a "You left the meeting" / "removed" / "meeting has ended"
+	// screen. UNVERIFIED best-guess text scan (mirrors meetIsEndedJS).
+	teamsIsEndedJS = `(function(){` +
+		`var t=(document.body&&document.body.innerText||"");` +
+		`return /you (?:left|.?ve left) the meeting|meeting has ended|call ended|you.?ve been removed|removed you from the meeting|left the meeting/i.test(t);` +
+		`})()`
+
+	// teamsInLobbyJS returns true while the bot sits in the Teams lobby waiting
+	// for a host to admit it ("Someone in the meeting should let you in soon").
+	// UNVERIFIED best-guess text scan; used only for an informational log, never
+	// fatal (the admission wait times out on its own).
+	teamsInLobbyJS = `(function(){` +
+		`var t=(document.body&&document.body.innerText||"");` +
+		`return /let you in soon|when the meeting starts|waiting for the host|in the lobby|someone.?s in the lobby/i.test(t);` +
+		`})()`
+
+	// teamsMuteMicCamJS best-effort turns OFF the mic and camera on the pre-join
+	// screen so the bot joins muted and dark. UNVERIFIED best-guess: Teams toggle
+	// buttons have used data-tid="toggle-mute" / "toggle-video" and expose an
+	// aria-checked / aria-pressed state; we click only when the control reads as
+	// currently ON so we don't accidentally re-enable it. Returns the count of
+	// controls toggled (informational). Never throws on no-match.
+	teamsMuteMicCamJS = `(function(){` +
+		`var sels=['button[data-tid="toggle-mute"]','button[data-tid="toggle-video"]',` +
+		`'button[aria-label*="microphone" i]','button[aria-label*="camera" i]'];` +
+		`var n=0;` +
+		`for(var i=0;i<sels.length;i++){var b=document.querySelector(sels[i]);if(!b)continue;` +
+		`var on=(b.getAttribute('aria-pressed')==='true'||b.getAttribute('aria-checked')==='true');` +
+		`if(on){b.click();n++;}}` +
+		`return n;})()`
+
+	// teamsLeaveJS clicks the in-call "Leave" / hang-up button so the bot exits
+	// gracefully. UNVERIFIED best-guess; reuses the admitted-check selector.
+	// Best-effort (browser Close() teardown is the backstop): returns true if a
+	// button was clicked, false on no-match. Does NOT throw on no-match.
+	teamsLeaveJS = `(function(){` +
+		`var b=document.querySelector('button[data-tid="hangup-button"],button[aria-label*="Leave" i],button[title*="Leave" i]');` +
+		`if(!b)return false;b.click();return true;})()`
+)
+
+// teamsContinueOnBrowserLabels are the button texts Teams shows on the "how do
+// you want to join" interstitial to proceed in the current browser (rather than
+// opening/installing the desktop app). Clicking one is best-effort — a Teams
+// "meet" link sometimes lands straight on the pre-join screen with no
+// interstitial. UNVERIFIED best-guess labels/casing.
+var teamsContinueOnBrowserLabels = []string{
+	"Continue on this browser",
+	"Join on the web instead",
+	"Use the web app instead",
+	"Continue in this browser",
+}
+
+// teamsJoinButtonLabels are the visible button texts for the Teams pre-join
+// join action, in priority order. UNVERIFIED best-guess casing/locale — confirm
+// against a real call.
+var teamsJoinButtonLabels = []string{"Join now", "Join", "Ask to join"}
+
+// runTeamsJoinFlow drives the Microsoft Teams web pre-join sequence (issue
+// #7000). It mirrors runMeetJoinFlow's structure: navigate, fail loudly if Teams
+// forces a Microsoft sign-in (the bot joins anonymously by design), then poll
+// interstitial → passcode → name → mute → join until admitted, then wait for the
+// host to admit the bot from the lobby. Non-fatal steps log and continue; the
+// join and admission are fatal. ⚠️ Every selector this touches is UNVERIFIED —
+// see the LIVE-TUNING block above.
+func (h *MeetingJoinHandler) runTeamsJoinFlow(ctx JobContext, br meetingBrowser, p meetingJoinParams) error {
+	if err := br.Navigate(p.MeetingURL); err != nil {
+		return fmt.Errorf("navigate to teams meeting url: %w", err)
+	}
+	time.Sleep(teamsPageSettle)
+
+	// Fatal: the Teams meeting is refusing an anonymous/guest web join and has
+	// redirected to a Microsoft sign-in wall (login.microsoftonline.com). The
+	// sovereign bot has no MS profile by design, so fail loudly with an
+	// actionable error rather than stalling at the login page. (The Meet flow's
+	// analogous check is IsGoogleSignInURL / ErrMeetingBotSignedOut.)
+	if curURL, err := br.CurrentURL(); err != nil {
+		ctx.Log("warn", "     - could not read current URL for Teams sign-in check (non-fatal): %v", err)
+	} else if platform.IsMicrosoftSignInURL(curURL) {
+		return fmt.Errorf("teams meeting requires a Microsoft sign-in (redirected to %s) — this meeting does not allow anonymous/guest web join; the sovereign bot has no MS profile", curURL)
+	}
+
+	// Informational: note if we appear to be sitting in the Teams lobby already
+	// (some meetings drop a guest straight into the lobby pre-join).
+	if v, err := br.Evaluate(teamsInLobbyJS); err == nil {
+		if inLobby, ok := v.(bool); ok && inLobby {
+			ctx.Log("info", "     - Teams lobby detected on landing; waiting for host admission")
+		}
+	}
+
+	// Fatal: poll admitted-check → continue-on-browser → passcode → name → mute
+	// → join until the bot is in-call or the join button is clicked, or timeout.
+	if err := pollForTeamsJoinClick(ctx, br, p.BotDisplayName, p.Passcode, teamsJoinButtonTimeout, meetingPollInterval); err != nil {
+		return err
+	}
+
+	// Fatal: wait until admitted (in-call toolbar appears) or the lobby timeout.
+	return h.waitUntilTeamsAdmitted(ctx, br, p)
+}
+
+// pollForTeamsJoinClick repeatedly (1) checks whether the bot is already in-call,
+// (2) best-effort dismisses the "Continue on this browser" interstitial, (3)
+// best-effort types the passcode (for /meet/<id>?p= links), (4) best-effort types
+// the guest display name, (5) best-effort mutes mic/camera, and (6) tries the
+// "Join now" button — until admitted or the button is clicked, or timeout. Steps
+// 2–5 are non-fatal every pass (a control not rendered yet is normal); only
+// reaching the timeout with neither admission nor a join click is fatal. Params
+// mirror pollForJoinClick so tests can run it in milliseconds. ⚠️ UNVERIFIED
+// selectors throughout.
+func pollForTeamsJoinClick(ctx JobContext, page joinPage, botDisplayName, passcode string, timeout, interval time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		// Already admitted / in the call: success, no join button needed.
+		if v, err := page.Evaluate(teamsIsAdmittedJS); err == nil {
+			if b, ok := v.(bool); ok && b {
+				ctx.Log("info", "     - already in Teams call, no join button needed")
+				return nil
+			}
+		} else {
+			ctx.Log("warn", "     - Teams already-admitted probe errored (non-fatal): %v", err)
+		}
+
+		// Best-effort: dismiss the "Continue on this browser" interstitial.
+		if _, err := page.Evaluate(clickButtonByTextOptionalJS(teamsContinueOnBrowserLabels)); err != nil {
+			ctx.Log("warn", "     - Teams continue-on-browser dismissal errored (non-fatal): %v", err)
+		}
+
+		// Best-effort: enter the pre-join passcode when the link carried one.
+		if passcode != "" {
+			if err := page.Type(teamsPasscodeInputSelector, passcode); err != nil {
+				ctx.Log("warn", "     - could not enter Teams passcode (non-fatal, field may not be rendered yet): %v", err)
+			}
+		}
+
+		// Best-effort: type the bot's guest display name.
+		if err := page.Type(teamsNameInputSelector, botDisplayName); err != nil {
+			ctx.Log("warn", "     - could not set Teams bot name (non-fatal, may not be rendered yet): %v", err)
+		}
+
+		// Best-effort: mute mic + camera before joining.
+		if _, err := page.Evaluate(teamsMuteMicCamJS); err != nil {
+			ctx.Log("warn", "     - Teams mute mic/cam errored (non-fatal): %v", err)
+		}
+
+		// Try the "Join now" button; a non-empty return means it was clicked.
+		if v, err := page.Evaluate(clickButtonByTextOptionalJS(teamsJoinButtonLabels)); err != nil {
+			ctx.Log("warn", "     - Teams join-button probe errored (retrying): %v", err)
+		} else if label, ok := v.(string); ok && label != "" {
+			ctx.Log("info", "     - clicked Teams join button (matched label %q)", label)
+			return nil
+		}
+
+		time.Sleep(interval)
+	}
+	return fmt.Errorf("click Teams join button: no button matched labels %v within %s (interstitial/pre-join page may have changed — re-tune meeting_join_teams.go labels)", teamsJoinButtonLabels, timeout)
+}
+
+// waitUntilTeamsAdmitted polls the Teams admission heuristic until the bot is
+// in-call or the lobby timeout elapses. Mirrors waitUntilAdmitted for Meet.
+func (h *MeetingJoinHandler) waitUntilTeamsAdmitted(ctx JobContext, br meetingBrowser, p meetingJoinParams) error {
+	deadline := time.Now().Add(admitTimeout)
+	for time.Now().Before(deadline) {
+		if v, err := br.Evaluate(teamsIsAdmittedJS); err == nil {
+			if b, ok := v.(bool); ok && b {
+				ctx.Log("info", "     - admitted to Teams meeting %s", p.MeetingID)
+				return nil
+			}
+		} else {
+			ctx.Log("warn", "     - Teams admission check errored (retrying): %v", err)
+		}
+		time.Sleep(meetingPollInterval)
+	}
+	return fmt.Errorf("not admitted to Teams meeting within %s (host did not let the bot in, or the admission selector is stale — re-tune teamsIsAdmittedJS)", admitTimeout)
+}
+
+// checkTeamsMeetingEnded runs the Teams end heuristic (the "you left / removed /
+// meeting has ended" text scan). Best-guess (see the LIVE-TUNING block); a read
+// error is treated as "not ended" so a transient DOM glitch never ends the call
+// early. Called by checkMeetingEndedFor for the plain record→transcribe loop.
+// Teams exposes no reliable participant-count selector we can trust yet, so —
+// unlike Meet — there is no bot-alone signal here; end detection leans on the
+// text scan plus the max_duration cap.
+func checkTeamsMeetingEnded(page meetPage) (string, bool) {
+	if v, err := page.Evaluate(teamsIsEndedJS); err == nil {
+		if b, ok := v.(bool); ok && b {
+			return "call_ended", true
+		}
+	}
+	return "", false
+}

--- a/internal/jobs/meeting_join_test.go
+++ b/internal/jobs/meeting_join_test.go
@@ -395,3 +395,134 @@ func TestMeetingJoin_MissingWorkspace(t *testing.T) {
 		t.Fatal("expected error when workspace is unconfigured")
 	}
 }
+
+// --- Teams URL / platform detection scaffold (issue #7000) ----------------
+// These cover the PURE, statically-verifiable deliverables: URL → platform
+// classification and Teams passcode extraction. The join flow itself needs a
+// live Teams meeting and is not unit-tested.
+
+func TestDetectMeetingPlatform(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+		want meetingPlatform
+	}{
+		{"meet standard", "https://meet.google.com/abc-defg-hij", platformMeet},
+		{"meet case-insensitive host", "https://MEET.GOOGLE.COM/abc", platformMeet},
+		{"teams meet link", "https://teams.microsoft.com/meet/1234567890?p=AbCdEf", platformTeams},
+		{"teams meetup-join link", "https://teams.microsoft.com/l/meetup-join/19%3ameeting_x/0?context=%7b%7d", platformTeams},
+		{"teams live personal", "https://teams.live.com/meet/9876543210", platformTeams},
+		{"teams gov cloud", "https://gov.teams.microsoft.us/l/meetup-join/xyz", platformTeams},
+		{"teams subdomain", "https://gov.teams.microsoft.com/meet/1", platformTeams},
+		{"scheme-less teams host", "teams.microsoft.com/meet/1?p=xyz", platformTeams},
+		{"scheme-less meet host", "meet.google.com/abc", platformMeet},
+		{"zoom is unsupported", "https://zoom.us/j/123456789", platformUnknown},
+		{"lookalike meet host not spoofable", "https://meet.google.com.attacker.test/abc", platformUnknown},
+		{"lookalike teams host not spoofable", "https://teams.microsoft.com.evil.test/meet/1", platformUnknown},
+		{"path spoof does not classify", "https://example.com/teams.microsoft.com/meet/1", platformUnknown},
+		{"empty", "", platformUnknown},
+		{"whitespace", "   ", platformUnknown},
+		{"unparseable", "http://[::1", platformUnknown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := detectMeetingPlatform(tc.url); got != tc.want {
+				t.Errorf("detectMeetingPlatform(%q) = %q, want %q", tc.url, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseTeamsPasscode(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"passcode present", "https://teams.microsoft.com/meet/1234567890?p=AbCdEf12", "AbCdEf12"},
+		{"passcode with other params", "https://teams.microsoft.com/meet/1?foo=bar&p=Secret9&x=1", "Secret9"},
+		{"no passcode param", "https://teams.microsoft.com/meet/1234567890", ""},
+		{"meetup-join has no p param", "https://teams.microsoft.com/l/meetup-join/19%3ax/0?context=%7b%7d", ""},
+		{"scheme-less still parses", "teams.microsoft.com/meet/1?p=xyz", "xyz"},
+		{"empty p is empty", "https://teams.microsoft.com/meet/1?p=", ""},
+		{"empty url", "", ""},
+		{"unparseable", "http://[::1?p=x", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseTeamsPasscode(tc.url); got != tc.want {
+				t.Errorf("parseTeamsPasscode(%q) = %q, want %q", tc.url, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseMeetingURL(t *testing.T) {
+	cases := []struct {
+		name         string
+		url          string
+		wantPlatform meetingPlatform
+		wantPasscode string
+	}{
+		{"meet has no passcode", "https://meet.google.com/abc", platformMeet, ""},
+		{"teams meet with passcode", "https://teams.microsoft.com/meet/1?p=Zz99", platformTeams, "Zz99"},
+		{"teams meetup-join no passcode", "https://teams.microsoft.com/l/meetup-join/19%3ax", platformTeams, ""},
+		{"unknown yields no passcode even with p", "https://zoom.us/j/1?p=abc", platformUnknown, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseMeetingURL(tc.url)
+			if got.Platform != tc.wantPlatform {
+				t.Errorf("Platform = %q, want %q", got.Platform, tc.wantPlatform)
+			}
+			if got.Passcode != tc.wantPasscode {
+				t.Errorf("Passcode = %q, want %q", got.Passcode, tc.wantPasscode)
+			}
+		})
+	}
+}
+
+func TestParseMeetingJoinParams_TeamsSetsPlatformAndPasscode(t *testing.T) {
+	p, err := parseMeetingJoinParams(map[string]string{
+		"meeting_url": "https://teams.microsoft.com/meet/1234567890?p=Passw0rd",
+		"meeting_id":  "mtg-teams-1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.Platform != platformTeams {
+		t.Errorf("Platform = %q, want %q", p.Platform, platformTeams)
+	}
+	if p.Passcode != "Passw0rd" {
+		t.Errorf("Passcode = %q, want %q", p.Passcode, "Passw0rd")
+	}
+}
+
+func TestParseMeetingJoinParams_MeetSetsPlatformNoPasscode(t *testing.T) {
+	p, err := parseMeetingJoinParams(map[string]string{
+		"meeting_url": "https://meet.google.com/abc-defg-hij",
+		"meeting_id":  "mtg-meet-1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.Platform != platformMeet {
+		t.Errorf("Platform = %q, want %q", p.Platform, platformMeet)
+	}
+	if p.Passcode != "" {
+		t.Errorf("Passcode = %q, want empty", p.Passcode)
+	}
+}
+
+func TestParseMeetingJoinParams_RejectsUnsupportedPlatform(t *testing.T) {
+	_, err := parseMeetingJoinParams(map[string]string{
+		"meeting_url": "https://zoom.us/j/123456789",
+		"meeting_id":  "mtg-zoom-1",
+	})
+	if err == nil {
+		t.Fatal("expected error for unsupported meeting platform, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported meeting_url") {
+		t.Errorf("error = %q, want it to mention 'unsupported meeting_url'", err)
+	}
+}

--- a/internal/platform/meeting_browser.go
+++ b/internal/platform/meeting_browser.go
@@ -112,6 +112,39 @@ func IsGoogleSignInURL(rawURL string) bool {
 	return strings.EqualFold(u.Hostname(), "accounts.google.com")
 }
 
+// microsoftSignInHosts are the Microsoft identity-platform hosts Teams redirects
+// to when a meeting requires an authenticated (non-guest) sign-in. login.live.com
+// covers personal Microsoft accounts; login.microsoftonline.com covers work/school
+// (Entra ID) tenants.
+var microsoftSignInHosts = []string{
+	"login.microsoftonline.com",
+	"login.live.com",
+	"login.microsoft.com",
+}
+
+// IsMicrosoftSignInURL reports whether rawURL is a Microsoft account / Entra ID
+// authentication page (login.microsoftonline.com and friends) — the signal that
+// the Teams meeting is refusing an anonymous/guest web join and is demanding an
+// authenticated Microsoft profile the bot does not (and by design should not)
+// have. The Teams join flow (issue #7000) PREFERS anonymous/guest join precisely
+// to avoid needing an MS profile; when a meeting forces sign-in the flow fails
+// loudly with an actionable error instead of stalling at a login wall. A
+// malformed URL returns false (see IsGoogleSignInURL). Host match is exact or a
+// subdomain suffix so a lookalike path cannot spoof it.
+func IsMicrosoftSignInURL(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	for _, base := range microsoftSignInHosts {
+		if host == base || strings.HasSuffix(host, "."+base) {
+			return true
+		}
+	}
+	return false
+}
+
 // ChromiumAvailable reports whether a Chromium/Chrome binary is on PATH. Exported
 // so capability detection can gate the `meeting` tag on a launchable browser
 // without reaching into this package's unexported findChromium.

--- a/internal/platform/meeting_browser_test.go
+++ b/internal/platform/meeting_browser_test.go
@@ -204,6 +204,37 @@ func TestMeetingBrowser_IsGoogleSignInURL(t *testing.T) {
 	}
 }
 
+// TestMeetingBrowser_IsMicrosoftSignInURL checks the Teams anonymous-join gate
+// (issue #7000): a redirect to a Microsoft identity host means the meeting is
+// refusing a guest web join, everything else (a real Teams URL, other MS hosts,
+// unparseable input) is not.
+func TestMeetingBrowser_IsMicrosoftSignInURL(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{"entra work/school login", "https://login.microsoftonline.com/common/oauth2/authorize?x=1", true},
+		{"personal MS account login", "https://login.live.com/login.srf", true},
+		{"login.microsoft.com", "https://login.microsoft.com/", true},
+		{"case-insensitive host", "https://LOGIN.MICROSOFTONLINE.COM/common", true},
+		{"tenant subdomain of login host", "https://foo.login.microsoftonline.com/x", true},
+		{"real teams meet url", "https://teams.microsoft.com/meet/1234567890?p=AbCdEf", false},
+		{"real teams meetup-join url", "https://teams.microsoft.com/l/meetup-join/19%3ameeting_x", false},
+		{"lookalike host is not spoofable", "https://evil-login.microsoftonline.com.attacker.test/", false},
+		{"unrelated ms host", "https://outlook.office.com/mail/", false},
+		{"empty string", "", false},
+		{"unparseable url", "http://[::1", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsMicrosoftSignInURL(tc.url); got != tc.want {
+				t.Errorf("IsMicrosoftSignInURL(%q) = %v, want %v", tc.url, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestMeetingProfileDir_CreatesWithOwnerOnlyPerms verifies a
 // freshly-created meeting profile dir is locked to 0700 — it will hold real
 // Google session cookies for the bot account (issue #5122).


### PR DESCRIPTION
## Context
Extends the sovereign self-hosted meeting bot (headless-Chromium/CDP on a Citadel node, currently **Google Meet only**) with a **Microsoft Teams** join flow, so a real bot can join a live Teams meeting, record audio, and transcribe — all on the user's own hardware, no tenant/Graph dependency. Parallel to the Meet flow in `internal/jobs/meeting_join.go`. Closes the citadel side of aceteam-ai/aceteam#7000.

This is a **scaffold**: the Teams web DOM is not knowable statically and must be **live-tuned against a real Teams meeting** (exactly how the Meet flow was tuned). The statically-verifiable parts are built and unit-tested; the selectors are a clearly-marked best-guess block for a human to tune.

## What's implemented (statically verifiable + unit-tested)
- **URL → platform detection** (`detectMeetingPlatform`, `parseMeetingURL`) — recognizes `meet.google.com` vs Teams (`teams.microsoft.com`, `teams.live.com`, `teams.microsoft.us`), handling **both** `teams.microsoft.com/meet/<id>?p=<passcode>` and `/l/meetup-join/…` link shapes. Host-anchored (exact or dot-anchored subdomain) so a lookalike host or a path segment can't spoof classification. Pure functions.
- **Teams passcode extraction** (`parseTeamsPasscode`) — pulls the `p` query param for `/meet/<id>?p=` links.
- `parseMeetingJoinParams` now sets `Platform` + `Passcode` on the job params and **rejects unsupported URLs** (fail-fast before launching a browser).
- `runJoinFlow` **branches by platform** (`runMeetJoinFlow` / `runTeamsJoinFlow`).
- **`platform.IsMicrosoftSignInURL`** alongside `IsGoogleSignInURL` — detects a `login.microsoftonline.com` / `login.live.com` redirect so the flow fails loudly when a meeting refuses anonymous/guest join (the bot prefers guest join, no MS profile by design).
- End-detection is **platform-aware** (`checkMeetingEndedFor`) so a Teams call ends on its own signal, not just the max-duration cap.
- Teams routes through the **plain record→transcribe loop** — the Meet-coupled interactive/`/ace`-chat layer is out of Teams MVP scope.
- **Reuses the existing platform-agnostic `MeetingMedia` capture + `TRANSCRIBE_AUDIO` path unchanged** — audio capture is NOT forked.

**Tests** (`go test ./... && go vet ./...` green): table tests for platform detection (incl. spoof/lookalike/scheme-less/unparseable cases), passcode extraction, `parseMeetingURL`, the new `parseMeetingJoinParams` platform/passcode/rejection behavior, and `IsMicrosoftSignInURL`.

## What needs LIVE-TUNING (a human + a real Teams meeting)
`internal/jobs/meeting_join_teams.go` mirrors the Meet flow's structure but **every selector / JS snippet is UNVERIFIED best-guess** — it has never been run against a live Teams call. A human must open a real `teams.microsoft.com` meeting and confirm/replace:
- `teamsNameInputSelector`, `teamsPasscodeInputSelector`
- `teamsContinueOnBrowserLabels` (the "Continue on this browser" interstitial), `teamsJoinButtonLabels`
- `teamsMuteMicCamJS` (pre-join mute mic/cam)
- `teamsIsAdmittedJS`, `teamsInLobbyJS`, `teamsIsEndedJS`, `teamsLeaveJS`
- Verify Teams actually allows anonymous/guest web join for the target meetings.

Everything is isolated in the one Teams file (and the LIVE-TUNING comment block) so tuning is a single-file edit.

## Dependency
Backend gates are owned by sibling issue **aceteam-ai/aceteam#6997** (add `'teams'` to the `meeting_platform` enum/migration, relax `_SUPPORTED_PLATFORMS` / `_validate_meeting_url`, the MCP `platform` hardcode, and the TS zod/form validators). This PR assumes those land; it touches **only** the citadel-cli repo.

## Follow-ups (documented, out of MVP scope)
- Live-tune + validate the Teams selectors against ≥1 real meeting (acceptance criterion).
- Wire the interactive/chat layer for Teams (currently Meet-coupled) once its DOM is tuned.
- Teams has no trusted participant-count selector yet, so there's no "bot alone" end signal (Meet has one); Teams end-detection leans on the text scan + max-duration cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)