### PR TITLE
fix(network): record the state-dir pointer on `citadel up` so a service run cannot register a duplicate node

### DIFF
--- a/internal/network/machinewide.go
+++ b/internal/network/machinewide.go
@@ -88,6 +88,20 @@ func ConnectMachineWide(ctx context.Context, config ServerConfig, elevated bool)
 	}
 
 	FixStatePermissions()
+
+	// Record where this node's state actually lives. `citadel up` is elevated
+	// and typically run interactively first (where $SUDO_USER makes resolution
+	// correct), then later as a launchd/systemd service — which has no
+	// $SUDO_USER and would otherwise resolve root's home, open an empty state
+	// dir, and register a SECOND node for this machine. Writing the pointer
+	// here converges the service run on the identity established now.
+	if err := EnsureMachineStatePointer(stateDir); err != nil {
+		// Non-fatal: the node is up and correct for THIS process. Only the
+		// later service run would be at risk, and that is worth a warning
+		// rather than refusing a working connection.
+		logf("warning: could not record machine state pointer (a later service run may register a duplicate node): %v", err)
+	}
+
 	s.connected = true
 	SetGlobal(s)
 	return s, nil

--- a/internal/network/state.go
+++ b/internal/network/state.go
@@ -155,8 +155,13 @@ func dirHasEntries(path string) bool {
 // Always the fixed machine-wide config dir (never a user-local one) so every
 // user on the box reads the same value.
 func machineStatePointerPath() string {
-	return filepath.Join(getGlobalConfigDirForState(), machineStatePointerFile)
+	return filepath.Join(globalConfigDirForState(), machineStatePointerFile)
 }
+
+// globalConfigDirForState is indirected so tests can point the machine-global
+// pointer file at a temp dir. Production always uses the real fixed path —
+// writing it requires root, which is exactly why it converges every user.
+var globalConfigDirForState = getGlobalConfigDirForState
 
 // readMachineStatePointer reads node_config_dir from the machine-global pointer
 // file, or returns "" if it is absent/unreadable. The file contains only a
@@ -180,12 +185,51 @@ func WriteMachineStatePointer(nodeConfigDir string) error {
 	if nodeConfigDir == "" {
 		return nil
 	}
-	dir := getGlobalConfigDirForState()
+	dir := globalConfigDirForState()
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return err
 	}
 	path := filepath.Join(dir, machineStatePointerFile)
 	return os.WriteFile(path, []byte(nodeConfigDir+"\n"), 0644)
+}
+
+// EnsureMachineStatePointer records the state dir this process resolved, so a
+// later run in a context WITHOUT $SUDO_USER converges on the same node identity.
+//
+// Why this is needed. resolveStateDir's owner-consistent fallback depends on
+// $SUDO_USER to find the owning user's home. A daemon started by launchd or
+// systemd has no $SUDO_USER and $HOME=/var/root, so it falls through to root's
+// home, opens an EMPTY state dir, mints a fresh machine key, and registers as a
+// SECOND node — the exact duplicate-node failure #383 fixed for sudo, resurfacing
+// for services. `citadel up` is the first command that routinely runs both ways
+// (interactive sudo, then as a service), which is what exposes it.
+//
+// Only `citadel init` wrote the pointer before this, so anyone who onboarded via
+// `citadel login` had none.
+//
+// It deliberately does NOT write a guess. The pointer is recorded only when the
+// resolved directory already holds real state — i.e. when this process demonstrably
+// found the right one. Persisting a wrong path would convert a transient
+// misresolution into a permanent one for every future context on the machine,
+// which is strictly worse than having no pointer at all.
+//
+// Takes the already-resolved stateDir rather than re-deriving it, so the value
+// recorded is exactly the one the caller is using.
+//
+// Best-effort: writing under the machine-global config dir needs root, so an
+// unprivileged caller simply skips it.
+func EnsureMachineStatePointer(stateDir string) error {
+	if readMachineStatePointer() != "" {
+		return nil // already converged
+	}
+	if !dirHasEntries(stateDir) {
+		// Nothing here yet, so we cannot tell a correct resolution from a
+		// fallback. Recording it now risks pinning the wrong directory.
+		return nil
+	}
+
+	// stateDir is <nodeConfigDir>/network; the pointer stores the parent.
+	return WriteMachineStatePointer(filepath.Dir(stateDir))
 }
 
 // isSystemProfilePath returns true if the path is under the Windows SYSTEM

--- a/internal/network/state_test.go
+++ b/internal/network/state_test.go
@@ -199,3 +199,108 @@ func TestFixStatePermissions_NoOpWhenNotRoot(t *testing.T) {
 	// Should not panic or error
 	FixStatePermissions()
 }
+
+// The launchd/systemd case that motivated EnsureMachineStatePointer: a daemon
+// has no $SUDO_USER and $HOME=/var/root, so the owner-consistent fallback
+// resolves ROOT's home rather than the user's. Without a pointer file, that is
+// a different, empty state dir -> fresh machine key -> a SECOND node registered
+// for one machine.
+func TestResolveStateDirDivergesWithoutPointerUnderService(t *testing.T) {
+	const userHome = "/Users/jason"
+	const rootHome = "/var/root"
+
+	// Interactive `sudo citadel up`: SUDO_USER resolves the owner's home.
+	interactive := resolveStateDir(stateDirInputs{
+		ownerHome:         userHome,
+		legacyStateExists: func(h string) bool { return h == userHome },
+		goos:              "darwin",
+	})
+
+	// The same machine under launchd: no SUDO_USER, so ownerHome is root's.
+	service := resolveStateDir(stateDirInputs{
+		ownerHome:         rootHome,
+		legacyStateExists: func(h string) bool { return h == userHome },
+		goos:              "darwin",
+	})
+
+	if interactive == service {
+		t.Fatalf("expected divergence without a pointer, got %q for both", interactive)
+	}
+
+	// ...and that the pointer is what reconciles them. This is the property
+	// EnsureMachineStatePointer exists to establish.
+	pointer := "/Users/jason/citadel-node"
+	reconciled := resolveStateDir(stateDirInputs{
+		pointerDir:        pointer,
+		ownerHome:         rootHome, // still the service context
+		legacyStateExists: func(h string) bool { return h == userHome },
+		goos:              "darwin",
+	})
+	if reconciled != interactive {
+		t.Errorf("with a pointer, service resolved %q; want %q (same as interactive)", reconciled, interactive)
+	}
+}
+
+// The pointer must never be overwritten once set: a second writer with a
+// different (possibly wrong) view would re-introduce the divergence.
+func TestEnsureMachineStatePointerNoopWhenAlreadySet(t *testing.T) {
+	dir := t.TempDir()
+	orig := globalConfigDirForState
+	globalConfigDirForState = func() string { return dir }
+	t.Cleanup(func() { globalConfigDirForState = orig })
+
+	existing := "/already/recorded"
+	if err := WriteMachineStatePointer(existing); err != nil {
+		t.Fatalf("WriteMachineStatePointer() error = %v", err)
+	}
+
+	if err := EnsureMachineStatePointer(t.TempDir()); err != nil {
+		t.Fatalf("EnsureMachineStatePointer() error = %v", err)
+	}
+	if got := readMachineStatePointer(); got != existing {
+		t.Errorf("pointer = %q, want %q unchanged", got, existing)
+	}
+}
+
+// The guard that keeps a misresolution from becoming permanent: with no state
+// present, EnsureMachineStatePointer must record NOTHING rather than pin
+// whatever the fallback happened to produce.
+func TestEnsureMachineStatePointerDoesNotRecordAGuess(t *testing.T) {
+	dir := t.TempDir()
+	orig := globalConfigDirForState
+	globalConfigDirForState = func() string { return dir }
+	t.Cleanup(func() { globalConfigDirForState = orig })
+
+	// An empty state dir: we cannot tell a correct resolution from a fallback.
+	if err := EnsureMachineStatePointer(t.TempDir()); err != nil {
+		t.Fatalf("EnsureMachineStatePointer() error = %v", err)
+	}
+	if got := readMachineStatePointer(); got != "" {
+		t.Errorf("recorded %q with no state present; want nothing written", got)
+	}
+}
+
+// The path that actually converges a later service run: state IS present, so
+// the location is known-good and gets recorded (as the PARENT of network/).
+func TestEnsureMachineStatePointerRecordsResolvedDir(t *testing.T) {
+	cfgDir := t.TempDir()
+	orig := globalConfigDirForState
+	globalConfigDirForState = func() string { return cfgDir }
+	t.Cleanup(func() { globalConfigDirForState = orig })
+
+	nodeDir := t.TempDir()
+	stateDir := filepath.Join(nodeDir, "network")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "tailscaled.state"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	if err := EnsureMachineStatePointer(stateDir); err != nil {
+		t.Fatalf("EnsureMachineStatePointer() error = %v", err)
+	}
+	if got := readMachineStatePointer(); got != nodeDir {
+		t.Errorf("pointer = %q, want %q (the parent of network/)", got, nodeDir)
+	}
+}


### PR DESCRIPTION
## Context

Found while scoping #670. A `citadel up` running as a launchd/systemd service can register a **second node** for a machine that is already on the fabric.

## Cause

`resolveStateDir`'s owner-consistent fallback depends on `$SUDO_USER` to locate the owning user's home. A daemon has no `$SUDO_USER` and `$HOME=/var/root`, so it falls through to **root's** home, opens an empty state dir, mints a fresh machine key, and registers again — the duplicate-node failure #383 fixed for sudo, resurfacing for services.

The machine-global pointer file already exists precisely to converge every context on one path, and is priority (1) in the resolution order. But **only `citadel init` ever wrote it**, so anyone who onboarded via `citadel login` has none. `citadel up` is the first command routinely run *both* ways — interactive sudo, then as a service — which is what exposes the gap.

Worth noting why the live testing on #650 did not catch this: `sudo citadel up` **has** `$SUDO_USER` and resolves correctly. The macOS run verifiably reused the existing identity (100.64.0.21), and node counts held on all three platforms. The divergence only appears once the same node is started by a service manager, which nothing does yet — it is latent, not currently broken in the field.

## Fix

`ConnectMachineWide` records the state dir it resolved, so a later service run converges on the identity established now.

It deliberately **does not write a guess**. The pointer is recorded only when the resolved directory already holds real state — i.e. when this process demonstrably found the right one. Persisting a wrong path would convert a transient misresolution into a permanent one for every future context on that machine, which is strictly worse than having no pointer at all.

Failure is non-fatal and warns rather than aborting: the node is up and correct for *this* process; only a later service run is at risk, and that does not justify refusing a working connection.

## Tests

`TestResolveStateDirDivergesWithoutPointerUnderService` reproduces the bug as a pure-function assertion — interactive and service contexts resolve **different** dirs with no pointer, and the **same** dir once one exists. Plus the three branches: no-op when already set, records nothing when no state is present (the anti-guess guard), and records the parent of `network/` when state is found.

`globalConfigDirForState` is now indirected so the pointer path can be aimed at a temp dir. Production still uses the fixed root-owned path, which is what makes it converge users. Without this the tests skipped on a normal dev machine — and a test that always skips is not a test.

`go build` / `go vet` / `go test ./...` clean; cross-compiles for linux, windows and darwin.