### PR TITLE
feat(status): embedding services report the model they serve

### DIFF
--- a/internal/status/embedding_models_test.go
+++ b/internal/status/embedding_models_test.go
@@ -1,0 +1,232 @@
+package status
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"reflect"
+	"testing"
+
+	nativesvc "github.com/aceteam-ai/citadel-cli/internal/services"
+)
+
+// citadel-cli#690: an embedding server reports the model it is actually serving,
+// and a stopped engine's <name>.env default stops claiming a model a running
+// service already serves.
+//
+// The live case this reproduces, from an RTX 3090 node: a running TEI answered
+// GET /info with model_id "Alibaba-NLP/gte-multilingual-base" while reporting no
+// models at all, so the platform credited that model to a STOPPED vllm entry
+// whose env default named the same id. The embedding model was advertised as a
+// chat model on a dead engine, and the live engine advertised nothing.
+
+// teiInfoHandler serves TEI's GET /info with the given model_id.
+func teiInfoHandler(modelID string) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/info", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"model_id":         modelID,
+			"model_dtype":      "float16",
+			"max_input_length": 512,
+		})
+	})
+	return mux
+}
+
+func TestDiscoverEmbeddingModel_ReportsServedModel(t *testing.T) {
+	discovery, port := newTestDiscovery(t, teiInfoHandler("Alibaba-NLP/gte-multilingual-base"))
+
+	models, err := discovery.DiscoverEmbeddingModel(context.Background(), port)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(models, []string{"Alibaba-NLP/gte-multilingual-base"}) {
+		t.Fatalf("Models = %v, want [Alibaba-NLP/gte-multilingual-base]", models)
+	}
+}
+
+func TestDiscoverEmbeddingModel_NoModelIDIsEmptyNotError(t *testing.T) {
+	discovery, port := newTestDiscovery(t, teiInfoHandler(""))
+
+	models, err := discovery.DiscoverEmbeddingModel(context.Background(), port)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(models) != 0 {
+		t.Fatalf("Models = %v, want empty", models)
+	}
+}
+
+func TestDiscoverEmbeddingModel_UnreachableErrors(t *testing.T) {
+	discovery := NewModelDiscovery()
+	discovery.host = "127.0.0.1"
+
+	// Port 1 is reserved and never listening.
+	if _, err := discovery.DiscoverEmbeddingModel(context.Background(), 1); err == nil {
+		t.Fatal("expected an error from an unreachable embedding server")
+	}
+}
+
+// stubEmbeddingLister answers DiscoverEmbeddingModel from a fixed table.
+type stubEmbeddingLister struct {
+	models []string
+	err    error
+}
+
+func (s stubEmbeddingLister) DiscoverEmbeddingModel(_ context.Context, _ int) ([]string, error) {
+	return s.models, s.err
+}
+
+// alwaysHealthy / neverRunning are injected stand-ins for the live probes.
+func alwaysHealthy(int) bool { return true }
+
+// A NATIVE embedding server (no container) must still be reported. Container
+// presence is not the test for "running": ollama on the 3090 node runs as a
+// systemd unit, and a docker-only check reports a false negative for exactly
+// that shape of install.
+func TestCollectEmbeddingServices_NativeProcessCounts(t *testing.T) {
+	// portIfRunning stands in for managedEnginePortIfRunning, whose real
+	// implementation checks the container first and falls back to the native
+	// service probe. Here only the native branch answers.
+	nativeOnly := func(_, name string) (int, bool) {
+		if name == "tei" {
+			return 8102, true
+		}
+		return 0, false
+	}
+	md := stubEmbeddingLister{models: []string{"Alibaba-NLP/gte-multilingual-base"}}
+
+	got := collectEmbeddingServices(context.Background(), "docker", nativeOnly, alwaysHealthy, md)
+	if len(got) != 1 {
+		t.Fatalf("expected the native embedding server reported, got %+v", got)
+	}
+	if got[0].Type != ServiceTypeEmbedding {
+		t.Errorf("Type = %q, want %q", got[0].Type, ServiceTypeEmbedding)
+	}
+	if !reflect.DeepEqual(got[0].Models, []string{"Alibaba-NLP/gte-multilingual-base"}) {
+		t.Errorf("Models = %v, want the model the server reports", got[0].Models)
+	}
+}
+
+// The production wrapper resolves "running" through managedEnginePortIfRunning,
+// so this pins the property that function must have: a service with NO container
+// but a live native listener counts as running.
+//
+// Hermetic on purpose. A bogus engine binary makes the container branch fail
+// unconditionally, and a temporary NativeServices entry pointed at a real
+// listener on an ephemeral port makes the native branch the only thing that can
+// answer. Reusing a real engine's port would pass or fail depending on what
+// happens to be running on the developer's machine, which is how a
+// container-only regression slips through green.
+func TestManagedEnginePortIfRunning_DetectsNativeWithoutAContainer(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	port, ok := ln.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("unexpected listener addr type %T", ln.Addr())
+	}
+
+	const name = "native-embedding-probe-test"
+	nativesvc.NativeServices[name] = nativesvc.NativeService{
+		Name:   name,
+		Binary: "definitely-not-installed-binary",
+		Port:   port.Port,
+	}
+	defer delete(nativesvc.NativeServices, name)
+
+	gotPort, running := managedEnginePortIfRunning("no-such-container-runtime", name)
+	if !running {
+		t.Fatal("a natively served engine with no container must count as running")
+	}
+	if gotPort != port.Port {
+		t.Errorf("port = %d, want the native listener port %d", gotPort, port.Port)
+	}
+}
+
+// A server whose /info probe fails is still reported (running is real state),
+// but must not have a model invented for it.
+func TestCollectEmbeddingServices_ProbeFailureLeavesModelsEmpty(t *testing.T) {
+	running := func(_, name string) (int, bool) { return 8102, name == "tei" }
+	md := stubEmbeddingLister{err: context.DeadlineExceeded}
+
+	got := collectEmbeddingServices(context.Background(), "docker", running, alwaysHealthy, md)
+	if len(got) != 1 {
+		t.Fatalf("expected tei reported, got %+v", got)
+	}
+	if len(got[0].Models) != 0 {
+		t.Errorf("Models = %v, want empty when the probe failed", got[0].Models)
+	}
+}
+
+// A stopped engine must not claim a model a RUNNING service already serves.
+// This is what re-attributes gte-multilingual-base from the stopped vllm to the
+// running tei on node 1297.
+func TestCollectInstalledEngines_SkipsModelClaimedByRunningService(t *testing.T) {
+	dir := t.TempDir()
+	writeInstalledEngine(t, dir, "vllm", "VLLM_MODEL=Alibaba-NLP/gte-multilingual-base")
+
+	c := NewCollector(CollectorConfig{ConfigDir: dir, ModelHotswap: true})
+
+	// Nothing running: the stopped vllm is still an honest swap candidate.
+	unclaimed := c.collectInstalledEngines(map[string]struct{}{}, map[string]struct{}{})
+	if len(unclaimed) != 1 || unclaimed[0].Name != "vllm" {
+		t.Fatalf("without a claim, expected vllm advertised, got %+v", unclaimed)
+	}
+
+	// tei is running and serving that exact model: the stopped vllm drops it.
+	claimed := map[string]struct{}{"Alibaba-NLP/gte-multilingual-base": {}}
+	got := c.collectInstalledEngines(map[string]struct{}{}, claimed)
+	for _, e := range got {
+		if e.Name == "vllm" {
+			t.Fatalf("stopped vllm still claims a model the running tei serves: %+v", e)
+		}
+	}
+}
+
+// applyModelHotswap builds the claimed set from the running services it is
+// handed, so the subtraction works end to end and not just via the helper.
+func TestApplyModelHotswap_RunningEmbeddingServiceOutranksStoppedEngine(t *testing.T) {
+	dir := t.TempDir()
+	writeInstalledEngine(t, dir, "vllm", "VLLM_MODEL=Alibaba-NLP/gte-multilingual-base")
+
+	c := NewCollector(CollectorConfig{ConfigDir: dir, ModelHotswap: true})
+	st := &NodeStatus{Services: []ServiceInfo{
+		{
+			Name:   "tei",
+			Type:   ServiceTypeEmbedding,
+			Status: ServiceStatusRunning,
+			Health: HealthStatusOK,
+			Models: []string{"Alibaba-NLP/gte-multilingual-base"},
+		},
+	}}
+	c.applyModelHotswap(st, map[string]struct{}{"tei": {}})
+
+	for _, s := range st.Services {
+		if s.Name == "vllm" {
+			t.Fatalf("stopped vllm advertised a model the running tei serves: %+v", s)
+		}
+	}
+
+	var tei *ServiceInfo
+	for i := range st.Services {
+		if st.Services[i].Name == "tei" {
+			tei = &st.Services[i]
+		}
+	}
+	if tei == nil {
+		t.Fatal("tei disappeared from the status")
+	}
+	if !reflect.DeepEqual(tei.Models, []string{"Alibaba-NLP/gte-multilingual-base"}) {
+		t.Fatalf("tei Models = %v, want the model it actually serves", tei.Models)
+	}
+	// An embedding server is not a serving engine for hotswap purposes, so it
+	// must not pick up a residency flag meant for chat engines.
+	if tei.Resident != nil {
+		t.Errorf("tei Resident = %v, want nil (embedding services are not swap candidates)", tei.Resident)
+	}
+}

--- a/internal/status/engines.go
+++ b/internal/status/engines.go
@@ -119,37 +119,80 @@ func (c *Collector) collectManagedEngineStatus() []ServiceInfo {
 // /v1/embeddings upstream, not /v1/chat/completions.
 var embeddingProbeServices = []string{"tei"}
 
-// collectEmbeddingServiceStatus reports running embedding services (container
-// "citadel-<name>") that answer a health check, as ServiceInfo with
-// Type=embedding. This is the discovery signal the sovereign-embeddings backend
-// (_find_tei_node) matches on: a node advertising a "tei" service becomes
-// eligible to embed on its own model. Kept separate from
-// collectManagedEngineStatus so an embedding server is never mistaken for a chat
-// LLM (whose model-discovery/idle probes and chat-router listing do not apply).
+// collectEmbeddingServiceStatus reports running embedding services that answer a
+// health check, as ServiceInfo with Type=embedding. This is the discovery signal
+// the sovereign-embeddings backend (_find_tei_node) matches on: a node
+// advertising a "tei" service becomes eligible to embed on its own model. Kept
+// separate from collectManagedEngineStatus so an embedding server is never
+// mistaken for a chat LLM (whose idle probe and chat-router listing do not
+// apply).
+//
+// Each entry carries the model the server is ACTUALLY serving, read from the
+// engine's own /info (citadel-cli#690). Reporting no models let a stopped vllm's
+// <name>.env default claim the embedding model instead, so the platform credited
+// a dead engine and reasoned about the wrong VRAM cost and lifecycle for both.
+//
+// Running is decided by managedEnginePortIfRunning, not by a container check:
+// an embedding server installed natively (systemd unit, `serve` process) is
+// serving just as much as one in a container, and a docker-only test reports a
+// false negative on exactly the consumer-grade box this product targets.
 func (c *Collector) collectEmbeddingServiceStatus() []ServiceInfo {
-	engineBin := catalog.SelectContainerRuntime().EngineBin
+	var lister embeddingModelLister
+	if c.modelDiscovery != nil {
+		lister = c.modelDiscovery
+	}
+	return collectEmbeddingServices(
+		context.Background(),
+		catalog.SelectContainerRuntime().EngineBin,
+		managedEnginePortIfRunning,
+		embeddingServiceHealthy,
+		lister,
+	)
+}
+
+// embeddingModelLister is the slice of ModelDiscovery collectEmbeddingServices
+// needs. Narrow interface + injected running/health checks so the SELECTION and
+// ATTRIBUTION logic is unit-testable without docker, a native process, or a bound
+// port, the same pattern discoverLocalEngines uses.
+type embeddingModelLister interface {
+	DiscoverEmbeddingModel(ctx context.Context, port int) ([]string, error)
+}
+
+func collectEmbeddingServices(
+	ctx context.Context,
+	engineBin string,
+	portIfRunning func(engineBin, name string) (int, bool),
+	healthy func(port int) bool,
+	md embeddingModelLister,
+) []ServiceInfo {
 	var out []ServiceInfo
 	for _, name := range embeddingProbeServices {
-		if !containerRunning(engineBin, "citadel-"+name) {
-			continue
-		}
-		port := managedEngineHostPort(name)
-		if port <= 0 {
+		port, running := portIfRunning(engineBin, name)
+		if !running || port <= 0 {
 			continue
 		}
 		// Advertise only once the model is loaded (TEI /health is 200 only then),
 		// so the backend never discovers a still-warming node and then fails the
 		// embed with a 503.
-		if !embeddingServiceHealthy(port) {
+		if !healthy(port) {
 			continue
 		}
-		out = append(out, ServiceInfo{
+		info := ServiceInfo{
 			Name:   name,
 			Type:   ServiceTypeEmbedding,
 			Status: ServiceStatusRunning,
 			Port:   port,
 			Health: HealthStatusOK,
-		})
+		}
+		if md != nil {
+			mctx, cancel := context.WithTimeout(ctx, ModelDiscoveryTimeout)
+			models, err := md.DiscoverEmbeddingModel(mctx, port)
+			cancel()
+			if err == nil {
+				info.Models = models
+			}
+		}
+		out = append(out, info)
 	}
 	return out
 }

--- a/internal/status/hotswap.go
+++ b/internal/status/hotswap.go
@@ -113,8 +113,23 @@ func (c *Collector) applyModelHotswap(st *NodeStatus, reported map[string]struct
 		}
 	}
 
-	// 2. Advertise installed-but-stopped engines as swap-in candidates.
-	for _, eng := range c.collectInstalledEngines(reported) {
+	// 2. Advertise installed-but-stopped engines as swap-in candidates, minus any
+	// model a RUNNING service on this node already reports serving. Without that
+	// subtraction a stopped vllm's <name>.env default claimed the very model the
+	// live tei server was serving, so the platform credited the dead engine and
+	// the live one advertised nothing (citadel-cli#690).
+	claimed := make(map[string]struct{})
+	for i := range st.Services {
+		if st.Services[i].Status != ServiceStatusRunning {
+			continue
+		}
+		for _, m := range st.Services[i].Models {
+			if m = strings.TrimSpace(m); m != "" {
+				claimed[m] = struct{}{}
+			}
+		}
+	}
+	for _, eng := range c.collectInstalledEngines(reported, claimed) {
 		st.Services = append(st.Services, eng)
 	}
 }
@@ -126,7 +141,13 @@ func (c *Collector) applyModelHotswap(st *NodeStatus, reported map[string]struct
 // at least once — AND a served model id resolves (persisted <name>.env override
 // or the compose default). Engines already in reported (running) are skipped.
 // Returns nil when the collector has no configDir (the model source is unknown).
-func (c *Collector) collectInstalledEngines(reported map[string]struct{}) []ServiceInfo {
+//
+// claimed holds the models a RUNNING service on this node already reports. A
+// stopped engine whose only resolvable model is in that set is dropped: the
+// model is being served, just not by this engine, and advertising it twice let
+// the platform attribute it to the stopped one (citadel-cli#690). Pass an empty
+// map to advertise unconditionally.
+func (c *Collector) collectInstalledEngines(reported, claimed map[string]struct{}) []ServiceInfo {
 	if c.configDir == "" {
 		return nil
 	}
@@ -144,6 +165,9 @@ func (c *Collector) collectInstalledEngines(reported map[string]struct{}) []Serv
 		model := c.resolveInstalledModel(name)
 		if model == "" {
 			continue // no advertisable model (e.g. vllm with none persisted)
+		}
+		if _, taken := claimed[model]; taken {
+			continue // a running service on this node already serves it (#690)
 		}
 		notResident := false
 		out = append(out, ServiceInfo{

--- a/internal/status/hotswap_test.go
+++ b/internal/status/hotswap_test.go
@@ -31,7 +31,7 @@ func TestCollectInstalledEngines_AdvertisesStoppedWithDefaultModel(t *testing.T)
 	writeInstalledEngine(t, dir, "bonsai", "") // no env -> compose default model
 
 	c := NewCollector(CollectorConfig{ConfigDir: dir, ModelHotswap: true})
-	engines := c.collectInstalledEngines(map[string]struct{}{})
+	engines := c.collectInstalledEngines(map[string]struct{}{}, map[string]struct{}{})
 
 	var bonsai *ServiceInfo
 	for i := range engines {
@@ -61,7 +61,7 @@ func TestResolveInstalledModel_EnvOverrideWins(t *testing.T) {
 	writeInstalledEngine(t, dir, "vllm", "VLLM_MODEL=my-org/my-model\n# a comment\n")
 
 	c := NewCollector(CollectorConfig{ConfigDir: dir, ModelHotswap: true})
-	engines := c.collectInstalledEngines(map[string]struct{}{})
+	engines := c.collectInstalledEngines(map[string]struct{}{}, map[string]struct{}{})
 
 	var found bool
 	for _, e := range engines {
@@ -83,7 +83,7 @@ func TestCollectInstalledEngines_SkipsAlreadyReported(t *testing.T) {
 
 	c := NewCollector(CollectorConfig{ConfigDir: dir, ModelHotswap: true})
 	// bonsai already reported (running) => must not be duplicated as stopped.
-	engines := c.collectInstalledEngines(map[string]struct{}{"bonsai": {}})
+	engines := c.collectInstalledEngines(map[string]struct{}{"bonsai": {}}, map[string]struct{}{})
 	for _, e := range engines {
 		if e.Name == "bonsai" {
 			t.Fatalf("bonsai should be skipped when already reported")
@@ -93,7 +93,7 @@ func TestCollectInstalledEngines_SkipsAlreadyReported(t *testing.T) {
 
 func TestCollectInstalledEngines_NoConfigDirReturnsNil(t *testing.T) {
 	c := NewCollector(CollectorConfig{ModelHotswap: true}) // ConfigDir empty
-	if got := c.collectInstalledEngines(map[string]struct{}{}); got != nil {
+	if got := c.collectInstalledEngines(map[string]struct{}{}, map[string]struct{}{}); got != nil {
 		t.Fatalf("expected nil with no configDir, got %v", got)
 	}
 }

--- a/internal/status/models.go
+++ b/internal/status/models.go
@@ -182,6 +182,51 @@ func (m *ModelDiscovery) discoverOllamaModels(ctx context.Context, port int) ([]
 	return models, nil
 }
 
+// DiscoverEmbeddingModel queries an OpenAI-compatible embedding server for the
+// model it is actually serving (citadel-cli#690).
+//
+// Kept off DiscoverModels deliberately: an embedding server is not a chat
+// engine, and routing it through the LLM switch is exactly the mis-attribution
+// this fixes. Text Embeddings Inference exposes GET /info with a `model_id`
+// field naming the loaded model; it is the only model a TEI process serves, so
+// a single-element slice is the whole servable set.
+//
+// A server that answers but names no model returns an empty slice and nil
+// error: running with nothing to report is real, reportable state. Transport
+// or parse failures return an error so the caller leaves Models empty rather
+// than inventing one.
+func (m *ModelDiscovery) DiscoverEmbeddingModel(ctx context.Context, port int) ([]string, error) {
+	url := fmt.Sprintf("http://%s:%d/info", m.host, port)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query embedding server info: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("embedding server returned status %d", resp.StatusCode)
+	}
+
+	var infoResp struct {
+		ModelID string `json:"model_id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&infoResp); err != nil {
+		return nil, fmt.Errorf("failed to parse embedding server info: %w", err)
+	}
+
+	id := strings.TrimSpace(infoResp.ModelID)
+	if id == "" {
+		return []string{}, nil
+	}
+	return []string{id}, nil
+}
+
 // CheckServiceHealth performs a health check on an LLM service.
 func (m *ModelDiscovery) CheckServiceHealth(ctx context.Context, serviceType string, port int) (string, error) {
 	switch serviceType {


### PR DESCRIPTION
Closes #690. Node half of the honest-advertisement slice of aceteam-ai/aceteam#7243.

## Heads up for reviewers: an engine's advertised model list gets SHORTER

This intentionally removes a model claim from a stopped engine. That is the fix,
not a regression. A stopped `vllm` was advertising a model a running `tei` was
actually serving; after this the running engine reports it and the stopped one
does not.

## What was broken

`collectEmbeddingServiceStatus` never populated `Models`. A running embedding
server therefore reported no models at all, while a stopped LLM engine's
`<name>.env` default claimed the very model the embedding server was serving.
Upstream, the embedding model was advertised as a chat model, attributed to a
dead engine, and the live engine advertised nothing.

Embedding servers are small and cheap to keep resident, which makes them exactly
the thing a constrained box should pin rather than swap. Mis-attributing their
models to a large stopped engine means the scheduler reasons about the wrong
VRAM cost and the wrong lifecycle for both.

## Changes

- `ModelDiscovery.DiscoverEmbeddingModel` reads the served model from TEI's
  `GET /info` (`model_id`). Deliberately kept OFF the `DiscoverModels`
  chat-engine switch: an embedding server is not a chat engine, and routing it
  through that switch is the mis-attribution being fixed. A server that answers
  but names no model returns an empty slice and no error; a transport or parse
  failure returns an error so the caller leaves `Models` empty rather than
  inventing one.
- `collectEmbeddingServiceStatus` decides "running" via
  `managedEnginePortIfRunning` instead of a bare container check. Container
  presence is not the test for running: an engine installed as a systemd unit is
  serving just as much as one in a container, and a docker-only check reports a
  false negative on exactly the consumer-grade hardware this targets.
- `collectInstalledEngines` now takes the set of models a RUNNING service on
  this node already reports and skips any stopped engine whose only resolvable
  model is in it. `applyModelHotswap` builds that set from `status.Services`.
- Selection and attribution logic moved behind injected running/health checks
  and a narrow `embeddingModelLister` interface, mirroring the existing
  `discoverLocalEngines` pattern, so it is unit-testable without docker, a
  native process, or a bound port.

Not in scope: the installed-engine predicate still keys on the compose file
existing on disk, so an engine whose image was garbage collected still
advertises as installable. That predicate is #683.

## Test plan

`go build ./... && go vet ./... && go test ./...` green.

New tests in `internal/status/embedding_models_test.go`:

- TEI `/info` parsing: served model, empty `model_id`, unreachable server.
- A native embedding server with no container is reported, and its models come
  from the server itself.
- `managedEnginePortIfRunning` reports a natively served engine as running with
  no container. Hermetic: a bogus engine binary kills the container branch and a
  temporary `NativeServices` entry points at a real listener on an ephemeral
  port, so the result does not depend on what happens to be running on the
  developer's machine.
- A failed `/info` probe leaves `Models` empty rather than inventing one.
- A stopped `vllm` whose env default names a model a running `tei` serves is not
  advertised, both through the helper and end to end via `applyModelHotswap`.
- The running embedding entry keeps its own models and picks up no residency
  flag (it is not a chat-engine swap candidate).

Tests were verified to bite. Reverting the `Models` population, the claimed-model
subtraction, and the native fallback each produced real assertion failures
(`TestCollectEmbeddingServices_NativeProcessCounts`,
`TestCollectInstalledEngines_SkipsModelClaimedByRunningService` +
`TestApplyModelHotswap_RunningEmbeddingServiceOutranksStoppedEngine`, and
`TestManagedEnginePortIfRunning_DetectsNativeWithoutAContainer` respectively),
then the source was restored and the suite went green again.

Not deployed to any node; nothing was started, stopped, or restarted anywhere.

## Overlaps

Touches `internal/status/`, which #680 (Ready-vs-Resident gate + typed warming
error) also works in. Changes here are confined to
`collectEmbeddingServiceStatus`, `collectInstalledEngines`, and a new discovery
method, so they should merge either order, but sequence with #680 if it lands
first.

Platform side: aceteam-ai/aceteam#7235.