### PR TITLE
fix(heartbeat): report the services that are actually running, not the ones we thought to probe

### DIFF
--- a/internal/status/collector.go
+++ b/internal/status/collector.go
@@ -133,7 +133,15 @@ func (c *Collector) Collect() (*NodeStatus, error) {
 	for _, svc := range status.Services {
 		reported[svc.Name] = struct{}{}
 	}
-	for _, eng := range c.collectManagedEngineStatus() {
+
+	// Enumerate the running "citadel-<name>" containers ONCE and thread the set
+	// through every service collector below (aceteam#7148). One container-runtime
+	// call per heartbeat instead of one per known engine, and, the reason it
+	// exists, a single source of truth for "what is actually up" that no longer
+	// depends on a service appearing in a hardcoded probe list.
+	runningServices := runningEmbeddedServices(containerRuntimeBin())
+
+	for _, eng := range c.collectManagedEngineStatus(runningServices) {
 		if _, dup := reported[eng.Name]; dup {
 			continue
 		}
@@ -145,12 +153,22 @@ func (c *Collector) Collect() (*NodeStatus, error) {
 	// is the discovery signal the sovereign-RAG backend matches on to embed on
 	// the org's own node; like the engine probe it runs in the heartbeat path
 	// where c.services is nil, so a manifest entry is not required.
-	for _, emb := range c.collectEmbeddingServiceStatus() {
+	for _, emb := range c.collectEmbeddingServiceStatus(runningServices) {
 		if _, dup := reported[emb.Name]; dup {
 			continue
 		}
 		reported[emb.Name] = struct{}{}
 		status.Services = append(status.Services, emb)
+	}
+
+	// Backstop: every OTHER running embedded-compose service (kokoro, transcribe,
+	// diffusers, extraction, sglang, lmstudio). None of these has a probe above,
+	// so before #7148 a node running them reported nothing at all: the operator
+	// saw an empty node right after a successful deploy, and an unreported
+	// service can never be flagged idle or reclaimable either.
+	for _, svc := range collectRunningEmbeddedServices(runningServices, reported) {
+		reported[svc.Name] = struct{}{}
+		status.Services = append(status.Services, svc)
 	}
 
 	// Mark pinned services (citadel #577) so the heartbeat and `citadel services`

--- a/internal/status/embedding_models_test.go
+++ b/internal/status/embedding_models_test.go
@@ -90,7 +90,7 @@ func TestCollectEmbeddingServices_NativeProcessCounts(t *testing.T) {
 	// portIfRunning stands in for managedEnginePortIfRunning, whose real
 	// implementation checks the container first and falls back to the native
 	// service probe. Here only the native branch answers.
-	nativeOnly := func(_, name string) (int, bool) {
+	nativeOnly := func(name string) (int, bool) {
 		if name == "tei" {
 			return 8102, true
 		}
@@ -98,7 +98,7 @@ func TestCollectEmbeddingServices_NativeProcessCounts(t *testing.T) {
 	}
 	md := stubEmbeddingLister{models: []string{"Alibaba-NLP/gte-multilingual-base"}}
 
-	got := collectEmbeddingServices(context.Background(), "docker", nativeOnly, alwaysHealthy, md)
+	got := collectEmbeddingServices(context.Background(), nativeOnly, alwaysHealthy, md)
 	if len(got) != 1 {
 		t.Fatalf("expected the native embedding server reported, got %+v", got)
 	}
@@ -151,10 +151,10 @@ func TestManagedEnginePortIfRunning_DetectsNativeWithoutAContainer(t *testing.T)
 // A server whose /info probe fails is still reported (running is real state),
 // but must not have a model invented for it.
 func TestCollectEmbeddingServices_ProbeFailureLeavesModelsEmpty(t *testing.T) {
-	running := func(_, name string) (int, bool) { return 8102, name == "tei" }
+	running := func(name string) (int, bool) { return 8102, name == "tei" }
 	md := stubEmbeddingLister{err: context.DeadlineExceeded}
 
-	got := collectEmbeddingServices(context.Background(), "docker", running, alwaysHealthy, md)
+	got := collectEmbeddingServices(context.Background(), running, alwaysHealthy, md)
 	if len(got) != 1 {
 		t.Fatalf("expected tei reported, got %+v", got)
 	}

--- a/internal/status/engines.go
+++ b/internal/status/engines.go
@@ -4,13 +4,10 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os/exec"
 	"regexp"
 	"strconv"
-	"strings"
 	"time"
 
-	"github.com/aceteam-ai/citadel-cli/internal/catalog"
 	nativesvc "github.com/aceteam-ai/citadel-cli/internal/services"
 	"github.com/aceteam-ai/citadel-cli/services"
 	"gopkg.in/yaml.v3"
@@ -49,30 +46,26 @@ var managedProbeEngines = []string{"vllm", "ollama", "llamacpp", "bonsai", "unli
 // model), ollama `GET /api/tags` (every pulled model, all auto-loadable on
 // request; citadel-cli#606).
 //
-// It only emits an entry for an engine that is actually running AND answered
-// at least one probe (idle scrape or model discovery). An engine that answers
-// model discovery with an empty list (llama.cpp up with no model loaded,
-// ollama with nothing pulled) IS emitted: running with no models is real,
-// reportable state. A running-but-unresponsive engine (e.g. still loading its
-// model, HTTP not yet up) is skipped rather than reported with a misleading
-// "idle since startup" — the existing manifest-driven collectServiceStatus
-// still reports its up/down state when configured. Probe failures never fail
-// the collection: each probe is bounded by ModelDiscoveryTimeout and a failure
-// simply leaves the corresponding field empty.
-func (c *Collector) collectManagedEngineStatus() []ServiceInfo {
+// It emits an entry for every engine that is actually running. An engine that
+// answered a probe carries Health=ok plus its models/idle signal; one whose
+// container is up but not answering yet (still loading weights, HTTP not up)
+// carries Health=starting with no models and no idle signal (aceteam#7148).
+// Dropping the unresponsive case is what made a just-deployed engine invisible
+// in the fabric UI while `service_status` reported it running; "running but not
+// ready yet" is real, reportable state, and callers that need readiness read
+// Health. Probe failures never fail the collection: each probe is bounded by
+// ModelDiscoveryTimeout and a failure simply leaves the corresponding field
+// empty.
+//
+// running is the set of embedded-service names whose "citadel-<name>" container
+// is up, collected once per heartbeat by runningEmbeddedServices.
+func (c *Collector) collectManagedEngineStatus(running map[string]bool) []ServiceInfo {
 	ctx := context.Background()
 	var out []ServiceInfo
 
-	// Resolve the container runtime once and use its engine binary for the
-	// running-check, mirroring the start path (cmd/service.go). GPU/inference
-	// containers are the ones most likely to run under the hardened podman
-	// runtime (#348); a docker-only inspect would miss them entirely and the
-	// idle signal would never fire on exactly the nodes this feature targets.
-	engineBin := catalog.SelectContainerRuntime().EngineBin
-
 	for _, name := range managedProbeEngines {
-		port, running := managedEnginePortIfRunning(engineBin, name)
-		if !running || port <= 0 {
+		port, isRunning := enginePortIfRunning(running, name)
+		if !isRunning || port <= 0 {
 			continue
 		}
 
@@ -104,7 +97,9 @@ func (c *Collector) collectManagedEngineStatus() []ServiceInfo {
 		}
 
 		if !responded {
-			continue
+			info.Health = HealthStatusStarting
+			info.Models = nil
+			info.IdleState = nil
 		}
 		out = append(out, info)
 	}
@@ -119,35 +114,32 @@ func (c *Collector) collectManagedEngineStatus() []ServiceInfo {
 // /v1/embeddings upstream, not /v1/chat/completions.
 var embeddingProbeServices = []string{"tei"}
 
-// collectEmbeddingServiceStatus reports running embedding services that answer a
-// health check, as ServiceInfo with Type=embedding. This is the discovery signal
-// the sovereign-embeddings backend (_find_tei_node) matches on: a node
-// advertising a "tei" service becomes eligible to embed on its own model. Kept
-// separate from collectManagedEngineStatus so an embedding server is never
-// mistaken for a chat LLM (whose idle probe and chat-router listing do not
-// apply).
+// collectEmbeddingServiceStatus reports running embedding services as
+// ServiceInfo with Type=embedding. This is the discovery signal the
+// sovereign-embeddings backend (_find_tei_node) matches on: a node advertising a
+// READY "tei" service becomes eligible to embed on its own model. Kept separate
+// from collectManagedEngineStatus so an embedding server is never mistaken for a
+// chat LLM (whose idle probe and chat-router listing do not apply).
 //
-// Each entry carries the model the server is ACTUALLY serving, read from the
-// engine's own /info (citadel-cli#690). Reporting no models let a stopped vllm's
-// <name>.env default claim the embedding model instead, so the platform credited
-// a dead engine and reasoned about the wrong VRAM cost and lifecycle for both.
+// Each ready entry carries the model the server is ACTUALLY serving, read from
+// the engine's own /info (citadel-cli#690). Reporting no models let a stopped
+// vllm's <name>.env default claim the embedding model instead, so the platform
+// credited a dead engine and reasoned about the wrong VRAM cost and lifecycle
+// for both.
 //
-// Running is decided by managedEnginePortIfRunning, not by a container check:
-// an embedding server installed natively (systemd unit, `serve` process) is
-// serving just as much as one in a container, and a docker-only test reports a
-// false negative on exactly the consumer-grade box this product targets.
-func (c *Collector) collectEmbeddingServiceStatus() []ServiceInfo {
+// running is the set of embedded-service names whose "citadel-<name>" container
+// is up, enumerated once per heartbeat by runningEmbeddedServices. It is only
+// half the running test: enginePortIfRunning falls back to the native probe, so
+// an embedding server installed as a systemd unit or a bare `serve` process
+// counts too (citadel-cli#690) instead of reporting a false negative on exactly
+// the consumer-grade box this product targets.
+func (c *Collector) collectEmbeddingServiceStatus(running map[string]bool) []ServiceInfo {
 	var lister embeddingModelLister
 	if c.modelDiscovery != nil {
 		lister = c.modelDiscovery
 	}
-	return collectEmbeddingServices(
-		context.Background(),
-		catalog.SelectContainerRuntime().EngineBin,
-		managedEnginePortIfRunning,
-		embeddingServiceHealthy,
-		lister,
-	)
+	portIfRunning := func(name string) (int, bool) { return enginePortIfRunning(running, name) }
+	return collectEmbeddingServices(context.Background(), portIfRunning, embeddingServiceHealthy, lister)
 }
 
 // embeddingModelLister is the slice of ModelDiscovery collectEmbeddingServices
@@ -158,23 +150,27 @@ type embeddingModelLister interface {
 	DiscoverEmbeddingModel(ctx context.Context, port int) ([]string, error)
 }
 
+// collectEmbeddingServices is collectEmbeddingServiceStatus with its live probes
+// injected.
+//
+// Readiness rides Health, not presence (aceteam#7148). A container that is up but
+// whose model is still downloading answers /health with a non-200 and used to be
+// omitted from the heartbeat entirely, so a node that had just been told to start
+// TEI reported "no services" for the whole warm-up while `service_status` said it
+// was running. It is now reported Status=running with Health=starting and no
+// models: a warming server has none to name, and naming one anyway would be
+// citadel-cli#690 in reverse. The platform gates embedding dispatch on
+// Health=ok, so a warming node is still never handed an embed that would 503.
 func collectEmbeddingServices(
 	ctx context.Context,
-	engineBin string,
-	portIfRunning func(engineBin, name string) (int, bool),
+	portIfRunning func(name string) (int, bool),
 	healthy func(port int) bool,
 	md embeddingModelLister,
 ) []ServiceInfo {
 	var out []ServiceInfo
 	for _, name := range embeddingProbeServices {
-		port, running := portIfRunning(engineBin, name)
+		port, running := portIfRunning(name)
 		if !running || port <= 0 {
-			continue
-		}
-		// Advertise only once the model is loaded (TEI /health is 200 only then),
-		// so the backend never discovers a still-warming node and then fails the
-		// embed with a 503.
-		if !healthy(port) {
 			continue
 		}
 		info := ServiceInfo{
@@ -182,14 +178,19 @@ func collectEmbeddingServices(
 			Type:   ServiceTypeEmbedding,
 			Status: ServiceStatusRunning,
 			Port:   port,
-			Health: HealthStatusOK,
+			Health: HealthStatusStarting,
 		}
-		if md != nil {
-			mctx, cancel := context.WithTimeout(ctx, ModelDiscoveryTimeout)
-			models, err := md.DiscoverEmbeddingModel(mctx, port)
-			cancel()
-			if err == nil {
-				info.Models = models
+		// TEI answers /health with 200 only once the model has loaded, so this
+		// is the ready-vs-warming decision.
+		if healthy(port) {
+			info.Health = HealthStatusOK
+			if md != nil {
+				mctx, cancel := context.WithTimeout(ctx, ModelDiscoveryTimeout)
+				models, err := md.DiscoverEmbeddingModel(mctx, port)
+				cancel()
+				if err == nil {
+					info.Models = models
+				}
 			}
 		}
 		out = append(out, info)
@@ -227,7 +228,14 @@ func engineInList(list []string, name string) bool {
 // embedded compose file's port mapping, falling back to the known native
 // default.
 func managedEnginePortIfRunning(engineBin, name string) (port int, running bool) {
-	if containerRunning(engineBin, "citadel-"+name) {
+	return enginePortIfRunning(runningEmbeddedServices(engineBin), name)
+}
+
+// enginePortIfRunning is managedEnginePortIfRunning against an already-collected
+// running-container set, so one heartbeat pass makes ONE container-runtime call
+// instead of one per engine.
+func enginePortIfRunning(running map[string]bool, name string) (port int, isRunning bool) {
+	if running[name] {
 		return managedEngineHostPort(name), true
 	}
 	// Serving, not process-present (#649). This function decides what the node
@@ -241,22 +249,6 @@ func managedEnginePortIfRunning(engineBin, name string) (port int, running bool)
 		return managedEngineHostPort(name), true
 	}
 	return 0, false
-}
-
-// containerRunning reports whether a container with the given name is in the
-// "running" state, using the provided engine binary (docker or podman). Any
-// error (runtime not installed, container absent) yields false so callers treat
-// the engine as not-managed-here.
-func containerRunning(engineBin, containerName string) bool {
-	if engineBin == "" {
-		engineBin = "docker"
-	}
-	cmd := exec.Command(engineBin, "inspect", "--format", "{{.State.Status}}", containerName)
-	out, err := cmd.Output()
-	if err != nil {
-		return false
-	}
-	return strings.TrimSpace(string(out)) == "running"
 }
 
 // composePortRe matches the host side of a compose short-form port mapping,

--- a/internal/status/running_services.go
+++ b/internal/status/running_services.go
@@ -1,0 +1,142 @@
+package status
+
+import (
+	"os/exec"
+	"sort"
+	"strings"
+
+	"github.com/aceteam-ai/citadel-cli/internal/catalog"
+	"github.com/aceteam-ai/citadel-cli/services"
+)
+
+// running_services.go: "report what is ACTUALLY running", the node side of
+// aceteam#7148.
+//
+// Before this, the heartbeat only ever named a service from one of three narrow
+// sources: the manifest-driven service list (nil on the heartbeat path), the
+// five engines in managedProbeEngines, and the one service in
+// embeddingProbeServices. A service materialized by SERVICE_START straight from
+// the embedded services.ServiceMap (the path Quick Deploy and the per-node
+// Deploy tab use) was therefore invisible unless it happened to be one of those
+// six AND answered a probe. Deploying TEI to node 1314 left `service_status`
+// saying "tei is running (docker)" while `fabric_node_status` said "Running
+// Services: none", and every embedded compose engine other than TEI (kokoro,
+// transcribe, diffusers, extraction, sglang, lmstudio) had no path into the
+// inventory at all.
+//
+// The fix is to enumerate the running containers and report them, so the
+// inventory answers "what is up" rather than "what did we think to ask about".
+
+// citadelContainerPrefix is the container_name prefix every embedded compose
+// service uses (services/compose/*.yml all set `container_name: citadel-<name>`)
+// and that the start path pins via `docker compose -p citadel-<name>`.
+const citadelContainerPrefix = "citadel-"
+
+// runningContainerNames returns the names of every running container on this
+// node. It is a package var so tests can exercise the enumeration logic without
+// a container runtime; production always uses listRunningContainerNames.
+var runningContainerNames = listRunningContainerNames
+
+// listRunningContainerNames runs ONE `<engineBin> ps` and returns the running
+// container names. `ps` without -a lists only running containers, so no state
+// filtering is needed. Any error (runtime absent, daemon down) yields nil, so
+// callers degrade to "nothing enumerable here" rather than reporting a false
+// stopped/absent state for services they cannot see.
+func listRunningContainerNames(engineBin string) []string {
+	if engineBin == "" {
+		engineBin = "docker"
+	}
+	out, err := exec.Command(engineBin, "ps", "--format", "{{.Names}}").Output()
+	if err != nil {
+		return nil
+	}
+	var names []string
+	for _, line := range strings.Split(string(out), "\n") {
+		if name := strings.TrimSpace(line); name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// runningEmbeddedServices returns the set of embedded ServiceMap names whose
+// "citadel-<name>" container is currently running. Collected ONCE per heartbeat
+// and threaded through the collectors, replacing the previous one
+// `docker inspect` per known engine.
+//
+// Only names present in services.ServiceMap are returned: a running
+// citadel-claudecode or citadel-whatsapp container belongs to the module/app
+// inventories (collectAppStatus), and reporting it as a service would double-
+// count it.
+func runningEmbeddedServices(engineBin string) map[string]bool {
+	set := make(map[string]bool)
+	for _, container := range runningContainerNames(engineBin) {
+		name := strings.TrimPrefix(container, citadelContainerPrefix)
+		if name == container {
+			continue // not a citadel-managed container
+		}
+		if _, ok := services.ServiceMap[name]; ok {
+			set[name] = true
+		}
+	}
+	return set
+}
+
+// containerRuntimeBin resolves the container runtime binary once per collection,
+// mirroring the start path (cmd/service.go). GPU/inference containers are the
+// ones most likely to run under the hardened podman runtime (#348); a
+// docker-only enumeration would miss them entirely.
+func containerRuntimeBin() string {
+	return catalog.SelectContainerRuntime().EngineBin
+}
+
+// embeddedServiceType classifies an embedded ServiceMap entry for the heartbeat.
+//
+// Deliberately conservative: only genuine OpenAI-compatible CHAT engines get
+// ServiceTypeLLM, because that type is what makes a service a candidate for the
+// gateway/chat routing surfaces. A speech (kokoro/transcribe), image
+// (diffusers), or extraction service is reported as ServiceTypeOther so it shows
+// up in the operator's inventory without ever being offered as a chat backend.
+func embeddedServiceType(name string) string {
+	switch name {
+	case "tei":
+		return ServiceTypeEmbedding
+	case "vllm", "ollama", "llamacpp", "lmstudio", "sglang", "bonsai", "unlimited-ocr":
+		return ServiceTypeLLM
+	default:
+		return ServiceTypeOther
+	}
+}
+
+// collectRunningEmbeddedServices reports every running embedded-compose service
+// that no richer collector already covered. These entries carry only what a
+// container listing can honestly support (name, type, port, running) with
+// Health=unknown, because this pass performs no readiness probe. That is the
+// point: an unprobed service used to be absent from the inventory entirely,
+// which reads as "nothing is deployed here" rather than "we did not ask".
+//
+// reported is the set of names already in NodeStatus.Services, so a service the
+// probe-driven collectors described in detail is never overwritten by this
+// coarser view.
+func collectRunningEmbeddedServices(running map[string]bool, reported map[string]struct{}) []ServiceInfo {
+	names := make([]string, 0, len(running))
+	for name := range running {
+		if _, dup := reported[name]; dup {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names) // deterministic heartbeat ordering
+
+	out := make([]ServiceInfo, 0, len(names))
+	for _, name := range names {
+		out = append(out, ServiceInfo{
+			Name:   name,
+			Type:   embeddedServiceType(name),
+			Status: ServiceStatusRunning,
+			Port:   managedEngineHostPort(name),
+			Health: HealthStatusUnknown,
+		})
+	}
+	return out
+}

--- a/internal/status/running_services_test.go
+++ b/internal/status/running_services_test.go
@@ -1,0 +1,140 @@
+package status
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/services"
+)
+
+// stubRunningContainers swaps the container-runtime enumeration for a fixed
+// list, so the SELECTION logic (which containers become reported services) is
+// testable without docker/podman. Restored on test cleanup.
+func stubRunningContainers(t *testing.T, names ...string) {
+	t.Helper()
+	prev := runningContainerNames
+	runningContainerNames = func(string) []string { return names }
+	t.Cleanup(func() { runningContainerNames = prev })
+}
+
+// TestRunningEmbeddedServices_MapsContainerNames is the core of aceteam#7148:
+// the inventory must come from the containers that are actually up, not from a
+// hardcoded probe list.
+func TestRunningEmbeddedServices_MapsContainerNames(t *testing.T) {
+	stubRunningContainers(t,
+		"citadel-tei",
+		"citadel-kokoro",
+		"citadel-claudecode", // a MODULE, not an embedded service
+		"some-unrelated-container",
+	)
+
+	got := runningEmbeddedServices("docker")
+
+	want := map[string]bool{"tei": true, "kokoro": true}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("runningEmbeddedServices = %v, want %v", got, want)
+	}
+}
+
+// TestRunningEmbeddedServices_RuntimeFailureIsEmpty guards the degradation
+// posture: an unavailable container runtime must yield "nothing enumerable",
+// never a panic and never a fabricated entry.
+func TestRunningEmbeddedServices_RuntimeFailureIsEmpty(t *testing.T) {
+	prev := runningContainerNames
+	runningContainerNames = func(string) []string { return nil }
+	t.Cleanup(func() { runningContainerNames = prev })
+
+	if got := runningEmbeddedServices("docker"); len(got) != 0 {
+		t.Fatalf("expected empty set when the runtime lists nothing, got %v", got)
+	}
+}
+
+// TestCollectRunningEmbeddedServices_CoversEveryEmbeddedEngine is the
+// regression the issue asks for by name: EVERY embedded-compose engine must be
+// reportable, not just the six that happen to have a probe. Before #7148,
+// kokoro/transcribe/diffusers/extraction/sglang/lmstudio had no path into the
+// heartbeat at all.
+func TestCollectRunningEmbeddedServices_CoversEveryEmbeddedEngine(t *testing.T) {
+	for name := range services.ServiceMap {
+		running := map[string]bool{name: true}
+		got := collectRunningEmbeddedServices(running, map[string]struct{}{})
+		if len(got) != 1 {
+			t.Fatalf("embedded service %q running but not reported (got %d entries)", name, len(got))
+		}
+		if got[0].Name != name {
+			t.Fatalf("expected service %q, got %q", name, got[0].Name)
+		}
+		if got[0].Status != ServiceStatusRunning {
+			t.Errorf("service %q: status = %q, want %q", name, got[0].Status, ServiceStatusRunning)
+		}
+		// No readiness probe ran, so health must be unknown rather than a
+		// fabricated "ok".
+		if got[0].Health != HealthStatusUnknown {
+			t.Errorf("service %q: health = %q, want %q", name, got[0].Health, HealthStatusUnknown)
+		}
+	}
+}
+
+// TestCollectRunningEmbeddedServices_SkipsAlreadyReported keeps the coarse
+// backstop from overwriting the richer probe-derived entry (models, idle state)
+// for a service a real collector already described.
+func TestCollectRunningEmbeddedServices_SkipsAlreadyReported(t *testing.T) {
+	running := map[string]bool{"vllm": true, "kokoro": true}
+	reported := map[string]struct{}{"vllm": {}}
+
+	got := collectRunningEmbeddedServices(running, reported)
+
+	if len(got) != 1 || got[0].Name != "kokoro" {
+		t.Fatalf("expected only kokoro, got %+v", got)
+	}
+}
+
+// TestCollectRunningEmbeddedServices_Deterministic guards against a heartbeat
+// whose service order churns every 30s purely from Go map iteration.
+func TestCollectRunningEmbeddedServices_Deterministic(t *testing.T) {
+	running := map[string]bool{"sglang": true, "kokoro": true, "diffusers": true}
+	want := []string{"diffusers", "kokoro", "sglang"}
+
+	for i := 0; i < 5; i++ {
+		got := collectRunningEmbeddedServices(running, map[string]struct{}{})
+		names := make([]string, 0, len(got))
+		for _, svc := range got {
+			names = append(names, svc.Name)
+		}
+		if !reflect.DeepEqual(names, want) {
+			t.Fatalf("iteration %d: got %v, want %v", i, names, want)
+		}
+	}
+}
+
+// TestEmbeddedServiceType_OnlyChatEnginesAreLLM guards the routing blast radius
+// of the new backstop pass: ServiceTypeLLM is what offers a service to the
+// chat/model surfaces, so a TTS or transcription service must never claim it.
+func TestEmbeddedServiceType_OnlyChatEnginesAreLLM(t *testing.T) {
+	if got := embeddedServiceType("tei"); got != ServiceTypeEmbedding {
+		t.Errorf("tei type = %q, want %q", got, ServiceTypeEmbedding)
+	}
+	for _, name := range []string{"vllm", "ollama", "llamacpp", "bonsai", "unlimited-ocr"} {
+		if got := embeddedServiceType(name); got != ServiceTypeLLM {
+			t.Errorf("%s type = %q, want %q", name, got, ServiceTypeLLM)
+		}
+	}
+	for _, name := range []string{"kokoro", "transcribe", "diffusers", "extraction"} {
+		if got := embeddedServiceType(name); got != ServiceTypeOther {
+			t.Errorf("%s type = %q, want %q (llm would make it a chat-router candidate)",
+				name, got, ServiceTypeOther)
+		}
+	}
+}
+
+// TestEnginePortIfRunning_UsesRunningSet confirms the collectors read the
+// once-per-heartbeat container set instead of shelling out per engine.
+func TestEnginePortIfRunning_UsesRunningSet(t *testing.T) {
+	port, running := enginePortIfRunning(map[string]bool{"vllm": true}, "vllm")
+	if !running {
+		t.Fatal("vllm in the running set must be reported running")
+	}
+	if port != services.VLLMHostPort {
+		t.Fatalf("port = %d, want %d", port, services.VLLMHostPort)
+	}
+}

--- a/internal/status/starting_service_test.go
+++ b/internal/status/starting_service_test.go
@@ -1,0 +1,132 @@
+package status
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/services"
+)
+
+// starting_service_test.go: a container that is UP but not answering yet must be
+// REPORTED, with its readiness on Health (aceteam#7148).
+//
+// The production repro: a deploy of gte-multilingual-base to node 1314 started
+// TEI, `service_status(1314, "tei")` said "tei is running (docker)", and
+// `fabric_node_status(1314)` said "Running Services: none" for the whole time
+// the model was downloading. The heartbeat dropped any service that failed its
+// probe, so the two views disagreed and the operator saw an empty node right
+// after a deploy that had worked.
+
+// neverHealthy is the injected stand-in for a readiness probe that has not
+// passed yet: the container is up, the HTTP endpoint is not answering.
+func neverHealthy(int) bool { return false }
+
+func TestCollectEmbeddingServices_WarmingIsReportedAsStarting(t *testing.T) {
+	running := func(name string) (int, bool) { return managedEngineHostPort("tei"), name == "tei" }
+	// A warming server answers nothing, so the lister must never be consulted.
+	// Handing it a model it would report proves the warming branch cannot leak
+	// one into the heartbeat.
+	md := stubEmbeddingLister{models: []string{"should-never-be-reported"}}
+
+	got := collectEmbeddingServices(context.Background(), running, neverHealthy, md)
+
+	if len(got) != 1 {
+		t.Fatalf("a running-but-warming tei must still be reported, got %d entries", len(got))
+	}
+	if got[0].Status != ServiceStatusRunning {
+		t.Errorf("status = %q, want %q (the container really is running)", got[0].Status, ServiceStatusRunning)
+	}
+	if got[0].Health != HealthStatusStarting {
+		t.Errorf("health = %q, want %q", got[0].Health, HealthStatusStarting)
+	}
+	if len(got[0].Models) != 0 {
+		t.Errorf("a warming service must claim no models, got %v", got[0].Models)
+	}
+}
+
+// The ready case still reports Health=ok and the served model, so making the
+// warming case visible did not weaken the readiness signal the platform's
+// embedding resolver gates on.
+func TestCollectEmbeddingServices_ReadyReportsModelAndOK(t *testing.T) {
+	running := func(name string) (int, bool) { return managedEngineHostPort("tei"), name == "tei" }
+	md := stubEmbeddingLister{models: []string{"Alibaba-NLP/gte-multilingual-base"}}
+
+	got := collectEmbeddingServices(context.Background(), running, alwaysHealthy, md)
+
+	if len(got) != 1 {
+		t.Fatalf("expected one tei entry, got %d", len(got))
+	}
+	if got[0].Health != HealthStatusOK {
+		t.Errorf("health = %q, want %q once /health answers 200", got[0].Health, HealthStatusOK)
+	}
+	if len(got[0].Models) != 1 || got[0].Models[0] != "Alibaba-NLP/gte-multilingual-base" {
+		t.Errorf("models = %v, want the served TEI model id", got[0].Models)
+	}
+}
+
+// The collector wrapper must thread the once-per-heartbeat running set into that
+// same decision, so the seam the tests above use is the one production runs.
+func TestCollectEmbeddingServiceStatus_UsesRunningSet(t *testing.T) {
+	c := &Collector{}
+
+	got := c.collectEmbeddingServiceStatus(map[string]bool{"tei": true})
+
+	if len(got) != 1 || got[0].Name != "tei" {
+		t.Fatalf("tei in the running set must be reported, got %+v", got)
+	}
+	if got[0].Status != ServiceStatusRunning {
+		t.Errorf("status = %q, want %q", got[0].Status, ServiceStatusRunning)
+	}
+	// Health is whichever branch the live /health probe took on this machine.
+	// Both are valid; what must never happen again is the entry being absent, or
+	// carrying a health value that says nothing about readiness.
+	if got[0].Health != HealthStatusOK && got[0].Health != HealthStatusStarting {
+		t.Errorf("health = %q, want %q or %q", got[0].Health, HealthStatusOK, HealthStatusStarting)
+	}
+}
+
+// TestCollectManagedEngineStatus_UnresponsiveEngineIsStarting covers the same
+// gap for serving engines: a vLLM whose container is up while it loads weights
+// used to vanish from the heartbeat entirely.
+func TestCollectManagedEngineStatus_UnresponsiveEngineIsStarting(t *testing.T) {
+	// No idleTracker and no modelDiscovery => no probe can respond, which is
+	// exactly the shape of an engine that is up but not serving yet.
+	c := &Collector{}
+
+	// Other entries can appear from the native-engine fallback if the machine
+	// running the tests happens to serve one, so select the engine under test
+	// rather than asserting on the slice length.
+	got := c.collectManagedEngineStatus(map[string]bool{"vllm": true})
+	var vllm *ServiceInfo
+	for i := range got {
+		if got[i].Name == "vllm" {
+			vllm = &got[i]
+			break
+		}
+	}
+	if vllm == nil {
+		t.Fatal("a running-but-unresponsive vllm must still be reported")
+	}
+	if vllm.Status != ServiceStatusRunning {
+		t.Errorf("status = %q, want %q", vllm.Status, ServiceStatusRunning)
+	}
+	if vllm.Health != HealthStatusStarting {
+		t.Errorf("health = %q, want %q", vllm.Health, HealthStatusStarting)
+	}
+	if vllm.IdleState != nil {
+		t.Error("an unresponsive engine must not claim an idle signal")
+	}
+}
+
+// The probe lists are now filtered through services.ServiceMap by
+// runningEmbeddedServices, which the per-engine `docker inspect` they replaced
+// was not. A probe engine missing from ServiceMap would silently lose container
+// detection and survive only on the native port fallback, so pin the subset.
+func TestProbeListsAreSubsetsOfServiceMap(t *testing.T) {
+	probed := append(append([]string{}, managedProbeEngines...), embeddingProbeServices...)
+	for _, name := range probed {
+		if _, ok := services.ServiceMap[name]; !ok {
+			t.Errorf("probe engine %q is not in services.ServiceMap, so its container can never be enumerated", name)
+		}
+	}
+}

--- a/internal/status/types.go
+++ b/internal/status/types.go
@@ -271,6 +271,14 @@ const (
 	HealthStatusDegraded  = "degraded"
 	HealthStatusUnhealthy = "unhealthy"
 	HealthStatusUnknown   = "unknown"
+	// HealthStatusStarting means the service's container is UP but the service
+	// is not answering yet: a serving engine still loading weights, a TEI whose
+	// /health is not yet 200. Status is still "running" (the container really is
+	// running, which is what SERVICE_STATUS reports), so the node no longer
+	// under-reports a service it was just told to start (aceteam#7148). Consumers
+	// that need READINESS, for example the platform's TEI embedding-node resolver,
+	// must gate on this health value, not on Status alone.
+	HealthStatusStarting = "starting"
 )
 
 // StatusVersion is the current version of the status payload format.


### PR DESCRIPTION
## Context

aceteam-ai/aceteam#7148. Deploying `gte-multilingual-base` to node `1314` started TEI successfully, but the node's own reported inventory did not show it:

| Call | Result |
| --- | --- |
| `service_status(1314, "tei")` | `tei is running (docker)` |
| `fabric_node_status(1314)` | `Running Services: none` |

The direct `SERVICE_STATUS` dispatch is authoritative, so the node was telling the platform two different things about the same container.

## Root cause

Not "the inventory enumerates manifest-declared services" as the issue guessed. The manifest list (`c.services`) is nil on the heartbeat path, and the `stopped` rows an operator sees come from `applyModelHotswap` (#632) advertising installed-but-stopped engines. The real defects are both in `internal/status/engines.go`:

1. **Coverage.** Only two hardcoded lists were ever consulted: `managedProbeEngines` (vllm, ollama, llamacpp, bonsai, unlimited-ocr) and `embeddingProbeServices` (tei). `kokoro`, `transcribe`, `diffusers`, `extraction`, `sglang` and `lmstudio` had no path into the heartbeat at all, running or not.

2. **Readiness gate.** Even for a listed service, an entry was emitted only if a probe answered (`if !responded { continue }`) or TEI's `/health` returned 200. A container that is up but still downloading weights was omitted **entirely** rather than reported as not-ready. That is the exact repro: TEI was pulling ~600MB of `gte-multilingual-base`, so it reported nothing for the whole warm-up. Node 1297 listed `tei` only because its TEI had finished warming long ago.

Because #6909's TEI provisioning uses `SERVICE_START` from the embedded `ServiceMap`, this hit every embedded-compose engine started through Quick Deploy or the per-node Deploy tab.

## Changes

- `internal/status/running_services.go` (new): enumerates running `citadel-*` containers with ONE `docker ps` (or podman, via `catalog.SelectContainerRuntime()`) per heartbeat and maps them back to `services.ServiceMap` keys. The container lister is a package var so the selection logic is unit-testable without a container runtime. Replaces the previous one `docker inspect` per known engine.
- `internal/status/engines.go`: both probe passes now report a running-but-unresponsive service with `health=starting` instead of dropping it. `status` stays `running` (the container really is running, which is what `SERVICE_STATUS` reports) and `health` carries readiness. Readiness gating moves from presence to health.
- Backstop pass reports every other running embedded-compose service. `Type` is deliberately conservative: only genuine OpenAI chat engines get `llm`, so kokoro/transcribe/diffusers/extraction show up in the inventory without becoming chat-router candidates.
- `internal/status/types.go`: `HealthStatusStarting`.

## Rebased onto main (v2.99.0), scope reduced

This branch was rebased onto `origin/main` after #699 landed. Two files conflicted, `internal/status/engines.go` and `internal/status/models.go`, and the resolution dropped one of this PR's original contributions:

- **TEI model discovery is no longer part of this PR.** `beaa29a9` (citadel-cli#690) already added `ModelDiscovery.DiscoverEmbeddingModel`, reading the served model id from TEI's `GET /info`, and deliberately kept it OFF the `DiscoverModels` chat-engine switch. This branch's `models.go` change added a `case "tei"` to that very switch, which would have reintroduced the mis-attribution #690 fixed. `models.go` is reverted to main's version and this PR now calls `DiscoverEmbeddingModel`.
- `collectEmbeddingServices` keeps #690's injected running/health seams. Its signature narrows from `(ctx, engineBin, func(engineBin, name string), healthy, md)` to `(ctx, func(name string), healthy, md)`: the production wrapper now supplies a closure over the once-per-heartbeat running set, so `engineBin` is no longer consulted inside. The two upstream call sites in `embedding_models_test.go` are updated. The native-install fallback #690 added is preserved, via `enginePortIfRunning`, so a natively served embedding server is still reported.
- This PR's own `embeddingHealthProbe` package var is removed in favour of upstream's injected `healthy` parameter, so there is one test seam for readiness rather than two.

## Deploy ordering (satisfied)

The platform half, aceteam-ai/aceteam#7263, shipped in **v1.359.0** and is deployed. It adds the readiness gate this change depends on: `utils/rag_embeddings._service_is_tei` matches on service NAME only, so a `starting` TEI reported without that gate would have made a warming node eligible for embedding dispatch and the embed would 503.

## Behaviour note

During an engine warmup, a managed engine now reports `running` + `starting` with no models instead of being absent and picked up by `collectInstalledEngines` as `stopped` with its `<name>.env` model. So for the warmup window that model id is not in the node's advertised set, and `applyModelHotswap` marks the warming engine `Resident=true` with a VRAM estimate. Both are more honest than the old shape: the card really is being occupied, and the model really is not servable yet. No duplicate entry is possible, `collectInstalledEngines` skips by name against `reported`.

## Testing

```
gofmt -l .   # clean
go vet ./... # clean
go test ./... # 68 packages pass
```

New tests:

- `running_services_test.go`: container-name mapping, module containers excluded, runtime failure degrades to empty, EVERY `ServiceMap` entry is reportable, already-reported services are not overwritten, deterministic ordering, and `llm` is reserved for chat engines.
- `starting_service_test.go`: a warming TEI is reported `running` + `starting` with no models; a ready TEI is `ok` and reports its served model id; an unresponsive vLLM is reported `starting` with no idle signal; the collector wrapper threads the running set into that same decision; and `managedProbeEngines` + `embeddingProbeServices` are subsets of `services.ServiceMap` (the new enumeration filters on `ServiceMap` membership, which the per-engine `docker inspect` it replaced did not).

Coverage is defined by `services.ServiceMap`: ollama, vllm, llamacpp, lmstudio, sglang, extraction, transcribe, diffusers, bonsai, kokoro, tei, unlimited-ocr. `transcribe` is the whisper service; there is no `comfyui` entry, `diffusers` is the image service.

Not verified on a live node: nodes 1297 and 1314 carry demo work for an Aug 14 customer meeting and were left untouched.
