### PR TITLE
Tell a refused engine port apart from a warming one

### DIFF
--- a/internal/worker/llm_inference.go
+++ b/internal/worker/llm_inference.go
@@ -933,6 +933,14 @@ func (h *LLMInferenceHandler) engineRequestFailure(
 	if isEngineNotServing(err) {
 		return h.warming(payload.Model, engineWarmETA(payload.Backend), 0)
 	}
+	// A refused connection here means the engine went away between the readiness
+	// probe and the request. That is warming ONLY while a start this node issued
+	// is still inside its load window; otherwise nothing is listening and no
+	// amount of retrying will change that, so it stays a failure the caller can
+	// act on (citadel-cli#705).
+	if isConnectionRefused(err) && h.engineStartInFlight(payload.Backend) {
+		return h.warming(payload.Model, engineWarmETA(payload.Backend), 0)
+	}
 	return h.failure(fmt.Errorf("%s: %w", wrap, err))
 }
 

--- a/internal/worker/llm_readiness.go
+++ b/internal/worker/llm_readiness.go
@@ -43,6 +43,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -75,6 +76,60 @@ var engineReadyPath = map[string]string{
 // engineReadyBudgetOverride shortens the budget in tests. Nil in production.
 var engineReadyBudgetOverride *time.Duration
 
+// engineStartBudget is how long after a start attempt "nothing is listening on
+// the engine's port" is still an expected state rather than a fault
+// (citadel-cli#705). A cold start binds its port somewhere inside its own load
+// window, so the per-engine load estimate is the honest ceiling; past it, a
+// refused connection means the start did not take.
+func engineStartBudget(backend string) time.Duration {
+	return defaultLoadEstimate(backend)
+}
+
+// probeOutcome is what a single readiness probe learned. Splitting "nothing is
+// listening" from "something answered badly" is the whole point of
+// citadel-cli#705: the first is a start that did not take (a hard error unless a
+// start is known to be in flight), the second is a real server that is not ready
+// yet (warming). Collapsing both to a bool made a never-started engine report
+// model_warming forever.
+type probeOutcome int
+
+const (
+	// probeServing: the engine answered 200. Safe to proxy.
+	probeServing probeOutcome = iota
+	// probeNotServing: something is listening but did not answer 200 (it accepted
+	// and closed, returned 503, timed out mid-response). A loading engine.
+	probeNotServing
+	// probeNoListener: the connection was refused, so nothing is bound to the
+	// port at all. Either the engine was never started or its start failed.
+	probeNoListener
+)
+
+// engineStartTracker reports when a start of an engine was last attempted on
+// this node. Implemented by *SwapManager, which is the component that actually
+// issues the start, so readiness never has to infer liveness from the probe
+// alone. Optional: when nothing tracks starts (hotswap disabled), a refused
+// connection is taken at face value and reported as an error, which is the
+// actionable answer.
+type engineStartTracker interface {
+	// EngineStartedAt returns the time of the last start attempt for backend and
+	// whether one is on record.
+	EngineStartedAt(backend string) (time.Time, bool)
+}
+
+// engineStartInFlight reports whether a start of backend is known to have been
+// attempted recently enough that an unbound port is still expected.
+func (h *LLMInferenceHandler) engineStartInFlight(backend string) bool {
+	tracker, ok := h.swapper.(engineStartTracker)
+	if !ok {
+		return false
+	}
+	startedAt, known := tracker.EngineStartedAt(backend)
+	if !known {
+		return false
+	}
+	return time.Since(startedAt) < engineStartBudget(backend)
+}
+
 // engineReadyBudget is how long to wait for an engine to start answering before
 // reporting it as warming.
 func engineReadyBudget(backend string) time.Duration {
@@ -100,6 +155,8 @@ func engineWarmETA(backend string) int {
 // or the per-engine budget elapses. A nil error means the engine is serving and
 // the request may be proxied. errEngineWarming means it is up but not serving
 // yet; the caller must return a typed warming result, never proxy into it.
+// errEngineNotRunning means nothing is listening at all and no start is in
+// flight, so waiting cannot help; the caller must fail the job.
 //
 // A backend with no known readiness endpoint is treated as ready (fail-open), so
 // adding a backend can never silently make it unservable.
@@ -118,8 +175,21 @@ func (h *LLMInferenceHandler) ensureEngineReady(ctx context.Context, backend str
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if h.probeEngine(ctx, baseURL+path) {
+		switch h.probeEngine(ctx, baseURL+path) {
+		case probeServing:
 			return nil
+		case probeNoListener:
+			// Nothing is bound to the port. That is only a normal, transient state
+			// while a start this node issued is still inside its load window
+			// (citadel-cli#705). Otherwise the engine is simply not running, and
+			// polling until the budget elapses would answer "warming, retry in 10s"
+			// to a caller whose retries can never succeed.
+			if !h.engineStartInFlight(backend) {
+				return fmt.Errorf(
+					"%w: %s is not running, nothing is listening on %s",
+					errEngineNotRunning, backend, baseURL,
+				)
+			}
 		}
 		if time.Now().After(deadline) {
 			return fmt.Errorf("%w: %s is not serving yet", errEngineWarming, backend)
@@ -132,27 +202,59 @@ func (h *LLMInferenceHandler) ensureEngineReady(ctx context.Context, backend str
 	}
 }
 
-// probeEngine reports whether a single GET returns 200. Bounded by its own short
-// timeout so a hung engine cannot consume the whole budget in one attempt.
-func (h *LLMInferenceHandler) probeEngine(ctx context.Context, url string) bool {
+// probeEngine reports what a single GET learned about the engine. Bounded by its
+// own short timeout so a hung engine cannot consume the whole budget in one
+// attempt. It reports "no listener" separately from "listener, bad response" so
+// the caller decides what each means (citadel-cli#705).
+func (h *LLMInferenceHandler) probeEngine(ctx context.Context, url string) probeOutcome {
 	pctx, cancel := context.WithTimeout(ctx, engineProbeTimeout)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(pctx, http.MethodGet, url, nil)
 	if err != nil {
-		return false
+		return probeNotServing
 	}
 	resp, err := h.client().Do(req)
 	if err != nil {
-		return false
+		if isConnectionRefused(err) {
+			return probeNoListener
+		}
+		return probeNotServing
 	}
 	defer resp.Body.Close()
-	return resp.StatusCode == http.StatusOK
+	if resp.StatusCode != http.StatusOK {
+		return probeNotServing
+	}
+	return probeServing
 }
 
 // errEngineWarming marks "the engine is up but not serving yet" so the handler
 // can answer with a typed warming result rather than a job failure.
 var errEngineWarming = errors.New("engine warming")
+
+// errEngineNotRunning marks "nothing is listening on the engine's port and no
+// start is in flight" (citadel-cli#705). This is the honest counterpart to
+// errEngineWarming: retrying cannot fix it, so the caller must fail the job with
+// a message that names the engine instead of quoting an ETA that will never
+// arrive.
+var errEngineNotRunning = errors.New("engine not started")
+
+// isConnectionRefused reports whether err is a refused TCP connection, meaning
+// nothing at all is bound to the target port. This is deliberately NOT folded
+// into isEngineNotServing: refused is the one transport signal that says "no
+// server", while every signal that function accepts says "a server, mid-start"
+// (citadel-cli#705).
+func isConnectionRefused(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, syscall.ECONNREFUSED) {
+		return true
+	}
+	// Fallback for wrapped errors that carry only the text, and for platforms
+	// whose refused errno is not syscall.ECONNREFUSED.
+	return strings.Contains(err.Error(), "connection refused")
+}
 
 // isEngineNotServing classifies an outbound engine request error as "the engine
 // was not listening / dropped the connection" rather than a genuine failure.
@@ -162,11 +264,23 @@ var errEngineWarming = errors.New("engine warming")
 // connection mid-write, and the raw string is indistinguishable from a real
 // fault. Context cancellation and deadline expiry are deliberately NOT warming:
 // those mean the job itself was cancelled or timed out, which is a real failure.
+//
+// Connection refused is NOT warming either (citadel-cli#705). Every other signal
+// here proves a server exists and is mid-start; refused proves the opposite, and
+// lumping it in is what let a never-started engine report model_warming forever.
+// The refused check runs BEFORE the net.OpError catch-all on purpose: a refused
+// dial arrives as *url.Error wrapping *net.OpError, so the catch-all would
+// otherwise swallow it and this change would be a no-op. Callers that know a
+// start is in flight can still choose to warm on refused; see
+// engineRequestFailure.
 func isEngineNotServing(err error) bool {
 	if err == nil {
 		return false
 	}
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	if isConnectionRefused(err) {
 		return false
 	}
 	var opErr *net.OpError
@@ -176,7 +290,6 @@ func isEngineNotServing(err error) bool {
 	msg := err.Error()
 	for _, fragment := range []string{
 		"use of closed network connection",
-		"connection refused",
 		"connection reset by peer",
 		"broken pipe",
 		"server closed idle connection",

--- a/internal/worker/llm_readiness_test.go
+++ b/internal/worker/llm_readiness_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/jobs"
 )
 
 // serveReadinessProbe answers the readiness endpoints a real serving engine
@@ -447,5 +449,30 @@ func TestRetryAfterFor(t *testing.T) {
 	}
 	if got := retryAfterFor(9999); got != warmingRetryAfterMax {
 		t.Errorf("retryAfterFor(9999) = %d, want %d", got, warmingRetryAfterMax)
+	}
+}
+
+// TestEngineRequestFailure_RefusedMidRequest covers the second-line defence: an
+// engine that goes away between the readiness probe and the request. That is
+// warming only while a start this node issued is still inside its load window;
+// otherwise nothing is listening and the caller gets a failure it can act on
+// (citadel-cli#705).
+func TestEngineRequestFailure_RefusedMidRequest(t *testing.T) {
+	payload := &jobs.LLMInferencePayload{Model: "baidu/Unlimited-OCR", Backend: "unlimited-ocr"}
+	refused := realRefusedError(t)
+
+	h := NewLLMInferenceHandler()
+	result := h.engineRequestFailure(payload, refused, "failed to connect to chat endpoint")
+	if result.Status != JobStatusFailure {
+		t.Fatalf("refused with no start on record = %v, want failure", result.Status)
+	}
+
+	h.swapper = &startTracker{startedAt: time.Now(), known: true}
+	result = h.engineRequestFailure(payload, refused, "failed to connect to chat endpoint")
+	if result.Status != JobStatusSuccess {
+		t.Fatalf("refused while a start is in flight = %v, want a warming success", result.Status)
+	}
+	if got, _ := result.Output["status"].(string); got != "model_warming" {
+		t.Errorf("status = %q, want model_warming", got)
 	}
 }

--- a/internal/worker/llm_readiness_test.go
+++ b/internal/worker/llm_readiness_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -190,10 +191,12 @@ func TestExecute_LoadingEngineReturnsWarmingNotSocketError(t *testing.T) {
 // TestIsEngineNotServing classifies transport errors. The literal string from
 // #7220 must be recognised, and job cancellation must NOT be, or a cancelled
 // job would be reported to the caller as a model that is merely loading.
+//
+// Connection refused is in the NOT-warming set as of citadel-cli#705: it means
+// nothing is listening, which no amount of retrying fixes.
 func TestIsEngineNotServing(t *testing.T) {
 	warming := []error{
 		errors.New(`Post "http://localhost:8213/v1/chat/completions": readfrom tcp 127.0.0.1:57222->127.0.0.1:8213: write tcp: use of closed network connection`),
-		errors.New("dial tcp 127.0.0.1:8213: connect: connection refused"),
 		errors.New("read tcp: connection reset by peer"),
 		&net.OpError{Op: "dial", Err: errors.New("boom")},
 	}
@@ -208,11 +211,227 @@ func TestIsEngineNotServing(t *testing.T) {
 		context.Canceled,
 		context.DeadlineExceeded,
 		errors.New("failed to parse llama.cpp response: invalid character"),
+		errors.New("dial tcp 127.0.0.1:8213: connect: connection refused"),
+		// The error a REAL dial to an unbound port produces. The literal string
+		// above is not enough on its own: a refused dial arrives as *url.Error
+		// wrapping *net.OpError, and the net.OpError catch-all in
+		// isEngineNotServing would swallow it, so this test would pass while
+		// production still classified refused as warming (citadel-cli#705).
+		realRefusedError(t),
 	}
 	for _, err := range notWarming {
 		if isEngineNotServing(err) {
 			t.Errorf("isEngineNotServing(%v) = true, want false", err)
 		}
+	}
+}
+
+// unboundAddr returns a host:port that is guaranteed to refuse connections: a
+// listener is bound to pick a free port, then closed. This is how the
+// never-started engine is reproduced without stopping anything real.
+func unboundAddr(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	_ = ln.Close()
+	return addr
+}
+
+// realRefusedError produces a genuine connection-refused error from the HTTP
+// client, wrappers and all.
+func realRefusedError(t *testing.T) error {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, "http://"+unboundAddr(t)+"/health", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Fatal("dial to an unbound port unexpectedly succeeded")
+	}
+	return err
+}
+
+// startTracker is a scriptable engineStartTracker + modelSwapper, standing in
+// for the swap manager's record of "did this node actually start that engine".
+type startTracker struct {
+	startedAt time.Time
+	known     bool
+}
+
+func (s *startTracker) EnsureResident(_ context.Context, _, _ string) (SwapOutcome, error) {
+	return SwapOutcome{Ready: true}, nil
+}
+
+func (s *startTracker) EngineStartedAt(string) (time.Time, bool) {
+	return s.startedAt, s.known
+}
+
+// TestIsConnectionRefused asserts the refused predicate fires on a real dial
+// error and not on the transient signals that mean "a server, mid-start".
+func TestIsConnectionRefused(t *testing.T) {
+	if !isConnectionRefused(realRefusedError(t)) {
+		t.Error("a real refused dial must be recognised as connection refused")
+	}
+	for _, err := range []error{
+		nil,
+		errors.New("use of closed network connection"),
+		errors.New("EOF"),
+		&net.OpError{Op: "read", Err: errors.New("boom")},
+	} {
+		if isConnectionRefused(err) {
+			t.Errorf("isConnectionRefused(%v) = true, want false", err)
+		}
+	}
+}
+
+// TestProbeEngine_NoListenerIsDistinctFromBadResponse is the probe half of
+// citadel-cli#705: collapsing both to false is what let the caller treat a
+// never-started engine like a loading one.
+func TestProbeEngine_NoListenerIsDistinctFromBadResponse(t *testing.T) {
+	h := NewLLMInferenceHandler()
+
+	if got := h.probeEngine(context.Background(), "http://"+unboundAddr(t)+"/health"); got != probeNoListener {
+		t.Errorf("probe of an unbound port = %v, want probeNoListener", got)
+	}
+
+	// Bound but not serving: accept and immediately close.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	if got := h.probeEngine(context.Background(), "http://"+ln.Addr().String()+"/health"); got != probeNotServing {
+		t.Errorf("probe of a bound-but-not-serving port = %v, want probeNotServing", got)
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !serveReadinessProbe(w, r) {
+			http.Error(w, "unexpected path", http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+	if got := h.probeEngine(context.Background(), ts.URL+"/health"); got != probeServing {
+		t.Errorf("probe of a serving engine = %v, want probeServing", got)
+	}
+}
+
+// TestEnsureEngineReady_NeverStartedEngineFailsFast is the headline case of
+// citadel-cli#705. Nothing is listening and no start was ever attempted, so the
+// gate must name the engine and error rather than quote an ETA that will never
+// arrive. The budget is left at its real value on purpose: the answer must come
+// back immediately, not after waiting it out.
+func TestEnsureEngineReady_NeverStartedEngineFailsFast(t *testing.T) {
+	addr := unboundAddr(t)
+
+	for _, backend := range []string{"vllm", "sglang", "ollama", "llamacpp", "bonsai", "unlimited-ocr"} {
+		t.Run(backend, func(t *testing.T) {
+			h := NewLLMInferenceHandler()
+			h.baseURLs[backend] = "http://" + addr
+
+			start := time.Now()
+			err := h.ensureEngineReady(context.Background(), backend)
+			if !errors.Is(err, errEngineNotRunning) {
+				t.Fatalf("ensureEngineReady(%s) = %v, want errEngineNotRunning", backend, err)
+			}
+			if errors.Is(err, errEngineWarming) {
+				t.Fatalf("a never-started engine must not report warming: %v", err)
+			}
+			if !strings.Contains(err.Error(), backend) {
+				t.Errorf("error must name the engine, got %q", err)
+			}
+			if elapsed := time.Since(start); elapsed > 5*time.Second {
+				t.Errorf("must fail fast, took %v", elapsed)
+			}
+		})
+	}
+}
+
+// TestEnsureEngineReady_StartingEngineStillWarms is the other half of the
+// contract: while a start this node issued is inside its load window, an unbound
+// port is a cold start, and the caller must still be told to retry. Without this
+// the fix would trade an infinite warm for a spurious hard failure on every
+// normal cold start.
+func TestEnsureEngineReady_StartingEngineStillWarms(t *testing.T) {
+	shortenReadinessBudget(t, 50*time.Millisecond)
+	addr := unboundAddr(t)
+
+	h := NewLLMInferenceHandler()
+	h.baseURLs["unlimited-ocr"] = "http://" + addr
+	h.swapper = &startTracker{startedAt: time.Now(), known: true}
+
+	err := h.ensureEngineReady(context.Background(), "unlimited-ocr")
+	if !errors.Is(err, errEngineWarming) {
+		t.Fatalf("ensureEngineReady = %v, want errEngineWarming", err)
+	}
+}
+
+// TestEnsureEngineReady_StaleStartFailsFast asserts the start record expires. A
+// start issued longer ago than the engine's own load window did not take, so the
+// port being unbound is a fault, not a cold start.
+func TestEnsureEngineReady_StaleStartFailsFast(t *testing.T) {
+	addr := unboundAddr(t)
+
+	h := NewLLMInferenceHandler()
+	h.baseURLs["unlimited-ocr"] = "http://" + addr
+	stale := time.Now().Add(-2 * engineStartBudget("unlimited-ocr"))
+	h.swapper = &startTracker{startedAt: stale, known: true}
+
+	err := h.ensureEngineReady(context.Background(), "unlimited-ocr")
+	if !errors.Is(err, errEngineNotRunning) {
+		t.Fatalf("ensureEngineReady = %v, want errEngineNotRunning", err)
+	}
+}
+
+// TestExecute_NeverStartedEngineFailsWithNamedError is the end-to-end form: the
+// caller gets an actionable failure naming the engine, not the model_warming /
+// retry_after loop reported in citadel-cli#705.
+func TestExecute_NeverStartedEngineFailsWithNamedError(t *testing.T) {
+	h := NewLLMInferenceHandler()
+	h.baseURLs["unlimited-ocr"] = "http://" + unboundAddr(t)
+
+	job := &Job{
+		ID:   "job-ocr-dead",
+		Type: JobTypeLLMInference,
+		Payload: map[string]any{
+			"model":    "baidu/Unlimited-OCR",
+			"backend":  "unlimited-ocr",
+			"messages": []map[string]any{{"role": "user", "content": "read this"}},
+		},
+	}
+	stream := &MockStreamWriter{}
+	result, execErr := h.Execute(context.Background(), job, stream)
+	if execErr != nil {
+		t.Fatalf("Execute error: %v", execErr)
+	}
+	if result.Status != JobStatusFailure {
+		t.Fatalf("status = %v, want failure (output=%v)", result.Status, result.Output)
+	}
+	if got, _ := result.Output["status"].(string); got == "model_warming" {
+		t.Fatal("a never-started engine must not be reported as model_warming")
+	}
+	msg, _ := result.Output["error"].(string)
+	if !strings.Contains(msg, "unlimited-ocr") {
+		t.Errorf("error must name the engine, got %q", msg)
+	}
+	if !strings.Contains(msg, "not running") {
+		t.Errorf("error must say the engine is not running, got %q", msg)
+	}
+	if len(stream.chunks) != 0 {
+		t.Fatalf("a failure must emit no content chunks, got %v", stream.chunks)
 	}
 }
 

--- a/internal/worker/swap.go
+++ b/internal/worker/swap.go
@@ -129,6 +129,13 @@ type SwapManager struct {
 	inflight *swapOp              // the single in-flight swap, or nil
 	lastUsed map[string]time.Time // per-engine last request time (LRU)
 	readyAt  map[string]time.Time // per-engine last became-ready time (min-residency)
+	// startedAt records when this node last ISSUED a start for an engine, which
+	// is the only trustworthy evidence that an unbound port is a cold start
+	// rather than an engine that is simply not running (citadel-cli#705). The
+	// readiness gate reads it through EngineStartedAt; it is cleared when a start
+	// fails and when an engine is evicted, so a stale entry can never keep an
+	// absent engine reporting "warming".
+	startedAt map[string]time.Time
 }
 
 // NewSwapManager builds a swap manager with default timing and VRAM/load
@@ -146,6 +153,7 @@ func NewSwapManager(ctrl SwapController) *SwapManager {
 		readyPoll:     swapReadyPollEvery,
 		lastUsed:      map[string]time.Time{},
 		readyAt:       map[string]time.Time{},
+		startedAt:     map[string]time.Time{},
 	}
 }
 
@@ -275,7 +283,13 @@ func (m *SwapManager) runSwap(op *swapOp) {
 	}
 
 	// Start the target engine (SERVICE_START {service, model}; no vram_mb).
+	// Record the attempt BEFORE issuing it: an inline compose build can take
+	// minutes, and the readiness gate must already see the start as in flight
+	// while it runs (citadel-cli#705). A failed start clears the record so it
+	// cannot pass as evidence that the engine is on its way up.
+	m.markStartAttempted(op.backend)
 	if err := m.ctrl.Start(ctx, op.backend, op.model); err != nil {
+		m.clearStartAttempt(op.backend)
 		op.err = fmt.Errorf("failed to start %s for swap: %w", op.backend, err)
 		return
 	}
@@ -382,11 +396,40 @@ func (m *SwapManager) markReady(backend string) {
 	m.mu.Unlock()
 }
 
-// forget clears the residency window of an evicted engine.
+// forget clears the residency window of an evicted engine, and with it the
+// record that a start was ever issued: an engine we just stopped is not booting.
 func (m *SwapManager) forget(name string) {
 	m.mu.Lock()
 	delete(m.readyAt, name)
+	delete(m.startedAt, name)
 	m.mu.Unlock()
+}
+
+// markStartAttempted records that a start of backend was just issued.
+func (m *SwapManager) markStartAttempted(backend string) {
+	now := m.now()
+	m.mu.Lock()
+	m.startedAt[backend] = now
+	m.mu.Unlock()
+}
+
+// clearStartAttempt drops the start record for backend.
+func (m *SwapManager) clearStartAttempt(backend string) {
+	m.mu.Lock()
+	delete(m.startedAt, backend)
+	m.mu.Unlock()
+}
+
+// EngineStartedAt reports when this node last issued a start for backend, and
+// whether one is on record at all. It is the supervisor's answer to "was this
+// engine ever actually started", which the readiness gate needs to tell a cold
+// start apart from an engine that is not running (citadel-cli#705). Satisfies
+// engineStartTracker.
+func (m *SwapManager) EngineStartedAt(backend string) (time.Time, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	t, ok := m.startedAt[backend]
+	return t, ok
 }
 
 // etaSeconds estimates remaining seconds until the in-flight swap is ready,

--- a/internal/worker/swap_test.go
+++ b/internal/worker/swap_test.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -280,4 +281,66 @@ func TestEnsureResident_BackgroundSwapSurvivesJobCancellation(t *testing.T) {
 		time.Sleep(5 * time.Millisecond)
 	}
 	t.Fatalf("background swap did not complete after job-context cancellation")
+}
+
+// TestSwap_EngineStartedAt_RecordsAttemptAndClearsOnFailure is the supervisor
+// half of citadel-cli#705. The readiness gate reads this record to tell a cold
+// start apart from an engine that is not running, so it must exist while a start
+// is in flight and must NOT survive a start that failed.
+func TestSwap_EngineStartedAt_RecordsAttemptAndClearsOnFailure(t *testing.T) {
+	ctrl := newMockController()
+	ctrl.readyAfterStart = true
+	m := newTestManager(ctrl)
+
+	if _, known := m.EngineStartedAt("bonsai"); known {
+		t.Fatal("no start should be on record before one is issued")
+	}
+
+	if _, err := m.EnsureResident(context.Background(), "bonsai", "Bonsai-27B"); err != nil {
+		t.Fatalf("EnsureResident: %v", err)
+	}
+	waitFor(t, func() bool {
+		_, known := m.EngineStartedAt("bonsai")
+		return known
+	}, "a start attempt must be recorded")
+
+	// A start that fails must not linger as evidence the engine is booting.
+	ctrl2 := newMockController()
+	ctrl2.startErr = errors.New("compose up failed")
+	m2 := newTestManager(ctrl2)
+	m2.waitBudget = 2 * time.Second // let the swap finish so the error surfaces
+	if _, err := m2.EnsureResident(context.Background(), "bonsai", "Bonsai-27B"); err == nil {
+		t.Fatal("expected a hard error from a failed start")
+	}
+	if _, known := m2.EngineStartedAt("bonsai"); known {
+		t.Error("a failed start must not stay on record")
+	}
+}
+
+// TestSwap_EngineStartedAt_ClearedOnEviction asserts an engine we just stopped
+// is no longer treated as booting.
+func TestSwap_EngineStartedAt_ClearedOnEviction(t *testing.T) {
+	ctrl := newMockController()
+	m := newTestManager(ctrl)
+	m.markStartAttempted("unlimited-ocr")
+	if _, known := m.EngineStartedAt("unlimited-ocr"); !known {
+		t.Fatal("start should be on record")
+	}
+	m.forget("unlimited-ocr")
+	if _, known := m.EngineStartedAt("unlimited-ocr"); known {
+		t.Error("an evicted engine must not stay on record as started")
+	}
+}
+
+// waitFor polls cond until it holds or the timeout elapses.
+func waitFor(t *testing.T, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal(msg)
 }


### PR DESCRIPTION
Closes #705. Stacked on #697 (`feat/680-ready-gate-warming`), which introduces `internal/worker/llm_readiness.go`; that file does not exist on `main`, so this PR targets #697's branch rather than `main`.

## What was wrong

`isEngineNotServing` listed `connection refused` alongside `use of closed network connection`, `connection reset by peer`, `broken pipe` and `EOF`, and `probeEngine` returned `false` on any error at all. Every one of those other signals proves a server exists and is mid-start. Refused proves the opposite: nothing is bound to the port.

Collapsing the two meant an engine that was never started, or whose start did not take, was answered as `model_warming, eta 78s, retry in 10s` forever. A caller polling on `Retry-After` never got an error it could act on, and an operator saw a model perpetually about to be ready.

## Changes

**`probeEngine` reports three outcomes, not a bool** (`internal/worker/llm_readiness.go`). `probeServing` (answered 200), `probeNotServing` (something is listening but did not answer 200) and `probeNoListener` (refused). The caller decides what each means instead of the probe collapsing them.

**`ensureEngineReady` fails fast on a refused port unless a start is in flight.** On `probeNoListener` it asks whether this node actually issued a start for that engine and whether that start is still inside the engine's own load window. If not, it returns the new `errEngineNotRunning`, wrapped with a message naming the engine:

```
engine not started: unlimited-ocr is not running, nothing is listening on http://localhost:8213
```

`Execute` already routes any non-`errEngineWarming` error to a job failure, so that reaches the caller as an actionable failure rather than an ETA. Inside the start budget the behaviour is unchanged: still warming, still retryable.

**The supervisor supplies the start evidence, not the probe** (`internal/worker/swap.go`). `SwapManager` now records `startedAt[backend]` immediately before it issues `ctrl.Start`, so an inline compose build is covered while it runs, and clears it when the start returns an error or when the engine is evicted. It is read through a new `EngineStartedAt(backend) (time.Time, bool)`, which the handler picks up via an optional `engineStartTracker` interface. Nothing else implements that interface, and no existing interface gained a method, so no mock had to change.

**The start budget is the engine's own cold-start estimate** (`defaultLoadEstimate`), shared with the warming ETA so a node never quotes two different numbers for the same engine.

**`isEngineNotServing` no longer treats refused as warming.** The refused check runs *before* the `net.OpError` catch-all on purpose: a refused dial arrives as `*url.Error` wrapping `*net.OpError` wrapping `*os.SyscallError` wrapping `syscall.ECONNREFUSED`, so the catch-all would otherwise swallow it and this change would be a silent no-op. `engineRequestFailure` still answers warming on refused when a start is known to be in flight, which covers an engine that restarts between the probe and the request.

## Fallback, no flag

Default-on with no feature flag. The fallback is the tracker being optional: nothing else implements `engineStartTracker`, so with hotswap disabled by the break-glass env var no start attempts are recorded at all and a refused port is always read as "not running".

Be clear about what that costs. `SwapManager` is not the only thing that starts an engine on a node: `SERVICE_START` and manifest reconcile at boot do too, and neither feeds the tracker. Under the break-glass path an engine that is genuinely cold-starting from one of those is now reported as not running rather than warming. Hotswap is on by default, so in normal operation the swap manager issues the start and the record exists. Threading `SERVICE_START`'s own start record into the tracker would close the gap and is a follow-up, not this change.

Unknown backends still fail open, exactly as before.

## Tests

`internal/worker/llm_readiness_test.go` and `internal/worker/swap_test.go`. All engine-down conditions are reproduced with a bound-then-closed local port, never by stopping a real container.

| Test | Asserts |
| --- | --- |
| `TestEnsureEngineReady_NeverStartedEngineFailsFast` | refused port, no start on record, for all six backends: `errEngineNotRunning`, not warming, message names the engine, returns immediately rather than waiting out the budget |
| `TestEnsureEngineReady_StartingEngineStillWarms` | refused port with a start recorded inside the budget: still `errEngineWarming` |
| `TestEnsureEngineReady_StaleStartFailsFast` | same, with the start aged past the budget: `errEngineNotRunning` |
| `TestExecute_NeverStartedEngineFailsWithNamedError` | end to end: `JobStatusFailure`, never `model_warming`, error names the engine and says it is not running, no content chunks |
| `TestProbeEngine_NoListenerIsDistinctFromBadResponse` | the three probe outcomes against an unbound port, an accept-then-close listener and a serving engine |
| `TestIsConnectionRefused` / `TestIsEngineNotServing` | refused is classified from a real dial error, wrappers and all, and is no longer warming; the genuinely transient signals still are |
| `TestSwap_EngineStartedAt_RecordsAttemptAndClearsOnFailure` | the start record exists while a start is in flight and does not survive a failed start |
| `TestSwap_EngineStartedAt_ClearedOnEviction` | an evicted engine is no longer treated as booting |
| `TestEngineRequestFailure_RefusedMidRequest` | an engine that goes away between the probe and the request: failure with no start on record, warming while a start is in flight |

#697's existing tests are unchanged and still green, including `TestEnsureEngineReady_EveryBackendIsProbed` (bound but not serving is still warming) and `TestEnsureEngineReady_EmptyModelListIsStillReady`.

Test-bite verified by mutation: removing the refused check from `isEngineNotServing` and forcing the fail-fast branch off produces real assertion failures in the new tests, then restored.

`gofmt -l`, `go build ./...`, `go vet ./...` and `go test ./...` are green.

Note that CI does not run on this PR: `.github/workflows/ci.yml` triggers only on pull requests targeting `main`, and this one targets #697's branch. It will run once the stack is retargeted at `main`.

## Scope, and what this does not fix

This fixes the readiness gate and the transport classification. It covers the hotswap-disabled path and the case of an engine that is resident but has nothing bound to its port.

It does not touch the swap manager's own warming loop. With hotswap on, which is the default, `EnsureResident` returns warming from the swap manager before the readiness gate is reached, so an engine whose container starts and immediately dies is still answered as warming by that path. Bounding that loop interacts with bonsai's multi-minute first-start image build and is deliberately left out of this change.

## Effect on #697

This removes the reason #697 was held in draft. Merging #697 remains yours to call, and its own merge-order dependency on aceteam-ai/aceteam#7249 being merged AND released to production still applies to the whole stack. Nothing here was merged or un-drafted.

## Not verified

- No live dispatch against a real cold-starting or a real dead engine. Node 1297 serves live OCR for other work, so nothing was stopped or restarted to reproduce the condition; the refused and bound-but-not-serving states are reproduced with real local sockets instead.
- The start budget equals the per-engine cold-start estimate (90s for vllm, sglang and unlimited-ocr; 3min for bonsai; 60s otherwise). That is a judgement call, not a measurement of when each engine actually binds its port. An engine that binds later than its own load estimate would be reported as not running while it is in fact still starting. `engineStartBudget` is the single knob.
