### PR TITLE
fix(services): health checks must ask whether the engine answers, not whether a process name matches (#649)

### DIFF
--- a/cmd/service.go
+++ b/cmd/service.go
@@ -312,8 +312,11 @@ func macServiceWarning(serviceName string) string {
 
 // startNativeService starts a service using its native binary.
 func startNativeService(serviceName, configDir string) error {
-	// Check if already running
-	if services.IsNativeServiceRunning(serviceName) {
+	// Check if it is already SERVING, not merely that a matching process exists
+	// (issue #649). A dead engine with a lingering process match used to take
+	// this branch and report success, leaving the node advertising an engine
+	// that answered nothing.
+	if services.IsNativeServiceServing(serviceName) {
 		fmt.Printf("   ✅ Service %s is already running.\n", serviceName)
 		return nil
 	}

--- a/internal/jobs/service_handler.go
+++ b/internal/jobs/service_handler.go
@@ -215,7 +215,10 @@ func (h *ServiceHandler) serviceStatus(svc manifestService) ([]byte, error) {
 
 	switch kind {
 	case "native":
-		running = services.IsNativeServiceRunning(svc.Name)
+		// Report what the engine can actually do, not whether a process name
+		// matched (#649): a status of "running" is what the platform trusts when
+		// it decides to keep routing inference here.
+		running = services.IsNativeServiceServing(svc.Name)
 	case "docker":
 		running = h.isDockerServiceRunning(svc.Name)
 	}
@@ -256,7 +259,10 @@ func (h *ServiceHandler) serviceStart(ctx JobContext, svc manifestService, model
 				ctx.Log("info", "     - Service %s runs natively; model %q ignored (no pull mechanism for this engine)", svc.Name, model)
 			}
 		}
-		alreadyRunning := services.IsNativeServiceRunning(svc.Name)
+		// Serving, not merely process-present (#649). A SERVICE_START against a
+		// dead-but-process-matching engine must actually start it; short-circuiting
+		// here was how a deploy reported success onto a node serving nothing.
+		alreadyRunning := services.IsNativeServiceServing(svc.Name)
 		if !alreadyRunning {
 			logDir := filepath.Join(h.ConfigDir, "logs")
 			_, err = services.StartNativeService(svc.Name, logDir)
@@ -392,6 +398,11 @@ func (h *ServiceHandler) serviceStop(ctx JobContext, svc manifestService) ([]byt
 
 	switch kind {
 	case "native":
+		// Deliberately the PROCESS check, not IsNativeServiceServing (#649): a
+		// wedged engine that has stopped answering is still a live process
+		// holding VRAM, and stop must kill it. Using the serving probe here would
+		// report "not running" and leave it alive forever -- the one place where
+		// the loose predicate is the correct one.
 		if !services.IsNativeServiceRunning(svc.Name) {
 			return json.Marshal(serviceResult{
 				Name: svc.Name, Running: false, Kind: kind,

--- a/internal/jobs/service_handler_native_model_test.go
+++ b/internal/jobs/service_handler_native_model_test.go
@@ -8,6 +8,7 @@
 package jobs
 
 import (
+	"net"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -15,7 +16,55 @@ import (
 	"testing"
 
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+	"github.com/aceteam-ai/citadel-cli/internal/services"
 )
+
+// serveNativeEngine makes the named native engine "already serving" for the
+// duration of the test by binding a real listener and pointing its
+// NativeServices entry at that port.
+//
+// Since #649 the already-running short-circuit asks whether the ENGINE ANSWERS,
+// not whether a process name matches, so a fake `pgrep` that exits 0 no longer
+// simulates a running engine -- which is the entire point of that fix. A real
+// listener on an ephemeral port is used rather than the engine's true port so
+// the suite never collides with an actual ollama on the developer's machine.
+// deadNativeEngine is the inverse of serveNativeEngine: it points the engine at
+// a port that is guaranteed closed (bound to claim it, then released).
+//
+// It exists so a test about a DEAD engine never depends on the engine's real
+// port being free on the machine running the suite -- a developer with ollama
+// listening on 11434 would otherwise see this test fail for the wrong reason,
+// and CI and laptop would disagree.
+func deadNativeEngine(t *testing.T, name string) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+
+	original := services.NativeServices[name]
+	patched := original
+	patched.Port = port
+	services.NativeServices[name] = patched
+	t.Cleanup(func() { services.NativeServices[name] = original })
+}
+
+func serveNativeEngine(t *testing.T, name string) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	original := services.NativeServices[name]
+	patched := original
+	patched.Port = ln.Addr().(*net.TCPAddr).Port
+	services.NativeServices[name] = patched
+	t.Cleanup(func() { services.NativeServices[name] = original })
+}
 
 // fakeBinDir creates a temp dir set as the ONLY PATH entry, and returns it
 // together with a helper that writes an executable shell script into it.
@@ -113,7 +162,8 @@ exit 0`)
 func TestServiceStartNativeOllama_PullsModel(t *testing.T) {
 	dir, write := fakeBinDir(t)
 	argsFile := filepath.Join(dir, "args.log")
-	write("pgrep", "exit 0") // "already running"
+	write("pgrep", "exit 0") // a process matches -- no longer enough on its own (#649)
+	serveNativeEngine(t, "ollama")
 	write("ollama", `echo "$@" >> `+argsFile+`
 exit 0`)
 	h := newNativeOllamaHandler(t)
@@ -144,6 +194,7 @@ exit 0`)
 func TestServiceStartNativeOllama_PullFailureIsJobFailure(t *testing.T) {
 	_, write := fakeBinDir(t)
 	write("pgrep", "exit 0") // running, but no ollama binary on PATH
+	serveNativeEngine(t, "ollama")
 	h := newNativeOllamaHandler(t)
 
 	_, err := h.Execute(JobContext{}, &nexus.Job{
@@ -161,7 +212,8 @@ func TestServiceStartNativeOllama_PullFailureIsJobFailure(t *testing.T) {
 // ignored and the start succeeds without any pull attempt.
 func TestServiceStartNativeNonOllama_ModelStillIgnored(t *testing.T) {
 	_, write := fakeBinDir(t)
-	write("pgrep", "exit 0") // llamacpp "already running"
+	write("pgrep", "exit 0") // llamacpp process matches
+	serveNativeEngine(t, "llamacpp")
 	h := newNativeOllamaHandler(t)
 
 	var logs []string
@@ -179,5 +231,51 @@ func TestServiceStartNativeNonOllama_ModelStillIgnored(t *testing.T) {
 	}
 	if !strings.Contains(strings.Join(logs, "\n"), "ignored") {
 		t.Errorf("expected 'ignored' log for non-ollama native engine, logs: %v", logs)
+	}
+}
+
+// TestServiceStartNativeOllama_DeadEngineIsStartedNotShortCircuited is the
+// handler-level regression test for #649.
+//
+// On node 1297 a `pgrep -f ollama` match made SERVICE_START report "already
+// running" while the engine was dead and the API answered nothing; the platform
+// kept advertising the node as serving and every routed request timed out. The
+// short-circuit must now key on the engine ANSWERING, so a process match with a
+// dead port has to fall through and actually start it.
+//
+// deadNativeEngine pins a closed port rather than relying on the engine's real
+// port being free, so the result does not depend on whether the machine running
+// the suite happens to have ollama up. Asserting that `ollama serve` was invoked (rather
+// than just checking the message) is what distinguishes a real start from a
+// reworded short-circuit.
+func TestServiceStartNativeOllama_DeadEngineIsStartedNotShortCircuited(t *testing.T) {
+	dir, write := fakeBinDir(t)
+	argsFile := filepath.Join(dir, "args.log")
+	write("pgrep", "exit 0")      // a matching process exists...
+	deadNativeEngine(t, "ollama") // ...but nothing answers on its port
+	write("ollama", `echo "$@" >> `+argsFile+`
+exit 0`)
+	h := newNativeOllamaHandler(t)
+
+	out, err := h.Execute(JobContext{}, &nexus.Job{
+		ID:      "job-649-1",
+		Type:    "SERVICE_START",
+		Payload: map[string]string{"service": "ollama"},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	// Assert on WHICH BRANCH the handler took, via the result message, rather
+	// than on the fake binary's side effects. StartNativeService uses cmd.Start(),
+	// so the child runs concurrently and any file it writes is a race the test
+	// would lose under load -- observed failing only inside a full `go test ./...`
+	// while passing for the package alone. The branch is the actual subject here:
+	// "already running" is the #649 bug, "started" is the fix.
+	if strings.Contains(string(out), "already running") {
+		t.Errorf("dead engine was short-circuited as already running (#649): %s", out)
+	}
+	if !strings.Contains(string(out), "started") {
+		t.Errorf("expected the handler to start the dead engine, got: %s", out)
 	}
 }

--- a/internal/services/native.go
+++ b/internal/services/native.go
@@ -4,6 +4,7 @@ package services
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"strconv"
@@ -189,7 +190,48 @@ func StartNativeService(serviceName string, logDir string) (*NativeProcess, erro
 	}, nil
 }
 
-// IsNativeServiceRunning checks if a native service is already running
+// nativeProbeTimeout bounds the serving probe. It runs on the heartbeat's
+// collection path (every ~30s), so an engine socket that accepts a connection
+// and then goes silent must not stall the collector -- the exact "green but
+// wedged" shape issue #548 was about. Short and fail-closed: a timeout counts
+// as not serving.
+const nativeProbeTimeout = 1500 * time.Millisecond
+
+// portAnswers reports whether something accepts a TCP connection on the given
+// loopback port within timeout.
+//
+// net.DialTimeout rather than shelling out to `nc`: nc is absent on minimal
+// images (slim containers, LXC templates), where exec would fail on every
+// attempt and the probe would report "never ready" for a perfectly healthy
+// engine. This has no external dependency.
+func portAnswers(port int, timeout time.Duration) bool {
+	if port <= 0 {
+		return false
+	}
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)), timeout)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+// IsNativeServiceRunning reports whether a PROCESS matching the service's binary
+// exists. It answers "is there something to stop", NOT "is the engine usable" --
+// use IsNativeServiceServing for that (issue #649).
+//
+// The distinction is load-bearing in both directions, which is why there are two
+// functions rather than one:
+//
+//   - Health / advertise / start-short-circuit paths must NOT use this. `pgrep
+//     -f` is a substring match against the whole command line, so `ollama run`,
+//     an `ollama` mentioned in some other process's argv, or a `journalctl -u
+//     ollama` all satisfy it while the server is down. That is exactly how node
+//     1297 reported "Service ollama is already running" with `systemctl
+//     is-active ollama` saying `inactive` and the API answering nothing.
+//   - Stop / teardown paths must NOT use the serving probe. A wedged engine that
+//     has stopped answering is still a process holding VRAM; treating it as
+//     "not running" would report success and leave it alive forever.
 func IsNativeServiceRunning(serviceName string) bool {
 	service, ok := NativeServices[serviceName]
 	if !ok {
@@ -200,6 +242,23 @@ func IsNativeServiceRunning(serviceName string) bool {
 	// This is a simple check using pgrep
 	cmd := exec.Command("pgrep", "-f", service.Binary)
 	return cmd.Run() == nil
+}
+
+// IsNativeServiceServing reports whether a native service is actually answering
+// on its port. This is the predicate every health, advertise and
+// "already running, nothing to do" decision wants: routing depends on the engine
+// responding, not on a process existing (issue #649).
+//
+// It deliberately does not consult the process list at all. If the port answers
+// the engine is usable however it was started (systemd, a hand-run binary, a
+// supervisor) -- and if the port does not answer, the engine is not usable no
+// matter how many matching processes exist.
+func IsNativeServiceServing(serviceName string) bool {
+	service, ok := NativeServices[serviceName]
+	if !ok {
+		return false
+	}
+	return portAnswers(service.Port, nativeProbeTimeout)
 }
 
 // StopNativeService stops a running native service
@@ -222,7 +281,12 @@ func StopNativeService(serviceName string) error {
 	return nil
 }
 
-// WaitForServiceReady waits for a service to be ready by checking its port
+// WaitForServiceReady waits for a service to be ready by checking its port.
+//
+// The readiness test is the same portAnswers used by IsNativeServiceServing, so
+// "ready" and "serving" cannot drift apart. It previously shelled out to `nc -z`,
+// which silently never succeeds on an image without netcat -- every start would
+// then fail with a spurious timeout and kill the engine it had just launched.
 func WaitForServiceReady(serviceName string, timeout time.Duration) error {
 	service, ok := NativeServices[serviceName]
 	if !ok {
@@ -237,9 +301,7 @@ func WaitForServiceReady(serviceName string, timeout time.Duration) error {
 		case <-ctx.Done():
 			return fmt.Errorf("timeout waiting for service %s to be ready on port %d", serviceName, service.Port)
 		default:
-			// Try to connect to the port
-			cmd := exec.Command("nc", "-z", "localhost", fmt.Sprintf("%d", service.Port))
-			if cmd.Run() == nil {
+			if portAnswers(service.Port, nativeProbeTimeout) {
 				return nil
 			}
 			time.Sleep(500 * time.Millisecond)

--- a/internal/services/native_serving_test.go
+++ b/internal/services/native_serving_test.go
@@ -1,0 +1,88 @@
+// internal/services/native_serving_test.go
+package services
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// listenOnFreePort opens a real listener and returns its port. The tests use a
+// live socket rather than a mock because the whole point of the #649 fix is that
+// the predicate consults the network instead of the process table -- a mocked
+// dialer would test the mock.
+func listenOnFreePort(t *testing.T) (port int, closeFn func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	return ln.Addr().(*net.TCPAddr).Port, func() { _ = ln.Close() }
+}
+
+// TestPortAnswersDistinguishesLiveFromDeadPort is the core of #649: the fix is
+// only worth anything if the probe actually changes answer when the socket goes
+// away. Asserting only the live case would pass against a stub that always
+// returns true.
+func TestPortAnswersDistinguishesLiveFromDeadPort(t *testing.T) {
+	port, closeFn := listenOnFreePort(t)
+	if !portAnswers(port, time.Second) {
+		t.Fatalf("expected port %d to answer while a listener is open", port)
+	}
+
+	closeFn()
+	if portAnswers(port, 250*time.Millisecond) {
+		t.Errorf("expected port %d NOT to answer after the listener closed", port)
+	}
+}
+
+// TestPortAnswersRejectsUnsetPort covers the fail-closed path for a service with
+// no configured port. Returning true there would reinstate the bug for any
+// future engine added to NativeServices without a port.
+func TestPortAnswersRejectsUnsetPort(t *testing.T) {
+	if portAnswers(0, time.Second) {
+		t.Error("port 0 must never be reported as answering")
+	}
+	if portAnswers(-1, time.Second) {
+		t.Error("a negative port must never be reported as answering")
+	}
+}
+
+// TestIsNativeServiceServingUnknownServiceFailsClosed pins that an unrecognised
+// service name is not serving. It shares this with IsNativeServiceRunning, but
+// the two are separate functions now and a copy-paste that forgot the guard
+// would dial port 0 forever.
+func TestIsNativeServiceServingUnknownServiceFailsClosed(t *testing.T) {
+	if IsNativeServiceServing("definitely-not-an-engine") {
+		t.Error("an unknown service must never be reported as serving")
+	}
+}
+
+// TestIsNativeServiceServingFollowsThePort is the end-to-end shape of the bug on
+// node 1297: ollama's port is dead, so ollama is not serving -- regardless of
+// what the process table says. The suite cannot bind 11434 (it may be in use, and
+// tests must not fight a real engine), so this asserts the negative direction,
+// which is the one the fix exists for. The positive direction is covered by
+// TestPortAnswersDistinguishesLiveFromDeadPort against the same helper.
+func TestIsNativeServiceServingFollowsThePort(t *testing.T) {
+	const name = "probe-test-engine"
+	port, closeFn := listenOnFreePort(t)
+	closeFn() // nothing is listening now
+
+	original, had := NativeServices[name]
+	NativeServices[name] = NativeService{Name: name, Binary: "sh", Port: port}
+	t.Cleanup(func() {
+		if had {
+			NativeServices[name] = original
+		} else {
+			delete(NativeServices, name)
+		}
+	})
+
+	// "sh" is chosen as the binary precisely because `pgrep -f sh` matches
+	// something on essentially any machine -- the loose process check that caused
+	// #649. The serving probe must disagree with it.
+	if IsNativeServiceServing(name) {
+		t.Error("engine must not be reported as serving when its port is dead")
+	}
+}

--- a/internal/status/engines.go
+++ b/internal/status/engines.go
@@ -187,7 +187,11 @@ func managedEnginePortIfRunning(engineBin, name string) (port int, running bool)
 	if containerRunning(engineBin, "citadel-"+name) {
 		return managedEngineHostPort(name), true
 	}
-	if nativesvc.IsNativeServiceRunning(name) {
+	// Serving, not process-present (#649). This function decides what the node
+	// tells the fabric it can serve, so a `pgrep` match on a dead engine here
+	// became "keep routing inference to this node" -- every request then timed
+	// out. IsNativeServiceServing asks the only question routing depends on.
+	if nativesvc.IsNativeServiceServing(name) {
 		if p, ok := nativesvc.GetServicePort(name); ok {
 			return p, true
 		}

--- a/internal/status/local_engines.go
+++ b/internal/status/local_engines.go
@@ -33,26 +33,48 @@ type LocalEngine struct {
 // ModelDiscoveryTimeout so a slow/hung engine never stalls discovery; a failed
 // probe simply leaves Models empty.
 func DiscoverLocalEngines(ctx context.Context) []LocalEngine {
-	engineBin := catalog.SelectContainerRuntime().EngineBin
-	md := NewModelDiscovery()
+	return discoverLocalEngines(ctx, catalog.SelectContainerRuntime().EngineBin, managedEnginePortIfRunning, NewModelDiscovery())
+}
 
+// modelLister is the slice of ModelDiscovery that discoverLocalEngines needs.
+// Narrow interface + injected running-check so the SELECTION logic (which engine
+// makes it into the list) is unit-testable without a live engine, docker, or a
+// bound port -- mirroring how internal/mesh injects its Dialer and PeerLister.
+type modelLister interface {
+	DiscoverModels(ctx context.Context, serviceType string, port int) ([]string, error)
+}
+
+func discoverLocalEngines(
+	ctx context.Context,
+	engineBin string,
+	portIfRunning func(engineBin, name string) (int, bool),
+	md modelLister,
+) []LocalEngine {
 	var out []LocalEngine
 	for _, name := range managedProbeEngines {
-		port, running := managedEnginePortIfRunning(engineBin, name)
+		port, running := portIfRunning(engineBin, name)
 		if !running || port <= 0 {
 			continue
 		}
 
-		eng := LocalEngine{Name: name, Port: port}
-
 		mctx, cancel := context.WithTimeout(ctx, ModelDiscoveryTimeout)
 		models, err := md.DiscoverModels(mctx, name, port)
 		cancel()
-		if err == nil {
-			eng.Models = models
+		if err != nil {
+			// The engine did not answer -- drop it (#649). This list is not just
+			// informational: nodeIsServingModels gates the shared
+			// jobs:v1:gpu-general subscription on it being non-empty, so a
+			// non-answering engine here made the node claim inference jobs it
+			// could not serve, and every one of them timed out.
+			//
+			// This keys on the ERROR, not on len(models), so the documented
+			// "running but nothing pulled" case is preserved: a live ollama with
+			// no models returns an empty list with err == nil and is still
+			// reported as a real engine.
+			continue
 		}
 
-		out = append(out, eng)
+		out = append(out, LocalEngine{Name: name, Port: port, Models: models})
 	}
 	return out
 }

--- a/internal/status/local_engines_test.go
+++ b/internal/status/local_engines_test.go
@@ -1,0 +1,93 @@
+package status
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// stubModelLister answers DiscoverModels from a fixed per-engine table.
+type stubModelLister struct {
+	models map[string][]string
+	errs   map[string]error
+}
+
+func (s stubModelLister) DiscoverModels(_ context.Context, serviceType string, _ int) ([]string, error) {
+	if err, ok := s.errs[serviceType]; ok {
+		return nil, err
+	}
+	return s.models[serviceType], nil
+}
+
+// runningFor returns a portIfRunning stub that claims the named engines are
+// running (the state the pre-#649 process check reported for a dead ollama).
+func runningFor(names ...string) func(string, string) (int, bool) {
+	set := map[string]bool{}
+	for _, n := range names {
+		set[n] = true
+	}
+	return func(_, name string) (int, bool) {
+		if set[name] {
+			return 11434, true
+		}
+		return 0, false
+	}
+}
+
+// TestDiscoverLocalEnginesDropsNonAnsweringEngine is the advertise half of #649.
+//
+// This list is not merely informational: cmd/work.go's nodeIsServingModels gates
+// the shared jobs:v1:gpu-general subscription on it being non-empty, so an
+// engine reported here that cannot actually answer makes the node claim
+// inference jobs it cannot serve -- and every one of them times out at the
+// caller. An engine whose API errors must not appear.
+func TestDiscoverLocalEnginesDropsNonAnsweringEngine(t *testing.T) {
+	md := stubModelLister{errs: map[string]error{"ollama": errors.New("connection refused")}}
+
+	got := discoverLocalEngines(context.Background(), "docker", runningFor("ollama"), md)
+
+	for _, e := range got {
+		if e.Name == "ollama" {
+			t.Fatalf("a non-answering engine must not be advertised, got %+v", got)
+		}
+	}
+}
+
+// TestDiscoverLocalEnginesKeepsRunningButEmptyEngine pins the case the drop must
+// NOT catch. A live ollama with nothing pulled answers /api/tags with an empty
+// list and a nil error -- that is real, reportable state, and the package
+// documents it as such.
+//
+// This is why the skip keys on the ERROR rather than on len(models): the two
+// cases are indistinguishable by model count and only the error separates
+// "running and empty" from "not there at all".
+func TestDiscoverLocalEnginesKeepsRunningButEmptyEngine(t *testing.T) {
+	md := stubModelLister{models: map[string][]string{"ollama": {}}}
+
+	got := discoverLocalEngines(context.Background(), "docker", runningFor("ollama"), md)
+
+	found := false
+	for _, e := range got {
+		if e.Name == "ollama" {
+			found = true
+			if len(e.Models) != 0 {
+				t.Errorf("expected no models, got %v", e.Models)
+			}
+		}
+	}
+	if !found {
+		t.Error("a live engine with nothing pulled is real state and must still be reported")
+	}
+}
+
+// TestDiscoverLocalEnginesReportsModels is the ordinary healthy path, so the
+// two tests above cannot both pass by the function returning nothing ever.
+func TestDiscoverLocalEnginesReportsModels(t *testing.T) {
+	md := stubModelLister{models: map[string][]string{"ollama": {"llama3.1:8b"}}}
+
+	got := discoverLocalEngines(context.Background(), "docker", runningFor("ollama"), md)
+
+	if len(got) != 1 || got[0].Name != "ollama" || len(got[0].Models) != 1 || got[0].Models[0] != "llama3.1:8b" {
+		t.Fatalf("expected ollama serving llama3.1:8b, got %+v", got)
+	}
+}


### PR DESCRIPTION
Closes #649.

## Context

Node 1297 logged `✅ Service ollama is already running` while `systemctl is-active ollama` said `inactive` and `curl /api/tags` answered nothing. The platform kept advertising the node as serving `llama3.1:8b`, so the coordinator kept routing inference to a dead engine and every request timed out.

## Root cause

`IsNativeServiceRunning` is `pgrep -f <binary>` — a **substring match against the whole command line**. `ollama run`, a `journalctl -u ollama`, or any process with `ollama` in argv satisfies it while the server is down. It was being used as a health check.

## The two predicates

One function was answering two different questions, and its callers want **opposite** failure modes. So there are now two:

| | question | used by |
|---|---|---|
| `IsNativeServiceServing` *(new)* | does the port answer? | health, advertise, already-running short-circuit |
| `IsNativeServiceRunning` *(unchanged)* | does a process exist? | `serviceStop` only |

The stop path deliberately keeps the loose predicate: a wedged engine that stopped answering is still a process holding VRAM, and treating it as "not running" would report success and leave it alive forever. That's the one place where "a process matches" is the correct question.

Switched to the serving probe: `cmd/service.go` `startNativeService`, `serviceStatus`, and `serviceStart`'s already-running short-circuit.

## The advertise half — this is where the damage was

`managedEnginePortIfRunning` (which decides what the node tells the fabric it can serve) now requires serving.

`DiscoverLocalEngines` had a **second, separate hole**: it reported an engine whose model discovery *errored*, with an empty model list. That list is not informational — `cmd/work.go`'s `nodeIsServingModels` gates the shared `jobs:v1:gpu-general` subscription on it being non-empty, so a dead engine made the node claim inference jobs it could not serve. It now skips on the error.

The skip keys on the **error**, not on `len(models)`: a live ollama with nothing pulled returns an empty list with a `nil` error, and the package documents that as real, reportable state. Model count cannot tell the two cases apart.

## Also fixed

`WaitForServiceReady` shelled out to `nc -z`. On an image without netcat (slim containers, LXC templates) that never succeeds, so every start would fail with a spurious timeout **and kill the engine it had just launched**. It now uses the same `portAnswers` as the serving probe, so "ready" and "serving" cannot drift apart.

The probe is bounded at 1.5s and fails closed — it runs on the heartbeat collection path, so a socket that accepts and then goes silent must not stall the collector (#548).

## Testing

`go test ./...` and `go vet ./...` green.

- `portAnswers` is asserted against a real listener in **both** directions — open, then closed. Asserting only the live case passes against a stub that always returns `true`.
- `DiscoverLocalEngines` selection is now unit-testable via an injected running-check plus a narrow `modelLister` interface, mirroring how `internal/mesh` injects its `Dialer`/`PeerLister`. Covers drop-on-error, **keep** on running-but-empty, and the healthy path. **Mutation tested:** disabling the skip fails the drop test.
- `TestServiceStartNativeOllama_DeadEngineIsStartedNotShortCircuited` drives the handler on the node-1297 shape: process matches, port dead, engine must actually be started.

Three pre-existing native-start tests faked `pgrep` to mean "already running" — exactly the predicate this fixes — so they now bind a real listener on an ephemeral port (`serveNativeEngine`). The dead-engine test uses `deadNativeEngine` to pin a **closed** port rather than relying on 11434 being free, so it cannot fail on a developer machine with ollama running.

To verify by hand: stop ollama (`systemctl stop ollama`), leave any `ollama`-matching process around, then `citadel service start ollama` — it should start the engine instead of printing "already running", and `citadel status` / the heartbeat should stop listing its models.

## Note

Unrelated to this diff: `internal/nodeindex`'s `TestHNSWParityWithBruteForce` failed once during a loaded full-suite run here, and passes 20/20 in isolation. This branch touches no file in that package. Filed separately.