### PR TITLE
feat(worker): render PDF pages to images with a document_rasterize job

### DIFF
--- a/cmd/nodejobs.go
+++ b/cmd/nodejobs.go
@@ -91,6 +91,14 @@ func buildNodeJobHandlers(opts nodeJobHandlerOpts) []worker.JobHandler {
 		llmHandler = llmHandler.WithSwapper(swapper)
 	}
 	handlers = append(handlers, llmHandler)
+	// document_rasterize (issue #675): render selected PDF pages to images so a
+	// scanned document can reach an OCR model, which only accepts raster images.
+	// Registered unconditionally alongside llm_inference: it needs no workspace
+	// or config, and the caller renders and then OCRs on the SAME node, so a
+	// control-center-only node must answer both or the pair splits.
+	handlers = append(handlers, worker.NewDocumentRasterizeHandler(worker.DocumentRasterizeConfig{
+		Log: opts.HandlerLog,
+	}))
 	return handlers
 }
 

--- a/install.sh
+++ b/install.sh
@@ -347,6 +347,29 @@ with open('$tmp', 'w') as f:
 }
 
 # ---------------------------------------------------------------------------
+# Node-local tools the agent shells out to
+# ---------------------------------------------------------------------------
+# poppler-utils provides pdftoppm, the renderer behind the document_rasterize
+# job (issue #675): a scanned PDF page has to be an image before an OCR model
+# will look at it. The agent detects its absence and fails that job with an
+# install instruction, so a node without it stays healthy for everything else.
+install_node_tools() {
+    step "Installing node tools"
+
+    if command -v pdftoppm >/dev/null 2>&1; then
+        ok "PDF renderer already installed ($(pdftoppm -v 2>&1 | head -1))"
+        return 0
+    fi
+
+    if ! apt-get install -y -qq poppler-utils >> "$LOG_FILE" 2>&1; then
+        warn "Failed to install poppler-utils - PDF rasterization jobs will report it as missing"
+        return 0
+    fi
+
+    ok "PDF renderer installed (poppler-utils)"
+}
+
+# ---------------------------------------------------------------------------
 # Download and install citadel binary
 # ---------------------------------------------------------------------------
 install_citadel_binary() {
@@ -628,6 +651,7 @@ main() {
     install_nvidia_drivers
     install_docker
     install_nvidia_toolkit
+    install_node_tools
     install_citadel_binary
     setup_citadel
     setup_systemd_service

--- a/internal/worker/document_rasterize.go
+++ b/internal/worker/document_rasterize.go
@@ -1,0 +1,404 @@
+// internal/worker/document_rasterize.go
+//
+// document_rasterize job handler (issue #675). Renders selected pages of a PDF
+// to images on THIS node so a scanned document can reach an OCR model.
+//
+// # Why the node has to do this
+//
+// The OCR engines served on a node (the Unlimited-OCR vLLM server, for one)
+// decode their image content part through PIL. A PDF posted as that part is
+// refused before the model sees anything:
+//
+//	HTTP 400 {"error":{"message":"Failed to load image: cannot identify image
+//	          file <_io.BytesIO object>","type":"BadRequestError","code":400}}
+//
+// So a page has to be a raster image before it is an inference request. Doing
+// that render on the node rather than on the caller keeps the CPU cost on the
+// hardware that already runs the model, and keeps the document's bytes on the
+// operator's own machine.
+//
+// # Contract
+//
+// Request payload:
+//
+//	pdf_base64          string  the PDF bytes, base64
+//	pages               []int   1-based page numbers to render, only these
+//	dpi                 int     render resolution (default 200)
+//	format              string  "png" (the only supported value)
+//	max_bytes_per_page  int     per-image ceiling the caller will accept
+//
+// Result:
+//
+//	{"pages": [{"page": 3, "image_base64": "...", "mime": "image/png"}, ...],
+//	 "dpi": 200, "format": "png", "renderer": "pdftoppm"}
+//
+// One entry per requested page, in the requested order. The caller validates
+// strictly, so a page that could not be rendered fails the whole job with a
+// named reason rather than being dropped from the list.
+//
+// # Renderer dependency
+//
+// citadel ships as a single static binary with no native runtime dependencies,
+// and rendering a PDF is the first thing that needs one. Rather than assume it,
+// the handler looks the renderer up at execution time and, when it is absent,
+// fails with a terminal message naming the missing binary and the package that
+// provides it. An operator gets an instruction, never a hang or an empty result.
+//
+// The renderer is poppler's pdftoppm, driven over stdin/stdout: the PDF is
+// piped in and the PNG is read back out, so a customer document is never
+// written to the node's disk.
+//
+// # Gating
+//
+// Unconditional, like WEB_FETCH. The input is bytes carried in the payload; the
+// handler reaches no file, no credential, and no device on the node, so there is
+// nothing for a per-node-stream gate to protect.
+package worker
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+const (
+	// rasterizeRenderer is the poppler utility that does the rendering, and
+	// rasterizePackage is what an operator installs to get it.
+	rasterizeRenderer = "pdftoppm"
+	rasterizePackage  = "poppler-utils"
+
+	// rasterizeDefaultDPI matches the caller's default. 200 DPI keeps small
+	// print legible to a vision model while a Letter page stays a few hundred
+	// KB as PNG.
+	rasterizeDefaultDPI = 200
+
+	// rasterizeMinDPI / rasterizeMaxDPI bound what a caller may ask for. Below
+	// the minimum nothing is legible; above the maximum one page can outgrow
+	// any sane transport before the per-page cap catches it.
+	rasterizeMinDPI = 36
+	rasterizeMaxDPI = 600
+
+	// rasterizeFormatPNG is the only supported output format. PNG is lossless:
+	// JPEG ringing around glyph edges is exactly the noise an OCR model reads
+	// as a wrong character.
+	rasterizeFormatPNG = "png"
+	rasterizeMimePNG   = "image/png"
+
+	// rasterizeMaxPDFBytes bounds the decoded input. The caller refuses to send
+	// a larger document; this is the node's own guard against a payload that
+	// would render this worker unresponsive.
+	rasterizeMaxPDFBytes = 16 << 20
+
+	// rasterizeMaxBytesPerPage is the hard per-image ceiling. A caller may ask
+	// for less, never for more.
+	rasterizeMaxBytesPerPage = 10 << 20
+
+	// rasterizeMaxTotalBytes bounds one job's whole result, independently of
+	// how many pages were requested.
+	rasterizeMaxTotalBytes = 32 << 20
+
+	// rasterizeMaxPages bounds the pages one job may ask for. Each page is a
+	// separate render process, and the caller's own page cap is far below this.
+	rasterizeMaxPages = 64
+)
+
+// errRasterizerMissing reports that the node has no PDF renderer installed. It
+// is terminal: retrying cannot install poppler.
+var errRasterizerMissing = fmt.Errorf(
+	"no PDF renderer on this node: %s not found in PATH (install %s, e.g. `apt-get install -y %s`)",
+	rasterizeRenderer, rasterizePackage, rasterizePackage,
+)
+
+// RasterizeRequest is the parsed document_rasterize payload.
+type RasterizeRequest struct {
+	// PDF is the decoded document.
+	PDF []byte
+	// Pages are the 1-based page numbers to render, deduplicated and ordered.
+	Pages []int
+	// DPI is the render resolution.
+	DPI int
+	// MaxBytesPerPage is the per-image ceiling, never above
+	// rasterizeMaxBytesPerPage.
+	MaxBytesPerPage int
+}
+
+// DocumentRasterizeConfig configures a DocumentRasterizeHandler. Both edges are
+// injectable so the handler's validation and assembly are unit-testable without
+// poppler installed.
+type DocumentRasterizeConfig struct {
+	// LookRenderer resolves the renderer binary. Defaults to exec.LookPath for
+	// rasterizeRenderer.
+	LookRenderer func() (string, error)
+
+	// RenderPage renders one 1-based page of pdf at dpi and returns PNG bytes.
+	// Defaults to the pdftoppm pipe.
+	RenderPage func(ctx context.Context, bin string, pdf []byte, page, dpi int) ([]byte, error)
+
+	// Log reports progress. Nil is a no-op.
+	Log func(format string, args ...any)
+}
+
+// DocumentRasterizeHandler processes document_rasterize jobs.
+type DocumentRasterizeHandler struct {
+	cfg DocumentRasterizeConfig
+}
+
+// NewDocumentRasterizeHandler constructs a document_rasterize handler with the
+// live poppler edges, overridable through cfg.
+func NewDocumentRasterizeHandler(cfg DocumentRasterizeConfig) *DocumentRasterizeHandler {
+	if cfg.LookRenderer == nil {
+		cfg.LookRenderer = func() (string, error) { return exec.LookPath(rasterizeRenderer) }
+	}
+	if cfg.RenderPage == nil {
+		cfg.RenderPage = renderPageWithPdftoppm
+	}
+	if cfg.Log == nil {
+		cfg.Log = func(string, ...any) {}
+	}
+	return &DocumentRasterizeHandler{cfg: cfg}
+}
+
+// CanHandle reports whether this handler processes the given job type.
+func (h *DocumentRasterizeHandler) CanHandle(jobType string) bool {
+	return jobType == JobTypeDocumentRasterize
+}
+
+// Execute renders the requested pages and returns one image per page. Every
+// failure is terminal: a malformed payload, an absent renderer, and a PDF
+// poppler cannot read are all things a retry would reproduce exactly.
+func (h *DocumentRasterizeHandler) Execute(ctx context.Context, job *Job, stream StreamWriter) (*JobResult, error) {
+	req, err := parseRasterizeRequest(job.Payload)
+	if err != nil {
+		return h.failure(fmt.Errorf("%s: %w", JobTypeDocumentRasterize, err)), nil
+	}
+
+	bin, lookErr := h.cfg.LookRenderer()
+	if lookErr != nil {
+		// Capability, not corruption. The message names the binary and the
+		// package so the caller can tell an operator what to install.
+		return h.failure(fmt.Errorf("%s: %w", JobTypeDocumentRasterize, errRasterizerMissing)), nil
+	}
+
+	h.cfg.Log("%s: rendering %d page(s) at %d DPI", JobTypeDocumentRasterize, len(req.Pages), req.DPI)
+
+	rendered := make([]map[string]any, 0, len(req.Pages))
+	total := 0
+	for _, page := range req.Pages {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return h.failure(fmt.Errorf(
+				"%s: ran out of time after %d of %d page(s): %w",
+				JobTypeDocumentRasterize, len(rendered), len(req.Pages), ctxErr)), nil
+		}
+
+		img, renderErr := h.cfg.RenderPage(ctx, bin, req.PDF, page, req.DPI)
+		if renderErr != nil {
+			return h.failure(fmt.Errorf(
+				"%s: rendering page %d failed: %w", JobTypeDocumentRasterize, page, renderErr)), nil
+		}
+		if len(img) == 0 {
+			return h.failure(fmt.Errorf(
+				"%s: rendering page %d produced no image", JobTypeDocumentRasterize, page)), nil
+		}
+		if len(img) > req.MaxBytesPerPage {
+			return h.failure(fmt.Errorf(
+				"%s: rendered page %d is %d bytes, over the %d byte per-page limit; ask for a lower dpi",
+				JobTypeDocumentRasterize, page, len(img), req.MaxBytesPerPage)), nil
+		}
+		total += len(img)
+		if total > rasterizeMaxTotalBytes {
+			return h.failure(fmt.Errorf(
+				"%s: rendered pages total more than the %d byte per-job limit; ask for fewer pages or a lower dpi",
+				JobTypeDocumentRasterize, rasterizeMaxTotalBytes)), nil
+		}
+
+		rendered = append(rendered, map[string]any{
+			"page":         page,
+			"image_base64": base64.StdEncoding.EncodeToString(img),
+			"mime":         rasterizeMimePNG,
+			"bytes":        len(img),
+		})
+	}
+
+	// The runner publishes this Output as the terminal `end` event, so `pages`
+	// sits at the top level of what the caller validates.
+	return &JobResult{Status: JobStatusSuccess, Output: map[string]any{
+		"pages":    rendered,
+		"dpi":      req.DPI,
+		"format":   rasterizeFormatPNG,
+		"renderer": rasterizeRenderer,
+	}}, nil
+}
+
+func (h *DocumentRasterizeHandler) failure(err error) *JobResult {
+	return &JobResult{Status: JobStatusFailure, Error: err, Output: map[string]any{"error": err.Error()}}
+}
+
+// parseRasterizeRequest validates a document_rasterize payload into a request.
+// Every rejection names what was wrong: the caller turns these into the message
+// a human reads, so "invalid payload" would be useless.
+func parseRasterizeRequest(payload map[string]any) (*RasterizeRequest, error) {
+	if format := strings.ToLower(strings.TrimSpace(payloadString(payload, "format"))); format != "" &&
+		format != rasterizeFormatPNG {
+		return nil, fmt.Errorf("unsupported format %q, this node renders %q", format, rasterizeFormatPNG)
+	}
+
+	encoded := payloadString(payload, "pdf_base64")
+	if encoded == "" {
+		return nil, errors.New("no pdf_base64 in the payload")
+	}
+	pdf, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("pdf_base64 is not valid base64: %w", err)
+	}
+	if len(pdf) == 0 {
+		return nil, errors.New("pdf_base64 decoded to no bytes")
+	}
+	if len(pdf) > rasterizeMaxPDFBytes {
+		return nil, fmt.Errorf(
+			"the document is %d bytes, over this node's %d byte render limit", len(pdf), rasterizeMaxPDFBytes)
+	}
+	// Cheap shape check before spawning a process. poppler would also refuse,
+	// but its refusal reads as a syntax error rather than "this is not a PDF".
+	if !bytes.HasPrefix(pdf, []byte("%PDF-")) {
+		return nil, errors.New("the decoded bytes are not a PDF (no %PDF- header)")
+	}
+
+	pages, err := rasterizePageNumbers(payload["pages"])
+	if err != nil {
+		return nil, err
+	}
+
+	dpi := payloadInt(payload, "dpi")
+	if dpi == 0 {
+		dpi = rasterizeDefaultDPI
+	}
+	if dpi < rasterizeMinDPI || dpi > rasterizeMaxDPI {
+		return nil, fmt.Errorf(
+			"dpi %d is outside the supported %d to %d range", dpi, rasterizeMinDPI, rasterizeMaxDPI)
+	}
+
+	maxPerPage := payloadInt(payload, "max_bytes_per_page")
+	if maxPerPage <= 0 || maxPerPage > rasterizeMaxBytesPerPage {
+		maxPerPage = rasterizeMaxBytesPerPage
+	}
+
+	return &RasterizeRequest{PDF: pdf, Pages: pages, DPI: dpi, MaxBytesPerPage: maxPerPage}, nil
+}
+
+// rasterizePageNumbers reads the 1-based page list. JSON decoding gives numbers
+// as float64, so every numeric shape a payload can carry is coerced rather than
+// type-asserted. The result is deduplicated and ascending, so a caller that
+// repeats a page pays for one render.
+func rasterizePageNumbers(raw any) ([]int, error) {
+	list, ok := raw.([]any)
+	if !ok {
+		// A payload that went through a string-flattening transport arrives as
+		// one value rather than a list; treat a single number as a single page.
+		if single, isSingle := coerceInt(raw); isSingle {
+			list = []any{single}
+		} else {
+			return nil, errors.New("no pages requested")
+		}
+	}
+	if len(list) == 0 {
+		return nil, errors.New("no pages requested")
+	}
+	if len(list) > rasterizeMaxPages {
+		return nil, fmt.Errorf(
+			"%d pages requested, over this node's %d page per-job limit", len(list), rasterizeMaxPages)
+	}
+
+	seen := make(map[int]struct{}, len(list))
+	pages := make([]int, 0, len(list))
+	for _, entry := range list {
+		page, okNum := coerceInt(entry)
+		if !okNum {
+			return nil, fmt.Errorf("page number %v is not a number", entry)
+		}
+		if page < 1 {
+			return nil, fmt.Errorf("page number %d is not 1-based", page)
+		}
+		if _, dup := seen[page]; dup {
+			continue
+		}
+		seen[page] = struct{}{}
+		pages = append(pages, page)
+	}
+	sort.Ints(pages)
+	return pages, nil
+}
+
+// coerceInt reads an int out of any JSON-decoded numeric shape.
+func coerceInt(v any) (int, bool) {
+	switch n := v.(type) {
+	case float64:
+		return int(n), true
+	case float32:
+		return int(n), true
+	case int:
+		return n, true
+	case int32:
+		return int(n), true
+	case int64:
+		return int(n), true
+	case string:
+		var p int
+		if _, err := fmt.Sscanf(strings.TrimSpace(n), "%d", &p); err == nil {
+			return p, true
+		}
+	}
+	return 0, false
+}
+
+// renderPageWithPdftoppm renders one page to PNG by piping the PDF through
+// poppler. `-singlefile` with no output prefix makes pdftoppm write the image
+// to stdout, so neither the document nor the rendered page touches the disk.
+func renderPageWithPdftoppm(ctx context.Context, bin string, pdf []byte, page, dpi int) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, bin,
+		"-png",
+		"-r", fmt.Sprint(dpi),
+		"-f", fmt.Sprint(page),
+		"-l", fmt.Sprint(page),
+		"-singlefile",
+		"-", // read the PDF from stdin
+	)
+	cmd.Stdin = bytes.NewReader(pdf)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		detail := strings.TrimSpace(stderr.String())
+		if detail == "" {
+			detail = err.Error()
+		}
+		// poppler exits 99 for a page outside the document, which is a caller
+		// mistake worth naming rather than a generic render failure.
+		return nil, errors.New(firstLine(detail))
+	}
+	if stdout.Len() == 0 {
+		detail := strings.TrimSpace(stderr.String())
+		if detail == "" {
+			detail = "the renderer produced no output"
+		}
+		return nil, errors.New(firstLine(detail))
+	}
+	return stdout.Bytes(), nil
+}
+
+// firstLine keeps an error message to poppler's first diagnostic. It emits a
+// warning cascade for a damaged file and all of it would drown the result.
+func firstLine(s string) string {
+	if idx := strings.IndexByte(s, '\n'); idx >= 0 {
+		return strings.TrimSpace(s[:idx])
+	}
+	return s
+}
+
+// Ensure DocumentRasterizeHandler implements JobHandler.
+var _ JobHandler = (*DocumentRasterizeHandler)(nil)

--- a/internal/worker/document_rasterize_test.go
+++ b/internal/worker/document_rasterize_test.go
@@ -1,0 +1,369 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// buildPDF writes a valid multi-page PDF with a real cross-reference table, so
+// the render tests exercise poppler on a document it accepts without falling
+// back to xref reconstruction. Every page carries visible text, which is what
+// makes a rendered PNG non-blank and therefore worth measuring.
+func buildPDF(pages int) []byte {
+	var objects []string
+	kids := make([]string, 0, pages)
+	for i := range pages {
+		kids = append(kids, fmt.Sprintf("%d 0 R", 3+i))
+	}
+	objects = append(objects,
+		"<< /Type /Catalog /Pages 2 0 R >>",
+		fmt.Sprintf("<< /Type /Pages /Kids [%s] /Count %d >>", strings.Join(kids, " "), pages),
+	)
+	contentsStart := 3 + pages
+	for i := range pages {
+		objects = append(objects, fmt.Sprintf(
+			"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 216 144] /Contents %d 0 R "+
+				"/Resources << /Font << /F1 %d 0 R >> >> >>",
+			contentsStart+i, contentsStart+pages))
+	}
+	for i := range pages {
+		stream := fmt.Sprintf("BT /F1 18 Tf 18 64 Td (page %d) Tj ET", i+1)
+		objects = append(objects, fmt.Sprintf(
+			"<< /Length %d >>\nstream\n%s\nendstream", len(stream), stream))
+	}
+	objects = append(objects, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>")
+
+	var buf bytes.Buffer
+	buf.WriteString("%PDF-1.4\n")
+	offsets := make([]int, 0, len(objects))
+	for i, body := range objects {
+		offsets = append(offsets, buf.Len())
+		fmt.Fprintf(&buf, "%d 0 obj\n%s\nendobj\n", i+1, body)
+	}
+	xref := buf.Len()
+	fmt.Fprintf(&buf, "xref\n0 %d\n0000000000 65535 f \n", len(objects)+1)
+	for _, off := range offsets {
+		fmt.Fprintf(&buf, "%010d 00000 n \n", off)
+	}
+	fmt.Fprintf(&buf, "trailer\n<< /Size %d /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF\n",
+		len(objects)+1, xref)
+	return buf.Bytes()
+}
+
+func rasterPayload(pdf []byte, pages ...any) map[string]any {
+	list := make([]any, 0, len(pages))
+	list = append(list, pages...)
+	return map[string]any{
+		"pdf_base64":         base64.StdEncoding.EncodeToString(pdf),
+		"pages":              list,
+		"dpi":                float64(200),
+		"format":             "png",
+		"max_bytes_per_page": float64(10 << 20),
+	}
+}
+
+// stubRenderer returns a handler whose render step yields fixed bytes, so the
+// validation and assembly paths are testable without poppler installed.
+func stubRenderer(t *testing.T, img []byte) *DocumentRasterizeHandler {
+	t.Helper()
+	return NewDocumentRasterizeHandler(DocumentRasterizeConfig{
+		LookRenderer: func() (string, error) { return "/usr/bin/pdftoppm", nil },
+		RenderPage: func(ctx context.Context, bin string, pdf []byte, page, dpi int) ([]byte, error) {
+			return img, nil
+		},
+	})
+}
+
+func runRaster(t *testing.T, h *DocumentRasterizeHandler, payload map[string]any) *JobResult {
+	t.Helper()
+	res, err := h.Execute(context.Background(), &Job{Type: JobTypeDocumentRasterize, Payload: payload}, nil)
+	if err != nil {
+		t.Fatalf("Execute returned a transport error: %v", err)
+	}
+	if res == nil {
+		t.Fatal("Execute returned no result")
+	}
+	return res
+}
+
+func TestDocumentRasterizeCanHandle(t *testing.T) {
+	h := NewDocumentRasterizeHandler(DocumentRasterizeConfig{})
+	if !h.CanHandle(JobTypeDocumentRasterize) {
+		t.Fatalf("handler does not claim %q", JobTypeDocumentRasterize)
+	}
+	if h.CanHandle(JobTypeWebFetch) {
+		t.Fatal("handler claims a job type it does not implement")
+	}
+}
+
+// The job type has to be in allKnownJobTypes or the unsupported-type failure
+// reports a node that supports it as not supporting it.
+func TestDocumentRasterizeIsAKnownJobType(t *testing.T) {
+	for _, jt := range allKnownJobTypes {
+		if jt == JobTypeDocumentRasterize {
+			return
+		}
+	}
+	t.Fatalf("%q is missing from allKnownJobTypes", JobTypeDocumentRasterize)
+}
+
+func TestDocumentRasterizeReturnsOneEntryPerRequestedPage(t *testing.T) {
+	h := stubRenderer(t, []byte("\x89PNG\r\n\x1a\nrendered"))
+	res := runRaster(t, h, rasterPayload(buildPDF(3), float64(1), float64(3)))
+	if res.Status != JobStatusSuccess {
+		t.Fatalf("status = %v, want success (%v)", res.Status, res.Error)
+	}
+
+	entries, ok := res.Output["pages"].([]map[string]any)
+	if !ok {
+		t.Fatalf("pages is %T, want a list the caller can read", res.Output["pages"])
+	}
+	if len(entries) != 2 {
+		t.Fatalf("got %d page(s), want 2", len(entries))
+	}
+	for i, want := range []int{1, 3} {
+		// The caller type-checks the page number as an integer, so a float here
+		// would fail validation on the other side of the wire.
+		page, isInt := entries[i]["page"].(int)
+		if !isInt || page != want {
+			t.Fatalf("page[%d] = %v (%T), want int %d", i, entries[i]["page"], entries[i]["page"], want)
+		}
+		if entries[i]["mime"] != rasterizeMimePNG {
+			t.Fatalf("page %d mime = %v, want %q", want, entries[i]["mime"], rasterizeMimePNG)
+		}
+		if entries[i]["image_base64"] == "" {
+			t.Fatalf("page %d carries no image", want)
+		}
+	}
+	if res.Output["renderer"] != rasterizeRenderer {
+		t.Fatalf("renderer = %v, want %q", res.Output["renderer"], rasterizeRenderer)
+	}
+}
+
+func TestDocumentRasterizeSortsAndDeduplicatesPages(t *testing.T) {
+	calls := 0
+	h := NewDocumentRasterizeHandler(DocumentRasterizeConfig{
+		LookRenderer: func() (string, error) { return "pdftoppm", nil },
+		RenderPage: func(ctx context.Context, bin string, pdf []byte, page, dpi int) ([]byte, error) {
+			calls++
+			return []byte("img"), nil
+		},
+	})
+	res := runRaster(t, h, rasterPayload(buildPDF(5), float64(4), float64(2), float64(4)))
+	if res.Status != JobStatusSuccess {
+		t.Fatalf("status = %v, want success (%v)", res.Status, res.Error)
+	}
+	if calls != 2 {
+		t.Fatalf("rendered %d time(s), want 2: a repeated page must not be rendered twice", calls)
+	}
+	entries := res.Output["pages"].([]map[string]any)
+	if entries[0]["page"] != 2 || entries[1]["page"] != 4 {
+		t.Fatalf("pages = %v, %v; want ascending 2, 4", entries[0]["page"], entries[1]["page"])
+	}
+}
+
+// A node without poppler must say so in a way an operator can act on, rather
+// than hanging or returning an empty page list that reads as a blank document.
+func TestDocumentRasterizeWithoutARendererFailsWithAnInstallableMessage(t *testing.T) {
+	h := NewDocumentRasterizeHandler(DocumentRasterizeConfig{
+		LookRenderer: func() (string, error) { return "", exec.ErrNotFound },
+		RenderPage: func(ctx context.Context, bin string, pdf []byte, page, dpi int) ([]byte, error) {
+			t.Fatal("render must not be attempted without a renderer")
+			return nil, nil
+		},
+	})
+	res := runRaster(t, h, rasterPayload(buildPDF(1), float64(1)))
+	if res.Status != JobStatusSuccess {
+		msg := res.Error.Error()
+		for _, want := range []string{rasterizeRenderer, rasterizePackage} {
+			if !strings.Contains(msg, want) {
+				t.Fatalf("error %q does not name %q", msg, want)
+			}
+		}
+		return
+	}
+	t.Fatal("a node with no renderer reported success")
+}
+
+// Every rejection is terminal. A retry re-runs the same bytes through the same
+// missing or unhappy renderer and reaches the same place.
+func TestDocumentRasterizeFailuresAreTerminal(t *testing.T) {
+	cases := map[string]map[string]any{
+		"no pdf":            {"pages": []any{float64(1)}},
+		"undecodable pdf":   {"pdf_base64": "not base64 !!", "pages": []any{float64(1)}},
+		"not a pdf":         {"pdf_base64": base64.StdEncoding.EncodeToString([]byte("GIF89a")), "pages": []any{float64(1)}},
+		"no pages":          {"pdf_base64": base64.StdEncoding.EncodeToString(buildPDF(1)), "pages": []any{}},
+		"page zero":         {"pdf_base64": base64.StdEncoding.EncodeToString(buildPDF(1)), "pages": []any{float64(0)}},
+		"unsupported dpi":   {"pdf_base64": base64.StdEncoding.EncodeToString(buildPDF(1)), "pages": []any{float64(1)}, "dpi": float64(5000)},
+		"wrong out format":  {"pdf_base64": base64.StdEncoding.EncodeToString(buildPDF(1)), "pages": []any{float64(1)}, "format": "jpeg"},
+		"non numeric pages": {"pdf_base64": base64.StdEncoding.EncodeToString(buildPDF(1)), "pages": []any{"three-ish"}},
+	}
+	h := stubRenderer(t, []byte("img"))
+	for name, payload := range cases {
+		t.Run(name, func(t *testing.T) {
+			res := runRaster(t, h, payload)
+			if res.Status != JobStatusFailure {
+				t.Fatalf("status = %v, want failure", res.Status)
+			}
+			if res.Error == nil || res.Error.Error() == "" {
+				t.Fatal("a failure carried no reason")
+			}
+		})
+	}
+}
+
+func TestDocumentRasterizeRejectsAnOversizedDocument(t *testing.T) {
+	oversized := append(buildPDF(1), bytes.Repeat([]byte("x"), rasterizeMaxPDFBytes)...)
+	res := runRaster(t, stubRenderer(t, []byte("img")), rasterPayload(oversized, float64(1)))
+	if res.Status != JobStatusFailure {
+		t.Fatalf("status = %v, want failure on a document over the render limit", res.Status)
+	}
+}
+
+func TestDocumentRasterizeRejectsTooManyPages(t *testing.T) {
+	pages := make([]any, rasterizeMaxPages+1)
+	for i := range pages {
+		pages[i] = float64(i + 1)
+	}
+	res := runRaster(t, stubRenderer(t, []byte("img")), rasterPayload(buildPDF(2), pages...))
+	if res.Status != JobStatusFailure {
+		t.Fatalf("status = %v, want failure past the per-job page limit", res.Status)
+	}
+}
+
+// An image over the caller's per-page ceiling is a failure, never a silently
+// dropped page: the caller validates that every requested page came back, so
+// dropping one would surface as a confusing "missing page" instead of "lower
+// the dpi".
+func TestDocumentRasterizeRejectsAPageOverTheCallerCeiling(t *testing.T) {
+	h := stubRenderer(t, bytes.Repeat([]byte("x"), 5000))
+	payload := rasterPayload(buildPDF(1), float64(1))
+	payload["max_bytes_per_page"] = float64(1000)
+	res := runRaster(t, h, payload)
+	if res.Status != JobStatusFailure {
+		t.Fatalf("status = %v, want failure on an oversized page", res.Status)
+	}
+	if !strings.Contains(res.Error.Error(), "dpi") {
+		t.Fatalf("error %q does not tell the caller what to change", res.Error)
+	}
+}
+
+// A caller cannot raise the per-page ceiling above the node's own.
+func TestDocumentRasterizeClampsTheCallerCeiling(t *testing.T) {
+	payload := rasterPayload(buildPDF(1), float64(1))
+	payload["max_bytes_per_page"] = float64(rasterizeMaxBytesPerPage * 4)
+	req, err := parseRasterizeRequest(payload)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if req.MaxBytesPerPage != rasterizeMaxBytesPerPage {
+		t.Fatalf("MaxBytesPerPage = %d, want it clamped to %d", req.MaxBytesPerPage, rasterizeMaxBytesPerPage)
+	}
+}
+
+func TestDocumentRasterizeDefaultsTheResolution(t *testing.T) {
+	payload := rasterPayload(buildPDF(1), float64(1))
+	delete(payload, "dpi")
+	req, err := parseRasterizeRequest(payload)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if req.DPI != rasterizeDefaultDPI {
+		t.Fatalf("DPI = %d, want the %d default", req.DPI, rasterizeDefaultDPI)
+	}
+}
+
+// An empty render is a failure. A zero-byte "image" would decode to nothing on
+// the caller's side and read as a page with no content.
+func TestDocumentRasterizeRejectsAnEmptyRender(t *testing.T) {
+	res := runRaster(t, stubRenderer(t, nil), rasterPayload(buildPDF(1), float64(1)))
+	if res.Status != JobStatusFailure {
+		t.Fatalf("status = %v, want failure on an empty render", res.Status)
+	}
+}
+
+func TestDocumentRasterizeStopsWhenTheJobDeadlinePasses(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	h := NewDocumentRasterizeHandler(DocumentRasterizeConfig{
+		LookRenderer: func() (string, error) { return "pdftoppm", nil },
+		RenderPage: func(ctx context.Context, bin string, pdf []byte, page, dpi int) ([]byte, error) {
+			cancel() // the deadline passes while the first page renders
+			return []byte("img"), nil
+		},
+	})
+	res, err := h.Execute(ctx, &Job{
+		Type:    JobTypeDocumentRasterize,
+		Payload: rasterPayload(buildPDF(2), float64(1), float64(2)),
+	}, nil)
+	if err != nil {
+		t.Fatalf("Execute returned a transport error: %v", err)
+	}
+	if res.Status != JobStatusFailure {
+		t.Fatalf("status = %v, want failure once the deadline passed", res.Status)
+	}
+	if !strings.Contains(res.Error.Error(), "of 2 page(s)") {
+		t.Fatalf("error %q does not say how far it got", res.Error)
+	}
+}
+
+// The live path: real poppler, a real PDF, real PNG bytes back. Skipped rather
+// than failed where poppler is absent, which is exactly the condition the
+// capability error above covers.
+func TestDocumentRasterizeRendersRealPagesWithPoppler(t *testing.T) {
+	if _, err := exec.LookPath(rasterizeRenderer); err != nil {
+		t.Skipf("%s is not installed", rasterizeRenderer)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	h := NewDocumentRasterizeHandler(DocumentRasterizeConfig{})
+	res, err := h.Execute(ctx, &Job{
+		Type:    JobTypeDocumentRasterize,
+		Payload: rasterPayload(buildPDF(3), float64(1), float64(3)),
+	}, nil)
+	if err != nil {
+		t.Fatalf("Execute returned a transport error: %v", err)
+	}
+	if res.Status != JobStatusSuccess {
+		t.Fatalf("status = %v, want success (%v)", res.Status, res.Error)
+	}
+
+	entries := res.Output["pages"].([]map[string]any)
+	if len(entries) != 2 {
+		t.Fatalf("got %d page(s), want 2", len(entries))
+	}
+	for _, entry := range entries {
+		raw, decErr := base64.StdEncoding.DecodeString(entry["image_base64"].(string))
+		if decErr != nil {
+			t.Fatalf("page %v did not decode: %v", entry["page"], decErr)
+		}
+		if !bytes.HasPrefix(raw, []byte("\x89PNG\r\n\x1a\n")) {
+			t.Fatalf("page %v is not a PNG", entry["page"])
+		}
+		if len(raw) < 1000 {
+			t.Fatalf("page %v rendered to %d bytes, too small to be a real page", entry["page"], len(raw))
+		}
+	}
+}
+
+// A page past the end of the document is named, not swallowed. poppler exits
+// non-zero and its first diagnostic is what the caller shows.
+func TestDocumentRasterizeNamesAPagePastTheEndOfTheDocument(t *testing.T) {
+	if _, err := exec.LookPath(rasterizeRenderer); err != nil {
+		t.Skipf("%s is not installed", rasterizeRenderer)
+	}
+	res := runRaster(t, NewDocumentRasterizeHandler(DocumentRasterizeConfig{}),
+		rasterPayload(buildPDF(1), float64(9)))
+	if res.Status != JobStatusFailure {
+		t.Fatalf("status = %v, want failure for a page the document does not have", res.Status)
+	}
+	if !strings.Contains(res.Error.Error(), "page 9") {
+		t.Fatalf("error %q does not name the page", res.Error)
+	}
+}

--- a/internal/worker/job.go
+++ b/internal/worker/job.go
@@ -146,6 +146,7 @@ const (
 	JobTypeModuleSet          = "MODULE_SET"           // Set the desired state of a single module on this node (interim, aceteam#5280)
 	JobTypeExposeSet          = "EXPOSE_SET"           // Expose a local service on the gateway with private/org/link visibility (issue #598)
 	JobTypeMeetingJoin        = "MEETING_JOIN"         // Auto-join a video call, record + transcribe it node-locally (aceteam#5098)
+	JobTypeDocumentRasterize  = "document_rasterize"   // Render selected PDF pages to images on this node so a scan can reach an OCR model (issue #675)
 
 	// Fabric instance provisioning on a local hypervisor (aceteam#5963). These
 	// act on hypervisor VMs; JobTypeInstanceMessage above predates this family
@@ -210,6 +211,7 @@ var allKnownJobTypes = []string{
 	JobTypeModuleSet,
 	JobTypeExposeSet,
 	JobTypeMeetingJoin,
+	JobTypeDocumentRasterize,
 	JobTypeInstanceProvision,
 	JobTypeInstanceStart,
 	JobTypeInstanceStop,

--- a/packer/scripts/01-base.sh
+++ b/packer/scripts/01-base.sh
@@ -24,6 +24,9 @@ wait_for_apt
 export DEBIAN_FRONTEND=noninteractive
 
 apt-get update -y
+# poppler-utils provides pdftoppm, the renderer behind the document_rasterize
+# job (issue #675). The agent reports its absence as a capability error, so a
+# baked image should just have it.
 apt-get install -y --no-install-recommends \
     curl \
     wget \
@@ -44,7 +47,8 @@ apt-get install -y --no-install-recommends \
     net-tools \
     iotop \
     sysstat \
-    nvme-cli
+    nvme-cli \
+    poppler-utils
 
 # Clean apt cache to reduce image size
 apt-get clean


### PR DESCRIPTION
Closes #675

Adds a `document_rasterize` job type that renders selected pages of a PDF to PNG on the node.

## Why

The OCR engines a node serves take raster images only. Posting a PDF as the `image_url` content part to the local vLLM OpenAI server is refused before the model sees anything:

```
HTTP 400 {"error":{"message":"Failed to load image: cannot identify image file <_io.BytesIO object>",
                   "type":"BadRequestError","code":400}}
```

So a scanned page has to be an image before it is an inference request, and nothing on the node could do that. Rendering belongs here rather than on the caller: it is CPU work that scales with the node, and the document's bytes stay on the operator's machine.

Gotenberg (already on the node for the DOCX to PDF path) was checked and cannot do it: every route that accepts a PDF emits a PDF, and the screenshot routes refuse a PDF. Details in #675.

## Renderer

poppler's `pdftoppm`, driven over stdin/stdout: the PDF is piped in and the PNG read back out, so neither the document nor the rendered page is written to disk.

This is the agent's first native runtime dependency, so it is not assumed. `exec.LookPath` runs at execution time and an absent binary is a terminal failure naming the binary and the package:

```
document_rasterize: no PDF renderer on this node: pdftoppm not found in PATH
(install poppler-utils, e.g. `apt-get install -y poppler-utils`)
```

The caller turns that into an instruction for the operator. Verified live by running the agent with a PATH that excludes `pdftoppm`: the job fails in ~3s with the message above, no hang and no empty result.

A node provisioned from `install.sh` or the packer image now gets `poppler-utils` up front, so the capability error is the fallback for an older or hand-built node rather than the normal case. The installer step is non-fatal: a node that cannot install it stays healthy for every other job type.

## Contract

Request payload:

| Field | Type | Meaning |
| --- | --- | --- |
| `pdf_base64` | string | PDF bytes, base64 |
| `pages` | int[] | 1-based page numbers, only these |
| `dpi` | int | render resolution, 36 to 600, default 200 |
| `format` | string | `png`, the only supported value |
| `max_bytes_per_page` | int | per-image ceiling the caller accepts |

Result, published as the terminal `end` event so `pages` is top level:

```json
{"pages": [{"page": 1, "image_base64": "...", "mime": "image/png", "bytes": 200362}],
 "dpi": 200, "format": "png", "renderer": "pdftoppm"}
```

One entry per requested page, ascending, deduplicated. The caller validates strictly, so a page that could not be rendered fails the whole job with a named reason instead of being dropped from the list.

Bounds: 16 MB decoded input, 10 MB per rendered page (a caller may ask for less, never more), 32 MB per job, 64 pages per job.

## Notes

- Implements `worker.JobHandler` directly, so the `map[string]any` payload is not flattened by the legacy adapter. `pages` is read through a numeric coercion because JSON decoding gives `float64`, and `page` is emitted as an `int` because the caller type-checks it.
- Registered in `buildNodeJobHandlers`, unconditionally, alongside `llm_inference`. Both `citadel work` and the control-center worker get it: the caller renders and then OCRs on the same node, so a node answering one and not the other splits the pair.
- No per-node-stream gate. The input is bytes in the payload and the handler reaches no file, credential, or device, so it sits with `WEB_FETCH` rather than with `AGENT_UPDATE`.
- Every failure is terminal (`JobStatusFailure`). A malformed payload, a missing renderer, and a PDF poppler cannot read all reproduce exactly on a retry.
- Registered in `allKnownJobTypes` so `supportedJobTypes()` does not report a node that supports it as not supporting it.

## Tests

`internal/worker/document_rasterize_test.go`, 15 test functions and 23 cases counting subtests, no mocks in the render path. Payload validation, page ordering and deduplication, the size and page bounds, the caller-ceiling clamp, deadline handling, the missing-renderer message, and two live poppler cases (a real multi-page PDF built in-test with a real xref table, and a page past the end of the document).

```
go build ./...   ok
go vet ./...     ok
go test ./...    ok
```

Live, against the real dispatch path on an RTX 3090 node running this build:

```
document_rasterize  pages [1]     -> 1 PNG, 200362 bytes, 9.5s round trip
document_rasterize  pages [1, 2]  -> 2 PNGs, 223798 + 225299 bytes, 6.3s
```

Each rendered page then went through the existing `llm_inference` path to the local OCR engine and came back as correct text for that page.

Platform half: aceteam-ai/aceteam#7224.
