### PR TITLE
feat(gateway): add unexpose to revoke a gateway exposure

### DIFF
--- a/cmd/agent_tools.go
+++ b/cmd/agent_tools.go
@@ -87,6 +87,9 @@ func buildAgentProviders(ctx context.Context, d agentProviderDeps) *status.Agent
 				Epoch:      spec.Epoch,
 			})
 		},
+		Unexpose: func(name string) (any, error) {
+			return liveExposeOps{}.Unexpose(ctx, name)
+		},
 	}
 }
 

--- a/cmd/expose_ops.go
+++ b/cmd/expose_ops.go
@@ -84,6 +84,49 @@ func (liveExposeOps) Expose(_ context.Context, req worker.ExposeRequest) (*worke
 	return res, nil
 }
 
+// UnexposeResult is what the unexpose path returns to its caller (the CLI, the
+// aceteam MCP verb).
+type UnexposeResult struct {
+	// Name is the exposed-service slug that was revoked.
+	Name string `json:"name"`
+	// WasExposed reports whether a live exposure actually existed. False means
+	// the call still succeeded (revoke is idempotent) but nothing was serving --
+	// surfaced so a caller can say "not exposed" instead of implying it tore
+	// something down.
+	WasExposed bool `json:"was_exposed"`
+}
+
+// Unexpose revokes an exposure: it drops the gateway's live route AND the
+// durable record, so the service stops being reachable now and does not come
+// back on the next restart (#647 made exposures survive restarts, which is
+// exactly why revoke must clear both halves).
+//
+// Order matters. The LIVE route is torn down first: if the durable delete fails,
+// the service is already unreachable and the residual failure is a stale record
+// that resurrects on the next restart -- noisy but not an exposure the operator
+// believes is gone. Deleting the record first would invert that into the unsafe
+// direction (record gone, service still serving, nothing left to reconcile it).
+func (liveExposeOps) Unexpose(_ context.Context, name string) (*UnexposeResult, error) {
+	if name == "" {
+		return nil, fmt.Errorf("unexpose requires a service name")
+	}
+	ref := getProvisionedServiceGateway()
+	if ref == nil {
+		return nil, fmt.Errorf("no in-process gateway (unexpose requires the node gateway to be running)")
+	}
+
+	wasExposed := ref.gw.Unexpose(name)
+
+	// Delete the durable record even when nothing was live: a record can outlive
+	// its route (restored for a port that no longer listens, or written by an
+	// older build), and revoke must be able to clear that too.
+	if err := config.DeleteExposure(platform.ConfigDir(), name); err != nil {
+		return nil, fmt.Errorf("exposure %q is no longer served, but its saved record could not be removed "+
+			"(it will return on the next restart): %w", name, err)
+	}
+	return &UnexposeResult{Name: name, WasExposed: wasExposed}, nil
+}
+
 // restoreExposures re-wires the persisted exposure set onto a gateway that has
 // not started serving yet (#647). It MUST be called before Start: restoring
 // after the listener is up leaves a window in which a valid exposure 404s, which

--- a/cmd/service_unexpose.go
+++ b/cmd/service_unexpose.go
@@ -1,0 +1,95 @@
+// cmd/service_unexpose.go
+//
+// `citadel service unexpose` — revoke a gateway exposure (#647 follow-up).
+//
+// The inverse of `citadel service expose`. Same transport reasoning: the gateway
+// lives inside the `citadel work` process, so this POSTs to that process's
+// /agent/unexpose control endpoint over the node's own mesh IP rather than
+// touching the gateway directly.
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var serviceUnexposeCmd = &cobra.Command{
+	Use:   "unexpose <name>",
+	Short: "Revoke a service exposed on the AceTeam Network gateway",
+	Long: `Stops serving /expose/<name>/ on this node's gateway and deletes its saved
+record, so the service is unreachable now AND does not come back the next time
+the node restarts.
+
+Any outstanding 'link' tokens for the service stop working, because the gateway
+fails closed for a name with no exposure policy.`,
+	Example: `  # Stop sharing the nvr module's Frigate UI
+  citadel service unexpose frigate`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := args[0]
+
+		// meshIPv4() only answers inside the process running the network stack;
+		// from a separate CLI process fall back to the persisted gateway facts.
+		facts := gatewayFactsForURL()
+		ip := meshIPv4()
+		if ip == "" {
+			ip = facts.MeshIP
+		}
+		if ip == "" {
+			return fmt.Errorf("cannot determine this node's AceTeam Network IP; is `citadel work` running?")
+		}
+
+		body, err := json.Marshal(map[string]string{"name": name})
+		if err != nil {
+			return err
+		}
+
+		url := fmt.Sprintf("http://%s:%d/agent/unexpose", ip, statusPortFrom(facts))
+		req, err := http.NewRequestWithContext(cmd.Context(), http.MethodPost, url, bytes.NewReader(body))
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := (&http.Client{Timeout: 20 * time.Second}).Do(req)
+		if err != nil {
+			return fmt.Errorf("reach the node agent at %s: %w (is `citadel work` running?)", url, err)
+		}
+		defer resp.Body.Close()
+
+		var out struct {
+			Name       string `json:"name"`
+			WasExposed bool   `json:"was_exposed"`
+			Error      string `json:"error"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			return fmt.Errorf("decode agent response (HTTP %d): %w", resp.StatusCode, err)
+		}
+		if resp.StatusCode != http.StatusOK || out.Error != "" {
+			msg := out.Error
+			if msg == "" {
+				msg = fmt.Sprintf("HTTP %d", resp.StatusCode)
+			}
+			return fmt.Errorf("unexpose failed: %s", msg)
+		}
+
+		// Distinguish "revoked something" from "there was nothing to revoke".
+		// Both are successes (revoke is idempotent), but claiming to have torn
+		// down a live exposure that never existed would be a lie.
+		if out.WasExposed {
+			fmt.Printf("\n✅ Revoked %q — no longer served on the gateway.\n\n", name)
+		} else {
+			fmt.Printf("\n%q was not exposed; nothing to revoke.\n\n", name)
+		}
+		return nil
+	},
+}
+
+func init() {
+	svcCmd.AddCommand(serviceUnexposeCmd)
+}

--- a/docs/gateway-ingress.md
+++ b/docs/gateway-ingress.md
@@ -47,7 +47,8 @@ is the reason the test drives the whole chain.
 ## Components
 
 - `internal/gateway/exposure.go` — the primitive: `Visibility`, `ExposePolicy`,
-  the per-Server exposure registry (`SetExposure`/`Expose`/`RemoveExposure`),
+  the per-Server exposure registry (`SetExposure`/`Expose`/`RemoveExposure`/
+  `Unexpose`),
   `exposureMiddleware`, the `MeshIdentityResolver` interface (mirrors the #585
   terminal resolver so the package stays standalone/testable), and the `link`
   token mint/verify (`MintLinkToken`/`verifyLinkToken`, HMAC-SHA256).
@@ -78,6 +79,20 @@ the exposure's current `TokenEpoch`, and `exp` is in the future. Revocation is
 **revoke-all-for-exposure** by bumping `TokenEpoch` (re-expose with `epoch+1`);
 every prior token then fails the epoch check. Per-token (`jti`) revocation is a
 follow-up.
+
+**Revoking the whole exposure** is `Server.Unexpose(name)` (driven by
+`citadel service unexpose <name>` / `POST /agent/unexpose`). It drops the policy
+AND clears the route's upstream address, then deletes the durable record so the
+exposure does not return on the next restart. Outstanding `link` tokens stop
+working immediately: `exposureMiddleware` 404s any `/expose/<name>` with no
+policy, whatever token the caller holds.
+
+Note `http.ServeMux` cannot deregister a handler, so the mux entry and its
+`Upstream` survive a revoke (with an empty address, which makes the stale route
+answer 502 rather than reach the revoked service). The `Upstream` is deliberately
+KEPT in `config.Upstreams` rather than deleted: `wireExposeRoute` re-points an
+existing entry in place, and that is what makes a later re-expose of the same
+name work.
 
 **Shareable URL:** the MCP verb composes it as `url + "?access_token=" + token`.
 The bare `url` is not usable for a `link` exposure without the token.

--- a/internal/gateway/exposure.go
+++ b/internal/gateway/exposure.go
@@ -201,6 +201,39 @@ func (s *Server) RemoveExposure(name string) {
 	delete(s.exposures, name)
 }
 
+// Unexpose revokes an exposure: it drops the visibility policy AND tears down
+// the route's proxy target, the inverse of Expose. Returns false if name was not
+// exposed, so a caller can report "not found" rather than a phantom success.
+//
+// Why both halves. Dropping the policy alone is already fail-closed --
+// exposureMiddleware 404s any /expose/<name> with no policy, and that middleware
+// is the SOLE gate for this namespace. But the registered mux handler and its
+// Upstream would survive, so a later Expose of the same name would inherit the
+// old target until it re-pointed it. Clearing the address makes the stale route
+// inert on its own terms: with no address, resolveTarget returns nil and the
+// proxy answers 502 instead of reaching a service the operator revoked.
+//
+// The mux entry itself CANNOT be removed -- http.ServeMux has no deregister --
+// so the Upstream is kept (with an empty address) rather than deleted from the
+// map. Deleting it would leave the registered handler closed over an orphan and
+// make a re-Expose silently no-op its re-wire (wireExposeRoute mutates the
+// EXISTING Upstream when the prefix is already present, which is what makes
+// re-exposing after an unexpose work).
+func (s *Server) Unexpose(name string) bool {
+	s.mu.Lock()
+	_, existed := s.exposures[name]
+	delete(s.exposures, name)
+	up := s.config.Upstreams[ExposeRoutePath(name)]
+	s.mu.Unlock()
+
+	// Outside the lock: setAddr takes the Upstream's own mutex.
+	if up != nil {
+		up.setAddr("")
+		up.Address = ""
+	}
+	return existed
+}
+
 // getExposure returns the policy for name, or nil if not exposed.
 func (s *Server) getExposure(name string) *ExposePolicy {
 	s.mu.RLock()

--- a/internal/gateway/exposure_test.go
+++ b/internal/gateway/exposure_test.go
@@ -394,3 +394,145 @@ func TestNonExposeRouteStripsClientIngressPath(t *testing.T) {
 		t.Errorf("X-Ingress-Path = %q, want it stripped on a non-subpath route", got)
 	}
 }
+
+// Unexpose must revoke at BOTH layers. The policy delete alone already 404s
+// (exposureMiddleware is the sole gate), so a test that only checks the status
+// code would pass even if the route still pointed at a live backend. This one
+// asserts the backend is never reached — the property that makes revoke real
+// rather than cosmetic.
+func TestUnexposeStopsReachingTheBackend(t *testing.T) {
+	var hits int
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(backend.Close)
+
+	gw := NewServer(Config{Port: 0, NodeName: "n"})
+	gw.SetPermissions(&config.Permissions{})
+	gw.SetMeshResolver(&MockMeshResolver{Identity: &MeshPeerIdentity{SameOwner: true}})
+	if err := gw.Expose("svc", backendAddr(t, backend), &ExposePolicy{Visibility: VisibilityOrg}); err != nil {
+		t.Fatal(err)
+	}
+	for prefix, up := range gw.config.Upstreams {
+		gw.registerProxy(prefix, up)
+	}
+	h := gw.BuildHandler()
+
+	if w := doGet(h, "/expose/svc/"); w.Code != http.StatusOK {
+		t.Fatalf("before revoke: got %d, want 200", w.Code)
+	}
+	if hits != 1 {
+		t.Fatalf("backend hits before revoke = %d, want 1", hits)
+	}
+
+	if !gw.Unexpose("svc") {
+		t.Error("Unexpose reported the exposure did not exist")
+	}
+
+	if w := doGet(h, "/expose/svc/"); w.Code != http.StatusNotFound {
+		t.Errorf("after Unexpose: got %d, want 404", w.Code)
+	}
+	if hits != 1 {
+		t.Errorf("backend was reached %d times after revoke (want 1, i.e. never again)", hits)
+	}
+
+	// The upstream target must be cleared too, so a route that somehow outlives
+	// the policy cannot proxy to the revoked service.
+	if up := gw.config.Upstreams[ExposeRoutePath("svc")]; up != nil && up.addr() != "" {
+		t.Errorf("upstream address = %q after revoke, want empty", up.addr())
+	}
+}
+
+// Revoking is idempotent, and the false return lets a caller say "not exposed"
+// rather than implying it tore something down.
+func TestUnexposeIsIdempotent(t *testing.T) {
+	gw := NewServer(Config{Port: 0, NodeName: "n"})
+	gw.SetPermissions(&config.Permissions{})
+
+	if gw.Unexpose("never-existed") {
+		t.Error("Unexpose of an unknown name returned true")
+	}
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	t.Cleanup(backend.Close)
+	if err := gw.Expose("svc", backendAddr(t, backend), &ExposePolicy{Visibility: VisibilityOrg}); err != nil {
+		t.Fatal(err)
+	}
+	if !gw.Unexpose("svc") {
+		t.Error("first Unexpose returned false")
+	}
+	if gw.Unexpose("svc") {
+		t.Error("second Unexpose returned true; revoke must be idempotent")
+	}
+}
+
+// A link token must not survive revocation. This is the shareable-credential
+// case: the holder has a signed token and needs no mesh identity, so if revoke
+// missed them the link would keep working for a stranger.
+func TestUnexposeInvalidatesOutstandingLinkTokens(t *testing.T) {
+	key := []byte("k")
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	t.Cleanup(backend.Close)
+
+	gw := NewServer(Config{Port: 0, NodeName: "n"})
+	gw.SetPermissions(&config.Permissions{})
+	gw.SetExposeSigningKey(key)
+	if err := gw.Expose("svc", backendAddr(t, backend), &ExposePolicy{Visibility: VisibilityLink, TokenEpoch: 1}); err != nil {
+		t.Fatal(err)
+	}
+	for prefix, up := range gw.config.Upstreams {
+		gw.registerProxy(prefix, up)
+	}
+	h := gw.BuildHandler()
+
+	tok := MintLinkToken(key, "svc", 1, time.Now().Add(time.Hour))
+	if w := doGet(h, "/expose/svc/?access_token="+tok); w.Code != http.StatusOK {
+		t.Fatalf("before revoke: got %d, want 200", w.Code)
+	}
+
+	gw.Unexpose("svc")
+	if w := doGet(h, "/expose/svc/?access_token="+tok); w.Code != http.StatusNotFound {
+		t.Errorf("link token still worked after revoke: got %d, want 404", w.Code)
+	}
+}
+
+// Re-exposing after a revoke must work and must land on the NEW target. This is
+// the case the kept-Upstream design exists for: http.ServeMux cannot deregister
+// a handler, so the route object is reused and re-pointed rather than replaced.
+func TestReExposeAfterUnexposeUsesTheNewBackend(t *testing.T) {
+	var oldHits, newHits int
+	oldBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { oldHits++ }))
+	t.Cleanup(oldBackend.Close)
+	newBackend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		newHits++
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(newBackend.Close)
+
+	gw := NewServer(Config{Port: 0, NodeName: "n"})
+	gw.SetPermissions(&config.Permissions{})
+	gw.SetMeshResolver(&MockMeshResolver{Identity: &MeshPeerIdentity{SameOwner: true}})
+	if err := gw.Expose("svc", backendAddr(t, oldBackend), &ExposePolicy{Visibility: VisibilityOrg}); err != nil {
+		t.Fatal(err)
+	}
+	for prefix, up := range gw.config.Upstreams {
+		gw.registerProxy(prefix, up)
+	}
+	h := gw.BuildHandler()
+	doGet(h, "/expose/svc/")
+	gw.Unexpose("svc")
+
+	if err := gw.Expose("svc", backendAddr(t, newBackend), &ExposePolicy{Visibility: VisibilityOrg}); err != nil {
+		t.Fatalf("re-Expose after Unexpose: %v", err)
+	}
+	if w := doGet(h, "/expose/svc/"); w.Code != http.StatusOK {
+		t.Fatalf("after re-Expose: got %d, want 200", w.Code)
+	}
+	if newHits != 1 {
+		t.Errorf("new backend hits = %d, want 1", newHits)
+	}
+	if oldHits != 1 {
+		t.Errorf("old backend was reached again after re-Expose (hits=%d, want 1)", oldHits)
+	}
+}

--- a/internal/status/agent.go
+++ b/internal/status/agent.go
@@ -60,6 +60,10 @@ type AgentProviders struct {
 	// runs in THIS process: an out-of-process caller (the CLI, the aceteam MCP)
 	// cannot reach it any other way (#598).
 	Expose func(ExposeSpec) (any, error)
+
+	// Unexpose revokes an exposure by name, the inverse of Expose. Same
+	// in-process reasoning: only this process holds the live gateway.
+	Unexpose func(name string) (any, error)
 }
 
 // ExposeSpec is the /agent/expose request body. It mirrors the EXPOSE_SET job
@@ -146,6 +150,40 @@ func (s *Server) registerAgentRoutes(mux *http.ServeMux) {
 		return p.WorkerRestart()
 	})))
 	mux.HandleFunc("/agent/expose", s.requireVPNOrAuth(s.handleAgentExpose))
+	mux.HandleFunc("/agent/unexpose", s.requireVPNOrAuth(s.handleAgentUnexpose))
+}
+
+// handleAgentUnexpose revokes an exposure on the in-process gateway. POST with
+// {"name": "..."}; same auth posture as /agent/expose.
+//
+// POST rather than DELETE to match every other /agent/* control route (they are
+// all POST), so the aceteam backend and the CLI need no special-casing here.
+func (s *Server) handleAgentUnexpose(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.agent == nil || s.agent.Unexpose == nil {
+		writeAgentError(w, errUnavailable)
+		return
+	}
+	var req struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 64*1024)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body: " + err.Error()})
+		return
+	}
+	if req.Name == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name is required"})
+		return
+	}
+	res, err := s.agent.Unexpose(req.Name)
+	if err != nil {
+		writeAgentError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, res)
 }
 
 // handleAgentExpose programs an exposure on the in-process gateway. POST only,


### PR DESCRIPTION
## Context

The last gap from #647. Exposures could be created (`citadel service expose`,
the MCP `expose` verb, the `EXPOSE_SET` job) and, since #648, they survive a
restart — but there was NO way to take one back. `Server.RemoveExposure` had no
caller outside tests, and `config.DeleteExposure` was written in #648 purely in
anticipation of this.

Concretely: an operator who shared Frigate by link had no supported way to stop
sharing it. Worse after #648 — the exposure is now durable, so the only
workaround (restart the worker) stopped working as one.

## Changes

- `internal/gateway/exposure.go`: `Server.Unexpose(name) bool` — drops the
  visibility policy AND clears the route's upstream address. Returns false if
  the name was not exposed, so a caller can say "not exposed" rather than
  claim a phantom teardown.
- `internal/status/agent.go`: `AgentProviders.Unexpose` + `POST /agent/unexpose`
  (same VPN-origin-or-org-token posture as `/agent/expose`; POST to match every
  other `/agent/*` route, so the backend needs no special-casing).
- `cmd/expose_ops.go`: `liveExposeOps.Unexpose` — tears down the live route
  first, then deletes the durable record.
- `cmd/service_unexpose.go`: `citadel service unexpose <name>`.
- `cmd/agent_tools.go`: wires the provider to the same live adapter as expose,
  so the CLI and any future job path cannot drift.
- `docs/gateway-ingress.md`: documents revoke and the ServeMux constraint.

## Two decisions worth reviewing

**Why clear the route as well as the policy.** Dropping the policy alone is
already fail-closed — `exposureMiddleware` 404s a name with no policy and is the
sole gate for that namespace. But the registered handler and its `Upstream`
would survive still pointing at the revoked service, so a later re-expose of the
same name would inherit the old target until it re-pointed it. Clearing the
address makes the stale route inert on its own terms (502, not a live backend).

**Why the Upstream is kept, not deleted.** `http.ServeMux` has no deregister, so
the mux entry outlives the revoke regardless. Deleting the `Upstream` from the
map would leave the registered handler closed over an orphan AND break
re-exposing: `wireExposeRoute` re-points an EXISTING entry in place, which is
exactly what makes a later expose of the same name work.

**Order: live route first, durable record second.** If the durable delete fails,
the service is already unreachable and the residue is a stale record that
resurrects on restart — noisy, but not an exposure the operator believes is
gone. The reverse order fails unsafely (record gone, service still serving,
nothing left to reconcile it). The error message says exactly that.

## Testing

`go test ./...` and `go vet ./...` pass.

New gateway tests assert the property that makes revoke real rather than
cosmetic — **the backend is never reached again**, not merely that the status
code is 404 (a policy-only revoke would pass a status-code-only test):
- backend hit count is unchanged after revoke, and the upstream address is empty
- an outstanding `link` token stops working (the shareable-credential case: the
  holder needs no mesh identity, so a missed revoke would keep working for a
  stranger)
- revoke is idempotent, and returns false for an unknown name
- re-expose after revoke works and lands on the NEW backend, not the old one

MUTATION TESTED both halves independently: disabling the route teardown fails
`TestUnexposeStopsReachingTheBackend`; disabling the policy delete fails three
tests. Neither half is redundant.

## Not included

No `EXPOSE_UNSET` job type and no aceteam-side MCP verb — the node side is what
was missing. `/agent/unexpose` is the endpoint the backend would call when an
MCP `unexpose` verb is added (aceteam repo, separate PR).