### PR TITLE
feat(huddle): resident realtime converse bridge for HUDDLE_JOIN (#7079)

### DIFF
--- a/internal/jobs/huddle_converse.go
+++ b/internal/jobs/huddle_converse.go
@@ -1,0 +1,567 @@
+// internal/jobs/huddle_converse.go
+//
+// The resident realtime CONVERSE bridge for HUDDLE_JOIN (aceteam#7079/#7081).
+// Once HUDDLE_JOIN reaches `joined`, this turns the joined-but-silent bot into a
+// live two-way voice participant by bridging three legs:
+//
+//	HEAR   room audio (meetingd GET /sessions/{id}/capture/pcm, raw s16le 24 kHz)
+//	       -> WS `input_audio_buffer.append` (base64 PCM16) to the realtime engine
+//	THINK  the AceTeam realtime engine (OpenAI Realtime behind an AceTeam WS proxy)
+//	       does STT + LLM + TTS with SERVER-SIDE VAD (we never force turns)
+//	SPEAK  engine `response.output_audio.delta` (base64 PCM16 24 kHz) -> meetingd
+//	       POST /mic/play/pcm -> the container virtual mic -> the huddle hears it
+//
+// It is ADDITIVE and GATED: HUDDLE_JOIN only starts it when the payload carries
+// `converse:true`. With converse off (the default) the handler behaves EXACTLY like
+// the #667 join+confirm wave -- no capture, no WS, no mic play.
+//
+// --- design notes ------------------------------------------------------------
+//
+// Standalone + injectable, like internal/mesh: the bridge talks to a `realtimeConn`
+// (a minimal duplex WS seam) and a `converseMedia` (capture + speak), so the whole
+// loop is unit-testable against a mock WS + mock media with no live container,
+// mesh, or engine. The production wiring lives in huddle_join.go.
+//
+// Echo hygiene: the room capture is the per-session sink `citadel_meeting_<sid>`'s
+// monitor -- the OTHER participants' mixed audio. The bot's own TTS is published on
+// a DIFFERENT sink (`citadel_mic`), and WebRTC does not echo a peer's own mic back
+// to it, so the capture is echo-free BY CONSTRUCTION. As belt-and-suspenders (and
+// for any node where the two ever merge) the bridge GATES the HEAR->engine stream
+// while it is speaking (default on), with a short hangover after playback and an
+// `input_audio_buffer.clear` on gate release so no half-buffered self-audio leaks
+// in. Barge-in: on the engine's `input_audio_buffer.speech_started` we drop queued
+// TTS so the agent stops talking over a human (current in-flight chunk still plays
+// -- bounded by the coalesce window; true mid-clip stop is a documented follow-up).
+package jobs
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Realtime engine wire format: PCM16 mono @ 24 kHz (aceteam
+// buildSessionConfig.PCM16_FORMAT). Both legs use it, so with the capture endpoint
+// serving 24 kHz there is no resample on the hot path.
+const (
+	converseEngineRate     = 24000
+	converseEngineChannels = 1
+	bytesPerSample         = 2 // s16le
+)
+
+// Client->server WS message types the bridge sends (aceteam types/realtimeWs.ts
+// zRealtimeClientPayloadSchema). With server VAD on we send ONLY append + clear;
+// commit / response.create would force turns and are deliberately never sent.
+const (
+	msgInputAudioAppend = "input_audio_buffer.append"
+	msgInputAudioClear  = "input_audio_buffer.clear"
+)
+
+// Server->client WS event types the bridge acts on (aceteam app/api/realtime).
+const (
+	evtAudioDelta    = "response.output_audio.delta"
+	evtAudioDone     = "response.output_audio.done"
+	evtSpeechStarted = "input_audio_buffer.speech_started"
+)
+
+// realtimeConn is the minimal duplex WebSocket surface the bridge needs. The
+// production impl (gorillaRealtimeConn) wraps gorilla/websocket; tests inject a
+// mock. Send/Recv are each called from a single goroutine (HEAR/speaker send;
+// recv reads), matching gorilla's one-reader/one-writer rule.
+type realtimeConn interface {
+	Send(payload []byte) error
+	Recv() ([]byte, error)
+	Close() error
+}
+
+// converseMedia is the container-media surface the bridge needs: a rolling raw-PCM
+// capture of the room (HEAR) and a raw-PCM inject into the virtual mic (SPEAK).
+// *containerMedia satisfies it.
+type converseMedia interface {
+	CaptureStream(ctx context.Context, rate, channels int) (io.ReadCloser, error)
+	SpeakPCM(pcm []byte, rate, channels int) error
+}
+
+// stateCheckFunc reports whether the bridge should stop because the call ended.
+// ended=true stops the loop; reason is for the log/result. huddle_join.go wires
+// this to a poll of window.__huddleBotState (left/error). A nil/never-ending check
+// keeps the bridge resident until ctx cancels (the worker deadline / node stop).
+type stateCheckFunc func() (ended bool, reason string)
+
+// converseStats is the additive per-run summary folded into the HUDDLE_JOIN
+// result JSON so the backend's existing `status:"joined"` parse is unaffected.
+type converseStats struct {
+	AppendedFrames int    `json:"appended_frames"`
+	AudioDeltas    int    `json:"audio_deltas"`
+	SpokenChunks   int    `json:"spoken_chunks"`
+	GatedFrames    int    `json:"gated_frames"`
+	Barges         int    `json:"barge_ins"`
+	DurationMS     int64  `json:"duration_ms"`
+	StopReason     string `json:"stop_reason"`
+}
+
+// converseConfig tunes the bridge; zero values fall back to package defaults so
+// callers set only what they need and tests set milliseconds.
+type converseConfig struct {
+	// EngineRate/EngineChannels default to 24000/1 (the engine's PCM16 format).
+	EngineRate     int
+	EngineChannels int
+	// CaptureRate is the rate CaptureStream is asked to serve. When it differs
+	// from EngineRate the HEAR path linearly resamples each frame. Default ==
+	// EngineRate (no resample).
+	CaptureRate int
+	// FrameDuration is the size of one HEAR->append frame (default 20ms).
+	FrameDuration time.Duration
+	// SpeakCoalesce is how long the speaker gathers newly-arrived deltas into one
+	// pacat play before posting, to avoid one subprocess spawn per delta (default
+	// 200ms).
+	SpeakCoalesce time.Duration
+	// SpeakHangover holds the speaking gate closed this long after the last chunk
+	// plays, before reopening HEAR (default 250ms).
+	SpeakHangover time.Duration
+	// GateWhileSpeaking drops HEAR frames while the bot is speaking (default on).
+	// Disable to allow full-duplex barge-in on an echo-free node.
+	GateWhileSpeaking *bool
+	// MicBusyBackoff is the retry pause on a 409 from SpeakPCM (default 50ms).
+	MicBusyBackoff time.Duration
+	// StatePollInterval is how often stateCheck is sampled (default 3s).
+	StatePollInterval time.Duration
+}
+
+// converseBridge is one resident conversation. Construct with newConverseBridge
+// and drive with Run. It owns no cleanup of conn/media -- the caller does.
+type converseBridge struct {
+	conn  realtimeConn
+	media converseMedia
+	state stateCheckFunc
+	log   func(level, format string, args ...any)
+	cfg   converseConfig
+
+	speaking atomic.Bool
+	speakCh  chan []byte
+
+	// stats is mutated only from the recv/hear/speaker goroutines; guarded so the
+	// final read in Run is race-free.
+	statsMu sync.Mutex
+	stats   converseStats
+}
+
+func newConverseBridge(conn realtimeConn, media converseMedia, state stateCheckFunc, log func(string, string, ...any), cfg converseConfig) *converseBridge {
+	if cfg.EngineRate <= 0 {
+		cfg.EngineRate = converseEngineRate
+	}
+	if cfg.EngineChannels <= 0 {
+		cfg.EngineChannels = converseEngineChannels
+	}
+	if cfg.CaptureRate <= 0 {
+		cfg.CaptureRate = cfg.EngineRate
+	}
+	if cfg.FrameDuration <= 0 {
+		cfg.FrameDuration = 20 * time.Millisecond
+	}
+	if cfg.SpeakCoalesce <= 0 {
+		cfg.SpeakCoalesce = 200 * time.Millisecond
+	}
+	if cfg.SpeakHangover <= 0 {
+		cfg.SpeakHangover = 250 * time.Millisecond
+	}
+	if cfg.MicBusyBackoff <= 0 {
+		cfg.MicBusyBackoff = 50 * time.Millisecond
+	}
+	if cfg.StatePollInterval <= 0 {
+		cfg.StatePollInterval = 3 * time.Second
+	}
+	if cfg.GateWhileSpeaking == nil {
+		on := true
+		cfg.GateWhileSpeaking = &on
+	}
+	if log == nil {
+		log = func(string, string, ...any) {}
+	}
+	return &converseBridge{
+		conn:    conn,
+		media:   media,
+		state:   state,
+		log:     log,
+		cfg:     cfg,
+		speakCh: make(chan []byte, 64),
+	}
+}
+
+// Run drives the bridge until the call ends (stateCheck), the parent ctx cancels,
+// or the WS closes, then returns the run stats. It fans out HEAR, RECV, SPEAK and a
+// state supervisor; the FIRST to finish cancels the rest via a derived context.
+func (b *converseBridge) Run(parent context.Context) (converseStats, error) {
+	ctx, cancel := context.WithCancel(parent)
+	defer cancel()
+	start := time.Now()
+
+	var stopReason atomic.Value // string
+	stop := func(reason string) {
+		stopReason.CompareAndSwap(nil, reason)
+		cancel()
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+	go func() { defer wg.Done(); b.hearLoop(ctx, stop) }()
+	go func() { defer wg.Done(); b.recvLoop(ctx, stop) }()
+	go func() { defer wg.Done(); b.speakerLoop(ctx) }()
+
+	// Supervisor: watch for parent cancel + the call ending. Runs on Run's
+	// goroutine so Run blocks here until a terminal condition.
+	b.superviseLoop(ctx, stop)
+
+	// A terminal condition fired: cancel everything and drain the workers. Closing
+	// the WS unblocks recvLoop's Recv; the media capture body is closed by hearLoop
+	// on ctx cancel.
+	cancel()
+	_ = b.conn.Close()
+	wg.Wait()
+
+	reason, _ := stopReason.Load().(string)
+	if reason == "" {
+		reason = "stopped"
+	}
+	b.statsMu.Lock()
+	out := b.stats
+	b.statsMu.Unlock()
+	out.DurationMS = time.Since(start).Milliseconds()
+	out.StopReason = reason
+	return out, nil
+}
+
+// superviseLoop blocks until parent ctx cancels or stateCheck reports the call
+// ended, then calls stop with a reason.
+func (b *converseBridge) superviseLoop(ctx context.Context, stop func(string)) {
+	t := time.NewTicker(b.cfg.StatePollInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			stop("context cancelled")
+			return
+		case <-t.C:
+			if b.state == nil {
+				continue
+			}
+			if ended, reason := b.state(); ended {
+				if reason == "" {
+					reason = "call ended"
+				}
+				b.log("info", "     - converse: stopping (%s)", reason)
+				stop(reason)
+				return
+			}
+		}
+	}
+}
+
+// hearLoop streams room PCM from the capture endpoint and forwards it as
+// `input_audio_buffer.append` frames. It fills fixed-size frames, resamples when
+// CaptureRate != EngineRate, and (when the gate is on) drops frames while speaking.
+func (b *converseBridge) hearLoop(ctx context.Context, stop func(string)) {
+	rc, err := b.media.CaptureStream(ctx, b.cfg.CaptureRate, b.cfg.EngineChannels)
+	if err != nil {
+		b.log("warn", "     - converse: capture stream failed: %v", err)
+		stop("capture stream error")
+		return
+	}
+	// Close the body when ctx cancels so a blocked Read returns.
+	go func() {
+		<-ctx.Done()
+		_ = rc.Close()
+	}()
+	defer rc.Close()
+
+	frameBytes := pcmFrameBytes(b.cfg.CaptureRate, b.cfg.EngineChannels, b.cfg.FrameDuration)
+	buf := make([]byte, frameBytes)
+	gate := *b.cfg.GateWhileSpeaking
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		n, err := readFullFrame(rc, buf)
+		// Drop a trailing partial SAMPLE (a short final read at stream teardown can
+		// leave an odd byte count, which would base64 into half an s16le sample the
+		// engine may reject).
+		n -= n % bytesPerSample
+		if n > 0 {
+			frame := buf[:n]
+			if b.cfg.CaptureRate != b.cfg.EngineRate {
+				frame = resamplePCM16(frame, b.cfg.CaptureRate, b.cfg.EngineRate, b.cfg.EngineChannels)
+			}
+			if gate && b.speaking.Load() {
+				b.bumpGated()
+			} else if sendErr := b.sendAppend(frame); sendErr != nil {
+				b.log("warn", "     - converse: append send failed: %v", sendErr)
+				stop("ws send error")
+				return
+			}
+		}
+		if err != nil {
+			if ctx.Err() == nil && !errors.Is(err, io.EOF) {
+				b.log("warn", "     - converse: capture read ended: %v", err)
+			}
+			stop("capture ended")
+			return
+		}
+	}
+}
+
+// sendAppend base64-encodes a PCM frame and sends it as input_audio_buffer.append.
+func (b *converseBridge) sendAppend(frame []byte) error {
+	msg, _ := json.Marshal(struct {
+		Type  string `json:"type"`
+		Audio string `json:"audio"`
+	}{Type: msgInputAudioAppend, Audio: base64.StdEncoding.EncodeToString(frame)})
+	if err := b.conn.Send(msg); err != nil {
+		return err
+	}
+	b.statsMu.Lock()
+	b.stats.AppendedFrames++
+	b.statsMu.Unlock()
+	return nil
+}
+
+func (b *converseBridge) sendClear() error {
+	msg, _ := json.Marshal(struct {
+		Type string `json:"type"`
+	}{Type: msgInputAudioClear})
+	return b.conn.Send(msg)
+}
+
+// recvLoop reads engine events: audio deltas become queued speak chunks; a
+// speech_started drops queued TTS (barge-in). A Recv error ends the run.
+func (b *converseBridge) recvLoop(ctx context.Context, stop func(string)) {
+	for {
+		raw, err := b.conn.Recv()
+		if err != nil {
+			if ctx.Err() == nil {
+				b.log("warn", "     - converse: ws recv ended: %v", err)
+			}
+			stop("ws closed")
+			return
+		}
+		var ev struct {
+			Type  string `json:"type"`
+			Delta string `json:"delta"`
+		}
+		if json.Unmarshal(raw, &ev) != nil {
+			continue
+		}
+		switch ev.Type {
+		case evtAudioDelta:
+			pcm, decErr := base64.StdEncoding.DecodeString(ev.Delta)
+			if decErr != nil || len(pcm) == 0 {
+				continue
+			}
+			b.statsMu.Lock()
+			b.stats.AudioDeltas++
+			b.statsMu.Unlock()
+			select {
+			case b.speakCh <- pcm:
+			case <-ctx.Done():
+				return
+			}
+		case evtSpeechStarted:
+			// Barge-in: the human started talking; drop pending TTS so the agent
+			// yields the floor.
+			if n := b.drainSpeakCh(); n > 0 {
+				b.statsMu.Lock()
+				b.stats.Barges++
+				b.statsMu.Unlock()
+				b.log("info", "     - converse: barge-in, dropped %d queued TTS chunk(s)", n)
+			}
+		case evtAudioDone:
+			// Nothing to force: the speaker releases the gate on idle.
+		}
+	}
+}
+
+// speakerLoop drains queued PCM deltas, coalesces the burst into one play to avoid
+// a pacat spawn per delta, injects it into the virtual mic, and releases the
+// speaking gate (with a hangover + clear) once the queue goes idle.
+func (b *converseBridge) speakerLoop(ctx context.Context) {
+	idle := time.NewTimer(time.Hour)
+	if !idle.Stop() {
+		<-idle.C
+	}
+	releasePending := false
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case chunk := <-b.speakCh:
+			b.speaking.Store(true)
+			releasePending = false
+			buf := b.coalesce(ctx, chunk)
+			b.play(ctx, buf)
+			releasePending = true
+			resetTimer(idle, b.cfg.SpeakHangover)
+		case <-idle.C:
+			if releasePending {
+				b.speaking.Store(false)
+				_ = b.sendClear()
+				releasePending = false
+			}
+		}
+	}
+}
+
+// coalesce appends any deltas already queued (up to SpeakCoalesce) to the first
+// chunk so a burst plays as one clip.
+func (b *converseBridge) coalesce(ctx context.Context, first []byte) []byte {
+	buf := append([]byte(nil), first...)
+	deadline := time.NewTimer(b.cfg.SpeakCoalesce)
+	defer deadline.Stop()
+	for {
+		select {
+		case more := <-b.speakCh:
+			buf = append(buf, more...)
+		case <-deadline.C:
+			return buf
+		case <-ctx.Done():
+			return buf
+		}
+	}
+}
+
+// play injects PCM into the virtual mic, retrying once on a mic-busy 409.
+func (b *converseBridge) play(ctx context.Context, pcm []byte) {
+	if len(pcm) == 0 {
+		return
+	}
+	err := b.media.SpeakPCM(pcm, b.cfg.EngineRate, b.cfg.EngineChannels)
+	if errors.Is(err, errMicBusy) {
+		select {
+		case <-time.After(b.cfg.MicBusyBackoff):
+		case <-ctx.Done():
+			return
+		}
+		err = b.media.SpeakPCM(pcm, b.cfg.EngineRate, b.cfg.EngineChannels)
+	}
+	if err != nil {
+		b.log("warn", "     - converse: mic play failed: %v", err)
+		return
+	}
+	b.statsMu.Lock()
+	b.stats.SpokenChunks++
+	b.statsMu.Unlock()
+}
+
+// drainSpeakCh removes all queued speak chunks without blocking; returns how many.
+func (b *converseBridge) drainSpeakCh() int {
+	n := 0
+	for {
+		select {
+		case <-b.speakCh:
+			n++
+		default:
+			return n
+		}
+	}
+}
+
+func (b *converseBridge) bumpGated() {
+	b.statsMu.Lock()
+	b.stats.GatedFrames++
+	b.statsMu.Unlock()
+}
+
+// snapshot returns a race-free copy of the current stats (used by tests to poll
+// side effects while the loops run).
+func (b *converseBridge) snapshot() converseStats {
+	b.statsMu.Lock()
+	defer b.statsMu.Unlock()
+	return b.stats
+}
+
+// --- pure helpers (unit-tested independent of goroutines) --------------------
+
+// pcmFrameBytes is the byte length of one s16le frame of `dur` at rate/channels.
+func pcmFrameBytes(rate, channels int, dur time.Duration) int {
+	samples := int(float64(rate) * dur.Seconds())
+	if samples < 1 {
+		samples = 1
+	}
+	n := samples * channels * bytesPerSample
+	if n < bytesPerSample {
+		n = bytesPerSample
+	}
+	return n
+}
+
+// resamplePCM16 linearly resamples interleaved s16le PCM from inRate to outRate.
+// A no-op when the rates match. Simple and allocation-light; good enough for a
+// speech bridge (the capture endpoint normally serves the engine rate, so this is
+// a safety path, not the hot path).
+func resamplePCM16(in []byte, inRate, outRate, channels int) []byte {
+	if inRate == outRate || inRate <= 0 || outRate <= 0 || channels <= 0 {
+		return in
+	}
+	inFrames := len(in) / (channels * bytesPerSample)
+	if inFrames < 2 {
+		return in
+	}
+	outFrames := int(float64(inFrames) * float64(outRate) / float64(inRate))
+	if outFrames < 1 {
+		outFrames = 1
+	}
+	out := make([]byte, outFrames*channels*bytesPerSample)
+	sample := func(frame, ch int) int16 {
+		off := (frame*channels + ch) * bytesPerSample
+		return int16(uint16(in[off]) | uint16(in[off+1])<<8)
+	}
+	for of := 0; of < outFrames; of++ {
+		// Position in the input timeline.
+		pos := float64(of) * float64(inRate) / float64(outRate)
+		i0 := int(pos)
+		frac := pos - float64(i0)
+		i1 := i0 + 1
+		if i1 >= inFrames {
+			i1 = inFrames - 1
+		}
+		for ch := 0; ch < channels; ch++ {
+			s0 := float64(sample(i0, ch))
+			s1 := float64(sample(i1, ch))
+			v := int16(s0 + (s1-s0)*frac)
+			outOff := (of*channels + ch) * bytesPerSample
+			out[outOff] = byte(uint16(v))
+			out[outOff+1] = byte(uint16(v) >> 8)
+		}
+	}
+	return out
+}
+
+// readFullFrame reads exactly len(buf) bytes unless the stream ends first. It
+// returns the number of bytes read and any terminal error (io.EOF/ctx-close). A
+// short final read still returns its bytes so a partial trailing frame is sent.
+func readFullFrame(r io.Reader, buf []byte) (int, error) {
+	total := 0
+	for total < len(buf) {
+		n, err := r.Read(buf[total:])
+		total += n
+		if err != nil {
+			return total, err
+		}
+	}
+	return total, nil
+}
+
+// resetTimer safely resets t to d (draining a fired channel first).
+func resetTimer(t *time.Timer, d time.Duration) {
+	if !t.Stop() {
+		select {
+		case <-t.C:
+		default:
+		}
+	}
+	t.Reset(d)
+}

--- a/internal/jobs/huddle_converse_test.go
+++ b/internal/jobs/huddle_converse_test.go
@@ -1,0 +1,430 @@
+package jobs
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"sync"
+	"testing"
+	"time"
+)
+
+// --- mocks -------------------------------------------------------------------
+
+// mockRealtimeConn is an injectable realtimeConn: Send records outbound frames,
+// Recv yields queued inbound events (and blocks until closed so the bridge stays
+// resident like a live engine).
+type mockRealtimeConn struct {
+	mu       sync.Mutex
+	sent     [][]byte
+	incoming chan []byte
+	closed   chan struct{}
+	once     sync.Once
+}
+
+func newMockConn() *mockRealtimeConn {
+	return &mockRealtimeConn{incoming: make(chan []byte, 32), closed: make(chan struct{})}
+}
+
+func (m *mockRealtimeConn) Send(p []byte) error {
+	m.mu.Lock()
+	m.sent = append(m.sent, append([]byte(nil), p...))
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *mockRealtimeConn) Recv() ([]byte, error) {
+	select {
+	case msg := <-m.incoming:
+		return msg, nil
+	case <-m.closed:
+		return nil, io.EOF
+	}
+}
+
+func (m *mockRealtimeConn) Close() error {
+	m.once.Do(func() { close(m.closed) })
+	return nil
+}
+
+func (m *mockRealtimeConn) sentTypes() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []string
+	for _, raw := range m.sent {
+		var ev struct {
+			Type string `json:"type"`
+		}
+		_ = json.Unmarshal(raw, &ev)
+		out = append(out, ev.Type)
+	}
+	return out
+}
+
+func (m *mockRealtimeConn) countType(t string) int {
+	n := 0
+	for _, got := range m.sentTypes() {
+		if got == t {
+			n++
+		}
+	}
+	return n
+}
+
+// mockConverseMedia records SpeakPCM calls and serves a caller-supplied capture
+// stream. SpeakPCM can be made to block on speakGate to simulate a long clip.
+type mockConverseMedia struct {
+	capture   io.ReadCloser
+	captureFn func(ctx context.Context) (io.ReadCloser, error)
+
+	mu        sync.Mutex
+	played    [][]byte
+	speakGate chan struct{} // nil => don't block
+}
+
+func (m *mockConverseMedia) CaptureStream(ctx context.Context, rate, channels int) (io.ReadCloser, error) {
+	if m.captureFn != nil {
+		return m.captureFn(ctx)
+	}
+	return m.capture, nil
+}
+
+func (m *mockConverseMedia) SpeakPCM(pcm []byte, rate, channels int) error {
+	if m.speakGate != nil {
+		<-m.speakGate
+	}
+	m.mu.Lock()
+	m.played = append(m.played, append([]byte(nil), pcm...))
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *mockConverseMedia) playedCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.played)
+}
+
+func (m *mockConverseMedia) playedBytes() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n := 0
+	for _, p := range m.played {
+		n += len(p)
+	}
+	return n
+}
+
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for: %s", what)
+}
+
+func audioDeltaMsg(pcm []byte) []byte {
+	b, _ := json.Marshal(struct {
+		Type  string `json:"type"`
+		Delta string `json:"delta"`
+	}{Type: evtAudioDelta, Delta: base64.StdEncoding.EncodeToString(pcm)})
+	return b
+}
+
+func speechStartedMsg() []byte {
+	b, _ := json.Marshal(struct {
+		Type string `json:"type"`
+	}{Type: evtSpeechStarted})
+	return b
+}
+
+// fastConfig makes frames tiny and timers short so tests run in milliseconds.
+func fastConfig() converseConfig {
+	return converseConfig{
+		EngineRate:        8000,
+		EngineChannels:    1,
+		CaptureRate:       8000,
+		FrameDuration:     1 * time.Millisecond, // 8 samples -> 16 bytes/frame
+		SpeakCoalesce:     5 * time.Millisecond,
+		SpeakHangover:     5 * time.Millisecond,
+		MicBusyBackoff:    1 * time.Millisecond,
+		StatePollInterval: 5 * time.Millisecond,
+	}
+}
+
+// --- tests -------------------------------------------------------------------
+
+// TestConverseBridge_ForwardsCapturedAudio asserts captured room PCM is forwarded
+// to the engine as input_audio_buffer.append frames, and that with server VAD the
+// bridge never sends commit/response.create.
+func TestConverseBridge_ForwardsCapturedAudio(t *testing.T) {
+	cfg := fastConfig()
+	pr, pw := io.Pipe()
+	media := &mockConverseMedia{capture: pr}
+	conn := newMockConn()
+	b := newConverseBridge(conn, media, nil, nil, cfg)
+
+	go b.Run(context.Background())
+
+	frameBytes := pcmFrameBytes(cfg.CaptureRate, cfg.EngineChannels, cfg.FrameDuration)
+	// Write 3 full frames of non-silent audio.
+	payload := make([]byte, frameBytes*3)
+	for i := range payload {
+		payload[i] = byte(i%200 + 1)
+	}
+	if _, err := pw.Write(payload); err != nil {
+		t.Fatalf("write capture: %v", err)
+	}
+
+	waitFor(t, "3 appends forwarded", func() bool { return conn.countType(msgInputAudioAppend) >= 3 })
+
+	if got := conn.countType("input_audio_buffer.commit"); got != 0 {
+		t.Errorf("sent %d commit frames; server VAD means we must never force a turn", got)
+	}
+	if got := conn.countType("response.create"); got != 0 {
+		t.Errorf("sent %d response.create; must never force a turn under server VAD", got)
+	}
+	_ = pw.Close()
+	conn.Close()
+}
+
+// TestConverseBridge_PlaysAudioDeltas asserts engine audio deltas are decoded and
+// injected into the virtual mic via SpeakPCM.
+func TestConverseBridge_PlaysAudioDeltas(t *testing.T) {
+	cfg := fastConfig()
+	pr, _ := io.Pipe() // capture blocks (no room audio) so only the SPEAK path runs
+	media := &mockConverseMedia{capture: pr}
+	conn := newMockConn()
+	b := newConverseBridge(conn, media, nil, nil, cfg)
+
+	go b.Run(context.Background())
+
+	ttsPCM := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	conn.incoming <- audioDeltaMsg(ttsPCM)
+
+	waitFor(t, "delta played into mic", func() bool { return media.playedCount() >= 1 })
+	waitFor(t, "audio delta counted", func() bool { return b.snapshot().AudioDeltas >= 1 })
+
+	if media.playedBytes() < len(ttsPCM) {
+		t.Errorf("played %d bytes, want >= %d", media.playedBytes(), len(ttsPCM))
+	}
+	conn.Close()
+}
+
+// TestConverseBridge_StopsOnLeft asserts the bridge stops when the state check
+// reports the call ended.
+func TestConverseBridge_StopsOnLeft(t *testing.T) {
+	cfg := fastConfig()
+	pr, _ := io.Pipe()
+	media := &mockConverseMedia{capture: pr}
+	conn := newMockConn()
+
+	ended := make(chan struct{})
+	var once sync.Once
+	state := func() (bool, string) {
+		select {
+		case <-ended:
+			return true, "bot left the call"
+		default:
+			once.Do(func() { close(ended) }) // end on the first poll
+			return false, ""
+		}
+	}
+	b := newConverseBridge(conn, media, state, nil, cfg)
+
+	done := make(chan converseStats, 1)
+	go func() { s, _ := b.Run(context.Background()); done <- s }()
+
+	select {
+	case s := <-done:
+		if s.StopReason != "bot left the call" {
+			t.Errorf("StopReason = %q, want %q", s.StopReason, "bot left the call")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("bridge did not stop on left state")
+	}
+}
+
+// TestConverseBridge_StopsOnContextCancel asserts a cancelled parent context ends
+// the resident loop.
+func TestConverseBridge_StopsOnContextCancel(t *testing.T) {
+	cfg := fastConfig()
+	pr, _ := io.Pipe()
+	media := &mockConverseMedia{capture: pr}
+	conn := newMockConn()
+	b := newConverseBridge(conn, media, nil, nil, cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan converseStats, 1)
+	go func() { s, _ := b.Run(ctx); done <- s }()
+
+	cancel()
+	select {
+	case s := <-done:
+		if s.StopReason == "" {
+			t.Error("expected a stop reason on context cancel")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("bridge did not stop on context cancel")
+	}
+}
+
+// TestConverseBridge_GateDropsFramesWhileSpeaking asserts that with the (default)
+// speaking gate on, captured frames are dropped while the bot is playing TTS, so
+// the bot's own audio can't be fed back as user speech.
+func TestConverseBridge_GateDropsFramesWhileSpeaking(t *testing.T) {
+	cfg := fastConfig()
+	pr, pw := io.Pipe()
+	gate := make(chan struct{})
+	media := &mockConverseMedia{capture: pr, speakGate: gate}
+	conn := newMockConn()
+	b := newConverseBridge(conn, media, nil, nil, cfg)
+
+	go b.Run(context.Background())
+
+	// Kick off a TTS delta; SpeakPCM blocks on `gate`, so `speaking` stays true.
+	conn.incoming <- audioDeltaMsg([]byte{9, 9, 9, 9})
+	waitFor(t, "bridge entered speaking state", func() bool { return b.speaking.Load() })
+
+	// Now push room audio: it must be gated (dropped), not appended.
+	frameBytes := pcmFrameBytes(cfg.CaptureRate, cfg.EngineChannels, cfg.FrameDuration)
+	if _, err := pw.Write(make([]byte, frameBytes*3)); err != nil {
+		t.Fatalf("write capture: %v", err)
+	}
+	waitFor(t, "frames gated while speaking", func() bool { return b.snapshot().GatedFrames >= 3 })
+
+	if got := conn.countType(msgInputAudioAppend); got != 0 {
+		t.Errorf("appended %d frames while speaking; gate should have dropped them", got)
+	}
+
+	// Release playback; the gate reopens (hangover) and a clear is sent.
+	close(gate)
+	waitFor(t, "clear sent on gate release", func() bool { return conn.countType(msgInputAudioClear) >= 1 })
+	conn.Close()
+}
+
+// TestConverseBridge_BargeInDropsQueuedTTS asserts a speech_started event drops
+// TTS still queued to play (the human interrupted), counted as a barge-in.
+func TestConverseBridge_BargeInDropsQueuedTTS(t *testing.T) {
+	cfg := fastConfig()
+	pr, _ := io.Pipe()
+	gate := make(chan struct{})
+	media := &mockConverseMedia{capture: pr, speakGate: gate}
+	conn := newMockConn()
+	b := newConverseBridge(conn, media, nil, nil, cfg)
+
+	go b.Run(context.Background())
+
+	// First delta enters the speaker and blocks on `gate`; subsequent deltas queue.
+	conn.incoming <- audioDeltaMsg([]byte{1, 1})
+	waitFor(t, "speaker holding first chunk", func() bool { return b.speaking.Load() })
+	// Let the first chunk's coalesce window close and playback block on `gate`, so
+	// the next deltas queue in speakCh rather than being folded into the first play.
+	time.Sleep(10 * cfg.SpeakCoalesce)
+	// Queue several more chunks behind the blocked speaker.
+	for i := 0; i < 5; i++ {
+		conn.incoming <- audioDeltaMsg([]byte{byte(i), byte(i)})
+	}
+	waitFor(t, "chunks queued", func() bool { return len(b.speakCh) > 0 })
+
+	// Human starts talking -> drop the queued TTS.
+	conn.incoming <- speechStartedMsg()
+	waitFor(t, "barge-in recorded", func() bool { return b.snapshot().Barges >= 1 })
+	waitFor(t, "speak queue drained", func() bool { return len(b.speakCh) == 0 })
+
+	close(gate)
+	conn.Close()
+}
+
+// TestResamplePCM16 checks the linear resampler: a no-op when rates match, and the
+// right output frame count when up/down-sampling, preserving endpoints.
+func TestResamplePCM16(t *testing.T) {
+	// s16le, mono. 4 samples: 0, 100, 200, 300.
+	in := pcm16([]int16{0, 100, 200, 300})
+
+	if got := resamplePCM16(in, 8000, 8000, 1); len(got) != len(in) {
+		t.Errorf("equal-rate resample changed length: got %d want %d", len(got), len(in))
+	}
+
+	// Upsample 8k -> 16k doubles frame count (approx).
+	up := resamplePCM16(in, 8000, 16000, 1)
+	upSamples := len(up) / 2
+	if upSamples < 7 || upSamples > 9 {
+		t.Errorf("upsample 8k->16k of 4 samples = %d samples, want ~8", upSamples)
+	}
+	// First sample preserved.
+	if first := int16(uint16(up[0]) | uint16(up[1])<<8); first != 0 {
+		t.Errorf("first upsampled sample = %d, want 0", first)
+	}
+
+	// Downsample 16k -> 8k halves frame count.
+	down := resamplePCM16(pcm16([]int16{0, 50, 100, 150, 200, 250, 300, 350}), 16000, 8000, 1)
+	if ds := len(down) / 2; ds < 3 || ds > 5 {
+		t.Errorf("downsample 16k->8k of 8 samples = %d samples, want ~4", ds)
+	}
+}
+
+func TestPCMFrameBytes(t *testing.T) {
+	// 20ms @ 24kHz mono s16le = 480 samples * 2 = 960 bytes.
+	if got := pcmFrameBytes(24000, 1, 20*time.Millisecond); got != 960 {
+		t.Errorf("pcmFrameBytes(24000,1,20ms) = %d, want 960", got)
+	}
+	// Stereo doubles it.
+	if got := pcmFrameBytes(24000, 2, 20*time.Millisecond); got != 1920 {
+		t.Errorf("pcmFrameBytes(24000,2,20ms) = %d, want 1920", got)
+	}
+	// A sub-sample duration still yields at least one sample.
+	if got := pcmFrameBytes(24000, 1, 0); got < bytesPerSample {
+		t.Errorf("pcmFrameBytes with 0 dur = %d, want >= %d", got, bytesPerSample)
+	}
+}
+
+func TestRealtimeWSURL(t *testing.T) {
+	got, err := realtimeWSURL("https://aceteam.ai", "", "agent-9")
+	if err != nil {
+		t.Fatalf("realtimeWSURL: %v", err)
+	}
+	// https -> wss, agentId + server_vad injected.
+	if !contains(got, "wss://aceteam.ai/api/realtime") {
+		t.Errorf("url = %q, want wss endpoint", got)
+	}
+	if !contains(got, "agentId=agent-9") {
+		t.Errorf("url = %q, missing agentId", got)
+	}
+	if !contains(got, "turnDetection=server_vad") {
+		t.Errorf("url = %q, missing server_vad turn detection", got)
+	}
+
+	// Explicit override is honored and upgraded http->ws.
+	got2, err := realtimeWSURL("https://aceteam.ai", "http://localhost:3000/api/realtime", "a")
+	if err != nil {
+		t.Fatalf("realtimeWSURL override: %v", err)
+	}
+	if !contains(got2, "ws://localhost:3000/api/realtime") {
+		t.Errorf("override url = %q, want ws://localhost endpoint", got2)
+	}
+}
+
+// pcm16 encodes int16 samples as little-endian bytes for the resampler tests.
+func pcm16(samples []int16) []byte {
+	out := make([]byte, len(samples)*2)
+	for i, s := range samples {
+		out[i*2] = byte(uint16(s))
+		out[i*2+1] = byte(uint16(s) >> 8)
+	}
+	return out
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/jobs/huddle_join.go
+++ b/internal/jobs/huddle_join.go
@@ -23,20 +23,21 @@
 // same browser surface (platform.CDPBrowser) MEETING_JOIN drives.
 //
 // --- aceteam-side contracts this file depends on (verified against the aceteam
-//     repo's #7081 commits, NOT re-implemented here) ---
 //
-//	Token mint  POST {api_base}/api/huddle-bot/token
-//	            Authorization: Bearer <internal secret>   (isInternalServiceRequest)
-//	            body   { "agentId": <id>, "channelId": <id> }
-//	            200 -> { token, expiresAt, selfUserId, channelId, access }
-//	            (channelId is the NORMALIZED id the page must join; access is
-//	             "member" => admitted directly, "read" => lobby-then-admit.)
+//	    repo's #7081 commits, NOT re-implemented here) ---
 //
-//	Bot page    {api_base}/huddle-bot/<channelId>#token=<token>
-//	            The token rides the URL FRAGMENT (never the server / never a log).
-//	            The page publishes window.__huddleBotState =
-//	              { state:"connecting"|"lobby"|"joined"|"left"|"error",
-//	                callId, selfId, peerCount, connectedPeerCount, error, updatedAt }
+//		Token mint  POST {api_base}/api/huddle-bot/token
+//		            Authorization: Bearer <internal secret>   (isInternalServiceRequest)
+//		            body   { "agentId": <id>, "channelId": <id> }
+//		            200 -> { token, expiresAt, selfUserId, channelId, access }
+//		            (channelId is the NORMALIZED id the page must join; access is
+//		             "member" => admitted directly, "read" => lobby-then-admit.)
+//
+//		Bot page    {api_base}/huddle-bot/<channelId>#token=<token>
+//		            The token rides the URL FRAGMENT (never the server / never a log).
+//		            The page publishes window.__huddleBotState =
+//		              { state:"connecting"|"lobby"|"joined"|"left"|"error",
+//		                callId, selfId, peerCount, connectedPeerCount, error, updatedAt }
 package jobs
 
 import (
@@ -70,6 +71,11 @@ const JobTypeHuddleJoinType = "HUDDLE_JOIN"
 const (
 	envHuddleBotSecret    = "CITADEL_HUDDLE_BOT_SECRET"
 	envInternalAuthSecret = "INTERNAL_AUTH_SECRET"
+	// envRealtimeToken is the fallback source for the realtime-engine auth token
+	// used by the converse bridge (payload realtime_token wins). It is an AceTeam
+	// API key (act_...) or user JWT the realtime WS server's authenticate() accepts
+	// — NOT the huddle-bot mint token (see huddle_realtime_conn.go).
+	envRealtimeToken = "CITADEL_REALTIME_TOKEN"
 )
 
 // defaultHuddleAPIBase is the AceTeam API base used when the payload omits
@@ -93,6 +99,15 @@ const (
 	// a same-node retry is never blocked by our own not-yet-reaped session; Close
 	// (DELETE /sessions) tears it down on the normal path well before this.
 	huddleSessionMaxDuration = 1 * time.Hour
+	// converseSessionMaxDuration is the reaper cap for a RESIDENT converse session:
+	// the bot stays in the call bridging audio for the meeting's whole length, so
+	// the 1h join+confirm cap would kill the bridge mid-meeting. Matches the worker
+	// long-session tier (4h) HUDDLE_JOIN now belongs to. Only used when converse is
+	// enabled, so the plain path keeps the tighter cap.
+	converseSessionMaxDuration = 4 * time.Hour
+	// converseStatePollInterval is how often the resident bridge re-samples
+	// window.__huddleBotState to notice the call ended (left/error).
+	converseStatePollInterval = 3 * time.Second
 )
 
 // huddleBrowser is the minimal CDP surface the huddle join drives — navigate to
@@ -112,14 +127,24 @@ type huddleJoinParams struct {
 	ChannelID string
 	AgentID   string
 	APIBase   string // optional; falls back to device creds base, then default
+	// Converse turns the join into a resident two-way voice bridge (aceteam#7079).
+	// Default false => exact #667 join+confirm behavior (no capture/WS/mic).
+	Converse bool
+	// RealtimeURL optionally overrides the realtime WS endpoint (else derived from
+	// APIBase). RealtimeToken is the engine auth token (else env CITADEL_REALTIME_TOKEN).
+	RealtimeURL   string
+	RealtimeToken string
 }
 
 // parseHuddleJoinParams validates + normalizes the raw string payload.
 func parseHuddleJoinParams(payload map[string]string) (huddleJoinParams, error) {
 	p := huddleJoinParams{
-		ChannelID: strings.TrimSpace(payload["channel_id"]),
-		AgentID:   strings.TrimSpace(payload["agent_id"]),
-		APIBase:   strings.TrimSpace(payload["api_base"]),
+		ChannelID:     strings.TrimSpace(payload["channel_id"]),
+		AgentID:       strings.TrimSpace(payload["agent_id"]),
+		APIBase:       strings.TrimSpace(payload["api_base"]),
+		Converse:      isTruthy(payload["converse"]),
+		RealtimeURL:   strings.TrimSpace(payload["realtime_url"]),
+		RealtimeToken: strings.TrimSpace(payload["realtime_token"]),
 	}
 	if p.ChannelID == "" {
 		return huddleJoinParams{}, fmt.Errorf("job payload missing required 'channel_id' field")
@@ -128,6 +153,16 @@ func parseHuddleJoinParams(payload map[string]string) (huddleJoinParams, error) 
 		return huddleJoinParams{}, fmt.Errorf("job payload missing required 'agent_id' field")
 	}
 	return p, nil
+}
+
+// isTruthy parses the common truthy string forms used across citadel payload flags.
+func isTruthy(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 // huddleToken is the subset of the mint route's 200 response the node needs.
@@ -170,8 +205,16 @@ type HuddleJoinHandler struct {
 	mintToken func(ctx context.Context, apiBase, secret string, p huddleJoinParams) (huddleToken, error)
 	// newBrowser launches (or reuses) the container session and returns the
 	// CDP-driven browser plus a cleanup that tears the session down. nil uses the
-	// real container-session implementation; tests inject a fake browser.
-	newBrowser func(p huddleJoinParams) (br huddleBrowser, cleanup func() error, err error)
+	// real container-session implementation; tests inject a fake browser. The
+	// converse media (capture + speak on the same session) is returned separately
+	// for the resident bridge; it is nil when this seam is a test fake (the
+	// converse path is then exercised via the runConverse seam instead).
+	newBrowser func(p huddleJoinParams) (br huddleBrowser, media converseMedia, cleanup func() error, err error)
+
+	// runConverse runs the resident converse bridge after `joined`. nil uses the
+	// real implementation (dial the realtime WS, bridge audio). Tests inject a fake
+	// to assert it is invoked only when converse:true, without a live WS/engine.
+	runConverse func(ctx JobContext, br huddleBrowser, media converseMedia, tok huddleToken, p huddleJoinParams) (converseStats, error)
 
 	// Tunables (zero => package defaults at use). Tests set them to milliseconds.
 	connectTimeout time.Duration
@@ -217,8 +260,8 @@ func (h *HuddleJoinHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, err
 	}
 	ctx.Log("info", "     - [Job %s] minted bot token (self=%s, access=%s, channel=%s)", job.ID, tok.SelfUserID, tok.Access, joinChannel)
 
-	// Launch (or reuse) the container session -> CDP browser.
-	br, cleanup, err := h.launchBrowser(p)
+	// Launch (or reuse) the container session -> CDP browser (+ converse media).
+	br, media, cleanup, err := h.launchBrowser(p)
 	if err != nil {
 		return nil, fmt.Errorf("launch huddle browser: %w", err)
 	}
@@ -255,7 +298,7 @@ func (h *HuddleJoinHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, err
 	ctx.Log("info", "     - [Job %s] JOINED huddle %s (self=%s, peers=%d, connected=%d)",
 		job.ID, joinChannel, selfID, final.PeerCount, final.ConnectedPeerCount)
 
-	out, _ := json.Marshal(map[string]any{
+	result := map[string]any{
 		"status":               "joined",
 		"channel_id":           joinChannel,
 		"agent_id":             p.AgentID,
@@ -265,8 +308,81 @@ func (h *HuddleJoinHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, err
 		"connected_peer_count": final.ConnectedPeerCount,
 		"access":               tok.Access,
 		"state":                final.State,
-	})
+	}
+
+	// Resident converse bridge (aceteam#7079). Additive: only when converse:true.
+	// It blocks (the session stays up, so `defer cleanup()` above tears it down
+	// after) until the call ends / the job context cancels.
+	if p.Converse {
+		ctx.Log("info", "     - [Job %s] converse enabled; starting resident voice bridge", job.ID)
+		stats, cErr := h.converse(ctx, br, media, tok, p)
+		result["converse"] = stats
+		if cErr != nil {
+			// A converse failure does not un-join: we DID join. Report it in the
+			// result but keep status joined so the backend sees a successful join.
+			ctx.Log("warn", "     - [Job %s] converse bridge ended with error: %v", job.ID, cErr)
+			result["converse_error"] = cErr.Error()
+		}
+		ctx.Log("info", "     - [Job %s] converse bridge ended (reason=%s, appended=%d, deltas=%d, spoken=%d)",
+			job.ID, stats.StopReason, stats.AppendedFrames, stats.AudioDeltas, stats.SpokenChunks)
+	}
+
+	out, _ := json.Marshal(result)
 	return out, nil
+}
+
+// converse runs (or delegates) the resident realtime bridge after the bot joined.
+// It resolves the realtime token, dials the engine, and bridges room audio <-> the
+// virtual mic until the call ends or ctx cancels.
+func (h *HuddleJoinHandler) converse(ctx JobContext, br huddleBrowser, media converseMedia, tok huddleToken, p huddleJoinParams) (converseStats, error) {
+	if h.runConverse != nil {
+		return h.runConverse(ctx, br, media, tok, p)
+	}
+	if media == nil {
+		return converseStats{StopReason: "no media"}, fmt.Errorf("converse requires a container media handle (meeting module)")
+	}
+	token := h.resolveRealtimeToken(p)
+	if token == "" {
+		return converseStats{StopReason: "no realtime token"}, fmt.Errorf(
+			"converse requires a realtime engine token; set payload 'realtime_token' or env %s", envRealtimeToken)
+	}
+	apiBase := h.resolveAPIBase(p)
+	conn, err := dialRealtime(apiBase, p.RealtimeURL, token, p.AgentID)
+	if err != nil {
+		return converseStats{StopReason: "ws dial failed"}, fmt.Errorf("dial realtime engine: %w", err)
+	}
+	defer conn.Close()
+
+	// stateCheck lets the bridge notice the call ended by re-reading the bot page's
+	// readiness signal (left/error) — the same signal the join poll used.
+	stateCheck := func() (bool, string) {
+		st, present, sErr := readHuddleBotState(br)
+		if sErr != nil || !present {
+			return false, "" // a transient probe miss is not "ended"
+		}
+		switch st.State {
+		case "left":
+			return true, "bot left the call"
+		case "error":
+			return true, "bot reported error: " + st.Error
+		default:
+			return false, ""
+		}
+	}
+
+	bridge := newConverseBridge(conn, media, stateCheck,
+		func(level, format string, args ...any) { ctx.Log(level, format, args...) },
+		converseConfig{StatePollInterval: converseStatePollInterval})
+	return bridge.Run(ctx.Context())
+}
+
+// resolveRealtimeToken returns the realtime-engine auth token: payload override
+// first, then env CITADEL_REALTIME_TOKEN.
+func (h *HuddleJoinHandler) resolveRealtimeToken(p huddleJoinParams) string {
+	if p.RealtimeToken != "" {
+		return p.RealtimeToken
+	}
+	return strings.TrimSpace(os.Getenv(envRealtimeToken))
 }
 
 // resolveSecret returns the internal service secret (seam-overridable).
@@ -341,8 +457,10 @@ func mintHuddleBotToken(ctx context.Context, client *http.Client, apiBase, secre
 }
 
 // launchBrowser delegates to the injected browser seam or the real container
-// session implementation.
-func (h *HuddleJoinHandler) launchBrowser(p huddleJoinParams) (huddleBrowser, func() error, error) {
+// session implementation. It returns the browser, the converse media handle (the
+// SAME container session, for the resident bridge; may be nil for a test fake or
+// the host path), and a session-teardown cleanup.
+func (h *HuddleJoinHandler) launchBrowser(p huddleJoinParams) (huddleBrowser, converseMedia, func() error, error) {
 	if h.newBrowser != nil {
 		return h.newBrowser(p)
 	}
@@ -351,21 +469,27 @@ func (h *HuddleJoinHandler) launchBrowser(p huddleJoinParams) (huddleBrowser, fu
 
 // defaultHuddleBrowser launches a meeting-service container session (reusing the
 // meeting media stack: this wires the in-container Chromium to the virtual mic +
-// capture sink) and returns its CDP browser plus a session-teardown cleanup. The
-// meeting module MUST be healthy on this node — huddle join is a WebRTC join that
-// needs the container's headless Chromium; there is no host fallback here.
-func defaultHuddleBrowser(p huddleJoinParams) (huddleBrowser, func() error, error) {
+// capture sink) and returns its CDP browser, the containerMedia (for the converse
+// bridge's capture+speak), plus a session-teardown cleanup. The meeting module MUST
+// be healthy on this node — huddle join is a WebRTC join that needs the container's
+// headless Chromium; there is no host fallback here.
+func defaultHuddleBrowser(p huddleJoinParams) (huddleBrowser, converseMedia, func() error, error) {
 	if !meetingdHealthy(&http.Client{Timeout: meetingContainerHealthTimeout}, meetingdBaseURL()) {
-		return nil, nil, fmt.Errorf("the meeting-service container is not healthy on this node; HUDDLE_JOIN requires it (install/enable the meeting module)")
+		return nil, nil, nil, fmt.Errorf("the meeting-service container is not healthy on this node; HUDDLE_JOIN requires it (install/enable the meeting module)")
+	}
+	// A resident converse session must outlive the 1h join+confirm reaper cap.
+	maxDur := huddleSessionMaxDuration
+	if p.Converse {
+		maxDur = converseSessionMaxDuration
 	}
 	// No recording for join+confirm, so the WAV paths are empty. Start() creates
 	// the session and returns the CDP browser; Close() (cleanup) deletes it.
-	media := newContainerMedia(p.ChannelID, "", "", huddleSessionMaxDuration)
+	media := newContainerMedia(p.ChannelID, "", "", maxDur)
 	br, err := media.Start()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	return br, media.Close, nil
+	return br, media, media.Close, nil
 }
 
 // huddlePollOpts bundles the poll budgets + the token's access level (for a

--- a/internal/jobs/huddle_join_test.go
+++ b/internal/jobs/huddle_join_test.go
@@ -74,10 +74,12 @@ func stateJSON(state, selfID string, peers, connected int) string {
 // injected mint, and an injected browser.
 func newTestHuddleHandler(secret string, mint func(ctx context.Context, apiBase, secret string, p huddleJoinParams) (huddleToken, error), br *fakeHuddleBrowser) *HuddleJoinHandler {
 	return &HuddleJoinHandler{
-		WorkspaceDir:   "/tmp",
-		secretFn:       func() string { return secret },
-		mintToken:      mint,
-		newBrowser:     func(p huddleJoinParams) (huddleBrowser, func() error, error) { return br, br.Close, nil },
+		WorkspaceDir: "/tmp",
+		secretFn:     func() string { return secret },
+		mintToken:    mint,
+		newBrowser: func(p huddleJoinParams) (huddleBrowser, converseMedia, func() error, error) {
+			return br, nil, br.Close, nil
+		},
 		connectTimeout: 200 * time.Millisecond,
 		admitTimeout:   400 * time.Millisecond,
 		pollInterval:   2 * time.Millisecond,
@@ -334,4 +336,63 @@ func TestHuddleBotURL_FragmentRedaction(t *testing.T) {
 	if strings.Contains(red, "act_supersecret") || !strings.Contains(red, "<redacted>") {
 		t.Errorf("redacted URL %q must not leak the token", red)
 	}
+}
+
+// TestHuddleJoin_ConverseGating asserts the resident converse bridge runs ONLY
+// when converse:true, that its stats fold into the (still "joined") result, and
+// that the default path never touches it (exact #667 behavior).
+func TestHuddleJoin_ConverseGating(t *testing.T) {
+	joined := []string{stateJSON("joined", "self-1", 1, 1)}
+	tok := huddleToken{Token: "tkn", ChannelID: "chan-norm", SelfUserID: "self-1", Access: "member"}
+
+	t.Run("converse false does not invoke bridge", func(t *testing.T) {
+		br := &fakeHuddleBrowser{states: joined}
+		h := newTestHuddleHandler("s3cr3t", okMint(tok), br)
+		called := false
+		h.runConverse = func(ctx JobContext, _ huddleBrowser, _ converseMedia, _ huddleToken, _ huddleJoinParams) (converseStats, error) {
+			called = true
+			return converseStats{}, nil
+		}
+		out, err := h.Execute(JobContext{}, huddleJob()) // no converse in payload
+		if err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		if called {
+			t.Error("runConverse invoked though converse was not requested")
+		}
+		var res map[string]any
+		_ = json.Unmarshal(out, &res)
+		if _, ok := res["converse"]; ok {
+			t.Error("result carried converse stats on the plain path")
+		}
+	})
+
+	t.Run("converse true invokes bridge and folds stats", func(t *testing.T) {
+		br := &fakeHuddleBrowser{states: joined}
+		h := newTestHuddleHandler("s3cr3t", okMint(tok), br)
+		h.runConverse = func(ctx JobContext, _ huddleBrowser, _ converseMedia, _ huddleToken, p huddleJoinParams) (converseStats, error) {
+			if !p.Converse {
+				t.Error("params.Converse should be true inside the bridge")
+			}
+			return converseStats{AppendedFrames: 7, AudioDeltas: 3, SpokenChunks: 2, StopReason: "bot left the call"}, nil
+		}
+		job := huddleJob()
+		job.Payload["converse"] = "true"
+		out, err := h.Execute(JobContext{}, job)
+		if err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		var res map[string]any
+		_ = json.Unmarshal(out, &res)
+		if res["status"] != "joined" {
+			t.Errorf("status = %v, want joined (converse must not change join status)", res["status"])
+		}
+		cv, ok := res["converse"].(map[string]any)
+		if !ok {
+			t.Fatalf("result missing converse stats: %v", res["converse"])
+		}
+		if cv["appended_frames"].(float64) != 7 || cv["spoken_chunks"].(float64) != 2 {
+			t.Errorf("converse stats not folded through: %v", cv)
+		}
+	})
 }

--- a/internal/jobs/huddle_realtime_conn.go
+++ b/internal/jobs/huddle_realtime_conn.go
@@ -1,0 +1,112 @@
+// internal/jobs/huddle_realtime_conn.go
+//
+// Production realtimeConn: a gorilla/websocket client to the AceTeam realtime
+// engine (wss://<api>/api/realtime), used by the HUDDLE_JOIN converse bridge.
+//
+// Auth: the AceTeam WS server (aceteam middleware/websocketServer.ts) accepts an
+// `Authorization: Bearer <token>` HEADER from device clients (citadel-cli) and
+// authenticates it via the same `authenticate()` path as the REST API -- i.e. an
+// `act_` API key or a Supabase user JWT. The huddle-bot mint token is NOT known to
+// be accepted there, so the bridge takes an EXPLICIT realtime token (payload
+// `realtime_token` / env CITADEL_REALTIME_TOKEN) rather than reusing the mint
+// token. See huddle_join.go's resolveRealtimeToken.
+//
+// Turn detection: `turnDetection=server_vad` rides the URL query so the engine
+// runs server-side VAD (the bridge never forces a turn with commit/response.create).
+package jobs
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// realtimeDialTimeout bounds the WS handshake (not the session).
+const realtimeDialTimeout = 20 * time.Second
+
+// gorillaRealtimeConn adapts a *websocket.Conn to the realtimeConn seam. gorilla
+// allows a single READER and a single WRITER at a time. recvLoop is the only
+// reader, but TWO goroutines call Send (hearLoop's append and speakerLoop's
+// clear), so writes MUST be serialized here — writeMu does that (gorilla panics
+// with "concurrent write to websocket connection" otherwise).
+type gorillaRealtimeConn struct {
+	c       *websocket.Conn
+	writeMu sync.Mutex
+}
+
+func (g *gorillaRealtimeConn) Send(payload []byte) error {
+	g.writeMu.Lock()
+	defer g.writeMu.Unlock()
+	return g.c.WriteMessage(websocket.TextMessage, payload)
+}
+
+func (g *gorillaRealtimeConn) Recv() ([]byte, error) {
+	_, data, err := g.c.ReadMessage()
+	return data, err
+}
+
+func (g *gorillaRealtimeConn) Close() error {
+	return g.c.Close()
+}
+
+// dialRealtime builds the realtime WS URL from the API base (or an explicit
+// override) and dials it with the Bearer token. agentID is passed as a query param
+// so the engine resolves the right agent session; turnDetection=server_vad opts
+// into hands-free turn taking.
+func dialRealtime(apiBase, explicitURL, token, agentID string) (realtimeConn, error) {
+	wsURL, err := realtimeWSURL(apiBase, explicitURL, agentID)
+	if err != nil {
+		return nil, err
+	}
+	dialer := &websocket.Dialer{HandshakeTimeout: realtimeDialTimeout}
+	hdr := http.Header{}
+	hdr.Set("Authorization", "Bearer "+token)
+	c, resp, err := dialer.Dial(wsURL, hdr)
+	if err != nil {
+		if resp != nil {
+			return nil, fmt.Errorf("dial realtime ws (status %d): %w", resp.StatusCode, err)
+		}
+		return nil, fmt.Errorf("dial realtime ws: %w", err)
+	}
+	return &gorillaRealtimeConn{c: c}, nil
+}
+
+// realtimeWSURL derives the wss:// realtime endpoint. An explicit realtime_url
+// wins (its query is preserved and agentId/turnDetection are ensured); otherwise
+// it is {api as ws}/api/realtime?agentId=..&turnDetection=server_vad.
+func realtimeWSURL(apiBase, explicitURL, agentID string) (string, error) {
+	raw := explicitURL
+	if raw == "" {
+		raw = strings.TrimRight(apiBase, "/") + "/api/realtime"
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("parse realtime url %q: %w", raw, err)
+	}
+	switch u.Scheme {
+	case "https":
+		u.Scheme = "wss"
+	case "http":
+		u.Scheme = "ws"
+	case "wss", "ws":
+		// already a ws scheme
+	default:
+		return "", fmt.Errorf("unsupported realtime url scheme %q", u.Scheme)
+	}
+	q := u.Query()
+	if agentID != "" && q.Get("agentId") == "" {
+		q.Set("agentId", agentID)
+	}
+	if q.Get("turnDetection") == "" {
+		q.Set("turnDetection", "server_vad")
+	}
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+var _ realtimeConn = (*gorillaRealtimeConn)(nil)

--- a/internal/jobs/meeting_media.go
+++ b/internal/jobs/meeting_media.go
@@ -21,6 +21,7 @@ package jobs
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -343,6 +344,67 @@ func (m *containerMedia) SpeakFile(wavRelPath string) error {
 	return nil
 }
 
+// errMicBusy is the sentinel a SpeakPCM caller sees on a 409 (another clip is
+// already playing on the node-wide virtual mic). The converse bridge treats it as
+// retryable (brief backoff) rather than fatal, since a client-side timeout can
+// leave meetingd still holding its mic lock.
+var errMicBusy = fmt.Errorf("meetingd mic busy (another clip is playing)")
+
+// SpeakPCM streams raw signed-16-bit little-endian PCM into the container's
+// virtual microphone via meetingd's POST /mic/play/pcm (the low-latency realtime
+// SPEAK path, the byte-stream sibling of SpeakFile). rate/channels are passed as
+// query params so meetingd plays at the engine's format (24000/1). It blocks until
+// meetingd finishes playing the clip (synchronous playback), so it uses the
+// dedicated long-timeout client. A 409 returns errMicBusy; a 503 means the virtual
+// mic is not present on this node.
+func (m *containerMedia) SpeakPCM(pcm []byte, rate, channels int) error {
+	u := fmt.Sprintf("%s/mic/play/pcm?rate=%d&channels=%d", m.base, rate, channels)
+	req, err := http.NewRequest(http.MethodPost, u, bytes.NewReader(pcm))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+	client := &http.Client{Timeout: meetingSpeakTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("meetingd mic play pcm: %w", err)
+	}
+	defer resp.Body.Close()
+	out, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	if resp.StatusCode == http.StatusConflict {
+		return errMicBusy
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("meetingd mic play pcm returned status %d: %s", resp.StatusCode, string(out))
+	}
+	return nil
+}
+
+// CaptureStream opens meetingd's GET /sessions/{id}/capture/pcm and returns the
+// live raw s16le PCM body (the room's mixed audio -- the HEAR source the converse
+// bridge forwards to the realtime engine). The caller MUST Close the returned
+// ReadCloser to stop the container-side pacat (meetingd kills it on client
+// disconnect). No client timeout is set: the stream is meant to run for the whole
+// meeting; cancellation flows through ctx (closing the response body).
+func (m *containerMedia) CaptureStream(ctx context.Context, rate, channels int) (io.ReadCloser, error) {
+	u := fmt.Sprintf("%s/sessions/%s/capture/pcm?rate=%d&channels=%d",
+		m.base, url.PathEscape(m.sessionID), rate, channels)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("meetingd capture stream: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		out, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+		resp.Body.Close()
+		return nil, fmt.Errorf("meetingd capture stream returned status %d: %s", resp.StatusCode, string(out))
+	}
+	return resp.Body, nil
+}
+
 func (m *containerMedia) sessionPath(suffix string) string {
 	return "/sessions/" + url.PathEscape(m.sessionID) + suffix
 }
@@ -395,6 +457,7 @@ func (m *containerMedia) postJSON(path string, body any) ([]byte, int, error) {
 var (
 	_ MeetingMedia   = (*hostMedia)(nil)
 	_ MeetingMedia   = (*containerMedia)(nil)
+	_ converseMedia  = (*containerMedia)(nil)
 	_ meetingBrowser = (*platform.MeetingBrowser)(nil)
 	_ meetingBrowser = (*platform.CDPBrowser)(nil)
 )

--- a/internal/worker/deadline.go
+++ b/internal/worker/deadline.go
@@ -49,6 +49,11 @@ const (
 var longSessionJobTypes = map[string]struct{}{
 	JobTypeMeetingJoin: {},
 	JobTypeCobrowse:    {},
+	// HUDDLE_JOIN with converse:true stays resident bridging audio for the whole
+	// meeting (aceteam#7079), so it needs the long-session tier like MEETING_JOIN
+	// rather than the default 60min cap. The plain join+confirm path returns in
+	// seconds, well under this, so the tier change is safe for both.
+	JobTypeHuddleJoin: {},
 }
 
 // unboundedJobTypes get NO fallback deadline: their duration is dominated by

--- a/services/meeting-service/meetingd.py
+++ b/services/meeting-service/meetingd.py
@@ -67,8 +67,8 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 
-from fastapi import Body, FastAPI
-from fastapi.responses import JSONResponse
+from fastapi import Body, FastAPI, Response
+from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
 
 
@@ -120,6 +120,14 @@ MIC_PLAY_TIMEOUT = int(os.environ.get("MEETING_MIC_PLAY_TIMEOUT", "120"))
 # Default raw-PCM format for /mic/play/pcm when the caller omits the query params.
 MIC_PCM_RATE = int(os.environ.get("MEETING_MIC_PCM_RATE", "24000"))
 MIC_PCM_CHANNELS = int(os.environ.get("MEETING_MIC_PCM_CHANNELS", "1"))
+# Default raw-PCM format for GET /sessions/{id}/capture/pcm (the room->bot HEAR
+# path, aceteam#7079). 24 kHz mono matches the realtime engine's PCM16 format, so
+# the converse bridge can forward captured frames without resampling; PulseAudio
+# does the monitor->24 kHz resample inside pacat. Read size for one stream chunk
+# is kept small so the bridge sees low-latency frames.
+CAPTURE_PCM_RATE = int(os.environ.get("MEETING_CAPTURE_PCM_RATE", "24000"))
+CAPTURE_PCM_CHANNELS = int(os.environ.get("MEETING_CAPTURE_PCM_CHANNELS", "1"))
+CAPTURE_CHUNK_BYTES = int(os.environ.get("MEETING_CAPTURE_CHUNK_BYTES", "1920"))
 
 # Serializes injection so two overlapping clips never garble the mic. One clip at a
 # time; a second concurrent request gets 409 (no barge-in / mid-clip stop yet --
@@ -296,6 +304,24 @@ def build_pacat_mic_args(sink: str, rate: int, channels: int) -> list[str]:
         "--format=s16le",
         f"--rate={int(rate)}",
         f"--channels={int(channels)}",
+    ]
+
+
+def build_pacat_capture_args(source: str, rate: int, channels: int) -> list[str]:
+    """pacat args to RECORD a pulse source (a per-session `<sink>.monitor`, i.e. the
+    room's mixed audio) as raw signed-16-bit little-endian PCM to stdout, at the
+    requested rate/channels (PulseAudio resamples the monitor to `rate` for us). This
+    is the low-latency room->bot HEAR path the converse bridge streams from -- the
+    mirror of build_pacat_mic_args. `--latency-msec=20` keeps the stream tight.
+    Pure so the format flags are unit-testable."""
+    return [
+        "pacat",
+        "--record",
+        f"--device={source}",
+        "--format=s16le",
+        f"--rate={int(rate)}",
+        f"--channels={int(channels)}",
+        "--latency-msec=20",
     ]
 
 
@@ -477,6 +503,12 @@ class Session:
     max_duration_seconds: int
     recorder: subprocess.Popen[bytes] | None = None
     record_path: str | None = None
+    # capture_proc is the live pacat --record streaming the room monitor to an HTTP
+    # client (the converse bridge's HEAR path). At most one at a time per session;
+    # killed on client disconnect (the StreamingResponse generator's finally) and on
+    # teardown. Independent of `recorder` -- a pulse monitor supports many readers,
+    # so recording to a WAV and live-streaming can run at once.
+    capture_proc: subprocess.Popen[bytes] | None = None
     lock: threading.Lock = field(default_factory=threading.Lock)
 
 
@@ -707,6 +739,74 @@ def stop_record(session_id: str) -> JSONResponse:
     return JSONResponse(content={"recording": False, "path": path})
 
 
+# --- listening path (room -> bot, aceteam#7079) --------------------------------
+#
+#   GET /sessions/{id}/capture/pcm?rate=<hz>&channels=<n>
+#       Streams the session's room audio (the per-session `<sink>.monitor`, which
+#       carries the OTHER participants -- NOT the bot's own virtual mic, a different
+#       sink) as raw signed-16-bit little-endian PCM. This is the HEAR source the
+#       converse bridge forwards to the realtime engine. Defaults 24000/1 to match
+#       the engine's PCM16 format. At most one live capture per session; a second
+#       concurrent GET returns 409. The pacat subprocess is killed when the client
+#       disconnects (generator finally) or the session is torn down.
+
+
+def _capture_pcm_stream(s: "Session", proc: subprocess.Popen[bytes]):
+    """Yield raw PCM chunks from `proc`'s stdout until it ends or the HTTP client
+    disconnects, then reap the pacat process and clear it off the session. FastAPI
+    closes this generator when the client goes away, so the finally is what prevents
+    a leaked pacat holding the monitor across reconnects."""
+    try:
+        assert proc.stdout is not None
+        while True:
+            chunk = proc.stdout.read(CAPTURE_CHUNK_BYTES)
+            if not chunk:
+                break
+            yield chunk
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+        with s.lock:
+            if s.capture_proc is proc:
+                s.capture_proc = None
+
+
+@app.get("/sessions/{session_id}/capture/pcm")
+def capture_pcm(
+    session_id: str,
+    rate: int = CAPTURE_PCM_RATE,
+    channels: int = CAPTURE_PCM_CHANNELS,
+    # Annotate the base Response (not a Union): FastAPI infers response_model from
+    # the return annotation, and a Union isn't a `type`, so it would try to build a
+    # Pydantic field from it and raise FastAPIError at route registration (the whole
+    # service would fail to start). A Response subclass is passed through as-is.
+) -> Response:
+    s = _get_session(session_id)
+    if s is None:
+        return JSONResponse(status_code=404, content={"error": "no such session"})
+    if rate <= 0 or channels <= 0:
+        return JSONResponse(status_code=400, content={"error": "rate and channels must be positive"})
+    if not pulse_ready():
+        return JSONResponse(status_code=503, content={"error": "pulse server not ready"})
+    with s.lock:
+        if s.capture_proc is not None and s.capture_proc.poll() is None:
+            return JSONResponse(status_code=409, content={"error": "already capturing"})
+        try:
+            proc = subprocess.Popen(
+                build_pacat_capture_args(f"{s.sink_name}.monitor", rate, channels),
+                env=_pactl_env(),
+                stdout=subprocess.PIPE,
+            )
+        except OSError as exc:
+            return JSONResponse(status_code=500, content={"error": f"start capture: {exc}"})
+        s.capture_proc = proc
+    return StreamingResponse(_capture_pcm_stream(s, proc), media_type="application/octet-stream")
+
+
 # --- speaking path (bot -> room, aceteam#7079) ---------------------------------
 #
 # Two operations, one body shape each (cleaner than content-type switching):
@@ -801,6 +901,15 @@ def end_session(session_id: str) -> JSONResponse:
 
 def _teardown(s: Session) -> None:
     with s.lock:
+        # Kill any live capture stream first so its pacat stops reading the monitor
+        # before we unload the sink module (otherwise it fights the unload).
+        if s.capture_proc is not None and s.capture_proc.poll() is None:
+            s.capture_proc.terminate()
+            try:
+                s.capture_proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                s.capture_proc.kill()
+        s.capture_proc = None
         if s.recorder is not None and s.recorder.poll() is None:
             s.recorder.send_signal(signal.SIGINT)
             try:

--- a/services/meeting-service/test_meetingd.py
+++ b/services/meeting-service/test_meetingd.py
@@ -246,6 +246,16 @@ def test_mic_arg_builders():
     assert "--rate=24000" in pc
     assert "--channels=1" in pc
 
+    # The room->bot HEAR path RECORDS the per-session monitor to stdout.
+    cap = meetingd.build_pacat_capture_args("citadel_meeting_abc.monitor", 24000, 1)
+    assert cap[0] == "pacat"
+    assert "--record" in cap
+    assert "--playback" not in cap
+    assert "--device=citadel_meeting_abc.monitor" in cap
+    assert "--format=s16le" in cap
+    assert "--rate=24000" in cap
+    assert "--channels=1" in cap
+
 
 def test_mic_play_503_when_mic_absent(monkeypatch):
     """The speaking endpoints refuse (503) when the virtual mic is not present, so a


### PR DESCRIPTION
## Context

Prior waves gave HUDDLE_JOIN a native-huddle join+presence-confirm (#667, on `feat/citadel-huddle-join`, this PR's base), a container **virtual mic** with `POST /mic/play/pcm` (raw s16le), and a **capture sink** recording the room's mixed audio. This wave closes the loop into a **live two-way voice bridge** to AceTeam's realtime engine, so the joined agent actually converses. Links aceteam #7079 (converse) / #7081 (huddle bot).

## Audio loop (HEAR → THINK → SPEAK)

All three legs use PCM16 mono @ 24 kHz (the engine's `PCM16_FORMAT`), so there's no resample on the hot path.

- **HEAR**: new meetingd `GET /sessions/{id}/capture/pcm?rate=24000&channels=1` streams the per-session room monitor (`citadel_meeting_<sid>.monitor`) as raw s16le via `pacat --record` — the low-latency mirror of `/mic/play/pcm`. The bridge frames it (20 ms) and forwards each as `input_audio_buffer.append` (base64) over the realtime WS.
- **THINK**: the AceTeam realtime engine (OpenAI Realtime behind the WS proxy) does STT+LLM+TTS with **server-side VAD** (`turnDetection=server_vad` in the URL). The bridge never sends `commit`/`response.create` — turns are the engine's job.
- **SPEAK**: `response.output_audio.delta` events are base64-decoded, coalesced (~200 ms, to avoid one `pacat` spawn per delta), and injected via `containerMedia.SpeakPCM` → `POST /mic/play/pcm` → virtual mic → the huddle hears the agent.

## Echo / barge-in handling

The room capture (`citadel_meeting_<sid>.monitor`) and the bot's own TTS (`citadel_mic`) are **different sinks**, and WebRTC doesn't echo a peer's own mic back, so capture is **echo-free by construction**. Belt-and-suspenders: the bridge **gates** the HEAR→engine stream while speaking (default on), with a ~250 ms hangover and an `input_audio_buffer.clear` on gate release. Barge-in: an `input_audio_buffer.speech_started` drops queued TTS so the agent yields the floor (current in-flight chunk still plays — bounded by the coalesce window; true mid-clip stop is a follow-up). Flipping the gate off to confirm full-duplex barge-in is the first thing to tune on the live node.

## Additive & gated

Runs **only** when the payload carries `converse:true`. With converse off (default) HUDDLE_JOIN behaves **exactly** like #667 — no capture, no WS, no mic — proven by a gating test plus the untouched #667 suite. MEETING_JOIN / Teams untouched. No aceteam changes (its realtime WS contract was read-only reference).

## Reuse

- `internal/jobs/meeting_media.go` `containerMedia` — added `SpeakPCM` (raw PCM, 409 → retryable `errMicBusy`) and `CaptureStream`.
- `services/meeting-service/meetingd.py` — new capture endpoint + `pacat` proc registered on the `Session` and killed on client disconnect + teardown.
- `internal/jobs/huddle_join.go` — runs the bridge after `joined`; folds stats into the still-`joined` result; raises the container reaper cap to 4h for a resident session.
- `internal/worker/deadline.go` — HUDDLE_JOIN → long-session timeout tier (a resident live meeting, like MEETING_JOIN; sits under the 5h self-heal ceiling). The worker threads the per-job ctx into legacy handlers (aceteam#6000), so bridge cancellation works — CLAUDE.md's "legacy handlers get no context" note is stale.

## What's deferred / assumptions

- **Realtime auth token**: the bridge takes an explicit `realtime_token` (payload) / `CITADEL_REALTIME_TOKEN` and sends it as `Authorization: Bearer` (the WS server's device-client path, an `act_` key or user JWT). The huddle-bot mint token is **not** assumed valid there. Missing token with `converse:true` is a clear hard error, not a mystery 401. **Unvalidated live** — flagged loudly.
- Streaming one long-lived `pacat` stdin for gapless playback (vs one POST per coalesced chunk); RAM/full-duplex tuning of the gate.

## Testing

- `go build ./...`, `go vet ./...`, `go test ./...` — all pass.
- `internal/jobs/huddle_converse_test.go`: mocked realtime WS + mocked container media assert captured audio → `input_audio_buffer.append`, deltas → `SpeakPCM`, stop on `left`/cancel, the speaking-gate drop + `clear`, barge-in drain, and pure `resamplePCM16`/`pcmFrameBytes`/`realtimeWSURL`. Passes under `-race`.
- `services/meeting-service/test_meetingd.py`: added `build_pacat_capture_args` coverage.

**Live-validation gaps (node-1297 smoke):** `services/meeting-service/` was **never executed** here — no pytest/fastapi in this environment, so Python coverage is `ast.parse` + the pure-helper test; `go test` says nothing about meetingd. Manual smoke: enable the meeting module, dispatch HUDDLE_JOIN with `converse:true` + a valid `realtime_token`, join the same call from a browser, speak → hear the agent reply; then flip the echo gate off and confirm barge-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)