### PR TITLE
fix: scope compose ps output to the service's own compose file

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -1492,7 +1492,7 @@ func ccGetServiceDetail(name string) *controlcenter.ServiceDetailInfo {
 			// Get container info via docker compose ps (no -p: default project,
 			// matching where production containers actually run, #528). The output
 			// is project-wide, so it must be narrowed to this compose file's own
-			// services before reading a container off it -- decoding the first
+			// services before reading a container off it. Decoding the first
 			// record showed another service's container here (#692).
 			if state, err := composeServiceState(fullComposePath, service.Name); err == nil && state.Container != nil {
 				container := state.Container

--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -3,7 +3,6 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -1246,36 +1245,10 @@ func gatherControlCenterData() (controlcenter.StatusData, error) {
 
 			fullComposePath := filepath.Join(configDir, service.ComposeFile)
 			if _, err := os.Stat(fullComposePath); err == nil {
-				psArgs := append(composeFileArgs(fullComposePath, fullComposePath), "ps", "--format", "json")
-				psCmd := composeCommand(psArgs...)
-				if output, err := psCmd.Output(); err == nil {
-					var containers []struct {
-						State  string `json:"State"`
-						Status string `json:"Status"`
-					}
-					decoder := json.NewDecoder(strings.NewReader(string(output)))
-					for decoder.More() {
-						var c struct {
-							State  string `json:"State"`
-							Status string `json:"Status"`
-						}
-						if err := decoder.Decode(&c); err == nil {
-							containers = append(containers, c)
-						}
-					}
-					if len(containers) > 0 {
-						state := strings.ToLower(containers[0].State)
-						if strings.Contains(state, "running") || strings.Contains(state, "up") {
-							svcInfo.Status = "running"
-							// Try to extract uptime from Status field
-							if containers[0].Status != "" {
-								svcInfo.Uptime = extractUptime(containers[0].Status)
-							}
-						} else if strings.Contains(state, "exited") || strings.Contains(state, "dead") {
-							svcInfo.Status = "stopped"
-						} else {
-							svcInfo.Status = state
-						}
+				if state, err := composeServiceState(fullComposePath, service.Name); err == nil {
+					svcInfo.Status = state.State
+					if state.Running && state.Container != nil && state.Container.Status != "" {
+						svcInfo.Uptime = extractUptime(state.Container.Status)
 					}
 				}
 			}
@@ -1517,29 +1490,21 @@ func ccGetServiceDetail(name string) *controlcenter.ServiceDetailInfo {
 			}
 
 			// Get container info via docker compose ps (no -p: default project,
-			// matching where production containers actually run, #528)
-			psArgs := append(composeFileArgs(fullComposePath, fullComposePath), "ps", "--format", "json")
-			psCmd := composeCommand(psArgs...)
-			if output, err := psCmd.Output(); err == nil {
-				var container struct {
-					ID      string `json:"ID"`
-					Image   string `json:"Image"`
-					Service string `json:"Service"`
-					State   string `json:"State"`
-					Ports   string `json:"Ports"`
+			// matching where production containers actually run, #528). The output
+			// is project-wide, so it must be narrowed to this compose file's own
+			// services before reading a container off it -- decoding the first
+			// record showed another service's container here (#692).
+			if state, err := composeServiceState(fullComposePath, service.Name); err == nil && state.Container != nil {
+				container := state.Container
+				if len(container.ID) > 12 {
+					detail.ContainerID = container.ID[:12]
+				} else {
+					detail.ContainerID = container.ID
 				}
-				decoder := json.NewDecoder(strings.NewReader(string(output)))
-				if err := decoder.Decode(&container); err == nil {
-					if len(container.ID) > 12 {
-						detail.ContainerID = container.ID[:12]
-					} else {
-						detail.ContainerID = container.ID
-					}
-					detail.Image = container.Image
-					if container.Ports != "" {
-						// Parse ports string like "0.0.0.0:8000->8000/tcp"
-						detail.Ports = strings.Split(container.Ports, ", ")
-					}
+				detail.Image = container.Image
+				if container.Ports != "" {
+					// Parse ports string like "0.0.0.0:8000->8000/tcp"
+					detail.Ports = strings.Split(container.Ports, ", ")
 				}
 			}
 

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -247,6 +247,38 @@ func composeFileArgs(origComposePath, actualComposePath string) []string {
 	return args
 }
 
+// composeServiceStateFrom resolves the run state of a manifest service from an
+// already-captured `docker compose ps --format json` output.
+//
+// The raw output is PROJECT-wide, not file-wide: citadel passes no `-p` (#528)
+// and every service compose file shares the default project (the services
+// directory basename), so `-f vllm.yml ps` also lists bonsai, kokoro and every
+// other citadel container. Reading containers[0] out of that is what made
+// `citadel status --json` report container-less services as running (#692).
+// internal/compose.ResolveServiceState narrows the output to the services this
+// compose file declares, and falls back to a native-serving probe so a service
+// running outside docker (ollama under systemd on port 11434) is not misreported
+// as stopped in the opposite direction.
+func composeServiceStateFrom(psOutput []byte, composePath, serviceName string) compose.ServiceState {
+	return compose.ResolveServiceState(
+		psOutput,
+		compose.DeclaredServices(composePath),
+		func() bool { return services.IsNativeServiceServing(serviceName) },
+	)
+}
+
+// composeServiceState runs `docker compose ps` for a manifest service and
+// resolves its run state. See composeServiceStateFrom for why the raw output
+// cannot be read directly.
+func composeServiceState(composePath, serviceName string) (compose.ServiceState, error) {
+	psArgs := append(composeFileArgs(composePath, composePath), "ps", "--format", "json")
+	output, err := composeCommand(psArgs...).Output()
+	if err != nil {
+		return compose.ServiceState{}, err
+	}
+	return composeServiceStateFrom(output, composePath, serviceName), nil
+}
+
 // sandboxOverridePathFor returns the path of the sandbox override that sits next
 // to a service's compose file (<dir>/<name>.sandbox.yml), or "" if it does not
 // exist. The compose file is "<name>.yml"; the override shares the same <name>.

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -296,31 +296,8 @@ func gatherStatusData() (dashboard.StatusData, error) {
 			if configDir != "" {
 				fullComposePath := filepath.Join(configDir, service.ComposeFile)
 				if _, err := os.Stat(fullComposePath); err == nil {
-					psArgs := append(composeFileArgs(fullComposePath, fullComposePath), "ps", "--format", "json")
-					psCmd := composeCommand(psArgs...)
-					if output, err := psCmd.Output(); err == nil {
-						var containers []struct {
-							State string `json:"State"`
-						}
-						decoder := json.NewDecoder(strings.NewReader(string(output)))
-						for decoder.More() {
-							var c struct {
-								State string `json:"State"`
-							}
-							if err := decoder.Decode(&c); err == nil {
-								containers = append(containers, c)
-							}
-						}
-						if len(containers) > 0 {
-							state := strings.ToLower(containers[0].State)
-							if strings.Contains(state, "running") || strings.Contains(state, "up") {
-								svcStatus.Status = "running"
-							} else if strings.Contains(state, "exited") || strings.Contains(state, "dead") {
-								svcStatus.Status = "stopped"
-							} else {
-								svcStatus.Status = state
-							}
-						}
+					if state, err := composeServiceState(fullComposePath, service.Name); err == nil {
+						svcStatus.Status = state.State
 					}
 				}
 			}
@@ -891,39 +868,32 @@ func printServiceInfo(w *tabwriter.Writer) {
 			continue
 		}
 
-		var containers []struct {
-			State string `json:"State"`
-		}
-		decoder := json.NewDecoder(strings.NewReader(string(output)))
-		for decoder.More() {
-			var c struct {
-				State string `json:"State"`
+		svcState := composeServiceStateFrom(output, fullComposePath, service.Name)
+		switch {
+		case svcState.Running:
+			statusStr := goodColor.Sprint("🟢 RUNNING")
+			if svcState.Native {
+				statusStr += labelColor.Sprint(" (native)")
 			}
-			if err := decoder.Decode(&c); err == nil {
-				containers = append(containers, c)
-			}
-		}
-
-		if len(containers) == 0 {
-			fmt.Fprintf(w, "  - %s:\t%s\n", service.Name, labelColor.Sprint("⚫ STOPPED"))
-		} else {
-			state := strings.ToUpper(containers[0].State)
-			var statusStr string
-			if strings.Contains(state, "RUNNING") || strings.Contains(state, "UP") {
-				statusStr = goodColor.Sprintf("🟢 %s", state)
-				// For running serving engines, show the model(s) actually loaded,
-				// e.g. "🟢 RUNNING (Qwen/Qwen3-8B)" (#529). Non-engine services and
-				// engines that don't answer within the short probe window print
-				// unchanged.
-				if models := discoverServiceModels(service.Name); len(models) > 0 {
-					statusStr += fmt.Sprintf(" (%s)", strings.Join(models, ", "))
-				}
-			} else if strings.Contains(state, "EXITED") || strings.Contains(state, "DEAD") {
-				statusStr = badColor.Sprintf("🔴 %s", state)
-			} else {
-				statusStr = warnColor.Sprintf("🟡 %s", state)
+			// For running serving engines, show the model(s) actually loaded,
+			// e.g. "🟢 RUNNING (Qwen/Qwen3-8B)" (#529). Non-engine services and
+			// engines that don't answer within the short probe window print
+			// unchanged.
+			if models := discoverServiceModels(service.Name); len(models) > 0 {
+				statusStr += fmt.Sprintf(" (%s)", strings.Join(models, ", "))
 			}
 			fmt.Fprintf(w, "  - %s:\t%s\n", service.Name, statusStr)
+		case svcState.Container != nil:
+			// A container exists for this service but is not up. Report its real
+			// state rather than a bare STOPPED so a crash loop is visible.
+			raw := strings.ToUpper(svcState.Container.State)
+			if strings.Contains(raw, "EXITED") || strings.Contains(raw, "DEAD") {
+				fmt.Fprintf(w, "  - %s:\t%s\n", service.Name, badColor.Sprintf("🔴 %s", raw))
+			} else {
+				fmt.Fprintf(w, "  - %s:\t%s\n", service.Name, warnColor.Sprintf("🟡 %s", raw))
+			}
+		default:
+			fmt.Fprintf(w, "  - %s:\t%s\n", service.Name, labelColor.Sprint("⚫ STOPPED"))
 		}
 	}
 }

--- a/cmd/status_service_state_test.go
+++ b/cmd/status_service_state_test.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/compose"
+)
+
+// livePS is a real `docker compose -f vllm.yml ps --format json` capture from a
+// citadel node, trimmed and genericized. It contains nine RUNNING containers and
+// no vllm: `ps` is project-scoped (citadel passes no `-p`, #528) and every
+// service compose file shares the default project, so a caller that reads the
+// first record out of it reports every declared service as running (#692).
+const livePS = `{"ID":"61bfa011e53f","Name":"citadel-bonsai","Service":"bonsai","State":"running","Status":"Up 10 hours"}
+{"ID":"53b6c466f956","Name":"citadel-kokoro","Service":"kokoro","State":"running","Status":"Up 10 hours (healthy)"}
+{"ID":"94b5ccaf96eb","Name":"citadel-tei","Service":"tei","State":"running","Status":"Up 10 hours"}
+{"ID":"2b1f20435fb5","Name":"services-bridge-1","Service":"bridge","State":"running","Status":"Up 10 hours (healthy)"}
+{"ID":"cd3c5f192d7e","Name":"services-db-1","Service":"db","State":"running","Status":"Up 10 hours (healthy)"}`
+
+// writeCompose writes a minimal compose file declaring the given service keys
+// and returns its path.
+func writeCompose(t *testing.T, name string, serviceKeys ...string) string {
+	t.Helper()
+	var b strings.Builder
+	b.WriteString("services:\n")
+	for _, k := range serviceKeys {
+		b.WriteString("  " + k + ":\n    image: example/" + k + ":latest\n")
+	}
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(b.String()), 0o600); err != nil {
+		t.Fatalf("write compose: %v", err)
+	}
+	return path
+}
+
+// TestComposeServiceStateFromContainerBacked: the service's own container is in
+// the project-wide output and is up.
+func TestComposeServiceStateFromContainerBacked(t *testing.T) {
+	path := writeCompose(t, "kokoro.yml", "kokoro")
+	got := composeServiceStateFrom([]byte(livePS), path, "kokoro")
+	if !got.Running || got.State != compose.StateRunning {
+		t.Fatalf("kokoro: got %+v, want running", got)
+	}
+	if got.Container == nil || got.Container.Name != "citadel-kokoro" {
+		t.Fatalf("resolved to the wrong container: %+v", got.Container)
+	}
+}
+
+// TestComposeServiceStateFromAbsent is the #692 regression test at the CLI
+// boundary: the service has no container, yet the ps output it is resolved
+// against is full of other services' running containers.
+//
+// The service name is one with no native equivalent (internal/services.
+// NativeServices covers only ollama/llamacpp/vllm), so the native probe returns
+// false without opening a socket and the assertion does not depend on what
+// happens to be listening on the test machine. The container-vs-native ordering
+// itself is tested deterministically with an injected probe in
+// internal/compose.TestResolveServiceStateNative.
+func TestComposeServiceStateFromAbsent(t *testing.T) {
+	path := writeCompose(t, "diffusers.yml", "diffusers")
+	got := composeServiceStateFrom([]byte(livePS), path, "diffusers")
+	if got.Running || got.State != compose.StateStopped {
+		t.Fatalf("absent service: got %+v, want stopped (#692)", got)
+	}
+	if got.Container != nil {
+		t.Errorf("absent service must not claim a container: %+v", got.Container)
+	}
+}
+
+// TestComposeServiceStateFromMultiContainer: whatsapp-bridge declares `bridge`
+// and `db` and pins no container_name, so its containers are services-bridge-1 /
+// services-db-1. A "citadel-<name>" container lookup would miss them and report
+// a running service as stopped.
+func TestComposeServiceStateFromMultiContainer(t *testing.T) {
+	path := writeCompose(t, "whatsapp-bridge.yml", "bridge", "db")
+	got := composeServiceStateFrom([]byte(livePS), path, "whatsapp-bridge")
+	if !got.Running {
+		t.Fatalf("whatsapp-bridge: got %+v, want running", got)
+	}
+}
+
+// TestComposeServiceStateFromUnknownService: a service with no compose file on
+// disk falls open to the previous project-wide reading rather than reporting a
+// running service stopped.
+func TestComposeServiceStateFromUnknownCompose(t *testing.T) {
+	got := composeServiceStateFrom([]byte(livePS), "/nonexistent/compose.yml", "whatever")
+	if !got.Running {
+		t.Fatalf("unreadable compose must fail open, got %+v", got)
+	}
+}
+
+// TestStatusNoProjectFlag pins the compose invocation convention on the status
+// surface, mirroring internal/jobs.TestUpdateManifestNoProjectFlag. #692's
+// suggested fix was to pass an explicit `-p` per service; doing that would
+// reintroduce the project-name mismatch #528 removed (containers actually live
+// in the shared default project) and status would then report every service
+// stopped. The fix is to filter the project-wide ps output instead.
+func TestStatusNoProjectFlag(t *testing.T) {
+	for _, file := range []string{"status.go", "service.go", "controlcenter.go"} {
+		data, err := os.ReadFile(file)
+		if err != nil {
+			t.Skipf("cannot read source %s: %v", file, err)
+		}
+		src := string(data)
+		if strings.Contains(src, `"-p", projectName`) || strings.Contains(src, `"-p", "citadel-`) {
+			t.Errorf("%s passes a compose -p project flag; the standardized convention is NO -p (#528)", file)
+		}
+	}
+}

--- a/internal/compose/psstate.go
+++ b/internal/compose/psstate.go
@@ -161,11 +161,16 @@ func FilterPS(containers []PSContainer, declared map[string]bool) []PSContainer 
 //
 // Order of evidence:
 //  1. A declared container that is running wins, and is reported.
-//  2. Otherwise a declared container in any other state is reported as-is
-//     (exited, restarting, ...).
-//  3. Otherwise, if nativeServing is non-nil and reports true, the service is
-//     running natively (no container). This is what keeps a systemd ollama from
-//     being called stopped.
+//  2. Otherwise, if nativeServing is non-nil and reports true, the service is
+//     running natively. This is what keeps a systemd ollama from being called
+//     stopped, and it deliberately outranks a non-running container: a live
+//     socket is stronger evidence of serving than a stale container is of
+//     stopped. Nodes accumulate exited containers (see
+//     compose.RemoveLegacyProjectContainers), so an exited citadel-ollama
+//     sitting next to a serving systemd ollama is a real shape. Same ordering as
+//     internal/status.managedEnginePortIfRunning on the heartbeat path.
+//  3. Otherwise a declared container in a non-running state is reported, with
+//     its raw state kept on Container so a crash loop stays visible.
 //  4. Otherwise the service is stopped. This is the case #692 got wrong.
 func ResolveServiceState(psOutput []byte, declared map[string]bool, nativeServing func() bool) ServiceState {
 	mine := FilterPS(ParsePS(psOutput), declared)
@@ -181,16 +186,17 @@ func ResolveServiceState(psOutput []byte, declared map[string]bool, nativeServin
 			first = &c
 		}
 	}
+
+	if nativeServing != nil && nativeServing() {
+		return ServiceState{State: StateRunning, Running: true, Native: true}
+	}
+
 	if first != nil {
 		state := strings.ToLower(first.State)
 		if strings.Contains(state, "exited") || strings.Contains(state, "dead") || state == "" {
 			state = StateStopped
 		}
 		return ServiceState{State: state, Container: first}
-	}
-
-	if nativeServing != nil && nativeServing() {
-		return ServiceState{State: StateRunning, Running: true, Native: true}
 	}
 	return ServiceState{State: StateStopped}
 }

--- a/internal/compose/psstate.go
+++ b/internal/compose/psstate.go
@@ -11,8 +11,8 @@ import (
 // This file resolves the single question every operator surface asks about a
 // managed service: is it actually running?
 //
-// The naive answer -- shell `docker compose -f <file> ps --format json` and read
-// the first container -- is wrong on a citadel node, and citadel-cli#692 is what
+// The naive answer, shell `docker compose -f <file> ps --format json` and read
+// the first container, is wrong on a citadel node, and citadel-cli#692 is what
 // that wrongness looks like: all 11 declared services report running while three
 // of them have no container at all.
 //

--- a/internal/compose/psstate.go
+++ b/internal/compose/psstate.go
@@ -1,0 +1,196 @@
+package compose
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// This file resolves the single question every operator surface asks about a
+// managed service: is it actually running?
+//
+// The naive answer -- shell `docker compose -f <file> ps --format json` and read
+// the first container -- is wrong on a citadel node, and citadel-cli#692 is what
+// that wrongness looks like: all 11 declared services report running while three
+// of them have no container at all.
+//
+// Why: citadel deliberately passes NO `-p` to compose (#528, pinned by
+// TestUpdateManifestNoProjectFlag). Every service compose file lives in the same
+// directory and none declares a top level `name:`, so they ALL share one default
+// compose project, the directory basename ("services"). `ps` is therefore
+// project-scoped, not file-scoped: `-f vllm.yml ps` returns bonsai, gotenberg,
+// kokoro and friends. Verified on a live node.
+//
+// The fix is NOT to add `-p citadel-<name>`, which is what #692 suggests: that
+// would reintroduce exactly the project-name mismatch #528 removed, and status
+// would then report every service stopped because the containers actually live
+// in the shared project. Instead, filter the project-wide `ps` output down to
+// the services the compose file itself declares. That works for both naming
+// conventions in use: the pinned `container_name: citadel-<name>` most services
+// use, and compose's own `<project>-<service>-<n>` (whatsapp-bridge's `bridge`
+// and `db`, which a `citadel-<name>` container lookup would miss entirely).
+//
+// Container presence is not the whole test either. Ollama runs as a NATIVE
+// systemd service on some nodes (`/usr/local/bin/ollama serve`, port 11434), so
+// "no container" must not mean "not running". ResolveServiceState takes an
+// injected native-serving probe and consults it only when no declared container
+// is present, mirroring internal/status.managedEnginePortIfRunning (the
+// heartbeat path, which already gets this right).
+
+// PSContainer is the subset of a `docker compose ps --format json` record the
+// operator surfaces read.
+type PSContainer struct {
+	ID      string `json:"ID"`
+	Name    string `json:"Name"`
+	Image   string `json:"Image"`
+	Service string `json:"Service"`
+	State   string `json:"State"`
+	Status  string `json:"Status"`
+	Ports   string `json:"Ports"`
+}
+
+// Running reports whether the container's state reads as up.
+func (c PSContainer) Running() bool {
+	state := strings.ToLower(c.State)
+	return strings.Contains(state, "running") || strings.Contains(state, "up")
+}
+
+// ServiceState is the resolved run state of one manifest service.
+type ServiceState struct {
+	// State is the normalized state string: "running", "stopped", or the raw
+	// docker state ("restarting", "paused", ...) when it is neither.
+	State string
+	// Running is true when the service is serving, whether by container or as a
+	// native process.
+	Running bool
+	// Native is true when no declared container exists but the injected native
+	// probe reported the service serving (e.g. ollama under systemd).
+	Native bool
+	// Container is the container the state was read from, or nil when the
+	// service is native or absent.
+	Container *PSContainer
+}
+
+const (
+	// StateRunning and StateStopped are the two normalized states.
+	StateRunning = "running"
+	StateStopped = "stopped"
+)
+
+// ParsePS decodes `docker compose ps --format json` output. Compose emits one
+// JSON object per line on some versions and a single JSON array on others, so
+// both forms are accepted; malformed records are skipped rather than failing the
+// whole read.
+func ParsePS(output []byte) []PSContainer {
+	trimmed := strings.TrimSpace(string(output))
+	if trimmed == "" {
+		return nil
+	}
+	if strings.HasPrefix(trimmed, "[") {
+		var arr []PSContainer
+		if err := json.Unmarshal([]byte(trimmed), &arr); err == nil {
+			return arr
+		}
+		return nil
+	}
+	var out []PSContainer
+	dec := json.NewDecoder(strings.NewReader(trimmed))
+	for dec.More() {
+		var c PSContainer
+		if err := dec.Decode(&c); err != nil {
+			break
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+// DeclaredServices returns the set of service keys declared by a compose file.
+// A nil result means the file could not be read or parsed; callers must treat
+// that as "unknown" and fall back to the unfiltered view rather than concluding
+// the service is stopped (a false "stopped" is a worse defect than the false
+// "running" this filtering removes).
+func DeclaredServices(composePath string) map[string]bool {
+	data, err := os.ReadFile(composePath)
+	if err != nil {
+		return nil
+	}
+	return DeclaredServicesFromYAML(data)
+}
+
+// DeclaredServicesFromYAML is the pure form of DeclaredServices.
+func DeclaredServicesFromYAML(data []byte) map[string]bool {
+	var doc struct {
+		Services map[string]yaml.Node `yaml:"services"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil
+	}
+	if len(doc.Services) == 0 {
+		return nil
+	}
+	set := make(map[string]bool, len(doc.Services))
+	for name := range doc.Services {
+		set[name] = true
+	}
+	return set
+}
+
+// FilterPS keeps only the containers belonging to the declared services. When
+// declared is empty (compose file unreadable or unparseable) it returns the
+// input unchanged: fail open to the pre-existing behavior rather than reporting
+// a running service as stopped.
+func FilterPS(containers []PSContainer, declared map[string]bool) []PSContainer {
+	if len(declared) == 0 {
+		return containers
+	}
+	out := make([]PSContainer, 0, len(containers))
+	for _, c := range containers {
+		if declared[c.Service] {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// ResolveServiceState decides whether a manifest service is running, given the
+// project-wide `docker compose ps --format json` output, the set of services its
+// compose file declares, and an optional native-serving probe.
+//
+// Order of evidence:
+//  1. A declared container that is running wins, and is reported.
+//  2. Otherwise a declared container in any other state is reported as-is
+//     (exited, restarting, ...).
+//  3. Otherwise, if nativeServing is non-nil and reports true, the service is
+//     running natively (no container). This is what keeps a systemd ollama from
+//     being called stopped.
+//  4. Otherwise the service is stopped. This is the case #692 got wrong.
+func ResolveServiceState(psOutput []byte, declared map[string]bool, nativeServing func() bool) ServiceState {
+	mine := FilterPS(ParsePS(psOutput), declared)
+
+	var first *PSContainer
+	for i := range mine {
+		if mine[i].Running() {
+			c := mine[i]
+			return ServiceState{State: StateRunning, Running: true, Container: &c}
+		}
+		if first == nil {
+			c := mine[i]
+			first = &c
+		}
+	}
+	if first != nil {
+		state := strings.ToLower(first.State)
+		if strings.Contains(state, "exited") || strings.Contains(state, "dead") || state == "" {
+			state = StateStopped
+		}
+		return ServiceState{State: state, Container: first}
+	}
+
+	if nativeServing != nil && nativeServing() {
+		return ServiceState{State: StateRunning, Running: true, Native: true}
+	}
+	return ServiceState{State: StateStopped}
+}

--- a/internal/compose/psstate_test.go
+++ b/internal/compose/psstate_test.go
@@ -82,6 +82,24 @@ func TestResolveServiceStateNative(t *testing.T) {
 	}
 }
 
+// TestResolveServiceStateNativeBeatsStaleContainer: a node that once ran ollama
+// under compose keeps an exited citadel-ollama around (which is why
+// RemoveLegacyProjectContainers exists) while ollama actually serves from
+// systemd. A live socket outranks a stale container, or the fix regresses the
+// very case #692 must not break.
+func TestResolveServiceStateNativeBeatsStaleContainer(t *testing.T) {
+	out := `{"ID":"a","Name":"citadel-ollama","Service":"ollama","State":"exited","Status":"Exited (0) 3 days ago"}`
+	got := ResolveServiceState([]byte(out), map[string]bool{"ollama": true}, always)
+	if !got.Running || !got.Native {
+		t.Fatalf("got %+v, want running via the native probe", got)
+	}
+	// Same input with nothing serving must still read the stale container.
+	got = ResolveServiceState([]byte(out), map[string]bool{"ollama": true}, never)
+	if got.Running || got.Container == nil || got.Container.State != "exited" {
+		t.Fatalf("got %+v, want stopped with the exited container reported", got)
+	}
+}
+
 // TestResolveServiceStateAbsent is the #692 regression test: vllm is declared,
 // has no container, and is not serving natively. The project-wide output is full
 // of OTHER services' running containers, and none of them may promote vllm to

--- a/internal/compose/psstate_test.go
+++ b/internal/compose/psstate_test.go
@@ -26,7 +26,7 @@ const livePSOutput = `
 {"ID":"cd3c5f192d7e","Name":"services-db-1","Image":"postgres:16-alpine","Service":"db","State":"running","Status":"Up 10 hours (healthy)","Ports":"5432/tcp"}
 `
 
-func never() bool { return false }
+func never() bool  { return false }
 func always() bool { return true }
 
 // TestResolveServiceStateContainerBacked covers the ordinary case: a service
@@ -49,7 +49,7 @@ func TestResolveServiceStateContainerBacked(t *testing.T) {
 
 // TestResolveServiceStateMultiContainerService covers whatsapp-bridge, whose
 // compose file declares two services (`bridge`, `db`) and pins no container_name
-// -- so its containers are named services-bridge-1 / services-db-1. This is the
+// so its containers are named services-bridge-1 / services-db-1. This is the
 // case that makes declared-service-name matching necessary: a lookup for a
 // container literally named "citadel-whatsapp-bridge" finds nothing and would
 // report a running service as stopped.

--- a/internal/compose/psstate_test.go
+++ b/internal/compose/psstate_test.go
@@ -1,0 +1,227 @@
+package compose
+
+import (
+	"strings"
+	"testing"
+)
+
+// livePSOutput is a real `docker compose -f vllm.yml ps --format json` capture
+// from a citadel node, trimmed to the fields the operator surfaces read and with
+// image names genericized.
+//
+// Note what it contains: nine running containers, and NOT ONE of them is vllm.
+// That is the whole of citadel-cli#692. Because citadel passes no `-p` (#528) and
+// every service compose file shares the default project, `ps` scoped to vllm.yml
+// returns the entire project, so a caller that reads the first record concludes
+// vllm is running when vllm has no container at all.
+const livePSOutput = `
+{"ID":"61bfa011e53f","Name":"citadel-bonsai","Image":"citadel-bonsai:local","Service":"bonsai","State":"running","Status":"Up 10 hours","Ports":"0.0.0.0:8210->8080/tcp"}
+{"ID":"97d7fac7c972","Name":"citadel-gotenberg","Image":"gotenberg:8","Service":"gotenberg","State":"running","Status":"Up 10 hours (healthy)","Ports":"127.0.0.1:8209->3000/tcp"}
+{"ID":"53b6c466f956","Name":"citadel-kokoro","Image":"kokoro-service:latest","Service":"kokoro","State":"running","Status":"Up 10 hours (healthy)","Ports":"127.0.0.1:8211->8080/tcp"}
+{"ID":"3e8aac0c4d1b","Name":"citadel-meeting","Image":"meeting-service:latest","Service":"meeting","State":"running","Status":"Up 10 hours (healthy)","Ports":"127.0.0.1:8207->8102/tcp"}
+{"ID":"94b5ccaf96eb","Name":"citadel-tei","Image":"text-embeddings-inference:cpu-1.6","Service":"tei","State":"running","Status":"Up 10 hours","Ports":"127.0.0.1:8102->80/tcp"}
+{"ID":"f85ff6db1979","Name":"citadel-transcribe","Image":"whisper-service:latest","Service":"transcribe","State":"running","Status":"Up 10 hours","Ports":"0.0.0.0:8101->8101/tcp"}
+{"ID":"88aee0273bb4","Name":"citadel-unlimited-ocr","Image":"vllm-openai:unlimited-ocr","Service":"unlimited-ocr","State":"running","Status":"Up 10 hours","Ports":"0.0.0.0:8213->8000/tcp"}
+{"ID":"2b1f20435fb5","Name":"services-bridge-1","Image":"whatsapp-bridge:latest","Service":"bridge","State":"running","Status":"Up 10 hours (healthy)","Ports":"0.0.0.0:8083->8080/tcp"}
+{"ID":"cd3c5f192d7e","Name":"services-db-1","Image":"postgres:16-alpine","Service":"db","State":"running","Status":"Up 10 hours (healthy)","Ports":"5432/tcp"}
+`
+
+func never() bool { return false }
+func always() bool { return true }
+
+// TestResolveServiceStateContainerBacked covers the ordinary case: a service
+// whose own container is in the project-wide output and is up.
+func TestResolveServiceStateContainerBacked(t *testing.T) {
+	got := ResolveServiceState([]byte(livePSOutput), map[string]bool{"kokoro": true}, never)
+	if !got.Running || got.State != StateRunning {
+		t.Fatalf("kokoro: got %+v, want running", got)
+	}
+	if got.Native {
+		t.Error("kokoro is container-backed; Native must be false")
+	}
+	if got.Container == nil || got.Container.Name != "citadel-kokoro" {
+		t.Fatalf("kokoro resolved to the wrong container: %+v", got.Container)
+	}
+	if got.Container.Status != "Up 10 hours (healthy)" {
+		t.Errorf("uptime source lost: Status = %q", got.Container.Status)
+	}
+}
+
+// TestResolveServiceStateMultiContainerService covers whatsapp-bridge, whose
+// compose file declares two services (`bridge`, `db`) and pins no container_name
+// -- so its containers are named services-bridge-1 / services-db-1. This is the
+// case that makes declared-service-name matching necessary: a lookup for a
+// container literally named "citadel-whatsapp-bridge" finds nothing and would
+// report a running service as stopped.
+func TestResolveServiceStateMultiContainerService(t *testing.T) {
+	declared := map[string]bool{"bridge": true, "db": true}
+	got := ResolveServiceState([]byte(livePSOutput), declared, never)
+	if !got.Running {
+		t.Fatalf("whatsapp-bridge: got %+v, want running", got)
+	}
+	if got.Container == nil || !strings.HasPrefix(got.Container.Name, "services-") {
+		t.Fatalf("resolved to the wrong container: %+v", got.Container)
+	}
+}
+
+// TestResolveServiceStateNative is the guard against fixing #692 in the opposite
+// direction. Ollama runs as a native systemd service on some nodes
+// (`/usr/local/bin/ollama serve`, port 11434) and has no container at all, so
+// "no container" must not be read as "not running": the native serving probe
+// decides.
+func TestResolveServiceStateNative(t *testing.T) {
+	got := ResolveServiceState([]byte(livePSOutput), map[string]bool{"ollama": true}, always)
+	if !got.Running || got.State != StateRunning {
+		t.Fatalf("native ollama: got %+v, want running", got)
+	}
+	if !got.Native {
+		t.Error("native ollama must be flagged Native")
+	}
+	if got.Container != nil {
+		t.Errorf("native service must not claim a container: %+v", got.Container)
+	}
+}
+
+// TestResolveServiceStateAbsent is the #692 regression test: vllm is declared,
+// has no container, and is not serving natively. The project-wide output is full
+// of OTHER services' running containers, and none of them may promote vllm to
+// running.
+func TestResolveServiceStateAbsent(t *testing.T) {
+	got := ResolveServiceState([]byte(livePSOutput), map[string]bool{"vllm": true}, never)
+	if got.Running || got.State != StateStopped {
+		t.Fatalf("absent vllm: got %+v, want stopped (#692)", got)
+	}
+	if got.Container != nil {
+		t.Errorf("absent service must not claim a container: %+v", got.Container)
+	}
+}
+
+// TestResolveServiceStateNilProbe: a caller that supplies no native probe still
+// gets a correct container-only answer.
+func TestResolveServiceStateNilProbe(t *testing.T) {
+	if got := ResolveServiceState([]byte(livePSOutput), map[string]bool{"vllm": true}, nil); got.Running {
+		t.Errorf("nil probe: got %+v, want stopped", got)
+	}
+	if got := ResolveServiceState([]byte(livePSOutput), map[string]bool{"tei": true}, nil); !got.Running {
+		t.Errorf("nil probe: got %+v, want running", got)
+	}
+}
+
+// TestResolveServiceStateExited keeps the crash-loop signal readable: a declared
+// container that is not up is reported with its real state, not swallowed.
+func TestResolveServiceStateExited(t *testing.T) {
+	out := `{"ID":"aaa","Name":"citadel-vllm","Service":"vllm","State":"exited","Status":"Exited (1) 2 minutes ago"}`
+	got := ResolveServiceState([]byte(out), map[string]bool{"vllm": true}, never)
+	if got.Running {
+		t.Fatalf("exited vllm reported running: %+v", got)
+	}
+	if got.State != StateStopped {
+		t.Errorf("State = %q, want %q", got.State, StateStopped)
+	}
+	if got.Container == nil || got.Container.State != "exited" {
+		t.Errorf("raw container state lost: %+v", got.Container)
+	}
+}
+
+// TestResolveServiceStatePrefersRunning: when a multi-service compose file has
+// one container up and one down, the running one is selected so the uptime and
+// state read off it are the live ones.
+func TestResolveServiceStatePrefersRunning(t *testing.T) {
+	out := `{"ID":"a","Name":"services-db-1","Service":"db","State":"exited","Status":"Exited (0)"}
+{"ID":"b","Name":"services-bridge-1","Service":"bridge","State":"running","Status":"Up 3 hours"}`
+	got := ResolveServiceState([]byte(out), map[string]bool{"bridge": true, "db": true}, never)
+	if !got.Running || got.Container == nil || got.Container.ID != "b" {
+		t.Fatalf("got %+v, want the running container", got)
+	}
+}
+
+// TestResolveServiceStateFailsOpen: when the compose file could not be parsed
+// for its declared services, fall back to the previous project-wide reading
+// rather than to "stopped". A false running is the status quo; a false stopped
+// would be a new defect in the more damaging direction.
+func TestResolveServiceStateFailsOpen(t *testing.T) {
+	got := ResolveServiceState([]byte(livePSOutput), nil, never)
+	if !got.Running {
+		t.Fatalf("unknown declared services must fail open to the old behavior, got %+v", got)
+	}
+}
+
+func TestResolveServiceStateEmptyOutput(t *testing.T) {
+	if got := ResolveServiceState(nil, map[string]bool{"vllm": true}, never); got.Running {
+		t.Errorf("empty ps output: got %+v, want stopped", got)
+	}
+	if got := ResolveServiceState([]byte("   \n"), nil, never); got.Running {
+		t.Errorf("blank ps output: got %+v, want stopped", got)
+	}
+}
+
+// TestParsePSArrayForm: newer docker compose emits a single JSON array for
+// `--format json` instead of one object per line. Both must parse, or the fix
+// silently degrades to "no containers" (i.e. everything stopped) on those hosts.
+func TestParsePSArrayForm(t *testing.T) {
+	arr := `[{"ID":"a","Service":"vllm","State":"running"},{"ID":"b","Service":"tei","State":"exited"}]`
+	got := ParsePS([]byte(arr))
+	if len(got) != 2 || got[0].Service != "vllm" || got[1].Service != "tei" {
+		t.Fatalf("array form parsed as %+v", got)
+	}
+	st := ResolveServiceState([]byte(arr), map[string]bool{"vllm": true}, never)
+	if !st.Running {
+		t.Errorf("array form: got %+v, want running", st)
+	}
+}
+
+func TestParsePSMalformed(t *testing.T) {
+	if got := ParsePS([]byte("not json at all")); len(got) != 0 {
+		t.Errorf("malformed output parsed as %+v", got)
+	}
+	if got := ParsePS([]byte("[{bad}]")); len(got) != 0 {
+		t.Errorf("malformed array parsed as %+v", got)
+	}
+}
+
+func TestDeclaredServicesFromYAML(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want []string
+	}{
+		{
+			name: "single service with pinned container name",
+			yaml: "services:\n  vllm:\n    image: vllm/vllm-openai\n    container_name: citadel-vllm\n",
+			want: []string{"vllm"},
+		},
+		{
+			name: "two services, compose-default container names",
+			yaml: "services:\n  bridge:\n    image: bridge:latest\n  db:\n    image: postgres:16-alpine\n",
+			want: []string{"bridge", "db"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DeclaredServicesFromYAML([]byte(tt.yaml))
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for _, name := range tt.want {
+				if !got[name] {
+					t.Errorf("missing declared service %q in %v", name, got)
+				}
+			}
+		})
+	}
+}
+
+// TestDeclaredServicesUnparseable pins the fail-open contract at the source: an
+// unreadable or malformed compose file yields nil, which FilterPS treats as
+// "unknown" rather than "declares nothing".
+func TestDeclaredServicesUnparseable(t *testing.T) {
+	if got := DeclaredServicesFromYAML([]byte(":::not yaml:::")); got != nil {
+		t.Errorf("malformed yaml: got %v, want nil", got)
+	}
+	if got := DeclaredServicesFromYAML([]byte("version: '3'\n")); got != nil {
+		t.Errorf("no services block: got %v, want nil", got)
+	}
+	if got := DeclaredServices("/nonexistent/path/to/compose.yml"); got != nil {
+		t.Errorf("missing file: got %v, want nil", got)
+	}
+}

--- a/internal/status/collector.go
+++ b/internal/status/collector.go
@@ -2,7 +2,6 @@ package status
 
 import (
 	"context"
-	"encoding/json"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -13,6 +12,7 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/desktop"
 	"github.com/aceteam-ai/citadel-cli/internal/network"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
+	nativesvc "github.com/aceteam-ai/citadel-cli/internal/services"
 	"github.com/aceteam-ai/citadel-cli/services"
 	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/shirou/gopsutil/v3/disk"
@@ -376,7 +376,7 @@ func (c *Collector) collectServiceStatus() []ServiceInfo {
 
 		// Check if service is running using docker compose
 		if svc.ComposeFile != "" {
-			status := c.getDockerComposeStatus(svc.ComposeFile)
+			status := c.getDockerComposeStatus(svc.ComposeFile, svc.Name)
 			info.Status = status
 			if status == ServiceStatusRunning {
 				info.Health = HealthStatusOK
@@ -413,8 +413,22 @@ func (c *Collector) detectLLMServiceType(serviceName string) string {
 	return EngineTypeFromName(serviceName)
 }
 
-// getDockerComposeStatus checks if a docker compose service is running.
-func (c *Collector) getDockerComposeStatus(composeFile string) string {
+// getDockerComposeStatus checks if a manifest-declared service is running.
+//
+// The `ps` output is PROJECT-wide, not file-wide: citadel passes no `-p` (#528)
+// and every service compose file shares the default project, so reading "is any
+// container up?" out of it reported every declared service as running once any
+// one of them ran (#692, observed on the operator CLI surface built on the same
+// mistake). compose.ResolveServiceState narrows the output to the services this
+// file declares, then falls back to a native-serving probe so a non-container
+// service (ollama under systemd) is not misreported as stopped instead.
+//
+// Note this path is currently unreachable in production: every collector is
+// constructed with Services: nil, so the heartbeat reports engines through
+// collectManagedEngineStatus (which has always done the narrow check) rather
+// than through here. Fixed as the same defect regardless, so passing Services
+// later does not silently reintroduce it.
+func (c *Collector) getDockerComposeStatus(composeFile, serviceName string) string {
 	// Pass the install-time config env (<name>.env) explicitly: compose
 	// interpolates the file even for `ps`, so a ${VAR:?...}-guarded service
 	// (claudecode, livekit) would report a false ServiceStatusError on every
@@ -427,23 +441,14 @@ func (c *Collector) getDockerComposeStatus(composeFile string) string {
 		return ServiceStatusError
 	}
 
-	// Parse JSON output (each line is a separate JSON object)
-	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
-	for _, line := range lines {
-		if line == "" {
-			continue
-		}
-		var container struct {
-			State string `json:"State"`
-		}
-		if err := json.Unmarshal([]byte(line), &container); err == nil {
-			state := strings.ToLower(container.State)
-			if strings.Contains(state, "running") || strings.Contains(state, "up") {
-				return ServiceStatusRunning
-			}
-		}
+	state := compose.ResolveServiceState(
+		output,
+		compose.DeclaredServices(composeFile),
+		func() bool { return nativesvc.IsNativeServiceServing(serviceName) },
+	)
+	if state.Running {
+		return ServiceStatusRunning
 	}
-
 	return ServiceStatusStopped
 }
 


### PR DESCRIPTION
Closes #692.

## Context

`citadel status --json` reported every declared service as `running`, including services with no container at all. On a live RTX 3090 node, all 11 declared services reported running while `vllm` and `llamacpp` had no container.

## Root cause

Citadel deliberately passes **no `-p`** to `docker compose` (the standardized convention from #528, pinned by `TestUpdateManifestNoProjectFlag`). No service compose file declares a top level `name:`, so every compose file in `~/citadel-node/services/` falls back to the same default project, the directory basename `services`.

`docker compose ps` is therefore **project**-scoped, not file-scoped. Verified on a live node:

```
$ docker compose -f vllm.yml ps --format json
citadel-bonsai         bonsai          running
citadel-gotenberg      gotenberg       running
citadel-kokoro         kokoro          running
citadel-meeting        meeting         running
citadel-tei            tei             running
citadel-transcribe     transcribe      running
citadel-unlimited-ocr  unlimited-ocr   running
services-bridge-1      bridge          running
services-db-1          db              running
```

Nine containers, none of them vllm. `cmd/status.go` read `containers[0].State` off that and called vllm running.

## Why the suggested fix is not the one taken

The issue suggests passing an explicit project name per service. That would reintroduce the exact project-name mismatch #528 removed: the containers really do live in the shared default project, so `-p citadel-vllm` would match nothing and `status` would report **every** service stopped, and disagree with `up` / `down` / `logs`, which all use the no-`-p` convention.

The fix instead narrows the project-wide `ps` output to the services the compose file itself declares. That works for both container-naming conventions in use: the pinned `container_name: citadel-<name>` most services use, and compose's own `<project>-<service>-<n>` (whatsapp-bridge declares `bridge` and `db`, which a `citadel-<name>` lookup would miss entirely and report as stopped).

`cmd/status_service_state_test.go:TestStatusNoProjectFlag` pins this so a future "fix" cannot reintroduce `-p`.

## Container presence is not the test for running

`ollama` runs as a **native systemd service** on some nodes (`/usr/local/bin/ollama serve`, port 11434) with no container at all. A fix that read "no container" as "not running" would be wrong in the opposite and more damaging direction. When no declared container is **running**, the resolver consults a native serving probe, mirroring `internal/status.managedEnginePortIfRunning`, which is what the heartbeat path already does.

The probe deliberately outranks a non-running container. Nodes accumulate exited containers (which is why `compose.RemoveLegacyProjectContainers` exists), so an exited `citadel-ollama` sitting next to a serving systemd ollama is a real shape, and a live socket is stronger evidence of serving than a stale container is of stopped. Covered by `TestResolveServiceStateNativeBeatsStaleContainer`.

Filtering also **fails open**: if the compose file cannot be read or parsed for its declared services, the previous project-wide reading is used. A false `running` is the status quo; a false `stopped` would be a new defect.

## Scope: this is a display defect, not a routing one

The heartbeat is a separate code path and it is already correct. Every collector construction site passes no services:

- `cmd/work.go:1166`, `cmd/work.go:1457` (heartbeat and status publisher): explicit `Services: nil`
- `cmd/services_cmd.go:56`: explicit `Services: nil`
- `cmd/controlcenter.go:1884`: explicit `Services: nil`
- `cmd/hotswap.go:63`: nil by omission, relying on the zero value

so `collectServiceStatus` / `getDockerComposeStatus` never executes. Engines are reported through `collectManagedEngineStatus` -> `managedEnginePortIfRunning`, which does a per-container inspect plus a native port probe. Confirmed live: the same node whose `status --json` claimed 11 of 11 running reports 4 through the heartbeat path.

```
$ citadel services
NAME           KIND     STATUS   PIN
bonsai         service  running  preemptible
ollama         service  running  preemptible
tei            service  running  preemptible
unlimited-ocr  service  running  preemptible
```

Nothing routes on `status --json`. `internal/status.getDockerComposeStatus` carried the same defect and is fixed with the same helper, but it is currently unreachable, so this is housekeeping there too, not a heartbeat fix. It is fixed so that passing `Services` later cannot silently reintroduce the bug.

## Changes

- `internal/compose/psstate.go` (new): `ParsePS`, `DeclaredServices`, `FilterPS`, `ResolveServiceState`. Pure and unit-tested, with the native probe injected, following the `collectEmbeddingServices` pattern. `ParsePS` accepts both the NDJSON and the JSON-array forms compose emits depending on version.
- `cmd/service.go`: `composeServiceState` / `composeServiceStateFrom`, the single resolution point for the CLI and TUI surfaces.
- `cmd/status.go`: `gatherStatusData` (`--json` and the TUI dashboard) and `printServiceInfo` use it. `printServiceInfo` now distinguishes "container exists but is down" (shows the real state, so a crash loop stays visible) from "no container and not serving" (`STOPPED`), and marks a native service as such.
- `cmd/controlcenter.go`: the service list and the service detail panel use it. The detail panel previously decoded the first record of the project-wide output, so it could show another service's container ID, image, and ports.
- `internal/status/collector.go`: `getDockerComposeStatus` uses it.

## Testing

`go test ./...` green.

New tests cover the three required cases plus the edges:

| Case | Test |
|---|---|
| Container-backed service | `TestResolveServiceStateContainerBacked`, `TestComposeServiceStateFromContainerBacked` |
| Native, non-container service | `TestResolveServiceStateNative` |
| Native service alongside a stale exited container | `TestResolveServiceStateNativeBeatsStaleContainer` |
| Genuinely absent service (the #692 regression) | `TestResolveServiceStateAbsent`, `TestComposeServiceStateFromAbsent` |
| Multi-container service with no pinned container_name | `TestResolveServiceStateMultiContainerService`, `TestComposeServiceStateFromMultiContainer` |
| Fail open on unparseable compose | `TestResolveServiceStateFailsOpen`, `TestComposeServiceStateFromUnknownCompose` |
| Exited container keeps its real state | `TestResolveServiceStateExited` |
| JSON-array `ps` output form | `TestParsePSArrayForm` |
| No `-p` reintroduced | `TestStatusNoProjectFlag` |

The fixture is a real `ps` capture from a live node, so the absent-service test is the actual production output that produced the bug.

### Verified on a live node

Before, v2.99.0:

```
vllm -> running          <- no container
ollama -> running
llamacpp -> running      <- no container
transcribe -> running
gotenberg -> running
meeting -> running
kokoro -> running
tei-embeddings -> running
unlimited-ocr -> running
bonsai -> running
tei -> running
```

After:

```
vllm -> stopped          <- correct, no container, nothing serving
ollama -> running        <- correct, native systemd on 11434, no container
llamacpp -> stopped      <- correct
transcribe -> running
gotenberg -> running
meeting -> running
kokoro -> running
tei-embeddings -> running
unlimited-ocr -> running
bonsai -> running
tei -> running
```

`ollama` is the case that matters: no container, `systemctl is-active ollama` = active, listening on 127.0.0.1:11434 and serving `llama3.1:8b`. It stays `running`.

### Not verified

- Podman nodes. The CLI path resolves the runtime through `composeCommand`, unchanged by this PR, but the fix was only exercised against docker.
- The JSON-array `ps` form is covered by a unit test only. This node's compose emits NDJSON.
- macOS and Windows.

## Not included

#691 (`last_request_at` coverage is vLLM only) is **not** in this PR. It is a different mechanism (record a timestamp locally on each served request), in different files (`internal/status/engines.go`, `collector.go`, and the request path), and it is a real heartbeat and `autostop.go` correctness issue rather than a display one. Folding it in here would mix a display fix with a behavior change on the eviction path.
