### PR TITLE
feat(memory): citadel memory onboarding for Claude Code (aceteam #7160)

### DIFF
--- a/cmd/memory.go
+++ b/cmd/memory.go
@@ -1,0 +1,419 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/memory"
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
+	"github.com/aceteam-ai/citadel-cli/internal/tui"
+	"github.com/aceteam-ai/citadel-cli/internal/ui"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+var (
+	memoryInstallForce bool
+	memoryRecallScope  string
+	memoryRecallQuery  string
+	memoryCaptureNote  string
+	memoryCaptureName  string
+	memoryCaptureScope string
+	memoryCaptureDesc  string
+)
+
+var memoryCmd = &cobra.Command{
+	Use:   "memory",
+	Short: "Wire an AI client into AceTeam's shared memory",
+	Long: `Connect this machine's AI coding client to AceTeam's shared memory so it
+recalls durable context before each prompt and captures new facts after each turn.
+
+'citadel memory install' authorizes this machine (device authorization) and
+wires up Claude Code: it registers the AceTeam memory MCP server and adds hooks
+that recall memory before a prompt and capture memory when a session ends.`,
+}
+
+// --- install ----------------------------------------------------------------
+
+var memoryInstallCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Authorize this machine and wire Claude Code into AceTeam memory",
+	Long: `Runs the AceTeam device-authorization flow (no sudo required), stores a
+scoped API key locally (user-only), and configures Claude Code to use AceTeam
+memory via an MCP server entry plus recall/capture hooks.
+
+Re-running is safe: an existing key is reused (use --force to re-authorize) and
+Claude Code hooks/entries are never duplicated.`,
+	Run: runMemoryInstall,
+}
+
+func runMemoryInstall(cmd *cobra.Command, args []string) {
+	configDir := platform.ConfigDir()
+
+	cfg, _ := memory.Load(configDir)
+
+	if cfg == nil || cfg.APIKey == "" || memoryInstallForce {
+		// Preflight: verify API reachability before an interactive prompt.
+		if err := nexus.CheckAPIReachable(authServiceURL); err != nil {
+			fmt.Fprintf(os.Stderr, "❌ Cannot reach AceTeam: %v\n", err)
+			os.Exit(1)
+		}
+
+		token, err := runMemoryDeviceAuthFlow(authServiceURL)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "❌ %v\n", err)
+			os.Exit(1)
+		}
+
+		cfg = &memory.Config{
+			APIKey:     token.APIKey,
+			APIBaseURL: authServiceURL,
+			OrgID:      token.OrgID,
+			OrgName:    token.OrgName,
+			Scopes:     token.Scopes,
+		}
+		if err := memory.Save(configDir, cfg); err != nil {
+			fmt.Fprintf(os.Stderr, "❌ Could not save memory config: %v\n", err)
+			os.Exit(1)
+		}
+		ok := color.New(color.FgGreen, color.Bold)
+		ok.Println("✅ Authorized. Memory key saved.")
+		if cfg.OrgName != "" {
+			fmt.Printf("   Organization: %s\n", cfg.OrgName)
+		}
+		fmt.Printf("   Key file:     %s (user-only)\n", memory.ConfigPath(configDir))
+	} else {
+		fmt.Printf("Using existing memory key (%s). Re-run with --force to re-authorize.\n", memory.ConfigPath(configDir))
+	}
+
+	// Wire up Claude Code.
+	home := userHomeDir()
+	if !memory.DetectClaudeCode(home) {
+		fmt.Println()
+		color.New(color.FgYellow).Println("⚠ Claude Code not detected (~/.claude not found).")
+		fmt.Println("  Your memory key is saved. Install Claude Code, then re-run:")
+		fmt.Println("    citadel memory install")
+		return
+	}
+
+	if err := wireClaudeCode(home, cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "⚠ Claude Code wiring incomplete: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// wireClaudeCode registers the MCP server + recall/capture hooks in Claude
+// Code's user config. Idempotent and additive.
+func wireClaudeCode(home string, cfg *memory.Config) error {
+	self := citadelBinaryPath()
+
+	mcpChanged, err := memory.WriteMCPServer(
+		memory.ClaudeJSONPath(home),
+		memory.MCPServerName,
+		cfg.EffectiveMCPURL(),
+		cfg.APIKey,
+	)
+	if err != nil {
+		return fmt.Errorf("write MCP server entry: %w", err)
+	}
+
+	settings := memory.ClaudeSettingsPath(home)
+	recallCmd := fmt.Sprintf("%s memory recall", self)
+	captureCmd := fmt.Sprintf("%s memory capture", self)
+
+	recallChanged, err := memory.MergeHook(settings, "UserPromptSubmit", recallCmd, memory.RecallMarker, 10)
+	if err != nil {
+		return fmt.Errorf("merge recall hook: %w", err)
+	}
+	captureChanged, err := memory.MergeHook(settings, "SessionEnd", captureCmd, memory.CaptureMarker, 15)
+	if err != nil {
+		return fmt.Errorf("merge capture hook: %w", err)
+	}
+
+	fmt.Println()
+	color.New(color.FgGreen, color.Bold).Println("✅ Claude Code wired into AceTeam memory")
+	printWire("MCP server", memory.ClaudeJSONPath(home), memory.MCPServerName, mcpChanged)
+	printWire("recall hook (UserPromptSubmit)", settings, memory.RecallMarker, recallChanged)
+	printWire("capture hook (SessionEnd)", settings, memory.CaptureMarker, captureChanged)
+	fmt.Println()
+	fmt.Println("Restart Claude Code (or start a new session) to load the changes.")
+	return nil
+}
+
+func printWire(label, path, detail string, changed bool) {
+	state := "already present"
+	mark := color.New(color.Faint).Sprint("=")
+	if changed {
+		state = "added"
+		mark = color.New(color.FgGreen).Sprint("+")
+	}
+	fmt.Printf("   %s %-32s %s  (%s)\n", mark, label, state, filepath.Base(path))
+}
+
+// runMemoryDeviceAuthFlow runs the device-authorization flow with
+// device_kind:"memory" and returns the minted act_ key on approval.
+func runMemoryDeviceAuthFlow(authURL string) (*nexus.MemoryTokenResponse, error) {
+	client := nexus.NewDeviceAuthClient(authURL)
+
+	resp, err := client.StartFlow(&nexus.StartFlowOptions{DeviceKind: "memory"})
+	if err != nil {
+		return nil, fmt.Errorf("failed to start device authorization: %w", err)
+	}
+
+	// Non-TTY: plain text, poll without bubbletea.
+	if !tui.IsTTY() {
+		completeURL := resp.VerificationURI + "?code=" + resp.UserCode
+		fmt.Println()
+		fmt.Println("Device authorization required.")
+		fmt.Printf("Open this URL to sign in: %s\n", completeURL)
+		fmt.Printf("Or enter code manually:   %s\n", resp.UserCode)
+		fmt.Println("\nWaiting for authorization...")
+		token, err := client.PollForMemoryToken(resp.DeviceCode, resp.Interval)
+		if err != nil {
+			return nil, fmt.Errorf("device authorization failed: %w", err)
+		}
+		fmt.Println("Authorization successful!")
+		return token, nil
+	}
+
+	// TTY: interactive bubbletea UI with background polling.
+	model := ui.NewDeviceCodeModel(resp.UserCode, resp.VerificationURI, resp.ExpiresIn)
+	program := ui.NewDeviceCodeProgram(model)
+
+	tokenChan := make(chan *nexus.MemoryTokenResponse, 1)
+	errChan := make(chan error, 1)
+
+	go func() {
+		token, err := client.PollForMemoryToken(resp.DeviceCode, resp.Interval)
+		if err != nil {
+			errChan <- err
+			ui.UpdateStatus(program, "error:"+err.Error())
+			return
+		}
+		tokenChan <- token
+		ui.UpdateStatus(program, "approved")
+	}()
+
+	fmt.Println()
+	if _, err := program.Run(); err != nil {
+		return nil, fmt.Errorf("UI error: %w", err)
+	}
+	fmt.Println()
+
+	select {
+	case token := <-tokenChan:
+		fmt.Println("✅ Authorization successful!")
+		return token, nil
+	case err := <-errChan:
+		return nil, fmt.Errorf("device authorization failed: %w", err)
+	case <-time.After(2 * time.Second):
+		return nil, fmt.Errorf("device authorization was canceled")
+	}
+}
+
+// --- recall ------------------------------------------------------------------
+
+var memoryRecallCmd = &cobra.Command{
+	Use:   "recall",
+	Short: "Print recalled AceTeam memory for the current prompt (hook)",
+	Long: `Queries AceTeam memory and prints a compact, token-bounded block to stdout.
+
+Designed to be run by Claude Code's UserPromptSubmit hook: its stdout is
+injected as context before your prompt. When run as a hook, the user's prompt
+(read from the hook JSON on stdin) is used as the search query.
+
+This command always exits 0 and prints nothing on error, so a memory outage or
+revoked key never blocks your prompt.`,
+	Run: runMemoryRecall,
+}
+
+func runMemoryRecall(cmd *cobra.Command, args []string) {
+	// Fail-open: any failure prints nothing and exits 0.
+	cfg, err := memory.Load(platform.ConfigDir())
+	if err != nil || cfg == nil || cfg.APIKey == "" {
+		os.Exit(0)
+	}
+
+	hook := readHookInput()
+
+	query := memoryRecallQuery
+	if query == "" && len(args) > 0 {
+		query = strings.Join(args, " ")
+	}
+	if query == "" {
+		query = hook.Prompt
+	}
+	// Default to searching ALL scopes (the memory_search "scope: null" contract);
+	// a cwd-derived scope almost never matches real memory scopes (global,
+	// project names). --scope narrows explicitly.
+	scope := memoryRecallScope
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	block, err := memory.Recall(ctx, cfg, scope, query, memory.DefaultRecallBudget)
+	if err != nil {
+		// Silent by design (stderr only for debugging).
+		fmt.Fprintf(os.Stderr, "citadel memory recall: %v\n", err)
+		os.Exit(0)
+	}
+	if strings.TrimSpace(block) != "" {
+		fmt.Println(block)
+	}
+	os.Exit(0)
+}
+
+// --- capture -----------------------------------------------------------------
+
+var memoryCaptureCmd = &cobra.Command{
+	Use:   "capture",
+	Short: "Capture a durable note into AceTeam memory (hook)",
+	Long: `Writes a durable note to AceTeam memory via memory_write.
+
+Designed to be run by Claude Code's SessionEnd hook. For the demo it captures a
+provided --note (or, if none, a short bounded tail of the session transcript
+referenced by the hook JSON on stdin). Full turn-by-turn extraction and
+deduplication is a follow-up (see PR description).
+
+Always exits 0 so it never disrupts Claude Code.`,
+	Run: runMemoryCapture,
+}
+
+func runMemoryCapture(cmd *cobra.Command, args []string) {
+	cfg, err := memory.Load(platform.ConfigDir())
+	if err != nil || cfg == nil || cfg.APIKey == "" {
+		os.Exit(0)
+	}
+
+	hook := readHookInput()
+
+	note := memoryCaptureNote
+	if note == "" && len(args) > 0 {
+		note = strings.Join(args, " ")
+	}
+	if note == "" {
+		// Best-effort: a short bounded tail of the transcript, if available.
+		note = transcriptTail(hook.TranscriptPath, 1500)
+	}
+	if strings.TrimSpace(note) == "" {
+		// Nothing durable to record; exit quietly.
+		os.Exit(0)
+	}
+
+	name := memoryCaptureName
+	if name == "" {
+		name = "claude-session-" + time.Now().Format("2006-01-02-1504")
+	}
+	// Empty scope lets memory_write default to "global" (predictable), rather
+	// than an unstable cwd/worktree-basename scope. --scope narrows explicitly.
+	scope := memoryCaptureScope
+	desc := memoryCaptureDesc
+	if desc == "" {
+		desc = "Captured from a Claude Code session"
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+
+	if _, err := memory.CaptureNote(ctx, cfg, name, note, desc, scope); err != nil {
+		fmt.Fprintf(os.Stderr, "citadel memory capture: %v\n", err)
+	}
+	os.Exit(0)
+}
+
+// --- helpers -----------------------------------------------------------------
+
+// hookInput is the subset of Claude Code's hook JSON (stdin) we consume.
+type hookInput struct {
+	Prompt         string `json:"prompt"`
+	Cwd            string `json:"cwd"`
+	TranscriptPath string `json:"transcript_path"`
+	SessionID      string `json:"session_id"`
+	HookEventName  string `json:"hook_event_name"`
+}
+
+// readHookInput reads and parses Claude Code hook JSON from stdin. It reads
+// only when stdin is piped (not a TTY) so an interactive invocation never
+// blocks. Any parse failure yields a zero-value struct.
+func readHookInput() hookInput {
+	var h hookInput
+	if tui.IsTTY() {
+		return h
+	}
+	data, err := io.ReadAll(io.LimitReader(os.Stdin, 1<<20))
+	if err != nil || len(data) == 0 {
+		return h
+	}
+	_ = json.Unmarshal(data, &h)
+	return h
+}
+
+// transcriptTail returns up to budget characters from the end of a Claude Code
+// transcript file (best-effort; empty on any error).
+func transcriptTail(path string, budget int) string {
+	if path == "" || budget <= 0 {
+		return ""
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	s := strings.TrimSpace(string(data))
+	if len(s) > budget {
+		s = s[len(s)-budget:]
+	}
+	return s
+}
+
+// citadelBinaryPath returns an absolute path to this binary for use in hook
+// commands, falling back to "citadel" (resolved via PATH) if unavailable.
+func citadelBinaryPath() string {
+	if p, err := os.Executable(); err == nil {
+		if abs, err := filepath.Abs(p); err == nil {
+			return abs
+		}
+		return p
+	}
+	return "citadel"
+}
+
+// userHomeDir resolves the invoking user's home directory, preferring the
+// SUDO_USER's home when running under sudo so hooks (which run as the user) can
+// read what install wrote.
+func userHomeDir() string {
+	if platform.IsRoot() {
+		if su := os.Getenv("SUDO_USER"); su != "" && su != "root" {
+			if home, err := platform.HomeDir(su); err == nil && home != "" {
+				return home
+			}
+		}
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		return home
+	}
+	return os.Getenv("HOME")
+}
+
+func init() {
+	rootCmd.AddCommand(memoryCmd)
+	memoryCmd.AddCommand(memoryInstallCmd)
+	memoryCmd.AddCommand(memoryRecallCmd)
+	memoryCmd.AddCommand(memoryCaptureCmd)
+
+	memoryInstallCmd.Flags().BoolVar(&memoryInstallForce, "force", false, "Re-authorize even if a memory key already exists")
+
+	memoryRecallCmd.Flags().StringVar(&memoryRecallScope, "scope", "", "Restrict search to a memory scope (project name or 'global'; default: all scopes)")
+	memoryRecallCmd.Flags().StringVar(&memoryRecallQuery, "query", "", "Search query (default: the prompt from the hook stdin)")
+
+	memoryCaptureCmd.Flags().StringVar(&memoryCaptureNote, "note", "", "Note text to capture (default: a bounded transcript tail)")
+	memoryCaptureCmd.Flags().StringVar(&memoryCaptureName, "name", "", "Memory slug (default: claude-session-<timestamp>)")
+	memoryCaptureCmd.Flags().StringVar(&memoryCaptureScope, "scope", "", "Memory scope to write (project name or 'global'; default: global)")
+	memoryCaptureCmd.Flags().StringVar(&memoryCaptureDesc, "description", "", "Short description for the memory frontmatter")
+}

--- a/internal/memory/capture.go
+++ b/internal/memory/capture.go
@@ -1,0 +1,62 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// CaptureNote persists a durable note to the memory substrate via memory_write.
+// name is a kebab-case slug; scope defaults to "global" server-side when empty.
+// Returns the tool output (best-effort).
+func CaptureNote(ctx context.Context, cfg *Config, name, content, description, scope string) (string, error) {
+	if cfg == nil || cfg.APIKey == "" {
+		return "", fmt.Errorf("no memory API key configured")
+	}
+	if strings.TrimSpace(content) == "" {
+		return "", fmt.Errorf("empty content; nothing to capture")
+	}
+	client := NewMCPClient(cfg.EffectiveMCPURL(), cfg.APIKey, 8*time.Second)
+
+	args := map[string]any{
+		"name":    Slugify(name),
+		"content": content,
+		"source":  "claude-code",
+	}
+	if description != "" {
+		args["description"] = description
+	}
+	if scope != "" {
+		args["scope"] = scope
+	}
+	return client.CallTool(ctx, "memory_write", args)
+}
+
+// Slugify converts arbitrary text into a bounded kebab-case slug suitable for a
+// memory name.
+func Slugify(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	var b strings.Builder
+	prevDash := false
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			prevDash = false
+		default:
+			if !prevDash && b.Len() > 0 {
+				b.WriteByte('-')
+				prevDash = true
+			}
+		}
+	}
+	slug := strings.Trim(b.String(), "-")
+	if len(slug) > 60 {
+		slug = strings.Trim(slug[:60], "-")
+	}
+	if slug == "" {
+		slug = "note"
+	}
+	return slug
+}

--- a/internal/memory/capture_test.go
+++ b/internal/memory/capture_test.go
@@ -1,0 +1,67 @@
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSlugify(t *testing.T) {
+	cases := map[string]string{
+		"Hello World":           "hello-world",
+		"  Railway Alignment!!": "railway-alignment",
+		"already-kebab":         "already-kebab",
+		"":                      "note",
+		"UPPER_snake.Case":      "upper-snake-case",
+	}
+	for in, want := range cases {
+		if got := Slugify(in); got != want {
+			t.Errorf("Slugify(%q)=%q want %q", in, got, want)
+		}
+	}
+}
+
+func TestCaptureNote_ForwardsArgs(t *testing.T) {
+	var args map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			Params struct {
+				Name      string         `json:"name"`
+				Arguments map[string]any `json:"arguments"`
+			} `json:"params"`
+		}
+		_ = json.Unmarshal(body, &req)
+		args = req.Params.Arguments
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0", "id": 2,
+			"result": map[string]any{"content": []map[string]any{{"type": "text", "text": "written"}}},
+		})
+	}))
+	defer srv.Close()
+
+	cfg := &Config{APIKey: "act_k", MCPURL: srv.URL}
+	out, err := CaptureNote(context.Background(), cfg, "My Note", "durable fact", "a desc", "aceteam")
+	if err != nil {
+		t.Fatalf("CaptureNote: %v", err)
+	}
+	if out != "written" {
+		t.Fatalf("bad out: %q", out)
+	}
+	if args["name"] != "my-note" {
+		t.Fatalf("name not slugified/forwarded: %v", args["name"])
+	}
+	if args["content"] != "durable fact" || args["scope"] != "aceteam" || args["source"] != "claude-code" {
+		t.Fatalf("args not forwarded: %v", args)
+	}
+}
+
+func TestCaptureNote_EmptyContentErrors(t *testing.T) {
+	if _, err := CaptureNote(context.Background(), &Config{APIKey: "k"}, "n", "  ", "", ""); err == nil {
+		t.Fatal("expected error on empty content")
+	}
+}

--- a/internal/memory/claude.go
+++ b/internal/memory/claude.go
@@ -1,0 +1,207 @@
+package memory
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Claude Code integration constants. The recall/capture hook commands are
+// matched by these markers for idempotency (re-running install must not add a
+// duplicate hook), independent of the absolute binary path prefix.
+const (
+	// MCPServerName is the key under mcpServers in ~/.claude.json.
+	MCPServerName = "aceteam-memory"
+	// RecallMarker / CaptureMarker identify our hooks for dedup.
+	RecallMarker  = "citadel memory recall"
+	CaptureMarker = "citadel memory capture"
+)
+
+// WriteMCPServer registers (or updates) an HTTP MCP server entry pointing at
+// the AceTeam memory endpoint with a bearer act_ key, in Claude Code's
+// user-scoped ~/.claude.json. All other keys are preserved verbatim (the file
+// is Claude Code's own live state). Returns changed=false when the entry is
+// already present and identical. The file is written 0600 (it holds a secret).
+func WriteMCPServer(claudeJSONPath, name, url, bearer string) (bool, error) {
+	root, err := readJSONObject(claudeJSONPath)
+	if err != nil {
+		return false, err
+	}
+
+	servers, _ := root["mcpServers"].(map[string]any)
+	if servers == nil {
+		servers = map[string]any{}
+	}
+
+	entry := map[string]any{
+		"type": "http",
+		"url":  url,
+		"headers": map[string]any{
+			"Authorization": "Bearer " + bearer,
+		},
+	}
+
+	if existing, ok := servers[name].(map[string]any); ok && jsonEqual(existing, entry) {
+		return false, nil
+	}
+
+	servers[name] = entry
+	root["mcpServers"] = servers
+	if err := writeJSONObject(claudeJSONPath, root, 0o600); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// hookGroup mirrors one entry of a hooks.<Event> array.
+type hookGroup struct {
+	Matcher string     `json:"matcher"`
+	Hooks   []hookSpec `json:"hooks"`
+}
+
+type hookSpec struct {
+	Type    string `json:"type"`
+	Command string `json:"command"`
+	Timeout int    `json:"timeout,omitempty"`
+}
+
+// MergeHook additively appends a command hook for the given event to Claude
+// Code's ~/.claude/settings.json, preserving all existing hooks and settings.
+// It is idempotent: if any existing hook command for that event already
+// contains marker, nothing is written and changed=false is returned.
+func MergeHook(settingsPath, event, command, marker string, timeout int) (bool, error) {
+	root, err := readJSONObject(settingsPath)
+	if err != nil {
+		return false, err
+	}
+
+	hooks, _ := root["hooks"].(map[string]any)
+	if hooks == nil {
+		hooks = map[string]any{}
+	}
+
+	// Existing groups for this event (as generic slice for preservation).
+	var groups []any
+	if raw, ok := hooks[event].([]any); ok {
+		groups = raw
+	}
+
+	// Idempotency: bail if marker already present in any command for this event.
+	if hookMarkerPresent(groups, marker) {
+		return false, nil
+	}
+
+	newGroup := map[string]any{
+		"matcher": "",
+		"hooks": []any{
+			map[string]any{"type": "command", "command": command, "timeout": timeout},
+		},
+	}
+	groups = append(groups, newGroup)
+	hooks[event] = groups
+	root["hooks"] = hooks
+
+	if err := writeJSONObject(settingsPath, root, 0o644); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// hookMarkerPresent reports whether any hook command in the event groups
+// contains the marker substring.
+func hookMarkerPresent(groups []any, marker string) bool {
+	for _, g := range groups {
+		gm, ok := g.(map[string]any)
+		if !ok {
+			continue
+		}
+		inner, ok := gm["hooks"].([]any)
+		if !ok {
+			continue
+		}
+		for _, h := range inner {
+			hm, ok := h.(map[string]any)
+			if !ok {
+				continue
+			}
+			if cmd, ok := hm["command"].(string); ok && strings.Contains(cmd, marker) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// DetectClaudeCode reports whether Claude Code appears installed for the user
+// (its config dir ~/.claude exists).
+func DetectClaudeCode(homeDir string) bool {
+	info, err := os.Stat(filepath.Join(homeDir, ".claude"))
+	return err == nil && info.IsDir()
+}
+
+// ClaudeJSONPath / ClaudeSettingsPath resolve the user-scoped config files.
+func ClaudeJSONPath(homeDir string) string {
+	return filepath.Join(homeDir, ".claude.json")
+}
+
+func ClaudeSettingsPath(homeDir string) string {
+	return filepath.Join(homeDir, ".claude", "settings.json")
+}
+
+// readJSONObject reads a JSON object file into a map, returning an empty map if
+// the file does not exist.
+func readJSONObject(path string) (map[string]any, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]any{}, nil
+		}
+		return nil, err
+	}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return map[string]any{}, nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if m == nil {
+		m = map[string]any{}
+	}
+	return m, nil
+}
+
+// writeJSONObject writes the map as indented JSON, creating parent dirs. The
+// write is atomic (temp file + rename) so a crash cannot truncate Claude Code's
+// live config.
+func writeJSONObject(path string, m map[string]any, perm os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	tmp := path + ".citadel.tmp"
+	if err := os.WriteFile(tmp, data, perm); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	_ = os.Chmod(path, perm)
+	return nil
+}
+
+func jsonEqual(a, b any) bool {
+	ab, err1 := json.Marshal(a)
+	bb, err2 := json.Marshal(b)
+	if err1 != nil || err2 != nil {
+		return false
+	}
+	return string(ab) == string(bb)
+}

--- a/internal/memory/claude_test.go
+++ b/internal/memory/claude_test.go
@@ -1,0 +1,180 @@
+package memory
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func readJSON(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return m
+}
+
+func TestWriteMCPServer_CreatesAndPreserves(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".claude.json")
+
+	// Pre-existing live config with unrelated keys + another MCP server.
+	seed := map[string]any{
+		"numStartups": float64(42),
+		"theme":       "dark",
+		"mcpServers": map[string]any{
+			"posthog": map[string]any{"type": "http", "url": "https://mcp.posthog.com/mcp"},
+		},
+	}
+	seedBytes, _ := json.MarshalIndent(seed, "", "  ")
+	if err := os.WriteFile(path, seedBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := WriteMCPServer(path, MCPServerName, "https://aceteam.ai/api/mcp/aceteam/mcp", "act_secret123")
+	if err != nil {
+		t.Fatalf("WriteMCPServer: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected changed=true on first write")
+	}
+
+	got := readJSON(t, path)
+	// Unrelated keys preserved.
+	if got["theme"] != "dark" || got["numStartups"].(float64) != 42 {
+		t.Fatalf("unrelated keys not preserved: %v", got)
+	}
+	servers := got["mcpServers"].(map[string]any)
+	if _, ok := servers["posthog"]; !ok {
+		t.Fatal("existing posthog MCP server was dropped")
+	}
+	entry := servers[MCPServerName].(map[string]any)
+	if entry["type"] != "http" || entry["url"] != "https://aceteam.ai/api/mcp/aceteam/mcp" {
+		t.Fatalf("bad entry: %v", entry)
+	}
+	headers := entry["headers"].(map[string]any)
+	if headers["Authorization"] != "Bearer act_secret123" {
+		t.Fatalf("bad auth header: %v", headers)
+	}
+
+	// User-only perms (holds a bearer secret).
+	info, _ := os.Stat(path)
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("expected 0600 perms, got %o", info.Mode().Perm())
+	}
+}
+
+func TestWriteMCPServer_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".claude.json")
+
+	if _, err := WriteMCPServer(path, MCPServerName, "https://x/mcp", "act_k"); err != nil {
+		t.Fatal(err)
+	}
+	changed, err := WriteMCPServer(path, MCPServerName, "https://x/mcp", "act_k")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Fatal("expected changed=false on identical re-write")
+	}
+}
+
+func TestMergeHook_AdditiveAndIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+
+	// Seed with an existing unrelated hook on the same event.
+	seed := map[string]any{
+		"theme": "dark",
+		"hooks": map[string]any{
+			"UserPromptSubmit": []any{
+				map[string]any{
+					"matcher": "",
+					"hooks": []any{
+						map[string]any{"type": "command", "command": "bash existing.sh", "timeout": float64(5)},
+					},
+				},
+			},
+		},
+	}
+	seedBytes, _ := json.MarshalIndent(seed, "", "  ")
+	if err := os.WriteFile(path, seedBytes, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := MergeHook(path, "UserPromptSubmit", "/usr/local/bin/citadel memory recall", RecallMarker, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("expected changed=true adding recall hook")
+	}
+
+	got := readJSON(t, path)
+	if got["theme"] != "dark" {
+		t.Fatal("unrelated settings dropped")
+	}
+	groups := got["hooks"].(map[string]any)["UserPromptSubmit"].([]any)
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 hook groups (existing + ours), got %d", len(groups))
+	}
+	// Existing hook still present.
+	if !hookMarkerPresent(groups, "bash existing.sh") {
+		t.Fatal("existing hook was clobbered")
+	}
+	if !hookMarkerPresent(groups, RecallMarker) {
+		t.Fatal("recall hook not added")
+	}
+
+	// Idempotency: re-merge with a DIFFERENT binary path but same marker.
+	changed, err = MergeHook(path, "UserPromptSubmit", "/opt/citadel memory recall", RecallMarker, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Fatal("expected changed=false; marker already present")
+	}
+	got = readJSON(t, path)
+	groups = got["hooks"].(map[string]any)["UserPromptSubmit"].([]any)
+	if len(groups) != 2 {
+		t.Fatalf("re-merge duplicated hook: got %d groups", len(groups))
+	}
+}
+
+func TestMergeHook_CreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sub", "settings.json") // parent dir absent
+
+	changed, err := MergeHook(path, "SessionEnd", "/bin/citadel memory capture", CaptureMarker, 15)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	got := readJSON(t, path)
+	groups := got["hooks"].(map[string]any)["SessionEnd"].([]any)
+	if !hookMarkerPresent(groups, CaptureMarker) {
+		t.Fatal("capture hook not written")
+	}
+}
+
+func TestDetectClaudeCode(t *testing.T) {
+	home := t.TempDir()
+	if DetectClaudeCode(home) {
+		t.Fatal("should be false without ~/.claude")
+	}
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if !DetectClaudeCode(home) {
+		t.Fatal("should be true with ~/.claude")
+	}
+}

--- a/internal/memory/config.go
+++ b/internal/memory/config.go
@@ -1,0 +1,101 @@
+// Package memory implements the Citadel-side onboarding for AceTeam agent
+// memory (epic aceteam #7160). It stores a scoped act_ API key minted via the
+// device-authorization "memory" flow and talks to the AceTeam memory MCP so
+// that an external client (Claude Code) can recall memory before each prompt
+// and capture durable facts after each turn.
+package memory
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ConfigFileName is the name of the memory config file within the Citadel
+// config directory.
+const ConfigFileName = "memory.yaml"
+
+// DefaultAPIBaseURL is the default AceTeam API/app host.
+const DefaultAPIBaseURL = "https://aceteam.ai"
+
+// Config holds the credential and endpoints for the AceTeam memory substrate.
+// It is stored user-only (0600) because APIKey is a bearer secret.
+type Config struct {
+	// APIKey is the scoped act_ API key minted by the device-auth memory flow.
+	APIKey string `yaml:"api_key"`
+	// APIBaseURL is the AceTeam host (default https://aceteam.ai).
+	APIBaseURL string `yaml:"api_base_url,omitempty"`
+	// MCPURL overrides the derived MCP endpoint (optional).
+	MCPURL string `yaml:"mcp_url,omitempty"`
+	// OrgID / OrgName identify the organization the key is scoped to.
+	OrgID   string `yaml:"org_id,omitempty"`
+	OrgName string `yaml:"org_name,omitempty"`
+	// Scopes echoes the grant the minted key carries (informational).
+	Scopes []string `yaml:"scopes,omitempty"`
+}
+
+// DefaultMCPURL derives the AceTeam MCP endpoint for external clients from an
+// API base URL, e.g. https://aceteam.ai/api/mcp/aceteam/mcp.
+func DefaultMCPURL(apiBaseURL string) string {
+	base := strings.TrimRight(apiBaseURL, "/")
+	if base == "" {
+		base = DefaultAPIBaseURL
+	}
+	return base + "/api/mcp/aceteam/mcp"
+}
+
+// EffectiveMCPURL returns the configured MCP URL or one derived from the base.
+func (c *Config) EffectiveMCPURL() string {
+	if c.MCPURL != "" {
+		return c.MCPURL
+	}
+	base := c.APIBaseURL
+	if base == "" {
+		base = DefaultAPIBaseURL
+	}
+	return DefaultMCPURL(base)
+}
+
+// ConfigPath returns the memory config path within the given config dir.
+func ConfigPath(configDir string) string {
+	return filepath.Join(configDir, ConfigFileName)
+}
+
+// Load reads the memory config from configDir. It returns (nil, nil) when the
+// file does not exist so callers (hooks) can fail open silently.
+func Load(configDir string) (*Config, error) {
+	data, err := os.ReadFile(ConfigPath(configDir))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var c Config
+	if err := yaml.Unmarshal(data, &c); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", ConfigFileName, err)
+	}
+	return &c, nil
+}
+
+// Save writes the memory config to configDir with user-only (0600) perms,
+// creating the directory if needed.
+func Save(configDir string, c *Config) error {
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+	data, err := yaml.Marshal(c)
+	if err != nil {
+		return fmt.Errorf("marshal memory config: %w", err)
+	}
+	path := ConfigPath(configDir)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	// Tighten perms even if the file pre-existed with looser mode.
+	_ = os.Chmod(path, 0o600)
+	return nil
+}

--- a/internal/memory/config_test.go
+++ b/internal/memory/config_test.go
@@ -1,0 +1,63 @@
+package memory
+
+import (
+	"os"
+	"testing"
+)
+
+func TestSaveLoadRoundTrip_UserOnlyPerms(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &Config{
+		APIKey:     "act_abc123",
+		APIBaseURL: "https://aceteam.ai",
+		OrgID:      "org_1",
+		OrgName:    "Acme",
+		Scopes:     []string{"memory:read", "memory:write"},
+	}
+	if err := Save(dir, cfg); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	info, err := os.Stat(ConfigPath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("expected 0600, got %o", info.Mode().Perm())
+	}
+
+	got, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got == nil || got.APIKey != "act_abc123" || got.OrgName != "Acme" || len(got.Scopes) != 2 {
+		t.Fatalf("round trip mismatch: %+v", got)
+	}
+}
+
+func TestLoadMissingReturnsNil(t *testing.T) {
+	got, err := Load(t.TempDir())
+	if err != nil {
+		t.Fatalf("expected nil error for missing file, got %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil config for missing file, got %+v", got)
+	}
+}
+
+func TestEffectiveMCPURL(t *testing.T) {
+	cases := []struct {
+		cfg  Config
+		want string
+	}{
+		{Config{APIBaseURL: "https://aceteam.ai"}, "https://aceteam.ai/api/mcp/aceteam/mcp"},
+		{Config{APIBaseURL: "https://aceteam.ai/"}, "https://aceteam.ai/api/mcp/aceteam/mcp"},
+		{Config{}, "https://aceteam.ai/api/mcp/aceteam/mcp"},
+		{Config{MCPURL: "https://custom/mcp"}, "https://custom/mcp"},
+	}
+	for _, c := range cases {
+		if got := c.cfg.EffectiveMCPURL(); got != c.want {
+			t.Errorf("EffectiveMCPURL(%+v)=%q want %q", c.cfg, got, c.want)
+		}
+	}
+}

--- a/internal/memory/mcp.go
+++ b/internal/memory/mcp.go
@@ -1,0 +1,290 @@
+package memory
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// mcpProtocolVersion is the MCP protocol version advertised in initialize.
+const mcpProtocolVersion = "2025-06-18"
+
+// MCPClient is a minimal streamable-HTTP MCP (JSON-RPC 2.0) client for the
+// AceTeam memory endpoint. It is deliberately small: it supports exactly the
+// tools/call requests the recall/capture commands need.
+//
+// It is "dual-mode": it first attempts a bare tools/call (works when the server
+// runs statelessly), and if the server requires a session it transparently runs
+// the initialize -> notifications/initialized -> tools/call handshake, carrying
+// the Mcp-Session-Id header. It parses both application/json and
+// text/event-stream (SSE) responses, since FastMCP streamable-HTTP may return
+// either.
+type MCPClient struct {
+	url    string
+	apiKey string
+	http   *http.Client
+}
+
+// NewMCPClient builds a client for the given MCP URL and act_ bearer token.
+// timeout bounds the entire call (important: recall runs on every prompt).
+func NewMCPClient(url, apiKey string, timeout time.Duration) *MCPClient {
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	return &MCPClient{
+		url:    url,
+		apiKey: apiKey,
+		http:   &http.Client{Timeout: timeout},
+	}
+}
+
+type rpcRequest struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      int    `json:"id,omitempty"`
+	Method  string `json:"method"`
+	Params  any    `json:"params,omitempty"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func (e *rpcError) Error() string { return fmt.Sprintf("MCP error %d: %s", e.Code, e.Message) }
+
+// toolCallResult is the subset of a tools/call result we care about.
+type toolCallResult struct {
+	Content []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"content"`
+	StructuredContent json.RawMessage `json:"structuredContent,omitempty"`
+	IsError           bool            `json:"isError,omitempty"`
+}
+
+// CallTool invokes an MCP tool and returns its text output (concatenated text
+// content blocks). It runs the session handshake only if the server demands it.
+func (c *MCPClient) CallTool(ctx context.Context, name string, args map[string]any) (string, error) {
+	params := map[string]any{"name": name}
+	if args != nil {
+		params["arguments"] = args
+	} else {
+		params["arguments"] = map[string]any{}
+	}
+
+	// Attempt 1: stateless tools/call (no session).
+	resp, _, err := c.post(ctx, "", rpcRequest{
+		JSONRPC: "2.0", ID: 2, Method: "tools/call", Params: params,
+	})
+	if err == nil && resp.Error == nil {
+		return decodeToolResult(resp.Result)
+	}
+
+	// If the failure isn't a "session required" signal, surface it.
+	if err != nil && !isSessionRequired(err) {
+		return "", err
+	}
+	if resp != nil && resp.Error != nil && !isSessionRequiredMsg(resp.Error.Message) {
+		return "", resp.Error
+	}
+
+	// Attempt 2: full handshake, then retry the tools/call with the session id.
+	session, err := c.initialize(ctx)
+	if err != nil {
+		return "", err
+	}
+	resp, _, err = c.post(ctx, session, rpcRequest{
+		JSONRPC: "2.0", ID: 2, Method: "tools/call", Params: params,
+	})
+	if err != nil {
+		return "", err
+	}
+	if resp.Error != nil {
+		return "", resp.Error
+	}
+	return decodeToolResult(resp.Result)
+}
+
+// initialize performs initialize + notifications/initialized and returns the
+// negotiated Mcp-Session-Id (may be empty if the server does not use one).
+func (c *MCPClient) initialize(ctx context.Context) (string, error) {
+	initResp, session, err := c.post(ctx, "", rpcRequest{
+		JSONRPC: "2.0", ID: 1, Method: "initialize", Params: map[string]any{
+			"protocolVersion": mcpProtocolVersion,
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "citadel-memory", "version": "1"},
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+	if initResp.Error != nil {
+		return "", initResp.Error
+	}
+	// Best-effort initialized notification (no response expected).
+	_, _, _ = c.post(ctx, session, rpcRequest{
+		JSONRPC: "2.0", Method: "notifications/initialized",
+	})
+	return session, nil
+}
+
+// post sends one JSON-RPC message and returns the parsed response (nil for
+// notifications) plus any Mcp-Session-Id the server assigned.
+func (c *MCPClient) post(ctx context.Context, session string, body rpcRequest) (*rpcResponse, string, error) {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, "", err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url, bytes.NewReader(payload))
+	if err != nil {
+		return nil, "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+	if session != "" {
+		req.Header.Set("Mcp-Session-Id", session)
+	}
+
+	httpResp, err := c.http.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer httpResp.Body.Close()
+
+	newSession := httpResp.Header.Get("Mcp-Session-Id")
+	if newSession == "" {
+		newSession = session
+	}
+
+	// A notification (no id) yields an empty/202 body.
+	if body.Method == "notifications/initialized" {
+		io.Copy(io.Discard, httpResp.Body)
+		return nil, newSession, nil
+	}
+
+	if httpResp.StatusCode == http.StatusBadRequest {
+		// Distinguish a "session required" 400 from other bad requests.
+		snippet, _ := io.ReadAll(io.LimitReader(httpResp.Body, 2048))
+		if isSessionRequiredMsg(string(snippet)) {
+			return nil, newSession, errSessionRequired
+		}
+		return nil, newSession, fmt.Errorf("MCP HTTP 400: %s", strings.TrimSpace(string(snippet)))
+	}
+	if httpResp.StatusCode != http.StatusOK && httpResp.StatusCode != http.StatusAccepted {
+		snippet, _ := io.ReadAll(io.LimitReader(httpResp.Body, 2048))
+		return nil, newSession, fmt.Errorf("MCP HTTP %d: %s", httpResp.StatusCode, strings.TrimSpace(string(snippet)))
+	}
+
+	resp, err := parseRPCResponse(httpResp.Header.Get("Content-Type"), httpResp.Body)
+	if err != nil {
+		return nil, newSession, err
+	}
+	return resp, newSession, nil
+}
+
+// parseRPCResponse handles both a plain JSON body and an SSE (text/event-stream)
+// body, returning the first JSON-RPC message found.
+func parseRPCResponse(contentType string, body io.Reader) (*rpcResponse, error) {
+	if strings.Contains(strings.ToLower(contentType), "text/event-stream") {
+		return parseSSE(body)
+	}
+	// Some servers omit/misreport the content type; sniff the first byte.
+	buf := bufio.NewReader(body)
+	first, err := buf.Peek(1)
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(first) > 0 && (first[0] == 'e' || first[0] == 'd' || first[0] == ':') {
+		return parseSSE(buf)
+	}
+	var resp rpcResponse
+	if err := json.NewDecoder(buf).Decode(&resp); err != nil {
+		return nil, fmt.Errorf("decode MCP response: %w", err)
+	}
+	return &resp, nil
+}
+
+// parseSSE reads Server-Sent Events and returns the JSON parsed from the first
+// "data:" line that decodes to a JSON-RPC response with a result or error.
+func parseSSE(body io.Reader) (*rpcResponse, error) {
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	var last *rpcResponse
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if data == "" || data == "[DONE]" {
+			continue
+		}
+		var resp rpcResponse
+		if err := json.Unmarshal([]byte(data), &resp); err != nil {
+			continue // skip non-JSON-RPC events
+		}
+		last = &resp
+		if resp.Result != nil || resp.Error != nil {
+			return &resp, nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	if last != nil {
+		return last, nil
+	}
+	return nil, fmt.Errorf("no JSON-RPC message in SSE stream")
+}
+
+// decodeToolResult extracts concatenated text from a tools/call result.
+func decodeToolResult(raw json.RawMessage) (string, error) {
+	if len(raw) == 0 {
+		return "", nil
+	}
+	var res toolCallResult
+	if err := json.Unmarshal(raw, &res); err != nil {
+		// Fall back to returning the raw JSON so callers still get something.
+		return string(raw), nil
+	}
+	var b strings.Builder
+	for _, c := range res.Content {
+		if c.Type == "text" && c.Text != "" {
+			if b.Len() > 0 {
+				b.WriteByte('\n')
+			}
+			b.WriteString(c.Text)
+		}
+	}
+	if b.Len() == 0 && len(res.StructuredContent) > 0 {
+		return string(res.StructuredContent), nil
+	}
+	return b.String(), nil
+}
+
+// errSessionRequired signals the server rejected a bare tools/call and needs a
+// session handshake first.
+var errSessionRequired = fmt.Errorf("mcp session required")
+
+func isSessionRequired(err error) bool { return err == errSessionRequired }
+
+func isSessionRequiredMsg(msg string) bool {
+	m := strings.ToLower(msg)
+	return strings.Contains(m, "session")
+}

--- a/internal/memory/mcp_test.go
+++ b/internal/memory/mcp_test.go
@@ -1,0 +1,151 @@
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// decodeMethod reads the JSON-RPC method + name from a request body.
+func decodeReq(t *testing.T, r *http.Request) (method, toolName string, sessionHdr string) {
+	t.Helper()
+	body, _ := io.ReadAll(r.Body)
+	var req struct {
+		Method string `json:"method"`
+		Params struct {
+			Name string `json:"name"`
+		} `json:"params"`
+	}
+	_ = json.Unmarshal(body, &req)
+	return req.Method, req.Params.Name, r.Header.Get("Mcp-Session-Id")
+}
+
+func writeResult(w http.ResponseWriter, text string) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"result": map[string]any{
+			"content": []map[string]any{{"type": "text", "text": text}},
+		},
+	})
+}
+
+func TestCallTool_Stateless(t *testing.T) {
+	var gotAuth, gotTool string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		method, name, _ := decodeReq(t, r)
+		if method != "tools/call" {
+			t.Errorf("stateless server got unexpected method %q", method)
+		}
+		gotTool = name
+		writeResult(w, "memory: railway uses socks5 relay")
+	}))
+	defer srv.Close()
+
+	c := NewMCPClient(srv.URL, "act_key", 2*time.Second)
+	out, err := c.CallTool(context.Background(), "memory_search", map[string]any{"query": "railway"})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if !strings.Contains(out, "socks5 relay") {
+		t.Fatalf("bad output: %q", out)
+	}
+	if gotAuth != "Bearer act_key" {
+		t.Fatalf("bearer not sent: %q", gotAuth)
+	}
+	if gotTool != "memory_search" {
+		t.Fatalf("tool name not sent: %q", gotTool)
+	}
+}
+
+func TestCallTool_SessionHandshake(t *testing.T) {
+	const sessionID = "sess-xyz"
+	var sawInitialized bool
+	var toolCallSession string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method, _, session := decodeReq(t, r)
+		switch method {
+		case "tools/call":
+			if session == "" {
+				// Reject bare tools/call → force handshake.
+				w.WriteHeader(http.StatusBadRequest)
+				io.WriteString(w, `{"error":"Bad Request: Missing session ID"}`)
+				return
+			}
+			toolCallSession = session
+			writeResult(w, "hello from session")
+		case "initialize":
+			w.Header().Set("Mcp-Session-Id", sessionID)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0", "id": 1,
+				"result": map[string]any{"protocolVersion": mcpProtocolVersion},
+			})
+		case "notifications/initialized":
+			sawInitialized = true
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			t.Errorf("unexpected method %q", method)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewMCPClient(srv.URL, "act_key", 2*time.Second)
+	out, err := c.CallTool(context.Background(), "memory_search", map[string]any{"query": "x"})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if !strings.Contains(out, "hello from session") {
+		t.Fatalf("bad output: %q", out)
+	}
+	if !sawInitialized {
+		t.Fatal("initialized notification not sent")
+	}
+	if toolCallSession != sessionID {
+		t.Fatalf("session id not carried into tools/call: %q", toolCallSession)
+	}
+}
+
+func TestCallTool_SSEResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, "event: message\n")
+		io.WriteString(w, `data: {"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"sse works"}]}}`+"\n\n")
+	}))
+	defer srv.Close()
+
+	c := NewMCPClient(srv.URL, "act_key", 2*time.Second)
+	out, err := c.CallTool(context.Background(), "memory_search", map[string]any{"query": "x"})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if out != "sse works" {
+		t.Fatalf("bad SSE output: %q", out)
+	}
+}
+
+func TestCallTool_ToolError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0", "id": 2,
+			"error": map[string]any{"code": -32000, "message": "boom"},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewMCPClient(srv.URL, "act_key", 2*time.Second)
+	_, err := c.CallTool(context.Background(), "memory_search", map[string]any{"query": "x"})
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("expected tool error, got %v", err)
+	}
+}

--- a/internal/memory/recall.go
+++ b/internal/memory/recall.go
@@ -1,0 +1,63 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// DefaultRecallBudget bounds the injected memory block (characters). Keeps the
+// pre-prompt context small so recall never floods the model's context window.
+const DefaultRecallBudget = 2000
+
+// RecallHeader prefixes the injected block so the model knows the provenance.
+const RecallHeader = "## AceTeam memory (recalled)"
+
+// Recall queries the memory substrate via memory_search and returns a compact,
+// character-bounded block suitable for injection by a UserPromptSubmit hook.
+// Returns "" (no error) when there are no memories, so the hook injects nothing.
+func Recall(ctx context.Context, cfg *Config, scope, query string, budget int) (string, error) {
+	if cfg == nil || cfg.APIKey == "" {
+		return "", fmt.Errorf("no memory API key configured")
+	}
+	if strings.TrimSpace(query) == "" {
+		// Nothing to search on; a UserPromptSubmit with an empty prompt.
+		return "", nil
+	}
+	if budget <= 0 {
+		budget = DefaultRecallBudget
+	}
+
+	client := NewMCPClient(cfg.EffectiveMCPURL(), cfg.APIKey, 3*time.Second)
+
+	args := map[string]any{"query": query}
+	if scope != "" {
+		args["scope"] = scope
+	}
+
+	text, err := client.CallTool(ctx, "memory_search", args)
+	if err != nil {
+		return "", err
+	}
+	return FormatRecall(text, budget), nil
+}
+
+// FormatRecall trims and bounds raw memory_search output into an injectable
+// block. Returns "" when the result is empty or indicates no matches.
+func FormatRecall(raw string, budget int) string {
+	body := strings.TrimSpace(raw)
+	if body == "" {
+		return ""
+	}
+	// Common "no results" phrasings — inject nothing rather than noise.
+	low := strings.ToLower(body)
+	if strings.Contains(low, "no memories") || strings.Contains(low, "no results") ||
+		strings.Contains(low, "no matching") || body == "[]" || body == "{}" {
+		return ""
+	}
+	if budget > 0 && len(body) > budget {
+		body = strings.TrimSpace(body[:budget]) + "\n…(truncated)"
+	}
+	return RecallHeader + "\n" + body
+}

--- a/internal/memory/recall_test.go
+++ b/internal/memory/recall_test.go
@@ -1,0 +1,124 @@
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestFormatRecall(t *testing.T) {
+	cases := []struct {
+		name   string
+		raw    string
+		budget int
+		want   string // "" means expect empty
+		sub    string // substring expected when non-empty
+	}{
+		{"empty", "  ", 100, "", ""},
+		{"no memories", "No memories found.", 100, "", ""},
+		{"empty array", "[]", 100, "", ""},
+		{"has content", "- railway needs socks5 relay", 100, "x", "railway needs socks5 relay"},
+	}
+	for _, c := range cases {
+		got := FormatRecall(c.raw, c.budget)
+		if c.want == "" {
+			if got != "" {
+				t.Errorf("%s: expected empty, got %q", c.name, got)
+			}
+			continue
+		}
+		if !strings.HasPrefix(got, RecallHeader) {
+			t.Errorf("%s: missing header: %q", c.name, got)
+		}
+		if !strings.Contains(got, c.sub) {
+			t.Errorf("%s: want substring %q in %q", c.name, c.sub, got)
+		}
+	}
+}
+
+func TestFormatRecall_Budget(t *testing.T) {
+	raw := strings.Repeat("a", 5000)
+	got := FormatRecall(raw, 100)
+	if !strings.Contains(got, "truncated") {
+		t.Fatalf("expected truncation marker, got len %d", len(got))
+	}
+	if len(got) > 200 {
+		t.Fatalf("budget not applied: len %d", len(got))
+	}
+}
+
+func TestRecall_EndToEnd(t *testing.T) {
+	var sawQuery, sawScope string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			Params struct {
+				Arguments map[string]any `json:"arguments"`
+			} `json:"params"`
+		}
+		_ = json.Unmarshal(body, &req)
+		sawQuery, _ = req.Params.Arguments["query"].(string)
+		sawScope, _ = req.Params.Arguments["scope"].(string)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0", "id": 2,
+			"result": map[string]any{"content": []map[string]any{{"type": "text", "text": "remembered: X"}}},
+		})
+	}))
+	defer srv.Close()
+
+	cfg := &Config{APIKey: "act_k", MCPURL: srv.URL}
+	block, err := Recall(context.Background(), cfg, "aceteam", "how does railway reach nodes", 0)
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	if !strings.Contains(block, "remembered: X") {
+		t.Fatalf("bad block: %q", block)
+	}
+	if sawQuery != "how does railway reach nodes" {
+		t.Fatalf("query not forwarded: %q", sawQuery)
+	}
+	if sawScope != "aceteam" {
+		t.Fatalf("scope not forwarded: %q", sawScope)
+	}
+}
+
+func TestRecall_EmptyScopeOmitted(t *testing.T) {
+	var hadScopeKey bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			Params struct {
+				Arguments map[string]any `json:"arguments"`
+			} `json:"params"`
+		}
+		_ = json.Unmarshal(body, &req)
+		_, hadScopeKey = req.Params.Arguments["scope"]
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0", "id": 2,
+			"result": map[string]any{"content": []map[string]any{{"type": "text", "text": "hit"}}},
+		})
+	}))
+	defer srv.Close()
+
+	cfg := &Config{APIKey: "act_k", MCPURL: srv.URL}
+	// Empty scope => search ALL scopes => no "scope" key in the arguments.
+	if _, err := Recall(context.Background(), cfg, "", "any query", 0); err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	if hadScopeKey {
+		t.Fatal("empty scope should be omitted (search all scopes), but scope key was sent")
+	}
+}
+
+func TestRecall_NoKeyErrors(t *testing.T) {
+	_, err := Recall(context.Background(), &Config{}, "", "q", 0)
+	if err == nil {
+		t.Fatal("expected error with no API key")
+	}
+}

--- a/internal/nexus/deviceauth.go
+++ b/internal/nexus/deviceauth.go
@@ -160,11 +160,34 @@ type StartFlowRequest struct {
 	Hostname      string `json:"hostname,omitempty"`
 	MachineID     string `json:"machine_id,omitempty"`
 	ForceNew      bool   `json:"force_new,omitempty"`
+	// DeviceKind selects the backend authorization path. Absent (empty) reads
+	// as "citadel" server-side, so existing callers are unaffected. The memory
+	// onboarding installer (aceteam #7160) sends "memory" so the backend mints
+	// a scoped act_ API key instead of a Headscale preauthkey.
+	DeviceKind string `json:"device_kind,omitempty"`
 }
 
 // StartFlowOptions contains options for starting the device authorization flow
 type StartFlowOptions struct {
 	ForceNew bool // Force fresh registration, ignoring existing machine mapping
+	// DeviceKind, when set (e.g. "memory"), is forwarded to the /start endpoint
+	// to select a non-citadel authorization path. Empty = citadel (default).
+	DeviceKind string
+}
+
+// MemoryTokenResponse is the poll response for a device_kind:"memory" flow
+// (aceteam #7160). Unlike the citadel TokenResponse (which returns a Headscale
+// authkey and signals pending via an HTTP 400 authorization_pending error),
+// the memory endpoint always returns HTTP 200 and signals lifecycle via the
+// Status field. On approval it carries a scoped act_ API key in APIKey — the
+// same credential external MCP clients (like Claude Code) authenticate with.
+type MemoryTokenResponse struct {
+	Status    string   `json:"status"` // pending | approved | expired | denied
+	APIKey    string   `json:"api_key,omitempty"`
+	ExpiresIn *int     `json:"expires_in,omitempty"` // nullable; memory keys are minted without expiry
+	OrgID     string   `json:"org_id,omitempty"`
+	OrgName   string   `json:"org_name,omitempty"`
+	Scopes    []string `json:"scopes,omitempty"`
 }
 
 // TokenRequest represents the request body for /token endpoint
@@ -205,6 +228,7 @@ func (c *DeviceAuthClient) StartFlow(opts *StartFlowOptions) (*DeviceCodeRespons
 	// Apply options if provided
 	if opts != nil {
 		reqBody.ForceNew = opts.ForceNew
+		reqBody.DeviceKind = opts.DeviceKind
 	}
 
 	jsonData, err := json.Marshal(reqBody)
@@ -353,6 +377,91 @@ func (c *DeviceAuthClient) CheckToken(deviceCode string) (*TokenResponse, error)
 	}
 
 	return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+}
+
+// PollForMemoryToken polls the /token endpoint for a device_kind:"memory" flow
+// until the device is approved, denied, expires, or the client times out.
+//
+// The memory endpoint always returns HTTP 200 with a Status field (it does NOT
+// use the RFC 8628 authorization_pending error), so this method cannot reuse
+// PollForToken. The citadel PollForToken path is left untouched.
+func (c *DeviceAuthClient) PollForMemoryToken(deviceCode string, interval int) (*MemoryTokenResponse, error) {
+	if interval <= 0 {
+		interval = 5
+	}
+	return c.pollMemory(deviceCode, time.Duration(interval)*time.Second, 10*time.Minute)
+}
+
+// pollMemory is the duration-parameterized core of PollForMemoryToken (tests
+// pass short durations to avoid real sleeps).
+func (c *DeviceAuthClient) pollMemory(deviceCode string, pollingInterval, timeout time.Duration) (*MemoryTokenResponse, error) {
+	startTime := time.Now()
+
+	for time.Since(startTime) < timeout {
+		resp, err := c.checkMemoryToken(deviceCode)
+		if err != nil {
+			return nil, err
+		}
+
+		switch resp.Status {
+		case "approved":
+			if resp.APIKey == "" {
+				return nil, fmt.Errorf("device approved but no API key was returned")
+			}
+			return resp, nil
+		case "denied":
+			return nil, fmt.Errorf("authorization denied by user")
+		case "expired":
+			return nil, fmt.Errorf("device code expired, please run the command again")
+		case "pending", "":
+			// keep polling
+		default:
+			// Unknown/future status: treat as pending rather than hard-failing.
+		}
+
+		time.Sleep(pollingInterval)
+	}
+
+	return nil, fmt.Errorf("authentication timeout after 10 minutes")
+}
+
+// checkMemoryToken makes a single /token request for a memory-kind device.
+func (c *DeviceAuthClient) checkMemoryToken(deviceCode string) (*MemoryTokenResponse, error) {
+	url := c.baseURL + "/api/fabric/device-auth/token"
+
+	reqBody := TokenRequest{
+		DeviceCode: deviceCode,
+		GrantType:  "urn:ietf:params:oauth:grant-type:device_code",
+	}
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, classifyNetworkError(err, c.baseURL)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusServiceUnavailable {
+		return nil, fmt.Errorf("authentication service unavailable")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var out MemoryTokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("failed to parse token response: %w", err)
+	}
+	return &out, nil
 }
 
 // Error implements the error interface for TokenError

--- a/internal/nexus/deviceauth_memory_test.go
+++ b/internal/nexus/deviceauth_memory_test.go
@@ -1,0 +1,83 @@
+package nexus
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestPollForMemoryToken_ApprovesAfterPending(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/fabric/device-auth/token" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		n := atomic.AddInt32(&calls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK) // memory endpoint always returns 200
+		if n < 2 {
+			w.Write([]byte(`{"status":"pending"}`))
+			return
+		}
+		w.Write([]byte(`{"status":"approved","api_key":"act_minted","org_id":"org_9","org_name":"Acme","scopes":["memory:read","memory:write"],"expires_in":null}`))
+	}))
+	defer srv.Close()
+
+	c := NewDeviceAuthClient(srv.URL)
+	tok, err := c.pollMemory("devcode", time.Millisecond, 2*time.Second)
+	if err != nil {
+		t.Fatalf("PollForMemoryToken: %v", err)
+	}
+	if tok.APIKey != "act_minted" {
+		t.Fatalf("bad api key: %q", tok.APIKey)
+	}
+	if tok.OrgName != "Acme" || len(tok.Scopes) != 2 {
+		t.Fatalf("bad org/scopes: %+v", tok)
+	}
+	if tok.ExpiresIn != nil {
+		t.Fatalf("expected nil expires_in, got %v", *tok.ExpiresIn)
+	}
+}
+
+func TestPollForMemoryToken_Denied(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"denied"}`))
+	}))
+	defer srv.Close()
+
+	c := NewDeviceAuthClient(srv.URL)
+	if _, err := c.checkMemoryToken("devcode"); err != nil {
+		t.Fatalf("checkMemoryToken: %v", err)
+	}
+	// The poll loop maps a "denied" status to an error.
+	_, err := c.pollMemory("devcode", time.Millisecond, 2*time.Second)
+	if err == nil {
+		t.Fatal("expected denied error")
+	}
+}
+
+func TestStartFlow_SendsDeviceKind(t *testing.T) {
+	var sawKind string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if k, ok := body["device_kind"].(string); ok {
+			sawKind = k
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"device_code":"dc","user_code":"UC","expires_in":600,"interval":1}`))
+	}))
+	defer srv.Close()
+
+	c := NewDeviceAuthClient(srv.URL)
+	if _, err := c.StartFlow(&StartFlowOptions{DeviceKind: "memory"}); err != nil {
+		t.Fatalf("StartFlow: %v", err)
+	}
+	if sawKind != "memory" {
+		t.Fatalf("device_kind not sent, got %q", sawKind)
+	}
+}


### PR DESCRIPTION
## Context

The "install into Claude Code → it remembers" half of the Aug-14 demo (epic aceteam #7160, design PR #7151 §4B). The aceteam side already ships (on `feat/agent-memory`): the `memory_*`/`record_*` MCP tools over the memory substrate, and a `device_kind:"memory"` device-auth branch that mints a scoped `act_` API key. This PR is the **Citadel side**: one command authorizes the device and wires Claude Code to recall AceTeam memory before each prompt and capture after each turn.

Scope discipline: **Claude Code only** (the reference impl; other clients later). No aceteam changes. Additive Go command + config writers.

## The `citadel memory` commands

- **`citadel memory install`** (user-scoped, no sudo): runs the device-auth flow with `device_kind:"memory"` (backend mints an `act_` key), stores it user-only in `memory.yaml` (0600), detects Claude Code (`~/.claude/`), and wires its integration. Idempotent: an existing key is reused (`--force` re-authorizes); hooks/entries are never duplicated.
- **`citadel memory recall`**: queries `memory_search` over the AceTeam MCP with the `act_` key and prints a compact, character-bounded block to stdout for the `UserPromptSubmit` hook to inject. **Fail-open**: always exits 0 and prints nothing on error, so a memory outage or revoked key never blocks a prompt. Defaults to searching **all scopes** (the `scope: null` contract); `--scope` narrows.
- **`citadel memory capture`**: best-effort `memory_write` from a `SessionEnd` hook. Writes a bounded `--note` (or a bounded transcript tail from the hook JSON) for the demo. Always exits 0.

New `internal/memory` package: config store, a **dual-mode streamable-HTTP MCP client** (tries stateless `tools/call`; on a session-required rejection falls back to `initialize → notifications/initialized → tools/call` carrying `Mcp-Session-Id`; parses both JSON and SSE responses), plus recall/capture and the Claude Code config writers. `internal/nexus/deviceauth.go` gains a `device_kind` field on the start request and a **separate** memory-kind poll loop (the memory endpoint returns HTTP 200 + a `status` field, unlike the citadel `authorization_pending` path, which is left byte-for-byte untouched).

## Claude Code wiring (additive + idempotent)

Verified against this machine's on-disk config and the Claude Code docs:

- **MCP server** → `~/.claude.json`, key `mcpServers.aceteam-memory` = `{"type":"http","url":"https://aceteam.ai/api/mcp/aceteam/mcp","headers":{"Authorization":"Bearer act_…"}}`. Written 0600 (holds a secret), atomically (temp + rename), round-tripping all other keys verbatim.
- **recall hook** → `~/.claude/settings.json`, `hooks.UserPromptSubmit` group running `citadel memory recall` (stdout injected pre-prompt).
- **capture hook** → `hooks.SessionEnd` group running `citadel memory capture` (side-effect only; cannot block).
- Hooks are appended, preserving existing hooks, and **deduped by command marker** (`citadel memory recall` / `citadel memory capture`), so re-running install adds nothing.

## How recall/capture use the `act_` key

Both load `memory.yaml`, build an `MCPClient` bearing `Authorization: Bearer act_…`, and call the AceTeam MCP (`memory_search` / `memory_write`). recall carries its own 3s timeout; capture 8s.

## Testing

`go build ./...`, `go vet ./...`, `go test ./...` — all clean.

Unit tests (temp `$HOME`, httptest mocks):
- Config writers: MCP entry creation preserves unrelated keys + other servers, 0600 perms, idempotent re-write; hook merge is additive (existing hook survives), idempotent across a different binary path (marker dedup), creates missing files.
- `act_` key stored user-only (0600) round-trip.
- recall formatting (no-results → empty, budget truncation) and default **empty-scope-omitted** (searches all scopes).
- MCP client: stateless, session-handshake (asserts `Mcp-Session-Id` carried), SSE, and tool-error branches.
- Memory device-auth poll (pending→approved, denied, `expires_in: null`) and `device_kind:"memory"` sent on start.

Manual smokes (built binary):
- `memory recall`/`capture` with **no config** → exit 0, silent (fail-open).
- **Happy path**: isolated `HOME` + `memory.yaml` pointing at a local stub MCP; `{"prompt":…}` piped in → injected block on stdout, scope correctly omitted, query forwarded.

Cannot run live device-auth here. **Manual smoke on a machine with Claude Code:**
1. `citadel memory install` → authorize at the device URL → confirm `~/.citadel-cli/memory.yaml` (0600), the `aceteam-memory` entry in `~/.claude.json`, and the two hooks in `~/.claude/settings.json`.
2. Restart Claude Code (see caveat below), start a session, submit a prompt → confirm recalled AceTeam memory appears as pre-prompt context. **Confirm recall returns non-empty content against the real endpoint and note which transport branch fired** (stateless vs handshake); if prod requires the session handshake, recall pays 3 round trips per prompt — consider raising the recall timeout.
3. End the session → confirm a memory is written (`memory list`).

**Caveat — `~/.claude.json` is Claude Code's live state file.** The write is atomic against readers, but if `install` runs *inside* a live Claude Code session, Claude Code's next state write can drop the `mcpServers` entry. Run install **outside** Claude Code (or restart it and re-run install if the server doesn't appear).

## Not done (follow-ups)

- Other AI clients (Claude Code only for now).
- Full turn-by-turn transcript extraction + dedup in `capture` (writes a bounded note/tail for the demo).
- No aceteam changes (that side ships on `feat/agent-memory`).

Links aceteam #7160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)