### PR TITLE
fix(services): stop the native engine citadel started, not every process whose argv mentions it (#696)

### DIFF
--- a/internal/jobs/service_handler_native_model_test.go
+++ b/internal/jobs/service_handler_native_model_test.go
@@ -100,6 +100,9 @@ services:
 	if err := os.WriteFile(filepath.Join(dir, "citadel.yaml"), []byte(manifest), 0600); err != nil {
 		t.Fatal(err)
 	}
+	// A native start records the engine's pid (#696); keep that out of the
+	// developer's real ~/.citadel-cli/run.
+	t.Setenv("CITADEL_RUN_DIR", t.TempDir())
 	return NewServiceHandler(dir)
 }
 

--- a/internal/services/native.go
+++ b/internal/services/native.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
-	"strings"
 	"time"
 
 	svcports "github.com/aceteam-ai/citadel-cli/services"
@@ -183,6 +182,19 @@ func StartNativeService(serviceName string, logDir string) (*NativeProcess, erro
 		return nil, fmt.Errorf("failed to start service: %w", err)
 	}
 
+	// Record the PID so a later stop can signal THIS process instead of
+	// pattern-matching command lines (#696). Every caller discards the returned
+	// NativeProcess, and the stop may arrive in a different citadel process
+	// entirely, so the PID has to outlive this one on disk.
+	//
+	// A pidfile that cannot be written is not a start failure: the engine is up,
+	// and stop still has its (narrow) name-matching fallback. Reported through
+	// the service's own log file, which is where anything else about this engine
+	// would be looked for.
+	if err := writeNativePidFile(serviceName, cmd.Process.Pid); err != nil {
+		fmt.Fprintf(logFile, "citadel: could not record pid for %s: %v\n", serviceName, err)
+	}
+
 	return &NativeProcess{
 		Name:    serviceName,
 		Cmd:     cmd,
@@ -261,25 +273,8 @@ func IsNativeServiceServing(serviceName string) bool {
 	return portAnswers(service.Port, nativeProbeTimeout)
 }
 
-// StopNativeService stops a running native service
-func StopNativeService(serviceName string) error {
-	service, ok := NativeServices[serviceName]
-	if !ok {
-		return fmt.Errorf("unknown service: %s", serviceName)
-	}
-
-	// Find and kill the process
-	cmd := exec.Command("pkill", "-f", service.Binary)
-	if err := cmd.Run(); err != nil {
-		// Check if it's just "no process found" which is OK
-		if strings.Contains(err.Error(), "no process") {
-			return nil
-		}
-		return fmt.Errorf("failed to stop service: %w", err)
-	}
-
-	return nil
-}
+// StopNativeService lives in native_stop.go: it targets the PID recorded at
+// start rather than pattern-matching command lines (#696).
 
 // WaitForServiceReady waits for a service to be ready by checking its port.
 //

--- a/internal/services/native_stop.go
+++ b/internal/services/native_stop.go
@@ -1,0 +1,373 @@
+// internal/services/native_stop.go
+package services
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
+)
+
+// Stopping a native engine used to be `pkill -f <binary>`, which matches the
+// pattern against the ENTIRE COMMAND LINE of every process and kills each match
+// (#696). Stopping ollama could therefore kill an operator's `journalctl -u
+// ollama`, an editor with an ollama path open, or any script whose argv merely
+// mentions the engine -- the write-side of the same looseness #677 fixed on the
+// read side.
+//
+// The replacement targets the process citadel actually started: StartNativeService
+// records its PID, and stop verifies that the recorded PID is STILL the expected
+// binary before signalling it. Verification is the load-bearing half. A stale
+// pidfile whose PID has been recycled by an unrelated process is exactly the bug
+// being fixed, so an unverified PID is treated as stale -- removed, never killed.
+//
+// An engine citadel did not start (systemd, a hand-run binary) must still be
+// stoppable, so there is a fallback -- but a narrow one: it matches the
+// EXECUTABLE NAME, not a substring of the command line, and anchors vllm's two
+// python forms (`python -m vllm.entrypoints...` and the pip console script) at
+// argv[0]/argv[1].
+//
+// Platform note: identifying and enumerating processes here uses /proc and `ps`,
+// which are unix-only, exactly like the `pkill`/`pgrep` this replaced and like
+// IsNativeServiceRunning still does. Windows support for the native engine path
+// is a pre-existing gap and is deliberately not addressed here.
+
+// runDirEnv overrides the directory holding <service>.pid files. It exists
+// because the run dir must be identical for the process that starts an engine
+// and the (possibly different) process that stops it; tests and container images
+// that cannot write the default location set it explicitly.
+const runDirEnv = "CITADEL_RUN_DIR"
+
+// Stop timing. Injectable so tests do not have to wait out the real grace
+// period; the shipped values are pinned by TestNativeStopTimingDefaults.
+var (
+	// nativeStopGrace is how long a SIGTERM'd engine gets to exit before SIGKILL.
+	// Engines flush state and release VRAM on the way out, so this is generous
+	// enough for an orderly exit but short enough that a stop job does not hang.
+	nativeStopGrace = 5 * time.Second
+	// nativeStopPoll is how often the exit is re-checked during the grace window.
+	nativeStopPoll = 100 * time.Millisecond
+)
+
+// nativeRunDir returns the directory holding native-engine pidfiles.
+//
+// It is deliberately NOT derived from the logDir passed to StartNativeService:
+// the two start call sites pass different directories (cmd/service.go uses
+// ~/citadel-node/logs, the job handler uses <ConfigDir>/logs), and the stop call
+// sites pass no directory at all. A pidfile only works if start and stop agree
+// on where it lives, so it is anchored to the single per-node location both can
+// resolve without an argument: the config dir.
+func nativeRunDir() string {
+	if v := strings.TrimSpace(os.Getenv(runDirEnv)); v != "" {
+		return v
+	}
+	return filepath.Join(platform.ConfigDir(), "run")
+}
+
+// nativePidFilePath returns the pidfile path for a service.
+func nativePidFilePath(serviceName string) string {
+	return filepath.Join(nativeRunDir(), serviceName+".pid")
+}
+
+// writeNativePidFile records the PID of an engine citadel just started.
+func writeNativePidFile(serviceName string, pid int) error {
+	dir := nativeRunDir()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create run directory: %w", err)
+	}
+	return os.WriteFile(nativePidFilePath(serviceName), []byte(strconv.Itoa(pid)+"\n"), 0644)
+}
+
+// readNativePidFile returns the recorded PID, or false when there is no usable
+// one. PIDs of 1 or less are rejected outright: a corrupt or truncated pidfile
+// must never resolve to init.
+func readNativePidFile(serviceName string) (int, bool) {
+	raw, err := os.ReadFile(nativePidFilePath(serviceName))
+	if err != nil {
+		return 0, false
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(raw)))
+	if err != nil || pid <= 1 {
+		return 0, false
+	}
+	return pid, true
+}
+
+// processEntry is one row of the process table.
+type processEntry struct {
+	pid     int
+	cmdline string
+}
+
+// processCmdline returns the full command line of pid, and false when there is
+// no such process (or nothing left to identify it by, e.g. a reaped zombie).
+// Indirected through a var so tests can drive the decision logic directly.
+var processCmdline = defaultProcessCmdline
+
+func defaultProcessCmdline(pid int) (string, bool) {
+	if pid <= 0 {
+		return "", false
+	}
+	if runtime.GOOS == "linux" {
+		raw, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "cmdline"))
+		if err != nil {
+			return "", false
+		}
+		args := strings.FieldsFunc(string(raw), func(r rune) bool { return r == 0 })
+		if len(args) == 0 {
+			// Kernel thread or a zombie: no argv to identify it with, so it is
+			// not something we can confirm as our engine.
+			return "", false
+		}
+		return strings.Join(args, " "), true
+	}
+	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "args=").Output()
+	if err != nil {
+		return "", false
+	}
+	line := strings.TrimSpace(string(out))
+	if line == "" {
+		return "", false
+	}
+	return line, true
+}
+
+// listProcesses enumerates the process table. Indirected through a var for the
+// same reason as processCmdline.
+var listProcesses = defaultListProcesses
+
+func defaultListProcesses() ([]processEntry, error) {
+	// -A rather than -e: both mean "every process", but -e is BSD-style
+	// "show environment" on macOS while -A is portable across procps and BSD ps.
+	out, err := exec.Command("ps", "-A", "-o", "pid=,args=").Output()
+	if err != nil {
+		return nil, err
+	}
+	var entries []processEntry
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		pidStr, rest, found := strings.Cut(line, " ")
+		if !found {
+			continue
+		}
+		pid, err := strconv.Atoi(pidStr)
+		if err != nil {
+			continue
+		}
+		rest = strings.TrimSpace(rest)
+		if rest == "" {
+			continue
+		}
+		entries = append(entries, processEntry{pid: pid, cmdline: rest})
+	}
+	return entries, nil
+}
+
+// processMatchesService reports whether a command line belongs to the service's
+// own engine process.
+//
+// The rule is executable-name equality on argv[0], never a substring of the
+// command line: `journalctl -u ollama`, `vim notes/ollama.md` and
+// `citadel service stop ollama` all mention the binary and none of them is the
+// engine. Multi-token AltBinaries (vllm's `python -m
+// vllm.entrypoints.openai.api_server`) are matched anchored: the interpreter has
+// to BE argv[0] and the remaining tokens have to be the leading arguments in
+// order.
+func processMatchesService(service NativeService, cmdline string) bool {
+	args := strings.Fields(cmdline)
+	if len(args) == 0 {
+		return false
+	}
+	exe := filepath.Base(args[0])
+
+	if service.Binary != "" && exe == service.Binary {
+		return true
+	}
+
+	for _, alt := range service.AltBinaries {
+		tokens := strings.Fields(alt)
+		switch {
+		case len(tokens) == 0:
+			continue
+		case len(tokens) == 1:
+			// A plain alternative executable name; exact match only.
+			// NOTE: llamacpp lists the very generic "server" here, so an
+			// unrelated program literally named `server` would be stopped. That
+			// is still strictly narrower than the old whole-command-line match,
+			// and pruning AltBinaries is a separate change (they double as the
+			// discovery list for GetNativeBinaryPath).
+			if exe == tokens[0] {
+				return true
+			}
+		default:
+			if !interpreterMatches(exe, tokens[0]) {
+				continue
+			}
+			// Console-script form. `vllm` is only ever installed by pip, so
+			// /usr/local/bin/vllm is a shebang script and the kernel rewrites
+			// argv to `<interpreter> /usr/local/bin/vllm serve <model>` --
+			// verified locally: a `#!/bin/sh` script named vllm-ish appears in
+			// the process table as `/bin/sh ./vllm-ish serve mymodel`. Neither
+			// the primary-name check (argv[0] is the interpreter) nor the -m
+			// comparison below sees that, so without this branch the one engine
+			// that motivated the anchored pattern would become unstoppable.
+			// Still anchored: the interpreter must BE argv[0] and the binary must
+			// BE the script at argv[1], so `vim /usr/local/bin/vllm` does not
+			// match.
+			if service.Binary != "" && len(args) >= 2 && filepath.Base(args[1]) == service.Binary {
+				return true
+			}
+			if len(args)-1 < len(tokens)-1 {
+				continue
+			}
+			matched := true
+			for i, tok := range tokens[1:] {
+				if args[1+i] != tok {
+					matched = false
+					break
+				}
+			}
+			if matched {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// interpreterMatches accepts the versioned names a scripting interpreter really
+// appears under -- python3, python3.11 -- for an AltBinaries token of "python",
+// while still rejecting anything else (pythonish-wrapper, mypython).
+func interpreterMatches(exe, token string) bool {
+	if exe == token {
+		return true
+	}
+	if !strings.HasPrefix(exe, token) {
+		return false
+	}
+	for _, r := range exe[len(token):] {
+		if (r < '0' || r > '9') && r != '.' {
+			return false
+		}
+	}
+	return true
+}
+
+// isServiceProcess reports whether pid is currently a live process belonging to
+// this service. This is the verification gate: everything that signals a PID
+// goes through it first.
+func isServiceProcess(pid int, service NativeService) bool {
+	cmdline, ok := processCmdline(pid)
+	if !ok {
+		return false
+	}
+	return processMatchesService(service, cmdline)
+}
+
+// stopVerifiedPID signals a PID that has already been verified as the service,
+// escalating to SIGKILL if it does not exit within the grace period.
+//
+// Aliveness during the wait is re-tested with the same identity check rather
+// than a bare existence probe, which handles both an unreaped zombie (no argv
+// left, therefore gone for our purposes) and the nastier case of the PID being
+// recycled inside the grace window -- escalating to SIGKILL against a recycled
+// PID would be the very bug this change removes.
+func stopVerifiedPID(pid int, service NativeService) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("failed to stop service: %w", err)
+	}
+	if err := proc.Signal(syscall.SIGTERM); err != nil {
+		if errors.Is(err, os.ErrProcessDone) {
+			return nil
+		}
+		return fmt.Errorf("failed to stop service: %w", err)
+	}
+
+	deadline := time.Now().Add(nativeStopGrace)
+	for {
+		if !isServiceProcess(pid, service) {
+			return nil
+		}
+		if !time.Now().Before(deadline) {
+			break
+		}
+		time.Sleep(nativeStopPoll)
+	}
+
+	if !isServiceProcess(pid, service) {
+		return nil
+	}
+	if err := proc.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return fmt.Errorf("failed to kill service after %s: %w", nativeStopGrace, err)
+	}
+	return nil
+}
+
+// stopMatchingProcesses is the fallback for an engine citadel did not start.
+// Finding nothing is success: "already stopped" is the desired end state, which
+// also preserves the old behaviour of treating pkill's "no process found" as OK.
+func stopMatchingProcesses(service NativeService) error {
+	entries, err := listProcesses()
+	if err != nil {
+		return fmt.Errorf("failed to stop service: could not list processes: %w", err)
+	}
+	self := os.Getpid()
+	var firstErr error
+	for _, entry := range entries {
+		if entry.pid <= 1 || entry.pid == self {
+			continue
+		}
+		if !processMatchesService(service, entry.cmdline) {
+			continue
+		}
+		if err := stopVerifiedPID(entry.pid, service); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// StopNativeService stops a running native service.
+//
+// Order matters: the recorded PID first (the process citadel owns), and the
+// name-matching sweep only when there is no usable pidfile. Stopping the engine
+// citadel started is the contract; sweeping every matching process on top of
+// that would widen the blast radius again for no gain.
+//
+// This deliberately never consults the service's port. A wedged engine that has
+// stopped answering is still a process holding VRAM and must still be killed --
+// see the comments on IsNativeServiceRunning and on serviceStop (#649/#677).
+func StopNativeService(serviceName string) error {
+	service, ok := NativeServices[serviceName]
+	if !ok {
+		return fmt.Errorf("unknown service: %s", serviceName)
+	}
+
+	if pid, ok := readNativePidFile(serviceName); ok {
+		if isServiceProcess(pid, service) {
+			if err := stopVerifiedPID(pid, service); err != nil {
+				return err
+			}
+			_ = os.Remove(nativePidFilePath(serviceName))
+			return nil
+		}
+		// The PID is dead, or -- the dangerous case -- has been recycled and now
+		// belongs to something unrelated. Either way the pidfile is stale: drop
+		// it and fall through to the name match. Never signal an unverified PID.
+		_ = os.Remove(nativePidFilePath(serviceName))
+	}
+
+	return stopMatchingProcesses(service)
+}

--- a/internal/services/native_stop_test.go
+++ b/internal/services/native_stop_test.go
@@ -1,0 +1,479 @@
+// internal/services/native_stop_test.go
+package services
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// helperSleepEnv turns a re-exec of this test binary into a process that does
+// nothing but sleep. Re-execing the test binary (rather than /bin/sleep or a
+// shell script) is what lets a test choose the process's argv[0]: the whole
+// subject here is which command lines a stop is allowed to match, and a shebang
+// script would appear in the process table as /bin/sh, not as the name under
+// test. It exits on SIGTERM through Go's default signal disposition, exactly
+// like a real engine would.
+const helperSleepEnv = "CITADEL_TEST_NATIVE_SLEEP"
+
+func TestMain(m *testing.M) {
+	if os.Getenv(helperSleepEnv) != "" {
+		time.Sleep(5 * time.Minute)
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+var fakeCounter atomic.Int64
+
+// uniqueBinaryName returns an engine binary name that cannot collide with any
+// real process on the machine running the suite. This matters: these tests kill
+// processes by name, and a generic name would put a developer's actual ollama
+// (or anything else) in the blast radius.
+func uniqueBinaryName(t *testing.T) string {
+	t.Helper()
+	return fmt.Sprintf("citadel-test-engine-%d-%d", os.Getpid(), fakeCounter.Add(1))
+}
+
+// registerTestEngine installs a throwaway service in NativeServices whose port
+// is closed. A closed port is the "wedged engine" shape from #649/#677: nothing
+// answers, yet the process is alive and holding VRAM, and stop must still kill
+// it.
+func registerTestEngine(t *testing.T, svc NativeService) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("native engine stop uses unix process tooling (ps//proc), as pkill/pgrep did before it")
+	}
+	name := svc.Name
+	if _, exists := NativeServices[name]; exists {
+		t.Fatalf("test service name %q collides with a real service", name)
+	}
+	NativeServices[name] = svc
+	t.Cleanup(func() { delete(NativeServices, name) })
+	// Isolate the pidfile from the developer's real ~/.citadel-cli/run.
+	t.Setenv(runDirEnv, t.TempDir())
+	return name
+}
+
+// fakeProc is a spawned process with a chosen argv.
+type fakeProc struct {
+	pid  int
+	done chan struct{}
+}
+
+// spawnFake starts a process whose command line is exactly argv and which sleeps
+// until signalled. It is reaped by a background Wait so an exited helper never
+// lingers as a zombie and confuses the process-table checks.
+func spawnFake(t *testing.T, argv ...string) *fakeProc {
+	t.Helper()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	cmd := &exec.Cmd{
+		Path: exe,
+		Args: argv,
+		Env:  append(os.Environ(), helperSleepEnv+"=1"),
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start fake %v: %v", argv, err)
+	}
+	fp := &fakeProc{pid: cmd.Process.Pid, done: make(chan struct{})}
+	go func() {
+		_ = cmd.Wait()
+		close(fp.done)
+	}()
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		<-fp.done
+	})
+
+	// Wait until the process table actually shows the argv we asked for; exec is
+	// asynchronous and a stop issued too early would find nothing to match.
+	deadline := time.Now().Add(10 * time.Second)
+	want := strings.Join(argv, " ")
+	for time.Now().Before(deadline) {
+		if line, ok := processCmdline(fp.pid); ok && strings.Contains(line, want) {
+			return fp
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("fake process %v never appeared in the process table", argv)
+	return nil
+}
+
+func assertExited(t *testing.T, fp *fakeProc, what string) {
+	t.Helper()
+	select {
+	case <-fp.done:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("%s (pid %d) was not stopped", what, fp.pid)
+	}
+}
+
+func assertSurvived(t *testing.T, fp *fakeProc, what string) {
+	t.Helper()
+	// A kill would already have been delivered by the time StopNativeService
+	// returned; the settle window only covers signal delivery and exit.
+	select {
+	case <-fp.done:
+		t.Fatalf("%s (pid %d) was killed -- it is not the engine (#696)", what, fp.pid)
+	case <-time.After(300 * time.Millisecond):
+	}
+	if _, ok := processCmdline(fp.pid); !ok {
+		t.Fatalf("%s (pid %d) is gone from the process table -- it is not the engine (#696)", what, fp.pid)
+	}
+}
+
+// TestProcessMatchesServiceRejectsCommandLineMentions is the decision table the
+// whole fix rests on: a command line that MENTIONS the binary is not the engine.
+func TestProcessMatchesServiceRejectsCommandLineMentions(t *testing.T) {
+	ollama := NativeServices["ollama"]
+	llamacpp := NativeServices["llamacpp"]
+	vllm := NativeServices["vllm"]
+
+	cases := []struct {
+		name    string
+		service NativeService
+		cmdline string
+		want    bool
+	}{
+		{"engine on PATH", ollama, "/usr/local/bin/ollama serve", true},
+		{"engine bare name", ollama, "ollama serve", true},
+		{"journalctl following the unit", ollama, "journalctl -u ollama -f", false},
+		{"systemctl status", ollama, "systemctl status ollama", false},
+		{"editor with an ollama path open", ollama, "vim /home/dev/notes/ollama.md", false},
+		{"citadel stopping ollama", ollama, "/usr/local/bin/citadel service stop ollama", false},
+		{"a wrapper script named after it", ollama, "/usr/bin/ollama-wrapper --serve", false},
+		{"llama-server", llamacpp, "/opt/llama.cpp/llama-server --host 0.0.0.0", true},
+		{"llamacpp alt binary", llamacpp, "llama-cpp-server --port 8081", true},
+		{"vllm entrypoint binary", vllm, "/usr/bin/vllm serve meta-llama/Llama-3-8B", true},
+		{"vllm python module form", vllm, "/usr/bin/python3 -m vllm.entrypoints.openai.api_server --model x", true},
+		{"vllm python module form, versioned interpreter", vllm, "python3.11 -m vllm.entrypoints.openai.api_server", true},
+		// pip installs vllm as a shebang console script, so the kernel rewrites
+		// argv to `<interpreter> <script> ...`. This is how a real `vllm serve`
+		// appears in the process table.
+		{"vllm console script", vllm, "/usr/bin/python3 /usr/local/bin/vllm serve meta-llama/Llama-3-8B", true},
+		{"python running an unrelated script", vllm, "/usr/bin/python3 /usr/local/bin/other-tool serve", false},
+		{"editor opening the console script", vllm, "vim /usr/local/bin/vllm", false},
+		{"pip installing it", vllm, "/usr/bin/python3 -m pip install vllm", false},
+		{"python running something else", vllm, "python3 -m http.server", false},
+		{"a log tail mentioning the module", vllm, "tail -f /var/log/vllm.entrypoints.openai.api_server.log", false},
+		{"grep for the module", vllm, "grep -r vllm.entrypoints.openai.api_server /etc", false},
+		{"empty command line", ollama, "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := processMatchesService(tc.service, tc.cmdline); got != tc.want {
+				t.Errorf("processMatchesService(%q) = %v, want %v", tc.cmdline, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestStopNativeServiceFallbackStopsEngineNotLookalikes is issue #696 end to end
+// for an engine citadel did not start (no pidfile): the engine must die and the
+// process that merely mentions it must not.
+//
+// The engine's port is closed for the whole test, so this doubles as the
+// #649/#677 acceptance criterion: a wedged engine that answers nothing is still
+// a process holding VRAM and is still stopped.
+func TestStopNativeServiceFallbackStopsEngineNotLookalikes(t *testing.T) {
+	bin := uniqueBinaryName(t)
+	name := registerTestEngine(t, NativeService{Name: bin, Binary: bin, Port: 1})
+
+	engine := spawnFake(t, bin, "serve")
+	bystander := spawnFake(t, "journalctl", "-u", bin, "-f")
+
+	if IsNativeServiceServing(name) {
+		t.Fatalf("test setup: the fake engine must not be answering on its port")
+	}
+	if err := StopNativeService(name); err != nil {
+		t.Fatalf("StopNativeService: %v", err)
+	}
+
+	assertExited(t, engine, "the engine")
+	assertSurvived(t, bystander, "journalctl -u <engine>")
+}
+
+// TestStopNativeServiceStopsAPythonConsoleScriptEngine is the vllm shape end to
+// end. A pip-installed engine runs under the interpreter's argv0, so an
+// exact-name match on argv[0] alone would leave vllm -- the engine the whole
+// anchored-pattern requirement exists for -- unstoppable, while `pkill -f` did
+// stop it.
+func TestStopNativeServiceStopsAPythonConsoleScriptEngine(t *testing.T) {
+	bin := uniqueBinaryName(t)
+	name := registerTestEngine(t, NativeService{
+		Name:        bin,
+		Binary:      bin,
+		AltBinaries: []string{"python -m " + bin + ".entrypoints.openai.api_server"},
+		Port:        1,
+	})
+
+	engine := spawnFake(t, "python3", "/usr/local/bin/"+bin, "serve", "some/model")
+	module := spawnFake(t, "python3", "-m", bin+".entrypoints.openai.api_server")
+	editor := spawnFake(t, "vim", "/usr/local/bin/"+bin)
+
+	if err := StopNativeService(name); err != nil {
+		t.Fatalf("StopNativeService: %v", err)
+	}
+
+	assertExited(t, engine, "the pip-installed console-script engine")
+	assertExited(t, module, "the python -m entrypoint form")
+	assertSurvived(t, editor, "an editor with the console script open")
+}
+
+// TestStopNativeServiceSignalsOnlyTheRecordedPID pins that the pidfile actually
+// TARGETS a process rather than just gating a sweep: with two identical engine
+// processes alive, only the recorded one is signalled.
+func TestStopNativeServiceSignalsOnlyTheRecordedPID(t *testing.T) {
+	bin := uniqueBinaryName(t)
+	name := registerTestEngine(t, NativeService{Name: bin, Binary: bin, Port: 1})
+
+	ours := spawnFake(t, bin, "serve")
+	theirs := spawnFake(t, bin, "serve", "--someone-elses")
+
+	if err := writeNativePidFile(name, ours.pid); err != nil {
+		t.Fatalf("writeNativePidFile: %v", err)
+	}
+
+	if err := StopNativeService(name); err != nil {
+		t.Fatalf("StopNativeService: %v", err)
+	}
+
+	assertExited(t, ours, "the engine citadel started")
+	assertSurvived(t, theirs, "an engine process citadel did not start")
+	if _, err := os.Stat(nativePidFilePath(name)); !os.IsNotExist(err) {
+		t.Errorf("pidfile should be removed after a successful stop, stat err = %v", err)
+	}
+}
+
+// TestStopNativeServiceTreatsRecycledPidFileAsStale is the case that makes the
+// PID approach safe: a pidfile whose PID has been recycled by an unrelated
+// process must never be signalled. Killing it would be strictly worse than the
+// bug being fixed.
+//
+// The stale record must also not block the stop: the real engine, running
+// alongside, still has to be stopped through the fallback.
+func TestStopNativeServiceTreatsRecycledPidFileAsStale(t *testing.T) {
+	bin := uniqueBinaryName(t)
+	name := registerTestEngine(t, NativeService{Name: bin, Binary: bin, Port: 1})
+
+	// The PID was recorded for the engine, but that process died and the PID now
+	// belongs to something else entirely.
+	recycled := spawnFake(t, "sshd", "-D")
+	engine := spawnFake(t, bin, "serve")
+
+	if err := writeNativePidFile(name, recycled.pid); err != nil {
+		t.Fatalf("writeNativePidFile: %v", err)
+	}
+
+	if err := StopNativeService(name); err != nil {
+		t.Fatalf("StopNativeService: %v", err)
+	}
+
+	assertSurvived(t, recycled, "the process that recycled the recorded PID")
+	assertExited(t, engine, "the engine")
+	if _, err := os.Stat(nativePidFilePath(name)); !os.IsNotExist(err) {
+		t.Errorf("a stale pidfile should be removed, stat err = %v", err)
+	}
+}
+
+// TestStopNativeServiceIgnoresDeadPidFile covers the ordinary stale case: the
+// recorded PID is simply gone. Stop must fall through to the name match instead
+// of reporting success while the engine (restarted out of band under a new PID)
+// keeps running.
+func TestStopNativeServiceIgnoresDeadPidFile(t *testing.T) {
+	bin := uniqueBinaryName(t)
+	name := registerTestEngine(t, NativeService{Name: bin, Binary: bin, Port: 1})
+
+	dead := spawnFake(t, bin, "serve")
+	deadPID := dead.pid
+	if err := writeNativePidFile(name, deadPID); err != nil {
+		t.Fatalf("writeNativePidFile: %v", err)
+	}
+	if err := stopVerifiedPID(deadPID, NativeServices[name]); err != nil {
+		t.Fatalf("test setup kill: %v", err)
+	}
+	assertExited(t, dead, "test setup process")
+
+	engine := spawnFake(t, bin, "serve")
+	if err := StopNativeService(name); err != nil {
+		t.Fatalf("StopNativeService: %v", err)
+	}
+	assertExited(t, engine, "the engine running under a new PID")
+}
+
+// TestStartNativeServiceRecordsPIDAndStopUsesIt is the start/stop round trip:
+// StartNativeService must persist the PID (callers all discard the returned
+// NativeProcess, and the stop can come from a different citadel process), and a
+// subsequent stop must use it without touching a lookalike.
+func TestStartNativeServiceRecordsPIDAndStopUsesIt(t *testing.T) {
+	bin := uniqueBinaryName(t)
+	name := registerTestEngine(t, NativeService{
+		Name:      bin,
+		Binary:    bin,
+		Port:      1,
+		StartArgs: []string{"serve"},
+		EnvVars:   map[string]string{helperSleepEnv: "1"},
+	})
+
+	// A symlink to this test binary stands in for the engine executable: real,
+	// on PATH, and long-running.
+	binDir := t.TempDir()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	if err := os.Symlink(exe, filepath.Join(binDir, bin)); err != nil {
+		t.Fatalf("symlink fake engine: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	proc, err := StartNativeService(name, t.TempDir())
+	if err != nil {
+		t.Fatalf("StartNativeService: %v", err)
+	}
+	started := proc.Cmd.Process.Pid
+	exited := make(chan struct{})
+	go func() {
+		_ = proc.Cmd.Wait()
+		close(exited)
+	}()
+	t.Cleanup(func() {
+		_ = proc.Cmd.Process.Kill()
+		<-exited
+	})
+
+	recorded, ok := readNativePidFile(name)
+	if !ok {
+		t.Fatalf("StartNativeService did not record a pidfile at %s", nativePidFilePath(name))
+	}
+	if recorded != started {
+		t.Fatalf("pidfile records pid %d, engine started as %d", recorded, started)
+	}
+
+	bystander := spawnFake(t, "journalctl", "-u", bin, "-f")
+	if err := StopNativeService(name); err != nil {
+		t.Fatalf("StopNativeService: %v", err)
+	}
+
+	select {
+	case <-exited:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("the started engine (pid %d) was not stopped", started)
+	}
+	assertSurvived(t, bystander, "journalctl -u <engine>")
+}
+
+// TestStopNativeServiceUnknownService pins the guard: an unrecognised name is an
+// error, never a process sweep.
+func TestStopNativeServiceUnknownService(t *testing.T) {
+	if err := StopNativeService("definitely-not-an-engine"); err == nil {
+		t.Error("expected an error for an unknown service")
+	}
+}
+
+// TestReadNativePidFileRejectsUnusableContent guards the parse: a truncated or
+// garbage pidfile must not resolve to a PID at all, and never to init.
+func TestReadNativePidFileRejectsUnusableContent(t *testing.T) {
+	t.Setenv(runDirEnv, t.TempDir())
+	for _, content := range []string{"", "\n", "not-a-pid", "0", "1", "-42"} {
+		if err := os.MkdirAll(nativeRunDir(), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(nativePidFilePath("x"), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if pid, ok := readNativePidFile("x"); ok {
+			t.Errorf("pidfile content %q yielded pid %d, want unusable", content, pid)
+		}
+	}
+}
+
+// TestNativeStopTimingDefaults pins the shipped values of the injectable timing
+// vars, so a test-local override can never quietly become the product default.
+func TestNativeStopTimingDefaults(t *testing.T) {
+	if nativeStopGrace != 5*time.Second {
+		t.Errorf("nativeStopGrace = %v, want 5s", nativeStopGrace)
+	}
+	if nativeStopPoll != 100*time.Millisecond {
+		t.Errorf("nativeStopPoll = %v, want 100ms", nativeStopPoll)
+	}
+}
+
+// TestNativeRunDirIsConfigAnchored pins where pidfiles live. Start and stop can
+// run in different citadel processes, so the location must be derivable without
+// an argument -- deriving it from the caller-supplied logDir would put the two
+// start call sites in different directories.
+func TestNativeRunDirIsConfigAnchored(t *testing.T) {
+	t.Setenv(runDirEnv, "")
+	if got := nativeRunDir(); filepath.Base(got) != "run" {
+		t.Errorf("nativeRunDir() = %q, want a <config>/run directory", got)
+	}
+	if got := nativePidFilePath("ollama"); filepath.Base(got) != "ollama.pid" {
+		t.Errorf("nativePidFilePath = %q, want .../ollama.pid", got)
+	}
+
+	dir := t.TempDir()
+	t.Setenv(runDirEnv, dir)
+	if got := nativePidFilePath("ollama"); got != filepath.Join(dir, "ollama.pid") {
+		t.Errorf("%s override not honoured: %q", runDirEnv, got)
+	}
+}
+
+// TestDefaultListProcessesSeesThisProcess is a smoke test for the process-table
+// reader: the enumeration is what the fallback stop is built on, so a `ps`
+// invocation that returns nothing (or that this parser mangles) would silently
+// turn every fallback stop into a no-op.
+func TestDefaultListProcessesSeesThisProcess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("ps is unix-only")
+	}
+	entries, err := defaultListProcesses()
+	if err != nil {
+		t.Fatalf("defaultListProcesses: %v", err)
+	}
+	self := os.Getpid()
+	for _, e := range entries {
+		if e.pid == self {
+			if e.cmdline == "" {
+				t.Fatalf("own process listed with an empty command line")
+			}
+			return
+		}
+	}
+	t.Fatalf("defaultListProcesses (%d entries) did not include this process (pid %d)", len(entries), self)
+}
+
+// TestDefaultProcessCmdlineIdentifiesThisProcess covers the verification
+// primitive on both of its implementations' terms: a live PID resolves to a
+// command line, an implausible one does not.
+func TestDefaultProcessCmdlineIdentifiesThisProcess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("/proc and ps are unix-only")
+	}
+	line, ok := defaultProcessCmdline(os.Getpid())
+	if !ok || strings.TrimSpace(line) == "" {
+		t.Fatalf("defaultProcessCmdline(self) = %q, %v; want a command line", line, ok)
+	}
+	if _, ok := defaultProcessCmdline(-1); ok {
+		t.Error("defaultProcessCmdline(-1) must not report a process")
+	}
+	// A PID that is almost certainly unassigned. Not fatal if it happens to
+	// exist; the assertion is only meaningful when it does not.
+	const unlikely = 4194303
+	if _, err := os.Stat(filepath.Join("/proc", strconv.Itoa(unlikely))); os.IsNotExist(err) || runtime.GOOS != "linux" {
+		if _, ok := defaultProcessCmdline(unlikely); ok && runtime.GOOS == "linux" {
+			t.Errorf("pid %d reported as live", unlikely)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #696.

## Context

`StopNativeService` ran `pkill -f <binary>`, which matches the pattern against the **entire command line of every process** and kills each match. A `SERVICE_STOP` for ollama could therefore kill an operator's `journalctl -u ollama`, an editor with an ollama path open, or any script whose argv merely mentions the engine. This is the write side of the looseness #677 fixed on the read side (`pgrep -f` reporting a dead engine as running) — there it misreported, here it kills.

## Root Cause

`pkill -f` is a substring match against `/proc/<pid>/cmdline`, and citadel never recorded which process it actually started, so the stop had nothing narrower to aim at.

Swapping in `pkill -x` alone would not have been enough: `NativeServices["vllm"].AltBinaries` contains `python -m vllm.entrypoints.openai.api_server`, which exact-name matching cannot express — and vllm is pip-installed, so `/usr/local/bin/vllm` is a shebang script and the kernel rewrites its argv to `python3 /usr/local/bin/vllm serve <model>`, where argv[0] is the interpreter. A pattern-only fix leaves the hazard alive on exactly one engine, or makes that engine unstoppable.

## Changes

- `internal/services/native.go` — `StartNativeService` records the engine's PID in `<ConfigDir>/run/<name>.pid`. Every caller discards the returned `NativeProcess`, and a stop can arrive in a different citadel process than the one that started the engine, so the PID has to outlive this process on disk. A pidfile that cannot be written is **not** a start failure (the engine is up; stop still has its fallback); it is noted in the engine's own log file.
- `internal/services/native_stop.go` (new) — `StopNativeService` now:
  1. reads the recorded PID and **verifies** it: the live process must still be the expected binary (`/proc/<pid>/cmdline` on Linux, `ps -p <pid> -o args=` elsewhere). Verification is the load-bearing half — a stale pidfile whose PID has been recycled is exactly the class of bug being fixed, so an unverified PID is removed and never signalled;
  2. SIGTERMs the verified PID, escalating to SIGKILL after a 5s grace. Aliveness during the wait is re-tested with the same identity check, so an unreaped zombie counts as gone and a PID recycled *inside* the grace window is never SIGKILLed;
  3. falls back, only when there is no usable pidfile, to a **narrow** name match for an engine citadel did not start (systemd, a hand-run binary): executable-name equality on argv[0], plus anchored matches for vllm's two python forms. Never a bare substring.
- `internal/jobs/service_handler_native_model_test.go` — the native-start tests now point `CITADEL_RUN_DIR` at a temp dir so the suite does not write pidfiles into the developer's real `~/.citadel-cli/run`.

Deliberately **not** changed: `IsNativeServiceRunning`, `IsNativeServiceServing`, and `serviceStop`'s choice between them. #677 established that stop must key on the PROCESS check because a wedged engine that stopped answering is still a process holding VRAM. `StopNativeService` never consults the port, so that still holds (covered by a test).

### Judgement calls worth a reviewer's attention

- **Where the run dir comes from.** Not the caller-supplied `logDir`: the two start call sites pass different directories (`cmd/service.go` uses `~/citadel-node/logs`, the job handler uses `<ConfigDir>/logs`) and the stop call sites pass none. It is anchored to `platform.ConfigDir()/run`, the one location both sides can resolve without an argument, overridable via `CITADEL_RUN_DIR`.
- **Root/user split.** `platform.ConfigDir()` returns `~/.citadel-cli` for a normal user and `/etc/citadel` for root, so an engine started by a systemd-root `citadel work` and stopped by a user-run `citadel service stop` will not see the same pidfile. That degrades to the narrow fallback, which stops it correctly.
- **A failed readiness wait leaves a stale pidfile** (`cmd/service.go` kills the process directly). Safe by construction: verification rejects it, removes it, and falls through.
- **The recorded PID wins; the fallback does not also run.** Stopping the process citadel owns is the contract; sweeping every matching process on top of it would widen the blast radius again.
- **Residual, unchanged from `pkill -x`:** a user's own `ollama run llama3` still matches by executable name, and llamacpp's `AltBinaries` includes the very generic `server`. Both are strictly narrower than today's whole-command-line match; pruning `AltBinaries` is a separate change (they double as the discovery list for `GetNativeBinaryPath`).
- Windows is not addressed: `ps`/`/proc` are unix-only, exactly as `pkill`/`pgrep` were. Noted in a comment.

## Testing

`go test ./...` and `go vet ./...` are green; `GOOS=windows GOARCH=amd64 go build ./...` also passes (the new file is not build-tagged). The new suite adds ~2s: it spawns real processes with chosen argvs (re-execs of the test binary, so argv[0] is under test control) and registers throwaway services under uniquely-named binaries, so it can never touch a real engine on the machine running it.

Key cases, each mutation-tested by disabling the corresponding half of the fix:

| Mutation | Test that fails |
|---|---|
| A. restore `pkill -f <binary>` | `TestStopNativeServiceFallbackStopsEngineNotLookalikes` ("journalctl -u <engine> was killed"), `TestStopNativeServiceSignalsOnlyTheRecordedPID`, `TestStopNativeServiceTreatsRecycledPidFileAsStale`, `TestStartNativeServiceRecordsPIDAndStopUsesIt` |
| B. signal the recorded PID without verifying identity | `TestStopNativeServiceTreatsRecycledPidFileAsStale` ("the process that recycled the recorded PID was killed"), `TestStopNativeServiceIgnoresDeadPidFile` |
| C. do not record the PID at start | `TestStartNativeServiceRecordsPIDAndStopUsesIt` |
| D. match a bare substring of the command line | `TestProcessMatchesServiceRejectsCommandLineMentions` (9 rows), `TestStopNativeServiceFallbackStopsEngineNotLookalikes`, `TestStopNativeServiceStopsAPythonConsoleScriptEngine` (the editor with the console script open is killed) |
| E. drop the pip-console-script branch | `TestProcessMatchesServiceRejectsCommandLineMentions`, `TestStopNativeServiceStopsAPythonConsoleScriptEngine` ("the pip-installed console-script engine was not stopped") |

The engine's port is closed throughout, so the fallback test doubles as the #649/#677 acceptance criterion: a wedged engine that answers nothing is still stopped. Timing bounds (`nativeStopGrace`, `nativeStopPoll`) are injectable vars with the shipped defaults pinned by `TestNativeStopTimingDefaults`.

Manual check of the argv-rewrite premise behind the console-script branch:

```
$ printf '#!/bin/sh\nsleep 30\n' > vllm-ish2 && chmod +x vllm-ish2 && ./vllm-ish2 serve mymodel &
$ ps -A -o pid=,args= | grep vllm-ish2
51824 /bin/sh ./vllm-ish2 serve mymodel
```