### PR TITLE
fix(redisapi): decode the responses the fabric redis routes actually send

### DIFF
--- a/internal/redisapi/client.go
+++ b/internal/redisapi/client.go
@@ -241,22 +241,48 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body any, r
 		atomic.StoreInt32(&c.lastConsumeStatus, int32(resp.StatusCode))
 	}
 
-	// Handle error responses
+	// Handle error responses.
+	//
+	// Every error here carries method, path, HTTP status and the (truncated)
+	// response body, because the callers of this package deliberately no longer
+	// second-guess a 2xx (see pubsub.go): this error string is the ONLY record of
+	// why a call failed. Issue #721 was slow to diagnose precisely because the
+	// old strings dropped the status and the path.
+	//
+	// The literal "status %d" substring is load-bearing: contains404 greps for it
+	// so FetchWorkerConfig can fall back to defaults on a 404. Keep it verbatim.
 	if resp.StatusCode >= 400 {
 		var apiErr APIError
 		if err := json.Unmarshal(respBody, &apiErr); err == nil && apiErr.Error != "" {
 			apiErr.StatusCode = resp.StatusCode
-			return fmt.Errorf("API error: %s", apiErr.Err())
+			return fmt.Errorf("%s %s failed with status %d: API error: %s", method, path, resp.StatusCode, apiErr.Err())
 		}
-		return fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(respBody))
+		return fmt.Errorf("%s %s failed with status %d: %s", method, path, resp.StatusCode, truncateBody(respBody))
 	}
 
 	// Parse success response
 	if result != nil && len(respBody) > 0 {
 		if err := json.Unmarshal(respBody, result); err != nil {
-			return fmt.Errorf("failed to parse response: %w", err)
+			return fmt.Errorf("%s %s returned status %d with an unparseable body (%s): %w",
+				method, path, resp.StatusCode, truncateBody(respBody), err)
 		}
 	}
 
 	return nil
+}
+
+// maxErrorBodyBytes bounds how much of a response body is quoted into an error
+// string. Enough to carry a JSON error payload, small enough that a stray HTML
+// error page does not flood the log.
+const maxErrorBodyBytes = 512
+
+// truncateBody renders a response body for inclusion in an error message.
+func truncateBody(body []byte) string {
+	if len(body) == 0 {
+		return "<empty body>"
+	}
+	if len(body) > maxErrorBodyBytes {
+		return string(body[:maxErrorBodyBytes]) + fmt.Sprintf("... (%d bytes total)", len(body))
+	}
+	return string(body)
 }

--- a/internal/redisapi/contract_test.go
+++ b/internal/redisapi/contract_test.go
@@ -1,0 +1,266 @@
+package redisapi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// The tests in this file pin the client against the EXACT JSON bodies the
+// aceteam platform routes emit today. Every fixture below is copied from the
+// `NextResponse.json(...)` calls in the corresponding route:
+//
+//	app/api/fabric/redis/pubsub/publish/route.ts  -> { published: true }
+//	app/api/fabric/redis/jobs/acknowledge/route.ts -> { acknowledged: <XACK > 0> }
+//	app/api/fabric/redis/kv/route.ts (GET)         -> { key, value, ttl }
+//	app/api/fabric/redis/kv/route.ts (POST)        -> { success: true }
+//	app/api/fabric/redis/kv/route.ts (DELETE)      -> { deleted: <DEL > 0> }
+//	app/api/fabric/redis/streams/add/route.ts      -> { success: true, messageId }
+//
+// citadel-cli #721: the client used to require a `success` field on the publish
+// and acknowledge responses, which neither route has ever sent, and an `exists`
+// field on the KV GET response, which that route has never sent either. Do not
+// relax these fixtures to make a client change pass; change the client.
+
+// newContractServer serves one canned JSON body for any request and records the
+// request path so the test can assert the client hit the route it claims to.
+func newContractServer(t *testing.T, status int, body string) (*httptest.Server, *string) {
+	t.Helper()
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &gotPath
+}
+
+func newContractClient(url string) *Client {
+	return NewClient(ClientConfig{BaseURL: url, Token: "test-token"})
+}
+
+func TestPublishAcceptsRoutePublishedField(t *testing.T) {
+	srv, gotPath := newContractServer(t, http.StatusOK, `{"published":true}`)
+	client := newContractClient(srv.URL)
+
+	err := client.Publish(context.Background(), "stream:v1:job-1", map[string]any{"hello": "world"})
+	if err != nil {
+		t.Fatalf("Publish should succeed on the route's real 200 body, got: %v", err)
+	}
+	if *gotPath != "/api/fabric/redis/pubsub/publish" {
+		t.Errorf("unexpected path: %s", *gotPath)
+	}
+}
+
+func TestPublishErrorCarriesStatusAndBody(t *testing.T) {
+	// The 403 the route returns when the device key lacks device_redis:pubsub.
+	srv, _ := newContractServer(t, http.StatusForbidden,
+		`{"error":"Unauthorized - requires device_redis:pubsub scope"}`)
+	client := newContractClient(srv.URL)
+
+	err := client.Publish(context.Background(), "stream:v1:job-1", map[string]any{})
+	if err == nil {
+		t.Fatal("Publish should error on 403")
+	}
+	msg := err.Error()
+	for _, want := range []string{"403", "/api/fabric/redis/pubsub/publish", "device_redis:pubsub"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q should contain %q so one log line is enough to diagnose it", msg, want)
+		}
+	}
+}
+
+func TestPublishErrorCarriesStatusAndBodyForNonJSONError(t *testing.T) {
+	// A gateway/proxy failure in front of the route: not JSON, no `error` key.
+	srv, _ := newContractServer(t, http.StatusBadGateway, `<html>502 Bad Gateway</html>`)
+	client := newContractClient(srv.URL)
+
+	err := client.Publish(context.Background(), "stream:v1:job-1", map[string]any{})
+	if err == nil {
+		t.Fatal("Publish should error on 502")
+	}
+	msg := err.Error()
+	for _, want := range []string{"502", "/api/fabric/redis/pubsub/publish", "Bad Gateway"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q should contain %q", msg, want)
+		}
+	}
+}
+
+func TestAcknowledgeJobAcceptsRouteAcknowledgedField(t *testing.T) {
+	srv, gotPath := newContractServer(t, http.StatusOK, `{"acknowledged":true}`)
+	client := newContractClient(srv.URL)
+
+	err := client.AcknowledgeJob(context.Background(), AcknowledgeRequest{
+		Queue: "jobs:v1:cpu-general", Group: "citadel-workers", MessageID: "1-0",
+	})
+	if err != nil {
+		t.Fatalf("AcknowledgeJob should succeed on the route's real 200 body, got: %v", err)
+	}
+	if *gotPath != "/api/fabric/redis/jobs/acknowledge" {
+		t.Errorf("unexpected path: %s", *gotPath)
+	}
+}
+
+func TestAcknowledgeJobTreatsDuplicateAckAsSuccess(t *testing.T) {
+	// XACK returns 0 when the message is already out of the PEL. ws_source acks
+	// over WebSocket first and retries over HTTP when that fails, so a duplicate
+	// ack is a routine outcome, not an error.
+	srv, _ := newContractServer(t, http.StatusOK, `{"acknowledged":false}`)
+	client := newContractClient(srv.URL)
+
+	err := client.AcknowledgeJob(context.Background(), AcknowledgeRequest{
+		Queue: "jobs:v1:cpu-general", Group: "citadel-workers", MessageID: "1-0",
+	})
+	if err != nil {
+		t.Fatalf("a duplicate ack (acknowledged=false on 200) must not be an error, got: %v", err)
+	}
+}
+
+func TestGetKeyParsesRouteBodyForExistingKey(t *testing.T) {
+	srv, gotPath := newContractServer(t, http.StatusOK,
+		`{"key":"job:cancelled:abc","value":"1","ttl":42}`)
+	client := newContractClient(srv.URL)
+
+	value, ttl, err := client.GetKey(context.Background(), "job:cancelled:abc")
+	if err != nil {
+		t.Fatalf("GetKey failed: %v", err)
+	}
+	if value != "1" {
+		t.Errorf("value = %q, want %q", value, "1")
+	}
+	if ttl != 42 {
+		t.Errorf("ttl = %d, want 42", ttl)
+	}
+	if *gotPath != "/api/fabric/redis/kv" {
+		t.Errorf("unexpected path: %s", *gotPath)
+	}
+}
+
+func TestGetKeyReportsMissingKeyFromNullValue(t *testing.T) {
+	srv, _ := newContractServer(t, http.StatusOK,
+		`{"key":"job:cancelled:abc","value":null,"ttl":-2}`)
+	client := newContractClient(srv.URL)
+
+	value, ttl, err := client.GetKey(context.Background(), "job:cancelled:abc")
+	if err != nil {
+		t.Fatalf("GetKey failed: %v", err)
+	}
+	if value != "" || ttl != -2 {
+		t.Errorf("GetKey = (%q, %d), want (\"\", -2) for an absent key", value, ttl)
+	}
+}
+
+func TestGetKeyHandlesEmptyStringValue(t *testing.T) {
+	// An empty string is a real value; only JSON null means absent.
+	srv, _ := newContractServer(t, http.StatusOK,
+		`{"key":"device:state:org:x","value":"","ttl":-1}`)
+	client := newContractClient(srv.URL)
+
+	value, ttl, err := client.GetKey(context.Background(), "device:state:org:x")
+	if err != nil {
+		t.Fatalf("GetKey failed: %v", err)
+	}
+	if value != "" {
+		t.Errorf("value = %q, want empty string", value)
+	}
+	if ttl != -1 {
+		t.Errorf("ttl = %d, want -1 (exists, no expiry)", ttl)
+	}
+}
+
+func TestIsJobCancelledReadsRouteBody(t *testing.T) {
+	t.Run("cancelled", func(t *testing.T) {
+		srv, _ := newContractServer(t, http.StatusOK,
+			`{"key":"job:cancelled:abc","value":"1","ttl":3600}`)
+		client := newContractClient(srv.URL)
+
+		cancelled, err := client.IsJobCancelled(context.Background(), "abc")
+		if err != nil {
+			t.Fatalf("IsJobCancelled failed: %v", err)
+		}
+		if !cancelled {
+			t.Error("IsJobCancelled = false, want true when the cancellation flag exists")
+		}
+	})
+
+	t.Run("not cancelled", func(t *testing.T) {
+		srv, _ := newContractServer(t, http.StatusOK,
+			`{"key":"job:cancelled:abc","value":null,"ttl":-2}`)
+		client := newContractClient(srv.URL)
+
+		cancelled, err := client.IsJobCancelled(context.Background(), "abc")
+		if err != nil {
+			t.Fatalf("IsJobCancelled failed: %v", err)
+		}
+		if cancelled {
+			t.Error("IsJobCancelled = true, want false when the flag is absent")
+		}
+	})
+}
+
+func TestSetKeyAcceptsRouteBody(t *testing.T) {
+	srv, gotPath := newContractServer(t, http.StatusOK, `{"success":true}`)
+	client := newContractClient(srv.URL)
+
+	if err := client.SetKey(context.Background(), "job:x:status", map[string]any{"status": "ok"}, 60); err != nil {
+		t.Fatalf("SetKey failed: %v", err)
+	}
+	if *gotPath != "/api/fabric/redis/kv" {
+		t.Errorf("unexpected path: %s", *gotPath)
+	}
+}
+
+func TestDeleteKeyParsesRouteBody(t *testing.T) {
+	srv, _ := newContractServer(t, http.StatusOK, `{"deleted":true}`)
+	client := newContractClient(srv.URL)
+
+	deleted, err := client.DeleteKey(context.Background(), "config:cache:x")
+	if err != nil {
+		t.Fatalf("DeleteKey failed: %v", err)
+	}
+	if !deleted {
+		t.Error("DeleteKey = false, want true")
+	}
+}
+
+func TestStreamAddAcceptsRouteBody(t *testing.T) {
+	srv, gotPath := newContractServer(t, http.StatusOK,
+		`{"success":true,"messageId":"1754400000000-0"}`)
+	client := newContractClient(srv.URL)
+
+	err := client.StreamAdd(context.Background(), "node:status:stream",
+		map[string]string{"node": "n1"}, 10000)
+	if err != nil {
+		t.Fatalf("StreamAdd failed: %v", err)
+	}
+	if *gotPath != "/api/fabric/redis/streams/add" {
+		t.Errorf("unexpected path: %s", *gotPath)
+	}
+}
+
+func TestConsumeJobParsesRouteBody(t *testing.T) {
+	srv, gotPath := newContractServer(t, http.StatusOK,
+		`{"messages":[{"id":"1-0","data":{"jobId":"job-1","type":"SHELL_COMMAND","payload":"{\"cmd\":\"ls\"}","enqueuedAt":"2026-08-05T00:00:00Z","rayId":"ray-1"}}]}`)
+	client := newContractClient(srv.URL)
+
+	job, err := client.ConsumeJob(context.Background(), ConsumeRequest{
+		Queue: "jobs:v1:cpu-general", Group: "citadel-workers", Consumer: "c1", BlockMs: 10,
+	})
+	if err != nil {
+		t.Fatalf("ConsumeJob failed: %v", err)
+	}
+	if job == nil {
+		t.Fatal("ConsumeJob returned nil job")
+	}
+	if job.JobID != "job-1" || job.Type != "SHELL_COMMAND" || job.MessageID != "1-0" {
+		t.Errorf("unexpected job: %+v", job)
+	}
+	if *gotPath != "/api/fabric/redis/jobs/consume" {
+		t.Errorf("unexpected path: %s", *gotPath)
+	}
+}

--- a/internal/redisapi/contract_test.go
+++ b/internal/redisapi/contract_test.go
@@ -173,6 +173,27 @@ func TestGetKeyHandlesEmptyStringValue(t *testing.T) {
 	}
 }
 
+func TestGetKeyNormalizesTTLWhenValueAndTTLDisagree(t *testing.T) {
+	// The route reads GET and TTL from a non-atomic Promise.all, so a key that
+	// expires between the two comes back with a real value and a TTL of -2.
+	// -2 is the callers' "absent" signal, so it must not be passed through
+	// alongside a value that is present.
+	srv, _ := newContractServer(t, http.StatusOK,
+		`{"key":"job:cancelled:abc","value":"1","ttl":-2}`)
+	client := newContractClient(srv.URL)
+
+	value, ttl, err := client.GetKey(context.Background(), "job:cancelled:abc")
+	if err != nil {
+		t.Fatalf("GetKey failed: %v", err)
+	}
+	if value != "1" {
+		t.Errorf("value = %q, want %q", value, "1")
+	}
+	if ttl != -1 {
+		t.Errorf("ttl = %d, want -1: a present value must not report the absent sentinel", ttl)
+	}
+}
+
 func TestIsJobCancelledReadsRouteBody(t *testing.T) {
 	t.Run("cancelled", func(t *testing.T) {
 		srv, _ := newContractServer(t, http.StatusOK,

--- a/internal/redisapi/jobs.go
+++ b/internal/redisapi/jobs.go
@@ -71,17 +71,19 @@ func ParseStreamMessage(msg StreamMessage) (*Job, error) {
 }
 
 // AcknowledgeJob acknowledges a successfully processed job.
+//
+// A 2xx is the ack. The route's `acknowledged` field is XACK's return value, so
+// it is false whenever the message was already out of the consumer group's PEL
+// — a duplicate ack, which is a no-op and not an error. Treating it as failure
+// (the pre-#721 behaviour, which additionally read a `success` field the route
+// never sent) made every HTTP ack report failure.
 func (c *Client) AcknowledgeJob(ctx context.Context, req AcknowledgeRequest) error {
 	var resp AcknowledgeResponse
-	err := c.doRequest(ctx, http.MethodPost, "/api/fabric/redis/jobs/acknowledge", req, &resp)
-	if err != nil {
+	if err := c.doRequest(ctx, http.MethodPost, "/api/fabric/redis/jobs/acknowledge", req, &resp); err != nil {
 		return err
 	}
 
-	if !resp.Success {
-		return fmt.Errorf("acknowledge failed: %s", resp.Message)
-	}
-
+	c.debug("acknowledge: message %s on %s (acknowledged=%v)", req.MessageID, req.Queue, resp.Acknowledged)
 	return nil
 }
 

--- a/internal/redisapi/pubsub.go
+++ b/internal/redisapi/pubsub.go
@@ -32,16 +32,17 @@ func (c *Client) Publish(ctx context.Context, channel string, message any) error
 		Message: string(msgJSON),
 	}
 
+	// A 2xx from doRequest IS the ack. The route returns a non-2xx for every
+	// failure it has (403 missing scope, 400 bad channel pattern, 403 org
+	// mismatch), and doRequest turns those into an error carrying the status and
+	// body. Re-checking a body flag on top only creates a second contract that
+	// can drift out of sync with the route — which is exactly what #721 was.
 	var resp PublishResponse
-	err = c.doRequest(ctx, http.MethodPost, "/api/fabric/redis/pubsub/publish", req, &resp)
-	if err != nil {
+	if err := c.doRequest(ctx, http.MethodPost, "/api/fabric/redis/pubsub/publish", req, &resp); err != nil {
 		return err
 	}
 
-	if !resp.Success {
-		return fmt.Errorf("publish failed")
-	}
-
+	c.debug("publish: channel %s acked (published=%v)", channel, resp.Published)
 	return nil
 }
 
@@ -128,6 +129,10 @@ func (c *Client) IsJobCancelled(ctx context.Context, jobID string) (bool, error)
 }
 
 // GetKey retrieves a value from Redis KV storage.
+//
+// The returned TTL follows Redis semantics and is the authoritative existence
+// signal for callers: -2 means the key does not exist, -1 means it exists with
+// no expiry, >= 0 is the remaining lifetime in seconds.
 func (c *Client) GetKey(ctx context.Context, key string) (string, int, error) {
 	path := fmt.Sprintf("/api/fabric/redis/kv?key=%s", url.QueryEscape(key))
 
@@ -137,11 +142,19 @@ func (c *Client) GetKey(ctx context.Context, key string) (string, int, error) {
 		return "", -2, err
 	}
 
-	if !resp.Exists {
+	// A JSON null value is the route's "key does not exist". Do not invent an
+	// empty string for it, and do not trust the TTL alone: the route serves GET
+	// and TTL from a non-atomic Promise.all, so a key that expires between the
+	// two reads comes back with a real value and a TTL of -2. Normalize that to
+	// -1 so the "-2 means absent" contract above holds for callers.
+	if resp.Value == nil {
 		return "", -2, nil
 	}
-
-	return resp.Value, resp.TTL, nil
+	ttl := resp.TTL
+	if ttl == -2 {
+		ttl = -1
+	}
+	return *resp.Value, ttl, nil
 }
 
 // SetKey stores a value in Redis KV storage.
@@ -165,14 +178,12 @@ func (c *Client) SetKey(ctx context.Context, key string, value any, ttl int) err
 		TTL:   ttl,
 	}
 
+	// 2xx is the ack; see Publish. This route does send `success: true`, so the
+	// old body check was correct here, but keeping one rule for the whole file
+	// is what stops the next route tweak from silently breaking a caller.
 	var resp KVSetResponse
-	err := c.doRequest(ctx, http.MethodPost, "/api/fabric/redis/kv", req, &resp)
-	if err != nil {
+	if err := c.doRequest(ctx, http.MethodPost, "/api/fabric/redis/kv", req, &resp); err != nil {
 		return err
-	}
-
-	if !resp.Success {
-		return fmt.Errorf("set key failed: %s", resp.Message)
 	}
 
 	return nil
@@ -200,15 +211,13 @@ func (c *Client) StreamAdd(ctx context.Context, stream string, values map[string
 		Approx: true,
 	}
 
+	// 2xx is the ack; see Publish. This route does send `success: true`, so the
+	// old body check was correct here too.
 	var resp StreamAddResponse
-	err := c.doRequest(ctx, http.MethodPost, "/api/fabric/redis/streams/add", req, &resp)
-	if err != nil {
+	if err := c.doRequest(ctx, http.MethodPost, "/api/fabric/redis/streams/add", req, &resp); err != nil {
 		return err
 	}
 
-	if !resp.Success {
-		return fmt.Errorf("stream add failed")
-	}
-
+	c.debug("stream add: %s acked (messageId=%s)", stream, resp.MessageID)
 	return nil
 }

--- a/internal/redisapi/types.go
+++ b/internal/redisapi/types.go
@@ -52,10 +52,15 @@ type AcknowledgeRequest struct {
 	MessageID string `json:"messageId"`
 }
 
-// AcknowledgeResponse is the response from POST /api/fabric/redis/jobs/acknowledge
+// AcknowledgeResponse is the response from POST /api/fabric/redis/jobs/acknowledge.
+//
+// The route returns `{ acknowledged: boolean }` where `acknowledged` is
+// `XACK > 0`. It is NOT a success flag: a re-ack of a message already out of the
+// consumer group's PEL is a legitimate 200 with `acknowledged: false`, which the
+// ws_source WS-ack-failed-then-HTTP-retry path produces routinely. Callers must
+// key off the HTTP status, not this field. See #721.
 type AcknowledgeResponse struct {
-	Success bool   `json:"success"`
-	Message string `json:"message,omitempty"`
+	Acknowledged bool `json:"acknowledged"`
 }
 
 // PublishRequest is the request body for POST /api/fabric/redis/pubsub/publish
@@ -64,10 +69,14 @@ type PublishRequest struct {
 	Message string `json:"message"` // JSON-encoded payload
 }
 
-// PublishResponse is the response from POST /api/fabric/redis/pubsub/publish
+// PublishResponse is the response from POST /api/fabric/redis/pubsub/publish.
+//
+// The route returns `{ published: true }`. It never sent `success`, so the old
+// `Success` field decoded to false on every successful 200 and the client
+// reported "publish failed" for a publish the server had executed (#721).
+// The field is kept only for logging; success is decided by the HTTP status.
 type PublishResponse struct {
-	Success   bool  `json:"success"`
-	Receivers int64 `json:"receivers,omitempty"`
+	Published bool `json:"published"`
 }
 
 // StreamAddRequest is the request body for POST /api/fabric/redis/streams/add
@@ -78,7 +87,8 @@ type StreamAddRequest struct {
 	Approx bool              `json:"approx,omitempty"`
 }
 
-// StreamAddResponse is the response from POST /api/fabric/redis/streams/add
+// StreamAddResponse is the response from POST /api/fabric/redis/streams/add.
+// This route does send `success`, alongside the Redis stream message ID.
 type StreamAddResponse struct {
 	Success   bool   `json:"success"`
 	MessageID string `json:"messageId,omitempty"`
@@ -89,11 +99,20 @@ type KVGetRequest struct {
 	Key string `json:"key"`
 }
 
-// KVGetResponse is the response from GET /api/fabric/redis/kv
+// KVGetResponse is the response from GET /api/fabric/redis/kv.
+//
+// The route returns `{ key, value, ttl }` and has never sent an `exists` field.
+// The struct used to declare one, so it decoded to false on every response and
+// GetKey reported every key as missing (#721) — which silently disabled
+// mid-job cancellation on API-path nodes, since IsJobCancelled is the only
+// caller. Existence is now derived from `value`/`ttl` inside GetKey.
+//
+// Value is a pointer because the route sends JSON null for a missing key, which
+// is the only way to tell "absent" from "present and empty".
 type KVGetResponse struct {
-	Value  string `json:"value"`
-	TTL    int    `json:"ttl"` // -1 if no TTL, -2 if key doesn't exist
-	Exists bool   `json:"exists"`
+	Key   string  `json:"key"`
+	Value *string `json:"value"`
+	TTL   int     `json:"ttl"` // -1 if no TTL, -2 if key doesn't exist
 }
 
 // KVSetRequest is the request body for POST /api/fabric/redis/kv
@@ -103,16 +122,16 @@ type KVSetRequest struct {
 	TTL   int    `json:"ttl,omitempty"` // TTL in seconds, 0 for no expiry
 }
 
-// KVSetResponse is the response from POST /api/fabric/redis/kv
+// KVSetResponse is the response from POST /api/fabric/redis/kv.
+// This route does send `success`. It does not send a message field.
 type KVSetResponse struct {
-	Success bool   `json:"success"`
-	Message string `json:"message,omitempty"`
+	Success bool `json:"success"`
 }
 
-// KVDeleteResponse is the response from DELETE /api/fabric/redis/kv
+// KVDeleteResponse is the response from DELETE /api/fabric/redis/kv.
+// `deleted` is DEL > 0, i.e. false when the key was already absent.
 type KVDeleteResponse struct {
-	Deleted bool   `json:"deleted"`
-	Message string `json:"message,omitempty"`
+	Deleted bool `json:"deleted"`
 }
 
 // APIError represents an error response from the API


### PR DESCRIPTION
Fixes #721.

## Context

The HTTP fallback for pub/sub publish reported failure on every call, including
calls the server accepted and executed. Verified against the platform routes on
`aceteam-ai/aceteam@origin/main` (read-only), not assumed.

## Root cause

Three response structs in `internal/redisapi/types.go` declared JSON fields the
routes have never sent, so each decoded to its zero value on a successful 200 and
the client turned that into an error:

| Client check | Route actually returns | Effect |
|---|---|---|
| `PublishResponse.Success` (`success`) | `pubsub/publish/route.ts` -> `{ published: true }` | every HTTP publish reports `publish failed` |
| `AcknowledgeResponse.Success` (`success`) | `jobs/acknowledge/route.ts` -> `{ acknowledged }` | every HTTP ack reports `acknowledge failed:` |
| `KVGetResponse.Exists` (`exists`) | `kv/route.ts` GET -> `{ key, value, ttl }`, no `exists` | `GetKey` reports every key as missing |

`acknowledged` is `XACK > 0`, not a success flag: it is legitimately `false` on a
duplicate ack, which the `ws_source` WS-ack-failed-then-HTTP-retry path produces
routinely. Mapping it to an error would have been wrong even with the right key.

Checked and **not** broken: `streams/add` and `kv` POST both send `success: true`;
`kv` DELETE sends `deleted`; `jobs/consume` sends `messages`.

## Blast radius

The server side succeeded in all three cases: the publish ran, XACK ran. The bug
is a false failure report and what each caller does with it.

- **Publish**: log spam, plus a real loss of data. `heartbeat.publishStatus`
  (`internal/heartbeat/api.go`) publishes to pub/sub first and returns early on its
  error, so the durable `StreamAdd` that follows never ran on a WebSocket-down node.
  Those nodes reported nothing at all and were marked offline while healthy and
  consuming jobs. Verified by reading the function, not inherited from the issue.
  WebSocket-down nodes only, which #723 makes permanent rather than transient.
- **Acknowledge**: `runner.go` calls `source.Ack` without checking the error, so the
  visible cost is a misleading error return, not a lost ack.
- **KV get**: this one is **not** limited to the WebSocket-down fallback.
  `ws_source.go` routes cancellation through `redisapi.IsJobCancelled` over HTTP KV
  unconditionally, so mid-job cancellation was silently ignored on every API-path
  node. Silent, so arguably worse than the log spam in #721.
  `internal/redis/client.go` has its own implementation and is unaffected.

## Changes

- `internal/redisapi/types.go`: structs now describe the real route responses.
  `KVGetResponse.Value` is `*string` because the route sends JSON `null` for a
  missing key, which is the only way to tell absent from present-and-empty.
- `internal/redisapi/pubsub.go`, `jobs.go`: success is decided by the HTTP status.
  The routes return a non-2xx for every failure case they have (403 scope, 400
  channel/stream pattern, 403 org mismatch), so a body flag was a second contract
  that could drift out of sync with the route, which is exactly what happened.
  `StreamAdd`/`SetKey` were correct and move to the same rule for consistency;
  labelled hardening, not a fix.
- `GetKey` derives existence from the null value and normalizes the TTL, so the
  documented "-2 means absent" contract holds despite the route serving GET and
  TTL from a non-atomic `Promise.all`.
- `internal/redisapi/client.go`: `doRequest` errors now carry method, path, HTTP
  status and a truncated (512B) body. The literal `status %d` substring is kept
  verbatim because `contains404` greps it for the worker-config 404 fallback.

## Testing

`internal/redisapi/contract_test.go` asserts the client against the exact JSON
bodies copied from each route, plus a 403 and a non-JSON 502 asserting the error
string carries the status, the path and the body.

Mutation test: each fix was reverted one at a time against the committed tree and
`go test ./internal/redisapi/` re-run. All six mutations were killed by a named
test, none by a compile error.

| Mutation | Result |
|---|---|
| M1 publish: re-add the body gate on a field the route never sends | KILLED by `TestPublishAcceptsRoutePublishedField` |
| M2 acknowledge: treat `acknowledged=false` as an error again | KILLED by `TestAcknowledgeJobTreatsDuplicateAckAsSuccess` |
| M3 kv get: go back to reading an `exists` field | KILLED by `TestGetKeyParsesRouteBodyForExistingKey`, `TestGetKeyHandlesEmptyStringValue`, `TestIsJobCancelledReadsRouteBody/cancelled` |
| M4 kv get: treat JSON null as empty-but-present | KILLED by `TestGetKeyReportsMissingKeyFromNullValue`, `TestIsJobCancelledReadsRouteBody/not_cancelled` |
| M5 doRequest: drop method/path/status from error strings | KILLED by `TestPublishErrorCarriesStatusAndBody`, `TestPublishErrorCarriesStatusAndBodyForNonJSONError` |
| M6 kv get: drop the TTL normalization | KILLED by `TestGetKeyNormalizesTTLWhenValueAndTTLDisagree` |

`go test ./...` and `go vet ./...` pass on the full repo. `gofmt` clean.

## Not verified

No live node was exercised. The evidence is the route source on `origin/main`
plus the contract tests; a real WebSocket-down node reproducing and then clearing
the `API status publish failed` spam is still owed.

## Related

- #723 (a single failed `EnableWebSocket` nils the client permanently) is what makes
  the HTTP path load-bearing rather than rare. Not addressed here.
