### PR TITLE
fix(heartbeat): write the durable status stream before the best-effort pub/sub

### DIFF
--- a/internal/heartbeat/api.go
+++ b/internal/heartbeat/api.go
@@ -280,14 +280,14 @@ func (p *APIPublisher) publishMessage(ctx context.Context, msg StatusMessage, ti
 	if pubErr := p.client.Publish(ctx, p.pubSubChannel, msg); pubErr != nil {
 		p.debug("heartbeat: pub/sub publish failed (non-fatal): %v", pubErr)
 		if report, escalate := p.pubSubHealth.recordFailure(time.Now()); escalate {
-			p.log("warning", "   - Warning: heartbeat pub/sub publish to %s failing for %s (%d consecutive): %v (live UI updates only; durable status stream unaffected)",
-				p.pubSubChannel, report.Duration.Round(time.Second), report.Failures, pubErr)
+			p.log("warning", "   - Warning: heartbeat pub/sub publish to %s failing (%s): %v (live UI updates only; durable status stream unaffected)",
+				p.pubSubChannel, report.describe(), pubErr)
 		}
 	} else {
 		p.debug("heartbeat: pub/sub publish successful")
 		if report, recovered := p.pubSubHealth.recordSuccess(time.Now()); recovered {
-			p.log("info", "   - heartbeat pub/sub publish to %s recovered after %d failures over %s",
-				p.pubSubChannel, report.Failures, report.Duration.Round(time.Second))
+			p.log("info", "   - heartbeat pub/sub publish to %s recovered after %s",
+				p.pubSubChannel, report.describe())
 		}
 	}
 

--- a/internal/heartbeat/api.go
+++ b/internal/heartbeat/api.go
@@ -3,14 +3,14 @@
 // This file implements API-based status publishing for real-time UI updates
 // when using the secure Redis API proxy instead of direct Redis connections.
 //
-// Architecture:
+// Architecture (durable write first; see publishMessage for why):
 //
 //	Citadel Node                                  AceTeam API
-//	┌─────────────┐    POST /redis/pubsub/publish ┌─────────────┐
-//	│    API      │ ─────────────────────────────▶│  Redis API  │ → Redis Pub/Sub
+//	┌─────────────┐    POST /redis/streams/add    ┌─────────────┐
+//	│    API      │ ─────────────────────────────▶│  Redis API  │ → Redis Streams (durable)
 //	│  Publisher  │                               │   Proxy     │
-//	│   (30s)     │    POST /redis/streams/add    └─────────────┘
-//	│             │ ─────────────────────────────▶│  Redis API  │ → Redis Streams
+//	│   (30s)     │    POST /redis/pubsub/publish └─────────────┘
+//	│             │ ─────────────────────────────▶│  Redis API  │ → Redis Pub/Sub (best effort)
 //	└─────────────┘                               └─────────────┘
 package heartbeat
 
@@ -52,6 +52,10 @@ type APIPublisher struct {
 
 	// heartbeatCount tracks heartbeats to trigger keep-alive every 60s
 	heartbeatCount int
+
+	// pubSubHealth rate-limits the log noise from a failing best-effort
+	// pub/sub publish while keeping a sustained outage visible (#722).
+	pubSubHealth pubSubHealth
 
 	// onStatus, when set, is invoked with each freshly collected status after a
 	// successful publish. It lets an auto-stop reconciler act on the exact state
@@ -227,17 +231,31 @@ func (p *APIPublisher) publishStatus(ctx context.Context) error {
 		msg.Stats = p.statsFn()
 	}
 
-	p.debug("heartbeat: publishing to channel %s", p.pubSubChannel)
-	p.debug("heartbeat: nodeId=%s, headscaleNodeId=%s, timestamp=%s", msg.NodeID, msg.HeadscaleNodeID, msg.Timestamp)
+	return p.publishMessage(ctx, msg, timestamp)
+}
 
-	// 1. Publish to Pub/Sub for real-time UI updates
-	if err := p.client.Publish(ctx, p.pubSubChannel, msg); err != nil {
-		return fmt.Errorf("failed to publish to pub/sub: %w", err)
-	}
-	p.debug("heartbeat: pub/sub publish successful")
-
-	// 2. Add to Stream for reliable processing by Python worker
-	// Marshal the full message as payload
+// publishMessage writes one heartbeat to both destinations. It is split out of
+// publishStatus so the write half is testable without a live status collector.
+//
+// The two writes are deliberately asymmetric in BOTH order and severity
+// (citadel-cli#722):
+//
+//   - The durable stream (`node:status:stream`) goes FIRST and owns the error.
+//     It is what the platform's NodeStatusWorker consumes to upsert
+//     fabric_node_status, which is the node's last-reported timestamp, which
+//     fail-closed per-node routing checks before dispatching to this node. If
+//     it does not land, the node leaves the fabric. Writing it first also means
+//     a kill between the two calls still leaves the durable record written.
+//
+//   - The pub/sub publish is best effort. It only feeds live dashboard
+//     freshness (and even that redundantly: the platform worker republishes to
+//     the same org-scoped channel after its DB upsert). A failure here is
+//     reported, never fatal.
+//
+// The previous order made the best-effort write a hard gate on the reliable
+// one: a pub/sub failure returned early, the XADD never ran, and a healthy node
+// read offline for 12 hours.
+func (p *APIPublisher) publishMessage(ctx context.Context, msg StatusMessage, timestamp string) error {
 	payloadJSON, err := json.Marshal(msg)
 	if err != nil {
 		return fmt.Errorf("failed to marshal payload: %w", err)
@@ -249,14 +267,33 @@ func (p *APIPublisher) publishStatus(ctx context.Context) error {
 		"payload":   string(payloadJSON),
 	}
 
-	if err := p.client.StreamAdd(ctx, p.streamName, streamFields, 10000); err != nil {
-		// Log but don't fail - pub/sub already succeeded
-		p.debug("heartbeat: stream add failed: %v", err)
-		p.log("warning", "   - Warning: Stream add failed: %v", err)
-	} else {
+	// 1. Durable stream for reliable processing by the platform worker.
+	// Attempted first; its failure is the only fatal one.
+	streamErr := p.client.StreamAdd(ctx, p.streamName, streamFields, 10000)
+	if streamErr == nil {
 		p.debug("heartbeat: stream add successful")
 	}
 
+	// 2. Best-effort pub/sub for real-time UI updates. Attempted even when the
+	// stream write failed, since the two paths fail independently in API mode.
+	p.debug("heartbeat: publishing to channel %s", p.pubSubChannel)
+	if pubErr := p.client.Publish(ctx, p.pubSubChannel, msg); pubErr != nil {
+		p.debug("heartbeat: pub/sub publish failed (non-fatal): %v", pubErr)
+		if report, escalate := p.pubSubHealth.recordFailure(time.Now()); escalate {
+			p.log("warning", "   - Warning: heartbeat pub/sub publish to %s failing for %s (%d consecutive): %v (live UI updates only; durable status stream unaffected)",
+				p.pubSubChannel, report.Duration.Round(time.Second), report.Failures, pubErr)
+		}
+	} else {
+		p.debug("heartbeat: pub/sub publish successful")
+		if report, recovered := p.pubSubHealth.recordSuccess(time.Now()); recovered {
+			p.log("info", "   - heartbeat pub/sub publish to %s recovered after %d failures over %s",
+				p.pubSubChannel, report.Failures, report.Duration.Round(time.Second))
+		}
+	}
+
+	if streamErr != nil {
+		return fmt.Errorf("failed to add to durable stream %s: %w", p.streamName, streamErr)
+	}
 	return nil
 }
 

--- a/internal/heartbeat/api_publish_test.go
+++ b/internal/heartbeat/api_publish_test.go
@@ -1,0 +1,334 @@
+package heartbeat
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/redisapi"
+	"github.com/aceteam-ai/citadel-cli/internal/status"
+)
+
+const (
+	pubSubPath = "/api/fabric/redis/pubsub/publish"
+	streamPath = "/api/fabric/redis/streams/add"
+)
+
+// redisAPIStub stands in for the AceTeam Redis API proxy, letting each of the
+// two heartbeat destinations be failed independently, which is the whole
+// point of citadel-cli#722.
+type redisAPIStub struct {
+	mu sync.Mutex
+
+	failPubSub bool
+	failStream bool
+
+	pubSubCalls int
+	streamCalls int
+	// streamPayloads holds the decoded "payload" field of each stream write,
+	// so a test can prove the heartbeat actually landed rather than merely
+	// that some request arrived.
+	streamPayloads []StatusMessage
+}
+
+func (s *redisAPIStub) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	mux.HandleFunc(pubSubPath, func(w http.ResponseWriter, _ *http.Request) {
+		s.mu.Lock()
+		s.pubSubCalls++
+		fail := s.failPubSub
+		s.mu.Unlock()
+
+		if fail {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":"pubsub down"}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"success": true, "receivers": 1})
+	})
+
+	mux.HandleFunc(streamPath, func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Stream string            `json:"stream"`
+			Values map[string]string `json:"values"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+
+		s.mu.Lock()
+		s.streamCalls++
+		fail := s.failStream
+		if !fail {
+			var msg StatusMessage
+			if err := json.Unmarshal([]byte(body.Values["payload"]), &msg); err == nil {
+				s.streamPayloads = append(s.streamPayloads, msg)
+			}
+		}
+		s.mu.Unlock()
+
+		if fail {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":"stream down"}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"success": true, "messageId": "1-0"})
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func (s *redisAPIStub) counts() (pubSub, stream int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.pubSubCalls, s.streamCalls
+}
+
+func (s *redisAPIStub) landed() []StatusMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]StatusMessage(nil), s.streamPayloads...)
+}
+
+// newTestAPIPublisher wires an APIPublisher at the stub server and captures its
+// operator-facing log lines.
+func newTestAPIPublisher(t *testing.T, stub *redisAPIStub) (*APIPublisher, *[]string) {
+	t.Helper()
+	srv := stub.server(t)
+
+	var mu sync.Mutex
+	var logs []string
+
+	pub, err := NewAPIPublisher(APIPublisherConfig{
+		Client:          redisapi.NewClient(redisapi.ClientConfig{BaseURL: srv.URL, Token: "test-token"}),
+		NodeID:          "test-node",
+		HeadscaleNodeID: "758",
+		OrgID:           "org-1",
+		LogFn: func(level, msg string) {
+			mu.Lock()
+			defer mu.Unlock()
+			logs = append(logs, level+": "+msg)
+		},
+	}, status.NewCollector(status.CollectorConfig{NodeName: "test-node"}))
+	if err != nil {
+		t.Fatalf("NewAPIPublisher: %v", err)
+	}
+	return pub, &logs
+}
+
+func testStatusMessage() StatusMessage {
+	return StatusMessage{
+		Version:         "1.0",
+		Timestamp:       "2026-08-10T00:00:00Z",
+		NodeID:          "test-node",
+		HeadscaleNodeID: "758",
+		Status:          &status.NodeStatus{Version: "1.0"},
+	}
+}
+
+// TestPublishMessagePubSubFailureIsNotFatal is the regression test for #722: a
+// failing best-effort pub/sub publish must NOT prevent the durable stream write
+// and must NOT be reported as a heartbeat failure. Before the fix, publishStatus
+// returned early on the pub/sub error and the XADD never ran, so a healthy node
+// went stale on the platform and fail-closed routing dropped it from the fabric.
+func TestPublishMessagePubSubFailureIsNotFatal(t *testing.T) {
+	stub := &redisAPIStub{failPubSub: true}
+	pub, logs := newTestAPIPublisher(t, stub)
+
+	msg := testStatusMessage()
+	if err := pub.publishMessage(context.Background(), msg, msg.Timestamp); err != nil {
+		t.Fatalf("pub/sub failure must not fail the heartbeat, got: %v", err)
+	}
+
+	pubSubCalls, streamCalls := stub.counts()
+	if pubSubCalls != 1 {
+		t.Errorf("pub/sub publish should still be attempted, got %d calls", pubSubCalls)
+	}
+	if streamCalls != 1 {
+		t.Fatalf("durable stream write must happen despite pub/sub failure, got %d calls", streamCalls)
+	}
+
+	landed := stub.landed()
+	if len(landed) != 1 {
+		t.Fatalf("expected 1 heartbeat on the durable stream, got %d", len(landed))
+	}
+	if landed[0].NodeID != "test-node" || landed[0].Timestamp != msg.Timestamp {
+		t.Errorf("durable stream payload mismatch: %+v", landed[0])
+	}
+
+	// A sustained failure must be visible somewhere: the first failure of a run
+	// is always reported.
+	if !containsSubstring(*logs, "pub/sub publish to node:status:org:org-1:test-node failing") {
+		t.Errorf("first pub/sub failure must be surfaced, logs: %v", *logs)
+	}
+}
+
+// TestPublishMessageStreamFailureIsFatal proves the severity is now on the
+// right write: losing the durable stream is the error the caller must see.
+// Before the fix this was logged and swallowed with a nil return.
+func TestPublishMessageStreamFailureIsFatal(t *testing.T) {
+	stub := &redisAPIStub{failStream: true}
+	pub, _ := newTestAPIPublisher(t, stub)
+
+	msg := testStatusMessage()
+	err := pub.publishMessage(context.Background(), msg, msg.Timestamp)
+	if err == nil {
+		t.Fatal("a failed durable stream write must return an error")
+	}
+	if !strings.Contains(err.Error(), "node:status:stream") {
+		t.Errorf("error should name the durable stream, got: %v", err)
+	}
+
+	// The best-effort publish is still attempted; the two paths fail
+	// independently in API mode, so a stream outage must not also blind the UI.
+	pubSubCalls, streamCalls := stub.counts()
+	if pubSubCalls != 1 {
+		t.Errorf("pub/sub publish should still be attempted when the stream fails, got %d calls", pubSubCalls)
+	}
+	if streamCalls != 1 {
+		t.Errorf("expected 1 stream attempt, got %d", streamCalls)
+	}
+}
+
+// TestPublishMessageBothFailReportsStreamError pins which error wins when
+// everything is down: the durable one, since that is the actionable failure.
+func TestPublishMessageBothFailReportsStreamError(t *testing.T) {
+	stub := &redisAPIStub{failPubSub: true, failStream: true}
+	pub, _ := newTestAPIPublisher(t, stub)
+
+	msg := testStatusMessage()
+	err := pub.publishMessage(context.Background(), msg, msg.Timestamp)
+	if err == nil {
+		t.Fatal("expected an error when the durable stream write fails")
+	}
+	if !strings.Contains(err.Error(), "durable stream") {
+		t.Errorf("the durable stream failure must be the reported one, got: %v", err)
+	}
+}
+
+// TestPublishMessageHappyPath keeps the ordinary case honest: both writes
+// happen, no error, and nothing is logged at operator level.
+func TestPublishMessageHappyPath(t *testing.T) {
+	stub := &redisAPIStub{}
+	pub, logs := newTestAPIPublisher(t, stub)
+
+	msg := testStatusMessage()
+	if err := pub.publishMessage(context.Background(), msg, msg.Timestamp); err != nil {
+		t.Fatalf("publishMessage: %v", err)
+	}
+
+	pubSubCalls, streamCalls := stub.counts()
+	if pubSubCalls != 1 || streamCalls != 1 {
+		t.Errorf("expected 1 pub/sub and 1 stream call, got %d and %d", pubSubCalls, streamCalls)
+	}
+	if len(*logs) != 0 {
+		t.Errorf("a healthy heartbeat must not log, got: %v", *logs)
+	}
+}
+
+// TestPublishMessageWarningIsRateLimitedThenRecovers exercises the noise
+// policy end to end through the publisher: a sustained pub/sub outage logs once
+// (not once per 30s interval), and the recovery is announced.
+func TestPublishMessageWarningIsRateLimitedThenRecovers(t *testing.T) {
+	stub := &redisAPIStub{failPubSub: true}
+	pub, logs := newTestAPIPublisher(t, stub)
+
+	msg := testStatusMessage()
+	for range 20 {
+		if err := pub.publishMessage(context.Background(), msg, msg.Timestamp); err != nil {
+			t.Fatalf("pub/sub failure must not fail the heartbeat: %v", err)
+		}
+	}
+	if got := len(*logs); got != 1 {
+		t.Fatalf("20 consecutive pub/sub failures should log once within the rate-limit window, got %d: %v", got, *logs)
+	}
+
+	stub.mu.Lock()
+	stub.failPubSub = false
+	stub.mu.Unlock()
+
+	if err := pub.publishMessage(context.Background(), msg, msg.Timestamp); err != nil {
+		t.Fatalf("publishMessage: %v", err)
+	}
+	if got := len(*logs); got != 2 {
+		t.Fatalf("recovery should be logged exactly once, got %d lines: %v", got, *logs)
+	}
+	if !strings.Contains((*logs)[1], "recovered after 20 failures") {
+		t.Errorf("recovery line should carry the failure count, got: %s", (*logs)[1])
+	}
+
+	// And it stays quiet once healthy.
+	if err := pub.publishMessage(context.Background(), msg, msg.Timestamp); err != nil {
+		t.Fatalf("publishMessage: %v", err)
+	}
+	if got := len(*logs); got != 2 {
+		t.Errorf("a healthy heartbeat must not re-log recovery, got %d lines: %v", got, *logs)
+	}
+}
+
+// TestPubSubHealthRateLimit pins the rate-limit policy directly, since the
+// 15-minute window is impractical to reach through the publisher.
+func TestPubSubHealthRateLimit(t *testing.T) {
+	var h pubSubHealth
+	start := time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC)
+
+	if report, escalate := h.recordFailure(start); !escalate || report.Failures != 1 {
+		t.Fatalf("first failure must be reported, got escalate=%v report=%+v", escalate, report)
+	}
+	// Every 30s for just under the window: suppressed.
+	now := start
+	for now.Sub(start) < pubSubWarnInterval-30*time.Second {
+		now = now.Add(30 * time.Second)
+		if _, escalate := h.recordFailure(now); escalate {
+			t.Fatalf("failure at %s should be suppressed inside the window", now.Sub(start))
+		}
+	}
+	// Crossing the window escalates again, carrying the elapsed duration.
+	now = now.Add(30 * time.Second)
+	report, escalate := h.recordFailure(now)
+	if !escalate {
+		t.Fatalf("failure at %s should escalate after the window", now.Sub(start))
+	}
+	if report.Duration != pubSubWarnInterval {
+		t.Errorf("report should carry the outage duration, got %s", report.Duration)
+	}
+	if report.Failures != 31 {
+		t.Errorf("report should carry the consecutive failure count, got %d", report.Failures)
+	}
+	if got := h.consecutiveFailures(); got != 31 {
+		t.Errorf("consecutiveFailures() = %d, want 31", got)
+	}
+
+	// Recovery reports once, then resets.
+	rec, recovered := h.recordSuccess(now.Add(30 * time.Second))
+	if !recovered || rec.Failures != 31 {
+		t.Fatalf("recovery should be reported once with the run length, got %v %+v", recovered, rec)
+	}
+	if _, recovered := h.recordSuccess(now.Add(time.Minute)); recovered {
+		t.Error("a second success must not re-report recovery")
+	}
+	if got := h.consecutiveFailures(); got != 0 {
+		t.Errorf("consecutiveFailures() after recovery = %d, want 0", got)
+	}
+
+	// A new run escalates immediately rather than inheriting the old window.
+	if _, escalate := h.recordFailure(now.Add(2 * time.Minute)); !escalate {
+		t.Error("the first failure of a NEW run must be reported immediately")
+	}
+}
+
+func containsSubstring(lines []string, want string) bool {
+	for _, l := range lines {
+		if strings.Contains(l, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/heartbeat/api_publish_test.go
+++ b/internal/heartbeat/api_publish_test.go
@@ -165,8 +165,8 @@ func TestPublishMessagePubSubFailureIsNotFatal(t *testing.T) {
 
 	// A sustained failure must be visible somewhere: the first failure of a run
 	// is always reported.
-	if !containsSubstring(*logs, "pub/sub publish to node:status:org:org-1:test-node failing") {
-		t.Errorf("first pub/sub failure must be surfaced, logs: %v", *logs)
+	if !containsSubstring(*logs, "pub/sub publish to node:status:org:org-1:test-node failing (1st consecutive failure)") {
+		t.Errorf("first pub/sub failure must be surfaced without a misleading 0s duration, logs: %v", *logs)
 	}
 }
 
@@ -260,7 +260,7 @@ func TestPublishMessageWarningIsRateLimitedThenRecovers(t *testing.T) {
 	if got := len(*logs); got != 2 {
 		t.Fatalf("recovery should be logged exactly once, got %d lines: %v", got, *logs)
 	}
-	if !strings.Contains((*logs)[1], "recovered after 20 failures") {
+	if !strings.Contains((*logs)[1], "recovered after 20 consecutive failures") {
 		t.Errorf("recovery line should carry the failure count, got: %s", (*logs)[1])
 	}
 

--- a/internal/heartbeat/pubsub_health.go
+++ b/internal/heartbeat/pubsub_health.go
@@ -1,0 +1,88 @@
+package heartbeat
+
+import (
+	"sync"
+	"time"
+)
+
+// pubSubWarnInterval bounds how often a sustained best-effort pub/sub failure
+// is escalated to a warning.
+//
+// Heartbeats publish every 30s, so warning on every failure produced ~120
+// identical lines an hour. That is why the outage in citadel-cli#722 stayed
+// unnoticed for 12 hours: the signal was present but indistinguishable from
+// background noise, and nothing marked the transition into failure. Silence is
+// the other failure mode, so this rate-limits rather than demotes: the first
+// failure of a run is always reported, and a sustained outage keeps reporting
+// on a slow cadence.
+const pubSubWarnInterval = 15 * time.Minute
+
+// pubSubHealth tracks consecutive failures of the best-effort pub/sub publish.
+//
+// Policy: report the first failure of a run, then at most once per
+// pubSubWarnInterval, then once more when publishing recovers. Every reported
+// line carries the consecutive failure count and how long the channel has been
+// down, so one log entry answers "how long has this been broken".
+//
+// Safe for concurrent use; the publishers call it from a single goroutine
+// today, but the zero value must be usable and the counters are shared state.
+type pubSubHealth struct {
+	mu       sync.Mutex
+	failures int
+	since    time.Time
+	lastWarn time.Time
+}
+
+// pubSubReport is the detail attached to a reported failure or recovery.
+type pubSubReport struct {
+	// Failures is the number of consecutive failures, including this one (for
+	// a failure report) or the run that just ended (for a recovery report).
+	Failures int
+	// Duration is how long the channel has been failing.
+	Duration time.Duration
+}
+
+// recordFailure notes a failed pub/sub publish. The second return value is
+// true when the caller should surface this failure rather than suppress it.
+func (h *pubSubHealth) recordFailure(now time.Time) (pubSubReport, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.failures == 0 {
+		h.since = now
+	}
+	h.failures++
+	report := pubSubReport{Failures: h.failures, Duration: now.Sub(h.since)}
+
+	// First failure of a run is always reported; after that, at most once per
+	// interval.
+	if h.failures == 1 || now.Sub(h.lastWarn) >= pubSubWarnInterval {
+		h.lastWarn = now
+		return report, true
+	}
+	return report, false
+}
+
+// recordSuccess notes a successful pub/sub publish. The second return value is
+// true when this success ended a run of failures and the caller should say so.
+func (h *pubSubHealth) recordSuccess(now time.Time) (pubSubReport, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.failures == 0 {
+		return pubSubReport{}, false
+	}
+	report := pubSubReport{Failures: h.failures, Duration: now.Sub(h.since)}
+	h.failures = 0
+	h.since = time.Time{}
+	h.lastWarn = time.Time{}
+	return report, true
+}
+
+// consecutiveFailures returns the current run length of pub/sub failures
+// (0 when the channel is healthy).
+func (h *pubSubHealth) consecutiveFailures() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.failures
+}

--- a/internal/heartbeat/pubsub_health.go
+++ b/internal/heartbeat/pubsub_health.go
@@ -1,6 +1,7 @@
 package heartbeat
 
 import (
+	"fmt"
 	"sync"
 	"time"
 )
@@ -40,6 +41,16 @@ type pubSubReport struct {
 	Failures int
 	// Duration is how long the channel has been failing.
 	Duration time.Duration
+}
+
+// describe renders the run for an operator. The first failure of a run has no
+// elapsed time worth printing: "failing for 0s" reads as a rounding artifact
+// and undercuts the one line an operator is most likely to act on.
+func (r pubSubReport) describe() string {
+	if r.Failures <= 1 {
+		return "1st consecutive failure"
+	}
+	return fmt.Sprintf("%d consecutive failures over %s", r.Failures, r.Duration.Round(time.Second))
 }
 
 // recordFailure notes a failed pub/sub publish. The second return value is

--- a/internal/heartbeat/redis.go
+++ b/internal/heartbeat/redis.go
@@ -3,14 +3,14 @@
 // This file implements Redis-based status publishing for real-time UI updates
 // and reliable status processing via Redis Streams.
 //
-// Architecture:
+// Architecture (durable write first; see APIPublisher.publishMessage for why):
 //
 //	Citadel Node                                Redis
-//	┌─────────────┐    PUBLISH node:status:X   ┌─────────────┐
-//	│   Redis     │ ────────────────────────▶  │  Pub/Sub    │ → Real-time UI
+//	┌─────────────┐    XADD node:status:stream ┌─────────────┐
+//	│   Redis     │ ────────────────────────▶  │  Streams    │ → Python Worker (durable)
 //	│  Publisher  │                            └─────────────┘
-//	│   (30s)     │    XADD node:status:stream ┌─────────────┐
-//	│             │ ────────────────────────▶  │  Streams    │ → Python Worker
+//	│   (30s)     │    PUBLISH node:status:X   ┌─────────────┐
+//	│             │ ────────────────────────▶  │  Pub/Sub    │ → Real-time UI (best effort)
 //	└─────────────┘                            └─────────────┘
 package heartbeat
 
@@ -88,6 +88,10 @@ type RedisPublisher struct {
 
 	// heartbeatCount tracks heartbeats to trigger keep-alive every 60s
 	heartbeatCount int
+
+	// pubSubHealth rate-limits the log noise from a failing best-effort
+	// pub/sub publish while keeping a sustained outage visible (#722).
+	pubSubHealth pubSubHealth
 
 	// onStatus, when set, is invoked with each freshly collected status after a
 	// successful publish, driving the config-gated auto-stop reconciler off the
@@ -286,23 +290,31 @@ func (p *RedisPublisher) publishStatus(ctx context.Context) error {
 		msg.Stats = p.statsFn()
 	}
 
+	return p.publishMessage(ctx, msg, deviceCode)
+}
+
+// publishMessage writes one heartbeat to both destinations. Split out of
+// publishStatus so the write half is testable without a live status collector.
+func (p *RedisPublisher) publishMessage(ctx context.Context, msg StatusMessage, deviceCode string) error {
 	// Marshal to JSON
 	jsonData, err := json.Marshal(msg)
 	if err != nil {
 		return fmt.Errorf("failed to marshal status: %w", err)
 	}
 
-	p.debug("heartbeat: publishing to channel %s", p.pubSubChannel)
 	p.debug("heartbeat: nodeId=%s, headscaleNodeId=%s, deviceCode=%s, timestamp=%s", msg.NodeID, msg.HeadscaleNodeID, msg.DeviceCode, msg.Timestamp)
 	p.debug("heartbeat: payload (%d bytes): %s", len(jsonData), string(jsonData))
 
-	// Publish to Pub/Sub for real-time UI updates
-	if err := p.client.Publish(ctx, p.pubSubChannel, jsonData).Err(); err != nil {
-		return fmt.Errorf("failed to publish to Pub/Sub: %w", err)
-	}
-	p.debug("heartbeat: pub/sub publish successful")
-
-	// Add to Stream for reliable processing
+	// Durable stream FIRST, and it owns the error. See the APIPublisher's
+	// publishMessage for the full rationale (citadel-cli#722): the stream is
+	// what the platform's NodeStatusWorker consumes to update the node's
+	// last-reported timestamp, while the pub/sub publish only drives live UI
+	// freshness. Making the best-effort write a gate on the reliable one is
+	// what dropped a healthy node out of the fabric.
+	//
+	// Unlike the API publisher, both writes here share ONE Redis connection, so
+	// their failures are strongly correlated and this ordering is a correctness
+	// and consistency fix rather than a fix for an observed failure mode.
 	streamFields := map[string]any{
 		"nodeId":    p.nodeID,
 		"timestamp": msg.Timestamp,
@@ -312,16 +324,35 @@ func (p *RedisPublisher) publishStatus(ctx context.Context) error {
 		streamFields["deviceCode"] = deviceCode
 	}
 
-	if err := p.client.XAdd(ctx, &redis.XAddArgs{
+	streamErr := p.client.XAdd(ctx, &redis.XAddArgs{
 		Stream: p.streamName,
 		Values: streamFields,
 		MaxLen: 10000, // Keep last 10k messages to prevent unbounded growth
 		Approx: true,  // Approximate trimming for performance
-	}).Err(); err != nil {
-		return fmt.Errorf("failed to add to stream: %w", err)
+	}).Err()
+	if streamErr == nil {
+		p.debug("heartbeat: stream XADD successful")
 	}
-	p.debug("heartbeat: stream XADD successful")
 
+	// Best-effort Pub/Sub for real-time UI updates. Never fatal.
+	p.debug("heartbeat: publishing to channel %s", p.pubSubChannel)
+	if pubErr := p.client.Publish(ctx, p.pubSubChannel, jsonData).Err(); pubErr != nil {
+		p.debug("heartbeat: pub/sub publish failed (non-fatal): %v", pubErr)
+		if report, escalate := p.pubSubHealth.recordFailure(time.Now()); escalate {
+			p.log("warning", "   - Warning: heartbeat pub/sub publish to %s failing for %s (%d consecutive): %v (live UI updates only; durable status stream unaffected)",
+				p.pubSubChannel, report.Duration.Round(time.Second), report.Failures, pubErr)
+		}
+	} else {
+		p.debug("heartbeat: pub/sub publish successful")
+		if report, recovered := p.pubSubHealth.recordSuccess(time.Now()); recovered {
+			p.log("info", "   - heartbeat pub/sub publish to %s recovered after %d failures over %s",
+				p.pubSubChannel, report.Failures, report.Duration.Round(time.Second))
+		}
+	}
+
+	if streamErr != nil {
+		return fmt.Errorf("failed to add to durable stream %s: %w", p.streamName, streamErr)
+	}
 	return nil
 }
 

--- a/internal/heartbeat/redis.go
+++ b/internal/heartbeat/redis.go
@@ -339,14 +339,14 @@ func (p *RedisPublisher) publishMessage(ctx context.Context, msg StatusMessage, 
 	if pubErr := p.client.Publish(ctx, p.pubSubChannel, jsonData).Err(); pubErr != nil {
 		p.debug("heartbeat: pub/sub publish failed (non-fatal): %v", pubErr)
 		if report, escalate := p.pubSubHealth.recordFailure(time.Now()); escalate {
-			p.log("warning", "   - Warning: heartbeat pub/sub publish to %s failing for %s (%d consecutive): %v (live UI updates only; durable status stream unaffected)",
-				p.pubSubChannel, report.Duration.Round(time.Second), report.Failures, pubErr)
+			p.log("warning", "   - Warning: heartbeat pub/sub publish to %s failing (%s): %v (live UI updates only; durable status stream unaffected)",
+				p.pubSubChannel, report.describe(), pubErr)
 		}
 	} else {
 		p.debug("heartbeat: pub/sub publish successful")
 		if report, recovered := p.pubSubHealth.recordSuccess(time.Now()); recovered {
-			p.log("info", "   - heartbeat pub/sub publish to %s recovered after %d failures over %s",
-				p.pubSubChannel, report.Failures, report.Duration.Round(time.Second))
+			p.log("info", "   - heartbeat pub/sub publish to %s recovered after %s",
+				p.pubSubChannel, report.describe())
 		}
 	}
 

--- a/internal/heartbeat/redis_publish_test.go
+++ b/internal/heartbeat/redis_publish_test.go
@@ -1,0 +1,149 @@
+package heartbeat
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/aceteam-ai/citadel-cli/internal/status"
+)
+
+// failCommandHook makes one Redis command fail while the rest of the
+// connection stays healthy. On a real node the direct-Redis publisher shares a
+// single connection for PUBLISH and XADD, so their failures are strongly
+// correlated; this hook lets the test isolate the ordering/severity contract
+// that the shared connection would otherwise hide.
+type failCommandHook struct {
+	command string
+	err     error
+}
+
+func (h failCommandHook) DialHook(next redis.DialHook) redis.DialHook { return next }
+
+func (h failCommandHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
+	return func(ctx context.Context, cmd redis.Cmder) error {
+		if strings.EqualFold(cmd.Name(), h.command) {
+			cmd.SetErr(h.err)
+			return h.err
+		}
+		return next(ctx, cmd)
+	}
+}
+
+func (h failCommandHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
+	return next
+}
+
+func newTestRedisPublisher(t *testing.T) (*RedisPublisher, *miniredis.Miniredis, *[]string) {
+	t.Helper()
+
+	mr := miniredis.RunT(t)
+
+	var mu sync.Mutex
+	var logs []string
+
+	pub, err := NewRedisPublisher(RedisPublisherConfig{
+		RedisURL: "redis://" + mr.Addr(),
+		NodeID:   "test-node",
+		LogFn: func(level, msg string) {
+			mu.Lock()
+			defer mu.Unlock()
+			logs = append(logs, level+": "+msg)
+		},
+	}, status.NewCollector(status.CollectorConfig{NodeName: "test-node"}))
+	if err != nil {
+		t.Fatalf("NewRedisPublisher: %v", err)
+	}
+	t.Cleanup(func() { _ = pub.Close() })
+	return pub, mr, &logs
+}
+
+// TestRedisPublishPubSubFailureIsNotFatal is the direct-Redis half of #722: a
+// failing PUBLISH must not skip the durable XADD, and must not be reported as a
+// heartbeat failure.
+func TestRedisPublishPubSubFailureIsNotFatal(t *testing.T) {
+	pub, mr, logs := newTestRedisPublisher(t)
+	pub.client.AddHook(failCommandHook{command: "publish", err: errors.New("simulated PUBLISH failure")})
+
+	msg := testStatusMessage()
+	if err := pub.publishMessage(context.Background(), msg, ""); err != nil {
+		t.Fatalf("PUBLISH failure must not fail the heartbeat, got: %v", err)
+	}
+
+	entries := streamEntries(t, mr)
+	if len(entries) != 1 {
+		t.Fatalf("durable stream write must happen despite PUBLISH failure, got %d entries", len(entries))
+	}
+	if got := entries[0]["nodeId"]; got != "test-node" {
+		t.Errorf("stream entry nodeId = %q, want test-node", got)
+	}
+
+	if !containsSubstring(*logs, "pub/sub publish to node:status:test-node failing") {
+		t.Errorf("first pub/sub failure must be surfaced, logs: %v", *logs)
+	}
+}
+
+// TestRedisPublishStreamFailureIsFatal proves the durable write owns the error.
+func TestRedisPublishStreamFailureIsFatal(t *testing.T) {
+	pub, mr, _ := newTestRedisPublisher(t)
+	pub.client.AddHook(failCommandHook{command: "xadd", err: errors.New("simulated XADD failure")})
+
+	msg := testStatusMessage()
+	err := pub.publishMessage(context.Background(), msg, "")
+	if err == nil {
+		t.Fatal("a failed durable stream write must return an error")
+	}
+	if !strings.Contains(err.Error(), "node:status:stream") {
+		t.Errorf("error should name the durable stream, got: %v", err)
+	}
+
+	if entries := streamEntries(t, mr); len(entries) != 0 {
+		t.Errorf("expected no stream entries, got %d", len(entries))
+	}
+}
+
+// TestRedisPublishHappyPath keeps the ordinary case honest.
+func TestRedisPublishHappyPath(t *testing.T) {
+	pub, mr, logs := newTestRedisPublisher(t)
+
+	msg := testStatusMessage()
+	if err := pub.publishMessage(context.Background(), msg, "device-code-1"); err != nil {
+		t.Fatalf("publishMessage: %v", err)
+	}
+
+	entries := streamEntries(t, mr)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 stream entry, got %d", len(entries))
+	}
+	if got := entries[0]["deviceCode"]; got != "device-code-1" {
+		t.Errorf("deviceCode field = %q, want device-code-1", got)
+	}
+	if len(*logs) != 0 {
+		t.Errorf("a healthy heartbeat must not log, got: %v", *logs)
+	}
+}
+
+// streamEntries reads node:status:stream out of miniredis as field maps.
+func streamEntries(t *testing.T, mr *miniredis.Miniredis) []map[string]string {
+	t.Helper()
+	raw, err := mr.Stream("node:status:stream")
+	if err != nil {
+		// miniredis returns an error for a key that was never created, which
+		// for these tests means "no heartbeat landed".
+		return nil
+	}
+	out := make([]map[string]string, 0, len(raw))
+	for _, e := range raw {
+		fields := map[string]string{}
+		for i := 0; i+1 < len(e.Values); i += 2 {
+			fields[e.Values[i]] = e.Values[i+1]
+		}
+		out = append(out, fields)
+	}
+	return out
+}


### PR DESCRIPTION
Fixes #722.

## Context

`publishStatus` published to Redis Pub/Sub first and `return`ed on error, so a
pub/sub failure skipped the `XADD node:status:stream` entirely. On the affected
node the worker was healthy and consuming jobs, but its platform status record
froze for 12+ hours and fail-closed per-node routing dropped it from the fabric
for anything node-pinned.

## Premise verification

The issue's load-bearing claim holds, and is understated. One correction to the
citation, and the full chain, read read-only from `aceteam-ai/aceteam`:

- The comment cites `python-backend/worker/node_usage/worker.py`. That worker
  consumes `node:usage:stream`, a different stream. The actual consumer of
  `node:status:stream` is **`python-backend/worker/node_status/worker.py`**.
- That worker upserts `fabric_node_status`, including `reported_at`
  (`_upsert_node_status`).
- `python-backend/coordinator/node_offline_sweep.py` flips `is_online` to false
  when `reported_at` is older than 120s (4 missed 30s heartbeats).
- `docs/fabric/node-status-realtime-system.md` labels the stream "persisted,
  reliable" and confirms the CLI publishes raw status to the stream only.

The stronger point the docs make: the org-scoped channel the CLI publishes to,
`node:status:org:{orgId}:{nodeId}`, is **the same channel the platform worker
publishes to itself** after its DB upsert, and the SSE endpoint is its only
subscriber. Nothing that touches the database reads the CLI's pub/sub write. It
is unambiguously best effort, and it was gating the only write that mattered.

The severity was inverted on the other side too: in `api.go` a failed
`StreamAdd` was logged and swallowed with a `nil` return.

## Changes

- `internal/heartbeat/api.go`, `internal/heartbeat/redis.go`: attempt both
  writes. The durable stream goes **first** and owns the returned error; the
  pub/sub publish is best effort and never fatal. Ordering the durable write
  first also means a kill between the two calls still leaves the record landed.
  Both files gained a `publishMessage` split so the write half is testable
  without a live status collector.
- `internal/heartbeat/pubsub_health.go` (new): rate-limits the pub/sub warning.
- Package header diagrams updated to match the new ordering.

### Log noise policy

The warning fired every 30s interval forever, which is how a 12-hour outage
stayed invisible: the signal was present but indistinguishable from background
noise, and nothing marked the transition into failure. Dropping it to debug
would have swapped one invisibility for another, so this rate-limits instead:

- The **first failure of a run is always reported** at warning.
- After that, at most once per **15 minutes** while it keeps failing.
- **Recovery** is reported once.
- Every reported line carries the consecutive failure count and the outage
  duration (omitted on the first line, where it would only ever read `0s`), so
  one log entry answers "how long has this been broken".

This rate-limits the *best-effort* channel only. If the durable stream write
starts failing, `Start` still warns every 30s interval, unbounded, and that is
deliberate: the issue's complaint was that a best-effort failure spammed a
warning forever, not that warnings are bad. A node dropping out of the fabric is
exactly the thing that should keep screaming.

Considered and not shipped: riding the consecutive-failure count on the
heartbeat payload as an additive field. It is useful to the platform but not to
the node-local case, and it grows the diff for a second consumer.

### `redis.go` is consistency, not the observed bug

The direct-Redis publisher had the same ordering, but both of its writes share
one Redis connection, so `PUBLISH` and `XADD` failures there are strongly
correlated. That change is correctness and consistency; the incident was on the
API path, where the two writes are independent HTTP calls.

## Follow-up

#726 tracks surfacing heartbeat freshness in `citadel status`. Deliberately not
done here: the publisher lives in the long-running `citadel work` process while
`citadel status` is a separate invocation, so it needs a state file or the
status endpoint, not a one-liner.

## Testing

`go test ./...`, `go vet ./...`, `gofmt -l .` and `go build ./cmd/citadel` all
clean (this repo's CI runs no linter beyond those).

New tests in `internal/heartbeat/`:

| Test | Pins |
|---|---|
| `TestPublishMessagePubSubFailureIsNotFatal` | pub/sub fails, stream succeeds: no error, heartbeat payload verified on the stream, first failure logged |
| `TestPublishMessageStreamFailureIsFatal` | stream fails: error returned naming the stream, pub/sub still attempted |
| `TestPublishMessageBothFailReportsStreamError` | the durable failure is the one reported |
| `TestPublishMessageHappyPath` | both writes, no error, no operator log |
| `TestPublishMessageWarningIsRateLimitedThenRecovers` | 20 consecutive failures log once; recovery logs once |
| `TestPubSubHealthRateLimit` | the 15-minute window, the failure counters, and a new run escalating immediately |
| `TestRedisPublish{PubSubFailureIsNotFatal,StreamFailureIsFatal,HappyPath}` | same contract on the direct-Redis path |

The API tests drive a real `redisapi.Client` at an `httptest` stub that can fail
each endpoint independently. The Redis tests use miniredis (already a dep) plus
a go-redis `ProcessHook` that fails one command, so `PUBLISH` and `XADD` can be
failed independently despite sharing a connection.

### Mutation testing

Eight mutations reintroducing the bug or weakening the policy, **8/8 killed**:

| Mutation | Killed by |
|---|---|
| M1 `api.go` pub/sub error returns early (the original bug) | `TestPublishMessagePubSubFailureIsNotFatal` |
| M2 `api.go` stream failure log-and-return-nil (the original) | `TestPublishMessageStreamFailureIsFatal`, `...BothFailReportsStreamError` |
| M3 `api.go` stream write skipped entirely | `TestPublishMessagePubSubFailureIsNotFatal`, `...HappyPath` |
| M4 `redis.go` PUBLISH error returns early | `TestRedisPublishPubSubFailureIsNotFatal` |
| M5 `redis.go` XADD failure swallowed | `TestRedisPublishStreamFailureIsFatal` |
| M6 no rate limit, every failure escalates | `...WarningIsRateLimitedThenRecovers`, `TestPubSubHealthRateLimit` |
| M7 sustained failure goes silent after the first line | `TestPubSubHealthRateLimit` |
| M8 recovery never reported | `...WarningIsRateLimitedThenRecovers`, `TestPubSubHealthRateLimit` |

Baseline re-verified passing after restore.

## Notes for review

- `PublishOnce` has no callers anywhere in the repo, so flipping `api.go`'s
  stream failure from `nil` to an error changes no existing behaviour outside
  `Start`, which only logs.
- `api.go` and `redis.go` are the only heartbeat status publish sites
  (`grep node:status:stream`, `grep StreamAdd(`).
- The observed 12-hour outage needed **both** #721 and #722: #721 made a
  server-side 200 read as a client-side failure, and #722 turned that false
  negative into a dropped durable write. Fixing #722 alone would have prevented
  the outage. #721 is still worth fixing on its own.

## Not verified

Not exercised against a live node or a real Redis API proxy. The failure modes
are simulated at the HTTP and Redis-command boundaries.
