### PR TITLE
fix(worker): surface an unresolved node identity on the heartbeat and correct the doctor's diagnosis (#654)

### DIFF
--- a/cmd/agent_tools.go
+++ b/cmd/agent_tools.go
@@ -344,9 +344,15 @@ func agentDoctor(snap worker.WorkerSnapshot) map[string]any {
 		checks = append(checks, map[string]any{"name": name, "ok": ok, "detail": detail})
 	}
 
-	// 1. Network / identity
+	// 1. Network / identity. The empty-ID detail changed with citadel-cli#654:
+	// an unidentified node no longer claims addressed work off the shared
+	// stream, it DECLINES it. The old wording ("falls back to the shared org
+	// stream") described the fail-open this node no longer has, and would send
+	// an operator looking for a peer that stole the job when in fact nothing ran
+	// it.
 	netOK := snap.HeadscaleNodeID != ""
-	add("headscale_node_id_resolved", netOK, valueOrEmpty(snap.HeadscaleNodeID, "unresolved (node-targeted jobs fall back to shared org stream)"))
+	add("headscale_node_id_resolved", netOK, valueOrEmpty(snap.HeadscaleNodeID,
+		"unresolved — this node declines every target_node-addressed job (citadel-cli#654), so node-targeted work times out instead of running here"))
 
 	// 2. Org id known
 	orgOK := snap.OrgID != ""
@@ -372,7 +378,7 @@ func agentDoctor(snap worker.WorkerSnapshot) map[string]any {
 	diagnosis := "Node looks healthy for per-node job routing."
 	switch {
 	case !netOK:
-		diagnosis = "Headscale node ID is unresolved, so the per-node shell stream was never subscribed. Per-node jobs (terminal_exec, code_*, file reads) fall back to the shared org stream where a peer may claim them. Try /agent/resubscribe or restart the worker after the VPN is fully connected."
+		diagnosis = "Headscale node ID is unresolved, so the per-node shell stream was never subscribed AND this node declines every target_node-addressed job (citadel-cli#654 — it cannot prove a job is meant for it, and claiming one would run a peer's work here). Node-targeted jobs (terminal_exec, code_*, file reads) aimed at this node therefore time out rather than executing. Try /agent/resubscribe, or restart the worker once the VPN is fully connected."
 	case !orgOK:
 		diagnosis = "Org ID is unknown, so the per-node shell stream was skipped. Re-run 'citadel init' to repopulate device config."
 	case !perNodeOK:

--- a/cmd/agent_tools_test.go
+++ b/cmd/agent_tools_test.go
@@ -234,3 +234,64 @@ func TestAgentWorkerRestartNotServiceManaged(t *testing.T) {
 	}
 	time.Sleep(5 * time.Millisecond) // give any errant goroutine a chance to fire
 }
+
+// TestAgentDoctorUnresolvedIDReportsDeclineNotFallback pins the WORDING, which
+// is the whole product of this diagnostic. Before citadel-cli#654 an
+// unidentified node claimed addressed jobs off the shared stream; now it
+// declines them. The doctor's old text ("fall back to the shared org stream
+// where a peer may claim them") described the removed fail-open and would send
+// an operator hunting for a peer that stole the job -- when in fact nothing ran
+// it at all. A test on `healthy` alone cannot catch a diagnosis that is
+// confidently wrong, so assert on the text.
+func TestAgentDoctorUnresolvedIDReportsDeclineNotFallback(t *testing.T) {
+	s := worker.NewWorkerState()
+	s.SetIdentity("w", "redis-api", "citadel-workers", "", "org-x")
+	s.SetPerNodeQueue("")
+	s.RecordConsumeStatus(200, "")
+	s.RecordPoll()
+
+	d := agentDoctor(s.Snapshot())
+	diag, _ := d["diagnosis"].(string)
+	if !strings.Contains(diag, "declines") {
+		t.Errorf("diagnosis must say the node DECLINES addressed jobs, got %q", diag)
+	}
+	if strings.Contains(diag, "fall back to the shared org stream where a peer may claim them") {
+		t.Errorf("diagnosis still describes the removed fail-open, got %q", diag)
+	}
+
+	// The per-check detail carries the same correction, since an agent reading
+	// the checks array may never render the prose diagnosis.
+	checks, _ := d["checks"].([]map[string]any)
+	var detail string
+	for _, c := range checks {
+		if c["name"] == "headscale_node_id_resolved" {
+			detail, _ = c["detail"].(string)
+		}
+	}
+	if !strings.Contains(detail, "declines") {
+		t.Errorf("headscale_node_id_resolved detail must say the node declines addressed jobs, got %q", detail)
+	}
+}
+
+// TestWorkerLivenessCarriesIdentityUnresolved pins the heartbeat half of
+// citadel-cli#654. Without it the signal exists only on the node's own /agent
+// snapshot, and the PLATFORM -- which is what actually notices a degraded node
+// across a fleet -- still sees nothing but a healthy-looking worker.
+//
+// The failure this guards against is not a wrong value but a DROPPED one:
+// workerLivenessFrom is a hand-maintained field-by-field copy, so a field added
+// to WorkerSnapshot and forgotten here vanishes silently with everything still
+// compiling and every other test passing.
+func TestWorkerLivenessCarriesIdentityUnresolved(t *testing.T) {
+	degraded := worker.NewWorkerState()
+	degraded.SetIdentity("w", "redis-api", "citadel-somehost", "", "org-x")
+	if !workerLivenessFrom(degraded.Snapshot()).IdentityUnresolved {
+		t.Error("heartbeat liveness must report identity_unresolved when the Headscale ID is empty")
+	}
+
+	healthy := worker.NewWorkerState()
+	healthy.SetIdentity("w", "redis-api", "citadel-node-1008", "1008", "org-x")
+	if workerLivenessFrom(healthy.Snapshot()).IdentityUnresolved {
+		t.Error("heartbeat liveness must not report identity_unresolved once the Headscale ID resolved")
+	}
+}

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1157,15 +1157,7 @@ func runWork(cmd *cobra.Command, args []string) {
 	// "green but wedged" node (heartbeating from a separate goroutine while the
 	// consume loop is blocked and draining nothing).
 	workerLivenessFn := func() *status.WorkerLiveness {
-		snap := workerState.Snapshot()
-		return &status.WorkerLiveness{
-			Consuming:         snap.Consuming,
-			LastJobConsumedAt: snap.LastJobAt,
-			LastPollAt:        snap.LastPollAt,
-			InFlight:          snap.InFlight,
-			Processed:         snap.Processed,
-			Failed:            snap.Failed,
-		}
+		return workerLivenessFrom(workerState.Snapshot())
 	}
 
 	// Create status collector (used by status server and Redis status publisher)
@@ -2531,6 +2523,23 @@ func nodeIsServingModels(ctx context.Context) bool {
 	probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	return len(status.DiscoverLocalEngines(probeCtx)) > 0
+}
+
+// workerLivenessFrom projects a WorkerSnapshot onto the heartbeat-facing
+// liveness payload. Extracted from the closure in runWork so the projection is
+// testable on its own: it is a hand-maintained field-by-field copy between two
+// structs that evolve independently, which is exactly the kind of mapping that
+// silently loses a field when one side gains one.
+func workerLivenessFrom(snap worker.WorkerSnapshot) *status.WorkerLiveness {
+	return &status.WorkerLiveness{
+		Consuming:          snap.Consuming,
+		LastJobConsumedAt:  snap.LastJobAt,
+		LastPollAt:         snap.LastPollAt,
+		InFlight:           snap.InFlight,
+		Processed:          snap.Processed,
+		Failed:             snap.Failed,
+		IdentityUnresolved: snap.IdentityUnresolved,
+	}
 }
 
 func resolveConsumerGroup(explicit, headscaleNodeID, hostname string) string {

--- a/internal/status/types.go
+++ b/internal/status/types.go
@@ -68,6 +68,19 @@ type WorkerLiveness struct {
 	// Processed / Failed are cumulative since worker start (diagnostic context).
 	Processed int64 `json:"processed,omitempty"`
 	Failed    int64 `json:"failed,omitempty"`
+
+	// IdentityUnresolved reports that this worker never resolved its Headscale
+	// node ID. Such a node is NOT wedged -- it polls, it heartbeats, it serves
+	// untargeted work, so every field above reads healthy -- but it declines
+	// every target_node-addressed job (citadel-cli#654), which surfaces to the
+	// caller as an unexplained dispatch timeout far from the cause. This is the
+	// field that explains it, and it is the only one here describing a node that
+	// is degraded rather than stuck.
+	//
+	// Stated positively on purpose: the node's ID is not on this struct at all,
+	// and on the /agent snapshot it is `omitempty`, so its absence cannot
+	// distinguish a degraded node from an older payload.
+	IdentityUnresolved bool `json:"identity_unresolved,omitempty"`
 }
 
 // AppInfo contains information about an installed catalog app.


### PR DESCRIPTION
Completes the observability half of #654. [#671](https://github.com/aceteam-ai/citadel-cli/pull/671) fixed the fail-open itself and added `identity_unresolved` to the `/agent` worker snapshot; this carries it to the two surfaces that actually get read, and repairs a diagnostic that #671 made wrong.

## Heartbeat

`status.WorkerLiveness` gains `identity_unresolved`. Without it the signal existed only on the node's own `/agent` snapshot — but the **platform** is what notices a degraded node across a fleet, and it saw nothing but a healthy-looking worker.

A node with no identity is **not wedged**: it polls, it heartbeats, it serves untargeted work, so every other field on `WorkerLiveness` reads healthy. It just declines every `target_node`-addressed job, which reaches the caller as an unexplained dispatch timeout far from the cause. This is the only field here describing a node that is *degraded* rather than *stuck*.

## Doctor diagnosis — this one was actively misleading

`agentDoctor`'s empty-ID text still described the fail-open #671 removed:

> "Per-node jobs … fall back to the shared org stream where a peer may claim them."

After #671 the opposite is true: this node **declines** the job and nothing runs it. An operator following the old text would hunt for a peer that stole the work. Both the prose diagnosis and the per-check `detail` now say the node declines addressed jobs — an agent reading the `checks` array may never render the prose.

## Structure

The snapshot → liveness projection moves out of the closure in `runWork` into `workerLivenessFrom`, so it is testable. It is a hand-maintained field-by-field copy between two structs that evolve independently — the exact shape that silently drops a field when one side gains one.

## Not done: `citadel status`

#654 also asks for this in `citadel status`. **Deliberately skipped:** `printWorkerInfo` reads the worklock *file*, while `WorkerState` lives inside the running worker process — so surfacing it there means a loopback call to `/agent`, which is new scope and a new failure mode for a command that today touches no sockets.

The heartbeat (platform-facing) and `/agent/doctor` (what `citadel_doctor` reports, and how these nodes are actually diagnosed remotely) are the surfaces where #654's *"today this is silent"* complaint bites, and both are now covered. Happy to add the `citadel status` line as a follow-up if you want it locally too.

## Testing

`go test ./...` and `go vet ./...` green.

- `TestWorkerLivenessCarriesIdentityUnresolved` — both directions. **Mutation tested:** dropping `IdentityUnresolved` from the projection fails it.
- `TestAgentDoctorUnresolvedIDReportsDeclineNotFallback` asserts on the **wording**, which is the entire product of a diagnostic — a test on `healthy` alone cannot catch a diagnosis that is confidently wrong. It also asserts the old fail-open sentence is gone.