### PR TITLE
fix(jobs): tell an absent extraction service apart from a slow one (#653 residual)

### DIFF
--- a/internal/jobs/extraction_handler.go
+++ b/internal/jobs/extraction_handler.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"time"
 
@@ -16,11 +17,16 @@ import (
 // ExtractionHandler proxies extraction requests to the local extraction service.
 type ExtractionHandler struct{}
 
+// extractionHostPort is the citadel-owned host port this handler talks to
+// (services/ports.go). It is a package var rather than a direct reference to the
+// const purely so tests can point it at an httptest listener; production never
+// reassigns it.
+var extractionHostPort = services.ExtractionHostPort
+
 // extractionBaseURL is the host-local base URL for the extraction service, using
-// the citadel-owned host port (services/ports.go) rather than a hardcoded
-// literal.
+// the citadel-owned host port rather than a hardcoded literal.
 func extractionBaseURL() string {
-	return fmt.Sprintf("http://localhost:%d", services.ExtractionHostPort)
+	return fmt.Sprintf("http://localhost:%d", extractionHostPort)
 }
 
 func (h *ExtractionHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, error) {
@@ -68,22 +74,76 @@ func (h *ExtractionHandler) Execute(ctx JobContext, job *nexus.Job) ([]byte, err
 	return bodyBytes, nil
 }
 
+// Readiness bounds. maxWait is the tolerance for a service that IS there and
+// still starting; notRunningGrace is the (much shorter) tolerance for one that
+// has never accepted a connection at all.
+//
+// The split exists because those are different situations with different right
+// answers, and collapsing them cost the caller 60s of silence either way
+// (citadel-cli#653). A node that simply does not run the extraction service is
+// the common case on a fabric where only some nodes carry the capability; making
+// it wait out the full startup budget produces a timeout at the caller, which is
+// the same signature as dead hardware. A few seconds is ample for a container
+// that has already been started to bind its port -- the long budget is for model
+// loading AFTER the port is up, which is what /health gates on.
+// Vars, not consts, so tests can shrink them: exercising the real 8s/60s bounds
+// would add ~20s to `go test ./...`, which scripts/release.sh gates on.
+// TestExtractionReadinessDefaults pins the production values, so shrinking them
+// in a test cannot quietly become the shipped behaviour.
+var (
+	extractionMaxWait        = 60 * time.Second
+	extractionNotRunningWait = 8 * time.Second
+	extractionPollInterval   = 1 * time.Second
+	extractionDialTimeout    = 500 * time.Millisecond
+)
+
+// waitForReady blocks until the extraction service answers /health with 200, or
+// returns an error naming WHICH failure occurred:
+//
+//   - nothing ever accepted a TCP connection -> the service is not running here
+//     (a capability this node does not provide), reported after a short grace.
+//   - the port answered but /health never returned 200 -> the service is present
+//     but did not finish starting, reported after the full budget.
+//
+// Distinguishing the two is the whole point: the first is "this node cannot do
+// that", the second is "this node is unwell". They read identically today.
 func (h *ExtractionHandler) waitForReady() error {
 	healthURL := extractionBaseURL() + "/health"
-	maxWait := 60 * time.Second
-	pollInterval := 1 * time.Second
+	addr := fmt.Sprintf("127.0.0.1:%d", extractionHostPort)
 	startTime := time.Now()
+	everAccepted := false
 
-	for time.Since(startTime) < maxWait {
+	for {
 		resp, err := http.Get(healthURL)
 		if err == nil && resp.StatusCode == http.StatusOK {
 			resp.Body.Close()
 			return nil
 		}
 		if resp != nil {
+			// A non-200 still proves something is listening and speaking HTTP.
+			everAccepted = true
 			resp.Body.Close()
 		}
-		time.Sleep(pollInterval)
+		if !everAccepted {
+			// Probe the socket directly: an HTTP error does not distinguish
+			// "connection refused" from "server returned garbage", and only the
+			// former means the service is absent.
+			if conn, dErr := net.DialTimeout("tcp", addr, extractionDialTimeout); dErr == nil {
+				_ = conn.Close()
+				everAccepted = true
+			}
+		}
+
+		elapsed := time.Since(startTime)
+		if !everAccepted && elapsed >= extractionNotRunningWait {
+			return fmt.Errorf("extraction service is not running on this node: nothing accepted a connection on %s within %v "+
+				"(start it with 'citadel service start extraction', or route this job to a node that provides the extraction capability)",
+				addr, extractionNotRunningWait)
+		}
+		if elapsed >= extractionMaxWait {
+			return fmt.Errorf("extraction service is listening on %s but did not report healthy within %v "+
+				"(it is still starting, or wedged)", addr, extractionMaxWait)
+		}
+		time.Sleep(extractionPollInterval)
 	}
-	return fmt.Errorf("extraction service did not become ready within %v", maxWait)
 }

--- a/internal/jobs/extraction_handler_ready_test.go
+++ b/internal/jobs/extraction_handler_ready_test.go
@@ -1,0 +1,146 @@
+// internal/jobs/extraction_handler_ready_test.go
+//
+// waitForReady must distinguish "this node does not run the extraction service"
+// from "the service is here but not ready yet" (#653 residual).
+package jobs
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// pinExtractionPort points the handler's target port at one of the test's
+// choosing for the duration of the test.
+func pinExtractionPort(t *testing.T, port int) {
+	t.Helper()
+	original := extractionHostPort
+	extractionHostPort = port
+	t.Cleanup(func() { extractionHostPort = original })
+}
+
+// shrinkExtractionBounds compresses the readiness budgets so the behavioural
+// tests run in milliseconds. The RATIO is what each test depends on (short grace
+// << long budget); the absolute production values are pinned separately by
+// TestExtractionReadinessDefaults.
+func shrinkExtractionBounds(t *testing.T) {
+	t.Helper()
+	maxW, notRunning, poll, dial := extractionMaxWait, extractionNotRunningWait, extractionPollInterval, extractionDialTimeout
+	extractionMaxWait = 3 * time.Second
+	extractionNotRunningWait = 300 * time.Millisecond
+	extractionPollInterval = 50 * time.Millisecond
+	extractionDialTimeout = 100 * time.Millisecond
+	t.Cleanup(func() {
+		extractionMaxWait, extractionNotRunningWait, extractionPollInterval, extractionDialTimeout = maxW, notRunning, poll, dial
+	})
+}
+
+// TestExtractionReadinessDefaults pins the SHIPPED bounds. The behavioural tests
+// shrink them for speed, so without this a change to the real budgets -- or a
+// test helper that forgot to restore them -- would go unnoticed.
+func TestExtractionReadinessDefaults(t *testing.T) {
+	if extractionNotRunningWait != 8*time.Second {
+		t.Errorf("not-running grace = %v, want 8s", extractionNotRunningWait)
+	}
+	if extractionMaxWait != 60*time.Second {
+		t.Errorf("startup budget = %v, want 60s", extractionMaxWait)
+	}
+	if extractionNotRunningWait >= extractionMaxWait {
+		t.Error("the not-running grace must be well under the startup budget, or the split buys nothing")
+	}
+}
+
+// freeClosedPort returns a port that is guaranteed to have nothing listening.
+func freeClosedPort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+	return port
+}
+
+// TestWaitForReadyNotRunningFailsFastAndSaysSo is the reported residual: with
+// nothing listening, the handler used to burn the FULL 60s startup budget before
+// erroring. If the platform's dispatch budget is shorter, the caller sees a bare
+// timeout -- the same signature as dead hardware -- for what is really "this
+// node does not provide that capability".
+//
+// Asserts both halves, because either alone is passable by a wrong
+// implementation: the elapsed bound (it no longer waits out the long budget) AND
+// the message (it says which of the two failures happened).
+func TestWaitForReadyNotRunningFailsFastAndSaysSo(t *testing.T) {
+	shrinkExtractionBounds(t)
+	pinExtractionPort(t, freeClosedPort(t))
+
+	h := &ExtractionHandler{}
+	start := time.Now()
+	err := h.waitForReady()
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error when nothing is listening")
+	}
+	if elapsed >= extractionMaxWait {
+		t.Errorf("waited %v -- must give up after the short not-running grace (%v), not the full startup budget (%v)",
+			elapsed, extractionNotRunningWait, extractionMaxWait)
+	}
+	if !strings.Contains(err.Error(), "not running on this node") {
+		t.Errorf("error must identify this as the service being absent, got: %v", err)
+	}
+}
+
+// TestWaitForReadyReturnsOnHealthy is the healthy path, so the test above cannot
+// pass by waitForReady always failing.
+func TestWaitForReadyReturnsOnHealthy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	pinExtractionPort(t, srv.Listener.Addr().(*net.TCPAddr).Port)
+
+	h := &ExtractionHandler{}
+	if err := h.waitForReady(); err != nil {
+		t.Fatalf("healthy service must be reported ready, got: %v", err)
+	}
+}
+
+// TestWaitForReadyListeningButUnhealthyKeepsTheLongBudget pins the case the
+// fast-fail must NOT steal. A service that has bound its port but is still
+// loading its model is legitimately slow, and cutting it off after the short
+// grace would break a working deploy -- turning a fix for a misleading message
+// into a real regression.
+//
+// Runs against a server that answers 503 forever; asserts the handler is still
+// waiting well past the short grace rather than giving up. It does not run to
+// the full 60s (that would make the suite unbearable) -- outliving the grace is
+// the discriminating observation.
+func TestWaitForReadyListeningButUnhealthyKeepsTheLongBudget(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+	shrinkExtractionBounds(t)
+	pinExtractionPort(t, srv.Listener.Addr().(*net.TCPAddr).Port)
+
+	done := make(chan error, 1)
+	go func() {
+		h := &ExtractionHandler{}
+		done <- h.waitForReady()
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("gave up after the short grace on a service that IS listening (err=%v); "+
+			"the long budget must still apply once the port answers", err)
+	case <-time.After(extractionNotRunningWait * 3):
+		// Still waiting, which is correct. The goroutine is left to finish on its
+		// own; it is bounded by extractionMaxWait.
+	}
+}


### PR DESCRIPTION
Follow-up to the #653 triage. **The issue as filed was wrong** — a handler *is* registered, and has been since PR #83 — but the residual I flagged when closing it is real, so this fixes that.

## The problem

`waitForReady` polled `/health` for a **full 60s** before erroring, even when nothing was listening on the port at all. Those are two different situations with different right answers, and collapsing them cost the caller 60s of silence either way:

| observed | means | right answer |
|---|---|---|
| nothing ever accepted a connection | this node does not run the extraction service | say so, quickly |
| port answers, `/health` not 200 yet | the service IS here, still loading its model | keep waiting |

The first is common on a fabric where only some nodes carry the capability. Making it wait out the whole startup budget produces a **timeout at the caller** — the same signature as dead hardware, which is exactly the confusion #653 was complaining about.

## The change

A short **8s** grace for the absent case, the full **60s** for the slow-start case, and an error that names which one happened. A few seconds is ample for a container that has already been started to bind its port; the long budget exists for model loading *after* the port is up, which is what `/health` gates on.

The socket is probed with a direct dial rather than inferred from the HTTP error — an `http.Get` failure does not distinguish "connection refused" from "server returned garbage", and only the former means absent.

## Testing

Three behaviours. **The third is the one that matters most**: a service that IS listening but unhealthy must still get the long budget. Without it, "fail fast when absent" would quietly become "kill slow starts" — turning a fix for a misleading message into a real regression.

The readiness bounds became vars so the tests can shrink them: exercising the real 8s/60s added ~20s to `go test ./...`, which `scripts/release.sh` gates on. `TestExtractionReadinessDefaults` pins the shipped values, so a shrunk bound — or a helper that forgot to restore one — cannot quietly become the shipped behaviour. `extractionHostPort` is likewise a package var over the const, purely so a test can point the handler at an `httptest` listener.

`go test ./...` and `go vet ./...` green; the readiness tests run in ~1.2s total.

By hand: on a node without the extraction service, dispatch a `GLINER_EXTRACTION` job — it should fail in ~8s with `extraction service is not running on this node: ...` instead of after 60s with `did not become ready within 1m0s`.