### PR TITLE
feat(worker): push-based dispatch wake — consume targeted jobs immediately (aceteam#7270 P1)

### DIFF
--- a/cmd/agent_tools.go
+++ b/cmd/agent_tools.go
@@ -163,12 +163,21 @@ func agentResubscribe(ctx context.Context, d agentProviderDeps, orgID string) (a
 	}
 
 	perNodeQueue := nodeQueueName(orgID, nodeID)
+	wakeChannel := nodeWakeChannel(nodeID)
 	switch src := d.source.(type) {
 	case *worker.APISource:
 		src.AddQueue(perNodeQueue)
+		// Re-establish the push-wake subscription alongside the stream (issue
+		// #7270). EnableWake is a no-op if already enabled; best-effort otherwise.
+		if err := src.EnableWake(ctx, wakeChannel); err != nil {
+			Debug("resubscribe: per-node push-wake unavailable (poll-only): %v", err)
+		}
 	case *worker.RedisSource:
 		if err := src.AddQueue(ctx, perNodeQueue); err != nil {
 			return nil, fmt.Errorf("failed to subscribe to %s: %w", perNodeQueue, err)
+		}
+		if err := src.EnableWake(ctx, wakeChannel); err != nil {
+			Debug("resubscribe: per-node push-wake unavailable (poll-only): %v", err)
 		}
 	default:
 		return map[string]any{"ok": false, "message": "source does not support resubscription"}, nil

--- a/cmd/wake_channel_test.go
+++ b/cmd/wake_channel_test.go
@@ -1,0 +1,34 @@
+package cmd
+
+import "testing"
+
+// TestNodeWakeChannel pins the wire literal for the push-based dispatch wake
+// (issue #7270). This string MUST match the backend's
+// utils.queue_names.build_node_wake_channel; the two repos cannot share a
+// constant, so each pins the literal in a test.
+func TestNodeWakeChannel(t *testing.T) {
+	cases := map[string]string{
+		"1297":    "wake:v1:node:1297",
+		"my-node": "wake:v1:node:my-node",
+	}
+	for nodeID, want := range cases {
+		if got := nodeWakeChannel(nodeID); got != want {
+			t.Errorf("nodeWakeChannel(%q) = %q, want %q", nodeID, got, want)
+		}
+	}
+}
+
+// TestNodeWakeChannelTracksNodeQueue guards that the wake channel and the
+// per-node stream stay keyed by the SAME node id (a nudge must address the same
+// node whose stream it wakes).
+func TestNodeWakeChannelTracksNodeQueue(t *testing.T) {
+	const org, node = "org-abc", "1297"
+	q := nodeQueueName(org, node)
+	w := nodeWakeChannel(node)
+	if want := "jobs:v1:shell:org_org-abc:node:1297"; q != want {
+		t.Fatalf("nodeQueueName = %q, want %q", q, want)
+	}
+	if want := "wake:v1:node:1297"; w != want {
+		t.Fatalf("nodeWakeChannel = %q, want %q", w, want)
+	}
+}

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1022,12 +1022,22 @@ func runWork(cmd *cobra.Command, args []string) {
 		}
 		if perNodeOrgID != "" {
 			perNodeQueue := nodeQueueName(perNodeOrgID, headscaleNodeID)
+			wakeChannel := nodeWakeChannel(headscaleNodeID)
 			switch src := source.(type) {
 			case *worker.APISource:
 				src.AddQueue(perNodeQueue)
+				// Push-wake (issue #7270): drain the per-node stream immediately on a
+				// backend nudge instead of on the next ~5s poll. Purely additive — a
+				// subscribe failure just leaves this node correctly poll-only.
+				if err := src.EnableWake(ctx, wakeChannel); err != nil {
+					Debug("per-node push-wake unavailable (poll-only): %v", err)
+				}
 			case *worker.RedisSource:
 				if err := src.AddQueue(ctx, perNodeQueue); err != nil {
 					fmt.Fprintf(os.Stderr, "   - Warning: per-node stream subscribe failed: %v\n", err)
+				}
+				if err := src.EnableWake(ctx, wakeChannel); err != nil {
+					Debug("per-node push-wake unavailable (poll-only): %v", err)
 				}
 			}
 			workerState.SetPerNodeQueue(perNodeQueue)
@@ -2397,6 +2407,20 @@ func hasCapabilityTag(tags []string, tag string) bool {
 //	jobs:v1:shell:org_{org_id}:node:{node_id}
 func nodeQueueName(orgID, nodeID string) string {
 	return fmt.Sprintf("jobs:v1:shell:org_%s:node:%s", orgID, nodeID)
+}
+
+// nodeWakeChannel returns the per-node Pub/Sub wake channel for push-based
+// dispatch (issue #7270). The backend PUBLISHes a nudge here right after XADDing
+// a targeted job to this node's per-node stream, and the worker subscribes so it
+// drains that stream immediately instead of waiting out its ~5s poll block.
+//
+// Keyed by the Headscale numeric node ID alone (globally unique across the
+// fabric), so it is org-agnostic — this literal MUST match the backend's
+// utils.queue_names.build_node_wake_channel (guarded by TestNodeWakeChannel and
+// a sibling test in the aceteam repo, since the two repos cannot share a
+// constant).
+func nodeWakeChannel(nodeID string) string {
+	return fmt.Sprintf("wake:v1:node:%s", nodeID)
 }
 
 // getWorkHostname returns the hostname to use for VPN reconnection.

--- a/internal/redis/client.go
+++ b/internal/redis/client.go
@@ -139,15 +139,28 @@ func (c *Client) EnsureConsumerGroups(ctx context.Context, queues []string) erro
 	return nil
 }
 
+// NonBlockingMs is the block value that makes a read return immediately (no
+// server-side XREADGROUP BLOCK). go-redis omits the BLOCK option when the block
+// duration is negative, so a negative millisecond count is a non-blocking read.
+// Used by the push-wake drain (issue #7270): on a wake nudge the worker reads
+// its per-node stream once, right now, instead of waiting out the poll block.
+const NonBlockingMs = -1
+
 // ReadJob reads the next available job from the stream using XREADGROUP.
 // Returns nil if no job is available within the block timeout.
 func (c *Client) ReadJob(ctx context.Context) (*Job, error) {
+	return c.ReadJobBlock(ctx, c.blockMs)
+}
+
+// ReadJobBlock is ReadJob with an explicit block timeout (ms). Pass
+// NonBlockingMs for an immediate, non-blocking read (issue #7270).
+func (c *Client) ReadJobBlock(ctx context.Context, blockMs int) (*Job, error) {
 	streams, err := c.client.XReadGroup(ctx, &redis.XReadGroupArgs{
 		Group:    c.consumerGroup,
 		Consumer: c.workerID,
 		Streams:  []string{c.queueName, ">"},
 		Count:    1,
-		Block:    time.Duration(c.blockMs) * time.Millisecond,
+		Block:    time.Duration(blockMs) * time.Millisecond,
 	}).Result()
 
 	if err != nil {
@@ -168,6 +181,12 @@ func (c *Client) ReadJob(ctx context.Context) (*Job, error) {
 // ReadJobMulti reads the next available job from multiple streams using XREADGROUP.
 // Returns the job and the queue it came from, or nil if no job is available.
 func (c *Client) ReadJobMulti(ctx context.Context, queues []string) (*Job, string, error) {
+	return c.ReadJobMultiBlock(ctx, queues, c.blockMs)
+}
+
+// ReadJobMultiBlock is ReadJobMulti with an explicit block timeout (ms). Pass
+// NonBlockingMs for an immediate, non-blocking read (issue #7270).
+func (c *Client) ReadJobMultiBlock(ctx context.Context, queues []string, blockMs int) (*Job, string, error) {
 	if len(queues) == 0 {
 		return nil, "", fmt.Errorf("no queues specified")
 	}
@@ -184,7 +203,7 @@ func (c *Client) ReadJobMulti(ctx context.Context, queues []string) (*Job, strin
 		Consumer: c.workerID,
 		Streams:  streamArgs,
 		Count:    1,
-		Block:    time.Duration(c.blockMs) * time.Millisecond,
+		Block:    time.Duration(blockMs) * time.Millisecond,
 	}).Result()
 
 	if err != nil {
@@ -485,6 +504,42 @@ func (c *Client) SetJobStatus(ctx context.Context, jobID, status string, data ma
 	}
 
 	return c.client.HSet(ctx, key, fields).Err()
+}
+
+// WatchWake subscribes to a Pub/Sub channel and invokes onWake for every
+// message received, until ctx is cancelled (issue #7270). It is the direct-Redis
+// half of push-based dispatch: the backend PUBLISHes a nudge on the node's wake
+// channel after a targeted XADD, and this fires onWake so the consume loop drains
+// its per-node stream immediately instead of waiting out its ~5s poll block.
+//
+// Best-effort by contract: the ~5s poll remains the correctness backstop, so a
+// dropped subscription only costs latency, never a job. The subscribe itself is
+// synchronous (so a bad channel surfaces immediately); message delivery then runs
+// in a background goroutine that exits on ctx cancellation.
+func (c *Client) WatchWake(ctx context.Context, channel string, onWake func()) error {
+	pubsub := c.client.Subscribe(ctx, channel)
+	// Wait for the subscribe to be confirmed so a failure is returned to the
+	// caller rather than swallowed in the goroutine.
+	if _, err := pubsub.Receive(ctx); err != nil {
+		_ = pubsub.Close()
+		return fmt.Errorf("failed to subscribe to wake channel %s: %w", channel, err)
+	}
+	ch := pubsub.Channel()
+	go func() {
+		defer pubsub.Close()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case _, ok := <-ch:
+				if !ok {
+					return
+				}
+				onWake()
+			}
+		}
+	}()
+	return nil
 }
 
 // Close closes the Redis connection.

--- a/internal/worker/api_source.go
+++ b/internal/worker/api_source.go
@@ -21,7 +21,19 @@ type APISource struct {
 	mu         sync.RWMutex
 	queueNames []string // resolved list of queues to consume from
 	queueIndex int      // round-robin index for multi-queue polling
+
+	// wake, when set (via EnableWake), makes Next return immediately on a
+	// per-node Pub/Sub nudge delivered over the WebSocket, instead of waiting out
+	// the HTTP consume block (issue #7270). Nil for the normal poll-only path.
+	wake *wakePump
 }
+
+// apiWakeDrainBlockMs is the (short) block used for the wake-triggered drain in
+// api-proxy mode. The Redis API proxy runs a server-side XREADGROUP BLOCK, so a
+// truly non-blocking read is not exposed; a brief block is plenty since the
+// nudge is published AFTER the XADD, so the job is already on the stream. Still
+// ~10x faster than the 5s poll — the whole point of the wake.
+const apiWakeDrainBlockMs = 500
 
 // APISourceConfig holds configuration for APISource.
 type APISourceConfig struct {
@@ -143,11 +155,78 @@ func (s *APISource) Connect(ctx context.Context) error {
 // iteration and the fungible tag queues in round-robin, each with a short
 // block timeout so no queue is starved (see nextMulti).
 func (s *APISource) Next(ctx context.Context) (*Job, error) {
+	if w := s.getWake(); w != nil {
+		return w.next(ctx)
+	}
+	return s.readOnce(ctx, s.config.BlockMs)
+}
+
+// getWake reads the wake pump under mu. EnableWake may be called from a
+// different goroutine than the run loop (e.g. /agent/resubscribe), so the
+// pointer is guarded like queueNames rather than read racily.
+func (s *APISource) getWake() *wakePump {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.wake
+}
+
+// readOnce performs one consume of the subscribed queue(s) with the given block
+// timeout. Core shared by the poll-only path and the wakePump closures.
+func (s *APISource) readOnce(ctx context.Context, blockMs int) (*Job, error) {
 	queues := s.snapshotQueues()
 	if len(queues) == 1 {
-		return s.nextSingle(ctx, queues[0])
+		return s.nextSingle(ctx, queues[0], blockMs)
 	}
-	return s.nextMulti(ctx, queues)
+	return s.nextMulti(ctx, queues, blockMs)
+}
+
+// EnableWake subscribes to the node's Pub/Sub wake channel over the WebSocket and
+// routes Next through the wakePump so a targeted-dispatch nudge is consumed
+// immediately (issue #7270). Requires the WebSocket to be enabled
+// (Client.EnableWebSocket, done in cmd/work.go); if it is not connected the wake
+// cannot be delivered and the node stays correctly poll-only. Best-effort: a
+// subscribe failure returns the error and leaves the source poll-only.
+func (s *APISource) EnableWake(ctx context.Context, channel string) error {
+	if channel == "" || s.client == nil || s.getWake() != nil {
+		return nil
+	}
+	ws := s.client.WebSocket()
+	if ws == nil || !ws.IsConnected() {
+		return fmt.Errorf("websocket not connected; wake unavailable (staying poll-only)")
+	}
+	pump := newWakePump(
+		func(c context.Context) (*Job, error) { return s.readOnce(c, s.config.BlockMs) },
+		func(c context.Context) (*Job, error) { return s.readOnce(c, apiWakeDrainBlockMs) },
+	)
+	// Incoming Pub/Sub messages arrive as WSMessage{Type:"message", Channel:...}.
+	// Filter to our wake channel and coalesce into the pump. NOTE: the WSClient
+	// keeps a single handler per message type; nothing else registers "message"
+	// in `citadel work` (the chat REPL is not co-resident with the worker), so
+	// this slot is free. If that ever changes, WSClient needs multi-handler fan-out.
+	ws.OnMessage("message", func(msg redisapi.WSMessage) {
+		if msg.Channel == channel {
+			pump.signal()
+		}
+	})
+	if err := ws.Subscribe(ctx, channel); err != nil {
+		return fmt.Errorf("failed to subscribe to wake channel %s: %w", channel, err)
+	}
+	// Re-subscribe after a WS reconnect so the wake survives connection churn.
+	ws.OnReconnect(func() {
+		if err := ws.Subscribe(context.Background(), channel); err != nil {
+			s.log("warning", "wake re-subscribe after reconnect failed: %v", err)
+		}
+	})
+	pump.start(ctx)
+	s.mu.Lock()
+	if s.wake != nil { // lost a race with a concurrent EnableWake; keep the winner
+		s.mu.Unlock()
+		return nil
+	}
+	s.wake = pump
+	s.mu.Unlock()
+	s.log("info", "   - Push-wake enabled: %s", channel)
+	return nil
 }
 
 // snapshotQueues returns a stable copy of the queue list for one poll cycle,
@@ -159,13 +238,13 @@ func (s *APISource) snapshotQueues() []string {
 }
 
 // nextSingle reads from a single queue (original behavior).
-func (s *APISource) nextSingle(ctx context.Context, queue string) (*Job, error) {
+func (s *APISource) nextSingle(ctx context.Context, queue string, blockMs int) (*Job, error) {
 	apiJob, err := s.client.ConsumeJob(ctx, redisapi.ConsumeRequest{
 		Queue:    queue,
 		Group:    s.config.ConsumerGroup,
 		Consumer: s.client.WorkerID(),
 		Count:    1,
-		BlockMs:  s.config.BlockMs,
+		BlockMs:  blockMs,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to consume job from API: %w", err)
@@ -256,7 +335,7 @@ func queueBlockBudget(totalBlockMs, rotatingCount, priorityCount int) (rotatingB
 // Individual queue failures (e.g., rejected by server validation) are skipped
 // rather than failing the entire poll cycle. Only when every distinct queue has
 // failed does the caller see an error (triggering backoff).
-func (s *APISource) nextMulti(ctx context.Context, queues []string) (*Job, error) {
+func (s *APISource) nextMulti(ctx context.Context, queues []string, blockMs int) (*Job, error) {
 	if len(queues) == 0 {
 		return nil, nil
 	}
@@ -268,7 +347,7 @@ func (s *APISource) nextMulti(ctx context.Context, queues []string) (*Job, error
 		priority, rotating = nil, queues
 	}
 
-	rotatingBlockMs, priorityBlockMs := queueBlockBudget(s.config.BlockMs, len(rotating), len(priority))
+	rotatingBlockMs, priorityBlockMs := queueBlockBudget(blockMs, len(rotating), len(priority))
 
 	// Failure accounting is per distinct queue, not per poll: the priority
 	// queue is polled len(rotating) times per cycle, so counting polls would

--- a/internal/worker/redis_source.go
+++ b/internal/worker/redis_source.go
@@ -39,6 +39,11 @@ type RedisSource struct {
 	// appended to at runtime by AddQueue (e.g. /agent/resubscribe, issue #236).
 	mu         sync.RWMutex
 	queueNames []string // resolved list of queues to consume from
+
+	// wake, when set (via EnableWake), makes Next return immediately on a
+	// per-node Pub/Sub nudge instead of waiting out the blocking poll (issue
+	// #7270). Nil for the normal poll-only path.
+	wake *wakePump
 }
 
 // RedisSourceConfig holds configuration for RedisSource.
@@ -148,12 +153,64 @@ func (s *RedisSource) Connect(ctx context.Context) error {
 }
 
 // Next blocks until a job is available or context is cancelled.
+//
+// With push-wake enabled (EnableWake), it delegates to the wakePump so a
+// per-node nudge triggers an immediate non-blocking drain; otherwise it does a
+// single blocking read at the configured BlockMs (the unchanged poll-only path).
 func (s *RedisSource) Next(ctx context.Context) (*Job, error) {
+	if w := s.getWake(); w != nil {
+		return w.next(ctx)
+	}
+	return s.readOnce(ctx, s.config.BlockMs)
+}
+
+// getWake reads the wake pump under mu. EnableWake may be called from a
+// different goroutine than the run loop (e.g. /agent/resubscribe), so the
+// pointer is guarded like queueNames rather than read racily.
+func (s *RedisSource) getWake() *wakePump {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.wake
+}
+
+// readOnce performs exactly one read of the subscribed queue(s) with the given
+// block timeout (redisclient.NonBlockingMs for an immediate read). It is the
+// core used by both the poll-only path and the wakePump's blocking/non-blocking
+// closures.
+func (s *RedisSource) readOnce(ctx context.Context, blockMs int) (*Job, error) {
 	queues := s.snapshotQueues()
 	if len(queues) == 1 {
-		return s.nextSingle(ctx, queues[0])
+		return s.nextSingle(ctx, queues[0], blockMs)
 	}
-	return s.nextMulti(ctx, queues)
+	return s.nextMulti(ctx, queues, blockMs)
+}
+
+// EnableWake subscribes to the node's Pub/Sub wake channel and routes Next
+// through the wakePump so a targeted-dispatch nudge is consumed immediately
+// (issue #7270). Idempotent-ish: a second call is ignored. Best-effort — on a
+// subscribe failure it returns the error and leaves the source in its normal
+// poll-only mode (the ~5s poll remains the backstop).
+func (s *RedisSource) EnableWake(ctx context.Context, channel string) error {
+	if channel == "" || s.client == nil || s.getWake() != nil {
+		return nil
+	}
+	pump := newWakePump(
+		func(c context.Context) (*Job, error) { return s.readOnce(c, s.config.BlockMs) },
+		func(c context.Context) (*Job, error) { return s.readOnce(c, redisclient.NonBlockingMs) },
+	)
+	if err := s.client.WatchWake(ctx, channel, pump.signal); err != nil {
+		return err
+	}
+	pump.start(ctx)
+	s.mu.Lock()
+	if s.wake != nil { // lost a race with a concurrent EnableWake; keep the winner
+		s.mu.Unlock()
+		return nil
+	}
+	s.wake = pump
+	s.mu.Unlock()
+	s.log("info", "   - Push-wake enabled: %s", channel)
+	return nil
 }
 
 // snapshotQueues returns a stable copy of the queue list for one poll cycle,
@@ -165,8 +222,8 @@ func (s *RedisSource) snapshotQueues() []string {
 }
 
 // nextSingle reads from a single queue (original behavior).
-func (s *RedisSource) nextSingle(ctx context.Context, queue string) (*Job, error) {
-	redisJob, err := s.client.ReadJob(ctx)
+func (s *RedisSource) nextSingle(ctx context.Context, queue string, blockMs int) (*Job, error) {
+	redisJob, err := s.client.ReadJobBlock(ctx, blockMs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read job from Redis: %w", err)
 	}
@@ -193,8 +250,8 @@ func (s *RedisSource) nextSingle(ctx context.Context, queue string) (*Job, error
 }
 
 // nextMulti reads from multiple queues simultaneously.
-func (s *RedisSource) nextMulti(ctx context.Context, queues []string) (*Job, error) {
-	redisJob, sourceQueue, err := s.client.ReadJobMulti(ctx, queues)
+func (s *RedisSource) nextMulti(ctx context.Context, queues []string, blockMs int) (*Job, error) {
+	redisJob, sourceQueue, err := s.client.ReadJobMultiBlock(ctx, queues, blockMs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read job from Redis: %w", err)
 	}

--- a/internal/worker/wake.go
+++ b/internal/worker/wake.go
@@ -1,0 +1,118 @@
+package worker
+
+import "context"
+
+// wakePump turns a per-node Pub/Sub "wake" nudge into an immediate, non-blocking
+// stream drain while keeping the normal blocking poll as the correctness backstop
+// (issue #7270, Phase 1). It is shared by RedisSource and APISource; only the
+// underlying read + subscribe mechanics differ.
+//
+// Design (see the #7270 design notes and the advisor review):
+//
+//   - **Never abandon a read.** A single reader goroutine does exactly ONE
+//     blocking read at a time via a request/response handshake (readReq/readResp).
+//     We never cancel a blocking XREADGROUP that may have already moved a message
+//     into the consumer group's pending list, so no message is lost.
+//   - **No continuous prefetch.** The reader only reads when next() asks, so
+//     read/process stays serialized exactly as before. A wake-path return can
+//     leave one blocking read still in flight; its result is delivered to the
+//     NEXT next() call — a bounded prefetch-by-one, never a runaway.
+//   - **Poll cadence preserved.** The blocking read returns at least every
+//     BlockMs (job or nil), so next() returns at least that often and the
+//     self-heal monitor (issue #548) never mistakes a wake-enabled idle node for
+//     a wedge.
+//   - **Coalesced signal.** trigger is buffered size 1 with a non-blocking send,
+//     so a burst of 100 nudges collapses to one pending drain and never backs up
+//     the subscriber goroutine.
+//
+// wakePump is deliberately kept OFF the JobSource interface (like AddQueue), so
+// the Nexus HTTP source and the test mocks are unaffected.
+type wakePump struct {
+	// readBlocking performs one normal (BlockMs) read; readNonBlocking performs
+	// an immediate, non-blocking read of the same stream(s).
+	readBlocking    func(context.Context) (*Job, error)
+	readNonBlocking func(context.Context) (*Job, error)
+
+	trigger  chan struct{}
+	readReq  chan struct{}
+	readResp chan wakeReadResult
+
+	// readInFlight tracks whether a blocking read is outstanding. Mutated only by
+	// next(), which is called by the single runner loop goroutine, so no lock is
+	// needed.
+	readInFlight bool
+}
+
+type wakeReadResult struct {
+	job *Job
+	err error
+}
+
+// newWakePump builds a pump over the two read closures.
+func newWakePump(readBlocking, readNonBlocking func(context.Context) (*Job, error)) *wakePump {
+	return &wakePump{
+		readBlocking:    readBlocking,
+		readNonBlocking: readNonBlocking,
+		trigger:         make(chan struct{}, 1),
+		readReq:         make(chan struct{}),
+		readResp:        make(chan wakeReadResult),
+	}
+}
+
+// start launches the single reader goroutine. It exits when ctx is cancelled.
+func (w *wakePump) start(ctx context.Context) {
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-w.readReq:
+				job, err := w.readBlocking(ctx)
+				select {
+				case w.readResp <- wakeReadResult{job: job, err: err}:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+}
+
+// signal delivers a coalesced wake. Safe to call from the subscriber goroutine
+// (or a burst of them); never blocks.
+func (w *wakePump) signal() {
+	select {
+	case w.trigger <- struct{}{}:
+	default:
+	}
+}
+
+// next returns the next job, waking immediately on a nudge. It blocks up to one
+// BlockMs (the reader's blocking read) when no nudge arrives, so the runner's
+// poll cadence is unchanged.
+func (w *wakePump) next(ctx context.Context) (*Job, error) {
+	// Ask the reader for a blocking read if one isn't already outstanding (an
+	// outstanding read is a prior wake-path prefetch we're still awaiting).
+	if !w.readInFlight {
+		select {
+		case w.readReq <- struct{}{}:
+			w.readInFlight = true
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	select {
+	case res := <-w.readResp:
+		w.readInFlight = false
+		return res.job, res.err
+	case <-w.trigger:
+		// A nudge arrived: drain the stream right now. The in-flight blocking
+		// read stays pending and its result is consumed by the next next() call.
+		// A nudge that raced ahead of the XADD's visibility yields (nil, nil)
+		// here; the pending blocking read (or the next poll) catches the job.
+		return w.readNonBlocking(ctx)
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}

--- a/internal/worker/wake_test.go
+++ b/internal/worker/wake_test.go
@@ -1,0 +1,153 @@
+package worker
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestWakePumpNudgeTriggersImmediateConsume is the core #7270 guarantee: a wake
+// nudge makes next() return via the non-blocking drain WITHOUT waiting out the
+// (here effectively infinite) blocking read.
+func TestWakePumpNudgeTriggersImmediateConsume(t *testing.T) {
+	readBlocking := func(ctx context.Context) (*Job, error) {
+		// Simulate a long poll block that only ends on shutdown, so if the wake
+		// path were broken the test would hang until the deadline below.
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	wakeJob := &Job{ID: "wake-job"}
+	readNonBlocking := func(ctx context.Context) (*Job, error) { return wakeJob, nil }
+
+	pump := newWakePump(readBlocking, readNonBlocking)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pump.start(ctx)
+
+	pump.signal() // nudge arrives (coalesced into the trigger)
+
+	done := make(chan *Job, 1)
+	go func() {
+		j, _ := pump.next(ctx)
+		done <- j
+	}()
+
+	select {
+	case j := <-done:
+		if j == nil || j.ID != "wake-job" {
+			t.Fatalf("expected wake-job from the non-blocking drain, got %v", j)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("next() did not return promptly on a wake nudge (blocked on the poll)")
+	}
+}
+
+// TestWakePumpReturnsBlockingReadWhenNoNudge: with no nudge, next() returns the
+// ordinary blocking read result and never touches the non-blocking drain.
+func TestWakePumpReturnsBlockingReadWhenNoNudge(t *testing.T) {
+	blockJob := &Job{ID: "block-job"}
+	readBlocking := func(ctx context.Context) (*Job, error) { return blockJob, nil }
+	readNonBlocking := func(ctx context.Context) (*Job, error) {
+		t.Error("non-blocking drain must not run without a nudge")
+		return nil, nil
+	}
+
+	pump := newWakePump(readBlocking, readNonBlocking)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pump.start(ctx)
+
+	j, err := pump.next(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if j == nil || j.ID != "block-job" {
+		t.Fatalf("expected block-job, got %v", j)
+	}
+}
+
+// TestWakePumpPrefetchDeliveredOnNextCall pins the prefetch-by-one contract: a
+// wake-path return leaves the in-flight blocking read pending; its result is
+// delivered to the NEXT next() call, and no message is dropped or double-read.
+func TestWakePumpPrefetchDeliveredOnNextCall(t *testing.T) {
+	releaseBlock := make(chan struct{})
+	blockJob := &Job{ID: "block-job"}
+	readCalls := 0
+	readBlocking := func(ctx context.Context) (*Job, error) {
+		readCalls++
+		<-releaseBlock
+		return blockJob, nil
+	}
+	wakeJob := &Job{ID: "wake-job"}
+	readNonBlocking := func(ctx context.Context) (*Job, error) { return wakeJob, nil }
+
+	pump := newWakePump(readBlocking, readNonBlocking)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pump.start(ctx)
+
+	pump.signal()
+	j1, _ := pump.next(ctx) // wake path -> wake-job; blocking read still pending
+	if j1 == nil || j1.ID != "wake-job" {
+		t.Fatalf("first next() should return wake-job, got %v", j1)
+	}
+
+	// Release the pending blocking read; the second next() must return its result
+	// WITHOUT issuing a second blocking read (readInFlight was carried over).
+	close(releaseBlock)
+	j2, _ := pump.next(ctx)
+	if j2 == nil || j2.ID != "block-job" {
+		t.Fatalf("second next() should return the prefetched block-job, got %v", j2)
+	}
+	if readCalls != 1 {
+		t.Fatalf("expected exactly one blocking read across a wake-then-drain cycle, got %d", readCalls)
+	}
+}
+
+// TestWakePumpSignalCoalesces: a burst of nudges must never block the caller
+// (subscriber goroutine); the buffered trigger collapses them to one.
+func TestWakePumpSignalCoalesces(t *testing.T) {
+	pump := newWakePump(
+		func(ctx context.Context) (*Job, error) { return nil, nil },
+		func(ctx context.Context) (*Job, error) { return nil, nil },
+	)
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 1000; i++ {
+			pump.signal()
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("signal() blocked under a burst; the trigger is not coalescing")
+	}
+}
+
+// TestWakePumpNextRespectsContextCancel: next() unblocks on ctx cancellation
+// even while a blocking read is outstanding (clean shutdown).
+func TestWakePumpNextRespectsContextCancel(t *testing.T) {
+	readBlocking := func(ctx context.Context) (*Job, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	pump := newWakePump(readBlocking, readBlocking)
+	ctx, cancel := context.WithCancel(context.Background())
+	pump.start(ctx)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := pump.next(ctx)
+		done <- err
+	}()
+	cancel()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected a context error on cancellation")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("next() did not unblock on context cancellation")
+	}
+}


### PR DESCRIPTION
## Context
Phase 1 of aceteam-ai/aceteam#7270. Targeted node jobs (memory FILE_WRITE/READ, shell, etc.) are XADDed to this node's per-node stream (`jobs:v1:shell:org_{org}:node:{node_id}`), but the worker only picks them up on its ~5s `XREADGROUP BLOCK` poll — so a **healthy** node looks slow/wedged to the backend's claim window (the aceteam#7260 symptom). This adds a Pub/Sub **wake** so the worker drains its per-node stream the instant a job is dispatched.

**Companion backend PR (publishes the nudge + WS-proxy allowlist):** aceteam-ai/aceteam#7289

## Root Cause
Claim latency == the worker's poll cadence. A per-node push nudge decouples them: on a nudge the worker does an immediate drain instead of waiting out the block.

## Wire contract
- The backend PUBLISHes `wake:v1:node:{node_id}` right after the targeted XADD. The worker subscribes and, on any message, drains its per-node stream.
- `nodeWakeChannel(nodeID)` (`cmd/work.go`) pins the literal — **must match** the backend's `utils.queue_names.build_node_wake_channel` (guarded by `TestNodeWakeChannel` here + a sibling test in aceteam).
- Backward-compatible: a subscriber that never gets nudged just keeps polling; the ~5s poll **remains the correctness backstop**. Latency-only.

## Design (consume loop)
`internal/worker/wake.go` — `wakePump`, shared by `RedisSource` and `APISource`:
- **Never abandons a read.** A single reader goroutine does exactly ONE blocking read at a time via a request/response handshake, so we never cancel an `XREADGROUP` that may already have moved a message into the group PEL → **no lost message**.
- **No continuous prefetch.** The reader only reads when `next()` asks; read/process stays serialized. A wake-path return can leave one blocking read in flight (**prefetch-by-one**), whose result is delivered to the next `next()` call — bounded, never runaway.
- **Poll cadence preserved.** The blocking read still returns at least every `BlockMs`, so `next()` returns at least that often and the #548 self-heal monitor is unaffected.
- **Coalesced signal** (buffered size-1, non-blocking send): a burst of nudges collapses to one drain and never backs up the subscriber goroutine.
- Kept **off** the `JobSource` interface (like `AddQueue`) — Nexus source and test mocks unaffected. The `wake` pointer is guarded by the source's existing `mu` (read in `Next`, written by `EnableWake`, which `/agent/resubscribe` may call from another goroutine).

## Changes
- `internal/redis/client.go` — `ReadJobBlock` / `ReadJobMultiBlock` (explicit block; `NonBlockingMs` = negative → go-redis omits `BLOCK` → immediate read) + `WatchWake` (subscribe + fire a callback per message).
- `internal/worker/wake.go` — the `wakePump` handshake (above).
- `internal/worker/redis_source.go` / `api_source.go` — `EnableWake` wires the pump. **Direct Redis:** go-redis Pub/Sub. **api-proxy:** WS `Subscribe` + `OnMessage("message", …)` filtered by channel, re-subscribed on reconnect; drain uses a short `apiWakeDrainBlockMs = 500` block (the proxy exposes no truly non-blocking read, still ~10x faster than the 5s poll).
- `cmd/work.go` / `cmd/agent_tools.go` — enable wake alongside the per-node stream subscription (and on `/agent/resubscribe`).

## api-proxy reachability (the question aceteam#7270 asks) — ANSWERED: covered
Production nodes run `APISource` + HTTP consume, with the WebSocket already live for pub/sub (`cmd/work.go` calls `EnableWebSocket`). `WSSource` (the server-push consume path) **exists but is dormant** — there is no `NewWSSource` anywhere in `cmd/`. Since the WS is live, the wake **is** reachable in api-proxy mode via `ws.Subscribe` (which is why the backend PR had to add the wake pattern to the WS-proxy `ALLOWED_SUBSCRIBE_PATTERNS`). Direct-Redis (debug) mode is covered too. So **both** modes get the speedup; a node whose WS is down stays correctly poll-only.

**Caveat:** `WSClient` keeps a single handler per message type. Nothing else registers `OnMessage("message", …)` during `citadel work` (the chat REPL isn't co-resident with the worker), so the slot is free. Multi-handler fan-out is the follow-up if that ever changes.

## Not in this PR (follow-ups)
- `cmd/controlcenter.go` (the TUI worker entry point) is not wired — poll-only, still correct.
- Multi-handler `OnMessage` fan-out (above).

## Testing
`go build ./... && go vet ./... ` clean. `go test ./internal/redis/...` ok. `go test -race ./internal/worker/ -run 'Wake|RedisSource|APISource|Runner'` → **ok, no data race**. New tests:
- `internal/worker/wake_test.go` — nudge triggers an immediate consume (≪ BlockMs); no nudge → ordinary blocking read (drain never runs); prefetch-by-one delivered on the next call with exactly one blocking read; signal coalesces under a 1000-nudge burst; `next()` unblocks on ctx cancel.
- `cmd/wake_channel_test.go` — pins `wake:v1:node:{id}` and that the wake channel + per-node stream stay keyed by the same node id.
- Pre-existing `TestDocumentRasterizeRendersRealPagesWithPoppler` fails in this sandbox (pdftoppm/GLIBC) on clean `main` too — **unrelated**.
- **Not live-verified end-to-end** — needs a deploy on both repos; hence draft.

Refs aceteam-ai/aceteam#7270.

🤖 Generated with [Claude Code](https://claude.com/claude-code)