### PR TITLE
fix(worker): bound the swap rate, and protect a loaded model until it serves (#687)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -971,6 +971,38 @@ and `citadel services`).
 - The TUI control center collector is not yet fed `PinnedServices` (heartbeat and
   `citadel services` are); low-priority follow-up.
 
+### Model Hotswap: residency invariant and swap rate bound (citadel #632, #687)
+
+With `CITADEL_MODEL_HOTSWAP` on, an inference request for an installed-but-absent
+engine triggers a swap (`internal/worker/swap.go`, `SwapManager`). Two rules
+decide whether a swap may take VRAM from a resident engine, both in
+`filterResidencyProtected`:
+
+- The min-residency floor, and on top of it the **served-once invariant**: an
+  engine that has had no request dispatched to it since it became ready is not
+  evictable yet. A load that served nothing was pure waste, and the floor alone
+  was shorter than a real load (a measured 78s load under a 60s floor), so a
+  model could become evictable before it finished loading.
+- The ceiling on that protection is the engine's **own load time** —
+  `unservedResidencyCeilingLocked` prefers a load this node has actually MEASURED
+  (`MeasuredLoad`) over the coarse table in `defaultLoadEstimate`.
+
+An engine with no `readyAt` record — operator-started, or resident since before
+the worker started — is protected by neither, deliberately: "we have no record"
+must not read as "recently loaded", or a worker restart would make every
+long-resident engine unevictable.
+
+**The rate bound** (`checkSwapRate`, ledger in `swap_ledger.go`) counts swaps that
+actually EVICTED something, so a node starting engines into its own free VRAM is
+never limited. At the ceiling the node REFUSES: `SwapRateLimitedError` becomes a
+job **failure** carrying `reason: "swap_rate_limited"`, not a `model_warming`
+success — refusing honestly beats thrashing politely, and a node that quietly
+warmed forever is indistinguishable from broken hardware.
+
+The knobs are package vars (so tests need not sleep an hour) with the shipped
+values pinned by `TestSwapAccountingDefaults` — change them there. The ledger is
+in-process: the bound resets on restart, so a crash-looping worker can exceed it.
+
 ### Consume-Loop Watchdog, Self-Heal & Liveness (citadel #548)
 
 A hung job handler must never silently stall the whole node. The wedge that

--- a/cmd/hotswap.go
+++ b/cmd/hotswap.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"context"
+	"strings"
+	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/jobs"
 	"github.com/aceteam-ai/citadel-cli/internal/nexus"
@@ -142,6 +144,24 @@ func (c *swapController) Ready(ctx context.Context, backend string) bool {
 		}
 	}
 	return false
+}
+
+// ObserveSwap logs the per-swap record and the running counter that
+// citadel-cli#687 asks the node to emit. Before this, an alternating two-model
+// workload could spend most of its wall clock loading rather than serving and
+// nothing anywhere counted it — the operator saw only "everything is slow".
+//
+// The eviction ceiling is included on every line so the log says how close the
+// node is to refusing, not just what it has done.
+func (c *swapController) ObserveSwap(rec worker.SwapRecord, stats worker.SwapStats) {
+	evicted := "none"
+	if len(rec.Evicted) > 0 {
+		evicted = strings.Join(rec.Evicted, ",")
+	}
+	c.logf("[hotswap] swap %s model=%s outcome=%s evicted=%s wait=%s "+
+		"(swaps this hour: %d, evicting: %d/%d)",
+		rec.Backend, rec.Model, rec.Outcome, evicted, rec.Wait.Round(time.Second),
+		stats.SwapsPerHour, stats.EvictingSwapsPerHour, stats.MaxEvictingPerHour)
 }
 
 // freeVRAMBytesFromGPU sums currently-free VRAM (total-used) across all GPUs that

--- a/internal/worker/llm_inference.go
+++ b/internal/worker/llm_inference.go
@@ -127,6 +127,16 @@ func (h *LLMInferenceHandler) Execute(ctx context.Context, job *Job, stream Stre
 	if h.swapper != nil {
 		outcome, swapErr := h.swapper.EnsureResident(ctx, payload.Backend, payload.Model)
 		if swapErr != nil {
+			// A node at its swap limit is refusing, not malfunctioning
+			// (citadel-cli#687). It is still a job FAILURE — every consumer that
+			// exists today renders a failure as a failure, whereas a new
+			// success-shaped control status nothing parses would be relayed as an
+			// empty reply, which is the thrash traded for silence. The reason rides
+			// along machine-readably for a consumer that wants to special-case it.
+			var rateErr *SwapRateLimitedError
+			if errors.As(swapErr, &rateErr) {
+				return h.unavailable(payload.Model, "swap_rate_limited", swapErr), nil
+			}
 			return h.failure(fmt.Errorf("model hotswap failed: %w", swapErr)), nil
 		}
 		if !outcome.Ready {
@@ -942,6 +952,31 @@ func (h *LLMInferenceHandler) engineRequestFailure(
 		return h.warming(payload.Model, engineWarmETA(payload.Backend), 0)
 	}
 	return h.failure(fmt.Errorf("%s: %w", wrap, err))
+}
+
+// unavailable reports that the node is deliberately declining to serve this
+// model right now, for a named reason — as opposed to warming (it is coming) or
+// a plain failure (something broke). It is a FAILURE result carrying
+// `status: "model_unavailable"` and a `reason` code alongside the human message.
+//
+// Why a failure and not a success-shaped control payload like warming: the
+// platform branches on `output.status == "model_warming"` and has no branch for
+// anything else, so an unrecognized control status returned as a success is
+// relayed as a successful empty reply — the user asks a question and gets
+// nothing, with no error recorded anywhere. A failure is legible to every
+// consumer that exists today; the structured `reason` is additive on top, for a
+// consumer that later wants to render "this node is at its swap limit" specially.
+func (h *LLMInferenceHandler) unavailable(model, reason string, err error) *JobResult {
+	return &JobResult{
+		Status: JobStatusFailure,
+		Error:  err,
+		Output: map[string]any{
+			"status": "model_unavailable",
+			"reason": reason,
+			"model":  model,
+			"error":  err.Error(),
+		},
+	}
 }
 
 func (h *LLMInferenceHandler) failure(err error) *JobResult {

--- a/internal/worker/swap.go
+++ b/internal/worker/swap.go
@@ -23,13 +23,18 @@
 //     carries only {service, model} (no vram_mb), so #577's DURABLE preemptForVRAM
 //     stays inert; the swap does its own non-durable PlanPreemption here.
 //   - Min-residency floor: an engine that became ready within minResidency is
-//     never evicted (filtered out of the candidate set before planning).
+//     never evicted (filtered out of the candidate set before planning). On top
+//     of that floor, an engine that has not yet had a request dispatched to it
+//     since becoming ready is protected until it has (citadel-cli#687) — a load
+//     that never served anything was pure waste, and a 60s floor under a 78s
+//     load meant a model could become evictable before it finished loading.
 //   - LRU: candidates are pre-sorted least-recently-used first so PlanPreemption's
 //     stable idle-then-largest-VRAM ordering breaks ties by LRU.
 package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -107,6 +112,16 @@ type swapOp struct {
 	ready     bool
 	transient bool
 	err       error
+
+	// evicted names the engines this swap stopped to make room. It is what the
+	// ledger's rate bound counts, so it must be appended to as stops succeed,
+	// not derived from the plan (a plan whose first stop failed evicted one
+	// engine, not all of them).
+	evicted []string
+	// started records whether a SERVICE_START was actually issued, which
+	// separates a swap that spent the box's time from one refused before it
+	// began.
+	started bool
 }
 
 // SwapManager serializes and observes model swaps on a node.
@@ -125,10 +140,29 @@ type SwapManager struct {
 	backgroundMax time.Duration // ceiling on a background swap (releases the lock)
 	readyPoll     time.Duration // readiness poll interval
 
+	// Swap rate bound (citadel-cli#687). See swap_ledger.go.
+	rateWindow           time.Duration
+	maxEvictingPerWindow int
+
 	mu       sync.Mutex
 	inflight *swapOp              // the single in-flight swap, or nil
 	lastUsed map[string]time.Time // per-engine last request time (LRU)
 	readyAt  map[string]time.Time // per-engine last became-ready time (min-residency)
+	// servedAt records when a request was last DISPATCHED to an engine — the
+	// moment EnsureResident hands it to the inference path. Compared against
+	// readyAt, it answers "has this engine done anything since it loaded?",
+	// which is the citadel-cli#687 eviction invariant. It is deliberately not
+	// lastUsed: lastUsed is touched on a MISS too, so an engine that was only
+	// ever asked for while absent would look served.
+	servedAt map[string]time.Time
+	// loadMeasured is the observed cold-start duration per engine, replacing the
+	// coarse table estimate once this node has actually timed one. It survives
+	// eviction on purpose: it measures the ENGINE, not the residency, and
+	// dropping it would send the next swap-in back to the table (the same defect
+	// citadel-cli#688 describes for lastUsed).
+	loadMeasured map[string]time.Duration
+	// swaps is the in-process swap ledger (swap_ledger.go).
+	swaps []SwapRecord
 	// startedAt records when this node last ISSUED a start for an engine, which
 	// is the only trustworthy evidence that an unbound port is a cold start
 	// rather than an engine that is simply not running (citadel-cli#705). The
@@ -143,17 +177,21 @@ type SwapManager struct {
 // side-effects.
 func NewSwapManager(ctrl SwapController) *SwapManager {
 	return &SwapManager{
-		ctrl:          ctrl,
-		requiredVRAM:  func(b string) uint64 { return uint64(status.EngineVRAMEstimateMB(b)) * 1024 * 1024 },
-		loadEstimate:  defaultLoadEstimate,
-		now:           time.Now,
-		waitBudget:    swapWaitBudget,
-		minResidency:  swapMinResidency,
-		backgroundMax: swapBackgroundMaxDur,
-		readyPoll:     swapReadyPollEvery,
-		lastUsed:      map[string]time.Time{},
-		readyAt:       map[string]time.Time{},
-		startedAt:     map[string]time.Time{},
+		ctrl:                 ctrl,
+		requiredVRAM:         func(b string) uint64 { return uint64(status.EngineVRAMEstimateMB(b)) * 1024 * 1024 },
+		loadEstimate:         defaultLoadEstimate,
+		now:                  time.Now,
+		waitBudget:           swapWaitBudget,
+		minResidency:         swapMinResidency,
+		backgroundMax:        swapBackgroundMaxDur,
+		readyPoll:            swapReadyPollEvery,
+		rateWindow:           swapRateWindow,
+		maxEvictingPerWindow: swapMaxEvictingPerWindow,
+		lastUsed:             map[string]time.Time{},
+		readyAt:              map[string]time.Time{},
+		startedAt:            map[string]time.Time{},
+		servedAt:             map[string]time.Time{},
+		loadMeasured:         map[string]time.Duration{},
 	}
 }
 
@@ -181,6 +219,7 @@ func (m *SwapManager) EnsureResident(ctx context.Context, backend, model string)
 
 	// Already resident: nothing to do (fast path, no lock contention with swaps).
 	if m.ctrl.Resident(ctx, backend) {
+		m.markServed(backend)
 		return SwapOutcome{Ready: true}, nil
 	}
 
@@ -217,6 +256,7 @@ func (m *SwapManager) EnsureResident(ctx context.Context, backend, model string)
 			return SwapOutcome{}, op.err
 		}
 		if op.ready {
+			m.markServed(backend)
 			return SwapOutcome{Ready: true}, nil
 		}
 		// Completed but not ready (transient block, e.g. min-residency): warm.
@@ -268,6 +308,7 @@ func (m *SwapManager) runSwap(op *swapOp) {
 			m.inflight = nil
 		}
 		m.mu.Unlock()
+		m.recordSwap(m.swapRecord(op))
 	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), m.backgroundMax)
@@ -288,6 +329,7 @@ func (m *SwapManager) runSwap(op *swapOp) {
 	// while it runs (citadel-cli#705). A failed start clears the record so it
 	// cannot pass as evidence that the engine is on its way up.
 	m.markStartAttempted(op.backend)
+	op.started = true
 	if err := m.ctrl.Start(ctx, op.backend, op.model); err != nil {
 		m.clearStartAttempt(op.backend)
 		op.err = fmt.Errorf("failed to start %s for swap: %w", op.backend, err)
@@ -298,6 +340,11 @@ func (m *SwapManager) runSwap(op *swapOp) {
 	for {
 		if m.ctrl.Ready(ctx, op.backend) {
 			op.ready = true
+			// Time the load before marking ready: this is the only place the node
+			// learns how long THIS engine actually takes to come up, and that
+			// measurement is what raises the residency ceiling above the load
+			// (citadel-cli#687) instead of trusting the coarse table.
+			m.recordLoadDuration(op.backend, m.now().Sub(op.startedAt))
 			m.markReady(op.backend)
 			return
 		}
@@ -336,38 +383,155 @@ func (m *SwapManager) preempt(ctx context.Context, op *swapOp) error {
 		return fmt.Errorf("cannot swap in %s: %s", op.backend, fullPlan.Reason)
 	}
 
-	// Now apply the min-residency floor: an engine that became ready within the
-	// floor is not a candidate right now.
-	eligible := m.filterMinResidency(candidates)
+	// Now apply the residency protections: an engine inside its min-residency
+	// floor, or one that has not served anything since it loaded, is not a
+	// candidate right now.
+	eligible := m.filterResidencyProtected(candidates)
 	plan := status.PlanPreemption(eligible, required, freeVRAM)
 	if !plan.Fits {
-		op.transient = true // blocked only by min-residency; retry soon
+		op.transient = true // blocked only by residency protection; retry soon
 		return nil
+	}
+
+	// This swap needs to take VRAM away from a resident engine, so it is the kind
+	// the rate bound governs (citadel-cli#687). Checked HERE rather than before
+	// the swap starts, so a node with free VRAM is never refused for swaps it
+	// made earlier: only an eviction counts against the ceiling, and only an
+	// eviction is refused by it.
+	if len(plan.Stop) > 0 {
+		if err := m.checkSwapRate(op.backend); err != nil {
+			return err
+		}
 	}
 
 	for _, name := range plan.Stop {
 		if err := m.ctrl.StopNonDurable(name); err != nil {
 			return fmt.Errorf("cannot swap in %s: failed to evict %s: %w", op.backend, name, err)
 		}
+		op.evicted = append(op.evicted, name)
 		m.forget(name)
 	}
 	return nil
 }
 
-// filterMinResidency drops candidates that became ready within the min-residency
-// floor (they must not be evicted yet).
-func (m *SwapManager) filterMinResidency(candidates []status.PreemptCandidate) []status.PreemptCandidate {
+// checkSwapRate refuses an evicting swap once the node has spent its allowance
+// for the window. The error is hard on purpose — see SwapRateLimitedError.
+func (m *SwapManager) checkSwapRate(backend string) error {
+	m.mu.Lock()
+	m.pruneSwapsLocked(m.now())
+	n := m.evictingSwapsInWindowLocked(m.now())
+	max := m.maxEvictingPerWindow
+	window := m.rateWindow
+	m.mu.Unlock()
+
+	if max > 0 && n >= max {
+		return &SwapRateLimitedError{Backend: backend, Swaps: n, Max: max, Window: window}
+	}
+	return nil
+}
+
+// filterResidencyProtected drops candidates that must not be evicted yet. Two
+// protections, in increasing strength:
+//
+//   - The min-residency floor: an engine that became ready within minResidency
+//     is off limits (pre-existing behaviour).
+//   - The served-once invariant (citadel-cli#687): an engine that has had NO
+//     request dispatched to it since it became ready is off limits until it
+//     does. Without this, a model whose load takes 78s under a 60s floor could
+//     be evicted before it ever served anything, making the whole load waste.
+//     It is bounded by unservedResidencyCeiling so an engine nobody ends up
+//     asking for cannot pin VRAM indefinitely.
+//
+// An engine with no readyAt entry — one this node never swapped in, e.g. started
+// by an operator or resident since boot — is protected by NEITHER. That is
+// deliberate: it has been up for an unknown-but-long time, and treating "we have
+// no record" as "recently loaded" would make long-resident engines unevictable
+// after a worker restart.
+func (m *SwapManager) filterResidencyProtected(candidates []status.PreemptCandidate) []status.PreemptCandidate {
 	now := m.now()
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	out := make([]status.PreemptCandidate, 0, len(candidates))
 	for _, c := range candidates {
-		if t, ok := m.readyAt[c.Name]; ok && now.Sub(t) < m.minResidency {
+		ready, known := m.readyAt[c.Name]
+		if !known {
+			out = append(out, c)
+			continue
+		}
+		age := now.Sub(ready)
+		if age < m.minResidency {
+			continue
+		}
+		served, everServed := m.servedAt[c.Name]
+		if (!everServed || served.Before(ready)) && age < m.unservedResidencyCeilingLocked(c.Name) {
 			continue
 		}
 		out = append(out, c)
 	}
 	return out
+}
+
+// unservedResidencyCeilingLocked is how long an engine that has served nothing
+// since loading stays protected. It is the engine's own load time — measured if
+// this node has timed one, else the table estimate — floored at minResidency, so
+// the protection can never be shorter than the load it exists to justify. That
+// is the "raise the floor above the measured load time, per engine" half of
+// citadel-cli#687. Callers hold m.mu.
+func (m *SwapManager) unservedResidencyCeilingLocked(backend string) time.Duration {
+	load, ok := m.loadMeasured[backend]
+	if !ok {
+		load = m.loadEstimate(backend)
+	}
+	if load < m.minResidency {
+		return m.minResidency
+	}
+	return load
+}
+
+// recordLoadDuration remembers how long an engine actually took to become ready.
+func (m *SwapManager) recordLoadDuration(backend string, d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	m.mu.Lock()
+	m.loadMeasured[backend] = d
+	m.mu.Unlock()
+}
+
+// MeasuredLoad reports the last observed cold-start duration for backend, and
+// whether one has been observed at all.
+func (m *SwapManager) MeasuredLoad(backend string) (time.Duration, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	d, ok := m.loadMeasured[backend]
+	return d, ok
+}
+
+// swapRecord builds the ledger entry for a finished swap. The outcome ordering
+// matters: a rate-limited or otherwise failed swap is reported as such even
+// though it also did not become ready.
+func (m *SwapManager) swapRecord(op *swapOp) SwapRecord {
+	outcome := swapOutcomeWarming
+	switch {
+	case op.err != nil:
+		outcome = swapOutcomeFailed
+		var rateErr *SwapRateLimitedError
+		if errors.As(op.err, &rateErr) {
+			outcome = swapOutcomeRateLimited
+		}
+	case op.ready:
+		outcome = swapOutcomeReady
+	case op.transient || !op.started:
+		outcome = swapOutcomeBlocked
+	}
+	return SwapRecord{
+		Backend:   op.backend,
+		Model:     op.model,
+		Evicted:   append([]string(nil), op.evicted...),
+		StartedAt: op.startedAt,
+		Wait:      m.now().Sub(op.startedAt),
+		Outcome:   outcome,
+	}
 }
 
 // sortByLRU orders candidates least-recently-used first (unknown = oldest).
@@ -396,12 +560,36 @@ func (m *SwapManager) markReady(backend string) {
 	m.mu.Unlock()
 }
 
+// markServed records that a request was just dispatched to backend — the moment
+// EnsureResident hands it to the inference path. Compared against readyAt it
+// answers "has this engine done anything since it loaded?" (citadel-cli#687).
+//
+// It means "a request was routed here", not "the engine produced a completion":
+// the swap manager hands off before the readiness gate runs and cannot observe
+// the result. That is the strongest honest signal available at this seam, and it
+// is the one the eviction invariant needs — a load followed by a dispatched
+// request was not wasted.
+func (m *SwapManager) markServed(backend string) {
+	now := m.now()
+	m.mu.Lock()
+	m.servedAt[backend] = now
+	m.mu.Unlock()
+}
+
 // forget clears the residency window of an evicted engine, and with it the
 // record that a start was ever issued: an engine we just stopped is not booting.
+// The served stamp goes too — it belongs to a residency that has ended.
+//
+// loadMeasured deliberately SURVIVES: it measures how long the engine takes to
+// load, which does not change because we stopped it, and dropping it would send
+// the next swap-in of this engine back to the coarse table estimate for its
+// residency ceiling. (This is exactly the defect citadel-cli#688 describes for
+// lastUsed, which is why it is called out here rather than left to be noticed.)
 func (m *SwapManager) forget(name string) {
 	m.mu.Lock()
 	delete(m.readyAt, name)
 	delete(m.startedAt, name)
+	delete(m.servedAt, name)
 	m.mu.Unlock()
 }
 

--- a/internal/worker/swap_ledger.go
+++ b/internal/worker/swap_ledger.go
@@ -1,0 +1,197 @@
+// internal/worker/swap_ledger.go
+//
+// Swap accounting and the swap rate bound (citadel-cli#687).
+//
+// A one-GPU node running an alternating two-model workload can spend most of its
+// wall clock loading rather than serving, and before this nothing counted it:
+// there was no swap counter, no rate limit, and no per-swap record. The symptom
+// reaching the user is "everything is slow", which is unactionable.
+//
+// So swaps are recorded, and the EVICTING ones are bounded. Two deliberate
+// choices:
+//
+//   - The bound counts swaps that actually EVICTED a resident engine, not every
+//     swap. Starting an engine into free VRAM costs a load but takes nothing
+//     away, so a roomy node is never rate-limited for using its own headroom.
+//     Thrash is specifically the evict-reload-evict cycle.
+//   - Hitting the ceiling REFUSES, it does not queue or degrade quietly. A user
+//     told "this node is at its swap limit" can make a decision; a user watching
+//     an unbounded thrash cannot.
+//
+// The ledger is in-process. It resets on restart, so a crash-looping worker can
+// still exceed the ceiling across restarts — persisting it is out of scope here
+// and belongs with the persisted `lastUsed` work in citadel-cli#688.
+package worker
+
+import (
+	"fmt"
+	"time"
+)
+
+// Swap accounting knobs. Vars, not consts, so tests can shrink the window
+// without sleeping through an hour; swapAccountingDefaults pins the shipped
+// values so a test tweak cannot silently become the default.
+var (
+	// swapRateWindow is the trailing window both the rate bound and the
+	// swaps-per-hour counter measure over.
+	swapRateWindow = time.Hour
+
+	// swapMaxEvictingPerWindow is how many evicting swaps a node will perform per
+	// window before refusing. Six is roughly "a swap every ten minutes": enough
+	// for a node genuinely serving several models in rotation, low enough that an
+	// alternating two-model workload hits it quickly instead of burning the box
+	// for hours.
+	swapMaxEvictingPerWindow = 6
+
+	// swapRecordsKept bounds the in-process ledger so a long-lived worker does
+	// not accumulate records forever.
+	swapRecordsKept = 64
+)
+
+// Swap outcomes recorded in the ledger.
+const (
+	swapOutcomeReady       = "ready"        // engine loaded and became ready
+	swapOutcomeWarming     = "warming"      // start issued; not ready before the background ceiling
+	swapOutcomeFailed      = "failed"       // the start (or an eviction) errored
+	swapOutcomeBlocked     = "blocked"      // could not proceed now (residency protection); nothing started
+	swapOutcomeRateLimited = "rate_limited" // refused by the swap rate bound; nothing started
+)
+
+// SwapRecord is one swap this node attempted. It records what the manager
+// genuinely knows.
+//
+// Deliberately absent: "whether a pull was required" (asked for in #687). The
+// manager issues a SERVICE_START and the weights pull, if any, happens inside
+// it — the manager cannot observe it, and a guessed field is worse than no
+// field. Reporting it needs the start path to report back; tracked separately.
+type SwapRecord struct {
+	// Backend is the engine swapped in.
+	Backend string `json:"backend"`
+	// Model is the model it was started for.
+	Model string `json:"model,omitempty"`
+	// Evicted names the engines stopped to make room, in stop order. Empty when
+	// the swap fit in free VRAM — the distinction the rate bound keys on.
+	Evicted []string `json:"evicted,omitempty"`
+	// StartedAt is when the swap began.
+	StartedAt time.Time `json:"started_at"`
+	// Wait is how long the swap ran before reaching its outcome.
+	Wait time.Duration `json:"wait"`
+	// Outcome is one of the swapOutcome* values.
+	Outcome string `json:"outcome"`
+}
+
+// Evicting reports whether this swap took VRAM away from a resident engine.
+func (r SwapRecord) Evicting() bool { return len(r.Evicted) > 0 }
+
+// SwapStats is the operator-facing view of swap activity: the counter #687 asks
+// for, plus the records behind it so a "why is this node slow" question has an
+// answer instead of a number.
+type SwapStats struct {
+	// SwapsPerHour counts every swap attempt in the trailing window.
+	SwapsPerHour int `json:"swaps_per_hour"`
+	// EvictingSwapsPerHour counts only those that stopped a resident engine —
+	// the subset the rate bound applies to.
+	EvictingSwapsPerHour int `json:"evicting_swaps_per_hour"`
+	// MaxEvictingPerHour is the ceiling in force, so a reader can tell how close
+	// to refusing the node is without knowing the build's defaults.
+	MaxEvictingPerHour int `json:"max_evicting_per_hour"`
+	// Recent holds the most recent records, oldest first.
+	Recent []SwapRecord `json:"recent,omitempty"`
+}
+
+// SwapRateLimitedError is returned when a swap would have to evict a resident
+// engine and the node has already done so its full allowance this window. It is
+// a hard error on purpose: the inference handler turns it into a job failure
+// naming the limit, rather than a warming result that invites a retry into the
+// same refusal.
+type SwapRateLimitedError struct {
+	Backend string
+	Swaps   int
+	Max     int
+	Window  time.Duration
+}
+
+func (e *SwapRateLimitedError) Error() string {
+	return fmt.Sprintf(
+		"cannot swap in %s: this node is at its swap limit (%d evicting swaps in the last %s, limit %d). "+
+			"Loading another model would evict a resident one and spend more time loading than serving; "+
+			"refusing instead of thrashing (citadel-cli#687)",
+		e.Backend, e.Swaps, e.Window, e.Max)
+}
+
+// swapObserver is an OPTIONAL SwapController capability. A controller that
+// implements it is handed each completed swap record, which is how the per-swap
+// record and the counter reach the node's logs. Controllers that do not
+// implement it are unaffected.
+type swapObserver interface {
+	ObserveSwap(rec SwapRecord, stats SwapStats)
+}
+
+// recordSwap appends a completed swap to the ledger, prunes anything outside the
+// window (and beyond the retention bound), and hands the record plus the
+// resulting counters to the controller if it observes swaps.
+func (m *SwapManager) recordSwap(rec SwapRecord) {
+	m.mu.Lock()
+	m.swaps = append(m.swaps, rec)
+	m.pruneSwapsLocked(m.now())
+	stats := m.swapStatsLocked(m.now())
+	m.mu.Unlock()
+
+	if obs, ok := m.ctrl.(swapObserver); ok {
+		obs.ObserveSwap(rec, stats)
+	}
+}
+
+// pruneSwapsLocked drops records older than the rate window, then caps the slice
+// at the retention bound. Callers hold m.mu.
+func (m *SwapManager) pruneSwapsLocked(now time.Time) {
+	cutoff := now.Add(-m.rateWindow)
+	keep := m.swaps[:0]
+	for _, r := range m.swaps {
+		if r.StartedAt.After(cutoff) {
+			keep = append(keep, r)
+		}
+	}
+	m.swaps = keep
+	if len(m.swaps) > swapRecordsKept {
+		m.swaps = append([]SwapRecord(nil), m.swaps[len(m.swaps)-swapRecordsKept:]...)
+	}
+}
+
+// evictingSwapsInWindow counts swaps in the trailing window that stopped a
+// resident engine. Callers hold m.mu.
+func (m *SwapManager) evictingSwapsInWindowLocked(now time.Time) int {
+	cutoff := now.Add(-m.rateWindow)
+	n := 0
+	for _, r := range m.swaps {
+		if r.Evicting() && r.StartedAt.After(cutoff) {
+			n++
+		}
+	}
+	return n
+}
+
+// swapStatsLocked builds the counter view. Callers hold m.mu.
+func (m *SwapManager) swapStatsLocked(now time.Time) SwapStats {
+	cutoff := now.Add(-m.rateWindow)
+	stats := SwapStats{MaxEvictingPerHour: m.maxEvictingPerWindow}
+	for _, r := range m.swaps {
+		if !r.StartedAt.After(cutoff) {
+			continue
+		}
+		stats.SwapsPerHour++
+		if r.Evicting() {
+			stats.EvictingSwapsPerHour++
+		}
+	}
+	stats.Recent = append([]SwapRecord(nil), m.swaps...)
+	return stats
+}
+
+// SwapStats reports swap activity over the trailing window. It is the read side
+// of the ledger the rate bound writes.
+func (m *SwapManager) SwapStats() SwapStats {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.swapStatsLocked(m.now())
+}

--- a/internal/worker/swap_rate_test.go
+++ b/internal/worker/swap_rate_test.go
@@ -1,0 +1,426 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/status"
+)
+
+// Tests for citadel-cli#687: the served-once eviction invariant, the per-engine
+// residency ceiling derived from the MEASURED load time, and the swap rate bound.
+
+// fullGPUWith builds a manager whose GPU is full and whose only preemption
+// candidate is `name` holding enough VRAM that evicting it WOULD fit a bonsai
+// swap-in. So whether the eviction happens isolates the residency/rate decision
+// from any VRAM arithmetic.
+func fullGPUWith(t *testing.T, name string) (*mockSwapController, *SwapManager) {
+	t.Helper()
+	ctrl := newMockController()
+	ctrl.haveVRAM = true
+	ctrl.freeVRAM = 0
+	ctrl.candidates = []status.PreemptCandidate{
+		{Name: name, VRAMBytes: 23 << 30, Idle: true},
+	}
+	// The swapped-in engine becomes ready as soon as it starts, so a swap that is
+	// allowed to proceed finishes immediately instead of polling out the
+	// background ceiling. Keeps these tests off the clock: `release.sh` gates on
+	// `go test ./...`, so seconds spent sleeping here are seconds on every release.
+	ctrl.readyAfterStart = true
+	return ctrl, newTestManager(ctrl)
+}
+
+// fillEvictingSwaps seeds the ledger with n completed swaps that each evicted an
+// engine, as if the node had already been swapping for a while.
+func fillEvictingSwaps(m *SwapManager, n int, age time.Duration) {
+	for i := 0; i < n; i++ {
+		m.swaps = append(m.swaps, SwapRecord{
+			Backend:   "filler",
+			Evicted:   []string{"someone"},
+			StartedAt: m.now().Add(-age),
+			Outcome:   swapOutcomeReady,
+		})
+	}
+}
+
+// expectNoEviction waits out the background swap and asserts nothing was stopped.
+func expectNoEviction(t *testing.T, ctrl *mockSwapController) {
+	t.Helper()
+	time.Sleep(50 * time.Millisecond)
+	if names := ctrl.stoppedNames(); len(names) != 0 {
+		t.Fatalf("expected NO eviction, got %v", names)
+	}
+}
+
+// TestSwap_UnservedEngineIsProtectedUntilItServes is the core #687 invariant. A
+// vLLM that loaded for ~90s and became ready 70s ago is PAST the 60s
+// min-residency floor, but has served nothing — evicting it now would make the
+// whole load pure waste, which is the reported failure (a 78s load under a 60s
+// floor).
+func TestSwap_UnservedEngineIsProtectedUntilItServes(t *testing.T) {
+	ctrl, m := fullGPUWith(t, "vllm")
+	// Ready 70s ago: past the 60s floor, inside vllm's 90s load-derived ceiling.
+	m.readyAt["vllm"] = m.now().Add(-70 * time.Second)
+
+	out, err := m.EnsureResident(context.Background(), "bonsai", "Bonsai-27B")
+	if err != nil {
+		t.Fatalf("expected a transient block, not a hard error: %v", err)
+	}
+	if out.Ready {
+		t.Fatalf("expected warming while the only candidate has served nothing since loading")
+	}
+	expectNoEviction(t, ctrl)
+}
+
+// TestSwap_ServedEngineBecomesEvictable is the other half of the invariant: once
+// a request has actually been dispatched to the engine, the load paid for itself
+// and normal eviction ordering resumes. Without this the protection would be a
+// permanent pin, not a floor.
+func TestSwap_ServedEngineBecomesEvictable(t *testing.T) {
+	ctrl, m := fullGPUWith(t, "vllm")
+	ready := m.now().Add(-70 * time.Second)
+	m.readyAt["vllm"] = ready
+	m.servedAt["vllm"] = ready.Add(time.Second) // a request arrived after it loaded
+
+	if _, err := m.EnsureResident(context.Background(), "bonsai", "Bonsai-27B"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	waitFor(t, func() bool {
+		for _, n := range ctrl.stoppedNames() {
+			if n == "vllm" {
+				return true
+			}
+		}
+		return false
+	}, "an engine that has served a request must be evictable again")
+}
+
+// TestSwap_StaleServedStampDoesNotUnprotect guards the comparison direction. The
+// served stamp must be compared against THIS residency's readyAt: a request
+// served before the engine was last restarted says nothing about the current
+// load, and treating it as "has served" would reopen the exact hole #687 closes.
+func TestSwap_StaleServedStampDoesNotUnprotect(t *testing.T) {
+	ctrl, m := fullGPUWith(t, "vllm")
+	ready := m.now().Add(-70 * time.Second)
+	m.readyAt["vllm"] = ready
+	m.servedAt["vllm"] = ready.Add(-30 * time.Minute) // from a PREVIOUS residency
+
+	if _, err := m.EnsureResident(context.Background(), "bonsai", "Bonsai-27B"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expectNoEviction(t, ctrl)
+}
+
+// TestSwap_UnknownEngineStaysEvictable is the scoping guard. An engine this node
+// never swapped in — operator-started, or resident since boot, or from before a
+// worker restart — has no readyAt record, and "no record" must NOT read as
+// "recently loaded". Otherwise a worker restart would make every long-resident
+// engine unevictable, which is worse than the bug being fixed.
+func TestSwap_UnknownEngineStaysEvictable(t *testing.T) {
+	ctrl, m := fullGPUWith(t, "vllm")
+	// Deliberately no readyAt and no servedAt entry for vllm.
+
+	if _, err := m.EnsureResident(context.Background(), "bonsai", "Bonsai-27B"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	waitFor(t, func() bool {
+		return len(ctrl.stoppedNames()) > 0
+	}, "an engine with no residency record must stay evictable")
+}
+
+// TestSwap_MeasuredLoadRaisesResidencyCeiling is the "per engine, measured"
+// requirement. ollama's table estimate (60s) equals the min-residency floor, so
+// the estimate alone protects nothing at 70s. Once this node has MEASURED a 120s
+// load for it, the same engine at the same age is protected — which is the whole
+// point of measuring rather than trusting the table.
+func TestSwap_MeasuredLoadRaisesResidencyCeiling(t *testing.T) {
+	// Without a measurement: the table estimate does not stretch past the floor.
+	ctrl, m := fullGPUWith(t, "ollama")
+	m.readyAt["ollama"] = m.now().Add(-70 * time.Second)
+	if _, err := m.EnsureResident(context.Background(), "bonsai", "Bonsai-27B"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	waitFor(t, func() bool { return len(ctrl.stoppedNames()) > 0 },
+		"with only a 60s estimate, a 70s-old unserved engine is past its ceiling")
+
+	// With a measured 120s load, the identical engine at the identical age is
+	// protected: the measurement, not the table, decides.
+	ctrl2, m2 := fullGPUWith(t, "ollama")
+	m2.readyAt["ollama"] = m2.now().Add(-70 * time.Second)
+	m2.loadMeasured["ollama"] = 120 * time.Second
+	if _, err := m2.EnsureResident(context.Background(), "bonsai", "Bonsai-27B"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expectNoEviction(t, ctrl2)
+}
+
+// TestSwap_LoadDurationIsMeasuredOnReady asserts the node actually records how
+// long a swap took, since every per-engine ceiling above depends on it.
+func TestSwap_LoadDurationIsMeasuredOnReady(t *testing.T) {
+	ctrl := newMockController()
+	ctrl.readyAfterStart = true
+	m := newTestManager(ctrl)
+	m.waitBudget = 2 * time.Second
+
+	if _, known := m.MeasuredLoad("bonsai"); known {
+		t.Fatal("no load should be measured before a swap runs")
+	}
+	if _, err := m.EnsureResident(context.Background(), "bonsai", "Bonsai-27B"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, known := m.MeasuredLoad("bonsai"); !known {
+		t.Fatal("a completed swap must record the engine's measured load time")
+	}
+}
+
+// TestSwap_ForgetKeepsMeasuredLoad pins the asymmetry in forget(): the residency
+// stamps belong to a residency that has ended, but the load measurement belongs
+// to the ENGINE and must survive eviction. Dropping it would send the next
+// swap-in of this engine back to the coarse estimate — the same defect #688
+// describes for lastUsed.
+func TestSwap_ForgetKeepsMeasuredLoad(t *testing.T) {
+	ctrl := newMockController()
+	m := newTestManager(ctrl)
+	m.readyAt["vllm"] = m.now()
+	m.servedAt["vllm"] = m.now()
+	m.loadMeasured["vllm"] = 78 * time.Second
+
+	m.forget("vllm")
+
+	if _, ok := m.readyAt["vllm"]; ok {
+		t.Error("readyAt must be cleared on eviction")
+	}
+	if _, ok := m.servedAt["vllm"]; ok {
+		t.Error("servedAt must be cleared on eviction: the residency it described has ended")
+	}
+	if d, ok := m.MeasuredLoad("vllm"); !ok || d != 78*time.Second {
+		t.Errorf("measured load must survive eviction, got %v ok=%v", d, ok)
+	}
+}
+
+// TestSwap_RateLimit_RefusesEvictingSwapAtCeiling is the swap rate bound. Once
+// the node has spent its allowance, another eviction is REFUSED rather than
+// performed — and refused before anything is stopped, so the refusal costs the
+// box nothing.
+func TestSwap_RateLimit_RefusesEvictingSwapAtCeiling(t *testing.T) {
+	ctrl, m := fullGPUWith(t, "vllm")
+	m.waitBudget = 2 * time.Second // observe the swap to completion so the error surfaces
+	fillEvictingSwaps(m, m.maxEvictingPerWindow, 5*time.Minute)
+
+	_, err := m.EnsureResident(context.Background(), "bonsai", "Bonsai-27B")
+	var rateErr *SwapRateLimitedError
+	if !errors.As(err, &rateErr) {
+		t.Fatalf("expected a SwapRateLimitedError at the ceiling, got %v", err)
+	}
+	if rateErr.Max != m.maxEvictingPerWindow {
+		t.Errorf("error should carry the ceiling in force, got %d", rateErr.Max)
+	}
+	if names := ctrl.stoppedNames(); len(names) != 0 {
+		t.Fatalf("a refused swap must evict nothing, got %v", names)
+	}
+	if ctrl.startCountVal() != 0 {
+		t.Fatalf("a refused swap must not start the target engine, got %d starts", ctrl.startCountVal())
+	}
+}
+
+// TestSwap_RateLimit_AllowsNonEvictingSwap is why the bound counts EVICTIONS and
+// not swaps. A node with free VRAM takes nothing away when it starts an engine,
+// so its own headroom must never be rate-limited by swaps it made earlier.
+func TestSwap_RateLimit_AllowsNonEvictingSwap(t *testing.T) {
+	ctrl := newMockController() // default: 1TiB free, so no eviction is planned
+	ctrl.readyAfterStart = true
+	m := newTestManager(ctrl)
+	m.waitBudget = 2 * time.Second
+	fillEvictingSwaps(m, m.maxEvictingPerWindow*2, 5*time.Minute) // way over the ceiling
+
+	out, err := m.EnsureResident(context.Background(), "bonsai", "Bonsai-27B")
+	if err != nil {
+		t.Fatalf("a swap that evicts nothing must not be rate-limited: %v", err)
+	}
+	if !out.Ready {
+		t.Fatal("expected the non-evicting swap to complete")
+	}
+}
+
+// TestSwap_RateLimit_IgnoresSwapsOutsideTheWindow asserts the bound is a RATE,
+// not a lifetime cap: a node that swapped heavily yesterday starts today with a
+// full allowance.
+func TestSwap_RateLimit_IgnoresSwapsOutsideTheWindow(t *testing.T) {
+	ctrl, m := fullGPUWith(t, "vllm")
+	m.waitBudget = 2 * time.Second
+	fillEvictingSwaps(m, m.maxEvictingPerWindow*2, m.rateWindow+time.Hour) // all stale
+
+	if _, err := m.EnsureResident(context.Background(), "bonsai", "Bonsai-27B"); err != nil {
+		t.Fatalf("stale swaps must not count against the window: %v", err)
+	}
+	waitFor(t, func() bool { return len(ctrl.stoppedNames()) > 0 },
+		"a node whose swaps are all outside the window must be allowed to evict")
+}
+
+// TestSwap_LedgerRecordsTheSwap covers the counter and per-swap record #687 asks
+// the node to emit: before this, an alternating workload could burn the box with
+// nothing anywhere counting it.
+func TestSwap_LedgerRecordsTheSwap(t *testing.T) {
+	_, m := fullGPUWith(t, "vllm")
+	m.waitBudget = 2 * time.Second
+
+	if _, err := m.EnsureResident(context.Background(), "bonsai", "Bonsai-27B"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	waitFor(t, func() bool { return m.SwapStats().SwapsPerHour == 1 }, "the swap must be recorded")
+
+	stats := m.SwapStats()
+	if stats.EvictingSwapsPerHour != 1 {
+		t.Errorf("a swap that stopped an engine must count as evicting, got %d", stats.EvictingSwapsPerHour)
+	}
+	if stats.MaxEvictingPerHour != m.maxEvictingPerWindow {
+		t.Errorf("stats must report the ceiling in force, got %d", stats.MaxEvictingPerHour)
+	}
+	if len(stats.Recent) != 1 {
+		t.Fatalf("expected one record, got %d", len(stats.Recent))
+	}
+	rec := stats.Recent[0]
+	if rec.Backend != "bonsai" || rec.Model != "Bonsai-27B" {
+		t.Errorf("record must name the swap, got %+v", rec)
+	}
+	if rec.Outcome != swapOutcomeReady {
+		t.Errorf("expected outcome %q, got %q", swapOutcomeReady, rec.Outcome)
+	}
+	if len(rec.Evicted) != 1 || rec.Evicted[0] != "vllm" {
+		t.Errorf("record must name what was evicted, got %v", rec.Evicted)
+	}
+}
+
+// TestSwap_LedgerRecordsRateLimitedRefusal asserts a refusal is recorded as a
+// refusal. A refused swap that logged as "blocked" or vanished entirely would
+// leave an operator asking why the node stopped serving with no answer.
+func TestSwap_LedgerRecordsRateLimitedRefusal(t *testing.T) {
+	_, m := fullGPUWith(t, "vllm")
+	m.waitBudget = 2 * time.Second
+	fillEvictingSwaps(m, m.maxEvictingPerWindow, time.Minute)
+
+	if _, err := m.EnsureResident(context.Background(), "bonsai", "Bonsai-27B"); err == nil {
+		t.Fatal("expected the swap to be refused")
+	}
+	stats := m.SwapStats()
+	last := stats.Recent[len(stats.Recent)-1]
+	if last.Outcome != swapOutcomeRateLimited {
+		t.Errorf("expected outcome %q, got %q", swapOutcomeRateLimited, last.Outcome)
+	}
+	if last.Evicting() {
+		t.Error("a refused swap evicted nothing and must not count against the next window")
+	}
+}
+
+// TestSwap_LedgerIsBounded asserts the in-process ledger cannot grow without
+// limit on a long-lived worker.
+func TestSwap_LedgerIsBounded(t *testing.T) {
+	ctrl := newMockController()
+	m := newTestManager(ctrl)
+	for i := 0; i < swapRecordsKept*3; i++ {
+		m.recordSwap(SwapRecord{Backend: "vllm", StartedAt: m.now(), Outcome: swapOutcomeReady})
+	}
+	if got := len(m.SwapStats().Recent); got > swapRecordsKept {
+		t.Errorf("ledger must stay bounded at %d, got %d", swapRecordsKept, got)
+	}
+}
+
+// TestSwapObserverReceivesEachSwap asserts the record reaches the controller,
+// which is how it reaches the node's logs — the "emit" half of #687. A ledger
+// nothing reads would leave the operator exactly as blind as before.
+func TestSwapObserverReceivesEachSwap(t *testing.T) {
+	ctrl := &observingController{mockSwapController: newMockController()}
+	ctrl.readyAfterStart = true
+	m := newTestManager(ctrl)
+	m.waitBudget = 2 * time.Second
+
+	if _, err := m.EnsureResident(context.Background(), "bonsai", "Bonsai-27B"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	waitFor(t, func() bool { return len(ctrl.observedRecords()) == 1 }, "the controller must observe the swap")
+	if got := ctrl.observedRecords()[0].Backend; got != "bonsai" {
+		t.Errorf("observed record names the wrong engine: %q", got)
+	}
+	if got := ctrl.observedStats()[0].SwapsPerHour; got != 1 {
+		t.Errorf("observed stats must include the swap just recorded, got %d", got)
+	}
+}
+
+// observingController is a mock controller that also implements swapObserver.
+type observingController struct {
+	*mockSwapController
+	records []SwapRecord
+	stats   []SwapStats
+}
+
+func (c *observingController) ObserveSwap(rec SwapRecord, stats SwapStats) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.records = append(c.records, rec)
+	c.stats = append(c.stats, stats)
+}
+
+func (c *observingController) observedRecords() []SwapRecord {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]SwapRecord(nil), c.records...)
+}
+
+func (c *observingController) observedStats() []SwapStats {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]SwapStats(nil), c.stats...)
+}
+
+// TestHotswap_RateLimited_FailsWithReason pins the wire shape of a refusal.
+//
+// It must be a FAILURE, not a success carrying a new control status: the
+// platform branches on `output.status == "model_warming"` and has no branch for
+// anything else, so a success-shaped refusal would be relayed as an empty reply —
+// the user asks a question and gets silence, with no error recorded. The machine
+// -readable reason rides along for a consumer that later wants to say "this node
+// is at its swap limit" specifically.
+func TestHotswap_RateLimited_FailsWithReason(t *testing.T) {
+	h := NewLLMInferenceHandler().WithSwapper(&fakeSwapper{
+		err: &SwapRateLimitedError{Backend: "bonsai", Swaps: 6, Max: 6, Window: time.Hour},
+	})
+
+	result, err := h.Execute(context.Background(), hotswapJob(), &MockStreamWriter{})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if result.Status != JobStatusFailure {
+		t.Fatalf("a refusal must be a job FAILURE, got %v", result.Status)
+	}
+	if got, _ := result.Output["reason"].(string); got != "swap_rate_limited" {
+		t.Errorf("reason = %q, want swap_rate_limited", got)
+	}
+	if got, _ := result.Output["status"].(string); got != "model_unavailable" {
+		t.Errorf("status = %q, want model_unavailable", got)
+	}
+	if got, _ := result.Output["error"].(string); got == "" {
+		t.Error("a refusal must carry a human-readable explanation")
+	}
+}
+
+// TestSwapAccountingDefaults pins the SHIPPED values. The knobs above are vars so
+// tests can shrink them without sleeping through an hour; this is what stops a
+// test's convenience from silently becoming the node's default.
+func TestSwapAccountingDefaults(t *testing.T) {
+	if swapRateWindow != time.Hour {
+		t.Errorf("swapRateWindow default changed to %v; #687 specifies swaps per hour", swapRateWindow)
+	}
+	if swapMaxEvictingPerWindow != 6 {
+		t.Errorf("swapMaxEvictingPerWindow default changed to %d", swapMaxEvictingPerWindow)
+	}
+	if swapMinResidency != 60*time.Second {
+		t.Errorf("swapMinResidency default changed to %v", swapMinResidency)
+	}
+
+	m := NewSwapManager(newMockController())
+	if m.rateWindow != swapRateWindow || m.maxEvictingPerWindow != swapMaxEvictingPerWindow {
+		t.Error("a manager built for a real node must ship with the default bound in force")
+	}
+}


### PR DESCRIPTION
Closes #687.

## Context

`swapMinResidency` was **60s — shorter than a measured 78s load**. A model could therefore become evictable before it had finished loading: it loads for 78s, becomes evictable at 60s, and the next miss takes it out. The load was pure waste.

And nothing counted any of it. There was no swap counter, no rate limit, and no per-swap record, so an alternating two-model workload on one card could spend the majority of its wall clock loading rather than serving, with the only symptom reaching the user being "everything is slow" — which is unactionable.

## Root cause

Two separate gaps in `SwapManager`:

1. **The residency floor was a global constant unrelated to how long engines actually take to load.** 60s is a number, not a property of the engine it protects. Any engine slower than the floor could be evicted mid-usefulness.
2. **Swaps were unaccounted.** Eviction was governed only by "does it fit", so a full card with two large models had no mechanism that could ever say *no* — every miss was another swap, forever.

## Changes

**Residency — `filterResidencyProtected` (`internal/worker/swap.go`)**

Keeps the existing min-residency floor and adds the **served-once invariant**: an engine that has had no request dispatched to it *since it became ready* is not evictable until it has. That is the issue's stated invariant implemented directly rather than approximated by a timer.

The protection is bounded by the engine's **own load time** (`unservedResidencyCeilingLocked`), preferring a load this node has actually **measured** (`MeasuredLoad`, recorded when a swap reaches ready) over the coarse `defaultLoadEstimate` table. So the floor can never be shorter than the load it exists to justify, and it is per-engine rather than global.

`servedAt` means *"a request was routed here"*, not *"the engine produced a completion"* — the manager hands off before the readiness gate runs and cannot observe the result. That is the strongest honest signal at this seam, and it is documented as such rather than overclaimed.

**Scoping guard.** An engine with **no `readyAt` record** — operator-started, or resident since before the worker started — is protected by *neither* rule. Deliberate: "we have no record" must not read as "recently loaded", or a worker restart would make every long-resident engine unevictable, which is worse than the bug being fixed. `TestSwap_UnknownEngineStaysEvictable` pins it.

**`forget()` asymmetry.** On eviction, `readyAt` and `servedAt` are dropped (that residency ended) but `loadMeasured` **survives** — it measures the *engine*, not the residency, and dropping it would send the next swap-in back to the table estimate. That is the same defect #688 describes for `lastUsed`, so it is fixed here rather than inherited.

**Rate bound — `checkSwapRate` + ledger (`internal/worker/swap_ledger.go`, new)**

A per-node ledger records every swap; the bound counts only those that **actually evicted** a resident engine. A node starting engines into its own free VRAM takes nothing away and is never limited — thrash is specifically the evict-reload-evict cycle. The check runs at the point the plan is known to require a stop, so a refusal costs nothing and stops nothing.

At the ceiling the node **refuses** rather than continuing to burn the box.

**The refusal is a job FAILURE**, carrying `reason: "swap_rate_limited"` and `status: "model_unavailable"` — not a new success-shaped control status. The platform branches on `output.status == "model_warming"` and has no branch for anything else, so an unrecognized control payload returned as a *success* would be relayed as a successful empty reply: the user asks a question and gets silence, with no error recorded anywhere. A failure is legible to every consumer that exists today; the structured reason is additive on top.

**Counter and per-swap record**

`SwapStats()` exposes `swaps_per_hour`, the evicting subset, and the ceiling in force. Each completed swap is handed to the controller through the optional `swapObserver` interface, which `cmd/hotswap.go` implements to log the record plus the running counter — so the log line says how close the node is to refusing, not just what it did.

**Deliberately absent:** *"whether a pull was required"*, which #687 asks for. The manager issues `SERVICE_START` and any weights pull happens inside it, unobservable from here. A guessed field is worse than no field; reporting it needs the start path to report back.

## Known limitations (stated, not fixed here)

- **The ledger is in-process.** The bound resets on restart, so a crash-looping worker can exceed the hourly ceiling. Persisting it belongs with the persisted `lastUsed` work in #688, which does not exist yet.
- **`SwapStats()` is not on the heartbeat yet** — the record reaches the node's logs, not the platform. The accessor is the API that wiring would use.
- **The structured `unavailable` / `swap_rate_limited` wire status the issue asks for needs an aceteam-side consumer.** Until one exists this is a job failure carrying the reason, which is the honest reading of "refusing honestly is better than thrashing politely" without shipping a payload nothing parses.

## Ordering

#687 states it must land **before** #688 (LRU as primary eviction key), so a bad ordering cannot thrash unbounded and unmeasured. That is now satisfied.

## Testing

`go build ./...`, `go vet ./...`, `go test ./...` all green.

New tests in `internal/worker/swap_rate_test.go` cover: the served-once invariant in both directions; a stale served stamp from a previous residency not unprotecting; the unknown-engine scoping guard; the measured load raising the ceiling where the estimate would not (a discriminating pair on the *same* engine at the *same* age); load measurement on ready; the `forget()` asymmetry; refusal at the ceiling with nothing stopped and nothing started; a non-evicting swap **not** being limited; stale swaps not counting against the window; ledger contents, bounding, and the refusal outcome; the observer handoff; and the failure wire shape.

**Mutation-tested.** Nine mutations of the new predicates — dropping the served-once protection, treating an unknown engine as protected, ignoring the stale-stamp comparison direction, ignoring the measured load, removing the rate check, applying the rate check to non-evicting swaps, dropping `loadMeasured` in `forget`, unbounding the ledger, and collapsing the rate-limited outcome into a plain failure — **all nine were killed** by the tests.

**Suite cost: none.** Timing knobs are package vars so tests need not sleep an hour, with the shipped values pinned by `TestSwapAccountingDefaults`; the package runs 15.9s against a 16.3s baseline on `main`.

## Verification on a node

With `CITADEL_MODEL_HOTSWAP` enabled, alternating requests between two models that each nearly fill the card should now show `[hotswap] swap ... (swaps this hour: N, evicting: M/6)` lines, and the seventh evicting swap in an hour should fail the job with the swap-limit message instead of evicting.