### PR TITLE
docs: reconcile the Git workflow section with the worktree policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,27 +145,28 @@ go run . test --service vllm
 
 ### Git Workflow
 
-**See "⛔ CRITICAL: Git Branch Policy" section above. NEVER push to main.**
-
-**Additional rules:**
-1. **If on main** - Create a feature branch first
-2. **If already on a feature branch** - Commit and push directly to that branch (don't create new branches)
-3. **Never auto-create PRs** - Only create a PR when the user explicitly asks
+**See "⛔ CRITICAL: Git Workflow Policy" above — it is the authority. NEVER push to main, and never commit from the shared main checkout.**
 
 ```bash
-# If on main, create a branch first
-git checkout -b fix/description-of-change
+# Always: an isolated worktree on a branch off the latest main
+git fetch origin
+git worktree add -b fix/description ../citadel-cli-wt-<name> origin/main
+cd ../citadel-cli-wt-<name>
 
-# If already on a feature branch, just commit and push
 git add <files>
 git commit -m "message"
-git push
+git push -u origin fix/description
 
-# Only create PR when user explicitly requests it
+# Open the PR right after pushing; --draft while the test plan
+# still needs manual or deploy-gated steps.
 gh pr create --title "fix: description" --body "..."
 ```
 
-Even for "small fixes" or "quick changes" - always use a branch and PR.
+Even for "small fixes" or "quick changes" — always a worktree, a branch, and a PR.
+
+Already on a feature branch in your own worktree? Keep committing to it; do not
+branch again. Branch off `origin/main`, never off a local `main`, which is
+frequently stale.
 
 ### Future Work and TODOs
 


### PR DESCRIPTION
## Context

CLAUDE.md gave two contradictory instructions about pull requests:

- **"⛔ CRITICAL: Git Workflow Policy"** — *"Open a PR right after pushing"*
- **"Development Workflow → Git Workflow"** — *"Never auto-create PRs - Only create a PR when the user explicitly asks"*

An agent working #642 hit this and had to stop and ask which one governed. That is a direct cost of the contradiction, and it will recur for every contributor and every agent until it is resolved.

Jason's call (2026-08-05): **the auto-create prohibition goes.** Opening the PR immediately is the intended workflow.

## Beyond the literal fix

The rest of that section had rotted the same way, so removing only the one line would have left it misleading:

- It referred to **"⛔ CRITICAL: Git Branch Policy"**, a section since renamed to *Git Workflow Policy*.
- Rule 1 said *"if on main, create a feature branch first"* and the example ran `git checkout -b` **in place** — both predate the worktree mandate, which exists precisely because a concurrent release can `git checkout main` underneath you (as happened on 2026-07-28 and is documented in the policy section itself).
- The code block carried a comment repeating the now-removed PR prohibition.

Following the old text literally would put you in the exact situation the critical section forbids.

## What it says now

It defers to the policy section as the single authority rather than restating it, shows the worktree flow end to end, and keeps the two clarifications that were genuinely load-bearing: don't re-branch if you already have a worktree, and branch off `origin/main` rather than a local `main` that is frequently stale.

## Note on #708

This is precisely the failure mode #708 is about — a doc restating a rule that lives elsewhere and then drifting from it. The edit is in a different part of the file (Development Workflow, vs #708's new section at the top), so the two should not conflict; happy to rebase behind it if preferred.