### PR TITLE
fix(redisapi): serialize websocket writes with a dedicated mutex

### DIFF
--- a/internal/redisapi/websocket.go
+++ b/internal/redisapi/websocket.go
@@ -22,6 +22,20 @@ type WSClient struct {
 	connMu    sync.RWMutex
 	connected bool
 
+	// writeMu serializes gorilla "write methods" (WriteMessage,
+	// SetWriteDeadline) on conn. gorilla supports exactly ONE concurrent
+	// writer and panics with "concurrent write to websocket connection"
+	// otherwise, which kills the whole worker process (#720).
+	//
+	// It is deliberately NOT connMu: connMu guards the conn POINTER, is taken
+	// shared (RLock) by every reader, and is released before any write
+	// happens, so it serializes nothing on the wire. Keeping them separate
+	// also keeps pointer reads cheap while a slow write is in flight.
+	//
+	// Lock order: never acquire connMu while holding writeMu. sendMessage
+	// releases connMu before taking writeMu; Close takes connMu then writeMu.
+	writeMu sync.Mutex
+
 	// Message handlers
 	handlers   map[string]func(WSMessage)
 	handlersMu sync.RWMutex
@@ -415,11 +429,39 @@ func (c *WSClient) sendMessage(_ context.Context, msg WSMessage) error {
 
 	c.debug("ws: sending message type=%s", msg.Type)
 
-	if err := conn.WriteMessage(websocket.TextMessage, data); err != nil {
+	// Single-writer discipline (#720). Callers are genuinely concurrent: the
+	// heartbeat publisher ticks every 30s, job streaming publishes per chunk,
+	// the consume loop acks per job, and reconnect re-subscribes from its own
+	// goroutine. Without this lock they all enter WriteMessage at once.
+	c.writeMu.Lock()
+	err = conn.WriteMessage(websocket.TextMessage, data)
+	c.writeMu.Unlock()
+
+	if err != nil {
 		return fmt.Errorf("failed to send message: %w", err)
 	}
 
 	return nil
+}
+
+// closeWriteWait bounds both the close-handshake write and how long Close
+// waits for an in-flight write to finish before giving up on the handshake.
+const closeWriteWait = 2 * time.Second
+
+// tryLockWrite acquires writeMu, giving up after d. Close must not block
+// forever behind a wedged writer (see the deadline note in Close), so it needs
+// a bounded acquire rather than a plain Lock.
+func (c *WSClient) tryLockWrite(d time.Duration) bool {
+	deadline := time.Now().Add(d)
+	for {
+		if c.writeMu.TryLock() {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
 }
 
 // OnMessage registers a handler for a specific message type.
@@ -495,13 +537,26 @@ func (c *WSClient) Close() error {
 		// network change) it can block indefinitely. That stalls shutdown via
 		// chat.Client.Close() (issue #312). A short deadline makes the write
 		// fail fast; we then close the underlying TCP conn regardless.
-		_ = c.conn.SetWriteDeadline(time.Now().Add(2 * time.Second))
-		err := c.conn.WriteMessage(
-			websocket.CloseMessage,
-			websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
-		)
-		if err != nil {
-			c.debug("ws: error sending close message: %v", err)
+		//
+		// SetWriteDeadline is itself one of gorilla's write methods (it is a
+		// bare field assignment on the Conn), so it and the close frame both
+		// have to run under writeMu, otherwise shutdown races an in-flight
+		// sendMessage. The acquire is bounded so a wedged writer cannot
+		// reintroduce the #312 stall; if we cannot get the lock we skip the
+		// courtesy close frame entirely. Closing the connection is documented
+		// safe alongside any other method, and it unblocks the stuck writer.
+		if c.tryLockWrite(closeWriteWait) {
+			_ = c.conn.SetWriteDeadline(time.Now().Add(closeWriteWait))
+			err := c.conn.WriteMessage(
+				websocket.CloseMessage,
+				websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+			)
+			c.writeMu.Unlock()
+			if err != nil {
+				c.debug("ws: error sending close message: %v", err)
+			}
+		} else {
+			c.debug("ws: write in flight, closing without close handshake")
 		}
 		return c.conn.Close()
 	}

--- a/internal/redisapi/websocket.go
+++ b/internal/redisapi/websocket.go
@@ -36,6 +36,12 @@ type WSClient struct {
 	// releases connMu before taking writeMu; Close takes connMu then writeMu.
 	writeMu sync.Mutex
 
+	// writeTimeout bounds a single WriteMessage. Serializing writes means a
+	// blocked write no longer stalls just its own caller, it stalls every
+	// publisher queued behind writeMu, so the write has to be bounded.
+	// Overridden in tests; see defaultWriteTimeout for the value rationale.
+	writeTimeout time.Duration
+
 	// Message handlers
 	handlers   map[string]func(WSMessage)
 	handlersMu sync.RWMutex
@@ -113,6 +119,7 @@ func NewWSClient(cfg WSClientConfig) *WSClient {
 		reconnectEnabled: reconnectEnabled,
 		reconnectBackoff: time.Second,
 		maxBackoff:       time.Minute,
+		writeTimeout:     defaultWriteTimeout,
 		debugFunc:        cfg.DebugFunc,
 	}
 }
@@ -240,7 +247,7 @@ func (c *WSClient) readLoop() {
 		_, message, err := conn.ReadMessage()
 		if err != nil {
 			c.debug("ws: read error: %v", err)
-			c.handleDisconnect()
+			c.handleDisconnect(conn)
 			continue
 		}
 
@@ -272,9 +279,18 @@ func (c *WSClient) readLoop() {
 	}
 }
 
-// handleDisconnect handles WebSocket disconnection
-func (c *WSClient) handleDisconnect() {
+// handleDisconnect tears down conn and schedules a reconnect.
+//
+// conn is the connection the caller observed failing. If the client has already
+// moved on to a different connection the call is a no-op, so a slow failure
+// cannot close a healthy socket that reconnect established in the meantime.
+func (c *WSClient) handleDisconnect(conn *websocket.Conn) {
 	c.connMu.Lock()
+	if conn != nil && c.conn != conn {
+		// Already replaced; whoever swapped it owns the old connection.
+		c.connMu.Unlock()
+		return
+	}
 	c.connected = false
 	if c.conn != nil {
 		c.conn.Close()
@@ -433,11 +449,26 @@ func (c *WSClient) sendMessage(_ context.Context, msg WSMessage) error {
 	// heartbeat publisher ticks every 30s, job streaming publishes per chunk,
 	// the consume loop acks per job, and reconnect re-subscribes from its own
 	// goroutine. Without this lock they all enter WriteMessage at once.
+	//
+	// The deadline is set AND cleared inside the same critical section:
+	// SetWriteDeadline is one of gorilla's write methods (a bare field
+	// assignment on the Conn), so touching it outside writeMu would race an
+	// in-flight WriteMessage, which is the bug this fix found in Close.
 	c.writeMu.Lock()
+	_ = conn.SetWriteDeadline(time.Now().Add(c.writeTimeout))
 	err = conn.WriteMessage(websocket.TextMessage, data)
+	_ = conn.SetWriteDeadline(time.Time{})
 	c.writeMu.Unlock()
 
 	if err != nil {
+		// gorilla latches the first write error (Conn.writeErr, set once by
+		// writeFatal) and returns it from every later write, so this
+		// connection can never carry another byte. Tear it down: that flips
+		// IsConnected to false so Client.Publish falls back to HTTP, and it
+		// kicks reconnect. Without it the socket stays "connected" while
+		// every publish fails forever, which is the silent stall shape this
+		// whole fix exists to avoid.
+		c.handleDisconnect(conn)
 		return fmt.Errorf("failed to send message: %w", err)
 	}
 
@@ -447,6 +478,17 @@ func (c *WSClient) sendMessage(_ context.Context, msg WSMessage) error {
 // closeWriteWait bounds both the close-handshake write and how long Close
 // waits for an in-flight write to finish before giving up on the handshake.
 const closeWriteWait = 2 * time.Second
+
+// defaultWriteTimeout bounds a single WriteMessage.
+//
+// 15s is chosen against the slowest-cadence caller rather than against network
+// latency: the heartbeat publishes every 30s, so a 15s bound guarantees a
+// wedged socket surfaces as an error before the next tick can queue behind it,
+// and at most one heartbeat interval is ever affected. It is also far above any
+// plausible time to hand a few-KB frame to the kernel on a healthy connection,
+// so it should never fire in normal operation, and well under the worker
+// self-heal stall timer (600s) that would otherwise be the only backstop.
+const defaultWriteTimeout = 15 * time.Second
 
 // tryLockWrite acquires writeMu, giving up after d. Close must not block
 // forever behind a wedged writer (see the deadline note in Close), so it needs

--- a/internal/redisapi/websocket_write_test.go
+++ b/internal/redisapi/websocket_write_test.go
@@ -1,0 +1,148 @@
+package redisapi
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// newDrainingWSServer returns an httptest server that upgrades any request and
+// then reads until the peer goes away. Draining matters: if the server never
+// reads, kernel socket buffers fill, every writer blocks, and the test hangs
+// instead of exercising the write path.
+func newDrainingWSServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	upgrader := websocket.Upgrader{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// newTestWSClient connects a WSClient to srv with reconnection disabled.
+//
+// Reconnect is off on purpose: reconnect() mutates reconnectBackoff without
+// holding connMu, which is a separate (real, unfixed) data race in this file.
+// Letting it run would make -race report something unrelated to the write path
+// under test.
+func newTestWSClient(t *testing.T, srv *httptest.Server) *WSClient {
+	t.Helper()
+
+	c := NewWSClient(WSClientConfig{BaseURL: srv.URL, Token: "test-token"})
+	c.reconnectEnabled = false
+
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	return c
+}
+
+// TestSendMessageConcurrentWriters drives many goroutines through the same
+// write path that the heartbeat publisher, job streaming, the consume-loop ack
+// and reconnect resubscription all share.
+//
+// gorilla permits exactly one concurrent writer per connection; more than one
+// raises "panic: concurrent write to websocket connection" from flushFrame,
+// which takes down the whole worker process (#720). Before the writeMu fix
+// this test panics or trips -race; the payload is deliberately several KB so
+// each WriteMessage is long enough to overlap the next.
+func TestSendMessageConcurrentWriters(t *testing.T) {
+	srv := newDrainingWSServer(t)
+	c := newTestWSClient(t, srv)
+
+	payload := map[string]any{"blob": strings.Repeat("x", 8192)}
+
+	const (
+		writers   = 50
+		perWriter = 50
+	)
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := range writers {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			for range perWriter {
+				// Errors are not the subject here: the connection may be torn
+				// down by a sibling goroutine's failure. The assertion is that
+				// concurrent writes do not panic or race.
+				_ = c.Publish(context.Background(), fmt.Sprintf("chan-%d", i), payload)
+			}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	if err := c.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}
+
+// TestCloseDuringConcurrentWrites covers the second write site: Close sends a
+// close frame and calls SetWriteDeadline, both of which are gorilla write
+// methods (SetWriteDeadline is a bare field assignment on the Conn, so it
+// races an in-flight WriteMessage under -race). Close must therefore take the
+// same writeMu, and must still finish promptly.
+func TestCloseDuringConcurrentWrites(t *testing.T) {
+	srv := newDrainingWSServer(t)
+	c := newTestWSClient(t, srv)
+
+	payload := map[string]any{"blob": strings.Repeat("y", 8192)}
+
+	const writers = 25
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	for i := range writers {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				_ = c.Publish(context.Background(), fmt.Sprintf("chan-%d", i), payload)
+			}
+		}(i)
+	}
+
+	// Let the writers get in flight, then close underneath them.
+	time.Sleep(50 * time.Millisecond)
+
+	closed := make(chan error, 1)
+	go func() { closed <- c.Close() }()
+
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Errorf("close: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Error("Close did not return; shutdown is blocked behind a writer (#312)")
+	}
+
+	close(stop)
+	wg.Wait()
+}

--- a/internal/redisapi/websocket_write_test.go
+++ b/internal/redisapi/websocket_write_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -34,6 +35,29 @@ func newDrainingWSServer(t *testing.T) *httptest.Server {
 		}
 	}))
 	t.Cleanup(srv.Close)
+	return srv
+}
+
+// newWedgedWSServer returns an httptest server that completes the WebSocket
+// handshake and then never reads, so the client's socket buffers fill and its
+// writes block for real.
+func newWedgedWSServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	upgrader := websocket.Upgrader{}
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		<-release
+	}))
+	// Cleanups run LIFO, so the handler is released before the server is shut
+	// down; otherwise srv.Close() would block waiting on the parked handler.
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(release) })
 	return srv
 }
 
@@ -158,18 +182,7 @@ func TestCloseDuringConcurrentWrites(t *testing.T) {
 // an error rather than parking. Without the deadline they park forever and this
 // test fails on its own timeout.
 func TestWedgedWriteTimesOutInsteadOfParkingPublishers(t *testing.T) {
-	upgrader := websocket.Upgrader{}
-	release := make(chan struct{})
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, err := upgrader.Upgrade(w, r, nil)
-		if err != nil {
-			return
-		}
-		defer func() { _ = conn.Close() }()
-		<-release // never read: let the socket buffers fill
-	}))
-	defer srv.Close()
-	defer close(release)
+	srv := newWedgedWSServer(t)
 
 	c := NewWSClient(WSClientConfig{BaseURL: srv.URL, Token: "test-token"})
 	c.reconnectEnabled = false
@@ -220,4 +233,69 @@ func TestWedgedWriteTimesOutInsteadOfParkingPublishers(t *testing.T) {
 	if failed == 0 {
 		t.Fatal("expected the wedged socket to surface a write error, got none")
 	}
+}
+
+// TestCloseReturnsWhileWriterIsWedged exercises the tryLockWrite timeout branch,
+// which the other Close test never reaches (its writes complete in
+// microseconds, so Close always takes writeMu on the first try).
+//
+// Here a writer is genuinely stuck holding writeMu with a write timeout far
+// longer than the test. Close must give up on the close handshake and shut down
+// anyway rather than block behind it, which is the guarantee #312 established
+// and the one most at risk from making Close take the write lock at all.
+func TestCloseReturnsWhileWriterIsWedged(t *testing.T) {
+	srv := newWedgedWSServer(t)
+
+	c := NewWSClient(WSClientConfig{BaseURL: srv.URL, Token: "test-token"})
+	c.reconnectEnabled = false
+	// Long enough that the wedged writer will not release writeMu on its own
+	// during this test: Close has to break the tie.
+	c.writeTimeout = 60 * time.Second
+
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+
+	payload := map[string]any{"blob": strings.Repeat("v", 1<<18)}
+
+	var completed atomic.Int64
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		for {
+			if err := c.Publish(context.Background(), "wedged", payload); err != nil {
+				return
+			}
+			completed.Add(1)
+		}
+	}()
+
+	// Wait for the writer to stop making progress, i.e. to be blocked inside
+	// WriteMessage holding writeMu.
+	prev := int64(-1)
+	for range 100 {
+		time.Sleep(50 * time.Millisecond)
+		cur := completed.Load()
+		if cur > 0 && cur == prev {
+			break
+		}
+		prev = cur
+	}
+	if completed.Load() == 0 {
+		t.Fatal("writer never completed a publish; the fixture is not wedging")
+	}
+
+	closed := make(chan error, 1)
+	go func() { closed <- c.Close() }()
+
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Errorf("close: %v", err)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("Close blocked behind a wedged writer; the bounded acquire is not working (#312)")
+	}
+
+	<-writerDone
 }

--- a/internal/redisapi/websocket_write_test.go
+++ b/internal/redisapi/websocket_write_test.go
@@ -146,3 +146,78 @@ func TestCloseDuringConcurrentWrites(t *testing.T) {
 	close(stop)
 	wg.Wait()
 }
+
+// TestWedgedWriteTimesOutInsteadOfParkingPublishers is the counterweight to the
+// write mutex. Serializing writes means a single blocked WriteMessage no longer
+// stalls only its own caller, it stalls every publisher queued behind writeMu:
+// heartbeat, stream chunks, acks, chat presence. Bounding the write with a
+// deadline is what keeps that from turning a panic into a silent stall.
+//
+// The server here completes the handshake and then never reads, so socket
+// buffers fill and writes block for real. Every publisher must come back with
+// an error rather than parking. Without the deadline they park forever and this
+// test fails on its own timeout.
+func TestWedgedWriteTimesOutInsteadOfParkingPublishers(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		<-release // never read: let the socket buffers fill
+	}))
+	defer srv.Close()
+	defer close(release)
+
+	c := NewWSClient(WSClientConfig{BaseURL: srv.URL, Token: "test-token"})
+	c.reconnectEnabled = false
+	// Production uses defaultWriteTimeout (15s). Scaled down so the test does
+	// not spend that long proving the bound exists.
+	c.writeTimeout = 250 * time.Millisecond
+
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	payload := map[string]any{"blob": strings.Repeat("w", 1<<18)} // 256KB per frame
+
+	const (
+		publishers    = 8
+		maxPerWriter  = 200
+		overallBudget = 30 * time.Second
+	)
+
+	results := make(chan error, publishers)
+	for i := range publishers {
+		go func(i int) {
+			var last error
+			for range maxPerWriter {
+				last = c.Publish(context.Background(), fmt.Sprintf("wedged-%d", i), payload)
+				if last != nil {
+					break
+				}
+			}
+			results <- last
+		}(i)
+	}
+
+	budget := time.After(overallBudget)
+	failed := 0
+	for range publishers {
+		select {
+		case err := <-results:
+			if err != nil {
+				failed++
+			}
+		case <-budget:
+			t.Fatal("publishers parked behind a wedged write: WriteMessage is not bounded by a write deadline")
+		}
+	}
+
+	if failed == 0 {
+		t.Fatal("expected the wedged socket to surface a write error, got none")
+	}
+}


### PR DESCRIPTION
Closes #720.

## Context

A node on 2.100.0 died with `panic: concurrent write to websocket connection`
raised inside `WSClient.sendMessage`. The panic is on a goroutine, so it takes
the whole worker process down rather than failing one publish.

## Root cause: the mechanism in #720 is wrong, read this instead

#720 says `sendMessage` "performs the write while still holding only that read
lock." **It does not.** `connMu.RLock()` is acquired *and released* to read the
conn pointer, and `conn.WriteMessage` then runs with **no lock held at all**.

That is strictly worse than described, and it changes what the fix has to be.
Widening `connMu` to an exclusive `Lock` around the write, the obvious reading of
the issue, would have been fixing a lock that was never in the write path.
Nothing was serializing writes to begin with, so a lock had to be introduced.

gorilla supports exactly one concurrent writer per connection (`doc.go`:
"Applications are responsible for ensuring that no more than one goroutine calls
the write methods ... concurrently") and panics from `flushFrame` otherwise. The
writers really are independent goroutines: `heartbeat/api.go` publishes on a 30s
ticker, `PublishStreamEvent` publishes per chunk, `worker/ws_source.go` acks per
job, `chat.Client` publishes messages and presence, and both `connectLocked` and
the `OnReconnect` callback re-subscribe from their own goroutines.

A second bug the issue does not name: `Close` was already calling
`SetWriteDeadline` concurrently with in-flight writes. That is a gorilla write
method (a bare field assignment on the `Conn`), so it was racing too.

## Changes

All in `internal/redisapi/websocket.go`.

**1. `writeMu`, a dedicated write mutex.** Separate from `connMu` so pointer
reads stay cheap and a slow write does not block them. Held across
`conn.WriteMessage` in `sendMessage`, and across **both** `SetWriteDeadline` and
the close frame in `Close`.

`Close`'s acquire is bounded (`tryLockWrite`, 2s). A wedged writer must not
reintroduce the shutdown stall that #312 fixed; if the lock is unavailable we
skip the courtesy close frame and go straight to `conn.Close()`, which gorilla
documents as safe alongside any other method and which unblocks the stuck writer
anyway.

**2. A 15s write deadline on every send.** Serializing writes has a cost worth
stating plainly: a blocked `WriteMessage` used to stall only its own goroutine,
but under `writeMu` it stalls *every* publisher queued behind it. Unbounded, that
trades "panic plus a 39s systemd restart" for "publishing silently stalled until
the 600s self-heal timer", which is the same silent-stall shape this whole
incident was about, and strictly harder to diagnose. So the write is bounded.

Why 15s: chosen against the slowest-cadence caller, not against network latency.
The heartbeat publishes every 30s, so a 15s bound guarantees a wedged socket
surfaces as an error before the next tick can queue behind it, and at most one
heartbeat interval is ever affected. It is far above any plausible time to hand a
few-KB frame to the kernel on a healthy connection, so it should never fire in
normal operation, and well under the 600s self-heal stall timer.

The deadline is set **and cleared inside the same `writeMu` critical section**,
which is exactly the discipline whose absence was the bug in `Close`.

**3. A failed write now tears the connection down.** gorilla latches the first
write error (`Conn.writeErr`, set once by `writeFatal`) and returns it from every
subsequent write, so after a timeout that connection can never carry another
byte. Without teardown the socket would stay `IsConnected() == true` while every
publish failed forever. `sendMessage` now calls `handleDisconnect`, which flips
`connected` false so `Client.Publish` falls back to HTTP and reconnect runs.

`handleDisconnect` gained a connection-pointer guard so a slow failure cannot
close a healthy socket that reconnect established in the meantime. `readLoop`
passes the conn it read from, which closes the same latent hole there.

This is what makes an occasional write timeout degrade gracefully rather than
latch: #721 puts the HTTP status and body into the fallback's errors, and #722
stops a pub/sub error from aborting the durable heartbeat write.

Control frames: there are no explicit ping/pong writes in this file. gorilla's
default ping handler replies via `WriteControl`, which is documented safe
concurrently with all other methods, so it needs no change. Verified against the
pinned module source, not assumed.

## Tests

`internal/redisapi/websocket_write_test.go` (new), all against an `httptest`
WebSocket server:

- `TestSendMessageConcurrentWriters`: 50 goroutines x 50 messages of an 8KB
  payload through `Publish` -> `sendMessage`, against a server that drains.
  Payload size matters: a tiny frame to a loopback server can complete before the
  next writer arrives.
- `TestCloseDuringConcurrentWrites`: covers the second write site, and asserts
  `Close` still returns promptly (the #312 constraint).
- `TestWedgedWriteTimesOutInsteadOfParkingPublishers`: server completes the
  handshake and then never reads, so buffers fill and writes block for real.
  Asserts every publisher returns an error rather than parking.
- `TestCloseReturnsWhileWriterIsWedged`: same wedged server, one writer stuck
  holding `writeMu` with a 60s write timeout. Covers the `tryLockWrite` timeout
  branch, which the other `Close` test never reaches because its writes complete
  in microseconds and always take the lock on the first try.

Reconnection is disabled in all three deliberately, so `-race` reports the write
path rather than the unrelated `reconnectBackoff` race noted below.

### Mutation results

Each change was reverted in isolation to confirm the test actually catches it.

**`writeMu` removed from `sendMessage`:**

```
WARNING: DATA RACE
Read at 0x00c000200338 by goroutine 33:
  github.com/gorilla/websocket.(*Conn).beginMessage()
  ...
  internal/redisapi.(*WSClient).sendMessage()
...
panic: concurrent write to websocket connection

goroutine 71 [running]:
github.com/gorilla/websocket.(*messageWriter).flushFrame(...)
github.com/gorilla/websocket.(*Conn).WriteMessage(...)
internal/redisapi.(*WSClient).sendMessage(...)
FAIL	github.com/aceteam-ai/citadel-cli/internal/redisapi	0.100s
```

That is the production stack from #720, reproduced.

**`writeMu` removed from `Close` only:**

```
WARNING: DATA RACE
Write at 0x00c000214060 by goroutine 52:
  github.com/gorilla/websocket.(*Conn).SetWriteDeadline()
  internal/redisapi.(*WSClient).Close()

Previous read at 0x00c000214060 by goroutine 29:
  github.com/gorilla/websocket.(*messageWriter).flushFrame()
  internal/redisapi.(*WSClient).sendMessage()
```

**Write deadline removed:**

```
--- FAIL: TestWedgedWriteTimesOutInsteadOfParkingPublishers (32.03s)
    websocket_write_test.go:216: publishers parked behind a wedged write:
    WriteMessage is not bounded by a write deadline
```

**Bounded `Close` acquire replaced with a plain `Lock`:**

```
--- FAIL: TestCloseReturnsWhileWriterIsWedged (20.17s)
    websocket_write_test.go:297: Close blocked behind a wedged writer;
    the bounded acquire is not working (#312)
```

All four restored; all pass, including `-count=2` under `-race`.

### Verification

```
go vet ./...                                   # clean
go test -race -count=2 ./internal/redisapi/... # ok
go test ./...                                  # ok, 76 packages
```

## Scope

This PR fixes the **trigger** only. Per the correction comment on #720, the
12-hour outage was sustained by #723 (`EnableWebSocket` is never retried), #721
and #722.

Two adjacent findings were surfaced during review and are being tracked
separately rather than expanded into this diff:

- **`reconnect()` mutates `reconnectBackoff` unsynchronized** (same file, lines
  296-303) while `connectLocked` writes it under `connMu.Lock`. Worth flagging
  that **this PR makes that race fire more often**: before, `reconnect()` ran
  only on read errors, and now a write failure schedules one too, so the read
  and write paths can start two `reconnect()` goroutines concurrently. The
  pointer guard in `handleDisconnect` prevents double teardown and the second
  goroutine bails at its `alreadyConnected` check, so this is a data race on an
  int64 rather than a correctness bug. It got more urgent, not less.
- **`internal/terminal/server.go`** has several `WriteMessage` sites that look
  like the same class of bug as #720.
