### PR TITLE
docs: stop presenting an external VPN client as part of node onboarding (#642)

### DIFF
--- a/DEVICE_AUTH_IMPLEMENTATION.md
+++ b/DEVICE_AUTH_IMPLEMENTATION.md
@@ -44,7 +44,8 @@ The OAuth 2.0 Device Authorization Grant flow (RFC 8628) has been successfully i
 4. **`cmd/login.go`**
    - Added device authorization case handler (~50 lines)
    - Similar flow to init but prompts for node name
-   - Uses received authkey with tailscale up
+   - Uses received authkey to join the AceTeam Network via the embedded
+     network client (`internal/network/`) — no external VPN client involved
 
 5. **`internal/nexus/deviceauth_test.go`** (NEW test file, ~145 lines)
    - 6 comprehensive unit tests

--- a/NIX_SETUP.md
+++ b/NIX_SETUP.md
@@ -56,7 +56,7 @@ cd /path/to/citadel-cli
 direnv allow
 ```
 
-That's it! The development environment with Go 1.24, Docker, Tailscale, and all build tools will be automatically loaded.
+That's it! The development environment with Go 1.24, Docker, and all build tools will be automatically loaded.
 
 ### What Gets Installed
 
@@ -64,8 +64,11 @@ The Nix flake provides:
 - **Go 1.24** - Exact version specified in go.mod
 - **Go tools** - gopls, go-tools, gotools for development
 - **Docker & Docker Compose** - Container management
-- **Tailscale** - Network mesh tooling
 - **Build utilities** - git, make, tree, curl, wget, jq
+
+No VPN or mesh client is provided (or needed): the mesh networking stack is the
+`tsnet` library compiled into the `citadel` binary, so a dev shell that can
+build the binary can also join the network with `citadel login`.
 
 ### Useful Commands
 

--- a/cmd/device.go
+++ b/cmd/device.go
@@ -72,8 +72,11 @@ network membership alive automatically: when the session breaks or its key
 nears expiry, the device proves its identity with a certificate and rejoins
 without any human involvement.
 
-Requires the Tailscale client to be installed (device mode drives it; it does
-not replace it).`,
+Device mode is the one Citadel command that needs the Tailscale client
+installed: it deliberately drives the machine's existing system client so a
+laptop keeps its own traffic policies. Joining a compute node to the AceTeam
+Network ('citadel login', 'citadel init') needs no external client at all --
+that path is built into this binary.`,
 }
 
 var deviceEnrollCmd = &cobra.Command{

--- a/docs-site/docs/getting-started/installation.md
+++ b/docs-site/docs/getting-started/installation.md
@@ -103,6 +103,7 @@ citadel version v2.3.0
 | **Docker** | Required for running AI services. Installed automatically by `citadel init --provision`. |
 | **GPU** | Optional but recommended. NVIDIA GPUs supported on Linux and Windows (via WSL2). Apple Silicon supported on macOS via Metal. |
 | **Network** | Outbound HTTPS access to `aceteam.ai` and `nexus.aceteam.ai` |
+| **VPN client** | None. The AceTeam Network client is built into the `citadel` binary — there is no separate app, daemon, or driver to install, and no admin rights are needed to join. |
 
 ## Next steps
 

--- a/docs-site/docs/getting-started/quick-start.md
+++ b/docs-site/docs/getting-started/quick-start.md
@@ -16,7 +16,7 @@ citadel
 The interactive control center launches and walks you through everything:
 
 1. **Login** -- If this is your first time, Citadel displays a one-time code and prompts you to open [aceteam.ai/device](https://aceteam.ai/device) in your browser. Enter the code to authorize your node.
-2. **Connect** -- Once authorized, your node joins the AceTeam Network automatically. No sudo required -- the CLI uses userspace networking with no system-level VPN or driver installation.
+2. **Connect** -- Once authorized, your node joins the AceTeam Network automatically. No sudo required -- the CLI uses userspace networking with no system-level VPN or driver installation. You never install a separate VPN app: the network client ships inside the `citadel` binary.
 3. **Work** -- The worker starts automatically, accepting AI workloads from the job queue.
 
 The control center shows a live dashboard with system vitals, GPU status, network connectivity, running services, and worker activity -- all in one place.

--- a/docs-site/docs/guides/networking.md
+++ b/docs-site/docs/guides/networking.md
@@ -64,8 +64,18 @@ This sends an HTTP-level ping through the mesh (not ICMP) and reports the round-
 Expose a local port to other nodes on the fabric:
 
 ```bash
-citadel expose --port 5432
+citadel expose 5432
 # Other nodes can now reach your PostgreSQL at <your-node-ip>:5432
+```
+
+Run it with no arguments to see this node's network IP and the URLs peers can
+use, `--peers` to see what other nodes are offering, and `--check` to verify
+that the services are actually reachable:
+
+```bash
+citadel expose            # this node's network IP and service URLs
+citadel expose --peers    # services offered by other nodes
+citadel expose --check    # verify reachability
 ```
 
 This makes the specified port on your node accessible to other fabric members through the mesh network. Any TCP service (databases, APIs, custom servers) can be exposed.
@@ -75,9 +85,13 @@ This makes the specified port on your node accessible to other fabric members th
 Proxy local traffic to a service on a remote node:
 
 ```bash
-citadel proxy gpu-server-01 --port 11434 --local-port 11434
+citadel proxy 11434 gpu-server-01:11434
 # Access remote Ollama as if it were local: http://localhost:11434
 ```
+
+The first argument is the local port, the second is `<peer>:<port>` (the peer
+can be a node name or a network IP). Run `citadel proxy` with no arguments for
+an interactive prompt. The proxy runs until interrupted with Ctrl+C.
 
 This sets up a local proxy that forwards requests to a remote node's services, allowing you to access them as if they were running locally.
 
@@ -89,6 +103,28 @@ This sets up a local proxy that forwards requests to a remote node's services, a
 | **Use when** | You run a service others need to reach | You need to access a service on another node |
 | **Port** | Listens on the mesh network interface | Listens on localhost |
 | **Example** | Expose a database for other nodes | Access a remote GPU node's inference API locally |
+
+## Reaching a Peer From Your Own Shell
+
+Citadel's own commands (`citadel ssh`, `citadel call`, `citadel ping`,
+`citadel proxy`) route over the mesh with no extra setup, because the network
+client is built into the binary. You do not need to install Tailscale or any
+other VPN app to use them.
+
+That membership is scoped to the Citadel process, not to your whole machine.
+So an unrelated host tool -- a plain `ssh`, `curl`, `psql`, or your browser --
+will not resolve a peer's network address on its own. Bring the port to
+localhost first:
+
+```bash
+# Make the peer's port 22 available at localhost:2222, then use plain ssh.
+citadel proxy 2222 gpu-server-01:22
+ssh -p 2222 user@localhost
+```
+
+`citadel proxy` is the supported answer whenever a non-Citadel program needs to
+talk to a peer service. (Machine-wide routing, which would let any program on
+the host address peers directly, is in development.)
 
 ## Security Model
 

--- a/docs/early-network-connection.md
+++ b/docs/early-network-connection.md
@@ -2,93 +2,94 @@
 
 ## Overview
 
-This change improves the `citadel init` flow by connecting to the network immediately after device authorization succeeds, rather than waiting for service selection and system provisioning to complete.
+`citadel init` connects to the AceTeam Network immediately after device
+authorization succeeds, rather than waiting for service selection and system
+provisioning to complete.
 
 ## Problem
 
-Previously, the `citadel init` flow would:
-1. Run device authorization (user approves at aceteam.ai/device)
-2. Prompt for service selection (vllm, ollama, etc.)
-3. Prompt for node name
-4. Run system provisioning (Docker, NVIDIA toolkit, Tailscale)
-5. Connect to network
-6. Start services
+An earlier version of the `citadel init` flow ran:
 
-This caused friction because:
-- Users had to wait through multiple prompts after authorization before seeing network connection
-- If Tailscale wasn't installed, the connection would fail late in the process
-- macOS users with App Store Tailscale installation couldn't use the CLI
+1. Device authorization (user approves at aceteam.ai/device)
+2. Service selection prompt (vllm, ollama, etc.)
+3. Node name prompt
+4. System provisioning (Docker, NVIDIA toolkit)
+5. Network connection
+6. Service startup
+
+Users had to sit through several prompts after approving the device before
+anything confirmed that the node had actually joined the network, and a
+connection failure surfaced late in a long-running flow.
 
 ## Solution
 
-The new flow connects immediately after authorization:
-1. Run device authorization
-2. **Get node name (hostname default)**
-3. **Install Tailscale if needed**
-4. **Connect to network immediately**
-5. Prompt for service selection
-6. Run system provisioning (Tailscale step skipped)
-7. Start services
+The flow connects as soon as the node has an authkey:
 
-## macOS Tailscale Detection
+1. Device authorization
+2. **Node name (hostname default)**
+3. **Connect to the network immediately**
+4. Service selection prompt
+5. System provisioning (Docker, NVIDIA toolkit)
+6. Service startup
 
-Added comprehensive Tailscale CLI detection for macOS:
+## No external network client
 
-```go
-// Check order:
-1. PATH lookup (exec.LookPath)
-2. /opt/homebrew/bin/tailscale     // Homebrew (Apple Silicon)
-3. /usr/local/bin/tailscale        // Homebrew (Intel)
-4. /Applications/Tailscale.app/Contents/MacOS/Tailscale  // App Store
-```
+Network connectivity is provided by the embedded `tsnet` library compiled into
+the `citadel` binary (`internal/network/`, see `connectToNetwork` in
+`cmd/init.go`). There is no daemon to install, no system VPN to configure, and
+no Tailscale/Tailscale.app prerequisite — `citadel login` (or `citadel init`) is
+the only step a user runs to put a node on the network. Because tsnet uses
+userspace networking, joining the network also needs no root/Administrator
+privileges.
 
-This allows users who installed Tailscale from the Mac App Store to use `citadel init` without needing to install via Homebrew.
+The connection is process-scoped: the mesh identity belongs to the `citadel`
+process, not to the whole host. Citadel's own subcommands (`citadel ssh`,
+`citadel call`, `citadel ping`, `citadel proxy`) route over the mesh, and
+`citadel proxy` is the documented way to reach a peer's service from an
+unrelated host tool (see `docs-site/docs/guides/networking.md`).
 
-## Files Changed
+## Behavior
 
-| File | Changes |
-|------|---------|
-| `cmd/login.go` | Added `getTailscalePath()` helper, updated all tailscale commands to use detected path |
-| `cmd/init.go` | Restructured flow for early network connection after device auth |
-| `internal/nexus/network_helpers.go` | Updated `getTailscaleCLI()` with macOS path detection |
+### Device authorization flow
 
-## Behavior Changes
+- After "Authorization Successful", the node connects to the network right away.
+- It no longer waits for the service selection prompt.
 
-### Device Authorization Flow
-- After "Authorization Successful", immediately connects to network
-- No longer waits for service selection prompt
+### Authkey flag (`--authkey`)
 
-### Authkey Flag (`--authkey`)
-- Also connects immediately when authkey is provided via flag
-- Consistent behavior with device auth flow
+- Also connects immediately when an authkey is supplied on the command line.
+- Consistent with the device auth flow.
 
-### Network-Only Mode (`--network-only`)
-- Now respects early connection state
-- If already connected via device auth, exits immediately
+### Network-only mode (default)
 
-### System Provisioning
-- Tailscale installation step is skipped if already installed during early connection
-- Other provisioning steps (Docker, NVIDIA) unchanged
+- Respects the early connection state: if the node connected during device auth,
+  `citadel init` exits once the manifest is written.
+
+### System provisioning (`--provision`)
+
+- Provisioning installs Docker and the NVIDIA Container Toolkit only. There is
+  no network-client installation step (`cmd/init.go`,
+  "Network connectivity is now handled via embedded tsnet library").
 
 ## Testing
 
-To test the changes:
+```bash
+# Interactive device auth: after "Authorization Successful" you should see
+# "Connecting to network" BEFORE the service selection prompt.
+citadel init
 
-1. **macOS with App Store Tailscale**:
-   ```bash
-   sudo citadel init
-   # Should detect /Applications/Tailscale.app/Contents/MacOS/Tailscale
-   ```
+# Non-interactive: connects immediately using the supplied key.
+citadel init --authkey <key>
 
-2. **macOS without Tailscale**:
-   ```bash
-   sudo citadel init
-   # Should install via Homebrew, then connect immediately after device auth
-   ```
+# Full provisioning (Docker + NVIDIA toolkit) on a fresh Linux box.
+sudo citadel init --provision
+```
 
-3. **Device auth flow**:
-   ```bash
-   sudo citadel init
-   # After "Authorization Successful", should see "Connecting to network"
-   # BEFORE service selection prompt
-   ```
+## Historical note
+
+Before the network client was embedded, this flow detected or installed the
+Tailscale CLI (Homebrew on macOS, with a fallback path for the Mac App Store
+app) and shelled out to `tailscale up`. Those helpers
+(`getTailscalePath`, `getTailscaleCLI`) and the Tailscale provisioning step were
+removed when `internal/network/` took over; nothing in the onboarding path
+depends on an external client any more.

--- a/flake.nix
+++ b/flake.nix
@@ -31,9 +31,10 @@
             # Utilities used by build script
             tree
 
-            # Note: Tailscale is intentionally not included here as it's
-            # typically installed system-wide and runs as a daemon.
-            # Install via: brew install tailscale (macOS) or system package manager
+            # Note: no mesh/VPN client is needed here. Citadel embeds tsnet,
+            # so `citadel login` joins the network with no external daemon.
+            # (The system `tailscale` CLI is only required by `citadel device`,
+            # which deliberately drives the system client rather than tsnet.)
 
             # Documentation site (Docusaurus)
             nodejs_22

--- a/internal/devicemode/tailscale.go
+++ b/internal/devicemode/tailscale.go
@@ -54,8 +54,11 @@ func findTailscale(
 		}
 	}
 	return "", fmt.Errorf(
-		"tailscale CLI not found — install Tailscale (https://tailscale.com/download) " +
-			"or set " + tailscaleBinEnv)
+		"tailscale CLI not found — 'citadel device' drives the system Tailscale " +
+			"client, so install it (https://tailscale.com/download) or set " +
+			tailscaleBinEnv + ". " +
+			"Note this applies to device mode only: putting a compute node on the " +
+			"AceTeam Network with 'citadel login' needs no external client")
 }
 
 // TailscaleStatus is the subset of `tailscale status --json` device mode


### PR DESCRIPTION
Closes #642 (citadel-cli side).

## Context

Citadel embeds the network client (`tsnet`) in the binary — `internal/network/server.go`. There is no daemon and no external client dependency for putting a node on the AceTeam Network. Several docs in this repo had not caught up and still described installing or running an external client as part of onboarding, or described a `citadel init` flow that installed one.

## Changes

| File | What |
|---|---|
| `docs/early-network-connection.md` | Rewritten. It documented "**Install Tailscale if needed**" as step 3 of `citadel init`, a "macOS Tailscale Detection" section, and a Files-Changed table pointing at `getTailscalePath()` / `getTailscaleCLI()` — helpers that no longer exist anywhere in the tree. Now describes the actual current flow (connect immediately after device auth, embedded client, no root), states the process-scoped constraint, and keeps the old behaviour as a short historical note. |
| `DEVICE_AUTH_IMPLEMENTATION.md` | `cmd/login.go` "Uses received authkey with `tailscale up`" → uses it to join via the embedded client. |
| `NIX_SETUP.md` | Removed "**Tailscale** – Network mesh tooling" from the dev-shell contents. This was factually wrong: `flake.nix` explicitly does *not* include it. Added a line explaining why none is needed. |
| `flake.nix` | The exclusion comment told developers to `brew install tailscale`. Replaced with the accurate reason (tsnet is embedded), noting the system CLI is only needed by `citadel device`. |
| `docs-site/.../installation.md` | New system-requirements row: **VPN client — None.** No separate app, daemon, or driver; no admin rights to join. |
| `docs-site/.../quick-start.md` | Step 2 now says explicitly that you never install a separate VPN app. |
| `docs-site/.../guides/networking.md` | New **"Reaching a Peer From Your Own Shell"** section — this is the issue's "constraint worth stating". Says plainly that citadel's own commands work with no extra setup, that mesh membership is scoped to the citadel process (so a plain `ssh`/`curl`/browser will not resolve a peer on its own), and that `citadel proxy` is the supported answer. |
| `cmd/device.go`, `internal/devicemode/tailscale.go` | Device mode genuinely requires the system client. Its long help and its `tailscale CLI not found` error now scope that requirement to `citadel device` and say `citadel login` needs no external client — so the error can't be misread as "citadel needs Tailscale". |

### Drive-by correctness fix

While writing the peer-access section I verified the examples against `cmd/proxy.go` and `cmd/expose.go`. Both existing examples in `networking.md` used flags that do not exist:

- `citadel proxy gpu-server-01 --port 11434 --local-port 11434` → actual usage is `citadel proxy [local-port] [peer:port]`, i.e. `citadel proxy 11434 gpu-server-01:11434`.
- `citadel expose --port 5432` → `--port` is not a flag; the port is positional (`citadel expose 5432`), and bare `citadel expose` / `--peers` / `--check` are the display modes.

This matters here: `citadel proxy` is the citadel-only answer for reaching a peer service, so a non-working example is exactly what pushes someone back toward an external client.

## Deliberately left alone

Per the issue's own framing — citadel nodes interoperate with regular clients on the same coordination server, so not every mention should be scrubbed.

- **`citadel device` still drives the system Tailscale client.** That is the design of #5959: a laptop keeps its own traffic policies, and device mode babysits the existing session rather than replacing it. Only the *wording* changed, not the dependency.
- **`internal/proxmox/provisioner.go`** renders cloud-init that installs a client and joins the mesh on first boot for fabric instance VMs. That is a machine-provisioning code path with no user instruction in it, and the VM wants machine-wide routing. Converting it is a functional change, not a docs fix — left for the machine-wide-routing work.
- **Architecture / interop content:** `docs-site/docs/architecture/{mesh-network,design-decisions}.md` (both already say users do *not* need to install anything separately), `CLAUDE.md`'s interop table, the control-center "Tailscale Already Connected" modal (shown only when a system client is *already* present — naming the actual product there is correct), `cmd/serve.go`'s note about the coordination server's cert API, `docs/fabric-status-reporting.md`, `docs/gateway-ingress.md`, and the `tailscale_ip` JSON field (kept for backwards compat per CLAUDE.md).
- **`docs/man/`** is generated (`go run docs/gen-manpage.go`) and is already stale on `main` — regenerating pulls in unrelated drift (a `--runtime` flag on every command, eight new command pages, a date bump across 119 files). Left for its own chore PR so this diff stays reviewable.

## Cross-repo follow-ups (not fixable here)

- **`aceteam-ai/nexus` — `register/app.py`.** The register page's help text and the mobile walkthrough are the largest remaining surface named in #642 and live in a different repo. Still needs: rewrite the help text to "install citadel, run `citadel login`", and rework/drop the mobile page (the AceTeam iOS app has its own tunnel provider path). The `?nodekey=` deep link should stay working but be demoted to an escape hatch.
- **`aceteam` — `docs/fabric/nexus-device-auth-flow.md`** documents the deep link as a first-class join path.

## Testing

```
go build ./...   # clean
go vet ./...     # clean
go test ./...    # all pass
```

No test asserts on the changed `findTailscale` error string (the test's own stub returns a different message), and no behaviour changed — the edits are help text, one error message, and docs.