### PR TITLE
Gate serving on engine readiness and return typed warming, not a socket error

### DIFF
--- a/internal/worker/llm_inference.go
+++ b/internal/worker/llm_inference.go
@@ -29,11 +29,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/jobs"
 	"github.com/aceteam-ai/citadel-cli/services"
@@ -130,8 +130,22 @@ func (h *LLMInferenceHandler) Execute(ctx context.Context, job *Job, stream Stre
 			return h.failure(fmt.Errorf("model hotswap failed: %w", swapErr)), nil
 		}
 		if !outcome.Ready {
-			return h.warming(payload.Model, outcome.ETASeconds), nil
+			return h.warming(payload.Model, outcome.ETASeconds, outcome.RetryAfterSeconds), nil
 		}
+	}
+
+	// Readiness gate (citadel-cli#680): residency is "the container is up", which
+	// is NOT the same as "the engine is serving". A container that has bound its
+	// port but is still loading weights used to be proxied into, and the caller
+	// got a raw socket string. Probe every backend and answer with the typed
+	// warming signal instead. See llm_readiness.go for why the probe asks "does
+	// the API answer" rather than "does it list a model", and why the budgets
+	// differ per engine.
+	if err := h.ensureEngineReady(ctx, payload.Backend); err != nil {
+		if errors.Is(err, errEngineWarming) {
+			return h.warming(payload.Model, engineWarmETA(payload.Backend), 0), nil
+		}
+		return h.failure(err), nil
 	}
 
 	switch payload.Backend {
@@ -182,10 +196,6 @@ func parseLLMInferencePayload(data map[string]any) (*jobs.LLMInferencePayload, e
 
 // executeVLLM handles inference via vLLM's OpenAI-compatible API.
 func (h *LLMInferenceHandler) executeVLLM(ctx context.Context, stream StreamWriter, payload *jobs.LLMInferencePayload) (*JobResult, error) {
-	if err := h.waitForReady(ctx, h.baseURL("vllm")+"/health", "vLLM"); err != nil {
-		return h.failure(err), nil
-	}
-
 	// Chat-style requests (gateway `messages`) use /v1/chat/completions so vLLM
 	// applies the served model's chat template; the legacy /v1/completions prompt
 	// path is kept for prompt-style jobs.
@@ -198,9 +208,6 @@ func (h *LLMInferenceHandler) executeVLLM(ctx context.Context, stream StreamWrit
 // executeSGLang handles inference via SGLang's OpenAI-compatible API. SGLang
 // exposes the same /v1/completions endpoint and response format as vLLM.
 func (h *LLMInferenceHandler) executeSGLang(ctx context.Context, stream StreamWriter, payload *jobs.LLMInferencePayload) (*JobResult, error) {
-	if err := h.waitForReady(ctx, h.baseURL("sglang")+"/health", "SGLang"); err != nil {
-		return h.failure(err), nil
-	}
 	return h.executeCompletions(ctx, stream, payload, h.baseURL("sglang"), "SGLang")
 }
 
@@ -223,7 +230,7 @@ func (h *LLMInferenceHandler) executeCompletions(ctx context.Context, stream Str
 
 	resp, err := h.postJSON(ctx, baseURL+"/v1/completions", reqPayload)
 	if err != nil {
-		return h.failure(fmt.Errorf("failed to connect to %s: %w", engine, err)), nil
+		return h.engineRequestFailure(payload, err, "failed to connect to "+engine), nil
 	}
 	defer resp.Body.Close()
 
@@ -345,7 +352,7 @@ func (h *LLMInferenceHandler) executeOllama(ctx context.Context, stream StreamWr
 
 	resp, err := h.postJSON(ctx, h.baseURL("ollama")+"/api/generate", reqPayload)
 	if err != nil {
-		return h.failure(fmt.Errorf("failed to connect to Ollama: %w", err)), nil
+		return h.engineRequestFailure(payload, err, "failed to connect to Ollama"), nil
 	}
 	defer resp.Body.Close()
 
@@ -457,7 +464,7 @@ func (h *LLMInferenceHandler) executeOllamaChat(ctx context.Context, stream Stre
 
 	resp, err := h.postJSON(ctx, h.baseURL("ollama")+"/api/chat", reqPayload)
 	if err != nil {
-		return h.failure(fmt.Errorf("failed to connect to Ollama: %w", err)), nil
+		return h.engineRequestFailure(payload, err, "failed to connect to Ollama"), nil
 	}
 	defer resp.Body.Close()
 
@@ -587,7 +594,7 @@ func (h *LLMInferenceHandler) executeLlamaCppAt(ctx context.Context, stream Stre
 
 	resp, err := h.postJSON(ctx, baseURL+"/completion", reqPayload)
 	if err != nil {
-		return h.failure(fmt.Errorf("failed to connect to llama.cpp: %w", err)), nil
+		return h.engineRequestFailure(payload, err, "failed to connect to llama.cpp"), nil
 	}
 	defer resp.Body.Close()
 
@@ -695,7 +702,7 @@ func (h *LLMInferenceHandler) executeChatCompletionsAt(ctx context.Context, stre
 
 	resp, err := h.postJSON(ctx, baseURL+"/v1/chat/completions", reqPayload)
 	if err != nil {
-		return h.failure(fmt.Errorf("failed to connect to chat endpoint: %w", err)), nil
+		return h.engineRequestFailure(payload, err, "failed to connect to chat endpoint"), nil
 	}
 	defer resp.Body.Close()
 
@@ -861,34 +868,6 @@ func (h *LLMInferenceHandler) postJSON(ctx context.Context, url string, payload 
 	return h.client().Do(req)
 }
 
-// waitForReady polls an engine's health endpoint until it returns 200 or the
-// wait budget elapses. Honors ctx cancellation. Only the vLLM/SGLang paths use
-// it (llama.cpp/bonsai/ollama start fast and 404 /health).
-func (h *LLMInferenceHandler) waitForReady(ctx context.Context, healthURL, engine string) error {
-	maxWait := 60 * time.Second
-	pollInterval := 1 * time.Second
-	startTime := time.Now()
-
-	for time.Since(startTime) < maxWait {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
-		resp, err := h.client().Do(req)
-		if err == nil && resp.StatusCode == http.StatusOK {
-			resp.Body.Close()
-			return nil
-		}
-		if resp != nil {
-			resp.Body.Close()
-		}
-		time.Sleep(pollInterval)
-	}
-	return fmt.Errorf("%s did not become ready within %v", engine, maxWait)
-}
-
 func (h *LLMInferenceHandler) client() *http.Client {
 	if h.httpClient != nil {
 		return h.httpClient
@@ -910,15 +889,25 @@ func (h *LLMInferenceHandler) success(output map[string]any) *JobResult {
 	return &JobResult{Status: JobStatusSuccess, Output: output}
 }
 
-// warming returns the structured model_warming result (citadel-cli#632) for a
-// swap that did not become ready within the wait budget. It is a SUCCESS result
-// (so the runner WriteEnds + Acks it) carrying a control payload rather than
-// assistant content — deliberately no WriteChunk, so the platform relays the
-// warming signal instead of streaming it as a reply. The platform inspects
+// warming returns the structured model_warming result (citadel-cli#632) for an
+// engine that is not serving yet: a swap that did not become ready within the
+// wait budget, an engine that is up but still loading (citadel-cli#680), or one
+// that dropped the connection mid-handshake. It is a SUCCESS result (so the
+// runner WriteEnds + Acks it) carrying a control payload rather than assistant
+// content — deliberately no WriteChunk, so the platform relays the warming
+// signal instead of streaming it as a reply. The platform inspects
 // output.status == "model_warming" and retries after retry_after seconds.
-func (h *LLMInferenceHandler) warming(model string, etaSeconds int) *JobResult {
+//
+// retryAfterSeconds <= 0 falls back to the standard hint. A caller that knows
+// better (e.g. a swap for a DIFFERENT model is holding the single-flight slot,
+// so this model's load has not even started) passes its own, so the platform
+// does not busy-retry against a node that is not working on its request.
+func (h *LLMInferenceHandler) warming(model string, etaSeconds, retryAfterSeconds int) *JobResult {
 	if etaSeconds < 0 {
 		etaSeconds = 0
+	}
+	if retryAfterSeconds <= 0 {
+		retryAfterSeconds = warmingRetryAfter
 	}
 	return &JobResult{
 		Status: JobStatusSuccess,
@@ -926,9 +915,25 @@ func (h *LLMInferenceHandler) warming(model string, etaSeconds int) *JobResult {
 			"status":      "model_warming",
 			"model":       model,
 			"eta_seconds": etaSeconds,
-			"retry_after": warmingRetryAfter,
+			"retry_after": retryAfterSeconds,
 		},
 	}
+}
+
+// engineRequestFailure maps an outbound engine request error to a job result. A
+// transport-level error means the engine was not listening or dropped the
+// connection, which on a loading engine is warming, not a fault: it is answered
+// with the typed signal so `use of closed network connection` never reaches a
+// caller (citadel-cli#680). Anything else stays a genuine failure.
+func (h *LLMInferenceHandler) engineRequestFailure(
+	payload *jobs.LLMInferencePayload,
+	err error,
+	wrap string,
+) *JobResult {
+	if isEngineNotServing(err) {
+		return h.warming(payload.Model, engineWarmETA(payload.Backend), 0)
+	}
+	return h.failure(fmt.Errorf("%s: %w", wrap, err))
 }
 
 func (h *LLMInferenceHandler) failure(err error) *JobResult {

--- a/internal/worker/llm_inference.go
+++ b/internal/worker/llm_inference.go
@@ -933,6 +933,14 @@ func (h *LLMInferenceHandler) engineRequestFailure(
 	if isEngineNotServing(err) {
 		return h.warming(payload.Model, engineWarmETA(payload.Backend), 0)
 	}
+	// A refused connection here means the engine went away between the readiness
+	// probe and the request. That is warming ONLY while a start this node issued
+	// is still inside its load window; otherwise nothing is listening and no
+	// amount of retrying will change that, so it stays a failure the caller can
+	// act on (citadel-cli#705).
+	if isConnectionRefused(err) && h.engineStartInFlight(payload.Backend) {
+		return h.warming(payload.Model, engineWarmETA(payload.Backend), 0)
+	}
 	return h.failure(fmt.Errorf("%s: %w", wrap, err))
 }
 

--- a/internal/worker/llm_inference_test.go
+++ b/internal/worker/llm_inference_test.go
@@ -29,6 +29,11 @@ func TestLLMInferenceHandler_CanHandle(t *testing.T) {
 func newChatCompletionsServer(t *testing.T, frames []string, lastPath *string) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// A serving engine answers its readiness endpoint (citadel-cli#680); the
+		// handler now probes before proxying.
+		if serveReadinessProbe(w, r) {
+			return
+		}
 		if lastPath != nil {
 			*lastPath = r.URL.Path
 		}
@@ -153,6 +158,9 @@ func TestLLMInferenceHandler_BackendRouting(t *testing.T) {
 		t.Run(backend, func(t *testing.T) {
 			var gotPath string
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if serveReadinessProbe(w, r) {
+					return
+				}
 				gotPath = r.URL.Path
 				if r.URL.Path != "/v1/chat/completions" {
 					http.Error(w, "unexpected path", http.StatusNotFound)
@@ -208,6 +216,9 @@ func TestLLMInferenceHandler_BackendRouting(t *testing.T) {
 		var gotPath, gotPrompt string
 		var sawMessages bool
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if serveReadinessProbe(w, r) {
+				return
+			}
 			gotPath = r.URL.Path
 			var req map[string]any
 			_ = json.NewDecoder(r.Body).Decode(&req)
@@ -277,6 +288,9 @@ func TestLLMInferenceHandler_BackendRouting(t *testing.T) {
 		}
 		var gotPath string
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if serveReadinessProbe(w, r) {
+				return
+			}
 			gotPath = r.URL.Path
 			if r.URL.Path != "/api/chat" {
 				http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
@@ -327,6 +341,9 @@ func TestLLMInferenceHandler_BackendRouting(t *testing.T) {
 	t.Run("ollama prompt still routes to /api/generate", func(t *testing.T) {
 		var gotPath string
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if serveReadinessProbe(w, r) {
+				return
+			}
 			gotPath = r.URL.Path
 			if r.URL.Path != "/api/generate" {
 				http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)

--- a/internal/worker/llm_readiness.go
+++ b/internal/worker/llm_readiness.go
@@ -43,6 +43,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -75,6 +76,60 @@ var engineReadyPath = map[string]string{
 // engineReadyBudgetOverride shortens the budget in tests. Nil in production.
 var engineReadyBudgetOverride *time.Duration
 
+// engineStartBudget is how long after a start attempt "nothing is listening on
+// the engine's port" is still an expected state rather than a fault
+// (citadel-cli#705). A cold start binds its port somewhere inside its own load
+// window, so the per-engine load estimate is the honest ceiling; past it, a
+// refused connection means the start did not take.
+func engineStartBudget(backend string) time.Duration {
+	return defaultLoadEstimate(backend)
+}
+
+// probeOutcome is what a single readiness probe learned. Splitting "nothing is
+// listening" from "something answered badly" is the whole point of
+// citadel-cli#705: the first is a start that did not take (a hard error unless a
+// start is known to be in flight), the second is a real server that is not ready
+// yet (warming). Collapsing both to a bool made a never-started engine report
+// model_warming forever.
+type probeOutcome int
+
+const (
+	// probeServing: the engine answered 200. Safe to proxy.
+	probeServing probeOutcome = iota
+	// probeNotServing: something is listening but did not answer 200 (it accepted
+	// and closed, returned 503, timed out mid-response). A loading engine.
+	probeNotServing
+	// probeNoListener: the connection was refused, so nothing is bound to the
+	// port at all. Either the engine was never started or its start failed.
+	probeNoListener
+)
+
+// engineStartTracker reports when a start of an engine was last attempted on
+// this node. Implemented by *SwapManager, which is the component that actually
+// issues the start, so readiness never has to infer liveness from the probe
+// alone. Optional: when nothing tracks starts (hotswap disabled), a refused
+// connection is taken at face value and reported as an error, which is the
+// actionable answer.
+type engineStartTracker interface {
+	// EngineStartedAt returns the time of the last start attempt for backend and
+	// whether one is on record.
+	EngineStartedAt(backend string) (time.Time, bool)
+}
+
+// engineStartInFlight reports whether a start of backend is known to have been
+// attempted recently enough that an unbound port is still expected.
+func (h *LLMInferenceHandler) engineStartInFlight(backend string) bool {
+	tracker, ok := h.swapper.(engineStartTracker)
+	if !ok {
+		return false
+	}
+	startedAt, known := tracker.EngineStartedAt(backend)
+	if !known {
+		return false
+	}
+	return time.Since(startedAt) < engineStartBudget(backend)
+}
+
 // engineReadyBudget is how long to wait for an engine to start answering before
 // reporting it as warming.
 func engineReadyBudget(backend string) time.Duration {
@@ -100,6 +155,8 @@ func engineWarmETA(backend string) int {
 // or the per-engine budget elapses. A nil error means the engine is serving and
 // the request may be proxied. errEngineWarming means it is up but not serving
 // yet; the caller must return a typed warming result, never proxy into it.
+// errEngineNotRunning means nothing is listening at all and no start is in
+// flight, so waiting cannot help; the caller must fail the job.
 //
 // A backend with no known readiness endpoint is treated as ready (fail-open), so
 // adding a backend can never silently make it unservable.
@@ -118,8 +175,21 @@ func (h *LLMInferenceHandler) ensureEngineReady(ctx context.Context, backend str
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if h.probeEngine(ctx, baseURL+path) {
+		switch h.probeEngine(ctx, baseURL+path) {
+		case probeServing:
 			return nil
+		case probeNoListener:
+			// Nothing is bound to the port. That is only a normal, transient state
+			// while a start this node issued is still inside its load window
+			// (citadel-cli#705). Otherwise the engine is simply not running, and
+			// polling until the budget elapses would answer "warming, retry in 10s"
+			// to a caller whose retries can never succeed.
+			if !h.engineStartInFlight(backend) {
+				return fmt.Errorf(
+					"%w: %s is not running, nothing is listening on %s",
+					errEngineNotRunning, backend, baseURL,
+				)
+			}
 		}
 		if time.Now().After(deadline) {
 			return fmt.Errorf("%w: %s is not serving yet", errEngineWarming, backend)
@@ -132,27 +202,59 @@ func (h *LLMInferenceHandler) ensureEngineReady(ctx context.Context, backend str
 	}
 }
 
-// probeEngine reports whether a single GET returns 200. Bounded by its own short
-// timeout so a hung engine cannot consume the whole budget in one attempt.
-func (h *LLMInferenceHandler) probeEngine(ctx context.Context, url string) bool {
+// probeEngine reports what a single GET learned about the engine. Bounded by its
+// own short timeout so a hung engine cannot consume the whole budget in one
+// attempt. It reports "no listener" separately from "listener, bad response" so
+// the caller decides what each means (citadel-cli#705).
+func (h *LLMInferenceHandler) probeEngine(ctx context.Context, url string) probeOutcome {
 	pctx, cancel := context.WithTimeout(ctx, engineProbeTimeout)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(pctx, http.MethodGet, url, nil)
 	if err != nil {
-		return false
+		return probeNotServing
 	}
 	resp, err := h.client().Do(req)
 	if err != nil {
-		return false
+		if isConnectionRefused(err) {
+			return probeNoListener
+		}
+		return probeNotServing
 	}
 	defer resp.Body.Close()
-	return resp.StatusCode == http.StatusOK
+	if resp.StatusCode != http.StatusOK {
+		return probeNotServing
+	}
+	return probeServing
 }
 
 // errEngineWarming marks "the engine is up but not serving yet" so the handler
 // can answer with a typed warming result rather than a job failure.
 var errEngineWarming = errors.New("engine warming")
+
+// errEngineNotRunning marks "nothing is listening on the engine's port and no
+// start is in flight" (citadel-cli#705). This is the honest counterpart to
+// errEngineWarming: retrying cannot fix it, so the caller must fail the job with
+// a message that names the engine instead of quoting an ETA that will never
+// arrive.
+var errEngineNotRunning = errors.New("engine not started")
+
+// isConnectionRefused reports whether err is a refused TCP connection, meaning
+// nothing at all is bound to the target port. This is deliberately NOT folded
+// into isEngineNotServing: refused is the one transport signal that says "no
+// server", while every signal that function accepts says "a server, mid-start"
+// (citadel-cli#705).
+func isConnectionRefused(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, syscall.ECONNREFUSED) {
+		return true
+	}
+	// Fallback for wrapped errors that carry only the text, and for platforms
+	// whose refused errno is not syscall.ECONNREFUSED.
+	return strings.Contains(err.Error(), "connection refused")
+}
 
 // isEngineNotServing classifies an outbound engine request error as "the engine
 // was not listening / dropped the connection" rather than a genuine failure.
@@ -162,11 +264,23 @@ var errEngineWarming = errors.New("engine warming")
 // connection mid-write, and the raw string is indistinguishable from a real
 // fault. Context cancellation and deadline expiry are deliberately NOT warming:
 // those mean the job itself was cancelled or timed out, which is a real failure.
+//
+// Connection refused is NOT warming either (citadel-cli#705). Every other signal
+// here proves a server exists and is mid-start; refused proves the opposite, and
+// lumping it in is what let a never-started engine report model_warming forever.
+// The refused check runs BEFORE the net.OpError catch-all on purpose: a refused
+// dial arrives as *url.Error wrapping *net.OpError, so the catch-all would
+// otherwise swallow it and this change would be a no-op. Callers that know a
+// start is in flight can still choose to warm on refused; see
+// engineRequestFailure.
 func isEngineNotServing(err error) bool {
 	if err == nil {
 		return false
 	}
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	if isConnectionRefused(err) {
 		return false
 	}
 	var opErr *net.OpError
@@ -176,7 +290,6 @@ func isEngineNotServing(err error) bool {
 	msg := err.Error()
 	for _, fragment := range []string{
 		"use of closed network connection",
-		"connection refused",
 		"connection reset by peer",
 		"broken pipe",
 		"server closed idle connection",

--- a/internal/worker/llm_readiness.go
+++ b/internal/worker/llm_readiness.go
@@ -1,0 +1,190 @@
+// internal/worker/llm_readiness.go
+//
+// Per-engine readiness gating for llm_inference (citadel-cli#680).
+//
+// Before this, serving was gated on residency ("the container is up"), and only
+// vllm and sglang had any pre-flight probe at all. unlimited-ocr, llamacpp,
+// bonsai and ollama were proxied straight through, so a container that had bound
+// its port but was still loading weights surfaced to the caller as a raw
+// transport string:
+//
+//	failed to connect to chat endpoint: Post "http://localhost:8213/v1/chat/completions":
+//	... use of closed network connection
+//
+// On a one-GPU box a cold start is the normal path, not an exception, so that
+// window is not a rare error branch: it is the first request of the day, every
+// day. A socket error there makes the product look broken rather than busy.
+//
+// This file adds a readiness probe for EVERY backend and turns "not serving yet"
+// into the typed warming answer the platform already understands. Two design
+// choices are deliberate and worth reading before changing them:
+//
+//  1. The probe asks "does the engine's HTTP API answer 200", NOT "does it list
+//     a model". llama.cpp and bonsai run in deferred-load / router mode where
+//     they answer /v1/models with an EMPTY list and still serve (they load on
+//     first request) -- see internal/status/local_engines.go and models.go, which
+//     both document that case. Gating on a non-empty model list would make such
+//     an engine permanently "warming" and permanently unservable. The stricter
+//     model-count predicate stays where it already lives, in the swap manager's
+//     post-start wait, where a false negative only means "keep waiting".
+//
+//  2. The engines that already had a 60s wait keep it; the four that had none get
+//     a SHORT probe. Raising every budget above the measured 78s cold start (as
+//     the issue first suggested) would exceed the platform's 120s buffered
+//     dispatch timeout and convert an honest warming answer into a 504, and it
+//     would add a 60s hang to four paths that fail fast today. A short probe plus
+//     a typed warming result tells the caller the truth sooner than any wait can.
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Readiness probe budgets. vllm and sglang keep the 60s wait they already had
+// (the vllm/sglang-only waitForReady this replaces) so their behavior does not
+// regress; the
+// engines that had no probe at all get a short one, because for them the choice
+// is between answering "loading, ~Ns" quickly and blocking a request that
+// previously failed in milliseconds.
+const (
+	engineReadyBudgetHealth = 60 * time.Second
+	engineReadyBudgetProbe  = 3 * time.Second
+	engineReadyPollEvery    = 500 * time.Millisecond
+	engineProbeTimeout      = 2 * time.Second
+)
+
+// engineReadyPath maps a backend to the endpoint that answers 200 once its API
+// is serving. These are the SAME endpoints the heartbeat's model discovery
+// already uses (internal/status/models.go), so they are proven against every
+// engine this fleet actually runs rather than guessed.
+var engineReadyPath = map[string]string{
+	"vllm":          "/health",
+	"sglang":        "/health",
+	"unlimited-ocr": "/v1/models",
+	"llamacpp":      "/v1/models",
+	"bonsai":        "/v1/models",
+	"ollama":        "/api/tags",
+}
+
+// engineReadyBudgetOverride shortens the budget in tests. Nil in production.
+var engineReadyBudgetOverride *time.Duration
+
+// engineReadyBudget is how long to wait for an engine to start answering before
+// reporting it as warming.
+func engineReadyBudget(backend string) time.Duration {
+	if engineReadyBudgetOverride != nil {
+		return *engineReadyBudgetOverride
+	}
+	switch backend {
+	case "vllm", "sglang":
+		return engineReadyBudgetHealth
+	default:
+		return engineReadyBudgetProbe
+	}
+}
+
+// engineWarmETA is the coarse remaining-load estimate reported to the caller when
+// an engine is up but not yet serving. Shares the swap manager's per-engine table
+// so one node never quotes two different numbers for the same engine.
+func engineWarmETA(backend string) int {
+	return int(defaultLoadEstimate(backend).Seconds())
+}
+
+// ensureEngineReady polls the backend's readiness endpoint until it answers 200
+// or the per-engine budget elapses. A nil error means the engine is serving and
+// the request may be proxied. errEngineWarming means it is up but not serving
+// yet; the caller must return a typed warming result, never proxy into it.
+//
+// A backend with no known readiness endpoint is treated as ready (fail-open), so
+// adding a backend can never silently make it unservable.
+func (h *LLMInferenceHandler) ensureEngineReady(ctx context.Context, backend string) error {
+	path, known := engineReadyPath[backend]
+	if !known {
+		return nil
+	}
+	baseURL := h.baseURL(backend)
+	if baseURL == "" {
+		return nil
+	}
+
+	deadline := time.Now().Add(engineReadyBudget(backend))
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if h.probeEngine(ctx, baseURL+path) {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("%w: %s is not serving yet", errEngineWarming, backend)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(engineReadyPollEvery):
+		}
+	}
+}
+
+// probeEngine reports whether a single GET returns 200. Bounded by its own short
+// timeout so a hung engine cannot consume the whole budget in one attempt.
+func (h *LLMInferenceHandler) probeEngine(ctx context.Context, url string) bool {
+	pctx, cancel := context.WithTimeout(ctx, engineProbeTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(pctx, http.MethodGet, url, nil)
+	if err != nil {
+		return false
+	}
+	resp, err := h.client().Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+// errEngineWarming marks "the engine is up but not serving yet" so the handler
+// can answer with a typed warming result rather than a job failure.
+var errEngineWarming = errors.New("engine warming")
+
+// isEngineNotServing classifies an outbound engine request error as "the engine
+// was not listening / dropped the connection" rather than a genuine failure.
+//
+// This is what stops `use of closed network connection` from ever reaching a
+// caller: a vLLM that has bound its port but not started serving closes the
+// connection mid-write, and the raw string is indistinguishable from a real
+// fault. Context cancellation and deadline expiry are deliberately NOT warming:
+// those mean the job itself was cancelled or timed out, which is a real failure.
+func isEngineNotServing(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return true
+	}
+	msg := err.Error()
+	for _, fragment := range []string{
+		"use of closed network connection",
+		"connection refused",
+		"connection reset by peer",
+		"broken pipe",
+		"server closed idle connection",
+		"EOF",
+	} {
+		if strings.Contains(msg, fragment) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/worker/llm_readiness.go
+++ b/internal/worker/llm_readiness.go
@@ -22,7 +22,7 @@
 //  1. The probe asks "does the engine's HTTP API answer 200", NOT "does it list
 //     a model". llama.cpp and bonsai run in deferred-load / router mode where
 //     they answer /v1/models with an EMPTY list and still serve (they load on
-//     first request) -- see internal/status/local_engines.go and models.go, which
+//     first request). See internal/status/local_engines.go and models.go, which
 //     both document that case. Gating on a non-empty model list would make such
 //     an engine permanently "warming" and permanently unservable. The stricter
 //     model-count predicate stays where it already lives, in the swap manager's

--- a/internal/worker/llm_readiness_test.go
+++ b/internal/worker/llm_readiness_test.go
@@ -38,7 +38,7 @@ func shortenReadinessBudget(t *testing.T, d time.Duration) {
 }
 
 // TestEnsureEngineReady_ServingEngineIsReady asserts the probe accepts an engine
-// whose API answers, for EVERY backend -- including the four that had no
+// whose API answers, for EVERY backend, including the four that had no
 // pre-flight probe at all before citadel-cli#680.
 func TestEnsureEngineReady_ServingEngineIsReady(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/worker/llm_readiness_test.go
+++ b/internal/worker/llm_readiness_test.go
@@ -1,0 +1,232 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// serveReadinessProbe answers the readiness endpoints a real serving engine
+// exposes, so an httptest engine in these tests behaves like one that is up AND
+// serving. Returns true when it handled the request (citadel-cli#680).
+func serveReadinessProbe(w http.ResponseWriter, r *http.Request) bool {
+	switch r.URL.Path {
+	case "/health":
+		w.WriteHeader(http.StatusOK)
+		return true
+	case "/v1/models":
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"m","object":"model"}]}`))
+		return true
+	case "/api/tags":
+		_, _ = w.Write([]byte(`{"models":[{"name":"m"}]}`))
+		return true
+	}
+	return false
+}
+
+// shortenReadinessBudget makes the "not serving" path fast enough to unit test
+// without waiting out the real budget.
+func shortenReadinessBudget(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := engineReadyBudgetOverride
+	engineReadyBudgetOverride = &d
+	t.Cleanup(func() { engineReadyBudgetOverride = prev })
+}
+
+// TestEnsureEngineReady_ServingEngineIsReady asserts the probe accepts an engine
+// whose API answers, for EVERY backend -- including the four that had no
+// pre-flight probe at all before citadel-cli#680.
+func TestEnsureEngineReady_ServingEngineIsReady(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if serveReadinessProbe(w, r) {
+			return
+		}
+		http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	for _, backend := range []string{"vllm", "sglang", "ollama", "llamacpp", "bonsai", "unlimited-ocr"} {
+		t.Run(backend, func(t *testing.T) {
+			h := NewLLMInferenceHandler()
+			h.baseURLs[backend] = ts.URL
+			if err := h.ensureEngineReady(context.Background(), backend); err != nil {
+				t.Fatalf("ensureEngineReady(%s) = %v, want nil", backend, err)
+			}
+		})
+	}
+}
+
+// TestEnsureEngineReady_EveryBackendIsProbed is the regression guard for the
+// actual #680 defect: only vllm and sglang were probed, so a loading
+// unlimited-ocr / llamacpp / bonsai / ollama was proxied into and the caller got
+// a socket error. Every backend must now report warming, not readiness.
+func TestEnsureEngineReady_EveryBackendIsProbed(t *testing.T) {
+	shortenReadinessBudget(t, 50*time.Millisecond)
+
+	// A listener that accepts and immediately closes: a port that is bound but
+	// not serving, which is exactly the 78s window measured on node 1297.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+
+	for _, backend := range []string{"vllm", "sglang", "ollama", "llamacpp", "bonsai", "unlimited-ocr"} {
+		t.Run(backend, func(t *testing.T) {
+			h := NewLLMInferenceHandler()
+			h.baseURLs[backend] = "http://" + ln.Addr().String()
+			err := h.ensureEngineReady(context.Background(), backend)
+			if !errors.Is(err, errEngineWarming) {
+				t.Fatalf("ensureEngineReady(%s) = %v, want errEngineWarming", backend, err)
+			}
+		})
+	}
+}
+
+// TestEnsureEngineReady_EmptyModelListIsStillReady is the deferred-load guard.
+// llama.cpp and bonsai can be up, answer /v1/models with an EMPTY list, and
+// still serve (they load on first request). Gating readiness on a non-empty
+// model list would make such an engine permanently unservable.
+func TestEnsureEngineReady_EmptyModelListIsStillReady(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
+	}))
+	defer ts.Close()
+
+	h := NewLLMInferenceHandler()
+	h.baseURLs["llamacpp"] = ts.URL
+	if err := h.ensureEngineReady(context.Background(), "llamacpp"); err != nil {
+		t.Fatalf("deferred-load llama.cpp must be servable, got %v", err)
+	}
+}
+
+// TestEnsureEngineReady_UnknownBackendFailsOpen asserts a backend with no known
+// readiness endpoint is never made unservable by this gate.
+func TestEnsureEngineReady_UnknownBackendFailsOpen(t *testing.T) {
+	h := NewLLMInferenceHandler()
+	if err := h.ensureEngineReady(context.Background(), "some-future-engine"); err != nil {
+		t.Fatalf("unknown backend must fail open, got %v", err)
+	}
+}
+
+// TestExecute_LoadingEngineReturnsWarmingNotSocketError is the end-to-end form
+// of #7220's third finding: a bound-but-not-serving port must reach the caller
+// as a typed warming result, never as `use of closed network connection`.
+func TestExecute_LoadingEngineReturnsWarmingNotSocketError(t *testing.T) {
+	shortenReadinessBudget(t, 50*time.Millisecond)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+
+	h := NewLLMInferenceHandler()
+	h.baseURLs["unlimited-ocr"] = "http://" + ln.Addr().String()
+
+	job := &Job{
+		ID:   "job-ocr",
+		Type: JobTypeLLMInference,
+		Payload: map[string]any{
+			"model":    "baidu/Unlimited-OCR",
+			"backend":  "unlimited-ocr",
+			"messages": []map[string]any{{"role": "user", "content": "read this"}},
+		},
+	}
+	stream := &MockStreamWriter{}
+	result, execErr := h.Execute(context.Background(), job, stream)
+	if execErr != nil {
+		t.Fatalf("Execute error: %v", execErr)
+	}
+	if result.Status != JobStatusSuccess {
+		t.Fatalf("warming must be a SUCCESS result, got %v (err=%v)", result.Status, result.Error)
+	}
+	if got, _ := result.Output["status"].(string); got != "model_warming" {
+		t.Fatalf("status = %q, want model_warming", got)
+	}
+	if got, _ := result.Output["model"].(string); got != "baidu/Unlimited-OCR" {
+		t.Fatalf("model = %q, want baidu/Unlimited-OCR", got)
+	}
+	if eta, _ := result.Output["eta_seconds"].(int); eta <= 0 {
+		t.Fatalf("eta_seconds = %v, want a positive estimate", eta)
+	}
+	if ra, _ := result.Output["retry_after"].(int); ra <= 0 {
+		t.Fatalf("retry_after = %v, want a positive hint", ra)
+	}
+	if len(stream.chunks) != 0 {
+		t.Fatalf("warming must emit no content chunks, got %v", stream.chunks)
+	}
+	if result.Error != nil {
+		t.Fatalf("warming must carry no error, got %v", result.Error)
+	}
+}
+
+// TestIsEngineNotServing classifies transport errors. The literal string from
+// #7220 must be recognised, and job cancellation must NOT be, or a cancelled
+// job would be reported to the caller as a model that is merely loading.
+func TestIsEngineNotServing(t *testing.T) {
+	warming := []error{
+		errors.New(`Post "http://localhost:8213/v1/chat/completions": readfrom tcp 127.0.0.1:57222->127.0.0.1:8213: write tcp: use of closed network connection`),
+		errors.New("dial tcp 127.0.0.1:8213: connect: connection refused"),
+		errors.New("read tcp: connection reset by peer"),
+		&net.OpError{Op: "dial", Err: errors.New("boom")},
+	}
+	for _, err := range warming {
+		if !isEngineNotServing(err) {
+			t.Errorf("isEngineNotServing(%v) = false, want true", err)
+		}
+	}
+
+	notWarming := []error{
+		nil,
+		context.Canceled,
+		context.DeadlineExceeded,
+		errors.New("failed to parse llama.cpp response: invalid character"),
+	}
+	for _, err := range notWarming {
+		if isEngineNotServing(err) {
+			t.Errorf("isEngineNotServing(%v) = true, want false", err)
+		}
+	}
+}
+
+// TestRetryAfterFor asserts the retry hint is paced to the quoted wait and
+// bounded, so a caller queued behind another model is neither polling every 10s
+// nor told to disappear indefinitely.
+func TestRetryAfterFor(t *testing.T) {
+	if got := retryAfterFor(3); got != warmingRetryAfter {
+		t.Errorf("retryAfterFor(3) = %d, want %d", got, warmingRetryAfter)
+	}
+	if got := retryAfterFor(45); got != 45 {
+		t.Errorf("retryAfterFor(45) = %d, want 45", got)
+	}
+	if got := retryAfterFor(9999); got != warmingRetryAfterMax {
+		t.Errorf("retryAfterFor(9999) = %d, want %d", got, warmingRetryAfterMax)
+	}
+}

--- a/internal/worker/llm_readiness_test.go
+++ b/internal/worker/llm_readiness_test.go
@@ -6,8 +6,11 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/jobs"
 )
 
 // serveReadinessProbe answers the readiness endpoints a real serving engine
@@ -190,10 +193,12 @@ func TestExecute_LoadingEngineReturnsWarmingNotSocketError(t *testing.T) {
 // TestIsEngineNotServing classifies transport errors. The literal string from
 // #7220 must be recognised, and job cancellation must NOT be, or a cancelled
 // job would be reported to the caller as a model that is merely loading.
+//
+// Connection refused is in the NOT-warming set as of citadel-cli#705: it means
+// nothing is listening, which no amount of retrying fixes.
 func TestIsEngineNotServing(t *testing.T) {
 	warming := []error{
 		errors.New(`Post "http://localhost:8213/v1/chat/completions": readfrom tcp 127.0.0.1:57222->127.0.0.1:8213: write tcp: use of closed network connection`),
-		errors.New("dial tcp 127.0.0.1:8213: connect: connection refused"),
 		errors.New("read tcp: connection reset by peer"),
 		&net.OpError{Op: "dial", Err: errors.New("boom")},
 	}
@@ -208,11 +213,227 @@ func TestIsEngineNotServing(t *testing.T) {
 		context.Canceled,
 		context.DeadlineExceeded,
 		errors.New("failed to parse llama.cpp response: invalid character"),
+		errors.New("dial tcp 127.0.0.1:8213: connect: connection refused"),
+		// The error a REAL dial to an unbound port produces. The literal string
+		// above is not enough on its own: a refused dial arrives as *url.Error
+		// wrapping *net.OpError, and the net.OpError catch-all in
+		// isEngineNotServing would swallow it, so this test would pass while
+		// production still classified refused as warming (citadel-cli#705).
+		realRefusedError(t),
 	}
 	for _, err := range notWarming {
 		if isEngineNotServing(err) {
 			t.Errorf("isEngineNotServing(%v) = true, want false", err)
 		}
+	}
+}
+
+// unboundAddr returns a host:port that is guaranteed to refuse connections: a
+// listener is bound to pick a free port, then closed. This is how the
+// never-started engine is reproduced without stopping anything real.
+func unboundAddr(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	_ = ln.Close()
+	return addr
+}
+
+// realRefusedError produces a genuine connection-refused error from the HTTP
+// client, wrappers and all.
+func realRefusedError(t *testing.T) error {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, "http://"+unboundAddr(t)+"/health", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Fatal("dial to an unbound port unexpectedly succeeded")
+	}
+	return err
+}
+
+// startTracker is a scriptable engineStartTracker + modelSwapper, standing in
+// for the swap manager's record of "did this node actually start that engine".
+type startTracker struct {
+	startedAt time.Time
+	known     bool
+}
+
+func (s *startTracker) EnsureResident(_ context.Context, _, _ string) (SwapOutcome, error) {
+	return SwapOutcome{Ready: true}, nil
+}
+
+func (s *startTracker) EngineStartedAt(string) (time.Time, bool) {
+	return s.startedAt, s.known
+}
+
+// TestIsConnectionRefused asserts the refused predicate fires on a real dial
+// error and not on the transient signals that mean "a server, mid-start".
+func TestIsConnectionRefused(t *testing.T) {
+	if !isConnectionRefused(realRefusedError(t)) {
+		t.Error("a real refused dial must be recognised as connection refused")
+	}
+	for _, err := range []error{
+		nil,
+		errors.New("use of closed network connection"),
+		errors.New("EOF"),
+		&net.OpError{Op: "read", Err: errors.New("boom")},
+	} {
+		if isConnectionRefused(err) {
+			t.Errorf("isConnectionRefused(%v) = true, want false", err)
+		}
+	}
+}
+
+// TestProbeEngine_NoListenerIsDistinctFromBadResponse is the probe half of
+// citadel-cli#705: collapsing both to false is what let the caller treat a
+// never-started engine like a loading one.
+func TestProbeEngine_NoListenerIsDistinctFromBadResponse(t *testing.T) {
+	h := NewLLMInferenceHandler()
+
+	if got := h.probeEngine(context.Background(), "http://"+unboundAddr(t)+"/health"); got != probeNoListener {
+		t.Errorf("probe of an unbound port = %v, want probeNoListener", got)
+	}
+
+	// Bound but not serving: accept and immediately close.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	if got := h.probeEngine(context.Background(), "http://"+ln.Addr().String()+"/health"); got != probeNotServing {
+		t.Errorf("probe of a bound-but-not-serving port = %v, want probeNotServing", got)
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !serveReadinessProbe(w, r) {
+			http.Error(w, "unexpected path", http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+	if got := h.probeEngine(context.Background(), ts.URL+"/health"); got != probeServing {
+		t.Errorf("probe of a serving engine = %v, want probeServing", got)
+	}
+}
+
+// TestEnsureEngineReady_NeverStartedEngineFailsFast is the headline case of
+// citadel-cli#705. Nothing is listening and no start was ever attempted, so the
+// gate must name the engine and error rather than quote an ETA that will never
+// arrive. The budget is left at its real value on purpose: the answer must come
+// back immediately, not after waiting it out.
+func TestEnsureEngineReady_NeverStartedEngineFailsFast(t *testing.T) {
+	addr := unboundAddr(t)
+
+	for _, backend := range []string{"vllm", "sglang", "ollama", "llamacpp", "bonsai", "unlimited-ocr"} {
+		t.Run(backend, func(t *testing.T) {
+			h := NewLLMInferenceHandler()
+			h.baseURLs[backend] = "http://" + addr
+
+			start := time.Now()
+			err := h.ensureEngineReady(context.Background(), backend)
+			if !errors.Is(err, errEngineNotRunning) {
+				t.Fatalf("ensureEngineReady(%s) = %v, want errEngineNotRunning", backend, err)
+			}
+			if errors.Is(err, errEngineWarming) {
+				t.Fatalf("a never-started engine must not report warming: %v", err)
+			}
+			if !strings.Contains(err.Error(), backend) {
+				t.Errorf("error must name the engine, got %q", err)
+			}
+			if elapsed := time.Since(start); elapsed > 5*time.Second {
+				t.Errorf("must fail fast, took %v", elapsed)
+			}
+		})
+	}
+}
+
+// TestEnsureEngineReady_StartingEngineStillWarms is the other half of the
+// contract: while a start this node issued is inside its load window, an unbound
+// port is a cold start, and the caller must still be told to retry. Without this
+// the fix would trade an infinite warm for a spurious hard failure on every
+// normal cold start.
+func TestEnsureEngineReady_StartingEngineStillWarms(t *testing.T) {
+	shortenReadinessBudget(t, 50*time.Millisecond)
+	addr := unboundAddr(t)
+
+	h := NewLLMInferenceHandler()
+	h.baseURLs["unlimited-ocr"] = "http://" + addr
+	h.swapper = &startTracker{startedAt: time.Now(), known: true}
+
+	err := h.ensureEngineReady(context.Background(), "unlimited-ocr")
+	if !errors.Is(err, errEngineWarming) {
+		t.Fatalf("ensureEngineReady = %v, want errEngineWarming", err)
+	}
+}
+
+// TestEnsureEngineReady_StaleStartFailsFast asserts the start record expires. A
+// start issued longer ago than the engine's own load window did not take, so the
+// port being unbound is a fault, not a cold start.
+func TestEnsureEngineReady_StaleStartFailsFast(t *testing.T) {
+	addr := unboundAddr(t)
+
+	h := NewLLMInferenceHandler()
+	h.baseURLs["unlimited-ocr"] = "http://" + addr
+	stale := time.Now().Add(-2 * engineStartBudget("unlimited-ocr"))
+	h.swapper = &startTracker{startedAt: stale, known: true}
+
+	err := h.ensureEngineReady(context.Background(), "unlimited-ocr")
+	if !errors.Is(err, errEngineNotRunning) {
+		t.Fatalf("ensureEngineReady = %v, want errEngineNotRunning", err)
+	}
+}
+
+// TestExecute_NeverStartedEngineFailsWithNamedError is the end-to-end form: the
+// caller gets an actionable failure naming the engine, not the model_warming /
+// retry_after loop reported in citadel-cli#705.
+func TestExecute_NeverStartedEngineFailsWithNamedError(t *testing.T) {
+	h := NewLLMInferenceHandler()
+	h.baseURLs["unlimited-ocr"] = "http://" + unboundAddr(t)
+
+	job := &Job{
+		ID:   "job-ocr-dead",
+		Type: JobTypeLLMInference,
+		Payload: map[string]any{
+			"model":    "baidu/Unlimited-OCR",
+			"backend":  "unlimited-ocr",
+			"messages": []map[string]any{{"role": "user", "content": "read this"}},
+		},
+	}
+	stream := &MockStreamWriter{}
+	result, execErr := h.Execute(context.Background(), job, stream)
+	if execErr != nil {
+		t.Fatalf("Execute error: %v", execErr)
+	}
+	if result.Status != JobStatusFailure {
+		t.Fatalf("status = %v, want failure (output=%v)", result.Status, result.Output)
+	}
+	if got, _ := result.Output["status"].(string); got == "model_warming" {
+		t.Fatal("a never-started engine must not be reported as model_warming")
+	}
+	msg, _ := result.Output["error"].(string)
+	if !strings.Contains(msg, "unlimited-ocr") {
+		t.Errorf("error must name the engine, got %q", msg)
+	}
+	if !strings.Contains(msg, "not running") {
+		t.Errorf("error must say the engine is not running, got %q", msg)
+	}
+	if len(stream.chunks) != 0 {
+		t.Fatalf("a failure must emit no content chunks, got %v", stream.chunks)
 	}
 }
 
@@ -228,5 +449,30 @@ func TestRetryAfterFor(t *testing.T) {
 	}
 	if got := retryAfterFor(9999); got != warmingRetryAfterMax {
 		t.Errorf("retryAfterFor(9999) = %d, want %d", got, warmingRetryAfterMax)
+	}
+}
+
+// TestEngineRequestFailure_RefusedMidRequest covers the second-line defence: an
+// engine that goes away between the readiness probe and the request. That is
+// warming only while a start this node issued is still inside its load window;
+// otherwise nothing is listening and the caller gets a failure it can act on
+// (citadel-cli#705).
+func TestEngineRequestFailure_RefusedMidRequest(t *testing.T) {
+	payload := &jobs.LLMInferencePayload{Model: "baidu/Unlimited-OCR", Backend: "unlimited-ocr"}
+	refused := realRefusedError(t)
+
+	h := NewLLMInferenceHandler()
+	result := h.engineRequestFailure(payload, refused, "failed to connect to chat endpoint")
+	if result.Status != JobStatusFailure {
+		t.Fatalf("refused with no start on record = %v, want failure", result.Status)
+	}
+
+	h.swapper = &startTracker{startedAt: time.Now(), known: true}
+	result = h.engineRequestFailure(payload, refused, "failed to connect to chat endpoint")
+	if result.Status != JobStatusSuccess {
+		t.Fatalf("refused while a start is in flight = %v, want a warming success", result.Status)
+	}
+	if got, _ := result.Output["status"].(string); got != "model_warming" {
+		t.Errorf("status = %q, want model_warming", got)
 	}
 }

--- a/internal/worker/swap.go
+++ b/internal/worker/swap.go
@@ -47,6 +47,7 @@ const (
 	swapBackgroundMaxDur = 15 * time.Minute
 	swapReadyPollEvery   = 1 * time.Second
 	warmingRetryAfter    = 10 // seconds; the platform's retry_after hint
+	warmingRetryAfterMax = 60 // seconds; ceiling on a paced retry hint
 )
 
 // SwapController abstracts the node side-effects a swap performs, so the swap
@@ -86,6 +87,11 @@ type SwapOutcome struct {
 	// ETASeconds is the estimated remaining seconds until the model is ready,
 	// surfaced in the model_warming result when Ready is false.
 	ETASeconds int
+	// RetryAfterSeconds is the hint the platform should wait before retrying.
+	// Zero means "use the standard hint". It is set above the default only when
+	// the node knows the caller's model is not being worked on yet, so a retry
+	// loop does not spin against a node doing nothing for it (citadel-cli#680).
+	RetryAfterSeconds int
 }
 
 // swapOp is a single in-flight background swap. done is closed when the swap
@@ -172,8 +178,19 @@ func (m *SwapManager) EnsureResident(ctx context.Context, backend, model string)
 
 	op := m.startOrJoin(backend, model)
 	if op == nil {
-		// A different swap is in flight — do not start a second one. Warm.
-		return SwapOutcome{Ready: false, ETASeconds: int(m.loadEstimate(backend).Seconds())}, nil
+		// A different model is being swapped in and single-flight refuses to start
+		// a second one, so THIS model's load has not begun. Reporting a bare
+		// cold-start estimate here would be a fabricated number: the real wait is
+		// the in-flight swap finishing PLUS this engine's own load. Quote that, and
+		// pace the retry hint to it, so a caller does not busy-retry a node that is
+		// not working on its request (citadel-cli#680). Telling the two cases apart
+		// on the wire ("loading yours" vs "busy with another") is citadel-cli#681.
+		eta := m.blockedETASeconds(backend)
+		return SwapOutcome{
+			Ready:             false,
+			ETASeconds:        eta,
+			RetryAfterSeconds: retryAfterFor(eta),
+		}, nil
 	}
 
 	// Observe the (possibly background) swap for the remaining wait budget.
@@ -381,4 +398,40 @@ func (m *SwapManager) etaSeconds(op *swapOp) int {
 		secs = warmingRetryAfter
 	}
 	return secs
+}
+
+// blockedETASeconds estimates the wait for a backend whose swap cannot start
+// because a DIFFERENT swap holds the single-flight slot: the in-flight swap's
+// remaining time plus this backend's own cold start. Without the first term the
+// node quotes a number that assumes work already underway that has not begun.
+func (m *SwapManager) blockedETASeconds(backend string) int {
+	own := int(m.loadEstimate(backend).Seconds())
+
+	m.mu.Lock()
+	op := m.inflight
+	m.mu.Unlock()
+	if op == nil {
+		// The blocking swap finished between startOrJoin and here. This backend
+		// still is not resident, so its own cold start is the honest estimate.
+		return own
+	}
+
+	remaining := int((op.loadEst - m.now().Sub(op.startedAt)).Seconds())
+	if remaining < 0 {
+		remaining = 0
+	}
+	return remaining + own
+}
+
+// retryAfterFor paces the platform's retry to the quoted wait, so a long queue
+// behind another model is not polled every 10 seconds. Bounded so a caller is
+// never told to disappear for an unbounded stretch.
+func retryAfterFor(etaSeconds int) int {
+	if etaSeconds <= warmingRetryAfter {
+		return warmingRetryAfter
+	}
+	if etaSeconds > warmingRetryAfterMax {
+		return warmingRetryAfterMax
+	}
+	return etaSeconds
 }

--- a/internal/worker/swap.go
+++ b/internal/worker/swap.go
@@ -129,6 +129,13 @@ type SwapManager struct {
 	inflight *swapOp              // the single in-flight swap, or nil
 	lastUsed map[string]time.Time // per-engine last request time (LRU)
 	readyAt  map[string]time.Time // per-engine last became-ready time (min-residency)
+	// startedAt records when this node last ISSUED a start for an engine, which
+	// is the only trustworthy evidence that an unbound port is a cold start
+	// rather than an engine that is simply not running (citadel-cli#705). The
+	// readiness gate reads it through EngineStartedAt; it is cleared when a start
+	// fails and when an engine is evicted, so a stale entry can never keep an
+	// absent engine reporting "warming".
+	startedAt map[string]time.Time
 }
 
 // NewSwapManager builds a swap manager with default timing and VRAM/load
@@ -146,6 +153,7 @@ func NewSwapManager(ctrl SwapController) *SwapManager {
 		readyPoll:     swapReadyPollEvery,
 		lastUsed:      map[string]time.Time{},
 		readyAt:       map[string]time.Time{},
+		startedAt:     map[string]time.Time{},
 	}
 }
 
@@ -275,7 +283,13 @@ func (m *SwapManager) runSwap(op *swapOp) {
 	}
 
 	// Start the target engine (SERVICE_START {service, model}; no vram_mb).
+	// Record the attempt BEFORE issuing it: an inline compose build can take
+	// minutes, and the readiness gate must already see the start as in flight
+	// while it runs (citadel-cli#705). A failed start clears the record so it
+	// cannot pass as evidence that the engine is on its way up.
+	m.markStartAttempted(op.backend)
 	if err := m.ctrl.Start(ctx, op.backend, op.model); err != nil {
+		m.clearStartAttempt(op.backend)
 		op.err = fmt.Errorf("failed to start %s for swap: %w", op.backend, err)
 		return
 	}
@@ -382,11 +396,40 @@ func (m *SwapManager) markReady(backend string) {
 	m.mu.Unlock()
 }
 
-// forget clears the residency window of an evicted engine.
+// forget clears the residency window of an evicted engine, and with it the
+// record that a start was ever issued: an engine we just stopped is not booting.
 func (m *SwapManager) forget(name string) {
 	m.mu.Lock()
 	delete(m.readyAt, name)
+	delete(m.startedAt, name)
 	m.mu.Unlock()
+}
+
+// markStartAttempted records that a start of backend was just issued.
+func (m *SwapManager) markStartAttempted(backend string) {
+	now := m.now()
+	m.mu.Lock()
+	m.startedAt[backend] = now
+	m.mu.Unlock()
+}
+
+// clearStartAttempt drops the start record for backend.
+func (m *SwapManager) clearStartAttempt(backend string) {
+	m.mu.Lock()
+	delete(m.startedAt, backend)
+	m.mu.Unlock()
+}
+
+// EngineStartedAt reports when this node last issued a start for backend, and
+// whether one is on record at all. It is the supervisor's answer to "was this
+// engine ever actually started", which the readiness gate needs to tell a cold
+// start apart from an engine that is not running (citadel-cli#705). Satisfies
+// engineStartTracker.
+func (m *SwapManager) EngineStartedAt(backend string) (time.Time, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	t, ok := m.startedAt[backend]
+	return t, ok
 }
 
 // etaSeconds estimates remaining seconds until the in-flight swap is ready,

--- a/internal/worker/swap_test.go
+++ b/internal/worker/swap_test.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -280,4 +281,66 @@ func TestEnsureResident_BackgroundSwapSurvivesJobCancellation(t *testing.T) {
 		time.Sleep(5 * time.Millisecond)
 	}
 	t.Fatalf("background swap did not complete after job-context cancellation")
+}
+
+// TestSwap_EngineStartedAt_RecordsAttemptAndClearsOnFailure is the supervisor
+// half of citadel-cli#705. The readiness gate reads this record to tell a cold
+// start apart from an engine that is not running, so it must exist while a start
+// is in flight and must NOT survive a start that failed.
+func TestSwap_EngineStartedAt_RecordsAttemptAndClearsOnFailure(t *testing.T) {
+	ctrl := newMockController()
+	ctrl.readyAfterStart = true
+	m := newTestManager(ctrl)
+
+	if _, known := m.EngineStartedAt("bonsai"); known {
+		t.Fatal("no start should be on record before one is issued")
+	}
+
+	if _, err := m.EnsureResident(context.Background(), "bonsai", "Bonsai-27B"); err != nil {
+		t.Fatalf("EnsureResident: %v", err)
+	}
+	waitFor(t, func() bool {
+		_, known := m.EngineStartedAt("bonsai")
+		return known
+	}, "a start attempt must be recorded")
+
+	// A start that fails must not linger as evidence the engine is booting.
+	ctrl2 := newMockController()
+	ctrl2.startErr = errors.New("compose up failed")
+	m2 := newTestManager(ctrl2)
+	m2.waitBudget = 2 * time.Second // let the swap finish so the error surfaces
+	if _, err := m2.EnsureResident(context.Background(), "bonsai", "Bonsai-27B"); err == nil {
+		t.Fatal("expected a hard error from a failed start")
+	}
+	if _, known := m2.EngineStartedAt("bonsai"); known {
+		t.Error("a failed start must not stay on record")
+	}
+}
+
+// TestSwap_EngineStartedAt_ClearedOnEviction asserts an engine we just stopped
+// is no longer treated as booting.
+func TestSwap_EngineStartedAt_ClearedOnEviction(t *testing.T) {
+	ctrl := newMockController()
+	m := newTestManager(ctrl)
+	m.markStartAttempted("unlimited-ocr")
+	if _, known := m.EngineStartedAt("unlimited-ocr"); !known {
+		t.Fatal("start should be on record")
+	}
+	m.forget("unlimited-ocr")
+	if _, known := m.EngineStartedAt("unlimited-ocr"); known {
+		t.Error("an evicted engine must not stay on record as started")
+	}
+}
+
+// waitFor polls cond until it holds or the timeout elapses.
+func waitFor(t *testing.T, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal(msg)
 }


### PR DESCRIPTION
Closes #680. Part of the serving-stack epic aceteam-ai/aceteam#7243, slice 1b.

## MERGE ORDER: THE PLATFORM PR SHIPS FIRST, AND MUST BE DEPLOYED BEFORE THIS

Platform counterpart: aceteam-ai/aceteam#7249 (draft, closes aceteam-ai/aceteam#7232).

**Do not merge this until aceteam-ai/aceteam#7249 is merged AND released to production.** Merged-to-main is not enough; the dependency is on the running platform.

This change makes a node emit `model_warming` in cases where it previously emitted a raw socket error. On the old platform, two inference paths marshal a warming result as HTTP 200 with an empty completion. Shipping the node side first therefore converts a loud, visible error into a silent wrong answer, which is worse than the bug being fixed. aceteam-ai/aceteam#7249 teaches every inference surface to understand the signal; once it is live, this change is strictly an improvement.

## What was broken

Serving was gated on residency, which means "the container is up". A container that has bound its port but is still loading weights passes that gate, so the request was proxied into an engine that was not listening yet. The caller got:

```
failed to connect to chat endpoint: Post "http://localhost:8213/v1/chat/completions":
readfrom tcp 127.0.0.1:57222->127.0.0.1:8213: write tcp ...: use of closed network connection
```

A pre-flight probe existed but covered two engines. `unlimited-ocr`, `llamacpp`, `bonsai` and `ollama` had none at all.

On a single-GPU box a cold start is the normal path, not an exception. The more constrained the machine, the more often that window is hit, so the product looked broken rather than busy exactly where it is supposed to look honest.

## Changes

**Readiness gate for every backend** (`internal/worker/llm_readiness.go`). `ensureEngineReady` probes before proxying and returns the typed warming result when the engine is not serving yet. Probe endpoints are the same ones the heartbeat's model discovery already uses (`internal/status/models.go`), so they are proven against every engine this fleet actually runs rather than guessed:

| Backend | Probe | Budget before | Budget now |
| --- | --- | --- | --- |
| vllm | `/health` | 60s | 60s |
| sglang | `/health` | 60s | 60s |
| unlimited-ocr | `/v1/models` | none | short |
| llamacpp | `/v1/models` | none | short |
| bonsai | `/v1/models` | none | short |
| ollama | `/api/tags` | none | short |

An unknown backend fails open, so adding an engine can never silently make it unservable.

**The probe asks whether the API answers, NOT whether it lists a model.** This is the trap in the obvious implementation. `swapController.Ready` is `len(e.Models) > 0`, but `internal/status/local_engines.go` and `models.go` both document that llama.cpp and bonsai run in deferred-load / router mode: up, answering `/v1/models` with an **empty list**, and still serving, because they load on the first request. Gating readiness on a non-empty model list would make such an engine permanently "warming" and permanently unservable, and a mocked-controller unit test would never show it. The model-count predicate stays where it already lives, in the swap manager's post-start wait, where a false negative only means "keep waiting".

**Deliberate deviation from the issue on budgets.** #680 suggests raising the readiness budget above the measured 78s cold start. I did not, and the reason is a constraint outside this repo: the platform's buffered dispatch timeout is 120s. A node-side wait long enough to cover a 78s load converts an honest warming answer into a 504, and it would add a 60s hang to four paths that fail in milliseconds today. A short probe plus a typed warming result tells the caller the truth sooner than any wait can. Flagging it so a reviewer reads it as a decision rather than an omission.

**Transport errors are classified** (`isEngineNotServing`). A refused, reset or mid-write-closed connection is warming; `use of closed network connection` never leaves the handler. Context cancellation and deadline expiry are deliberately NOT warming: those mean the job itself was cancelled or timed out, and reporting them as "your model is loading" would be a new lie. This is a second line of defence behind the probe, so an engine that dies between the probe and the request still produces an honest answer.

**`retry_after` is now chosen by the node.** `startOrJoin` returns nil when a swap for a DIFFERENT model holds the single-flight slot, so the caller's model has not started loading. The old code quoted a bare cold-start estimate and the fixed 10s retry hint, so a retry loop would spin against a node doing no work for it. The ETA is now the in-flight swap's remaining time plus this engine's own load, and the retry hint is paced to that and bounded at 60s. Telling the two cases apart on the wire ("loading yours" vs "busy with another") is #681, deliberately not done here.

**Removed** the vllm/sglang-only `waitForReady`, superseded by the per-engine gate.

## What the caller gets now

```json
{
  "status": "model_warming",
  "model": "baidu/Unlimited-OCR",
  "eta_seconds": 90,
  "retry_after": 10
}
```

A success `JobResult` carrying a control payload and no content chunks, which is the shape four platform handlers already understand and (after aceteam-ai/aceteam#7249) all of them do.

## Tests

`internal/worker/llm_readiness_test.go`. Test-bite verified by mutating source and confirming real assertion failures, then restoring:

| Mutant | Result |
| --- | --- |
| `engineReadyPath` reduced to vllm + sglang (the pre-#680 state) | `TestEnsureEngineReady_EveryBackendIsProbed` fails on all four previously-unprobed engines |
| the above plus `isEngineNotServing` always false | additionally `TestExecute_LoadingEngineReturnsWarmingNotSocketError` fails with `failure (err=failed to connect to chat endpoint: Post "...": EOF)`, i.e. the exact pre-fix defect, and `TestIsEngineNotServing` fails on the literal `use of closed network connection` string from the field report |
| `probeEngine` requires a non-empty model list | `TestEnsureEngineReady_EmptyModelListIsStillReady` fails: `deferred-load llama.cpp must be servable, got engine warming` |

The "loading engine" tests use a real listener that accepts and immediately closes, which is the bound-but-not-serving condition measured in the field, rather than a mock.

Existing tests were updated so their httptest engines answer the readiness endpoint, which is what a serving engine does. `go build`, `go vet` and `go test ./...` are all green.

## Overlap note

Another change (aceteam-ai/aceteam#7224, PDF rasterization) touches citadel-cli. This PR is confined to `internal/worker/llm_inference.go`, `internal/worker/swap.go` and two new files, and does not restructure the backend dispatch switch, so conflicts should be limited to import blocks if any.

## Not verified

- No live dispatch was run against a real cold-starting engine. Restarting `unlimited-ocr` on the reference node costs 78s and other work depends on it, so inspection stayed read-only. The bound-but-not-serving condition is reproduced in tests with a real socket, not a mock, but not with a real vLLM.
- **A loaded but saturated engine could now be reported as warming.** The probe budget is short, so if a busy `llamacpp` / `bonsai` / `ollama` does not answer `/v1/models` or `/api/tags` inside the window, the request is answered as warming instead of being queued and served as it would have been before. All three endpoints are trivial static handlers that respond during generation, so the risk is low, but it is unmeasured, and on consumer hardware saturation is common. If the fleet reports spurious warming under load, `engineReadyBudgetProbe` (and `engineProbeTimeout`) in `internal/worker/llm_readiness.go` are the knobs. Separating "busy" from "loading" on the wire is #681.
- The short probe budget is a judgement call, not a measured optimum. If a nearly-loaded engine routinely needs slightly longer than the probe window, this will report warming where a brief wait would have served; the per-engine constant is the single knob to tune.
