### PR TITLE
feat(meeting): bot->room virtual-mic speaking path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -711,6 +711,35 @@ shaped like:
 The `engine` must be `bonsai` so the node routes `MODEL_CACHE_PULL` to the
 single-file GGUF pull and `SERVICE_START` to `services/compose/bonsai.yml`.
 
+### Meeting media stack — virtual mic / bot speaking path (aceteam#7079)
+
+The `meeting-service` module (`services/meeting-service/`) is a headed Chromium +
+Xvfb + PulseAudio container (`meetingd` control API on host 8207 / container 8102,
+CDP on host 8208) that lets the bot HEAR a meeting via a null sink whose monitor
+ffmpeg records. The bot->room SPEAKING path adds a **virtual microphone**:
+`citadel.pa` boots a `citadel_mic` null sink whose monitor is **remapped**
+(`module-remap-source`, `device.class=sound`) to a real source `citadel_virtmic`,
+set as the default input device so the Chromium tab publishes it as its mic.
+
+- **Inject audio** via meetingd: `POST /mic/play` (JSON `{"path": "<ws-rel file>"}`,
+  any ffmpeg format → `paplay`) or `POST /mic/play/pcm` (raw s16le body,
+  `?rate=&channels=` → `pacat`). Node-wide, serialized (409 `already speaking`),
+  synchronous (returns when the clip finishes); no barge-in yet. Go transport:
+  `containerMedia.SpeakFile` (own 3-min client, not the 30s control client).
+- **Strictly additive & gated:** capture sinks and the `/health` canary name
+  `<sink>.monitor` explicitly, so making `citadel_virtmic` the default *source*
+  can't touch capture. `/health` **reports** `virtual_mic:{present,sink,source,
+  required}` but only 503s on absence when `MEETING_MIC_REQUIRED=1` — a node that
+  never speaks behaves exactly as before.
+- **Load-bearing subtlety:** Chromium filters *monitor*-class sources out of
+  `getUserMedia`, which is why the monitor is remapped to a `device.class=sound`
+  source rather than used raw. Live-validation #1: `pactl list sources` must show
+  `citadel_virtmic` with **no** `Monitor of Sink:` line (see the meeting-service
+  README + `smoke_test.py` step 6).
+- **NOT done (next wave):** mic-permission grant (`build_chrome_args` has no
+  `--use-fake-ui-for-media-stream`; rely on the profile's prior grant or a CDP
+  `Browser.grantPermissions`), realtime-engine WS streaming, and barge-in.
+
 ### Per-request Energy Receipt (footprint energy, aceteam#6635)
 
 The footprint sampler can record a per-interval node energy estimate so the

--- a/internal/jobs/meeting_media.go
+++ b/internal/jobs/meeting_media.go
@@ -152,6 +152,12 @@ const (
 	meetingContainerCDPTimeout = 30 * time.Second
 	// meetingContainerHTTPTimeout bounds a single meetingd control call.
 	meetingContainerHTTPTimeout = 30 * time.Second
+	// meetingSpeakTimeout bounds a blocking POST /mic/play. meetingd plays the clip
+	// SYNCHRONOUSLY (it returns when playback finishes), and a TTS clip can run tens
+	// of seconds — well past meetingContainerHTTPTimeout — so speaking uses its own
+	// generous client, else a legitimately long clip surfaces as a spurious timeout
+	// error mid-playback.
+	meetingSpeakTimeout = 3 * time.Minute
 )
 
 // meetingdBaseURL is the loopback base URL for the meeting module's control API.
@@ -301,6 +307,40 @@ func (m *containerMedia) Close() error {
 		m.browser = nil
 	}
 	return m.deleteSession()
+}
+
+// SpeakFile injects a workspace-relative audio file into the container's virtual
+// microphone (meetingd POST /mic/play), so the bot is HEARD in the live meeting —
+// the bot->room complement of the room->bot capture path (aceteam#7079). It is
+// strictly ADDITIVE: the join/record flow never calls it, so a bot that only
+// listens behaves exactly as before. Wiring it to a realtime TTS/agent engine is a
+// later wave; this is the tested, minimal transport.
+//
+// It blocks until meetingd finishes playing the clip (synchronous playback), so it
+// uses a dedicated long-timeout client rather than m.client (30s). A 409 means
+// another clip is already playing; a 503 means the virtual mic is not present on
+// this node.
+func (m *containerMedia) SpeakFile(wavRelPath string) error {
+	body, err := json.Marshal(map[string]any{"path": wavRelPath})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest(http.MethodPost, m.base+"/mic/play", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{Timeout: meetingSpeakTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("meetingd mic play: %w", err)
+	}
+	defer resp.Body.Close()
+	out, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("meetingd mic play returned status %d: %s", resp.StatusCode, string(out))
+	}
+	return nil
 }
 
 func (m *containerMedia) sessionPath(suffix string) string {

--- a/internal/jobs/meeting_media_test.go
+++ b/internal/jobs/meeting_media_test.go
@@ -260,3 +260,47 @@ func TestMeetingWavRelPathMatchesAbs(t *testing.T) {
 		}
 	}
 }
+
+// TestContainerMediaSpeakFile exercises the bot->room speaking transport
+// (aceteam#7079): SpeakFile POSTs the workspace-relative path as JSON to meetingd's
+// /mic/play and treats a 200 as success. Verified without a real container/pulse.
+func TestContainerMediaSpeakFile(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/mic/play" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"played":true,"source":"file","path":"/workspace/tts/hi.wav"}`))
+	}))
+	defer srv.Close()
+
+	m := newTestContainerMedia(srv.URL)
+	if err := m.SpeakFile("tts/hi.wav"); err != nil {
+		t.Fatalf("SpeakFile: %v", err)
+	}
+	if gotBody["path"] != "tts/hi.wav" {
+		t.Errorf("posted path = %v, want the workspace-relative tts/hi.wav", gotBody["path"])
+	}
+}
+
+// TestContainerMediaSpeakFileErrorStatus: a non-200 (e.g. 409 already speaking, or
+// 503 mic absent) surfaces as an error with the status, not a silent success.
+func TestContainerMediaSpeakFileErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"error":"already speaking"}`))
+	}))
+	defer srv.Close()
+
+	m := newTestContainerMedia(srv.URL)
+	err := m.SpeakFile("tts/hi.wav")
+	if err == nil {
+		t.Fatal("SpeakFile returned nil error on a 409, want an error")
+	}
+	if !strings.Contains(err.Error(), "409") {
+		t.Errorf("error = %q, want it to mention the 409 status", err.Error())
+	}
+}

--- a/services/meeting-service/README.md
+++ b/services/meeting-service/README.md
@@ -54,6 +54,47 @@ merely "a process is up". The live meeting crash that motivated this work record
   host while still publishing the port. Both published ports bind `127.0.0.1` only
   (the sole consumer is the co-located citadel process).
 
+## Virtual microphone (bot -> room speaking, aceteam#7079)
+
+The capture path above is room -> bot (the bot HEARS). The speaking path is the
+mirror: `citadel.pa` boots a second null sink `citadel_mic` whose monitor is
+**remapped** to a real capture source `citadel_virtmic`, set as the container's
+default input device -- so the Chromium tab publishes `citadel_virtmic` as its mic
+into the live meeting. Audio played **into** `citadel_mic` is therefore heard by
+the meeting.
+
+```
+  meetingd POST /mic/play {"path": "<ws-rel audio>"}   (JSON, any ffmpeg format)
+  meetingd POST /mic/play/pcm  (raw s16le body, ?rate=&channels=)
+        |  paplay / pacat --device=citadel_mic
+        v
+  null sink citadel_mic ──monitor──> module-remap-source ──> source citadel_virtmic
+                                                             (default source; device.class=sound
+                                                              so Chromium does NOT filter it as a
+                                                              monitor)  ──getUserMedia──> the tab's mic
+```
+
+- **Why remap, not the raw monitor:** Chromium filters monitor-class sources out
+  of `getUserMedia` enumeration, so `citadel_mic.monitor` would be invisible as a
+  mic. `device.class=sound` on the remap overrides the inherited monitor class.
+- **Strictly additive:** the capture sinks and the `/health` canary both name
+  `<sink>.monitor` **explicitly**, so making `citadel_virtmic` the default *source*
+  cannot touch them. A bot that never calls `/mic/play` publishes silence, exactly
+  as before. `/health` **reports** `virtual_mic: {present, sink, source, required}`
+  but does **not** fail on an absent mic (a speaking node opts in with
+  `MEETING_MIC_REQUIRED=1`); capture-broken still 503s as before.
+- **Endpoints** (loopback, meetingd 8207/8102): `POST /mic/play` plays a
+  workspace-relative file (path-safety via the same guard the recorder uses);
+  `POST /mic/play/pcm` streams raw PCM16. Both are node-wide, serialized (409
+  `already speaking`), and **synchronous** (return when the clip finishes) -- there
+  is no mid-clip stop / barge-in yet (later realtime wave).
+- **Live validation** (cannot be unit-tested without pulse + a browser): the
+  `smoke_test.py` step 6 grants mic permission, confirms `citadel_virtmic`
+  enumerates as an `audioinput`, then asserts a `getUserMedia` analyser HEARS a
+  tone POSTed to `/mic/play`. Also confirm `pactl list sources` shows
+  `citadel_virtmic` with **no** `Monitor of Sink:` line (the #1 thing that would
+  silently break Chromium's mic selection).
+
 ## Ports
 
 Registered in `services/ports.go` (the host-port registry) so no other module can

--- a/services/meeting-service/citadel.pa
+++ b/services/meeting-service/citadel.pa
@@ -8,3 +8,31 @@
 load-module module-native-protocol-unix
 load-module module-null-sink sink_name=citadel_default sink_properties=device.description=citadel_default
 set-default-sink citadel_default
+
+# Virtual microphone (bot -> room SPEAKING path, aceteam#7079). A null sink whose
+# monitor is REMAPPED to a real capture source; audio played into citadel_mic
+# (meetingd POST /mic/play) is published on citadel_virtmic, which Chromium selects
+# as its default input device and publishes as the tab's mic into the live meeting.
+#
+# Why remap the monitor instead of using citadel_mic.monitor directly: Chromium
+# filters monitor-class sources out of getUserMedia enumeration, so a monitor would
+# be invisible as a mic. device.class=sound on the remap overrides the monitor
+# class it would otherwise inherit from the master, so Chromium treats it as a real
+# input. (LIVE-VALIDATION #1: confirm `pactl list sources` shows citadel_virtmic
+# with no "Monitor of Sink:" line -- see README.)
+#
+# This is purely ADDITIVE: the per-meeting CAPTURE sinks and the /health canary both
+# name `<sink>.monitor` EXPLICITLY, so making citadel_virtmic the DEFAULT source
+# cannot reach them. A bot that never plays audio publishes silence, exactly as
+# before.
+#
+# `.nofail` is LOAD-BEARING: `pulseaudio -n -F` runs fail-fast by default, so a mic
+# line that fails to load (module missing on the slim image, arg rejected by this
+# PulseAudio version, master monitor not ready) would EXIT the daemon and take
+# down CAPTURE too. .nofail degrades a mic failure to "mic absent" (health reports
+# present=false) instead of "pulse dead". It is last in the file, so its only blast
+# radius is this mic block. Do NOT delete it.
+.nofail
+load-module module-null-sink sink_name=citadel_mic sink_properties=device.description=citadel_mic
+load-module module-remap-source master=citadel_mic.monitor source_name=citadel_virtmic source_properties=device.class=sound
+set-default-source citadel_virtmic

--- a/services/meeting-service/compose.yml
+++ b/services/meeting-service/compose.yml
@@ -32,6 +32,12 @@ services:
       - XVFB_RESOLUTION=${XVFB_RESOLUTION:-1280x720x24}
       - MEETING_PROFILE_DIR=/profile
       - CITADEL_WORKSPACE=/workspace
+      # Virtual-mic speaking path (aceteam#7079). Default OFF: a missing mic is only
+      # REPORTED in /health, never fails CAPTURE. Set to 1 on a node that MUST speak
+      # so an absent mic becomes a hard 503. Compose does not pass host env vars
+      # that aren't listed here, so this passthrough is what makes the opt-in reach
+      # meetingd.
+      - MEETING_MIC_REQUIRED=${MEETING_MIC_REQUIRED:-}
       # Run the in-container `bot` user as the NODE OWNER's UID/GID so the recorded
       # WAV (written into the /workspace mount) is owned by the node process that
       # reads it back for transcription — no cross-UID perms fixup. citadel injects

--- a/services/meeting-service/meetingd.py
+++ b/services/meeting-service/meetingd.py
@@ -67,9 +67,13 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 
-from fastapi import FastAPI
+from fastapi import Body, FastAPI
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
+
+
+def _truthy(val: str | None) -> bool:
+    return (val or "").strip().lower() in {"1", "true", "yes", "on"}
 
 # --- configuration (env, with the same defaults the service.yaml declares) ---
 
@@ -93,6 +97,34 @@ CANARY_FLOOR_DBFS = -50.0
 # buildAudioFFmpegArgs so the transcribe sidecar reads it unchanged.
 WAV_CHANNELS = "1"
 WAV_RATE = "16000"
+
+# --- virtual microphone (bot -> room speaking path, aceteam#7079) ---
+#
+# The container boots (citadel.pa) a null sink MIC_SINK whose monitor is remapped
+# to a real capture source MIC_SOURCE, set as the default source so the Chromium
+# tab publishes it as its mic. Audio played INTO MIC_SINK is therefore heard by the
+# meeting. This is strictly ADDITIVE to the capture path (the per-meeting sinks and
+# the canary both name `<sink>.monitor` EXPLICITLY, so making MIC_SOURCE the default
+# source cannot touch them): a bot that never calls /mic/play publishes silence,
+# exactly as before.
+MIC_SINK = os.environ.get("MEETING_MIC_SINK", "citadel_mic")
+MIC_SOURCE = os.environ.get("MEETING_MIC_SOURCE", "citadel_virtmic")
+# By default a missing virtual mic is REPORTED in /health (never fails it): a node
+# that pulls the new image but hits a remap-source hiccup must keep its existing
+# meeting-CAPTURE capability, which works today. Set MEETING_MIC_REQUIRED truthy on
+# a speaking node to make an absent mic a hard 503.
+MIC_REQUIRED = _truthy(os.environ.get("MEETING_MIC_REQUIRED"))
+# Upper bound on a single /mic/play or /mic/play/pcm playback. A TTS clip is
+# seconds-to-a-minute; this is a safety cap, not the expected duration.
+MIC_PLAY_TIMEOUT = int(os.environ.get("MEETING_MIC_PLAY_TIMEOUT", "120"))
+# Default raw-PCM format for /mic/play/pcm when the caller omits the query params.
+MIC_PCM_RATE = int(os.environ.get("MEETING_MIC_PCM_RATE", "24000"))
+MIC_PCM_CHANNELS = int(os.environ.get("MEETING_MIC_PCM_CHANNELS", "1"))
+
+# Serializes injection so two overlapping clips never garble the mic. One clip at a
+# time; a second concurrent request gets 409 (no barge-in / mid-clip stop yet --
+# that is the later realtime wave).
+_mic_lock = threading.Lock()
 
 
 def _chromium_binary() -> str | None:
@@ -191,6 +223,120 @@ def _unload_module(module_id: str) -> None:
         )
     except (subprocess.SubprocessError, OSError):
         pass
+
+
+def _pactl_short(kind: str) -> list[str]:
+    """Names of the pulse objects of `kind` ("sinks"/"sources") via `pactl list
+    short`. Column 1 is the object name (tab-separated). Returns [] on any failure
+    so a probe treats 'pactl unavailable' the same as 'object absent'."""
+    if not shutil.which("pactl"):
+        return []
+    try:
+        r = subprocess.run(
+            ["pactl", "list", "short", kind],
+            env=_pactl_env(),
+            capture_output=True,
+            timeout=5,
+            text=True,
+            check=False,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return []
+    if r.returncode != 0:
+        return []
+    names: list[str] = []
+    for line in r.stdout.splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 2:
+            names.append(parts[1])
+    return names
+
+
+def virtual_mic_present() -> bool:
+    """True when BOTH the virtual-mic null sink and its remapped source exist, i.e.
+    citadel.pa's mic topology loaded. Cheap (two `pactl list short` calls), so it is
+    safe to call on every /health."""
+    return MIC_SINK in _pactl_short("sinks") and MIC_SOURCE in _pactl_short("sources")
+
+
+def build_mic_decode_ffmpeg_args(in_path: str, out_path: str) -> list[str]:
+    """ffmpeg args to decode ANY audio file the caller supplies into a plain WAV
+    that paplay streams into the virtual-mic sink. Format-agnostic on input; the
+    output is a mono 48 kHz WAV (a normal mic rate). Pure so it is unit-testable."""
+    return [
+        "ffmpeg",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-i",
+        in_path,
+        "-ac",
+        "1",
+        "-ar",
+        "48000",
+        "-y",
+        out_path,
+    ]
+
+
+def build_paplay_mic_args(sink: str, wav_path: str) -> list[str]:
+    """paplay args to play a WAV into `sink` (the virtual-mic null sink). Mirrors the
+    canary's `paplay --device=<sink> <file>` invocation, which is proven to work."""
+    return ["paplay", f"--device={sink}", wav_path]
+
+
+def build_pacat_mic_args(sink: str, rate: int, channels: int) -> list[str]:
+    """pacat args to play raw signed-16-bit little-endian PCM (read from stdin) into
+    `sink`. This is the low-latency path a realtime TTS engine would stream to. Pure
+    so the format flags are unit-testable."""
+    return [
+        "pacat",
+        "--playback",
+        f"--device={sink}",
+        "--format=s16le",
+        f"--rate={int(rate)}",
+        f"--channels={int(channels)}",
+    ]
+
+
+def _play_file_into_mic(src_path: str) -> None:
+    """Decode `src_path` to a scratch WAV and play it into MIC_SINK, so it is
+    published on the virtual mic into the live meeting. Blocks until playback
+    finishes (pulse paces the null sink at wall-clock rate)."""
+    tmpdir = tempfile.mkdtemp(prefix="mic_")
+    wav = os.path.join(tmpdir, "play.wav")
+    # ONE budget shared across decode + playback (not MIC_PLAY_TIMEOUT each), so
+    # meetingd's total worst case stays under MIC_PLAY_TIMEOUT and never holds
+    # _mic_lock past the Go client's (larger) timeout -- otherwise the next call
+    # gets a confusing 409 while a runaway clip is still "playing".
+    start = time.monotonic()
+    try:
+        subprocess.run(
+            build_mic_decode_ffmpeg_args(src_path, wav),
+            env=_pactl_env(),
+            check=True,
+            timeout=MIC_PLAY_TIMEOUT,
+        )
+        remaining = max(1.0, MIC_PLAY_TIMEOUT - (time.monotonic() - start))
+        subprocess.run(
+            build_paplay_mic_args(MIC_SINK, wav),
+            env=_pactl_env(),
+            check=True,
+            timeout=remaining,
+        )
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def _play_pcm_into_mic(pcm: bytes, rate: int, channels: int) -> None:
+    """Play raw s16le PCM bytes into MIC_SINK via pacat. Blocks until done."""
+    subprocess.run(
+        build_pacat_mic_args(MIC_SINK, rate, channels),
+        env=_pactl_env(),
+        input=pcm,
+        check=True,
+        timeout=MIC_PLAY_TIMEOUT,
+    )
 
 
 def build_record_ffmpeg_args(monitor_source: str, out_path: str) -> list[str]:
@@ -343,6 +489,13 @@ class RecordRequest(BaseModel):
     out: str
 
 
+class MicPlayRequest(BaseModel):
+    # path is a workspace-relative audio file (any format ffmpeg decodes). It is
+    # resolved through _safe_workspace_path, so it cannot escape the /workspace
+    # mount -- same guard the recorder uses for its output path.
+    path: str
+
+
 @asynccontextmanager
 async def _lifespan(_: FastAPI) -> AsyncIterator[None]:
     threading.Thread(target=_reaper, name="session-reaper", daemon=True).start()
@@ -368,6 +521,21 @@ def _safe_workspace_path(rel: str) -> str:
     return full
 
 
+def _virtual_mic_health() -> dict[str, object]:
+    """The virtual-mic block attached to every /health body. Best-effort: a probe
+    failure reports present=False rather than raising."""
+    try:
+        present = virtual_mic_present()
+    except Exception:  # noqa: BLE001 -- report, never fail the whole probe
+        present = False
+    return {
+        "present": present,
+        "sink": MIC_SINK,
+        "source": MIC_SOURCE,
+        "required": MIC_REQUIRED,
+    }
+
+
 @app.get("/health")
 def health() -> JSONResponse:
     chromium = _chromium_binary()
@@ -378,28 +546,46 @@ def health() -> JSONResponse:
         problems.append("ffmpeg not found")
     if not pulse_ready():
         problems.append("pulse server not ready")
+    mic = _virtual_mic_health()
+    # The virtual mic is the SPEAKING path; a missing one never breaks CAPTURE, so by
+    # default it is only reported. Only a node explicitly required to speak
+    # (MEETING_MIC_REQUIRED) treats its absence as unhealthy.
+    if MIC_REQUIRED and not mic["present"]:
+        problems.append(f"virtual mic not present (sink={MIC_SINK}, source={MIC_SOURCE})")
     if problems:
         return JSONResponse(
             status_code=503,
-            content={"status": "unhealthy", "problems": problems},
+            content={"status": "unhealthy", "problems": problems, "virtual_mic": mic},
         )
     try:
         canary = run_canary()
     except Exception as exc:  # noqa: BLE001 -- any canary failure is unhealthy
         return JSONResponse(
             status_code=503,
-            content={"status": "unhealthy", "problems": [f"canary error: {exc}"]},
+            content={
+                "status": "unhealthy",
+                "problems": [f"canary error: {exc}"],
+                "virtual_mic": mic,
+            },
         )
     if not canary.ok:
         # 503 (5xx) so catalog.ProbeHealth classifies this as UNHEALTHY. A 4xx
         # would be read as healthy by that prober.
         return JSONResponse(
             status_code=503,
-            content={"status": "unhealthy", "canary": canary.model_dump()},
+            content={
+                "status": "unhealthy",
+                "canary": canary.model_dump(),
+                "virtual_mic": mic,
+            },
         )
     return JSONResponse(
         status_code=200,
-        content={"status": "healthy", "canary": canary.model_dump()},
+        content={
+            "status": "healthy",
+            "canary": canary.model_dump(),
+            "virtual_mic": mic,
+        },
     )
 
 
@@ -519,6 +705,88 @@ def stop_record(session_id: str) -> JSONResponse:
         path = s.record_path
         s.recorder = None
     return JSONResponse(content={"recording": False, "path": path})
+
+
+# --- speaking path (bot -> room, aceteam#7079) ---------------------------------
+#
+# Two operations, one body shape each (cleaner than content-type switching):
+#   POST /mic/play        JSON {"path": "<workspace-relative audio file>"}
+#                         Decodes any ffmpeg-readable file and plays it into the
+#                         virtual mic. 200 {"played": true, "source": "file", ...}.
+#   POST /mic/play/pcm    raw body = signed-16-bit little-endian PCM
+#                         query: ?rate=<hz>&channels=<n> (default 24000/1)
+#                         Streams the bytes straight into the virtual mic via pacat.
+#                         200 {"played": true, "source": "pcm", "bytes": N}.
+#
+# Both are node-wide (the mic is one boot-level device, not per session): they are
+# serialized by _mic_lock and return 409 while a clip is already playing. Playback
+# is SYNCHRONOUS (the request returns when the clip finishes) and there is no
+# mid-clip stop / barge-in yet -- that is the later realtime wave.
+
+
+def _mic_not_ready() -> JSONResponse | None:
+    """Shared pre-flight for the speaking endpoints: pulse up and the virtual mic
+    present. Returns a 503 response when not ready, else None."""
+    if not pulse_ready():
+        return JSONResponse(status_code=503, content={"error": "pulse server not ready"})
+    if not virtual_mic_present():
+        return JSONResponse(
+            status_code=503,
+            content={"error": f"virtual mic not present (sink={MIC_SINK}, source={MIC_SOURCE})"},
+        )
+    return None
+
+
+@app.post("/mic/play")
+def mic_play(req: MicPlayRequest) -> JSONResponse:
+    not_ready = _mic_not_ready()
+    if not_ready is not None:
+        return not_ready
+    try:
+        src = _safe_workspace_path(req.path)
+    except ValueError as exc:
+        return JSONResponse(status_code=400, content={"error": str(exc)})
+    if not os.path.isfile(src):
+        return JSONResponse(status_code=404, content={"error": f"no such file: {req.path}"})
+    if not _mic_lock.acquire(blocking=False):
+        return JSONResponse(status_code=409, content={"error": "already speaking"})
+    try:
+        _play_file_into_mic(src)
+    except subprocess.TimeoutExpired:
+        return JSONResponse(status_code=504, content={"error": "mic playback timed out"})
+    except subprocess.CalledProcessError as exc:
+        return JSONResponse(status_code=500, content={"error": f"mic playback failed: {exc}"})
+    finally:
+        _mic_lock.release()
+    return JSONResponse(content={"played": True, "source": "file", "path": src})
+
+
+@app.post("/mic/play/pcm")
+def mic_play_pcm(
+    # Default to empty (not required) so an empty body reaches the explicit 400
+    # below instead of FastAPI's generic 422 required-body error.
+    pcm: bytes = Body(b"", media_type="application/octet-stream"),
+    rate: int = MIC_PCM_RATE,
+    channels: int = MIC_PCM_CHANNELS,
+) -> JSONResponse:
+    not_ready = _mic_not_ready()
+    if not_ready is not None:
+        return not_ready
+    if not pcm:
+        return JSONResponse(status_code=400, content={"error": "empty PCM body"})
+    if rate <= 0 or channels <= 0:
+        return JSONResponse(status_code=400, content={"error": "rate and channels must be positive"})
+    if not _mic_lock.acquire(blocking=False):
+        return JSONResponse(status_code=409, content={"error": "already speaking"})
+    try:
+        _play_pcm_into_mic(pcm, rate, channels)
+    except subprocess.TimeoutExpired:
+        return JSONResponse(status_code=504, content={"error": "mic playback timed out"})
+    except subprocess.CalledProcessError as exc:
+        return JSONResponse(status_code=500, content={"error": f"mic playback failed: {exc}"})
+    finally:
+        _mic_lock.release()
+    return JSONResponse(content={"played": True, "source": "pcm", "bytes": len(pcm)})
 
 
 @app.delete("/sessions/{session_id}")

--- a/services/meeting-service/smoke_test.py
+++ b/services/meeting-service/smoke_test.py
@@ -11,10 +11,14 @@ asserts
      published (socat-forwarded) port;
   3. driving that CDP to play a WebAudio tone, then recording via meetingd,
      produces a NON-SILENT WAV under /workspace.
+  4. (bot -> room SPEAKING path, aceteam#7079) the tab's getUserMedia sees the
+     virtual mic (citadel_virtmic) as an audioinput, and audio POSTed to meetingd's
+     /mic/play is HEARD by the tab -- the live-validation of the mic topology.
 
 Step 3 is the exact thing the live meeting crash failed to do (it recorded
-nothing). It needs docker + the `websocket-client` package, so it is a documented
-MANUAL check, not a CI gate.
+nothing). Step 4 is the honest live proof of the speaking path (item that cannot
+be unit-tested without pulse + a browser). It needs docker + the
+`websocket-client` package, so it is a documented MANUAL check, not a CI gate.
 
 Run:
     pip install websocket-client
@@ -83,6 +87,101 @@ def wav_rms_dbfs(path: str) -> float:
     return 20 * math.log10(rms / 32768.0) if rms > 0 else -120.0
 
 
+def write_tone_wav(path: str, seconds: float = 1.5, freq: int = 440, rate: int = 48000) -> None:
+    """Write a half-scale mono sine WAV (no ffmpeg dependency on the host)."""
+    import array
+
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    n = int(seconds * rate)
+    samples = array.array(
+        "h", (int(16000 * math.sin(2 * math.pi * freq * i / rate)) for i in range(n))
+    )
+    with wave.open(path, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(rate)
+        w.writeframes(samples.tobytes())
+
+
+def cdp_eval(ws, cid: int, expression: str, await_promise: bool = False):
+    """Run one Runtime.evaluate over an open CDP page ws and return the by-value
+    result, draining unrelated events until the matching id comes back."""
+    ws.send(
+        json.dumps(
+            {
+                "id": cid,
+                "method": "Runtime.evaluate",
+                "params": {
+                    "expression": expression,
+                    "returnByValue": True,
+                    "awaitPromise": await_promise,
+                },
+            }
+        )
+    )
+    while True:
+        m = json.loads(ws.recv())
+        if m.get("id") == cid:
+            return m.get("result", {}).get("result", {}).get("value")
+
+
+def mic_check(ws, workdir: str) -> None:
+    """Step 4: prove the SPEAKING path end to end. Grant mic permission, confirm the
+    virtual mic enumerates as an audioinput, then start a getUserMedia analyser,
+    POST a tone to /mic/play, and assert the tab HEARD non-silence."""
+    # /health must now report the virtual mic present.
+    _, h = http("GET", f"http://127.0.0.1:{HOST_MEETINGD}/health")
+    assert h.get("virtual_mic", {}).get("present") is True, f"virtual_mic not present: {h}"
+    print("      /health virtual_mic:", h["virtual_mic"])
+
+    # Grant mic permission so getUserMedia resolves and device labels populate.
+    ws.send(json.dumps({"id": 90, "method": "Browser.grantPermissions",
+                        "params": {"permissions": ["audioCapture"]}}))
+    while True:
+        if json.loads(ws.recv()).get("id") == 90:
+            break
+
+    inputs = cdp_eval(
+        ws, 91,
+        "navigator.mediaDevices.enumerateDevices()."
+        "then(ds=>ds.filter(d=>d.kind==='audioinput').map(d=>d.label||d.deviceId))",
+        await_promise=True,
+    )
+    print("      audioinput devices:", inputs)
+    assert inputs, "no audioinput devices enumerated (Chromium filtered the virtual mic?)"
+
+    # Start a getUserMedia analyser that tracks the peak RMS into window.__micMax.
+    started = cdp_eval(
+        ws, 92,
+        "navigator.mediaDevices.getUserMedia({audio:{echoCancellation:false,"
+        "noiseSuppression:false,autoGainControl:false}}).then(s=>{"
+        "const c=new AudioContext();const src=c.createMediaStreamSource(s);"
+        "const an=c.createAnalyser();an.fftSize=2048;src.connect(an);"
+        "const buf=new Float32Array(an.fftSize);window.__micMax=0;"
+        "window.__micTimer=setInterval(()=>{an.getFloatTimeDomainData(buf);"
+        "let sum=0;for(const v of buf)sum+=v*v;"
+        "const rms=Math.sqrt(sum/buf.length);"
+        "if(rms>window.__micMax)window.__micMax=rms;},50);return true;})",
+        await_promise=True,
+    )
+    assert started is True, f"getUserMedia did not start: {started}"
+
+    # Inject a tone into the virtual mic (blocks ~1.5s while it plays).
+    write_tone_wav(os.path.join(workdir, "workspace", "tts", "mic_tone.wav"))
+    st, _ = http("POST", f"http://127.0.0.1:{HOST_MEETINGD}/mic/play",
+                 {"path": "tts/mic_tone.wav"})
+    assert st == 200, f"/mic/play returned {st}"
+    time.sleep(0.5)  # let the analyser drain the tail
+
+    peak = cdp_eval(ws, 93, "(window.__micMax||0)")
+    print(f"      mic peak RMS = {peak}")
+    # Silence sits at ~0; a real tone through the virtual mic lands well above 1e-3.
+    assert isinstance(peak, (int, float)) and peak > 1e-3, (
+        f"virtual mic captured silence (peak={peak}); the tab did NOT hear /mic/play"
+    )
+    print("PASS: bot -> room speaking path (tab heard the injected tone)")
+
+
 def main() -> int:
     from websocket import create_connection
 
@@ -134,16 +233,20 @@ def main() -> int:
              {"out": "meetings/smoke.wav"})
         time.sleep(3.5)
         http("POST", f"http://127.0.0.1:{HOST_MEETINGD}/sessions/smoke/record/stop")
-        ws.close()
 
-        print("[5/5] assert non-silent WAV ...")
+        print("[5/6] assert non-silent WAV ...")
         wav = os.path.join(workdir, "workspace", "meetings", "smoke.wav")
         db = wav_rms_dbfs(wav)
         print(f"      WAV RMS = {db:.2f} dBFS (floor {FLOOR_DBFS})")
         if db <= FLOOR_DBFS:
             print("FAIL: recording is silent")
+            ws.close()
             return 1
         print("PASS: end-to-end non-silent capture on a bare box")
+
+        print("[6/6] assert bot -> room speaking path (virtual mic) ...")
+        mic_check(ws, workdir)
+        ws.close()
         return 0
     finally:
         subprocess.run(["docker", "logs", NAME], capture_output=True)

--- a/services/meeting-service/test_meetingd.py
+++ b/services/meeting-service/test_meetingd.py
@@ -143,6 +143,7 @@ def test_health_returns_503_when_pulse_down(monkeypatch):
     monkeypatch.setattr(meetingd, "_chromium_binary", lambda: "/usr/bin/chromium")
     monkeypatch.setattr(meetingd.shutil, "which", lambda _: "/usr/bin/ffmpeg")
     monkeypatch.setattr(meetingd, "pulse_ready", lambda: False)
+    monkeypatch.setattr(meetingd, "virtual_mic_present", lambda: True)
     with TestClient(meetingd.app) as client:
         r = client.get("/health")
     assert r.status_code == 503
@@ -155,6 +156,7 @@ def test_health_returns_503_when_canary_silent(monkeypatch):
     monkeypatch.setattr(meetingd, "_chromium_binary", lambda: "/usr/bin/chromium")
     monkeypatch.setattr(meetingd.shutil, "which", lambda _: "/usr/bin/ffmpeg")
     monkeypatch.setattr(meetingd, "pulse_ready", lambda: True)
+    monkeypatch.setattr(meetingd, "virtual_mic_present", lambda: True)
     monkeypatch.setattr(
         meetingd,
         "run_canary",
@@ -170,6 +172,7 @@ def test_health_returns_200_when_canary_passes(monkeypatch):
     monkeypatch.setattr(meetingd, "_chromium_binary", lambda: "/usr/bin/chromium")
     monkeypatch.setattr(meetingd.shutil, "which", lambda _: "/usr/bin/ffmpeg")
     monkeypatch.setattr(meetingd, "pulse_ready", lambda: True)
+    monkeypatch.setattr(meetingd, "virtual_mic_present", lambda: True)
     monkeypatch.setattr(
         meetingd,
         "run_canary",
@@ -179,3 +182,164 @@ def test_health_returns_200_when_canary_passes(monkeypatch):
         r = client.get("/health")
     assert r.status_code == 200
     assert r.json()["status"] == "healthy"
+    # The virtual-mic block rides every /health body (additive; #7079).
+    vm = r.json()["virtual_mic"]
+    assert vm["present"] is True
+    assert vm["sink"] == meetingd.MIC_SINK
+    assert vm["source"] == meetingd.MIC_SOURCE
+
+
+# --- virtual microphone (bot -> room speaking path, aceteam#7079) --------------
+
+
+def test_health_reports_but_does_not_fail_on_missing_mic(monkeypatch):
+    """CRITICAL additive contract: a missing virtual mic must NOT 503 /health by
+    default -- that would strip meeting-CAPTURE capability from every node that
+    pulls the new image but hits a remap-source hiccup. It is only REPORTED
+    (present=false) unless MEETING_MIC_REQUIRED opts in."""
+    monkeypatch.setattr(meetingd, "_chromium_binary", lambda: "/usr/bin/chromium")
+    monkeypatch.setattr(meetingd.shutil, "which", lambda _: "/usr/bin/ffmpeg")
+    monkeypatch.setattr(meetingd, "pulse_ready", lambda: True)
+    monkeypatch.setattr(meetingd, "MIC_REQUIRED", False)
+    monkeypatch.setattr(meetingd, "virtual_mic_present", lambda: False)
+    monkeypatch.setattr(
+        meetingd,
+        "run_canary",
+        lambda: meetingd.CanaryResult(ok=True, rms_dbfs=-12.0, detail="non-silent capture"),
+    )
+    with TestClient(meetingd.app) as client:
+        r = client.get("/health")
+    assert r.status_code == 200
+    assert r.json()["virtual_mic"]["present"] is False
+
+
+def test_health_fails_on_missing_mic_when_required(monkeypatch):
+    """When MEETING_MIC_REQUIRED is set (a speaking node), an absent mic IS a 503."""
+    monkeypatch.setattr(meetingd, "_chromium_binary", lambda: "/usr/bin/chromium")
+    monkeypatch.setattr(meetingd.shutil, "which", lambda _: "/usr/bin/ffmpeg")
+    monkeypatch.setattr(meetingd, "pulse_ready", lambda: True)
+    monkeypatch.setattr(meetingd, "MIC_REQUIRED", True)
+    monkeypatch.setattr(meetingd, "virtual_mic_present", lambda: False)
+    with TestClient(meetingd.app) as client:
+        r = client.get("/health")
+    assert r.status_code == 503
+    assert r.json()["virtual_mic"]["present"] is False
+
+
+def test_mic_arg_builders():
+    """Pin the pure arg builders for the speaking path (no pulse needed)."""
+    dec = meetingd.build_mic_decode_ffmpeg_args("/workspace/tts/hi.mp3", "/tmp/play.wav")
+    assert dec[0] == "ffmpeg"
+    assert dec[dec.index("-i") + 1] == "/workspace/tts/hi.mp3"
+    assert dec[dec.index("-ac") + 1] == "1"
+    assert dec[dec.index("-ar") + 1] == "48000"
+    assert dec[-1] == "/tmp/play.wav"
+
+    pa = meetingd.build_paplay_mic_args("citadel_mic", "/tmp/play.wav")
+    assert pa == ["paplay", "--device=citadel_mic", "/tmp/play.wav"]
+
+    pc = meetingd.build_pacat_mic_args("citadel_mic", 24000, 1)
+    assert pc[0] == "pacat"
+    assert "--playback" in pc
+    assert "--device=citadel_mic" in pc
+    assert "--format=s16le" in pc
+    assert "--rate=24000" in pc
+    assert "--channels=1" in pc
+
+
+def test_mic_play_503_when_mic_absent(monkeypatch):
+    """The speaking endpoints refuse (503) when the virtual mic is not present, so a
+    caller gets a clear signal rather than silently playing into nothing."""
+    monkeypatch.setattr(meetingd, "pulse_ready", lambda: True)
+    monkeypatch.setattr(meetingd, "virtual_mic_present", lambda: False)
+    with TestClient(meetingd.app) as client:
+        r = client.post("/mic/play", json={"path": "tts/hi.wav"})
+    assert r.status_code == 503
+
+
+def test_mic_play_404_on_missing_file(monkeypatch):
+    monkeypatch.setattr(meetingd, "pulse_ready", lambda: True)
+    monkeypatch.setattr(meetingd, "virtual_mic_present", lambda: True)
+    monkeypatch.setattr(meetingd, "WORKSPACE", "/workspace")
+    with TestClient(meetingd.app) as client:
+        r = client.post("/mic/play", json={"path": "tts/does-not-exist.wav"})
+    assert r.status_code == 404
+
+
+def test_mic_play_rejects_path_traversal(monkeypatch):
+    monkeypatch.setattr(meetingd, "pulse_ready", lambda: True)
+    monkeypatch.setattr(meetingd, "virtual_mic_present", lambda: True)
+    monkeypatch.setattr(meetingd, "WORKSPACE", "/workspace")
+    with TestClient(meetingd.app) as client:
+        r = client.post("/mic/play", json={"path": "../etc/passwd"})
+    assert r.status_code == 400
+
+
+def test_mic_play_file_happy_path(monkeypatch, tmp_path):
+    """A present mic + a real file plays: the injection helper is stubbed (no pulse
+    in CI) so this pins the endpoint wiring/response, not the audio subprocess."""
+    ws = tmp_path
+    (ws / "tts").mkdir()
+    f = ws / "tts" / "hi.wav"
+    f.write_bytes(b"RIFF....")
+    played: dict[str, str] = {}
+    monkeypatch.setattr(meetingd, "pulse_ready", lambda: True)
+    monkeypatch.setattr(meetingd, "virtual_mic_present", lambda: True)
+    monkeypatch.setattr(meetingd, "WORKSPACE", str(ws))
+    monkeypatch.setattr(meetingd, "_play_file_into_mic", lambda p: played.update(path=p))
+    with TestClient(meetingd.app) as client:
+        r = client.post("/mic/play", json={"path": "tts/hi.wav"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["played"] is True and body["source"] == "file"
+    assert played["path"] == str(f)
+
+
+def test_mic_play_pcm_happy_path(monkeypatch):
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(meetingd, "pulse_ready", lambda: True)
+    monkeypatch.setattr(meetingd, "virtual_mic_present", lambda: True)
+    monkeypatch.setattr(
+        meetingd,
+        "_play_pcm_into_mic",
+        lambda pcm, rate, channels: captured.update(n=len(pcm), rate=rate, channels=channels),
+    )
+    with TestClient(meetingd.app) as client:
+        r = client.post(
+            "/mic/play/pcm?rate=16000&channels=1",
+            content=b"\x01\x02\x03\x04",
+            headers={"content-type": "application/octet-stream"},
+        )
+    assert r.status_code == 200
+    assert r.json() == {"played": True, "source": "pcm", "bytes": 4}
+    assert captured == {"n": 4, "rate": 16000, "channels": 1}
+
+
+def test_mic_play_pcm_rejects_empty_body(monkeypatch):
+    monkeypatch.setattr(meetingd, "pulse_ready", lambda: True)
+    monkeypatch.setattr(meetingd, "virtual_mic_present", lambda: True)
+    with TestClient(meetingd.app) as client:
+        r = client.post(
+            "/mic/play/pcm",
+            content=b"",
+            headers={"content-type": "application/octet-stream"},
+        )
+    assert r.status_code == 400
+
+
+def test_citadel_pa_declares_virtual_mic():
+    """Pin the citadel.pa virtual-mic topology the way the entrypoint test pins its
+    load-bearing lines: the null sink, the monitor REMAP to a real source (not the
+    raw monitor, which Chromium filters), and the default-source selection."""
+    pa = os.path.join(os.path.dirname(__file__), "citadel.pa")
+    body = open(pa).read()
+    # .nofail keeps a mic-line failure from killing PulseAudio (and CAPTURE) under
+    # `pulseaudio -n -F`'s fail-fast default. The line a future cleanup deletes.
+    assert ".nofail" in body
+    assert "sink_name=citadel_mic" in body
+    assert "module-remap-source" in body
+    assert "master=citadel_mic.monitor" in body
+    assert "source_name=citadel_virtmic" in body
+    # device.class=sound is what stops Chromium filtering it as a monitor.
+    assert "device.class=sound" in body
+    assert "set-default-source citadel_virtmic" in body


### PR DESCRIPTION
## Context

Part of aceteam#7079 (real-time two-way conversation in meetings). Today the
containerized meeting bot can **HEAR** a meeting (room->bot capture via a
PulseAudio null-sink monitor recorded by ffmpeg) but cannot **SPEAK** into it —
there is no path to inject audio as the Chromium tab's microphone. This adds the
mirror path: a virtual microphone plus a `meetingd` control endpoint to inject
audio into it. Strictly additive and gated, so a bot that never speaks behaves
exactly as today.

## Root Cause

The meeting-service container (`services/meeting-service/`) had only a capture
null sink. There was no virtual *source* the tab could publish as its mic, and no
control path to feed audio into one.

## Changes

- **`citadel.pa`** — boot a `citadel_mic` null sink whose monitor is **remapped**
  (`module-remap-source`, `device.class=sound`) to a real source `citadel_virtmic`,
  set as the container's default input device so the Chromium tab publishes it as
  its mic. Guarded by `.nofail` (load-bearing: `pulseaudio -n -F` is fail-fast by
  default, so a mic-line failure would otherwise EXIT the daemon and kill capture
  too — `.nofail` degrades it to "mic absent"). Additive: the capture sinks and the
  `/health` canary name `<sink>.monitor` explicitly, so the new default source
  cannot touch them.
- **`meetingd.py`** — two speaking endpoints (one body shape each):
  - `POST /mic/play` — JSON `{"path": "<workspace-relative audio file>"}`, any
    ffmpeg-decodable format, path-safety via the same `_safe_workspace_path` guard
    the recorder uses; decoded and played into `citadel_mic` via `paplay`.
  - `POST /mic/play/pcm` — raw signed-16-bit LE PCM body, `?rate=&channels=`
    (default 24000/1), streamed via `pacat`.

  Both are node-wide, serialized (`_mic_lock`, 409 `already speaking`), and
  **synchronous**. `/health` now reports `virtual_mic:{present,sink,source,required}`
  and only 503s on an absent mic when `MEETING_MIC_REQUIRED` is set (default:
  reported, never fails capture).
- **`compose.yml`** — pass through `MEETING_MIC_REQUIRED` (compose does not forward
  host env vars that aren't listed, so the documented opt-in needs this).
- **`internal/jobs/meeting_media.go`** — `containerMedia.SpeakFile` helper POSTs to
  `/mic/play` with its own 3-min client (a clip outlasts the 30s control client).
  Additive/unused until the realtime engine is wired in a later wave.
- **Tests** — 12 new `meetingd` tests (pure arg builders, health report-not-fail
  contract, mic-play guards + happy paths, `citadel.pa`/`.nofail` pins) and 2 Go
  `SpeakFile` httptest cases. `smoke_test.py` step 6 live-validates the path. README
  + CLAUDE.md documented.

## Testing

Ran from the worktree root:

- `go build ./...` — pass (exit 0)
- `go vet ./...` — pass (exit 0)
- `go test ./...` — pass (all packages `ok`; new `TestContainerMediaSpeakFile` +
  `...ErrorStatus` pass)
- `python3 -m py_compile services/meeting-service/{meetingd,test_meetingd,smoke_test}.py` — OK
- `pytest services/meeting-service/test_meetingd.py` — **26 passed**
- `ruff check` — flags only the same PLW1510/SIM115/F541 categories already present
  in the pre-existing files (no repo ruff config is enforced on this service).

**Not runnable here (no Docker on this box):** the meeting-service image was not
built. Live validation on a node (meeting container runs on node 1297; CDP host
8208, meetingd host 8207):

1. `python3 services/meeting-service/smoke_test.py` (needs Docker + `websocket-client`).
   Step 6 grants mic permission, confirms `citadel_virtmic` enumerates as an
   `audioinput`, then asserts a `getUserMedia` analyser HEARS a tone POSTed to
   `/mic/play`. **A step-6 failure at the `getUserMedia`/`started` assert means
   "mic permission not granted, not mic broken"** (the browser-domain
   `Browser.grantPermissions` over a page target can be inconsistent) — the human
   fallback is a profile-level mic grant for the origin.
2. **Live-validation #1:** exec into the container and confirm
   `pactl list sources` shows `citadel_virtmic` with **no** `Monitor of Sink:`
   line and `device.class = sound` — this single fact decides whether Chromium
   selects it as a mic. If it inherits the monitor class, Chromium filters it out.
3. `curl -sS -XPOST 127.0.0.1:8207/health | jq .virtual_mic` → `present:true`.

## What is NOT done / known risks

- **Mic permission grant** is not wired: `build_chrome_args` deliberately keeps the
  pinned flag set (it's the capture path's tested contract), so no
  `--use-fake-ui-for-media-stream`. The tab is granted mic access only via the
  persisted profile's prior grant or a CDP `Browser.grantPermissions`. Next
  required piece.
- **No realtime-engine WS wiring** and **no barge-in / mid-clip stop** (playback is
  synchronous, one clip at a time) — the later wave.
- The monitor-vs-source classing (item 2 above) is the #1 live-validation item;
  `device.class=sound` is the intended fix but is unverified without a container.

## Endpoint request contracts

- `POST /mic/play` — `Content-Type: application/json`, body `{"path":"<ws-rel>"}`.
  → 200 `{"played":true,"source":"file","path":"<abs>"}`; 400 bad/traversal path;
  404 missing file; 409 already speaking; 503 pulse down / mic absent; 504 timeout.
- `POST /mic/play/pcm` — raw `application/octet-stream` body = s16le PCM; query
  `rate` (default 24000), `channels` (default 1). → 200
  `{"played":true,"source":"pcm","bytes":N}`; 400 empty body / non-positive params;
  409 already speaking; 503 pulse down / mic absent; 504 timeout.

Closes part of aceteam#7079.

🤖 Generated with [Claude Code](https://claude.com/claude-code)