### PR TITLE
fix: drop the committed .wt/gate-5028 worktree gitlink, ignore .wt/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ docs-site/.docusaurus/
 
 # git worktrees created for isolated feature work
 .worktrees/
+.wt/


### PR DESCRIPTION
Closes #712.

A git worktree directory was `git add`-ed at some point, so git recorded it as a **nested submodule**: mode `160000` at `.wt/gate-5028`, declared in no `.gitmodules` (this repo has none at all).

## Impact

`aceteam-ai/workspace` includes citadel-cli as a submodule and checks out with `submodules: recursive`. That checkout dies at the first step:

```
Entering 'citadel-cli'
fatal: No url found for submodule path 'citadel-cli/.wt/gate-5028' in .gitmodules
fatal: run_command returned non-zero status while recursing in the nested submodules of citadel-cli
##[error]The process '/usr/bin/git' failed with exit code 128
```

Its **Deploy to Staging** workflow has failed at `Checkout repository` on every PR since at least 2026-07-24 (verified on `fix/6549-migrator-privilege` in July and `fix/selfhost-uvicorn-host` this week), with all later steps skipped. No staging deploy has run in about two weeks. Because it surfaces as a plain red X on whatever PR is open, it kept getting blamed on unrelated changes.

## The change

- `git rm --cached .wt/gate-5028` — index entry only; the directory on disk is untouched, and it is a stale Jul 7 leftover rather than a live worktree (it does not appear in `git worktree list`).
- Add `.wt/` to `.gitignore`. The file already listed `.worktrees/` under the same comment, but `.wt/` is the root that actually got committed, and a bare `git add -A` from a worktree-hosting checkout is all it takes to redo this.

## Verification

```
$ git ls-tree -r HEAD | awk '$1=="160000"'      # before: .wt/gate-5028
$ git ls-tree -r HEAD | awk '$1=="160000"'      # after:  (empty)
```

`.wt/` confirmed ignored after the change. No source or build files touched.

## Follow-up outside this PR

`aceteam-ai/workspace` needs its citadel-cli submodule pointer bumped past this commit before its CI recovers.