### PR TITLE
feat(huddle): HUDDLE_JOIN — join a native AceTeam huddle as the agent (#7081)

### DIFF
--- a/internal/jobs/huddle_join.go
+++ b/internal/jobs/huddle_join.go
@@ -1,0 +1,512 @@
+// internal/jobs/huddle_join.go
+//
+// HUDDLE_JOIN handler (aceteam#7081 — the native-huddle agent join). Drives the
+// EXISTING meeting-service container's headless Chromium (over CDP) to the
+// aceteam-side headless "huddle bot" page and confirms the agent actually joined
+// the native huddle call. This is the native-huddle sibling of MEETING_JOIN's
+// Google Meet / Teams flows, but it is MUCH simpler because the join UX lives in
+// aceteam's own React page (app/(huddle-bot)/huddle-bot/[channelId]) rather than
+// a third-party DOM we must reverse-engineer — the page auto-joins audio-only and
+// publishes a machine-pollable readiness signal we just read.
+//
+// SCOPE (this wave): JOIN + presence CONFIRMATION only. The handler mints a
+// short-lived bot token, navigates the container browser to the bot page, polls
+// `window.__huddleBotState.state` until `joined` (patiently handling the
+// `connecting` and lobby states), reports the roster/presence, then tears the
+// session down (the bot LEAVES). Staying resident in the call and bridging a
+// realtime STT/TTS engine to the container's virtual mic (aceteam#7079) is the
+// NEXT wave — deliberately NOT here.
+//
+// The container + virtual mic are reused verbatim from the meeting media stack
+// (meeting_media.go): a session launch (POST /sessions) wires the in-container
+// Chromium to the virtual mic + capture sink, so the huddle join runs against the
+// same browser surface (platform.CDPBrowser) MEETING_JOIN drives.
+//
+// --- aceteam-side contracts this file depends on (verified against the aceteam
+//     repo's #7081 commits, NOT re-implemented here) ---
+//
+//	Token mint  POST {api_base}/api/huddle-bot/token
+//	            Authorization: Bearer <internal secret>   (isInternalServiceRequest)
+//	            body   { "agentId": <id>, "channelId": <id> }
+//	            200 -> { token, expiresAt, selfUserId, channelId, access }
+//	            (channelId is the NORMALIZED id the page must join; access is
+//	             "member" => admitted directly, "read" => lobby-then-admit.)
+//
+//	Bot page    {api_base}/huddle-bot/<channelId>#token=<token>
+//	            The token rides the URL FRAGMENT (never the server / never a log).
+//	            The page publishes window.__huddleBotState =
+//	              { state:"connecting"|"lobby"|"joined"|"left"|"error",
+//	                callId, selfId, peerCount, connectedPeerCount, error, updatedAt }
+package jobs
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/config"
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
+)
+
+// JobTypeHuddleJoinType is the wire type string for the huddle-join job,
+// duplicated here as a local const (the worker package owns the canonical
+// JobType constants and imports this package, not the reverse). Kept in sync with
+// worker.JobTypeHuddleJoin.
+const JobTypeHuddleJoinType = "HUDDLE_JOIN"
+
+// Env vars sourcing the internal service secret used to mint a bot token. The
+// aceteam mint route gates on INTERNAL_AUTH_SECRET (isInternalServiceRequest);
+// the node presents the SAME secret. CITADEL_HUDDLE_BOT_SECRET wins so an
+// operator can scope a dedicated value, falling back to a co-located
+// INTERNAL_AUTH_SECRET when both services share a host/env.
+const (
+	envHuddleBotSecret    = "CITADEL_HUDDLE_BOT_SECRET"
+	envInternalAuthSecret = "INTERNAL_AUTH_SECRET"
+)
+
+// defaultHuddleAPIBase is the AceTeam API base used when the payload omits
+// api_base and no device-creds base URL is on disk.
+const defaultHuddleAPIBase = "https://aceteam.ai"
+
+// Timeouts and cadence for the mint -> navigate -> confirm lifecycle. Two
+// distinct budgets (mirroring MEETING_JOIN's joinButtonTimeout vs admitTimeout):
+//   - huddleConnectTimeout bounds reaching ANY non-`connecting` state (the page
+//     mounting, acquiring the mic, and opening the mesh). Seconds, not minutes;
+//     a page stuck in `connecting` past this never joined.
+//   - huddleAdmitTimeout bounds the human-gated lobby wait once `lobby` is
+//     observed (a non-member on a lobby-enabled call needs a host to admit it).
+const (
+	huddleConnectTimeout   = 45 * time.Second
+	huddleAdmitTimeout     = 3 * time.Minute
+	huddlePollInterval     = 2 * time.Second
+	huddleTokenHTTPTimeout = 20 * time.Second
+	// huddleSessionMaxDuration is the container session's own reaper cap (meetingd
+	// clears a session at its max_duration). Generous relative to a join+confirm so
+	// a same-node retry is never blocked by our own not-yet-reaped session; Close
+	// (DELETE /sessions) tears it down on the normal path well before this.
+	huddleSessionMaxDuration = 1 * time.Hour
+)
+
+// huddleBrowser is the minimal CDP surface the huddle join drives — navigate to
+// the bot page and poll the readiness signal. It is a subset of the
+// meetingBrowser surface (meeting_media.go), so *platform.CDPBrowser satisfies it
+// and a real container session's browser drops straight in. Tests inject a fake.
+type huddleBrowser interface {
+	Navigate(url string) error
+	Evaluate(expression string) (any, error)
+	Close() error
+}
+
+// huddleJoinParams is the typed, validated job payload. channel_id and agent_id
+// are BOTH required: the aceteam mint route needs agentId to resolve the agent's
+// author (the bot's mesh identity) and channelId to gate + normalize the target.
+type huddleJoinParams struct {
+	ChannelID string
+	AgentID   string
+	APIBase   string // optional; falls back to device creds base, then default
+}
+
+// parseHuddleJoinParams validates + normalizes the raw string payload.
+func parseHuddleJoinParams(payload map[string]string) (huddleJoinParams, error) {
+	p := huddleJoinParams{
+		ChannelID: strings.TrimSpace(payload["channel_id"]),
+		AgentID:   strings.TrimSpace(payload["agent_id"]),
+		APIBase:   strings.TrimSpace(payload["api_base"]),
+	}
+	if p.ChannelID == "" {
+		return huddleJoinParams{}, fmt.Errorf("job payload missing required 'channel_id' field")
+	}
+	if p.AgentID == "" {
+		return huddleJoinParams{}, fmt.Errorf("job payload missing required 'agent_id' field")
+	}
+	return p, nil
+}
+
+// huddleToken is the subset of the mint route's 200 response the node needs.
+type huddleToken struct {
+	Token string `json:"token"`
+	// ChannelID is the NORMALIZED channel id the bot page must join (chat-v2
+	// normalizes ids); prefer it over the raw payload channel_id when navigating.
+	ChannelID  string `json:"channelId"`
+	SelfUserID string `json:"selfUserId"`
+	// Access is "member" (admitted directly) or "read" (lobby, needs host admit).
+	Access    string `json:"access"`
+	ExpiresAt string `json:"expiresAt"`
+}
+
+// huddleBotState mirrors aceteam's window.__huddleBotState readiness payload
+// (utils/huddle/botState.ts). Null JSON fields decode to Go zero values, which is
+// exactly what we want (callId/selfId/error -> "").
+type huddleBotState struct {
+	State              string  `json:"state"`
+	CallID             string  `json:"callId"`
+	SelfID             string  `json:"selfId"`
+	PeerCount          int     `json:"peerCount"`
+	ConnectedPeerCount int     `json:"connectedPeerCount"`
+	Error              string  `json:"error"`
+	UpdatedAt          float64 `json:"updatedAt"`
+}
+
+// HuddleJoinHandler handles HUDDLE_JOIN jobs. All external dependencies are
+// injectable seams so the whole flow is unit-testable without a live container,
+// mesh, or backend.
+type HuddleJoinHandler struct {
+	WorkspaceDir string
+
+	// secretFn returns the internal service secret used to mint a bot token, read
+	// at USE-time (like meeting_audio_backup's backupCreds) so a rotated secret is
+	// honored. nil uses the env-var resolver.
+	secretFn func() string
+	// mintToken mints a bot token from the aceteam backend. nil uses the real HTTP
+	// implementation; tests inject a fake mint endpoint.
+	mintToken func(ctx context.Context, apiBase, secret string, p huddleJoinParams) (huddleToken, error)
+	// newBrowser launches (or reuses) the container session and returns the
+	// CDP-driven browser plus a cleanup that tears the session down. nil uses the
+	// real container-session implementation; tests inject a fake browser.
+	newBrowser func(p huddleJoinParams) (br huddleBrowser, cleanup func() error, err error)
+
+	// Tunables (zero => package defaults at use). Tests set them to milliseconds.
+	connectTimeout time.Duration
+	admitTimeout   time.Duration
+	pollInterval   time.Duration
+}
+
+// NewHuddleJoinHandler constructs a handler rooted at the node workspace.
+func NewHuddleJoinHandler(workspace string) *HuddleJoinHandler {
+	return &HuddleJoinHandler{WorkspaceDir: workspace}
+}
+
+// Execute mints a token, drives the container browser to the bot page, confirms
+// the agent joined, and returns a structured result. Order is deliberate: parse
+// -> resolve secret -> resolve base -> MINT -> launch browser. Minting BEFORE the
+// container means a misconfigured secret (401) or an unreachable/forbidden
+// channel (403/404) costs nothing — we never pay for a container session we would
+// immediately abandon.
+func (h *HuddleJoinHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
+	p, err := parseHuddleJoinParams(job.Payload)
+	if err != nil {
+		return nil, err
+	}
+
+	secret := h.resolveSecret()
+	if secret == "" {
+		return nil, fmt.Errorf("HUDDLE_JOIN requires the internal service secret; set %s (or %s) on this node",
+			envHuddleBotSecret, envInternalAuthSecret)
+	}
+	apiBase := h.resolveAPIBase(p)
+
+	ctx.Log("info", "     - [Job %s] HUDDLE_JOIN channel=%s agent=%s (api_base=%s)", job.ID, p.ChannelID, p.AgentID, apiBase)
+
+	// Mint the short-lived bot token FIRST (before any container work).
+	tok, err := h.mint(ctx.Context(), apiBase, secret, p)
+	if err != nil {
+		return nil, fmt.Errorf("mint huddle bot token: %w", err)
+	}
+	// Navigate to the mint response's NORMALIZED channel id when present.
+	joinChannel := tok.ChannelID
+	if joinChannel == "" {
+		joinChannel = p.ChannelID
+	}
+	ctx.Log("info", "     - [Job %s] minted bot token (self=%s, access=%s, channel=%s)", job.ID, tok.SelfUserID, tok.Access, joinChannel)
+
+	// Launch (or reuse) the container session -> CDP browser.
+	br, cleanup, err := h.launchBrowser(p)
+	if err != nil {
+		return nil, fmt.Errorf("launch huddle browser: %w", err)
+	}
+	defer func() {
+		if cleanup != nil {
+			_ = cleanup()
+		}
+	}()
+
+	// Navigate to the bot page. The token rides the URL FRAGMENT so it never
+	// reaches the server; we also NEVER log the full URL (redacted form only) so a
+	// live org-wildcard key is never written to the node journal.
+	navURL := huddleBotURL(apiBase, joinChannel, tok.Token)
+	if err := br.Navigate(navURL); err != nil {
+		return nil, fmt.Errorf("navigate to huddle bot page %s: %w", redactedHuddleBotURL(apiBase, joinChannel), err)
+	}
+	ctx.Log("info", "     - [Job %s] navigated to %s; waiting for join", job.ID, redactedHuddleBotURL(apiBase, joinChannel))
+
+	// Poll the readiness signal until joined / terminal failure / timeout.
+	final, err := pollForHuddleJoined(ctx, br, huddlePollOpts{
+		connectTimeout: h.effConnectTimeout(),
+		admitTimeout:   h.effAdmitTimeout(),
+		interval:       h.effPollInterval(),
+		access:         tok.Access,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	selfID := final.SelfID
+	if selfID == "" {
+		selfID = tok.SelfUserID
+	}
+	ctx.Log("info", "     - [Job %s] JOINED huddle %s (self=%s, peers=%d, connected=%d)",
+		job.ID, joinChannel, selfID, final.PeerCount, final.ConnectedPeerCount)
+
+	out, _ := json.Marshal(map[string]any{
+		"status":               "joined",
+		"channel_id":           joinChannel,
+		"agent_id":             p.AgentID,
+		"self_id":              selfID,
+		"call_id":              final.CallID,
+		"peer_count":           final.PeerCount,
+		"connected_peer_count": final.ConnectedPeerCount,
+		"access":               tok.Access,
+		"state":                final.State,
+	})
+	return out, nil
+}
+
+// resolveSecret returns the internal service secret (seam-overridable).
+func (h *HuddleJoinHandler) resolveSecret() string {
+	if h.secretFn != nil {
+		return h.secretFn()
+	}
+	return defaultHuddleSecret()
+}
+
+// defaultHuddleSecret reads the secret from env, preferring the citadel-scoped
+// name and falling back to the shared internal-auth name.
+func defaultHuddleSecret() string {
+	if s := strings.TrimSpace(os.Getenv(envHuddleBotSecret)); s != "" {
+		return s
+	}
+	return strings.TrimSpace(os.Getenv(envInternalAuthSecret))
+}
+
+// resolveAPIBase resolves the AceTeam API base: explicit payload override, then
+// the node's device-creds base URL, then the default.
+func (h *HuddleJoinHandler) resolveAPIBase(p huddleJoinParams) string {
+	if p.APIBase != "" {
+		return strings.TrimRight(p.APIBase, "/")
+	}
+	if base := config.LoadDeviceCreds(platform.ConfigDir()).APIBaseURL; base != "" {
+		return strings.TrimRight(base, "/")
+	}
+	return defaultHuddleAPIBase
+}
+
+// mint delegates to the injected mint seam or the real HTTP implementation.
+func (h *HuddleJoinHandler) mint(ctx context.Context, apiBase, secret string, p huddleJoinParams) (huddleToken, error) {
+	if h.mintToken != nil {
+		return h.mintToken(ctx, apiBase, secret, p)
+	}
+	return mintHuddleBotToken(ctx, &http.Client{Timeout: huddleTokenHTTPTimeout}, apiBase, secret, p)
+}
+
+// mintHuddleBotToken POSTs to {apiBase}/api/huddle-bot/token with the internal
+// secret as the Bearer credential and returns the minted bot token. A non-200 is
+// surfaced with the status + response body (the body carries the backend's error
+// message and never the token, so it is safe to include).
+func mintHuddleBotToken(ctx context.Context, client *http.Client, apiBase, secret string, p huddleJoinParams) (huddleToken, error) {
+	body, err := json.Marshal(map[string]string{"agentId": p.AgentID, "channelId": p.ChannelID})
+	if err != nil {
+		return huddleToken{}, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiBase+"/api/huddle-bot/token", bytes.NewReader(body))
+	if err != nil {
+		return huddleToken{}, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+secret)
+	resp, err := client.Do(req)
+	if err != nil {
+		return huddleToken{}, err
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode != http.StatusOK {
+		return huddleToken{}, fmt.Errorf("mint endpoint returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	var tok huddleToken
+	if err := json.Unmarshal(raw, &tok); err != nil {
+		return huddleToken{}, fmt.Errorf("parse mint response: %w", err)
+	}
+	if tok.Token == "" {
+		return huddleToken{}, fmt.Errorf("mint endpoint returned an empty token")
+	}
+	return tok, nil
+}
+
+// launchBrowser delegates to the injected browser seam or the real container
+// session implementation.
+func (h *HuddleJoinHandler) launchBrowser(p huddleJoinParams) (huddleBrowser, func() error, error) {
+	if h.newBrowser != nil {
+		return h.newBrowser(p)
+	}
+	return defaultHuddleBrowser(p)
+}
+
+// defaultHuddleBrowser launches a meeting-service container session (reusing the
+// meeting media stack: this wires the in-container Chromium to the virtual mic +
+// capture sink) and returns its CDP browser plus a session-teardown cleanup. The
+// meeting module MUST be healthy on this node — huddle join is a WebRTC join that
+// needs the container's headless Chromium; there is no host fallback here.
+func defaultHuddleBrowser(p huddleJoinParams) (huddleBrowser, func() error, error) {
+	if !meetingdHealthy(&http.Client{Timeout: meetingContainerHealthTimeout}, meetingdBaseURL()) {
+		return nil, nil, fmt.Errorf("the meeting-service container is not healthy on this node; HUDDLE_JOIN requires it (install/enable the meeting module)")
+	}
+	// No recording for join+confirm, so the WAV paths are empty. Start() creates
+	// the session and returns the CDP browser; Close() (cleanup) deletes it.
+	media := newContainerMedia(p.ChannelID, "", "", huddleSessionMaxDuration)
+	br, err := media.Start()
+	if err != nil {
+		return nil, nil, err
+	}
+	return br, media.Close, nil
+}
+
+// huddlePollOpts bundles the poll budgets + the token's access level (for a
+// legible lobby-timeout diagnosis).
+type huddlePollOpts struct {
+	connectTimeout time.Duration
+	admitTimeout   time.Duration
+	interval       time.Duration
+	access         string
+}
+
+// huddleReadinessPage is the slice of the browser pollForHuddleJoined needs, so
+// the poll loop is unit-testable without a full browser.
+type huddleReadinessPage interface {
+	Evaluate(expression string) (any, error)
+}
+
+// readHuddleBotStateJS reads window.__huddleBotState and returns it JSON-encoded,
+// or "" when the page has not published it yet (still mounting). A try/catch keeps
+// a not-yet-defined window from throwing.
+const readHuddleBotStateJS = `(function(){try{var s=window.__huddleBotState;` +
+	`return s?JSON.stringify(s):"";}catch(e){return "";}})()`
+
+// readHuddleBotState evaluates the readiness signal. It returns (state, present,
+// err): present=false means the page has not published a signal yet (keep
+// polling), which is NOT an error — it is the expected first-N-polls condition.
+func readHuddleBotState(page huddleReadinessPage) (huddleBotState, bool, error) {
+	v, err := page.Evaluate(readHuddleBotStateJS)
+	if err != nil {
+		return huddleBotState{}, false, err
+	}
+	s, ok := v.(string)
+	if !ok || strings.TrimSpace(s) == "" {
+		return huddleBotState{}, false, nil
+	}
+	var st huddleBotState
+	if err := json.Unmarshal([]byte(s), &st); err != nil {
+		return huddleBotState{}, false, fmt.Errorf("parse huddle bot state %q: %w", s, err)
+	}
+	return st, true, nil
+}
+
+// pollForHuddleJoined polls the readiness signal until the bot is `joined`
+// (terminal SUCCESS — returned immediately, never re-sampled, so a post-join
+// `left` can't race a confirmed success into a failure), a terminal failure
+// (`error`/`left`), or a timeout. Timeout budgets are split: reaching any
+// non-`connecting` state must happen within connectTimeout; once `lobby` is
+// observed the human-gated admission gets the longer admitTimeout. A transient
+// Evaluate error or a not-yet-published signal is non-fatal (keep polling).
+func pollForHuddleJoined(ctx JobContext, page huddleReadinessPage, opts huddlePollOpts) (huddleBotState, error) {
+	start := time.Now()
+	connectDeadline := start.Add(opts.connectTimeout)
+	var lobbyDeadline time.Time // set the first time `lobby` is observed
+	var last huddleBotState
+	var everSaw bool
+
+	for {
+		st, present, err := readHuddleBotState(page)
+		if err != nil {
+			ctx.Log("warn", "     - huddle readiness probe errored (retrying): %v", err)
+		} else if present {
+			last, everSaw = st, true
+			switch st.State {
+			case "joined":
+				// Terminal success. Return NOW without another sample so a later
+				// `left` (call ended after we confirmed) can't flip a real success.
+				return st, nil
+			case "error":
+				msg := st.Error
+				if msg == "" {
+					msg = "unknown error"
+				}
+				return st, fmt.Errorf("huddle bot reported an error state: %s", msg)
+			case "left":
+				// `left` is only reachable AFTER a prior join (see botState.ts): the
+				// bot joined then the call ended / it was removed before we sampled
+				// `joined`. Fail this wave (join+confirm), but say so accurately.
+				return st, fmt.Errorf("huddle bot left the call before its join was confirmed (state=left)")
+			case "lobby":
+				if lobbyDeadline.IsZero() {
+					ctx.Log("info", "     - in huddle lobby (access=%s); waiting for host admission", opts.access)
+					lobbyDeadline = time.Now().Add(opts.admitTimeout)
+				}
+			case "connecting":
+				// Page mounting / acquiring mic / opening the mesh. Keep waiting.
+			}
+		}
+
+		now := time.Now()
+		switch {
+		case !lobbyDeadline.IsZero() && now.After(lobbyDeadline):
+			return last, fmt.Errorf("not admitted from the huddle lobby within %s (access=%q — the agent's owner may not be a channel member, so no host admitted the bot)", opts.admitTimeout, opts.access)
+		case lobbyDeadline.IsZero() && now.After(connectDeadline):
+			detail := "the bot never left 'connecting'"
+			if everSaw {
+				detail = fmt.Sprintf("the bot never left '%s'", last.State)
+			} else {
+				detail = "the bot page never published a readiness signal"
+			}
+			return last, fmt.Errorf("huddle join not confirmed within %s: %s (page failed to mount or join)", opts.connectTimeout, detail)
+		}
+		time.Sleep(opts.interval)
+	}
+}
+
+// huddleBotURL builds the bot-page URL with the token in the FRAGMENT (so it
+// never reaches the server). Only this value is passed to Navigate; it is NEVER
+// logged — use redactedHuddleBotURL for any log or error string.
+func huddleBotURL(apiBase, channelID, token string) string {
+	return strings.TrimRight(apiBase, "/") + "/huddle-bot/" + url.PathEscape(channelID) + "#token=" + token
+}
+
+// redactedHuddleBotURL is huddleBotURL with the token replaced, safe to log.
+func redactedHuddleBotURL(apiBase, channelID string) string {
+	return strings.TrimRight(apiBase, "/") + "/huddle-bot/" + url.PathEscape(channelID) + "#token=<redacted>"
+}
+
+func (h *HuddleJoinHandler) effConnectTimeout() time.Duration {
+	if h.connectTimeout > 0 {
+		return h.connectTimeout
+	}
+	return huddleConnectTimeout
+}
+
+func (h *HuddleJoinHandler) effAdmitTimeout() time.Duration {
+	if h.admitTimeout > 0 {
+		return h.admitTimeout
+	}
+	return huddleAdmitTimeout
+}
+
+func (h *HuddleJoinHandler) effPollInterval() time.Duration {
+	if h.pollInterval > 0 {
+		return h.pollInterval
+	}
+	return huddlePollInterval
+}
+
+// Ensure HuddleJoinHandler implements JobHandler and CDPBrowser satisfies the
+// huddleBrowser surface the container path relies on.
+var (
+	_ JobHandler    = (*HuddleJoinHandler)(nil)
+	_ huddleBrowser = (*platform.CDPBrowser)(nil)
+)

--- a/internal/jobs/huddle_join_test.go
+++ b/internal/jobs/huddle_join_test.go
@@ -1,0 +1,337 @@
+package jobs
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+)
+
+// fakeHuddleBrowser is an injectable huddleBrowser that returns a scripted
+// sequence of window.__huddleBotState JSON strings from Evaluate. Each Evaluate
+// consumes the next scripted value; once exhausted it repeats the last one (so a
+// terminal "joined"/"error" keeps being observed if the loop samples again).
+type fakeHuddleBrowser struct {
+	mu        sync.Mutex
+	states    []string // JSON strings (or "" for "not published yet")
+	idx       int
+	navigated []string
+	evalCalls int
+	closed    bool
+}
+
+func (f *fakeHuddleBrowser) Navigate(u string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.navigated = append(f.navigated, u)
+	return nil
+}
+
+func (f *fakeHuddleBrowser) Evaluate(expr string) (any, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.evalCalls++
+	if len(f.states) == 0 {
+		return "", nil
+	}
+	i := f.idx
+	if i >= len(f.states) {
+		i = len(f.states) - 1
+	} else {
+		f.idx++
+	}
+	return f.states[i], nil
+}
+
+func (f *fakeHuddleBrowser) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closed = true
+	return nil
+}
+
+// stateJSON builds a window.__huddleBotState JSON string for the fake browser.
+func stateJSON(state, selfID string, peers, connected int) string {
+	b, _ := json.Marshal(huddleBotState{
+		State:              state,
+		CallID:             "call-123",
+		SelfID:             selfID,
+		PeerCount:          peers,
+		ConnectedPeerCount: connected,
+		UpdatedAt:          1,
+	})
+	return string(b)
+}
+
+// newTestHuddleHandler wires a handler with fast poll budgets, a fixed secret, an
+// injected mint, and an injected browser.
+func newTestHuddleHandler(secret string, mint func(ctx context.Context, apiBase, secret string, p huddleJoinParams) (huddleToken, error), br *fakeHuddleBrowser) *HuddleJoinHandler {
+	return &HuddleJoinHandler{
+		WorkspaceDir:   "/tmp",
+		secretFn:       func() string { return secret },
+		mintToken:      mint,
+		newBrowser:     func(p huddleJoinParams) (huddleBrowser, func() error, error) { return br, br.Close, nil },
+		connectTimeout: 200 * time.Millisecond,
+		admitTimeout:   400 * time.Millisecond,
+		pollInterval:   2 * time.Millisecond,
+	}
+}
+
+func okMint(tok huddleToken) func(ctx context.Context, apiBase, secret string, p huddleJoinParams) (huddleToken, error) {
+	return func(ctx context.Context, apiBase, secret string, p huddleJoinParams) (huddleToken, error) {
+		return tok, nil
+	}
+}
+
+func huddleJob() *nexus.Job {
+	return &nexus.Job{
+		ID:      "job-1",
+		Type:    JobTypeHuddleJoinType,
+		Payload: map[string]string{"channel_id": "chan-1", "agent_id": "agent-1", "api_base": "https://example.test"},
+	}
+}
+
+// TestHuddleJoin_ConnectingLobbyJoined asserts the handler patiently polls
+// through connecting -> lobby -> joined and reports the final joined state.
+func TestHuddleJoin_ConnectingLobbyJoined(t *testing.T) {
+	br := &fakeHuddleBrowser{states: []string{
+		"",                                // not published yet
+		stateJSON("connecting", "", 0, 0), // mounting
+		stateJSON("lobby", "", 0, 0),      // waiting for admit
+		stateJSON("lobby", "", 0, 0),
+		stateJSON("joined", "agent-author-1", 2, 1), // admitted + mic
+	}}
+	tok := huddleToken{Token: "act_secret", ChannelID: "chan-norm", SelfUserID: "agent-author-1", Access: "read"}
+	h := newTestHuddleHandler("s3cr3t", okMint(tok), br)
+
+	out, err := h.Execute(JobContext{}, huddleJob())
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	var res map[string]any
+	if err := json.Unmarshal(out, &res); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if res["status"] != "joined" || res["state"] != "joined" {
+		t.Errorf("status/state = %v/%v, want joined/joined", res["status"], res["state"])
+	}
+	if res["channel_id"] != "chan-norm" {
+		t.Errorf("channel_id = %v, want normalized chan-norm", res["channel_id"])
+	}
+	if res["self_id"] != "agent-author-1" {
+		t.Errorf("self_id = %v, want agent-author-1", res["self_id"])
+	}
+	if res["connected_peer_count"].(float64) != 1 {
+		t.Errorf("connected_peer_count = %v, want 1", res["connected_peer_count"])
+	}
+	if res["access"] != "read" {
+		t.Errorf("access = %v, want read", res["access"])
+	}
+	// The lobby state must have been observed before joined (patient polling).
+	if br.evalCalls < 4 {
+		t.Errorf("evalCalls = %d, expected the loop to poll through connecting+lobby", br.evalCalls)
+	}
+	// The bot page URL must carry the token in the FRAGMENT and target the
+	// normalized channel id.
+	if len(br.navigated) != 1 {
+		t.Fatalf("navigated = %v, want exactly one navigation", br.navigated)
+	}
+	nav := br.navigated[0]
+	if !strings.Contains(nav, "/huddle-bot/chan-norm#token=act_secret") {
+		t.Errorf("navigation URL %q missing normalized channel + fragment token", nav)
+	}
+	if !br.closed {
+		t.Errorf("session cleanup (Close) was not called")
+	}
+}
+
+// TestHuddleJoin_ErrorState asserts a terminal error state fails the job and
+// surfaces the page's error string verbatim.
+func TestHuddleJoin_ErrorState(t *testing.T) {
+	errState, _ := json.Marshal(huddleBotState{State: "error", Error: "microphone permission denied"})
+	br := &fakeHuddleBrowser{states: []string{
+		stateJSON("connecting", "", 0, 0),
+		string(errState),
+	}}
+	h := newTestHuddleHandler("s3cr3t", okMint(huddleToken{Token: "t", ChannelID: "c", Access: "member"}), br)
+
+	_, err := h.Execute(JobContext{}, huddleJob())
+	if err == nil {
+		t.Fatal("Execute should have failed on error state")
+	}
+	if !strings.Contains(err.Error(), "microphone permission denied") {
+		t.Errorf("error %q should surface the page error verbatim", err)
+	}
+}
+
+// TestHuddleJoin_LobbyTimeout asserts an unadmitted lobby times out with an
+// access-aware diagnosis rather than a generic timeout.
+func TestHuddleJoin_LobbyTimeout(t *testing.T) {
+	br := &fakeHuddleBrowser{states: []string{stateJSON("lobby", "", 0, 0)}}
+	h := newTestHuddleHandler("s3cr3t", okMint(huddleToken{Token: "t", ChannelID: "c", Access: "read"}), br)
+
+	_, err := h.Execute(JobContext{}, huddleJob())
+	if err == nil {
+		t.Fatal("Execute should have timed out in the lobby")
+	}
+	if !strings.Contains(err.Error(), "lobby") || !strings.Contains(err.Error(), "read") {
+		t.Errorf("lobby timeout error %q should mention the lobby and access=read", err)
+	}
+}
+
+// TestHuddleJoin_NeverPublishes asserts a page that never publishes a readiness
+// signal fails via the connect budget (NOT a parse error) — the most likely
+// real-world first-run failure.
+func TestHuddleJoin_NeverPublishes(t *testing.T) {
+	br := &fakeHuddleBrowser{states: []string{""}} // always ""
+	h := newTestHuddleHandler("s3cr3t", okMint(huddleToken{Token: "t", ChannelID: "c", Access: "member"}), br)
+
+	_, err := h.Execute(JobContext{}, huddleJob())
+	if err == nil {
+		t.Fatal("Execute should have failed when no signal is published")
+	}
+	if !strings.Contains(err.Error(), "never published") {
+		t.Errorf("error %q should explain the page never published a signal", err)
+	}
+}
+
+// TestHuddleJoin_JoinedIsTerminal asserts that once joined is observed the loop
+// returns immediately and does NOT re-sample (so a post-join left can't race a
+// confirmed success into failure).
+func TestHuddleJoin_JoinedIsTerminal(t *testing.T) {
+	br := &fakeHuddleBrowser{states: []string{
+		stateJSON("joined", "self-1", 1, 1),
+		stateJSON("left", "self-1", 0, 0), // would fail if re-sampled
+	}}
+	h := newTestHuddleHandler("s3cr3t", okMint(huddleToken{Token: "t", ChannelID: "c", Access: "member"}), br)
+
+	out, err := h.Execute(JobContext{}, huddleJob())
+	if err != nil {
+		t.Fatalf("Execute should have succeeded on first joined, got: %v", err)
+	}
+	var res map[string]any
+	_ = json.Unmarshal(out, &res)
+	if res["status"] != "joined" {
+		t.Errorf("status = %v, want joined", res["status"])
+	}
+	if br.idx > 1 {
+		t.Errorf("browser was sampled %d times; joined should be terminal (no re-poll into left)", br.idx)
+	}
+}
+
+// TestHuddleJoin_MissingSecret asserts the handler fails closed (before any
+// container work) when no internal secret is configured.
+func TestHuddleJoin_MissingSecret(t *testing.T) {
+	br := &fakeHuddleBrowser{}
+	minted := false
+	h := newTestHuddleHandler("", func(ctx context.Context, apiBase, secret string, p huddleJoinParams) (huddleToken, error) {
+		minted = true
+		return huddleToken{}, nil
+	}, br)
+
+	_, err := h.Execute(JobContext{}, huddleJob())
+	if err == nil {
+		t.Fatal("Execute should fail with no secret configured")
+	}
+	if !strings.Contains(err.Error(), envHuddleBotSecret) {
+		t.Errorf("error %q should name the secret env var", err)
+	}
+	if minted {
+		t.Error("mint must not be attempted when the secret is missing (fail closed first)")
+	}
+	if len(br.navigated) != 0 {
+		t.Error("browser must not be launched when the secret is missing")
+	}
+}
+
+// TestHuddleJoin_MissingParams asserts required-field validation.
+func TestHuddleJoin_MissingParams(t *testing.T) {
+	h := NewHuddleJoinHandler("/tmp")
+	for _, tc := range []map[string]string{
+		{"agent_id": "a"},   // no channel_id
+		{"channel_id": "c"}, // no agent_id
+	} {
+		if _, err := h.Execute(JobContext{}, &nexus.Job{ID: "j", Payload: tc}); err == nil {
+			t.Errorf("payload %v should be rejected", tc)
+		}
+	}
+}
+
+// TestMintHuddleBotToken_RequestShape pins the mint request contract (body
+// {agentId, channelId} + Authorization: Bearer <secret>) against a mock endpoint,
+// so a future aceteam-side contract drift shows up as a red test.
+func TestMintHuddleBotToken_RequestShape(t *testing.T) {
+	var gotAuth, gotPath string
+	var gotBody map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"token":      "act_xyz",
+			"channelId":  "chan-normalized",
+			"selfUserId": "author-9",
+			"access":     "member",
+			"expiresAt":  "2026-01-01T00:00:00Z",
+		})
+	}))
+	defer srv.Close()
+
+	tok, err := mintHuddleBotToken(context.Background(), srv.Client(), srv.URL, "top-secret",
+		huddleJoinParams{ChannelID: "chan-1", AgentID: "agent-1"})
+	if err != nil {
+		t.Fatalf("mint returned error: %v", err)
+	}
+	if gotPath != "/api/huddle-bot/token" {
+		t.Errorf("path = %q, want /api/huddle-bot/token", gotPath)
+	}
+	if gotAuth != "Bearer top-secret" {
+		t.Errorf("auth = %q, want Bearer top-secret", gotAuth)
+	}
+	if gotBody["agentId"] != "agent-1" || gotBody["channelId"] != "chan-1" {
+		t.Errorf("body = %v, want {agentId:agent-1, channelId:chan-1}", gotBody)
+	}
+	if tok.Token != "act_xyz" || tok.ChannelID != "chan-normalized" || tok.Access != "member" {
+		t.Errorf("parsed token = %+v, want token/channelId/access populated", tok)
+	}
+}
+
+// TestMintHuddleBotToken_Non200 asserts a non-200 (e.g. 403 unreachable channel)
+// surfaces the status + backend message and never a token.
+func TestMintHuddleBotToken_Non200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"owner cannot access this channel"}`))
+	}))
+	defer srv.Close()
+
+	_, err := mintHuddleBotToken(context.Background(), srv.Client(), srv.URL, "s",
+		huddleJoinParams{ChannelID: "c", AgentID: "a"})
+	if err == nil {
+		t.Fatal("expected an error on 403")
+	}
+	if !strings.Contains(err.Error(), "403") || !strings.Contains(err.Error(), "owner cannot access") {
+		t.Errorf("error %q should carry status + backend message", err)
+	}
+}
+
+// TestHuddleBotURL_FragmentRedaction asserts the token rides the fragment and the
+// redacted form never contains it.
+func TestHuddleBotURL_FragmentRedaction(t *testing.T) {
+	full := huddleBotURL("https://aceteam.ai/", "chan-1", "act_supersecret")
+	if !strings.Contains(full, "/huddle-bot/chan-1#token=act_supersecret") {
+		t.Errorf("full URL %q malformed", full)
+	}
+	red := redactedHuddleBotURL("https://aceteam.ai/", "chan-1")
+	if strings.Contains(red, "act_supersecret") || !strings.Contains(red, "<redacted>") {
+		t.Errorf("redacted URL %q must not leak the token", red)
+	}
+}

--- a/internal/worker/handler_adapter.go
+++ b/internal/worker/handler_adapter.go
@@ -325,6 +325,18 @@ func CreateLegacyHandlersWithOpts(opts LegacyHandlerOpts) []JobHandler {
 		}
 	}
 
+	// Native-huddle agent join (aceteam#7081). Part of the SAME default-on meeting
+	// capability as MEETING_JOIN, but registered OUTSIDE the workspace gate above:
+	// HUDDLE_JOIN records nothing (join + presence confirmation only), so it needs
+	// no workspace — a meeting-enabled node without a configured workspace must
+	// still take it. It drives the meeting-service container's headless Chromium to
+	// the aceteam huddle-bot page over CDP.
+	if config.LoadMeeting(platform.ConfigDir()).MeetingEnabled {
+		handlers = append(handlers,
+			NewLegacyHandlerAdapter(JobTypeHuddleJoin, jobs.NewHuddleJoinHandler(opts.WorkspaceDir)),
+		)
+	}
+
 	// Register service-management handlers when a config directory is available.
 	if opts.ConfigDir != "" {
 		svcHandler := jobs.NewServiceHandlerWithWorkspace(opts.ConfigDir, opts.WorkspaceDir)

--- a/internal/worker/job.go
+++ b/internal/worker/job.go
@@ -146,6 +146,7 @@ const (
 	JobTypeModuleSet          = "MODULE_SET"           // Set the desired state of a single module on this node (interim, aceteam#5280)
 	JobTypeExposeSet          = "EXPOSE_SET"           // Expose a local service on the gateway with private/org/link visibility (issue #598)
 	JobTypeMeetingJoin        = "MEETING_JOIN"         // Auto-join a video call, record + transcribe it node-locally (aceteam#5098)
+	JobTypeHuddleJoin         = "HUDDLE_JOIN"          // Join a native AceTeam huddle AS the agent (headless bot page) + confirm presence (aceteam#7081)
 
 	// Fabric instance provisioning on a local hypervisor (aceteam#5963). These
 	// act on hypervisor VMs; JobTypeInstanceMessage above predates this family
@@ -210,6 +211,7 @@ var allKnownJobTypes = []string{
 	JobTypeModuleSet,
 	JobTypeExposeSet,
 	JobTypeMeetingJoin,
+	JobTypeHuddleJoin,
 	JobTypeInstanceProvision,
 	JobTypeInstanceStart,
 	JobTypeInstanceStop,


### PR DESCRIPTION
## Context

aceteam #7081 shipped (on the aceteam repo) a headless "huddle bot" join surface: a route `/(huddle-bot)/huddle-bot/[channelId]` + `HuddleBotClient` that auto-joins a native huddle call audio-only and publishes a machine-pollable readiness signal on `window.__huddleBotState`. A bot token is minted at `POST /api/huddle-bot/token` (gated by the internal `INTERNAL_AUTH_SECRET`) and passed in the URL **fragment**.

This PR is the **citadel (node) side**: a `HUDDLE_JOIN` handler that drives the **existing** meeting-service container's headless Chromium (over CDP) to that page and confirms the agent joined. It reuses the container + virtual mic from the meeting media stack (`feat/meeting-bot-audio`, #665 — the base of this branch).

Contracts were taken verbatim from the aceteam #7081 commits (`app/api/huddle-bot/token/route.ts`, `utils/huddle/botState.ts`), not re-invented.

## Flow

1. Parse payload `{ channel_id, agent_id, api_base? }` (both ids required — the mint route needs `agentId`).
2. Resolve the internal secret (`CITADEL_HUDDLE_BOT_SECRET`, fallback `INTERNAL_AUTH_SECRET`). **Fail closed** if unset — *before* any container work.
3. Resolve API base (payload `api_base` → node device-creds base → `https://aceteam.ai`).
4. **Mint** the bot token: `POST {api_base}/api/huddle-bot/token`, `Authorization: Bearer <secret>`, body `{agentId, channelId}` → `{token, channelId (normalized), selfUserId, access, expiresAt}`. Minting before launching a session means a 401/403/404 costs nothing.
5. Launch (or reuse) the container session via meetingd `POST /sessions` (wires the in-container Chromium to the virtual mic + capture sink) → `platform.CDPBrowser`.
6. `Navigate` to `{api_base}/huddle-bot/<normalized channelId>#token=<token>` — token in the **fragment**, and **never logged** (redacted form only, so a live org-wildcard key is never written to the node journal).
7. Poll `window.__huddleBotState.state` with **split budgets**: a short `connectTimeout` (45s) to leave `connecting`, and a longer `admitTimeout` (3m) once `lobby` is observed (a non-member on a lobby-enabled call needs a host to admit it — the lobby-timeout error names `access` so the diagnosis is legible). `joined` is **terminal success** (returned immediately, never re-sampled, so a post-join `left` can't race a confirmed success into failure); `error`/`left` fail with the page's message.
8. Return a structured result and tear the session down (the bot leaves).

**Result contract** (`HUDDLE_JOIN` success):
`{ status:"joined", channel_id, agent_id, self_id, call_id, peer_count, connected_peer_count, access, state:"joined" }`

## What's deferred (next wave)

- **Staying resident + realtime STT/TTS bridge** (aceteam #7079): this wave is JOIN + presence confirmation only. Execute confirms `joined` then tears down. When the bot later stays in-call, `HUDDLE_JOIN` must be moved into `worker.longSessionJobTypes` (currently it takes the default 60-min fallback deadline, correct for a bounded join+confirm).
- **`connectedPeerCount > 0` ("two-way audio actually flowing")**: reported in the result but not gated on — `joined` means "roster + local mic published", which is the correct milestone for this wave.
- **Token TTL refresh**: the minted token defaults to a 1h TTL — irrelevant for a 3-min join+confirm, relevant to the resident wave.
- **Backend dispatch**: confirm aceteam dispatches `HUDDLE_JOIN` to a queue this node consumes (the meeting capability tag). If it needs its own tag, that's an aceteam-side follow-up.

## Testing

- `go build ./...` — pass
- `go vet ./...` — pass
- `go test ./...` — pass (full suite)
- New unit tests (`internal/jobs/huddle_join_test.go`, mocked CDP browser + mocked token endpoint + scripted readiness progression):
  - `connecting → lobby → joined` patient poll + result shape (normalized channel id, self id, connected peers, access, fragment-token navigation)
  - terminal `error` state surfaces the page message
  - unadmitted `lobby` times out with an access-aware message
  - page never publishes a signal → connect-budget failure (not a parse error)
  - `joined` is terminal (a following `left` is never re-sampled)
  - missing secret fails closed before mint/browser
  - required-field validation
  - mint request shape pinned (`{agentId, channelId}` body + `Bearer` header) + non-200 handling
  - URL fragment/redaction

**Live-validation gap (cannot run a live WebRTC join in CI):** a real join must be smoke-tested on node 1297 (container `citadel-meeting`, CDP host `8208`, meetingd host `8207`). Manual smoke:
1. Mint a token by hand: `curl -sS -X POST https://aceteam.ai/api/huddle-bot/token -H "Authorization: Bearer $INTERNAL_AUTH_SECRET" -H 'content-type: application/json' -d '{"agentId":"<id>","channelId":"<id>"}'`
2. Dispatch `HUDDLE_JOIN` `{channel_id, agent_id}` for a live huddle.
3. Confirm the huddle roster shows the agent and that on the container browser `window.__huddleBotState.state === "joined"`.

Links aceteam #7081. Stacks on #665 (`feat/meeting-bot-audio`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)