### PR TITLE
fix(nvr): build internal/nvr on Windows; guard every package in the cross-compile matrix (#663)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,3 +108,17 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
         run: go build -o /dev/null ./cmd/citadel
+
+      # EVERY package, not just the shipped binary. ./cmd/citadel alone left a
+      # blind spot: internal/nvr used Unix-only syscalls and broke `go build ./...`
+      # for GOOS=windows for weeks (#663) while this matrix stayed green, because
+      # only ./cmd/nvrconfig imports it. Releases were unaffected, which is
+      # exactly what made it invisible -- the failure landed on whoever next
+      # checked their own Windows build and found a break that was not theirs.
+      # No -o: a multi-package build discards its output.
+      - name: go build ./... ${{ matrix.goos }}/${{ matrix.goarch }}
+        env:
+          CGO_ENABLED: "0"
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: go build ./...

--- a/internal/nvr/storage.go
+++ b/internal/nvr/storage.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 )
 
 // Fixed, citadel-owned LOCAL paths (relative to the node owner's home) that the
@@ -138,17 +137,6 @@ func DefaultMountProbe() MountProbe {
 	return MountProbe{IsMountpoint: isMountpoint, WritableAsUID: writableAsUID}
 }
 
-func isMountpoint(path string) (bool, error) {
-	var st, parent syscall.Stat_t
-	if err := syscall.Stat(path, &st); err != nil {
-		return false, err
-	}
-	if err := syscall.Stat(filepath.Dir(path), &parent); err != nil {
-		return false, err
-	}
-	return st.Dev != parent.Dev, nil
-}
-
 func writableAsUID(dir string, uid int) (bool, error) {
 	_ = uid
 	f, err := os.CreateTemp(dir, ".citadel-nvr-writecheck-")
@@ -229,14 +217,5 @@ func VerifyMediaIsNetworkFS(path string, uid int, probe NetFSProbe) error {
 
 // DefaultNetFSProbe returns a NetFSProbe backed by real statfs + a probe write.
 func DefaultNetFSProbe() NetFSProbe {
-	return NetFSProbe{
-		FSType: func(path string) (int64, error) {
-			var st syscall.Statfs_t
-			if err := syscall.Statfs(path, &st); err != nil {
-				return 0, err
-			}
-			return int64(st.Type), nil
-		},
-		Writable: writableAsUID,
-	}
+	return NetFSProbe{FSType: fsType, Writable: writableAsUID}
 }

--- a/internal/nvr/storage_unix.go
+++ b/internal/nvr/storage_unix.go
@@ -1,0 +1,35 @@
+//go:build !windows
+
+package nvr
+
+import (
+	"path/filepath"
+	"syscall"
+)
+
+// isMountpoint reports whether path has its own filesystem mounted, by comparing
+// its st_dev against its parent's. This is the HOST-side check: a failed NFS
+// mount leaves a plain local directory whose st_dev matches its parent.
+func isMountpoint(path string) (bool, error) {
+	var st, parent syscall.Stat_t
+	if err := syscall.Stat(path, &st); err != nil {
+		return false, err
+	}
+	if err := syscall.Stat(filepath.Dir(path), &parent); err != nil {
+		return false, err
+	}
+	return st.Dev != parent.Dev, nil
+}
+
+// fsType returns the filesystem magic number for path (statfs f_type). This is
+// what the CONTAINER-side check must use: inside the frigate container /media is
+// always a bind mount, so st_dev always differs from its parent and an
+// isMountpoint check there is a false pass. Widened to int64 because f_type is
+// int64 on Linux and uint32 on darwin.
+func fsType(path string) (int64, error) {
+	var st syscall.Statfs_t
+	if err := syscall.Statfs(path, &st); err != nil {
+		return 0, err
+	}
+	return int64(st.Type), nil
+}

--- a/internal/nvr/storage_windows.go
+++ b/internal/nvr/storage_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package nvr
+
+import "fmt"
+
+// The nvr module does not run on Windows. Frigate and wyze-bridge are Linux
+// containers, and the module additionally requires host networking (TUTK camera
+// discovery) plus an NFS/SMB mount owned by the node — none of which Docker
+// Desktop's WSL2 backend provides in the shape the module needs.
+//
+// These stubs exist so the package COMPILES for GOOS=windows (`go build ./...`,
+// which is what a contributor runs to check they have not broken Windows) rather
+// than failing on the Unix-only syscall.Stat/Statfs in storage_unix.go. They
+// return an error rather than a zero value on purpose: a silent `false, nil`
+// from isMountpoint would read as "not a mountpoint" and a silent `0, nil` from
+// fsType as "not a network filesystem", turning a build error into a runtime
+// guard that quietly passes the wrong verdict.
+//
+// The Windows binary never reaches this code: nothing in ./cmd/citadel imports
+// internal/nvr (only ./cmd/nvrconfig, the Linux init container, does).
+
+func isMountpoint(path string) (bool, error) {
+	return false, fmt.Errorf("nvr: mountpoint check for %s is not supported on Windows (the nvr module is Linux-only)", path)
+}
+
+func fsType(path string) (int64, error) {
+	return 0, fmt.Errorf("nvr: filesystem-type check for %s is not supported on Windows (the nvr module is Linux-only)", path)
+}


### PR DESCRIPTION
Closes #663.

## Context

`GOOS=windows go build ./...` fails on `main`:

```
# github.com/aceteam-ai/citadel-cli/internal/nvr
internal/nvr/storage.go:142:25: undefined: syscall.Stat_t
internal/nvr/storage.go:234:19: undefined: syscall.Statfs_t
```

`syscall.Stat`/`Statfs` and their result types do not exist on Windows.

## Why nobody noticed

**Releases were unaffected, which is exactly what made it invisible.** `build.sh` and the CI cross-compile matrix both build `./cmd/citadel`, and nothing under it imports `internal/nvr` — only `./cmd/nvrconfig` does, and that is the Linux init-container image built by its own workflow. So every release and every CI run stayed green while the full-module build was broken.

The cost is a trap rather than an outage: a contributor checking they have not broken Windows runs `go build ./...`, hits a failure that is not theirs, and either burns time on it or learns to ignore that output — which is how a real Windows break eventually ships.

## Changes

- **`internal/nvr/storage_unix.go`** (`//go:build !windows`) — `isMountpoint` (st_dev vs parent) and `fsType` (statfs `f_type`), moved out of `storage.go` unchanged. `int64(st.Type)` covers both Linux (`int64`) and darwin (`uint32`).
- **`internal/nvr/storage_windows.go`** — stubs that return an **error, not a zero value**. A silent `false, nil` from `isMountpoint` would read as *"not a mountpoint"* and a silent `0, nil` from `fsType` as *"not a network filesystem"* — converting a build failure into a runtime guard that quietly returns the wrong verdict. The nvr module is Linux-only by nature (Frigate/wyze-bridge Linux containers, host networking for TUTK, an NFS/SMB mount), so these are unreachable in practice.
- **`internal/nvr/storage.go`** — drops the `syscall` import; the probe constructors reference the per-platform helpers. No behavior change on Linux/darwin.
- **`.github/workflows/ci.yml`** — the cross-compile matrix now also runs `go build ./...` per target, so a Unix-only syscall in *any* package fails CI instead of hiding behind the shipped binary's import graph. This is the half that stops #663 from recurring.

The issue offered a cheaper alternative (`//go:build !windows` on the whole file plus a stub). I went with the split because the package's exported API — `DefaultMountProbe`, `DefaultNetFSProbe`, `VerifyMediaMount` — stays present and identically shaped on every platform, so callers need no build tags of their own.

## Testing

Verified for every release target, before and after:

```bash
CGO_ENABLED=0 GOOS={windows,linux,darwin} GOARCH={amd64,arm64} go build ./...
```

All pass; `windows/amd64` and `windows/arm64` previously failed with the errors above.

`go test ./...` and `go vet ./...` green.