### PR TITLE
fix(whatsapp): pull the bridge image before up, and report what changed (#718)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -740,11 +740,11 @@ doc helped hide.
 
 The bridge compose pins a FLOATING tag, so `docker compose up -d` alone can never
 upgrade it: with that tag already present locally, compose sees an unchanged
-config and an unchanged image ID and does nothing — while `whatsapp.Provision`
+config and an unchanged image ID and does nothing, while `whatsapp.Provision`
 went on to report `already_linked` success on the stale image. `startBridgeStack`
 (`cmd/whatsapp.go`) owns the rule: pull the `bridge` service, then up. The pull is
 best-effort (a node without `docker login` still serves its cached image) but
-never silent — `whatsapp.ProvisionDeps.BridgeImageID` samples the RUNNING
+never silent: `whatsapp.ProvisionDeps.BridgeImageID` samples the RUNNING
 CONTAINER's image before and after the deploy, and `ProvisionResult` carries
 `Upgraded` + both IDs + `ImagePullError`. The `status` string deliberately still
 has only two values (`provisioned` / `already_linked`): the aceteam backend

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -736,6 +736,21 @@ sibling services too. Anything reasoning about "is THIS service up" must filter 
 container name rather than trusting project scoping — see #692, which this stale
 doc helped hide.
 
+### WhatsApp bridge deploys must pull (#718)
+
+The bridge compose pins a FLOATING tag, so `docker compose up -d` alone can never
+upgrade it: with that tag already present locally, compose sees an unchanged
+config and an unchanged image ID and does nothing — while `whatsapp.Provision`
+went on to report `already_linked` success on the stale image. `startBridgeStack`
+(`cmd/whatsapp.go`) owns the rule: pull the `bridge` service, then up. The pull is
+best-effort (a node without `docker login` still serves its cached image) but
+never silent — `whatsapp.ProvisionDeps.BridgeImageID` samples the RUNNING
+CONTAINER's image before and after the deploy, and `ProvisionResult` carries
+`Upgraded` + both IDs + `ImagePullError`. The `status` string deliberately still
+has only two values (`provisioned` / `already_linked`): the aceteam backend
+branches on `status == "already_linked"` by equality, so upgrade information is
+additive, never a new status. `TestStartBridgeStackPullsBeforeUp` pins the argv.
+
 ### Bonsai service (PrismML Bonsai-27B, 1-bit)
 
 Bonsai-27B is PrismML's 1-bit quantized Qwen3.6-27B. The `bonsai` service serves

--- a/cmd/whatsapp.go
+++ b/cmd/whatsapp.go
@@ -512,8 +512,8 @@ func runWhatsAppDown(cmd *cobra.Command, args []string) error {
 	// Must use the SAME `-p` project the stack was brought up under, otherwise
 	// compose targets a different (empty) project and the containers survive.
 	// Left UNSCOPED (no service argument) on purpose: `down` should take the
-	// Postgres sidecar with it, and compose limits `down` to the services of the
-	// loaded -f file, so the sibling modules sharing this project are untouched.
+	// Postgres sidecar with it too. As everywhere in this file, `--remove-orphans`
+	// is never passed, so the sibling modules sharing this project survive.
 	out, err := runBridgeCompose(context.Background(),
 		bridgeComposeArgs(whatsapp.ProjectName(servicesDir), composePath, whatsapp.EnvPath(servicesDir), "down")...)
 	if err != nil {

--- a/cmd/whatsapp.go
+++ b/cmd/whatsapp.go
@@ -26,6 +26,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/catalog"
@@ -182,7 +183,44 @@ func bridgeBaseURL(port int) string {
 // GIT_TERMINAL_PROMPT=0 is set so a private-repo clone with missing credentials
 // fails fast with a clear error instead of blocking on an interactive prompt
 // (which would hang a headless node job).
-func deployWhatsAppCompose(source, image string) func(servicesDir string, env map[string]string) error {
+// deployReport carries the NON-FATAL outcomes of a deploy back out to
+// whatsappProvisionDeps, which exposes them to whatsapp.Provision through the
+// optional ImagePullError dep (the DeployCompose dep itself returns only an
+// error, and its signature is shared with every existing caller and test stub).
+//
+// Today it carries one thing: the image-pull error. A pull failure must not fail
+// the provision -- a node that never ran `docker login` for the private registry
+// can still serve from its cached image, and failing would regress re-provisions
+// that work today -- but it must not vanish either, because "provisioned fine,
+// silently still on the old image" is exactly the false-green #718 is about.
+//
+// The mutex is load-bearing: deployWhatsAppCompose runs the deploy in a goroutine
+// and abandons it on deployTimeout, so the writer can still be running when the
+// reader looks.
+type deployReport struct {
+	mu      sync.Mutex
+	pullErr string
+}
+
+func (r *deployReport) setPullError(err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if err == nil {
+		r.pullErr = ""
+		return
+	}
+	r.pullErr = err.Error()
+}
+
+// PullError returns the recorded pull error text ("" when the pull succeeded or
+// was never attempted). It is the whatsapp.ProvisionDeps.ImagePullError edge.
+func (r *deployReport) PullError() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.pullErr
+}
+
+func deployWhatsAppCompose(source, image string, report *deployReport) func(servicesDir string, env map[string]string) error {
 	return func(servicesDir string, env map[string]string) error {
 		// Fail fast on a private-repo clone with missing credentials instead of
 		// blocking on an interactive git prompt (which would hang a headless job).
@@ -207,7 +245,9 @@ func deployWhatsAppCompose(source, image string) func(servicesDir string, env ma
 
 		type result struct{ err error }
 		done := make(chan result, 1)
-		go func() { done <- result{err: deployWhatsAppComposeOnce(ctx, source, image, servicesDir, env)} }()
+		go func() {
+			done <- result{err: deployWhatsAppComposeOnce(ctx, source, image, servicesDir, env, report)}
+		}()
 
 		select {
 		case r := <-done:
@@ -222,7 +262,7 @@ func deployWhatsAppCompose(source, image string) func(servicesDir string, env ma
 
 // deployWhatsAppComposeOnce performs the actual resolve + write + compose-up. It
 // is split out so deployWhatsAppCompose can run it under a hard deadline.
-func deployWhatsAppComposeOnce(ctx context.Context, source, image, servicesDir string, env map[string]string) error {
+func deployWhatsAppComposeOnce(ctx context.Context, source, image, servicesDir string, env map[string]string, report *deployReport) error {
 	if source == "" {
 		source = defaultWhatsAppSource
 	}
@@ -250,19 +290,50 @@ func deployWhatsAppComposeOnce(ctx context.Context, source, image, servicesDir s
 	if image != "" {
 		env["BRIDGE_IMAGE"] = image
 	}
-	// Persist env before compose up so --env-file sees the admin key + port.
+	// Persist env before compose pull/up so --env-file sees the admin key + port.
+	// The compose declares `ADMIN_API_KEY: ${ADMIN_API_KEY:?...}`, so even `pull`
+	// (which parses the file) fails without it.
 	if err := whatsapp.SaveEnv(servicesDir, env); err != nil {
 		return fmt.Errorf("write bridge config: %w", err)
 	}
-	return composeUp(ctx, whatsapp.ProjectName(servicesDir), composePath, whatsapp.EnvPath(servicesDir))
+	return startBridgeStack(ctx, whatsapp.ProjectName(servicesDir), composePath, whatsapp.EnvPath(servicesDir), report)
+}
+
+// startBridgeStack refreshes the bridge image and then starts the stack. Pull
+// THEN up, in that order, is the fix for aceteam-ai/citadel-cli#718: the compose
+// pins the floating tag `ghcr.io/sunapi386/whatsapp-bridge:latest`, and when that
+// tag is already present locally a bare `up -d` sees an unchanged config and an
+// unchanged image ID and does nothing -- so a provisioned bridge could never be
+// upgraded through the API, while `Provision` still reported success.
+//
+// A pull failure is recorded and logged but NOT fatal (see deployReport): the
+// cached image still runs, and the caller learns the truth from
+// ProvisionResult.ImagePullError plus the unchanged image IDs.
+func startBridgeStack(ctx context.Context, project, composePath, envPath string, report *deployReport) error {
+	pullErr := bridgeComposePull(ctx, project, composePath, envPath)
+	if report != nil {
+		report.setPullError(pullErr)
+	}
+	if pullErr != nil {
+		// Loud, but not fatal. Provision surfaces this in its result too.
+		fmt.Fprintf(os.Stderr, "   ⚠️ could not refresh the bridge image; starting the locally cached one instead: %v\n", pullErr)
+	}
+	return bridgeComposeUp(ctx, project, composePath, envPath)
 }
 
 // whatsappProvisionDeps builds the ProvisionDeps for the local CLI, wiring the
 // real catalog / docker / network edges. source/image are the CLI flag values.
 func whatsappProvisionDeps(source, image string) whatsapp.ProvisionDeps {
+	// One report per deps set, so the pull outcome recorded by DeployCompose is
+	// the one ImagePullError reads back for this provision.
+	report := &deployReport{}
 	return whatsapp.ProvisionDeps{
 		ServicesDir:   servicesDirForNode,
-		DeployCompose: deployWhatsAppCompose(source, image),
+		DeployCompose: deployWhatsAppCompose(source, image, report),
+		// Image identity before/after the deploy, so an `already_linked` result
+		// can be told apart from a real upgrade (#718).
+		BridgeImageID:  bridgeImageIDForNode,
+		ImagePullError: report.PullError,
 		NewBridgeClient: func(port int, adminKey string) whatsapp.BridgeClient {
 			return whatsapp.NewClient(bridgeBaseURL(port), adminKey)
 		},
@@ -320,6 +391,10 @@ func runWhatsAppUp(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	// Say what the deploy actually did to the image. A re-run that changed
+	// nothing must not look like an upgrade (#718).
+	printImageOutcome(res)
 
 	// Show the connect details + pairing QR. Use the port Provision actually
 	// published on (res.Port) -- with auto-selection waPortFlag is 0.
@@ -436,9 +511,11 @@ func runWhatsAppDown(cmd *cobra.Command, args []string) error {
 	fmt.Println("--- 🛑 Stopping WhatsApp bridge ---")
 	// Must use the SAME `-p` project the stack was brought up under, otherwise
 	// compose targets a different (empty) project and the containers survive.
-	dc := exec.Command("docker", "compose", "-p", whatsapp.ProjectName(servicesDir),
-		"-f", composePath, "--env-file", whatsapp.EnvPath(servicesDir), "down")
-	out, err := dc.CombinedOutput()
+	// Left UNSCOPED (no service argument) on purpose: `down` should take the
+	// Postgres sidecar with it, and compose limits `down` to the services of the
+	// loaded -f file, so the sibling modules sharing this project are untouched.
+	out, err := runBridgeCompose(context.Background(),
+		bridgeComposeArgs(whatsapp.ProjectName(servicesDir), composePath, whatsapp.EnvPath(servicesDir), "down")...)
 	if err != nil {
 		return fmt.Errorf("docker compose down failed:\n%s", strings.TrimSpace(string(out)))
 	}
@@ -446,7 +523,8 @@ func runWhatsAppDown(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// composeUp runs `docker compose -p <project> -f <compose> --env-file <env> up -d`.
+// bridgeComposeUp runs `docker compose -p <project> -f <compose> --env-file <env>
+// up -d bridge`.
 //
 // The explicit `-p <project>` (whatsapp.ProjectName(servicesDir)) is load-bearing:
 // the module compose no longer hardcodes `container_name`, so compose derives each
@@ -459,10 +537,13 @@ func runWhatsAppDown(cmd *cobra.Command, args []string) error {
 // It runs under ctx so a wedged `docker compose up` (e.g. pulling an image from an
 // unreachable registry) fails fast with a bounded, descriptive error instead of
 // hanging the caller (aceteam-ai/citadel-cli#436 Landmine 2).
-func composeUp(ctx context.Context, project, composePath, envPath string) error {
-	dc := exec.CommandContext(ctx, "docker", "compose", "-p", project,
-		"-f", composePath, "--env-file", envPath, "up", "-d")
-	out, err := dc.CombinedOutput()
+func bridgeComposeUp(ctx context.Context, project, composePath, envPath string) error {
+	// Scope to the bridge service. `db` still comes up: the compose declares
+	// `depends_on: db: {condition: service_healthy}`, so compose starts and waits
+	// on it. Naming the service keeps this invocation from ever acting on the
+	// sibling modules that share the `services` compose project.
+	out, err := runBridgeCompose(ctx, bridgeComposeArgs(project, composePath, envPath,
+		"up", "-d", whatsapp.BridgeService)...)
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return fmt.Errorf("docker compose up timed out after %s (is the image registry reachable and is Docker running? check with 'docker info'):\n%s",
@@ -471,6 +552,67 @@ func composeUp(ctx context.Context, project, composePath, envPath string) error 
 		return fmt.Errorf("docker compose up failed:\n%s\n   Hint: is Docker running? Check with 'docker info'", strings.TrimSpace(string(out)))
 	}
 	return nil
+}
+
+// bridgeComposePull refreshes the bridge image from the registry (`docker compose
+// ... pull bridge`), the step whose absence made an upgrade impossible (#718).
+//
+// It is scoped to the `bridge` service and deliberately does NOT pass
+// `--include-deps`: an unscoped pull would also refresh `postgres:16-alpine`, and
+// if that tag has moved the following `up` recreates the Postgres sidecar that
+// holds the Baileys auth state. That is gratuitous risk for a bridge upgrade.
+//
+// `--ignore-pull-failures` is likewise deliberately NOT used: it makes compose
+// exit 0 on a failed pull, which would destroy the very signal this change
+// exists to surface. The failure is handled by the caller instead
+// (startBridgeStack), which records it and proceeds with the cached image.
+func bridgeComposePull(ctx context.Context, project, composePath, envPath string) error {
+	out, err := runBridgeCompose(ctx, bridgeComposeArgs(project, composePath, envPath,
+		"pull", whatsapp.BridgeService)...)
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("docker compose pull timed out after %s (is the image registry reachable? check with 'docker info' and, for the private bridge image, 'docker login ghcr.io'):\n%s",
+				deployTimeout, strings.TrimSpace(string(out)))
+		}
+		return fmt.Errorf("docker compose pull failed (is the image registry reachable and is this node logged in? the bridge image is private -- try 'docker login ghcr.io'):\n%s",
+			strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// bridgeComposeArgs builds the argv for a docker compose invocation against the bridge
+// stack. Every bridge compose call must carry the same `-p <project> -f <compose>
+// --env-file <env>` triple: the project keeps up/pull/ps/down in agreement, and
+// the env file carries ADMIN_API_KEY, which the compose file interpolates with
+// `:?` (so even `pull` fails to parse without it).
+func bridgeComposeArgs(project, composePath, envPath string, rest ...string) []string {
+	args := []string{"compose", "-p", project, "-f", composePath, "--env-file", envPath}
+	return append(args, rest...)
+}
+
+// bridgeComposeEnv is the environment for bridge compose subprocesses. It does
+// NOT reuse cmd/service.go's composeEnv: that one injects the citadel-owned
+// host-port and workspace vars the embedded inference composes guard with `:?`,
+// none of which the bridge compose declares.
+//
+// COMPOSE_IGNORE_ORPHANS silences the orphan warning. The bridge shares the
+// `services` compose project with every other module on the node (citadel-tei,
+// citadel-unlimited-ocr, and friends, each from its own sibling .yml), and
+// compose computes orphans from the services of the LOADED file -- so naming the
+// `bridge` service on the command line does not suppress it. Never pass
+// `--remove-orphans` here: in this shared project it would delete those modules.
+func bridgeComposeEnv() []string {
+	return append(os.Environ(), "COMPOSE_IGNORE_ORPHANS=true")
+}
+
+// runBridgeCompose executes `docker <args...>` and returns its combined output.
+// It is a package-level var (the same seam as internal/catalog's
+// runCosignVerify) so tests can assert the exact argv -- including that a pull
+// precedes the up -- without a Docker daemon.
+var runBridgeCompose = func(ctx context.Context, args ...string) ([]byte, error) {
+	dc := exec.CommandContext(ctx, "docker", args...)
+	dc.Env = bridgeComposeEnv()
+	return dc.CombinedOutput()
 }
 
 // bridgeContainerRunning reports whether the bridge app container of the given
@@ -511,6 +653,46 @@ func bridgeContainerID(ctx context.Context, project string) (string, error) {
 	return "", nil
 }
 
+// bridgeImageIDForNode reports the docker image ID (sha256:...) the bridge
+// container is CURRENTLY running, or "" when the bridge is not running, Docker
+// is unavailable, or the node config cannot be resolved.
+//
+// It reads the RUNNING CONTAINER's image (`docker inspect {{.Image}}`), NOT the
+// local `:latest` tag. That distinction is the whole point: after a pull the tag
+// already resolves to the new image while the container keeps running the old one
+// until compose recreates it, so a tag-derived value would claim an upgrade that
+// never happened (aceteam-ai/citadel-cli#718).
+//
+// Best-effort by contract: every failure returns "", which Provision reads as
+// "unknown" and never as "upgraded".
+func bridgeImageIDForNode() string {
+	servicesDir, err := servicesDirForNode()
+	if err != nil {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	id, err := bridgeContainerID(ctx, whatsapp.ProjectName(servicesDir))
+	if err != nil || id == "" {
+		return ""
+	}
+	out, err := exec.CommandContext(ctx, "docker", "inspect", "--format", "{{.Image}}", id).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// shortImageID trims a docker image ID to the 12-hex-char form docker itself
+// prints, for human-facing output. Non-sha256 or short values pass through.
+func shortImageID(id string) string {
+	trimmed := strings.TrimPrefix(id, "sha256:")
+	if len(trimmed) > 12 {
+		return trimmed[:12]
+	}
+	return trimmed
+}
+
 // containerRunning reports whether a container (by name or ID) is in the running
 // state.
 func containerRunning(nameOrID string) bool {
@@ -530,6 +712,23 @@ func portFromEnv(env map[string]string) int {
 		}
 	}
 	return whatsapp.DefaultPort
+}
+
+// printImageOutcome reports whether the deploy actually moved the bridge onto a
+// new image. Before #718 a re-run on a stale image was indistinguishable from a
+// real upgrade -- both printed the same success -- so the no-op case is stated
+// explicitly rather than left silent.
+func printImageOutcome(res *whatsapp.ProvisionResult) {
+	switch {
+	case res.Upgraded:
+		fmt.Printf("   - bridge image upgraded: %s -> %s\n",
+			shortImageID(res.ImageIDBefore), shortImageID(res.ImageIDAfter))
+	case res.ImagePullError != "":
+		fmt.Fprintf(os.Stderr, "   ⚠️ bridge image NOT refreshed (%s); it is running the locally cached image %s\n",
+			res.ImagePullError, shortImageID(res.ImageIDAfter))
+	case res.ImageIDBefore != "" && res.ImageIDAfter != "":
+		fmt.Printf("   - bridge image unchanged (%s); already up to date\n", shortImageID(res.ImageIDAfter))
+	}
 }
 
 // printConnectDetails prints the api_url + api_key and the whatsapp_connect hint.

--- a/cmd/whatsapp_compose_test.go
+++ b/cmd/whatsapp_compose_test.go
@@ -1,0 +1,178 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// The bug in aceteam-ai/citadel-cli#718 was a missing argv: `docker compose ...
+// up -d` with no pull, against a floating `:latest` tag, is a no-op on an image
+// that is already present locally -- so a provisioned bridge could never be
+// upgraded, and the provision reported success anyway. These tests therefore
+// assert the argv itself, through the runBridgeCompose seam, without Docker.
+
+// recordCompose swaps runBridgeCompose for a recorder and restores it on
+// cleanup. errFor lets a test fail a specific subcommand (matched on the first
+// non-flag word after the -p/-f/--env-file preamble).
+func recordCompose(t *testing.T, errFor map[string]error) *[][]string {
+	t.Helper()
+	prev := runBridgeCompose
+	var calls [][]string
+	runBridgeCompose = func(ctx context.Context, args ...string) ([]byte, error) {
+		calls = append(calls, args)
+		if err, ok := errFor[composeSubcommand(args)]; ok {
+			return []byte("boom"), err
+		}
+		return []byte(""), nil
+	}
+	t.Cleanup(func() { runBridgeCompose = prev })
+	return &calls
+}
+
+// composeSubcommand extracts the compose subcommand ("pull", "up", "down") from
+// a recorded argv.
+func composeSubcommand(args []string) string {
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "compose", "-d":
+			continue
+		case "-p", "-f", "--env-file":
+			i++ // skip the flag's value
+			continue
+		default:
+			return args[i]
+		}
+	}
+	return ""
+}
+
+func TestBridgeComposeArgsCarryProjectFileAndEnv(t *testing.T) {
+	got := bridgeComposeArgs("services", "/n/services/whatsapp-bridge.yml", "/n/services/whatsapp-bridge.env", "pull", "bridge")
+	want := []string{
+		"compose", "-p", "services",
+		"-f", "/n/services/whatsapp-bridge.yml",
+		"--env-file", "/n/services/whatsapp-bridge.env",
+		"pull", "bridge",
+	}
+	if strings.Join(got, " ") != strings.Join(want, " ") {
+		t.Errorf("argv = %v\nwant  %v", got, want)
+	}
+}
+
+// TestStartBridgeStackPullsBeforeUp is the regression test for #718: a pull must
+// precede the up, and both must name the `bridge` service.
+func TestStartBridgeStackPullsBeforeUp(t *testing.T) {
+	calls := recordCompose(t, nil)
+	report := &deployReport{}
+
+	if err := startBridgeStack(context.Background(), "services", "/n/wa.yml", "/n/wa.env", report); err != nil {
+		t.Fatalf("startBridgeStack() error = %v", err)
+	}
+	if len(*calls) != 2 {
+		t.Fatalf("compose invocations = %d (%v), want 2 (pull then up)", len(*calls), *calls)
+	}
+
+	pull, up := (*calls)[0], (*calls)[1]
+	if composeSubcommand(pull) != "pull" {
+		t.Errorf("first invocation = %v, want the image pull FIRST (an up-only deploy is the #718 bug)", pull)
+	}
+	if composeSubcommand(up) != "up" {
+		t.Errorf("second invocation = %v, want the up", up)
+	}
+	if pull[len(pull)-1] != "bridge" {
+		t.Errorf("pull argv = %v, want it scoped to the bridge service", pull)
+	}
+	// Scoping the pull matters: an unscoped pull would also refresh
+	// postgres:16-alpine and let the following up recreate the sidecar holding
+	// the Baileys auth state.
+	for _, a := range pull {
+		if a == "--include-deps" {
+			t.Errorf("pull argv = %v, must NOT pull dependencies (the Postgres sidecar)", pull)
+		}
+		// --ignore-pull-failures would make compose exit 0 on a failed pull,
+		// destroying the signal this change exists to surface.
+		if a == "--ignore-pull-failures" {
+			t.Errorf("pull argv = %v, must NOT swallow pull failures", pull)
+		}
+	}
+	if up[len(up)-1] != "bridge" {
+		t.Errorf("up argv = %v, want it scoped to the bridge service", up)
+	}
+	for _, a := range up {
+		if a == "--remove-orphans" {
+			t.Fatalf("up argv = %v, must NEVER pass --remove-orphans: the `services` project is shared and it would delete the node's other modules", up)
+		}
+	}
+	if report.PullError() != "" {
+		t.Errorf("PullError = %q, want empty on a successful pull", report.PullError())
+	}
+}
+
+// TestStartBridgeStackPullFailureIsNonFatalButRecorded: a node without
+// `docker login` for the private registry must still start its cached image
+// (no regression), while the failure stays visible in the result.
+func TestStartBridgeStackPullFailureIsNonFatalButRecorded(t *testing.T) {
+	calls := recordCompose(t, map[string]error{"pull": errors.New("exit status 1")})
+	report := &deployReport{}
+
+	if err := startBridgeStack(context.Background(), "services", "/n/wa.yml", "/n/wa.env", report); err != nil {
+		t.Fatalf("startBridgeStack() error = %v, want a pull failure to be non-fatal", err)
+	}
+	if len(*calls) != 2 {
+		t.Fatalf("compose invocations = %d, want the up to still run after a failed pull", len(*calls))
+	}
+	pullErr := report.PullError()
+	if pullErr == "" {
+		t.Fatal("PullError = \"\", want the failure recorded (a silent failed pull is the false-green #718 is about)")
+	}
+	if !strings.Contains(pullErr, "docker login") {
+		t.Errorf("PullError = %q, want it to keep the registry-reachability hint", pullErr)
+	}
+}
+
+// TestStartBridgeStackUpFailureIsFatal: only the pull is best-effort. A failed
+// `up` must still fail the deploy.
+func TestStartBridgeStackUpFailureIsFatal(t *testing.T) {
+	recordCompose(t, map[string]error{"up": errors.New("exit status 1")})
+
+	err := startBridgeStack(context.Background(), "services", "/n/wa.yml", "/n/wa.env", &deployReport{})
+	if err == nil {
+		t.Fatal("startBridgeStack() error = nil, want the up failure to be fatal")
+	}
+	if !strings.Contains(err.Error(), "docker info") {
+		t.Errorf("error = %q, want it to keep the 'is Docker running' hint", err)
+	}
+}
+
+// TestBridgeComposeEnvIgnoresOrphans: the bridge shares the `services` compose
+// project with every other module on the node, so compose reports those siblings
+// as orphans on every up. Naming the `bridge` service does not suppress that
+// (compose derives orphans from the loaded file's services), so the env var is
+// what silences it -- and --remove-orphans must never be the answer.
+func TestBridgeComposeEnvIgnoresOrphans(t *testing.T) {
+	found := false
+	for _, kv := range bridgeComposeEnv() {
+		if kv == "COMPOSE_IGNORE_ORPHANS=true" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("bridgeComposeEnv() must set COMPOSE_IGNORE_ORPHANS=true")
+	}
+}
+
+func TestShortImageID(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"sha256:af88f094aabbccddeeff", "af88f094aabb"},
+		{"af88f094aabbccddeeff", "af88f094aabb"},
+		{"sha256:short", "short"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := shortImageID(tt.in); got != tt.want {
+			t.Errorf("shortImageID(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/whatsapp/provision.go
+++ b/internal/whatsapp/provision.go
@@ -81,6 +81,12 @@ type ProvisionDeps struct {
 	// container still runs the old one until it is recreated, so a tag-derived
 	// value would report an upgrade that did not happen. Nil leaves the image
 	// fields empty and Upgraded false (never a fabricated "upgraded").
+	//
+	// A false "unknown" is possible and accepted: the post-deploy sample races a
+	// container that compose has only just started, so it can legitimately read
+	// "" on a real upgrade. That direction is safe (Upgraded stays false and the
+	// result says the image is unknown); the opposite -- claiming an upgrade that
+	// did not happen -- is the failure this whole field exists to prevent.
 	BridgeImageID func() string
 
 	// ImagePullError returns the error text of the image pull DeployCompose

--- a/internal/whatsapp/provision.go
+++ b/internal/whatsapp/provision.go
@@ -60,11 +60,37 @@ type ProvisionDeps struct {
 	ServicesDir func() (string, error)
 
 	// DeployCompose ensures the bridge compose is materialized into servicesDir
-	// and started (docker compose up -d) with the given env. It mirrors the
-	// resolve-source + write-compose + composeUp steps of `citadel whatsapp up`.
-	// It must fail fast (never hang) when Docker is unavailable or the private
-	// module repo cannot be cloned for lack of credentials.
+	// and started (docker compose pull + up -d) with the given env. It mirrors the
+	// resolve-source + write-compose + composePull + composeUp steps of
+	// `citadel whatsapp up`. It must fail fast (never hang) when Docker is
+	// unavailable or the private module repo cannot be cloned for lack of
+	// credentials.
+	//
+	// It MUST refresh the bridge image before starting. The compose pins a
+	// floating `:latest` tag, so a bare `up -d` with that tag already present
+	// locally is a no-op and a provisioned bridge can never be upgraded
+	// (aceteam-ai/citadel-cli#718).
 	DeployCompose func(servicesDir string, env map[string]string) error
+
+	// BridgeImageID reports the docker image ID (sha256:...) the bridge container
+	// is CURRENTLY running, or "" when the bridge is not running or Docker is
+	// unavailable. Provision samples it immediately before and immediately after
+	// DeployCompose so the result can distinguish a real upgrade from a no-op
+	// re-provision (#718). It must read the RUNNING CONTAINER's image, not the
+	// local tag: after a pull the tag already points at the new image while the
+	// container still runs the old one until it is recreated, so a tag-derived
+	// value would report an upgrade that did not happen. Nil leaves the image
+	// fields empty and Upgraded false (never a fabricated "upgraded").
+	BridgeImageID func() string
+
+	// ImagePullError returns the error text of the image pull DeployCompose
+	// attempted, or "" when it succeeded (or was not attempted). A pull failure
+	// is deliberately NOT fatal -- a node without `docker login` for the private
+	// registry can still run its locally cached image, and failing would regress
+	// re-provisions that work today -- but it MUST be visible, because a pull
+	// that silently did nothing is exactly the false-green #718 is about. Nil
+	// leaves ProvisionResult.ImagePullError empty.
+	ImagePullError func() string
 
 	// NewBridgeClient builds a BridgeClient for the locally running bridge at the
 	// given loopback port using the admin key.
@@ -164,6 +190,26 @@ type ProvisionResult struct {
 	// from on rotation: http://<mesh-ip>:<status-port>/gateway-cert.pem. Empty when
 	// the node is off-mesh or the status server's port is unknown.
 	CertRefreshURL string
+	// ImageIDBefore is the docker image ID the bridge container was running before
+	// the deploy, or "" when the bridge was not running (a first deploy) or the
+	// image could not be read. Together with ImageIDAfter it makes the outcome
+	// legible: an `already_linked` result on an unchanged image is a no-op, not an
+	// upgrade (aceteam-ai/citadel-cli#718).
+	ImageIDBefore string
+	// ImageIDAfter is the docker image ID the bridge container is running after the
+	// deploy, or "" when it could not be read.
+	ImageIDAfter string
+	// Upgraded is true only when BOTH image IDs were readable AND they differ --
+	// i.e. the deploy actually moved the bridge onto a new image. A first deploy
+	// (no "before" container) and an unreadable image both report false: an
+	// unknown is never reported as an upgrade.
+	Upgraded bool
+	// ImagePullError is the error text of the pre-deploy image pull, or "" when it
+	// succeeded or was not attempted. Non-empty means the bridge is running the
+	// locally cached image and an upgrade could NOT have happened -- the provision
+	// still succeeds (the bridge is up and linked), but the caller must not read
+	// that success as "running the latest image".
+	ImagePullError string
 }
 
 // persistedBridgePort returns the bridge's previously-persisted BRIDGE_PORT from
@@ -281,6 +327,15 @@ func Provision(ctx context.Context, req ProvisionRequest, deps ProvisionDeps) (*
 	// treat a bind-collision as recoverable: re-select a fresh free port and
 	// retry a bounded number of times. An explicit operator override is never
 	// silently moved -- its bind error surfaces as-is.
+	// Sample the image the bridge is running BEFORE the deploy. Paired with the
+	// post-deploy sample below this is what lets a caller tell a real upgrade from
+	// a no-op `up -d` (aceteam-ai/citadel-cli#718). Best-effort: "" (bridge not
+	// running / Docker unreadable) simply means "unknown", never "upgraded".
+	imageIDBefore := ""
+	if deps.BridgeImageID != nil {
+		imageIDBefore = deps.BridgeImageID()
+	}
+
 	const maxDeployAttempts = 4
 	autoSelected := req.Port <= 0
 	for attempt := 1; ; attempt++ {
@@ -301,6 +356,27 @@ func Provision(ctx context.Context, req ProvisionRequest, deps ProvisionDeps) (*
 			return nil, fmt.Errorf("retry after host-port collision on %d: %w", port, serr)
 		}
 		port = next
+	}
+
+	// Sample the image again now the deploy has returned. Compare on the CONTAINER's
+	// image, so "upgraded" means the container was actually recreated onto a new
+	// image -- not merely that a newer tag was pulled into the local store.
+	imageIDAfter := ""
+	if deps.BridgeImageID != nil {
+		imageIDAfter = deps.BridgeImageID()
+	}
+	upgraded := imageIDBefore != "" && imageIDAfter != "" && imageIDBefore != imageIDAfter
+	pullErr := ""
+	if deps.ImagePullError != nil {
+		pullErr = deps.ImagePullError()
+	}
+	switch {
+	case pullErr != "":
+		log("warning: could not refresh the bridge image (%s); the bridge is running its locally cached image, so this provision could NOT have upgraded it", pullErr)
+	case upgraded:
+		log("bridge image upgraded: %s -> %s", imageIDBefore, imageIDAfter)
+	case imageIDAfter != "" && imageIDBefore != "":
+		log("bridge image unchanged (%s); already up to date", imageIDAfter)
 	}
 
 	// Recompute the mesh api_url from the port we actually published on (a
@@ -372,10 +448,14 @@ func Provision(ctx context.Context, req ProvisionRequest, deps ProvisionDeps) (*
 	}
 
 	result := &ProvisionResult{
-		APIURL: apiURL,
-		APIKey: tenantKey,
-		Tenant: tenant,
-		Port:   port,
+		APIURL:         apiURL,
+		APIKey:         tenantKey,
+		Tenant:         tenant,
+		Port:           port,
+		ImageIDBefore:  imageIDBefore,
+		ImageIDAfter:   imageIDAfter,
+		Upgraded:       upgraded,
+		ImagePullError: pullErr,
 	}
 	// Publish the gateway cert (so the backend can trust the https api_url) and the
 	// plaintext refresh URL (so it re-fetches on rotation). Both deps are optional:

--- a/internal/whatsapp/provision_test.go
+++ b/internal/whatsapp/provision_test.go
@@ -361,3 +361,173 @@ func TestProvisionCertFieldsEmptyOffMeshOrNoTLS(t *testing.T) {
 		t.Errorf("cert fields should be empty when deps are nil, got pem=%q url=%q", res2.GatewayCertPEM, res2.CertRefreshURL)
 	}
 }
+
+// --- image upgrade legibility (aceteam-ai/citadel-cli#718) -------------------
+
+// scriptedImageID returns a BridgeImageID stub that yields the given values in
+// order (the first call is the pre-deploy sample, the second the post-deploy
+// one) and records how many times it was called.
+func scriptedImageID(values ...string) (func() string, *int) {
+	calls := 0
+	return func() string {
+		v := ""
+		if calls < len(values) {
+			v = values[calls]
+		}
+		calls++
+		return v
+	}, &calls
+}
+
+// TestProvisionImageUpgradeDetection pins the upgraded-vs-unchanged contract:
+// `already_linked` must stop being indistinguishable from a real upgrade. An
+// UNKNOWN image (bridge not previously running, Docker unreadable, dep absent)
+// must never be reported as an upgrade.
+func TestProvisionImageUpgradeDetection(t *testing.T) {
+	tests := []struct {
+		name         string
+		images       []string // successive BridgeImageID() results; nil = no dep
+		nilDep       bool
+		wantUpgraded bool
+		wantBefore   string
+		wantAfter    string
+	}{
+		{
+			name:         "recreated onto a new image",
+			images:       []string{"sha256:af88f094", "sha256:8fc94272"},
+			wantUpgraded: true,
+			wantBefore:   "sha256:af88f094",
+			wantAfter:    "sha256:8fc94272",
+		},
+		{
+			name:         "no-op re-provision on the same image",
+			images:       []string{"sha256:af88f094", "sha256:af88f094"},
+			wantUpgraded: false,
+			wantBefore:   "sha256:af88f094",
+			wantAfter:    "sha256:af88f094",
+		},
+		{
+			name:         "first deploy has no before image",
+			images:       []string{"", "sha256:8fc94272"},
+			wantUpgraded: false,
+			wantBefore:   "",
+			wantAfter:    "sha256:8fc94272",
+		},
+		{
+			name:         "unreadable after image is unknown, not an upgrade",
+			images:       []string{"sha256:af88f094", ""},
+			wantUpgraded: false,
+			wantBefore:   "sha256:af88f094",
+			wantAfter:    "",
+		},
+		{
+			name:         "nil dep degrades to unknown",
+			nilDep:       true,
+			wantUpgraded: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bridge := &fakeBridge{health: &Health{LoggedIn: true}}
+			deps, _ := baseDeps(t, bridge)
+			var calls *int
+			if !tt.nilDep {
+				deps.BridgeImageID, calls = scriptedImageID(tt.images...)
+			}
+
+			res, err := Provision(context.Background(), ProvisionRequest{}, deps)
+			if err != nil {
+				t.Fatalf("Provision() error = %v", err)
+			}
+			if res.Upgraded != tt.wantUpgraded {
+				t.Errorf("Upgraded = %v, want %v", res.Upgraded, tt.wantUpgraded)
+			}
+			if res.ImageIDBefore != tt.wantBefore {
+				t.Errorf("ImageIDBefore = %q, want %q", res.ImageIDBefore, tt.wantBefore)
+			}
+			if res.ImageIDAfter != tt.wantAfter {
+				t.Errorf("ImageIDAfter = %q, want %q", res.ImageIDAfter, tt.wantAfter)
+			}
+			// The already-linked path must still carry the image fields: that
+			// combination (already_linked + unchanged image) IS the false-green.
+			if !res.AlreadyLinked {
+				t.Error("AlreadyLinked = false, want true for this fixture")
+			}
+			if calls != nil && *calls != 2 {
+				t.Errorf("BridgeImageID called %d times, want exactly 2 (before + after deploy)", *calls)
+			}
+		})
+	}
+}
+
+// TestProvisionSamplesImageAroundDeploy pins the ORDER: the "before" sample must
+// be taken before DeployCompose runs and the "after" sample after it returns.
+// Sampling both afterwards would always report "unchanged" and re-hide the bug.
+func TestProvisionSamplesImageAroundDeploy(t *testing.T) {
+	bridge := &fakeBridge{health: &Health{LoggedIn: true}}
+	deps, _ := baseDeps(t, bridge)
+
+	var order []string
+	deps.DeployCompose = func(servicesDir string, env map[string]string) error {
+		order = append(order, "deploy")
+		return nil
+	}
+	deps.BridgeImageID = func() string {
+		order = append(order, "image")
+		return ""
+	}
+
+	if _, err := Provision(context.Background(), ProvisionRequest{}, deps); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+	want := []string{"image", "deploy", "image"}
+	if len(order) != len(want) {
+		t.Fatalf("call order = %v, want %v", order, want)
+	}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Fatalf("call order = %v, want %v", order, want)
+		}
+	}
+}
+
+// TestProvisionSurfacesImagePullError verifies a failed image pull does NOT fail
+// the provision (the cached image still serves) but IS reported, so a caller can
+// never read "provisioned" as "running the latest image".
+func TestProvisionSurfacesImagePullError(t *testing.T) {
+	bridge := &fakeBridge{health: &Health{LoggedIn: true}}
+	deps, deployed := baseDeps(t, bridge)
+	deps.BridgeImageID = func() string { return "sha256:af88f094" }
+	deps.ImagePullError = func() string { return "docker compose pull failed: unauthorized" }
+
+	res, err := Provision(context.Background(), ProvisionRequest{}, deps)
+	if err != nil {
+		t.Fatalf("Provision() error = %v, want the provision to survive a pull failure", err)
+	}
+	if !*deployed {
+		t.Error("expected DeployCompose to still run after a pull failure")
+	}
+	if res.ImagePullError != "docker compose pull failed: unauthorized" {
+		t.Errorf("ImagePullError = %q, want the injected pull error", res.ImagePullError)
+	}
+	if res.Upgraded {
+		t.Error("Upgraded = true, want false: a failed pull cannot have upgraded anything")
+	}
+}
+
+// TestProvisionNoPullErrorWhenPullSucceeded is the negative half: an empty
+// ImagePullError must not be turned into a spurious warning field.
+func TestProvisionNoPullErrorWhenPullSucceeded(t *testing.T) {
+	bridge := &fakeBridge{health: &Health{LoggedIn: true}}
+	deps, _ := baseDeps(t, bridge)
+	deps.ImagePullError = func() string { return "" }
+
+	res, err := Provision(context.Background(), ProvisionRequest{}, deps)
+	if err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+	if res.ImagePullError != "" {
+		t.Errorf("ImagePullError = %q, want empty", res.ImagePullError)
+	}
+}

--- a/internal/worker/whatsapp_provision.go
+++ b/internal/worker/whatsapp_provision.go
@@ -24,10 +24,25 @@
 //	  "qr":      "data:image/png;base64,...",  // "" when already linked
 //	  "tenant":  "<name>",
 //	  "status":  "provisioned" | "already_linked",
+//	  // Upgrade legibility (#718), always present:
+//	  "upgraded": true,                        // the deploy moved the bridge onto a new image
+//	  "image_id_before": "sha256:...",         // omitted when unknown (first deploy / unreadable)
+//	  "image_id_after":  "sha256:...",         // omitted when unknown
+//	  "image_pull_error": "...",               // omitted when the pull succeeded
 //	  // Optional cert-publish contract (#448), omitted when off-mesh / no-TLS:
 //	  "gateway_cert_pem": "-----BEGIN CERTIFICATE-----...", // trust to reach api_url
 //	  "cert_refresh_url": "http://<mesh-ip>:<status-port>/gateway-cert.pem"
 //	}
+//
+// # Upgrade vs. no-op (aceteam-ai/citadel-cli#718)
+//
+// `status` deliberately keeps its two original values. The aceteam backend
+// branches on `status == "already_linked"` by equality, so a third value would
+// silently fall through to the generic branch. The upgrade signal is carried
+// additively instead: read `upgraded` (and the two image IDs) alongside `status`.
+// A two-second `already_linked` with `upgraded: false` and identical image IDs is
+// a no-op re-provision, not an upgrade -- and `image_pull_error` says when the
+// node could not even reach the registry to try.
 //
 // # Privilege gating
 //
@@ -142,6 +157,23 @@ func (h *WhatsAppProvisionHandler) Execute(ctx context.Context, job *Job, stream
 		"qr":      qrDataURL,
 		"tenant":  res.Tenant,
 		"status":  status,
+		// Always present so a caller can tell an upgrade from a no-op without
+		// having to know whether the node is new enough to report image IDs.
+		"upgraded": res.Upgraded,
+	}
+	// Image identity is omitted when unknown (bridge not previously running, or
+	// Docker unreadable) rather than reported as an empty string that could be
+	// mistaken for "no image".
+	if res.ImageIDBefore != "" {
+		doc["image_id_before"] = res.ImageIDBefore
+	}
+	if res.ImageIDAfter != "" {
+		doc["image_id_after"] = res.ImageIDAfter
+	}
+	// A failed pull is not fatal (the cached image still runs), but it means this
+	// provision CANNOT have upgraded anything -- say so.
+	if res.ImagePullError != "" {
+		doc["image_pull_error"] = res.ImagePullError
 	}
 	// Optional cert-publish contract (aceteam-ai/citadel-cli#448): hand the backend
 	// the gateway leaf cert to trust (the api_url is an https gateway route) plus

--- a/internal/worker/whatsapp_provision_test.go
+++ b/internal/worker/whatsapp_provision_test.go
@@ -263,3 +263,94 @@ func TestWhatsAppProvisionOmitsEmptyCertFields(t *testing.T) {
 		t.Errorf("cert_refresh_url must be omitted when empty, got %v", doc["cert_refresh_url"])
 	}
 }
+
+// TestWhatsAppProvisionReportsUpgrade verifies the #718 contract: an upgrade and
+// a no-op re-provision must be distinguishable in the returned document. `status`
+// keeps its original values (the aceteam backend branches on
+// `status == "already_linked"` by equality), so the signal rides on `upgraded`
+// plus the two image IDs.
+func TestWhatsAppProvisionReportsUpgrade(t *testing.T) {
+	h := NewWhatsAppProvisionHandler(WhatsAppProvisionConfig{
+		Provision: func(ctx context.Context, req whatsapp.ProvisionRequest) (*whatsapp.ProvisionResult, error) {
+			return &whatsapp.ProvisionResult{
+				APIURL: "u", APIKey: "k", Tenant: "default", AlreadyLinked: true,
+				ImageIDBefore: "sha256:af88f094", ImageIDAfter: "sha256:8fc94272", Upgraded: true,
+			}, nil
+		},
+	})
+	res, err := h.Execute(context.Background(), whatsappJob(perNodeQueue, nil), &NoOpStreamWriter{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	doc := decodeOutput(t, res)
+	if doc["status"] != "already_linked" {
+		t.Errorf("status = %v, want already_linked (the value the backend equality-checks)", doc["status"])
+	}
+	if doc["upgraded"] != true {
+		t.Errorf("upgraded = %v, want true", doc["upgraded"])
+	}
+	if doc["image_id_before"] != "sha256:af88f094" || doc["image_id_after"] != "sha256:8fc94272" {
+		t.Errorf("image ids = %v / %v, want the before/after pair", doc["image_id_before"], doc["image_id_after"])
+	}
+	if _, ok := doc["image_pull_error"]; ok {
+		t.Errorf("image_pull_error present on a successful pull: %v", doc["image_pull_error"])
+	}
+}
+
+// TestWhatsAppProvisionReportsNoOp is the other half: the exact scenario from the
+// issue -- a two-second already_linked on an unchanged image -- must now say so.
+func TestWhatsAppProvisionReportsNoOp(t *testing.T) {
+	h := NewWhatsAppProvisionHandler(WhatsAppProvisionConfig{
+		Provision: func(ctx context.Context, req whatsapp.ProvisionRequest) (*whatsapp.ProvisionResult, error) {
+			return &whatsapp.ProvisionResult{
+				APIURL: "u", APIKey: "k", Tenant: "default", AlreadyLinked: true,
+				ImageIDBefore: "sha256:af88f094", ImageIDAfter: "sha256:af88f094",
+			}, nil
+		},
+	})
+	res, err := h.Execute(context.Background(), whatsappJob(perNodeQueue, nil), &NoOpStreamWriter{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	doc := decodeOutput(t, res)
+	if doc["upgraded"] != false {
+		t.Errorf("upgraded = %v, want false for an unchanged image", doc["upgraded"])
+	}
+	if doc["image_id_before"] != doc["image_id_after"] {
+		t.Errorf("image ids should match on a no-op, got %v / %v", doc["image_id_before"], doc["image_id_after"])
+	}
+}
+
+// TestWhatsAppProvisionSurfacesPullError verifies a failed image pull rides the
+// contract (non-fatal, but never invisible), and that unknown image IDs are
+// omitted rather than emitted as empty strings.
+func TestWhatsAppProvisionSurfacesPullError(t *testing.T) {
+	h := NewWhatsAppProvisionHandler(WhatsAppProvisionConfig{
+		Provision: func(ctx context.Context, req whatsapp.ProvisionRequest) (*whatsapp.ProvisionResult, error) {
+			return &whatsapp.ProvisionResult{
+				APIURL: "u", APIKey: "k", Tenant: "default", QR: "2@payload",
+				ImagePullError: "docker compose pull failed: unauthorized",
+			}, nil
+		},
+	})
+	res, err := h.Execute(context.Background(), whatsappJob(perNodeQueue, nil), &NoOpStreamWriter{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Status != JobStatusSuccess {
+		t.Fatalf("status = %v, want success: a pull failure must not fail the provision", res.Status)
+	}
+	doc := decodeOutput(t, res)
+	if doc["image_pull_error"] != "docker compose pull failed: unauthorized" {
+		t.Errorf("image_pull_error = %v, want the pull error", doc["image_pull_error"])
+	}
+	if doc["upgraded"] != false {
+		t.Errorf("upgraded = %v, want false", doc["upgraded"])
+	}
+	if _, ok := doc["image_id_before"]; ok {
+		t.Errorf("image_id_before should be omitted when unknown, got %v", doc["image_id_before"])
+	}
+	if _, ok := doc["image_id_after"]; ok {
+		t.Errorf("image_id_after should be omitted when unknown, got %v", doc["image_id_after"])
+	}
+}


### PR DESCRIPTION
## Context

Closes #718. Hit for real shipping the media-metadata bridge upgrade: `whatsapp_provision` on node 1297 returned in two seconds with `status: already_linked` while the bridge was still on the Jul 29 image, so every WhatsApp voice note stayed invisible. Nothing in the response said so.

## Root cause

`composeUp` ran `docker compose -p <project> -f <file> --env-file <env> up -d` with **no pull**. The bridge compose pins the floating tag `ghcr.io/sunapi386/whatsapp-bridge:latest`; when that tag is already present locally, `up -d` sees an unchanged config and an unchanged image ID and does nothing. `Provision` then reached `VerifyReachable`, found the old bridge healthy and linked, and returned success. `DeployCompose` **is** always called (`internal/whatsapp/provision.go`), so this was not a skipped deploy: the deploy ran and correctly did nothing.

## On the premise

The issue asked whether the intended upgrade path is really some other command. It is not, but the module system is a separate story:

- The bridge is deliberately **not** in the node manifest and **not** in the module lockfile. `runWhatsAppUp` documents why (the generic `citadel run` start path runs `docker compose up` without an `--env-file`, and this stack hard-requires `ADMIN_API_KEY`). `citadel module update` / `MODULE_SET` therefore cannot reach it, and `whatsapp_provision` is in fact the only upgrade path there is, and it just could not upgrade.
- So the fix belongs here. The `fabric_node_modules_list` blank is a **separate root cause**, not fixed in this PR: `nodestate.BuildActualState` reports modules from the catalog lockfile, and the bridge deploy path never calls `catalog.UpsertLockEntry`. Bringing the bridge under module management is a design decision (it would change its lifecycle ownership), not a bug fix.

## Changes

**`cmd/whatsapp.go`**
- `startBridgeStack` pulls, then ups. Both inside the existing 150s `deployTimeout`, whose comment already says it is sized to include image pulls.
- The pull is scoped to the `bridge` service and deliberately passes **neither** `--include-deps` (an unscoped pull would refresh `postgres:16-alpine` and let the following `up` recreate the sidecar holding the Baileys auth state) **nor** `--ignore-pull-failures` (it makes compose exit 0 on failure, destroying the signal this PR exists to surface).
- A pull failure is **non-fatal but recorded**. The bridge image is private, so a node that never ran `docker login` would otherwise regress from "works" to "cannot provision". It is logged loudly and rides out through `deployReport` -> `ProvisionDeps.ImagePullError` -> `ProvisionResult.ImagePullError`.
- `bridgeImageIDForNode` reads the **running container's** image (`docker inspect {{.Image}}`), not the local tag. After a pull the tag already points at the new image while the container still runs the old one, so a tag-derived value would claim an upgrade that never happened.
- All bridge compose calls go through one argv builder and one runner var, scoped to the `bridge` service where correct and run with `COMPOSE_IGNORE_ORPHANS=true`. `--remove-orphans` is never emitted: the `services` project is shared by seven live modules on that node and it would delete them.

**`internal/whatsapp/provision.go`**
- New optional deps `BridgeImageID` and `ImagePullError`, following the existing `GatewayCertPEM` / `CertRefreshURL` convention (`func() string`, nil degrades to empty). Existing stubs compile untouched.
- `ProvisionResult` gains `ImageIDBefore`, `ImageIDAfter`, `Upgraded`, `ImagePullError`. `Upgraded` is true **only** when both IDs are known and differ: a first deploy and an unreadable image are "unknown", never "upgraded".

**`internal/worker/whatsapp_provision.go`**
- The document gains `upgraded` (always) plus `image_id_before` / `image_id_after` / `image_pull_error` (omitted when unknown).
- **`status` deliberately keeps its two values.** `aceteam/python-backend/routes/aceteam_mcp_whatsapp.py` branches on `status == "already_linked"` by equality, so an `already_linked_and_upgraded` value would silently fall into the generic branch of a repo this PR cannot change atomically. The upgrade signal is additive.

## The display half is NOT in this repo (read before closing #718)

`_finalize_provision` in `aceteam/python-backend/routes/aceteam_mcp_whatsapp.py` renders a fixed Job ID / Status / Node / Tenant table and reads none of the new keys. So until that changes, a node that just upgraded and one sitting on a stale image still produce the **identical** MCP response: the node now puts the truth on the wire, but nobody displays it. That is the operator-visible symptom #718 says stands either way.

Filed as aceteam-ai/aceteam#7378 (render `upgraded` / `image_pull_error` in all three success branches of `_finalize_provision`). #718 should not be considered fully closed until that lands.

## Deliberate non-goal

`force_recreate` passthrough (ask 4 in the issue, phrased as "consider"). It would need the `DeployCompose` signature change this PR avoids, and once the image ID actually changes compose recreates on its own, which removes most of the need for it.

## Testing

`go build ./...`, `go vet ./...`, `go test ./...` all pass locally (68 packages ok, 0 failures). No Docker is touched by any test: this node runs the live production bridge.

New tests:
- `cmd/whatsapp_compose_test.go` asserts the **argv** through the `runBridgeCompose` seam (the bug was a missing argv): pull precedes up, both are scoped to `bridge`, the pull carries neither `--include-deps` nor `--ignore-pull-failures`, the up never carries `--remove-orphans`, a pull failure is non-fatal but recorded with its registry hint, an up failure stays fatal, and the compose env sets `COMPOSE_IGNORE_ORPHANS`.
- `internal/whatsapp/provision_test.go` table-tests upgraded / unchanged / no-before-image / unreadable-after / nil-dep, pins that `BridgeImageID` is sampled exactly twice in the order `image, deploy, image` (sampling both after the deploy would always read "unchanged" and re-hide the bug), and covers the pull-error passthrough.
- `internal/worker/whatsapp_provision_test.go` covers the wire document for upgrade, no-op, and pull-failure.

Manual verification on a node (not run here, since this host runs the live bridge):

```
citadel whatsapp up          # expect "bridge image upgraded: <old> -> <new>" or "unchanged"
docker inspect --format '{{.Image}}' $(docker compose -p services ps -q bridge)
```

## Not verified

The `COMPOSE_IGNORE_ORPHANS` suppression is **inferred**, not verified: compose derives orphans from the loaded file's services, so naming `bridge` on the command line does not silence the warning, and the env var is the documented knob. Verifying it would have meant a compose invocation against the live shared `services` project, which was out of bounds. If v5.4.0 ignores the variable, an unrecognized env var is a harmless no-op and the warning simply remains cosmetic.
