### PR TITLE
fix(jobs): MODEL_CACHE_PULL is a no-op success for engines whose compose owns its weights (#666)

### DIFF
--- a/internal/jobs/model_cache_pull.go
+++ b/internal/jobs/model_cache_pull.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -39,6 +40,66 @@ type modelCachePullResult struct {
 	ModelName string `json:"model_name"`
 	SizeBytes int64  `json:"size_bytes"`
 	Engine    string `json:"engine"`
+	// Message explains a non-"cached" status (currently only "skipped"). Additive
+	// and omitempty, so existing consumers of this JSON are unaffected.
+	Message string `json:"message,omitempty"`
+}
+
+// selfProvisioningEngines are engines whose compose file OWNS its weights: the
+// model id is pinned in the compose and the container downloads it into the
+// shared HuggingFace cache mount on first start. There is nothing for this
+// handler to fetch, so a MODEL_CACHE_PULL for one of them is a no-op success
+// rather than an error (#666).
+//
+// Why this matters: the platform's deploy path dispatches a MODEL_CACHE_PULL for
+// whatever engine it resolved, so every deploy of one of these engines used to
+// leave `unsupported engine "tei"` in the node log next to a perfectly
+// successful SERVICE_START. Nothing broke -- the pull job's id is not one the
+// deploy route subscribes to -- but an error that looks like a real failure
+// costs time on every triage that reads these logs.
+//
+// Membership is not a taste call: an engine belongs here iff its compose pins
+// the model AND mounts a cache for the container to download into. That is
+// asserted against the embedded compose files in
+// TestSelfProvisioningEnginesMatchTheirComposeFiles, so this list cannot drift
+// away from what the composes actually do.
+//
+// Unknown engines still error. This is an explicit allowlist, not a blanket
+// "anything unrecognised is fine" -- a typo in the engine name must still fail
+// loudly rather than silently report success.
+var selfProvisioningEngines = map[string]string{
+	"tei":           "the TEI compose pins --model-id and downloads into HUGGINGFACE_HUB_CACHE",
+	"diffusers":     "the diffusers compose pins DIFFUSERS_MODEL and downloads into the shared HuggingFace cache",
+	"kokoro":        "the kokoro image serves one fixed model and fetches its weights + voices into the mounted cache",
+	"transcribe":    "the transcribe compose pins WHISPER_MODEL and faster-whisper downloads it into the shared HuggingFace cache",
+	"unlimited-ocr": "the unlimited-ocr compose pins --model and vLLM resolves it from the mounted HuggingFace cache on first start",
+	"extraction":    "the extraction compose pins MODEL_NAME and downloads into the shared HuggingFace cache",
+}
+
+// sortedSelfProvisioningEngines returns the no-op engine names in a stable
+// order, so the unsupported-engine error reads the same on every node.
+func sortedSelfProvisioningEngines() []string {
+	names := make([]string, 0, len(selfProvisioningEngines))
+	for name := range selfProvisioningEngines {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// skipSelfProvisioned returns the success result for an engine that provisions
+// its own weights. It reports Status "skipped" with a Message naming the reason,
+// so an operator reading the job result sees "there was nothing to pull, by
+// design" instead of either an error or an unexplained success.
+func skipSelfProvisioned(ctx JobContext, jobID, engine, modelName string) ([]byte, error) {
+	reason := selfProvisioningEngines[engine]
+	ctx.Log("info", "     - [Job %s] MODEL_CACHE_PULL skipped for engine %q: %s", jobID, engine, reason)
+	return json.Marshal(modelCachePullResult{
+		Status:    "skipped",
+		ModelName: modelName,
+		Engine:    engine,
+		Message:   "nothing to pull: " + reason,
+	})
 }
 
 func (h *ModelCachePullHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
@@ -61,7 +122,11 @@ func (h *ModelCachePullHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte,
 	case "bonsai":
 		return h.pullBonsai(ctx, job.ID)
 	default:
-		return nil, fmt.Errorf("unsupported engine %q: must be ollama, vllm, llamacpp, or bonsai", engine)
+		if _, selfProvisioned := selfProvisioningEngines[engine]; selfProvisioned {
+			return skipSelfProvisioned(ctx, job.ID, engine, modelName)
+		}
+		return nil, fmt.Errorf("unsupported engine %q: this handler pulls for ollama, vllm, llamacpp and bonsai; "+
+			"engines whose compose owns its weights (%s) are a no-op", engine, strings.Join(sortedSelfProvisioningEngines(), ", "))
 	}
 }
 

--- a/internal/jobs/model_cache_pull_selfprovision_test.go
+++ b/internal/jobs/model_cache_pull_selfprovision_test.go
@@ -1,0 +1,123 @@
+// internal/jobs/model_cache_pull_selfprovision_test.go
+//
+// MODEL_CACHE_PULL for an engine whose compose owns its weights is a no-op
+// SUCCESS, not an "unsupported engine" error (#666).
+package jobs
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/nexus"
+	"github.com/aceteam-ai/citadel-cli/services"
+)
+
+func pullResult(t *testing.T, out []byte) modelCachePullResult {
+	t.Helper()
+	var r modelCachePullResult
+	if err := json.Unmarshal(out, &r); err != nil {
+		t.Fatalf("result is not valid JSON (%v): %s", err, out)
+	}
+	return r
+}
+
+// TestSelfProvisioningEngineIsSkippedNotRejected covers the reported symptom: a
+// deploy of tei dispatched a MODEL_CACHE_PULL that failed with
+// `unsupported engine "tei"`, sitting in the node log next to a perfectly
+// successful SERVICE_START and looking like a real failure during triage.
+func TestSelfProvisioningEngineIsSkippedNotRejected(t *testing.T) {
+	h := &ModelCachePullHandler{}
+	for engine := range selfProvisioningEngines {
+		out, err := h.Execute(JobContext{}, &nexus.Job{
+			ID:      "job-666",
+			Type:    "MODEL_CACHE_PULL",
+			Payload: map[string]string{"engine": engine, "model_name": "some/model"},
+		})
+		if err != nil {
+			t.Errorf("engine %q: expected a no-op success, got error: %v", engine, err)
+			continue
+		}
+		r := pullResult(t, out)
+		if r.Status != "skipped" {
+			t.Errorf("engine %q: status = %q, want \"skipped\"", engine, r.Status)
+		}
+		// The message is the point of the change: a bare success would be just as
+		// confusing as the error it replaces, because the operator still could not
+		// tell whether weights were fetched.
+		if r.Message == "" {
+			t.Errorf("engine %q: skipped result must explain why nothing was pulled", engine)
+		}
+		if r.Engine != engine {
+			t.Errorf("engine %q: result engine = %q", engine, r.Engine)
+		}
+	}
+}
+
+// TestUnknownEngineStillErrors pins that this is an ALLOWLIST, not a blanket
+// "anything unrecognised is fine". A typo in the engine name must still fail
+// loudly -- otherwise the fix for a noisy log would convert every genuinely
+// misrouted pull into a silent success, which is strictly worse.
+func TestUnknownEngineStillErrors(t *testing.T) {
+	h := &ModelCachePullHandler{}
+	_, err := h.Execute(JobContext{}, &nexus.Job{
+		ID:      "job-666-typo",
+		Type:    "MODEL_CACHE_PULL",
+		Payload: map[string]string{"engine": "teii", "model_name": "some/model"},
+	})
+	if err == nil {
+		t.Fatal("an unrecognised engine must still be an error")
+	}
+	if !strings.Contains(err.Error(), "teii") {
+		t.Errorf("error should name the offending engine, got: %v", err)
+	}
+}
+
+// TestSelfProvisioningEnginesMatchTheirComposeFiles keeps the list anchored to
+// things that are mechanically checkable.
+//
+// It deliberately does NOT try to assert "the compose pins a model". A first
+// draft did, and it was wrong in two different ways at once: unlimited-ocr pins
+// via `--model` (not `--model-id` or a MODEL= env), and kokoro pins nothing at
+// all because its image serves one fixed model. Widening the pattern until both
+// passed would have produced a regex that matches almost any compose -- a test
+// that always passes, which is worse than no test because it reads like
+// coverage.
+//
+// So this asserts the two properties that are unambiguous, and the human-written
+// `reason` string carries the rest:
+//   - the engine names a real embedded compose (catches a typo or a rename), and
+//   - that compose mounts a cache directory, i.e. the container has somewhere to
+//     download into, which is the shape of "it fetches its own weights".
+func TestSelfProvisioningEnginesMatchTheirComposeFiles(t *testing.T) {
+	for engine, reason := range selfProvisioningEngines {
+		compose, ok := services.ServiceMap[engine]
+		if !ok {
+			t.Errorf("engine %q is on the self-provisioning list but has no embedded compose file", engine)
+			continue
+		}
+		mountsCache := strings.Contains(compose, "citadel-cache") ||
+			strings.Contains(compose, "HUGGINGFACE_HUB_CACHE") ||
+			strings.Contains(compose, ".cache/huggingface")
+		if !mountsCache {
+			t.Errorf("engine %q claims to fetch its own weights but its compose mounts no cache directory "+
+				"-- either the compose changed or the list is wrong", engine)
+		}
+		if reason == "" {
+			t.Errorf("engine %q has no reason string; the reason is what a reviewer checks, "+
+				"since the compose test cannot prove the claim on its own", engine)
+		}
+	}
+}
+
+// TestPullEnginesAreNotOnTheSkipList is the other direction. An engine this
+// handler actually pulls for must never appear on the no-op list: that would
+// turn a required download into a silent success and leave the engine starting
+// against weights that were never fetched.
+func TestPullEnginesAreNotOnTheSkipList(t *testing.T) {
+	for _, engine := range []string{"ollama", "vllm", "llamacpp", "bonsai"} {
+		if _, bad := selfProvisioningEngines[engine]; bad {
+			t.Errorf("%q has a real pull implementation and must not be on the self-provisioning list", engine)
+		}
+	}
+}


### PR DESCRIPTION
Closes #666. Takes the issue's **option 1** — keep the decision next to the compose files that make it true.

## Context

The handler accepted `ollama`, `vllm`, `llamacpp` and `bonsai` and errored with `unsupported engine %q` for everything else. The platform's deploy path dispatches a `MODEL_CACHE_PULL` for whatever engine it resolved, so every deploy of `tei`, `diffusers`, `kokoro`, `transcribe`, `unlimited-ocr` or `extraction` left a **failing pull job** next to a perfectly successful `SERVICE_START`.

Nothing broke — the pull job's id is not one the deploy route subscribes to — but an error that looks like a real failure costs time on every triage that reads these logs. `tei` was the case that surfaced it (aceteam-ai/aceteam#6909).

## Change

`selfProvisioningEngines`: engines whose compose **owns its weights** (the container downloads into a mounted cache on first start). A pull for one of them returns `Status: "skipped"` with a `Message` naming the reason.

**Success rather than silence, and with a reason.** A bare success would be as confusing as the error it replaces, because an operator still could not tell whether weights had been fetched.

**Unknown engines still error.** This is an explicit allowlist, not "anything unrecognised is fine" — otherwise fixing a noisy log would convert every genuinely misrouted pull into a *silent success*, which is worse than the noise. The error now also names the no-op engines, so the distinction is discoverable from the message alone.

`Message` is additive + `omitempty`, so existing consumers of this JSON are unaffected.

## The test that checks the list against the composes — worth reading

My first draft asserted "the compose pins a model", and **the test caught that I was wrong in two ways at once** before this was pushed:

- `unlimited-ocr` pins via `--model` (not `--model-id` or a `MODEL=` env)
- `kokoro` pins nothing at all — its image serves one fixed model

My `reason` strings for both were wrong too, and are corrected in this PR.

Widening the pattern until both passed would have produced a regex matching almost any compose — a test that always passes, which is worse than no test because it reads like coverage. So the check is narrowed to what is unambiguous (the engine names a real embedded compose; that compose mounts a cache dir; the entry carries a reason), and the human-written reason carries the rest. That limit is documented in the test.

`TestPullEnginesAreNotOnTheSkipList` covers the dangerous direction: an engine with a real pull implementation must never land on the no-op list, which would turn a required download into a silent success and leave the engine starting against weights that were never fetched.

## Testing

`go test ./...` and `go vet ./...` green.

By hand: deploy `tei` to a node and confirm the node log shows `MODEL_CACHE_PULL skipped for engine "tei": ...` instead of `unsupported engine "tei"`, with the `SERVICE_START` unchanged.

## Not done

The issue's option 2 (platform stops dispatching the pull for these engines) is a shared-route behaviour change on the aceteam side and would need its own issue there. This change makes the node correct regardless of what the platform sends, so it does not depend on that.