### PR TITLE
fix(worker): poll the per-node queue on every rotation iteration (#704)

### DIFF
--- a/internal/worker/api_source.go
+++ b/internal/worker/api_source.go
@@ -139,8 +139,9 @@ func (s *APISource) Connect(ctx context.Context) error {
 }
 
 // Next blocks until a job is available or context is cancelled.
-// When consuming from multiple queues, polls each queue in round-robin
-// with a short block timeout to avoid starving any queue.
+// When consuming from multiple queues, polls the per-node queue on every
+// iteration and the fungible tag queues in round-robin, each with a short
+// block timeout so no queue is starved (see nextMulti).
 func (s *APISource) Next(ctx context.Context) (*Job, error) {
 	queues := s.snapshotQueues()
 	if len(queues) == 1 {
@@ -179,39 +180,114 @@ func (s *APISource) nextSingle(ctx context.Context, queue string) (*Job, error) 
 	return job, nil
 }
 
-// nextMulti round-robins across queues with a shorter block timeout.
-// Each poll checks one queue; if empty, advances to the next.
-// Individual queue failures (e.g., rejected by server validation) are
-// logged and skipped rather than failing the entire poll cycle. Only
-// when all queues error does the caller see an error (triggering backoff).
+// Block-timeout tuning for the multi-queue rotation. Deliberately fixed: there
+// is no flag or config knob for these.
+const (
+	// minQueueBlockMs floors the per-queue block so a node with many queues
+	// does not turn the rotation into a request storm. Each consume request
+	// costs the server a duplicated Redis connection for the length of the
+	// block, so the floor is what bounds request rate per node.
+	minQueueBlockMs = 500
+
+	// priorityQueueBlockMs is the block used for the per-node queue, which is
+	// polled on every iteration of the rotation. It is deliberately short: a
+	// node-pinned job's wait is bounded by the block of the *rotating* queue
+	// being polled when it arrives, not by this one, so time spent blocking
+	// here only delays the rotating queues.
+	priorityQueueBlockMs = 100
+)
+
+// splitPriorityQueues separates the per-node queue(s) from the fungible ones.
+//
+// The per-node queue (jobs:v1:shell:org_<id>:node:<nodeid>, identified by the
+// ":node:" marker) has exactly one eligible consumer: this node. A job sitting
+// on it is picked up by nobody else, so its pickup latency is the node's alone.
+// Every other queue is a shared capability/tag pool served by every node
+// carrying that tag, so a round robin over those is fine.
+func splitPriorityQueues(queues []string) (priority, rotating []string) {
+	for _, q := range queues {
+		if isPerNodeStream(q) {
+			priority = append(priority, q)
+		} else {
+			rotating = append(rotating, q)
+		}
+	}
+	return priority, rotating
+}
+
+// queueBlockBudget splits the configured block timeout across one rotation so a
+// full cycle still takes roughly BlockMs, accounting for the priority queue
+// being polled once per iteration.
+//
+// With no priority queue this reduces exactly to the previous behavior:
+// BlockMs/len(queues), floored at minQueueBlockMs.
+func queueBlockBudget(totalBlockMs, rotatingCount, priorityCount int) (rotatingBlockMs, priorityBlockMs int) {
+	if rotatingCount < 1 {
+		rotatingCount = 1
+	}
+	// The priority queue is polled once per rotating queue, so it consumes
+	// rotatingCount*priorityCount*priorityQueueBlockMs of the cycle budget.
+	remaining := totalBlockMs - rotatingCount*priorityCount*priorityQueueBlockMs
+	rotatingBlockMs = remaining / rotatingCount
+	if rotatingBlockMs < minQueueBlockMs {
+		rotatingBlockMs = minQueueBlockMs
+	}
+	priorityBlockMs = priorityQueueBlockMs
+	if priorityBlockMs > rotatingBlockMs {
+		priorityBlockMs = rotatingBlockMs
+	}
+	if priorityBlockMs < 1 {
+		priorityBlockMs = 1 // the server rejects blockMs < 1
+	}
+	return rotatingBlockMs, priorityBlockMs
+}
+
+// nextMulti polls across queues within one call, returning the first job found.
+//
+// The per-node queue is polled on EVERY iteration of the rotation; the fungible
+// tag queues stay on a round robin (issue #704). Polls are serial because the
+// consume endpoint takes a single queue per request, so a plain round robin over
+// N queues meant a node-pinned job could wait a full cycle (N block timeouts
+// plus N round trips, roughly 9s on a 12-queue node) before the worker even
+// looked at its queue. Interleaving bounds that wait at one rotating block plus
+// a round trip, while a full sweep of the fungible queues still takes about the
+// configured BlockMs.
+//
+// Individual queue failures (e.g., rejected by server validation) are skipped
+// rather than failing the entire poll cycle. Only when every distinct queue has
+// failed does the caller see an error (triggering backoff).
 func (s *APISource) nextMulti(ctx context.Context, queues []string) (*Job, error) {
-	// Use a shorter block per queue so we cycle through them all within
-	// roughly the configured block timeout.
-	perQueueBlockMs := s.config.BlockMs / len(queues)
-	if perQueueBlockMs < 500 {
-		perQueueBlockMs = 500
+	if len(queues) == 0 {
+		return nil, nil
 	}
 
+	priority, rotating := splitPriorityQueues(queues)
+	if len(priority) == 0 || len(rotating) == 0 {
+		// No per-node queue (or nothing but per-node queues): fall back to the
+		// flat round robin over everything, which is the pre-#704 behavior.
+		priority, rotating = nil, queues
+	}
+
+	rotatingBlockMs, priorityBlockMs := queueBlockBudget(s.config.BlockMs, len(rotating), len(priority))
+
+	// Failure accounting is per distinct queue, not per poll: the priority
+	// queue is polled len(rotating) times per cycle, so counting polls would
+	// let a single failing queue masquerade as a total outage. A queue that
+	// succeeds at least once in the cycle is not counted as failed.
+	failed := make(map[string]struct{}, len(queues))
+	succeeded := make(map[string]struct{}, len(queues))
 	var lastErr error
 	var lastQueue string
-	errCount := 0
 
-	for i := 0; i < len(queues); i++ {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		default:
-		}
-
-		queue := queues[s.queueIndex%len(queues)]
-		s.queueIndex = (s.queueIndex + 1) % len(queues)
-
+	// poll consumes one queue. Returns the job (nil when the queue is empty)
+	// and whether the caller should return it.
+	poll := func(queue string, blockMs int) (*Job, bool) {
 		apiJob, err := s.client.ConsumeJob(ctx, redisapi.ConsumeRequest{
 			Queue:    queue,
 			Group:    s.config.ConsumerGroup,
 			Consumer: s.client.WorkerID(),
 			Count:    1,
-			BlockMs:  perQueueBlockMs,
+			BlockMs:  blockMs,
 		})
 		if err != nil {
 			// Skip this queue so one rejected queue can't block the others.
@@ -219,21 +295,51 @@ func (s *APISource) nextMulti(ctx context.Context, queues []string) (*Job, error
 			// failure is self-healing and logging it every poll floods the
 			// activity panel. The cycle-level outcome is coalesced by the
 			// runner instead (the queue name is carried in the wrapped error).
+			if _, ok := succeeded[queue]; !ok {
+				failed[queue] = struct{}{}
+			}
 			lastErr = err
 			lastQueue = queue
-			errCount++
-			continue
+			return nil, false
+		}
+		succeeded[queue] = struct{}{}
+		delete(failed, queue)
+		if apiJob == nil {
+			return nil, false
+		}
+		job := s.convertJob(apiJob)
+		job.SourceQueue = queue
+		return job, true
+	}
+
+	for i := 0; i < len(rotating); i++ {
+		// Per-node queue first, on every iteration.
+		for _, pq := range priority {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			default:
+			}
+			if job, ok := poll(pq, priorityBlockMs); ok {
+				return job, nil
+			}
 		}
 
-		if apiJob != nil {
-			job := s.convertJob(apiJob)
-			job.SourceQueue = queue
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		queue := rotating[s.queueIndex%len(rotating)]
+		s.queueIndex = (s.queueIndex + 1) % len(rotating)
+		if job, ok := poll(queue, rotatingBlockMs); ok {
 			return job, nil
 		}
 	}
 
 	// Only propagate error (triggering backoff) if ALL queues failed.
-	if errCount == len(queues) {
+	if len(failed) == len(queues) {
 		return nil, fmt.Errorf("all %d queues failed (last: %s): %w", len(queues), lastQueue, lastErr)
 	}
 

--- a/internal/worker/api_source_rotation_test.go
+++ b/internal/worker/api_source_rotation_test.go
@@ -418,6 +418,37 @@ func TestNextMulti_ErrorAccounting(t *testing.T) {
 		}
 	})
 
+	t.Run("per-node queue succeeds then fails mid-cycle", func(t *testing.T) {
+		// The per-node queue is polled once per iteration, so it can succeed
+		// early in a cycle and fail later. A queue that succeeded at least once
+		// this cycle is deliberately NOT counted as failed: the conservative
+		// direction is to under-report, since the next cycle catches a real
+		// outage and a spurious backoff would stall an otherwise healthy node.
+		var perNodePolls int
+		var mu sync.Mutex
+		srv := newFakeConsumeServer(t, func(call consumeCall, _ int) (*redisapi.StreamMessage, int) {
+			if call.Queue != testPerNodeQueue {
+				return nil, http.StatusInternalServerError
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			perNodePolls++
+			if perNodePolls == 1 {
+				return nil, http.StatusOK // healthy on the first poll only
+			}
+			return nil, http.StatusInternalServerError
+		})
+		s := newConnectedSource(t, srv, queues, 5000)
+
+		job, err := s.Next(context.Background())
+		if err != nil {
+			t.Fatalf("Next returned error %v, want nil (the per-node queue answered this cycle)", err)
+		}
+		if job != nil {
+			t.Fatalf("Next returned job %+v, want nil", job)
+		}
+	})
+
 	t.Run("every queue fails", func(t *testing.T) {
 		srv := newFakeConsumeServer(t, func(consumeCall, int) (*redisapi.StreamMessage, int) {
 			return nil, http.StatusInternalServerError

--- a/internal/worker/api_source_rotation_test.go
+++ b/internal/worker/api_source_rotation_test.go
@@ -1,0 +1,454 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/redisapi"
+)
+
+// Tests for the multi-queue rotation (issue #704): the per-node queue must be
+// polled on every iteration of the rotation so a node-pinned job waits at most
+// one round trip, while the fungible tag queues stay on the round robin.
+
+const testPerNodeQueue = "jobs:v1:shell:org_test:node:1297"
+
+// consumeCall is one recorded POST to the consume endpoint.
+type consumeCall struct {
+	Queue   string
+	BlockMs int
+}
+
+// fakeConsumeServer is an httptest server standing in for the Redis API proxy.
+// respond decides what a consume request returns: a job, nothing, or an error.
+type fakeConsumeServer struct {
+	*httptest.Server
+
+	mu    sync.Mutex
+	calls []consumeCall
+}
+
+// consumeResponder returns (job, httpStatus). A nil job with status 200 means
+// "queue empty"; a non-200 status makes the consume call fail.
+type consumeResponder func(call consumeCall, nth int) (*redisapi.StreamMessage, int)
+
+func newFakeConsumeServer(t *testing.T, respond consumeResponder) *fakeConsumeServer {
+	t.Helper()
+	f := &fakeConsumeServer{}
+	f.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/fabric/redis/ping" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.URL.Path != "/api/fabric/redis/jobs/consume" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		var req redisapi.ConsumeRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		call := consumeCall{Queue: req.Queue, BlockMs: req.BlockMs}
+		f.mu.Lock()
+		f.calls = append(f.calls, call)
+		nth := len(f.calls)
+		f.mu.Unlock()
+
+		msg, status := respond(call, nth)
+		if status != http.StatusOK {
+			w.WriteHeader(status)
+			_, _ = w.Write([]byte(`{"error":"queue rejected"}`))
+			return
+		}
+		resp := redisapi.ConsumeResponse{}
+		if msg != nil {
+			resp.Messages = []redisapi.StreamMessage{*msg}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(f.Server.Close)
+	return f
+}
+
+func (f *fakeConsumeServer) recorded() []consumeCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]consumeCall(nil), f.calls...)
+}
+
+func (f *fakeConsumeServer) queueSequence() []string {
+	var out []string
+	for _, c := range f.recorded() {
+		out = append(out, c.Queue)
+	}
+	return out
+}
+
+// alwaysEmpty is the default responder: every queue is empty.
+func alwaysEmpty(consumeCall, int) (*redisapi.StreamMessage, int) {
+	return nil, http.StatusOK
+}
+
+func newConnectedSource(t *testing.T, srv *fakeConsumeServer, queues []string, blockMs int) *APISource {
+	t.Helper()
+	s := NewAPISource(APISourceConfig{
+		BaseURL:    srv.URL,
+		Token:      "test-token",
+		QueueNames: queues,
+		BlockMs:    blockMs,
+	})
+	if err := s.Connect(context.Background()); err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	return s
+}
+
+func jobMessage(jobID string) *redisapi.StreamMessage {
+	return &redisapi.StreamMessage{
+		ID: "1-0",
+		Data: redisapi.StreamMessageData{
+			JobID:   jobID,
+			Type:    "SHELL_COMMAND",
+			Payload: `{"command":"hostname"}`,
+		},
+	}
+}
+
+func TestSplitPriorityQueues(t *testing.T) {
+	queues := []string{
+		"jobs:v1:cpu-general",
+		testPerNodeQueue,
+		"jobs:v1:tag:gpu:rtx3090",
+		"jobs:v1:shell:org_test",
+	}
+	priority, rotating := splitPriorityQueues(queues)
+	if len(priority) != 1 || priority[0] != testPerNodeQueue {
+		t.Fatalf("priority = %v, want [%s]", priority, testPerNodeQueue)
+	}
+	want := []string{"jobs:v1:cpu-general", "jobs:v1:tag:gpu:rtx3090", "jobs:v1:shell:org_test"}
+	if strings.Join(rotating, ",") != strings.Join(want, ",") {
+		t.Fatalf("rotating = %v, want %v", rotating, want)
+	}
+}
+
+func TestQueueBlockBudget(t *testing.T) {
+	tests := []struct {
+		name                       string
+		totalBlockMs               int
+		rotating, priority         int
+		wantRotatingMs, wantPrioMs int
+	}{
+		{
+			// No per-node queue: identical to the pre-#704 formula
+			// (BlockMs/len(queues) floored at minQueueBlockMs).
+			name:         "no priority queue keeps old formula",
+			totalBlockMs: 5000, rotating: 2, priority: 0,
+			wantRotatingMs: 2500, wantPrioMs: 1,
+		},
+		{
+			name:         "no priority queue hits the floor",
+			totalBlockMs: 5000, rotating: 12, priority: 0,
+			wantRotatingMs: 500, wantPrioMs: 1,
+		},
+		{
+			// 12 queues (11 fungible + per-node): rotating polls hit the
+			// floor, and the per-node poll gets the short block.
+			name:         "many queues floor the rotating block",
+			totalBlockMs: 5000, rotating: 11, priority: 1,
+			wantRotatingMs: 500, wantPrioMs: 100,
+		},
+		{
+			// Small queue set: the priority budget is subtracted so a full
+			// cycle still fits inside the configured block timeout.
+			name:         "few queues keep the cycle within BlockMs",
+			totalBlockMs: 5000, rotating: 1, priority: 1,
+			wantRotatingMs: 4900, wantPrioMs: 100,
+		},
+		{
+			// A tiny configured block must never produce blockMs < 1, which
+			// the server rejects.
+			name:         "tiny budget stays valid",
+			totalBlockMs: 1, rotating: 1, priority: 1,
+			wantRotatingMs: 500, wantPrioMs: 100,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotRotating, gotPrio := queueBlockBudget(tc.totalBlockMs, tc.rotating, tc.priority)
+			if gotRotating != tc.wantRotatingMs {
+				t.Errorf("rotating block = %d, want %d", gotRotating, tc.wantRotatingMs)
+			}
+			if tc.priority > 0 && gotPrio != tc.wantPrioMs {
+				t.Errorf("priority block = %d, want %d", gotPrio, tc.wantPrioMs)
+			}
+			if gotPrio < 1 {
+				t.Errorf("priority block = %d, must be >= 1 (server rejects 0)", gotPrio)
+			}
+		})
+	}
+}
+
+// TestNextMulti_PollsPerNodeQueueEveryIteration is the core of #704: over one
+// rotation the per-node queue is visited before every fungible queue, so its
+// revisit interval is one round trip rather than one full cycle.
+func TestNextMulti_PollsPerNodeQueueEveryIteration(t *testing.T) {
+	srv := newFakeConsumeServer(t, alwaysEmpty)
+	queues := []string{
+		testPerNodeQueue,
+		"jobs:v1:tag:gpu:rtx3090",
+		"jobs:v1:tag:engine:vllm",
+		"jobs:v1:shell:org_test",
+	}
+	s := newConnectedSource(t, srv, queues, 5000)
+
+	job, err := s.Next(context.Background())
+	if err != nil {
+		t.Fatalf("Next returned error: %v", err)
+	}
+	if job != nil {
+		t.Fatalf("Next returned a job from empty queues: %+v", job)
+	}
+
+	seq := srv.queueSequence()
+	// 3 fungible queues => 3 iterations, each: per-node then one fungible.
+	if len(seq) != 6 {
+		t.Fatalf("consume calls = %d (%v), want 6", len(seq), seq)
+	}
+	for i, q := range seq {
+		if i%2 == 0 {
+			if q != testPerNodeQueue {
+				t.Errorf("call %d = %q, want the per-node queue on every iteration (seq %v)", i, q, seq)
+			}
+			continue
+		}
+		if q == testPerNodeQueue {
+			t.Errorf("call %d = %q, want a fungible queue (seq %v)", i, q, seq)
+		}
+	}
+
+	// Every fungible queue is still visited exactly once per cycle.
+	seen := map[string]int{}
+	for _, q := range seq {
+		seen[q]++
+	}
+	for _, q := range queues[1:] {
+		if seen[q] != 1 {
+			t.Errorf("fungible queue %s polled %d times per cycle, want 1", q, seen[q])
+		}
+	}
+	if seen[testPerNodeQueue] != 3 {
+		t.Errorf("per-node queue polled %d times, want 3 (once per iteration)", seen[testPerNodeQueue])
+	}
+
+	// The per-node poll uses the short block; the rotating polls share what is
+	// left of the configured block timeout, so a full cycle still takes about
+	// BlockMs (here 3*1566 + 3*100 = 4998ms).
+	wantRotatingMs, wantPrioMs := queueBlockBudget(5000, 3, 1)
+	for _, c := range srv.recorded() {
+		if c.Queue == testPerNodeQueue {
+			if c.BlockMs != wantPrioMs {
+				t.Errorf("per-node blockMs = %d, want %d", c.BlockMs, wantPrioMs)
+			}
+			continue
+		}
+		if c.BlockMs != wantRotatingMs {
+			t.Errorf("fungible blockMs = %d, want %d", c.BlockMs, wantRotatingMs)
+		}
+	}
+}
+
+// TestNextMulti_PerNodeJobPickedUpWithinOneRoundTrip covers the latency claim:
+// a job that lands on the per-node queue right after it was polled is picked up
+// after at most one intervening fungible poll, not after a full rotation.
+func TestNextMulti_PerNodeJobPickedUpWithinOneRoundTrip(t *testing.T) {
+	var perNodePolls int
+	var mu sync.Mutex
+	srv := newFakeConsumeServer(t, func(call consumeCall, _ int) (*redisapi.StreamMessage, int) {
+		if call.Queue != testPerNodeQueue {
+			return nil, http.StatusOK
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		perNodePolls++
+		if perNodePolls == 1 {
+			// Job is enqueued just after the first visit.
+			return nil, http.StatusOK
+		}
+		return jobMessage("job-pinned"), http.StatusOK
+	})
+
+	queues := []string{
+		testPerNodeQueue,
+		"jobs:v1:tag:gpu:rtx3090",
+		"jobs:v1:tag:engine:vllm",
+		"jobs:v1:tag:vram:24",
+		"jobs:v1:tag:meeting:org_test",
+		"jobs:v1:shell:org_test",
+	}
+	s := newConnectedSource(t, srv, queues, 5000)
+
+	job, err := s.Next(context.Background())
+	if err != nil {
+		t.Fatalf("Next returned error: %v", err)
+	}
+	if job == nil {
+		t.Fatal("Next returned no job, want the per-node job")
+	}
+	if job.ID != "job-pinned" {
+		t.Errorf("job ID = %q, want job-pinned", job.ID)
+	}
+	if job.SourceQueue != testPerNodeQueue {
+		t.Errorf("SourceQueue = %q, want %q", job.SourceQueue, testPerNodeQueue)
+	}
+
+	seq := srv.queueSequence()
+	// per-node (empty), one fungible, per-node (job) => 3 calls. Before #704
+	// this took 6 calls: one full rotation over every queue.
+	if len(seq) != 3 {
+		t.Fatalf("consume calls = %d (%v), want 3 (one intervening fungible poll)", len(seq), seq)
+	}
+	if seq[0] != testPerNodeQueue || seq[2] != testPerNodeQueue {
+		t.Errorf("call sequence = %v, want per-node first and third", seq)
+	}
+	if seq[1] == testPerNodeQueue {
+		t.Errorf("call sequence = %v, want a fungible queue in between", seq)
+	}
+}
+
+// TestNextMulti_NoPerNodeQueueIsUnchanged is the fallback: a queue set with no
+// per-node queue behaves exactly as it did before #704.
+func TestNextMulti_NoPerNodeQueueIsUnchanged(t *testing.T) {
+	srv := newFakeConsumeServer(t, alwaysEmpty)
+	queues := []string{
+		"jobs:v1:cpu-general",
+		"jobs:v1:tag:gpu:rtx3090",
+		"jobs:v1:shell:org_test",
+	}
+	s := newConnectedSource(t, srv, queues, 5000)
+
+	if _, err := s.Next(context.Background()); err != nil {
+		t.Fatalf("Next returned error: %v", err)
+	}
+
+	seq := srv.queueSequence()
+	if strings.Join(seq, ",") != strings.Join(queues, ",") {
+		t.Fatalf("call sequence = %v, want a flat round robin %v", seq, queues)
+	}
+	// Old formula: 5000/3 = 1666ms per queue.
+	for _, c := range srv.recorded() {
+		if c.BlockMs != 5000/len(queues) {
+			t.Errorf("blockMs for %s = %d, want %d", c.Queue, c.BlockMs, 5000/len(queues))
+		}
+	}
+
+	// The rotation still advances across calls.
+	if _, err := s.Next(context.Background()); err != nil {
+		t.Fatalf("second Next returned error: %v", err)
+	}
+	seq = srv.queueSequence()
+	if len(seq) != 2*len(queues) {
+		t.Fatalf("consume calls after two cycles = %d, want %d", len(seq), 2*len(queues))
+	}
+}
+
+// TestNextMulti_SingleQueueUnchanged verifies the single-queue path still makes
+// one request with the full configured block timeout.
+func TestNextMulti_SingleQueueUnchanged(t *testing.T) {
+	srv := newFakeConsumeServer(t, alwaysEmpty)
+	s := newConnectedSource(t, srv, []string{testPerNodeQueue}, 5000)
+
+	if _, err := s.Next(context.Background()); err != nil {
+		t.Fatalf("Next returned error: %v", err)
+	}
+	calls := srv.recorded()
+	if len(calls) != 1 {
+		t.Fatalf("consume calls = %d, want 1", len(calls))
+	}
+	if calls[0].BlockMs != 5000 {
+		t.Errorf("blockMs = %d, want the full configured 5000", calls[0].BlockMs)
+	}
+}
+
+// TestNextMulti_ErrorAccounting guards the failure denominator: the per-node
+// queue is polled many times per cycle, so counting failed polls rather than
+// failed queues would either fake a total outage or hide a real one.
+func TestNextMulti_ErrorAccounting(t *testing.T) {
+	queues := []string{
+		testPerNodeQueue,
+		"jobs:v1:tag:gpu:rtx3090",
+		"jobs:v1:shell:org_test",
+	}
+
+	t.Run("only the per-node queue fails", func(t *testing.T) {
+		srv := newFakeConsumeServer(t, func(call consumeCall, _ int) (*redisapi.StreamMessage, int) {
+			if call.Queue == testPerNodeQueue {
+				return nil, http.StatusForbidden
+			}
+			return nil, http.StatusOK
+		})
+		s := newConnectedSource(t, srv, queues, 5000)
+
+		job, err := s.Next(context.Background())
+		if err != nil {
+			t.Fatalf("Next returned error %v, want nil (other queues are healthy)", err)
+		}
+		if job != nil {
+			t.Fatalf("Next returned job %+v, want nil", job)
+		}
+	})
+
+	t.Run("only a fungible queue fails", func(t *testing.T) {
+		srv := newFakeConsumeServer(t, func(call consumeCall, _ int) (*redisapi.StreamMessage, int) {
+			if call.Queue == "jobs:v1:tag:gpu:rtx3090" {
+				return nil, http.StatusForbidden
+			}
+			return nil, http.StatusOK
+		})
+		s := newConnectedSource(t, srv, queues, 5000)
+
+		if _, err := s.Next(context.Background()); err != nil {
+			t.Fatalf("Next returned error %v, want nil (other queues are healthy)", err)
+		}
+	})
+
+	t.Run("every queue fails", func(t *testing.T) {
+		srv := newFakeConsumeServer(t, func(consumeCall, int) (*redisapi.StreamMessage, int) {
+			return nil, http.StatusInternalServerError
+		})
+		s := newConnectedSource(t, srv, queues, 5000)
+
+		if _, err := s.Next(context.Background()); err == nil {
+			t.Fatal("Next returned nil error, want an error so the runner backs off")
+		}
+	})
+}
+
+// TestNextMulti_ContextCancellationStopsRotation makes sure a cancelled context
+// aborts the interleaved rotation promptly instead of finishing the cycle.
+func TestNextMulti_ContextCancellationStopsRotation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	srv := newFakeConsumeServer(t, func(consumeCall, int) (*redisapi.StreamMessage, int) {
+		cancel() // cancel during the very first poll
+		return nil, http.StatusOK
+	})
+	queues := []string{
+		testPerNodeQueue,
+		"jobs:v1:tag:gpu:rtx3090",
+		"jobs:v1:shell:org_test",
+	}
+	s := newConnectedSource(t, srv, queues, 5000)
+
+	if _, err := s.Next(ctx); err == nil {
+		t.Fatal("Next returned nil error after cancellation, want context error")
+	}
+	if n := len(srv.recorded()); n > 2 {
+		t.Errorf("consume calls after cancellation = %d, want the rotation to stop promptly", n)
+	}
+}


### PR DESCRIPTION
## Context

Closes #704.

`APISource.nextMulti` polled queues serially, one HTTP round trip per queue with a 500ms floor on each, so revisiting any single queue took a full cycle (about 9s on a 12-queue node). Node-pinned jobs are the ones that suffer: the per-node stream `jobs:v1:shell:<org>:node:<id>` has exactly one eligible consumer, so a job sitting on it waits for this node's rotation and nothing else picks it up. The platform's targeted-dispatch claim window (3s) cannot be met by a 9s rotation.

The direct-Redis source has no such delay: `RedisSource.nextMulti` issues one `XREADGROUP` across every stream at once.

## Changes

`internal/worker/api_source.go`:

- `splitPriorityQueues` separates the per-node stream (the `:node:` marker, reusing the existing `isPerNodeStream` helper) from the fungible tag queues.
- `nextMulti` polls the per-node queue before every fungible queue in the rotation, so its revisit interval is one round trip rather than one full cycle. Fungible tag queues stay on the round robin, one visit per cycle, in the same order as before.
- `queueBlockBudget` splits the configured `BlockMs` across the cycle. The per-node poll uses a short 100ms block; the rotating queues share the rest, floored at 500ms. With no per-node queue present the function reduces exactly to the previous formula (`BlockMs/len(queues)`, floored at 500ms), so that path is unchanged.
- Failure accounting is now per distinct queue rather than per poll. The per-node queue is polled `len(rotating)` times per cycle, so a poll counter would let one persistently failing queue look like a total outage (spurious backoff) or, with the old denominator, let a real outage go unnoticed. Backoff still triggers only when every distinct queue has failed.

`internal/worker/api_source_rotation_test.go` (new): an `httptest` stand-in for the consume endpoint that records the queue and `blockMs` of every request.

## On the per-queue block floor

The issue asks for the floor to be reconsidered. It is kept at 500ms for the rotating queues, deliberately:

- Interleaving alone takes the per-node wait from about 9s to under 1s worst case, which clears the 3s claim window with margin. Lowering the floor would only move that from roughly 750ms to roughly 500ms.
- The server duplicates a Redis connection per consume request and disconnects it in a `finally` (`app/api/fabric/redis/jobs/consume/route.ts`). The floor is what bounds per-node request rate, so halving it doubles connection churn fleet-wide for a latency win that is not needed.

Instead the saving comes from the per-node poll's own block being short (100ms). A node-pinned job's wait is bounded by the block of the *rotating* queue being polled when the job arrives, not by the per-node block, so time spent blocking on the per-node queue only delays the rotating queues.

Net effect on a 12-queue node (11 fungible plus per-node), with a 250ms round trip: per-node revisit goes from about 9s to about 1s; a full sweep of the fungible queues goes from about 9s to about 12s.

## Why not the preferred fix (multi-queue in one request)

Not feasible within this repo. The consume endpoint takes a single queue:

- `app/api/fabric/redis/jobs/consume/route.ts` validates `queue: z.string().min(1).max(256)` and calls `xreadgroup(..., "STREAMS", queue, ">")` against that one stream.

Reading several streams in one call needs a request-schema change (queue to queues), a handler change to pass multiple streams to `XREADGROUP`, a response shape that says which stream each message came from, and the per-queue ownership check applied per stream. That is a change in `aceteam-ai/aceteam`, so it is out of scope here. The interim fix in this PR is compatible with it: when a multi-queue endpoint exists, `nextMulti` collapses to a single call and the interleaving plus the block budget both become unnecessary.

## Testing

`go test ./...` green.

New tests:

- `TestNextMulti_PollsPerNodeQueueEveryIteration`: over one cycle with 1 per-node plus 3 fungible queues, the recorded request sequence alternates per-node, fungible, per-node, fungible, and each fungible queue is still visited exactly once. Also asserts the block values (short for per-node, budget share for rotating).
- `TestNextMulti_PerNodeJobPickedUpWithinOneRoundTrip`: 6 queues, the per-node queue is empty on its first visit and has a job on its second. The job comes back after 3 requests (one intervening fungible poll). Before this change it took a full 6-request rotation.
- `TestNextMulti_NoPerNodeQueueIsUnchanged`: with no per-node queue the sequence is a flat round robin and the block is the old `BlockMs/len(queues)`.
- `TestNextMulti_SingleQueueUnchanged`: single-queue path still makes one request with the full configured block.
- `TestNextMulti_ErrorAccounting`: only the per-node queue failing returns no error; only a fungible queue failing returns no error; every queue failing returns an error so the runner backs off. A fourth subtest pins the mid-cycle case: the per-node queue answering once and failing on its later polls is not counted as failed, so no spurious backoff.
- `TestNextMulti_ContextCancellationStopsRotation`, `TestQueueBlockBudget`, `TestSplitPriorityQueues`.

Not verified: no live node was touched, so the end-to-end latency numbers above are computed from the block budget and the issue's measured round trip, not measured on a node. A live check would be to dispatch a node-targeted job and confirm the consume log shows the per-node queue between every pair of tag-queue polls.

## Notes

- One knock-on: a full `Next()` cycle now takes roughly 12s instead of 9s on a 12-queue node, and the runner only checks its drain flag between `Next()` calls, so a drain (auto-update) can take up to one extra cycle to take effect. Context cancellation is still checked before every poll.
- Related: `aceteam-ai/aceteam#7318` (platform-side claim window). No coordination done here.
