### PR TITLE
fix(network): wire the engine's diagnostic logger once, for every command (#662)

### DIFF
--- a/cmd/network_logf_test.go
+++ b/cmd/network_logf_test.go
@@ -1,0 +1,60 @@
+// cmd/network_logf_test.go
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/network"
+	"github.com/spf13/cobra"
+)
+
+// TestRootPersistentPreRunWiresNetworkLogf is the regression test for #662.
+//
+// internal/network's logf defaults to a no-op, so a command that never calls
+// SetLogf discards every engine diagnostic -- and the discard is INVISIBLE:
+// every call site still compiles, still runs, and produces no signal that
+// anything was lost. That is what made this cost hours in #643. A no-op logger
+// cannot be distinguished from a working one by observing behaviour, so the
+// wiring itself has to be asserted.
+func TestRootPersistentPreRunWiresNetworkLogf(t *testing.T) {
+	if rootCmd.PersistentPreRun == nil {
+		t.Fatal("rootCmd has no PersistentPreRun, so nothing wires the network logger")
+	}
+
+	rootCmd.PersistentPreRun(rootCmd, nil)
+
+	if !network.LogfConfigured() {
+		t.Error("PersistentPreRun must install a real network diagnostic logger; " +
+			"without it every command silently discards engine diagnostics (#662)")
+	}
+}
+
+// TestNoSubcommandShadowsRootPersistentPreRun guards the trap that would undo
+// the fix silently.
+//
+// Cobra runs only the CLOSEST PersistentPreRun in the chain, not all of them. A
+// subcommand that grows its own would stop inheriting the root's wiring and go
+// back to discarding diagnostics -- with no compile error and no test failure
+// anywhere else. If this fires, the new hook must call
+// rootCmd.PersistentPreRun(cmd, args) itself.
+func TestNoSubcommandShadowsRootPersistentPreRun(t *testing.T) {
+	var shadowed []string
+	var walk func(c *cobra.Command)
+	walk = func(c *cobra.Command) {
+		for _, sub := range c.Commands() {
+			if sub.PersistentPreRun != nil || sub.PersistentPreRunE != nil {
+				shadowed = append(shadowed, sub.CommandPath())
+			}
+			walk(sub)
+		}
+	}
+	walk(rootCmd)
+
+	if len(shadowed) > 0 {
+		t.Errorf("these commands define their own PersistentPreRun, which shadows the root hook "+
+			"and drops the network-logf wiring (#662): %s\n"+
+			"Each must call rootCmd.PersistentPreRun(cmd, args) itself.",
+			strings.Join(shadowed, ", "))
+	}
+}

--- a/cmd/reconnect.go
+++ b/cmd/reconnect.go
@@ -69,8 +69,8 @@ func runReconnect() {
 		apiBaseURL = authServiceURL
 	}
 
-	// Wire up diagnostic logging
-	network.SetLogf(Debug)
+	// Diagnostic logging is wired once in root.go's PersistentPreRun (#662),
+	// so every command gets it -- not just the ones that remembered.
 
 	var result VPNRecoveryResult
 	if reconnectForce {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/aceteam-ai/citadel-cli/internal/catalog"
 	"github.com/aceteam-ai/citadel-cli/internal/clilog"
+	"github.com/aceteam-ai/citadel-cli/internal/network"
 	"github.com/aceteam-ai/citadel-cli/internal/tui"
 	"github.com/aceteam-ai/citadel-cli/internal/update"
 	"github.com/fatih/color"
@@ -110,6 +111,30 @@ control center. All other subcommands are for scripting and advanced use.`,
 		if cmd.Name() == "mcp" {
 			debugToStderr = true
 		}
+
+		// Route the network engine's diagnostics into the CLI log for EVERY
+		// command, not just the two that remembered to ask (#662).
+		//
+		// internal/network's logf defaults to a no-op, so a command that skipped
+		// this discarded backend-state transitions, control-plane auth results
+		// and route/DNS reconfiguration -- the exact lines that turn "Error:
+		// timeout waiting for network connection" into a diagnosis. In #643 that
+		// opaque line was a node parked in NeedsLogin, and `Switching ipn state
+		// NoState -> NeedsLogin` had been generated and thrown away the whole
+		// time.
+		//
+		// Wired here rather than per-command because a checklist of 18 bring-up
+		// sites cannot hold: a missing call is invisible until someone is already
+		// debugging a production problem with no output to read. PersistentPreRun
+		// runs before any command's Run, so this precedes every Connect /
+		// EnsureConnected / VerifyOrReconnect. Note for future commands: if you
+		// ever give a subcommand its OWN PersistentPreRun, cobra runs only the
+		// closest one in the chain and this wiring is lost -- call
+		// rootCmd.PersistentPreRun from it.
+		//
+		// Debug routes to the dated log file always and to the console only under
+		// --debug, so this costs nothing at the terminal.
+		network.SetLogf(Debug)
 
 		// Handle global --no-color flag and NO_COLOR env var
 		if noColorGlobal || os.Getenv("NO_COLOR") != "" {

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -855,7 +855,7 @@ func runWork(cmd *cobra.Command, args []string) {
 	// Ensure network connection is established (reconnects if state exists).
 	// Uses attemptVPNRecovery (shared with 'citadel reconnect') to handle
 	// stale state: IP-preserving reconnect first, then clear + fresh connect.
-	network.SetLogf(Debug)
+	// (network.SetLogf is wired once in root.go's PersistentPreRun -- #662.)
 	Log("verifying network connection (state_dir=%s, has_state=%v)...",
 		network.GetStateDir(), network.HasState())
 	connected, err := network.VerifyOrReconnect(ctx)

--- a/internal/network/server.go
+++ b/internal/network/server.go
@@ -24,14 +24,30 @@ import (
 // through the Debug/Log infrastructure (which respects --debug).
 var logf = func(format string, args ...any) {}
 
+// logfSet records whether SetLogf has installed a real logger. It exists so the
+// wiring can be asserted in a test: a no-op logf is indistinguishable from a
+// working one at every call site, which is precisely how #643 lost hours to
+// diagnostics that were being generated and discarded.
+var logfSet bool
+
 // SetLogf sets the package-level diagnostic logger. Pass cmd.Debug or
 // cmd.Log to route network-layer messages through the CLI's log infra.
 // Must be called before any Connect / VerifyOrReconnect calls.
+//
+// The CLI wires this ONCE, in rootCmd's PersistentPreRun (cmd/root.go), so
+// every command that brings up the network gets engine diagnostics without
+// having to remember. Do not add per-command calls -- see #662 for why the
+// per-command approach failed.
 func SetLogf(fn func(string, ...any)) {
 	if fn != nil {
 		logf = fn
+		logfSet = true
 	}
 }
+
+// LogfConfigured reports whether a real diagnostic logger has been installed.
+// Intended for wiring assertions, not for control flow.
+func LogfConfigured() bool { return logfSet }
 
 // NetworkServer wraps tsnet.Server with AceTeam-specific functionality.
 type NetworkServer struct {


### PR DESCRIPTION
Closes #662.

## Context

`internal/network`'s `logf` defaults to a no-op and only comes alive via `SetLogf`. Exactly **two** of the eighteen commands that bring up the network called it, so every other one silently discarded backend-state transitions, control-plane auth results, and route/DNS reconfiguration.

## Why this warrants a structural fix rather than adding the missing calls

**The discard is invisible.** Every call site still compiles, still runs, and gives no hint that anything was lost. The failure only shows up later, as an *absence*, to whoever is already debugging a production problem.

#643 is the case in point — `citadel up` failed with:

```
Error: timeout waiting for network connection
```

which reads like a network fault. It wasn't: the node was parked in `NeedsLogin` because registration had never been started. The lines that identified it (`Switching ipn state NoState -> NeedsLogin`, `authRoutine: loggedIn=false; goal=nil`) had been generated and thrown away the entire time. Today a user hitting a connection problem on `citadel login`, `citadel init` or `citadel rename` gets that same opaque line, with `--debug` doing nothing to help.

A checklist of eighteen bring-up sites cannot hold, and a missed entry is undetectable until it matters. So this takes the issue's "better" option.

## Changes

- **`cmd/root.go`** — `network.SetLogf(Debug)` in rootCmd's `PersistentPreRun`, which runs before any command's `Run` and therefore before every `Connect` / `EnsureConnected` / `VerifyOrReconnect`.
- **`cmd/work.go`, `cmd/reconnect.go`** — per-command calls removed, so there is one place that does this and no implication that new commands need their own.
- **`internal/network/server.go`** — `LogfConfigured()` so the wiring is assertable. A no-op logger is behaviourally indistinguishable from a working one, so nothing else could test this.

**No console output changes.** `Debug` always writes to the dated log file and prints only under `--debug`. What changes is that engine diagnostics now reach the log file for every command — which is what makes a post-mortem possible (#246).

## Testing

`go test ./...` and `go vet ./...` green.

- `TestRootPersistentPreRunWiresNetworkLogf` — **mutation tested**: removing the call fails it.
- `TestNoSubcommandShadowsRootPersistentPreRun` guards the trap that would undo this silently. Cobra runs only the **closest** `PersistentPreRun` in the chain, so a subcommand that grows its own would quietly stop inheriting the wiring — no compile error, no other test failing. The test walks the command tree, names any offender, and tells it to call `rootCmd.PersistentPreRun(cmd, args)` itself.

By hand: `citadel login --debug` on a node with stale state now prints backend-state transitions (issue's acceptance criterion #1). Criterion #2 — "no command that brings up the network can silently discard diagnostics" — is now structural rather than a convention, and the second test is what keeps it that way.