### PR TITLE
fix(worker): keep the target_node filter on when the node's identity is unresolved (#654)

### DIFF
--- a/internal/worker/runner.go
+++ b/internal/worker/runner.go
@@ -50,10 +50,14 @@ type RunnerConfig struct {
 	// WorkerID identifies this worker instance
 	WorkerID string
 
-	// NodeID is this node's Headscale numeric node ID (e.g. "758").
-	// Used to filter jobs with a target_node field: if set and the job's
-	// target_node doesn't match, the job is acknowledged and skipped.
-	// When empty, target_node filtering is disabled (all jobs are processed).
+	// NodeID is this node's Headscale numeric node ID (e.g. "758"). It is the
+	// identity the target_node filter compares against: a job addressed to a
+	// different node is acknowledged and skipped.
+	//
+	// An empty NodeID means this node could not resolve its own identity. The
+	// filter stays ACTIVE in that case (citadel-cli#654) -- an unidentified node
+	// matches no target_node at all, so it declines every addressed job rather
+	// than claiming work meant for a peer. Untargeted jobs are unaffected.
 	NodeID string
 
 	// AgentVersion is this node's citadel build version (e.g. "v2.46.0").
@@ -363,15 +367,29 @@ func (r *Runner) processJob(ctx context.Context, job *Job) {
 	// Target-node filter: when per-node consumer groups are used, every node
 	// sees every message on the shared org queue. If the job specifies a
 	// target_node that doesn't match this node's Headscale ID, acknowledge
-	// and skip it silently -- the correct node will process it from its own
-	// read position. When this node's ID is unknown (empty), skip filtering
-	// to preserve pre-filter behavior and avoid dropping jobs.
-	if r.config.NodeID != "" {
-		if targetNode, ok := job.Payload["target_node"].(string); ok && targetNode != "" && targetNode != r.config.NodeID {
+	// and skip it -- the addressed node processes it from its own read
+	// position, and our Ack only clears OUR consumer group's pending list.
+	//
+	// The filter is UNCONDITIONAL, including when this node's own ID is unknown
+	// (citadel-cli#654). It used to be gated on NodeID != "", which made an
+	// identity failure fail OPEN: a node that could not resolve its Headscale ID
+	// matched nothing, so it claimed and executed every addressed job it saw off
+	// a shared stream -- including SHELL_COMMAND/terminal_exec work an operator
+	// aimed at a DIFFERENT machine -- while the real target sat waiting out its
+	// timeout. Failing closed costs a timeout on the addressed job and says so in
+	// the log; failing open ran it on the wrong host. The platform's per-node
+	// streams (aceteam#6889) remove most of the blast radius, but it still falls
+	// back to the shared stream during a mixed-version rollout, where this pin is
+	// the only thing routing the job.
+	if targetNode, ok := job.Payload["target_node"].(string); ok && targetNode != "" && targetNode != r.config.NodeID {
+		if r.config.NodeID == "" {
+			r.log("warning", "Declining job %s: addressed to target_node=%s but this node's Headscale ID is unresolved, "+
+				"so it cannot claim addressed work (citadel-cli#654)", job.ID, targetNode)
+		} else {
 			r.log("info", "Skipping job %s: target_node=%s (this node=%s)", job.ID, targetNode, r.config.NodeID)
-			r.source.Ack(ctx, job)
-			return
 		}
+		r.source.Ack(ctx, job)
+		return
 	}
 
 	// Claim-ack (aceteam#6000): publish a lightweight "claimed" event the moment

--- a/internal/worker/runner_test.go
+++ b/internal/worker/runner_test.go
@@ -1028,11 +1028,16 @@ func TestRunnerTargetNodeEmptyStringProcessesJob(t *testing.T) {
 	}
 }
 
-// TestRunnerNodeIDEmptySkipsFilter verifies that when the runner's NodeID is
-// empty (Headscale ID unresolved), the target_node filter is disabled and
-// all jobs are processed -- including ones with a target_node set. This
-// preserves pre-filter behavior and avoids dropping jobs that might be ours.
-func TestRunnerNodeIDEmptySkipsFilter(t *testing.T) {
+// TestRunnerNodeIDEmptyDeclinesAddressedJob is the regression test for
+// citadel-cli#654. A node that could not resolve its Headscale ID must NOT
+// execute a job addressed to some other node.
+//
+// The filter used to be gated on NodeID != "", so an unidentified node matched
+// nothing and ran every addressed job it read off a shared stream -- executing
+// on the wrong machine work the operator had aimed at a specific one. This
+// asserts on the HANDLER (the job never runs), not merely on the ack, because
+// acking a job we also executed would be the very bug.
+func TestRunnerNodeIDEmptyDeclinesAddressedJob(t *testing.T) {
 	jobs := []*Job{
 		{ID: "job-1", Type: "TEST_JOB", Payload: map[string]any{
 			"target_node": "999",
@@ -1053,9 +1058,40 @@ func TestRunnerNodeIDEmptySkipsFilter(t *testing.T) {
 	defer cancel()
 	runner.Run(ctx)
 
-	// Handler SHOULD have executed (filter disabled when NodeID is empty)
-	if len(handler.ExecutedJobs()) != 1 {
-		t.Errorf("Expected 1 executed job (filter should be disabled), got %d", len(handler.ExecutedJobs()))
+	if got := len(handler.ExecutedJobs()); got != 0 {
+		t.Errorf("Expected 0 executed jobs (an unidentified node must not claim addressed work), got %d", got)
+	}
+	acked := source.AckedJobs()
+	if len(acked) != 1 || acked[0].ID != "job-1" {
+		t.Errorf("Expected the declined job to be acked so it leaves this node's pending list, got %d ack(s)", len(acked))
+	}
+}
+
+// TestRunnerNodeIDEmptyStillRunsUntargetedJob pins the other half of #654: the
+// fail-closed change must cost nothing for ORG-WIDE work. A job with no
+// target_node is addressed to nobody in particular, so an unidentified node is
+// still a legitimate server for it. Without this, "fail closed on identity"
+// would silently become "an unidentified node serves nothing at all".
+func TestRunnerNodeIDEmptyStillRunsUntargetedJob(t *testing.T) {
+	jobs := []*Job{
+		{ID: "job-1", Type: "TEST_JOB", Payload: map[string]any{"command": "hostname"}},
+	}
+
+	source := NewMockJobSource("test", jobs)
+	handler := NewMockJobHandler("TEST_JOB", false)
+
+	config := RunnerConfig{
+		WorkerID: "test-worker",
+		NodeID:   "", // Empty -- Headscale ID not resolved
+	}
+	runner := NewRunner(source, []JobHandler{handler}, config)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	runner.Run(ctx)
+
+	if got := len(handler.ExecutedJobs()); got != 1 {
+		t.Errorf("Expected 1 executed job (untargeted work is still ours to serve), got %d", got)
 	}
 }
 

--- a/internal/worker/state.go
+++ b/internal/worker/state.go
@@ -139,23 +139,31 @@ func (s *WorkerState) RecordJobDone(ok bool) {
 
 // WorkerSnapshot is a point-in-time, JSON-serializable view of WorkerState.
 type WorkerSnapshot struct {
-	WorkerID          string     `json:"worker_id"`
-	Source            string     `json:"source"`
-	ConsumerGroup     string     `json:"consumer_group"`
-	Queues            []string   `json:"queues"`
-	PerNodeQueue      string     `json:"per_node_queue,omitempty"`
-	HeadscaleNodeID   string     `json:"headscale_node_id,omitempty"`
-	OrgID             string     `json:"org_id,omitempty"`
-	Consuming         bool       `json:"consuming"`
-	StartedAt         time.Time  `json:"started_at"`
-	UptimeSeconds     int64      `json:"uptime_seconds"`
-	LastPollAt        *time.Time `json:"last_poll_at,omitempty"`
-	LastJobAt         *time.Time `json:"last_job_at,omitempty"`
-	LastConsumeStatus int        `json:"last_consume_status"`
-	LastConsumeError  string     `json:"last_consume_error,omitempty"`
-	InFlight          int64      `json:"in_flight"`
-	Processed         int64      `json:"processed"`
-	Failed            int64      `json:"failed"`
+	WorkerID        string   `json:"worker_id"`
+	Source          string   `json:"source"`
+	ConsumerGroup   string   `json:"consumer_group"`
+	Queues          []string `json:"queues"`
+	PerNodeQueue    string   `json:"per_node_queue,omitempty"`
+	HeadscaleNodeID string   `json:"headscale_node_id,omitempty"`
+	// IdentityUnresolved reports that this worker never resolved its Headscale
+	// node ID. It is stated POSITIVELY rather than left to the absence of
+	// HeadscaleNodeID (which is omitempty, so a degraded node was previously
+	// indistinguishable from an older payload) because it changes what the node
+	// will do: with no identity it declines every target_node-addressed job
+	// (citadel-cli#654). Untargeted work still runs, so the node looks healthy
+	// on every other signal -- this is the field that explains the timeouts.
+	IdentityUnresolved bool       `json:"identity_unresolved,omitempty"`
+	OrgID              string     `json:"org_id,omitempty"`
+	Consuming          bool       `json:"consuming"`
+	StartedAt          time.Time  `json:"started_at"`
+	UptimeSeconds      int64      `json:"uptime_seconds"`
+	LastPollAt         *time.Time `json:"last_poll_at,omitempty"`
+	LastJobAt          *time.Time `json:"last_job_at,omitempty"`
+	LastConsumeStatus  int        `json:"last_consume_status"`
+	LastConsumeError   string     `json:"last_consume_error,omitempty"`
+	InFlight           int64      `json:"in_flight"`
+	Processed          int64      `json:"processed"`
+	Failed             int64      `json:"failed"`
 }
 
 // Snapshot returns a consistent copy of the current state. Safe for concurrent
@@ -176,6 +184,7 @@ func (s *WorkerState) Snapshot() WorkerSnapshot {
 		OrgID:           s.orgID,
 		StartedAt:       s.startedAt,
 	}
+	snap.IdentityUnresolved = s.headscaleID == ""
 	s.mu.RUnlock()
 
 	snap.UptimeSeconds = int64(time.Since(snap.StartedAt).Seconds())

--- a/internal/worker/state_test.go
+++ b/internal/worker/state_test.go
@@ -108,3 +108,24 @@ func TestWorkerStateConcurrent(t *testing.T) {
 		t.Fatalf("expected 50 processed, got %d", got)
 	}
 }
+
+// TestSnapshotIdentityUnresolved pins the operator-facing half of
+// citadel-cli#654. A node that never resolved its Headscale ID declines every
+// target_node-addressed job, yet stays green on every other signal (it polls,
+// it heartbeats, it serves untargeted work). IdentityUnresolved is the field
+// that explains the resulting timeouts, so it must be asserted POSITIVELY --
+// HeadscaleNodeID is omitempty, which makes a degraded node indistinguishable
+// from an older payload that simply never carried the field.
+func TestSnapshotIdentityUnresolved(t *testing.T) {
+	unidentified := NewWorkerState()
+	unidentified.SetIdentity("w", "redis", "citadel-somehost", "", "org-1")
+	if snap := unidentified.Snapshot(); !snap.IdentityUnresolved {
+		t.Error("expected IdentityUnresolved=true when the Headscale node ID is empty")
+	}
+
+	identified := NewWorkerState()
+	identified.SetIdentity("w", "redis", "citadel-node-758", "758", "org-1")
+	if snap := identified.Snapshot(); snap.IdentityUnresolved {
+		t.Error("expected IdentityUnresolved=false when the Headscale node ID resolved")
+	}
+}


### PR DESCRIPTION
Closes #654.

## Context

A node that cannot resolve its own Headscale ID was executing jobs **addressed to a different node**.

Measured on prod (#654): with two nodes online, gateway calls succeeded roughly 1 in 3; with one node, 4 for 4. The culprit node had been started by hand outside its supervisor — exactly the case where identity resolution is most likely to fail.

## Root cause

The `target_node` filter in `processJob` was gated on `r.config.NodeID != ""`:

```go
if r.config.NodeID != "" {
    if targetNode, ok := ...; ok && targetNode != "" && targetNode != r.config.NodeID {
        // skip
    }
}
```

That makes an identity failure fail **open**, which is the worst direction for an identity check. With an empty `NodeID` the node matched no `target_node` at all, so instead of declining addressed work it claimed **all** of it off the shared org stream — including `SHELL_COMMAND`/`terminal_exec` work an operator had aimed at a specific machine — while the addressed node waited out its full timeout and the caller got a 504.

## Changes

- `internal/worker/runner.go` — apply the filter unconditionally. An unidentified node matches no `target_node`, so it declines every addressed job. The skip logs at `warning` (not `info`) when caused by an unresolved identity, so the two cases read differently: *"not addressed to me"* vs *"I do not know who I am"*.
- `internal/worker/state.go` — `WorkerSnapshot` gains `identity_unresolved`.

**Untargeted (org-wide) jobs are deliberately unaffected.** They are addressed to nobody in particular, so an unidentified node is still a legitimate server for them. Failing closed on identity must not quietly become *"a node with an unresolved ID serves nothing"*.

`identity_unresolved` is stated **positively** rather than left to the absence of `headscale_node_id`, which is `omitempty` — a degraded node was previously indistinguishable from an older payload that never carried the field. This is the signal that explains the timeouts: such a node polls, heartbeats and serves untargeted work, so it looks healthy on every other axis.

## Why this still matters given aceteam-ai/aceteam#6889

The platform now routes to per-node streams and falls back to the shared stream only when no per-node consumer exists (mixed-version rollout). In exactly that fallback the `target_node` pin is the **only** thing routing the job — so this is where a fail-open costs the most, not the least. Defense in depth: this half holds regardless of platform version.

## On the issue's ask #1 (deliberately not done)

#654 also asks that a node with an unresolved ID not subscribe to shared capability queues at all. That is **not** in this PR, on purpose: it buys the same guarantee this fix already buys — an unidentified node cannot claim addressed work — but pays for it with an availability cliff, since the node would also stop serving legitimate untargeted work. The filter is the correctness guarantee; the subscription is an optimisation. Happy to revisit if you want the stricter posture.

## Testing

`go test ./...` green; `go vet ./...` clean.

- `TestRunnerNodeIDEmptyDeclinesAddressedJob` **replaces** `TestRunnerNodeIDEmptySkipsFilter`, which pinned the fail-open as intended behavior. It asserts on the **handler** (the job never runs), not merely on the ack — acking a job we also executed would be the bug.
- `TestRunnerNodeIDEmptyStillRunsUntargetedJob` pins the other half.
- `TestSnapshotIdentityUnresolved` covers both snapshot directions.

**Mutation tested:** restoring the `NodeID != ""` gate fails `TestRunnerNodeIDEmptyDeclinesAddressedJob`, confirming the test detects the regression rather than passing vacuously.

To verify by hand on a node: start `citadel work` where the Headscale ID cannot resolve, dispatch a `terminal_exec` addressed to a *peer*, and confirm the log shows `Declining job ... Headscale ID is unresolved` and the handler never runs.