### PR TITLE
fix(pubsub): retry the WebSocket connect instead of giving up after one try (#723)

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -1776,10 +1776,14 @@ func runTUIWorker(ctx context.Context, activityFn func(level, msg string)) error
 			return fmt.Errorf("failed to connect to Redis API: %w", err)
 		}
 
-		// Enable WebSocket for real-time pub/sub
-		if err := apiSource.Client().EnableWebSocket(ctx); err != nil {
-			activity("warning", "WebSocket not available, using HTTP")
-		}
+		// Enable WebSocket for real-time pub/sub. Same defect and same fix as
+		// the worker path (issue #723): one failed connect used to disable
+		// real-time pub/sub for the life of the process. Retries in the
+		// background with backoff/jitter, honoring any 429 retry_after.
+		enableWebSocketWithRetry(ctx, wsConnector{client: apiSource.Client()},
+			func(format string, args ...any) {
+				activity("warning", fmt.Sprintf(format, args...))
+			})
 
 		source = apiSource
 		streamFactory = worker.CreateAPIStreamWriterFactory(ctx, apiSource)

--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -1781,8 +1781,8 @@ func runTUIWorker(ctx context.Context, activityFn func(level, msg string)) error
 		// real-time pub/sub for the life of the process. Retries in the
 		// background with backoff/jitter, honoring any 429 retry_after.
 		enableWebSocketWithRetry(ctx, wsConnector{client: apiSource.Client()},
-			func(format string, args ...any) {
-				activity("warning", fmt.Sprintf(format, args...))
+			func(level, format string, args ...any) {
+				activity(level, fmt.Sprintf(format, args...))
 			})
 
 		source = apiSource

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -176,12 +176,16 @@ func printWorkerInfo(w io.Writer) {
 // reported as "unknown" rather than guessed at -- claiming "http" here when we
 // simply could not ask would be a worse lie than saying nothing.
 func printPubSubInfo(w io.Writer) {
-	transport, ok := probeWorkerPubSubTransport()
+	transport, state := probeWorkerPubSubTransport()
 	label := labelColor.Sprint("Pub/Sub:")
 	switch {
-	case !ok:
+	case state == pubSubProbeUnreachable:
 		fmt.Fprintf(w, "  %s\t%s\n", label,
-			faintColor.Sprint("unknown (worker status server not reachable on loopback)"))
+			faintColor.Sprint("unknown (worker status server not reachable on loopback; "+
+				"enable it with --status-port or --gateway)"))
+	case state == pubSubProbeNotReported:
+		fmt.Fprintf(w, "  %s\t%s\n", label,
+			faintColor.Sprint("unknown (worker reports no pub/sub transport: not API mode, or an older build)"))
 	case transport == redisapi.PubSubTransportWebSocket:
 		fmt.Fprintf(w, "  %s\t%s\n", label, goodColor.Sprint("websocket (real-time)"))
 	case transport == redisapi.PubSubTransportHTTP:
@@ -192,18 +196,31 @@ func printPubSubInfo(w io.Writer) {
 	}
 }
 
+// pubSubProbeState distinguishes the two ways the transport can be unknown, so
+// the status line says WHY rather than implying a verdict it did not obtain.
+type pubSubProbeState int
+
+const (
+	pubSubProbeOK pubSubProbeState = iota
+	// pubSubProbeUnreachable: no answer on loopback. The worker's status server
+	// is opt-in (--status-port / --gateway), so this is the common case.
+	pubSubProbeUnreachable
+	// pubSubProbeNotReported: the server answered but carried no transport --
+	// direct-Redis mode (no WebSocket/HTTP split) or a pre-#723 build.
+	pubSubProbeNotReported
+)
+
 // probeWorkerPubSubTransport GETs the running worker's /status over loopback and
-// returns worker.pubsub_transport. ok=false when the server is unreachable or
-// the field is absent (older worker, or direct-Redis mode, which has no split).
-func probeWorkerPubSubTransport() (string, bool) {
+// returns worker.pubsub_transport.
+func probeWorkerPubSubTransport() (string, pubSubProbeState) {
 	port := resolveStatusPort()
 	if port <= 0 {
-		return "", false
+		return "", pubSubProbeUnreachable
 	}
 	body, ok := httpGetBody(&http.Client{Timeout: 2 * time.Second},
 		fmt.Sprintf("http://127.0.0.1:%d/status", port))
 	if !ok {
-		return "", false
+		return "", pubSubProbeUnreachable
 	}
 	return parsePubSubTransport(body)
 }
@@ -211,19 +228,19 @@ func probeWorkerPubSubTransport() (string, bool) {
 // parsePubSubTransport extracts worker.pubsub_transport from a /status payload.
 // Split out from the fetch so the "older worker / no worker / malformed" cases
 // are unit-testable without a live status server.
-func parsePubSubTransport(body []byte) (string, bool) {
+func parsePubSubTransport(body []byte) (string, pubSubProbeState) {
 	var payload struct {
 		Worker *struct {
 			PubSubTransport string `json:"pubsub_transport"`
 		} `json:"worker"`
 	}
 	if err := json.Unmarshal(body, &payload); err != nil {
-		return "", false
+		return "", pubSubProbeUnreachable
 	}
 	if payload.Worker == nil || payload.Worker.PubSubTransport == "" {
-		return "", false
+		return "", pubSubProbeNotReported
 	}
-	return payload.Worker.PubSubTransport, true
+	return payload.Worker.PubSubTransport, pubSubProbeOK
 }
 
 // runInteractiveDashboard runs the interactive TUI dashboard

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,6 +18,7 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/capabilities"
 	"github.com/aceteam-ai/citadel-cli/internal/network"
 	"github.com/aceteam-ai/citadel-cli/internal/platform"
+	"github.com/aceteam-ai/citadel-cli/internal/redisapi"
 	"github.com/aceteam-ai/citadel-cli/internal/resmon"
 	statuspkg "github.com/aceteam-ai/citadel-cli/internal/status"
 	"github.com/aceteam-ai/citadel-cli/internal/tui"
@@ -36,6 +38,7 @@ var (
 	goodColor     = color.New(color.FgGreen)
 	warnColor     = color.New(color.FgYellow)
 	badColor      = color.New(color.FgRed)
+	faintColor    = color.New(color.Faint)
 	labelColor    = color.New(color.Bold)
 	interactiveUI bool // Flag to enable interactive TUI dashboard
 	statusJSON    bool // Flag to output JSON format
@@ -155,6 +158,72 @@ func printWorkerInfo(w io.Writer) {
 		}
 	}
 	fmt.Fprintf(w, "  %s\t%s (%s)\n", labelColor.Sprint("Status:"), goodColor.Sprint("running"), detail)
+	printPubSubInfo(w)
+}
+
+// printPubSubInfo reports which transport the running worker's pub/sub
+// publishes are using (issue #723).
+//
+// This is the line that would have ended a twelve-hour outage in seconds. A
+// worker whose startup WebSocket connect failed silently degraded to the HTTP
+// publish fallback -- which does not work (citadel-cli#721) -- and nothing
+// anywhere said so: the failure was logged at Debug, and every other status
+// signal read healthy.
+//
+// Read over loopback from the worker's own status server, so it reflects the
+// live process rather than a file written at startup. Best-effort: the status
+// server is opt-in (--status-port / --gateway), so an unreachable server is
+// reported as "unknown" rather than guessed at -- claiming "http" here when we
+// simply could not ask would be a worse lie than saying nothing.
+func printPubSubInfo(w io.Writer) {
+	transport, ok := probeWorkerPubSubTransport()
+	label := labelColor.Sprint("Pub/Sub:")
+	switch {
+	case !ok:
+		fmt.Fprintf(w, "  %s\t%s\n", label,
+			faintColor.Sprint("unknown (worker status server not reachable on loopback)"))
+	case transport == redisapi.PubSubTransportWebSocket:
+		fmt.Fprintf(w, "  %s\t%s\n", label, goodColor.Sprint("websocket (real-time)"))
+	case transport == redisapi.PubSubTransportHTTP:
+		fmt.Fprintf(w, "  %s\t%s\n", label,
+			warnColor.Sprint("HTTP fallback: real-time pub/sub is DOWN (heartbeat may not reach the platform)"))
+	default:
+		fmt.Fprintf(w, "  %s\t%s\n", label, transport)
+	}
+}
+
+// probeWorkerPubSubTransport GETs the running worker's /status over loopback and
+// returns worker.pubsub_transport. ok=false when the server is unreachable or
+// the field is absent (older worker, or direct-Redis mode, which has no split).
+func probeWorkerPubSubTransport() (string, bool) {
+	port := resolveStatusPort()
+	if port <= 0 {
+		return "", false
+	}
+	body, ok := httpGetBody(&http.Client{Timeout: 2 * time.Second},
+		fmt.Sprintf("http://127.0.0.1:%d/status", port))
+	if !ok {
+		return "", false
+	}
+	return parsePubSubTransport(body)
+}
+
+// parsePubSubTransport extracts worker.pubsub_transport from a /status payload.
+// Split out from the fetch so the "older worker / no worker / malformed" cases
+// are unit-testable without a live status server.
+func parsePubSubTransport(body []byte) (string, bool) {
+	var payload struct {
+		Worker *struct {
+			PubSubTransport string `json:"pubsub_transport"`
+		} `json:"worker"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return "", false
+	}
+	if payload.Worker == nil || payload.Worker.PubSubTransport == "" {
+		return "", false
+	}
+	return payload.Worker.PubSubTransport, true
 }
 
 // runInteractiveDashboard runs the interactive TUI dashboard

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -266,7 +266,7 @@ func connectWithBackoffLabeled(ctx context.Context, label string, source apiConn
 		if backoff > connectBackoffMax {
 			backoff = connectBackoffMax
 		}
-		if !sleepCtx(ctx, sleep) {
+		if !backoffSleep(ctx, sleep) {
 			return ctx.Err()
 		}
 	}
@@ -300,6 +300,13 @@ func jitter(d time.Duration) time.Duration {
 	delta := float64(d) * 0.2
 	return time.Duration(float64(d) - delta + rand.Float64()*2*delta)
 }
+
+// backoffSleep is the retry loop's sleep, indirected through a var so a test can
+// observe the durations the loop ASKS for instead of measuring wall-clock gaps.
+// Timing-based assertions on a loaded CI box are flaky in the direction that
+// hides a regression: an overloaded machine overshoots a short sleep enough to
+// look like a long one, so a hot loop can pass. Defaults to sleepCtx.
+var backoffSleep = sleepCtx
 
 // sleepCtx sleeps for d or until ctx is cancelled. Returns true if the full
 // sleep elapsed, false if the context was cancelled first (so backoff loops
@@ -625,6 +632,10 @@ func runWork(cmd *cobra.Command, args []string) {
 	// mode has no such split). Read by the worker-liveness payload so
 	// `citadel status` can show a node stuck on the HTTP fallback (issue #723).
 	var pubSubTransportFn func() string
+	// wsRetryDone closes when the background WebSocket connect retry finishes.
+	// Post-connect wiring that runs LATER in startup (push-wake) waits on it so a
+	// late connect still gets armed. nil outside API mode.
+	var wsRetryDone <-chan struct{}
 
 	// Live worker introspection state for the out-of-band control path
 	// (issue #236). Created here so the same pointer is shared by the runner
@@ -750,7 +761,7 @@ func runWork(cmd *cobra.Command, args []string) {
 		// blip left pub/sub on the (broken) HTTP fallback for the whole process
 		// lifetime, with only a Debug line to show for it (issue #723).
 		apiClient := apiSource.Client()
-		enableWebSocketWithRetry(ctx, wsConnector{client: apiClient}, Log)
+		wsRetryDone = enableWebSocketWithRetry(ctx, wsConnector{client: apiClient}, workerWSLog)
 		pubSubTransportFn = apiClient.PubSubTransport
 
 		source = apiSource
@@ -1048,6 +1059,11 @@ func runWork(cmd *cobra.Command, args []string) {
 				// subscribe failure just leaves this node correctly poll-only.
 				if err := src.EnableWake(ctx, wakeChannel); err != nil {
 					Debug("per-node push-wake unavailable (poll-only): %v", err)
+					// The WebSocket may not be up YET -- its connect retries in
+					// the background (#723). Re-arm the wake when it lands;
+					// otherwise a node that started during a control-plane blip
+					// recovers its heartbeat but stays poll-only for good.
+					armWakeAfterWebSocket(ctx, wsRetryDone, src, wakeChannel, workerWSLog)
 				}
 			case *worker.RedisSource:
 				if err := src.AddQueue(ctx, perNodeQueue); err != nil {

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -208,6 +208,15 @@ type apiConnector interface {
 // context is cancelled (clean shutdown), never on a connect failure -- the
 // process stays up and keeps retrying rather than dying into a restart storm.
 func connectWithBackoff(ctx context.Context, source apiConnector) error {
+	return connectWithBackoffLabeled(ctx, "Redis API", source)
+}
+
+// connectWithBackoffLabeled is connectWithBackoff with the subject named in the
+// log lines, so a second caller (the WebSocket pub/sub connect, issue #723) can
+// reuse the exact same retry policy -- exponential backoff with jitter, 429
+// retry_after honored in full, ctx-aware chunked sleeps -- without its failures
+// reading as control-plane failures in the journal. One scheme, one place.
+func connectWithBackoffLabeled(ctx context.Context, label string, source apiConnector) error {
 	backoff := connectBackoffInitial
 	attempt := 0
 	for {
@@ -219,7 +228,7 @@ func connectWithBackoff(ctx context.Context, source apiConnector) error {
 		err := source.Connect(ctx)
 		if err == nil {
 			if attempt > 1 {
-				Log("connected to Redis API after %d attempt(s)", attempt)
+				Log("connected to %s after %d attempt(s)", label, attempt)
 			}
 			return nil
 		}
@@ -242,8 +251,8 @@ func connectWithBackoff(ctx context.Context, source apiConnector) error {
 				wait = backoff
 			}
 			backoff = connectBackoffInitial
-			Log("Redis API rate limited (limit=%d window=%q); honoring server backoff of %s before retry: %v",
-				rle.Limit, rle.Window, wait, err)
+			Log("%s rate limited (limit=%d window=%q); honoring server backoff of %s before retry: %v",
+				label, rle.Limit, rle.Window, wait, err)
 			if !sleepUntilCtx(ctx, time.Now().Add(wait)) {
 				return ctx.Err()
 			}
@@ -252,7 +261,7 @@ func connectWithBackoff(ctx context.Context, source apiConnector) error {
 
 		// Generic transient failure: exponential backoff with jitter.
 		sleep := jitter(backoff)
-		Log("Redis API connect failed (attempt %d), retrying in %s: %v", attempt, sleep, err)
+		Log("%s connect failed (attempt %d), retrying in %s: %v", label, attempt, sleep, err)
 		backoff *= 2
 		if backoff > connectBackoffMax {
 			backoff = connectBackoffMax
@@ -611,6 +620,11 @@ func runWork(cmd *cobra.Command, args []string) {
 	var useAPIMode bool
 	var apiSource *worker.APISource               // Keep reference for heartbeat
 	var setNodeMeta func(nodeID, nodeName string) // Set after node identity is resolved
+	// pubSubTransportFn reports the transport Publish is currently using
+	// ("websocket" or "http"). Set only in API mode; nil elsewhere (direct-Redis
+	// mode has no such split). Read by the worker-liveness payload so
+	// `citadel status` can show a node stuck on the HTTP fallback (issue #723).
+	var pubSubTransportFn func() string
 
 	// Live worker introspection state for the out-of-band control path
 	// (issue #236). Created here so the same pointer is shared by the runner
@@ -728,13 +742,16 @@ func runWork(cmd *cobra.Command, args []string) {
 			return
 		}
 
-		// Enable WebSocket for real-time pub/sub (heartbeat, streaming responses)
-		if err := apiSource.Client().EnableWebSocket(ctx); err != nil {
-			// WebSocket is optional - fall back to HTTP
-			Debug("WebSocket not available, using HTTP for pub/sub: %v", err)
-		} else {
-			Debug("WebSocket enabled for real-time pub/sub")
-		}
+		// Enable WebSocket for real-time pub/sub (heartbeat, streaming responses).
+		//
+		// A failed connect here is NOT terminal: it retries in the background
+		// with the same backoff/jitter/429 treatment as the control-plane
+		// connect above. Before that, one unlucky attempt during a control-plane
+		// blip left pub/sub on the (broken) HTTP fallback for the whole process
+		// lifetime, with only a Debug line to show for it (issue #723).
+		apiClient := apiSource.Client()
+		enableWebSocketWithRetry(ctx, wsConnector{client: apiClient}, Log)
+		pubSubTransportFn = apiClient.PubSubTransport
 
 		source = apiSource
 		streamFactory = worker.CreateAPIStreamWriterFactory(ctx, apiSource)
@@ -1167,7 +1184,14 @@ func runWork(cmd *cobra.Command, args []string) {
 	// "green but wedged" node (heartbeating from a separate goroutine while the
 	// consume loop is blocked and draining nothing).
 	workerLivenessFn := func() *status.WorkerLiveness {
-		return workerLivenessFrom(workerState.Snapshot())
+		live := workerLivenessFrom(workerState.Snapshot())
+		// Pub/sub transport is read live off the API client rather than mirrored
+		// through WorkerState: it can flip at any moment (background retry
+		// succeeds, connection drops) and a snapshot field would go stale.
+		if pubSubTransportFn != nil {
+			live.PubSubTransport = pubSubTransportFn()
+		}
+		return live
 	}
 
 	// Create status collector (used by status server and Redis status publisher)

--- a/cmd/ws_pubsub.go
+++ b/cmd/ws_pubsub.go
@@ -29,6 +29,12 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/redisapi"
 )
 
+// wsLogFunc reports retry progress at a severity the caller's log sink
+// understands. Levels used: "warning" for the degrade, "info" for the recovery.
+// The worker's Log() ignores the level (it has one stream); the control center's
+// activity() renders it, so a recovery does not surface there as a warning.
+type wsLogFunc func(level, format string, args ...any)
+
 // wsConnector adapts a redisapi.Client's WebSocket enablement to the
 // apiConnector interface connectWithBackoff retries against.
 //
@@ -61,7 +67,7 @@ func (w wsConnector) Connect(ctx context.Context) error {
 // The returned channel closes when the retry loop has finished (immediately
 // when no loop was needed). Production callers ignore it; it exists so a test
 // can join the goroutine instead of sleeping and guessing.
-func enableWebSocketWithRetry(ctx context.Context, conn apiConnector, logf func(string, ...any)) <-chan struct{} {
+func enableWebSocketWithRetry(ctx context.Context, conn apiConnector, logf wsLogFunc) <-chan struct{} {
 	done := make(chan struct{})
 
 	err := conn.Connect(ctx)
@@ -70,7 +76,7 @@ func enableWebSocketWithRetry(ctx context.Context, conn apiConnector, logf func(
 		return done
 	}
 
-	logf("pub/sub WebSocket unavailable, falling back to HTTP and retrying in background: %v", err)
+	logf("warning", "pub/sub WebSocket unavailable, falling back to HTTP and retrying in background: %v", err)
 
 	go func() {
 		defer close(done)
@@ -78,8 +84,65 @@ func enableWebSocketWithRetry(ctx context.Context, conn apiConnector, logf func(
 			// The only non-nil return is context cancellation (clean shutdown).
 			return
 		}
-		logf("pub/sub WebSocket connected on retry; publishes are back on the real-time transport")
+		logf("info", "pub/sub WebSocket connected on retry; publishes are back on the real-time transport")
 	}()
 
 	return done
+}
+
+// wakeEnabler is the subset of worker.APISource armWakeAfterWebSocket needs.
+type wakeEnabler interface {
+	EnableWake(ctx context.Context, channel string) error
+}
+
+// armWakeAfterWebSocket re-arms per-node push-wake once a background WebSocket
+// connect finally lands.
+//
+// Push-wake (#7270) is one-shot post-connect setup: APISource.EnableWake
+// registers a "message" handler and subscribes to the node's wake channel, and
+// it refuses when the WebSocket is not connected. Before #723 that check could
+// only ever see the startup verdict, because the verdict was permanent. Now the
+// WebSocket can come up minutes later -- and because a late connect goes through
+// Connect rather than reconnect, WSClient's OnReconnect callbacks do NOT fire,
+// so nothing would re-run this wiring.
+//
+// Without this, a node that started during a control-plane blip would recover
+// its heartbeat (visible) but stay poll-only forever (invisible, and reported as
+// a healthy "websocket" transport) -- the same class of silent partial failure
+// #723 is about.
+//
+// No-op when the retry already finished: EnableWake was then called against the
+// final state and there is nothing further to wait for.
+func armWakeAfterWebSocket(ctx context.Context, wsRetryDone <-chan struct{}, src wakeEnabler, channel string, logf wsLogFunc) {
+	if wsRetryDone == nil || src == nil || channel == "" {
+		return
+	}
+	select {
+	case <-wsRetryDone:
+		return
+	default:
+	}
+
+	go func() {
+		select {
+		case <-wsRetryDone:
+		case <-ctx.Done():
+			return
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		if err := src.EnableWake(ctx, channel); err != nil {
+			logf("warning", "per-node push-wake still unavailable after the WebSocket retry (staying poll-only): %v", err)
+			return
+		}
+		logf("info", "per-node push-wake armed after WebSocket recovery: %s", channel)
+	}()
+}
+
+// workerWSLog adapts the worker's single-stream Log() to wsLogFunc. The level is
+// dropped deliberately: latest.log has no severity column, and the point of
+// #723 is that these lines appear AT ALL (they used to be Debug-only).
+func workerWSLog(_ string, format string, args ...any) {
+	Log(format, args...)
 }

--- a/cmd/ws_pubsub.go
+++ b/cmd/ws_pubsub.go
@@ -1,0 +1,85 @@
+// cmd/ws_pubsub.go
+//
+// Background retry for the real-time pub/sub WebSocket (issue #723).
+//
+// The bug this closes: EnableWebSocket was called exactly once at worker
+// startup. A single failed connect was logged at Debug and then forgotten for
+// the lifetime of the process -- ReconnectEnabled only ever governed a
+// connection that had already succeeded once, so there was nothing left to
+// reconnect. And the "optional HTTP fallback" it degraded to does not actually
+// work (citadel-cli#721), so the node published no durable heartbeat and the
+// platform considered it offline. A node sat that way for twelve hours.
+//
+// The timing is the ordinary case, not bad luck: workers restart BECAUSE the
+// control plane blipped, so the startup connect is disproportionately likely to
+// land inside the very window that breaks it.
+//
+// The retry deliberately reuses connectWithBackoffLabeled -- the same policy the
+// control-plane connect a few lines above already uses -- rather than inventing
+// a second scheme: exponential backoff (2s..2min) with +/-20% jitter, a 429
+// retry_after honored IN FULL, and ctx-aware chunked sleeps so shutdown stays
+// instant. That is what keeps this from recreating #443: the retry is
+// in-process (no systemd restart storm), it never polls tighter than the server
+// asked, and it stops permanently on first success.
+package cmd
+
+import (
+	"context"
+
+	"github.com/aceteam-ai/citadel-cli/internal/redisapi"
+)
+
+// wsConnector adapts a redisapi.Client's WebSocket enablement to the
+// apiConnector interface connectWithBackoff retries against.
+//
+// Client.EnableWebSocket is idempotent (no-op when already connected, exactly
+// one dial attempt otherwise) and no longer discards the WebSocket client on
+// failure, which is what makes retrying it meaningful at all.
+type wsConnector struct{ client *redisapi.Client }
+
+func (w wsConnector) Connect(ctx context.Context) error {
+	return w.client.EnableWebSocket(ctx)
+}
+
+// enableWebSocketWithRetry connects the pub/sub WebSocket, and on failure keeps
+// retrying in the background instead of giving up.
+//
+// It returns immediately. The first attempt is made synchronously so the common
+// (healthy) case is unchanged and the heartbeat's first publish already has the
+// WebSocket; only a FAILED first attempt spawns the background retry loop, which
+// exits on first success or on ctx cancellation.
+//
+// Non-fatal by design -- pub/sub is degraded, not dead, and the worker must
+// still consume jobs -- but no longer silent: the failure is logged at Log
+// level (it used to be Debug, which is why a node in this state produced no
+// evidence at default verbosity), and so is the recovery.
+//
+// Re-arming after a LOST connection is already handled one layer down by
+// WSClient.handleDisconnect -> reconnect, which retries indefinitely and
+// restores subscriptions. This function deliberately does not duplicate that:
+// a second connect path could start a second readLoop on the same connection.
+// The returned channel closes when the retry loop has finished (immediately
+// when no loop was needed). Production callers ignore it; it exists so a test
+// can join the goroutine instead of sleeping and guessing.
+func enableWebSocketWithRetry(ctx context.Context, conn apiConnector, logf func(string, ...any)) <-chan struct{} {
+	done := make(chan struct{})
+
+	err := conn.Connect(ctx)
+	if err == nil || ctx.Err() != nil {
+		close(done)
+		return done
+	}
+
+	logf("pub/sub WebSocket unavailable, falling back to HTTP and retrying in background: %v", err)
+
+	go func() {
+		defer close(done)
+		if err := connectWithBackoffLabeled(ctx, "pub/sub WebSocket", conn); err != nil {
+			// The only non-nil return is context cancellation (clean shutdown).
+			return
+		}
+		logf("pub/sub WebSocket connected on retry; publishes are back on the real-time transport")
+	}()
+
+	return done
+}

--- a/cmd/ws_pubsub_test.go
+++ b/cmd/ws_pubsub_test.go
@@ -60,10 +60,10 @@ type logCollector struct {
 	lines []string
 }
 
-func (l *logCollector) logf(format string, args ...any) {
+func (l *logCollector) logf(level, format string, args ...any) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	l.lines = append(l.lines, fmt.Sprintf(format, args...))
+	l.lines = append(l.lines, level+": "+fmt.Sprintf(format, args...))
 }
 
 func (l *logCollector) contains(sub string) bool {
@@ -160,50 +160,67 @@ func TestEnableWebSocketWithRetry_SucceedsFirstTry(t *testing.T) {
 // TestEnableWebSocketWithRetry_BacksOffRatherThanHotLooping is the #443 guard:
 // the retry must not become a tight dial loop that burns the node's daily
 // Redis-API quota and self-DoSes the node it is trying to reconnect.
+//
+// It asserts on the durations the loop REQUESTS rather than the gaps it
+// achieves. Wall-clock gaps are flaky in the dangerous direction: a loaded
+// machine overshoots a 20ms sleep to 87ms, which is indistinguishable from a
+// correct 80ms backoff, so a hot-loop regression would pass.
 func TestEnableWebSocketWithRetry_BacksOffRatherThanHotLooping(t *testing.T) {
-	// Deliberately NOT withFastBackoff: this test asserts on growth, so it needs
-	// bounds it controls precisely.
 	origInitial, origMax := connectBackoffInitial, connectBackoffMax
 	connectBackoffInitial = 20 * time.Millisecond
 	connectBackoffMax = time.Second
 	t.Cleanup(func() { connectBackoffInitial, connectBackoffMax = origInitial, origMax })
 
+	var mu sync.Mutex
+	var requested []time.Duration
+	origSleep := backoffSleep
+	backoffSleep = func(ctx context.Context, d time.Duration) bool {
+		mu.Lock()
+		requested = append(requested, d)
+		mu.Unlock()
+		return ctx.Err() == nil
+	}
+	t.Cleanup(func() { backoffSleep = origSleep })
+
+	requestedCount := func() int {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(requested)
+	}
+
 	conn := &recordingConnector{failures: 1 << 30} // never succeeds
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	done := enableWebSocketWithRetry(ctx, conn, func(string, ...any) {})
-	defer func() { <-done }()
+	done := enableWebSocketWithRetry(ctx, conn, func(string, string, ...any) {})
 
-	// Attempt 1 is the synchronous one; the background loop then attempts
-	// immediately and sleeps 20/40/80ms (+/-20% jitter) between its own tries.
-	// Five attempts is ~140ms of sleeping.
-	if !waitFor(t, 3*time.Second, func() bool { return conn.attempts() >= 5 }) {
-		t.Fatalf("only %d attempts; the retry loop is not running", conn.attempts())
+	if !waitFor(t, 3*time.Second, func() bool { return requestedCount() >= 4 }) {
+		t.Fatalf("loop requested %d sleeps; it is hot-looping or not running", requestedCount())
 	}
 	cancel()
+	<-done
 
-	gaps := conn.gaps()
-	if len(gaps) < 4 {
-		t.Fatalf("recorded %d gaps, want >= 4", len(gaps))
-	}
+	mu.Lock()
+	got := append([]time.Duration(nil), requested[:4]...)
+	mu.Unlock()
 
-	// gaps[0] spans the synchronous attempt to the loop's first attempt (no
-	// sleep by design). Every gap after that must be at least the jittered floor
-	// of its nominal backoff (jitter is +/-20%, so 0.8x). A hot loop shows gaps
-	// near zero throughout.
+	// Nominal 20/40/80/160ms, each jittered by +/-20%.
 	nominal := connectBackoffInitial
-	for i := 1; i <= 3; i++ {
-		floor := time.Duration(float64(nominal) * 0.8)
-		if gaps[i] < floor {
-			t.Errorf("gap %d = %s, want >= %s (hot loop: backoff is not being applied)", i, gaps[i], floor)
+	for i, d := range got {
+		lo := time.Duration(float64(nominal) * 0.8)
+		hi := time.Duration(float64(nominal) * 1.2)
+		if d < lo || d > hi {
+			t.Errorf("sleep %d = %s, want within [%s, %s] of the %s backoff step", i, d, lo, hi, nominal)
 		}
 		nominal *= 2
 	}
 
-	// And the backoff must actually GROW, not stay flat at the initial value.
-	if gaps[3] <= gaps[1] {
-		t.Errorf("backoff is not growing: gap 1 = %s, gap 3 = %s", gaps[1], gaps[3])
+	// Jitter is +/-20%, so consecutive doubling steps cannot overlap: growth
+	// must be strictly monotonic. A flat backoff (or none) fails here.
+	for i := 1; i < len(got); i++ {
+		if got[i] <= got[i-1] {
+			t.Errorf("backoff is not growing: sleep %d = %s, sleep %d = %s", i-1, got[i-1], i, got[i])
+		}
 	}
 }
 
@@ -226,7 +243,7 @@ func TestEnableWebSocketWithRetry_HonorsRateLimitRetryAfter(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	done := enableWebSocketWithRetry(ctx, conn, func(string, ...any) {})
+	done := enableWebSocketWithRetry(ctx, conn, func(string, string, ...any) {})
 	defer func() { <-done }()
 
 	// One attempt happens synchronously, one more from the loop's first pass;
@@ -246,7 +263,7 @@ func TestEnableWebSocketWithRetry_StopsOnContextCancel(t *testing.T) {
 	conn := &recordingConnector{failures: 1 << 30}
 	ctx, cancel := context.WithCancel(context.Background())
 
-	done := enableWebSocketWithRetry(ctx, conn, func(string, ...any) {})
+	done := enableWebSocketWithRetry(ctx, conn, func(string, string, ...any) {})
 	waitFor(t, time.Second, func() bool { return conn.attempts() >= 2 })
 	cancel()
 
@@ -269,23 +286,103 @@ func TestEnableWebSocketWithRetry_StopsOnContextCancel(t *testing.T) {
 // direct-Redis mode, no worker at all) would invent an outage.
 func TestParsePubSubTransport(t *testing.T) {
 	cases := []struct {
-		name string
-		body string
-		want string
-		ok   bool
+		name  string
+		body  string
+		want  string
+		state pubSubProbeState
 	}{
-		{"websocket", `{"worker":{"consuming":true,"pubsub_transport":"websocket"}}`, "websocket", true},
-		{"http fallback", `{"worker":{"consuming":true,"pubsub_transport":"http"}}`, "http", true},
-		{"no worker section", `{"version":"v1"}`, "", false},
-		{"older worker, field absent", `{"worker":{"consuming":true}}`, "", false},
-		{"malformed", `not json`, "", false},
+		{"websocket", `{"worker":{"consuming":true,"pubsub_transport":"websocket"}}`, "websocket", pubSubProbeOK},
+		{"http fallback", `{"worker":{"consuming":true,"pubsub_transport":"http"}}`, "http", pubSubProbeOK},
+		{"no worker section", `{"version":"v1"}`, "", pubSubProbeNotReported},
+		{"older worker, field absent", `{"worker":{"consuming":true}}`, "", pubSubProbeNotReported},
+		{"malformed", `not json`, "", pubSubProbeUnreachable},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, ok := parsePubSubTransport([]byte(tc.body))
-			if got != tc.want || ok != tc.ok {
-				t.Errorf("parsePubSubTransport(%s) = (%q, %v), want (%q, %v)", tc.body, got, ok, tc.want, tc.ok)
+			got, state := parsePubSubTransport([]byte(tc.body))
+			if got != tc.want || state != tc.state {
+				t.Errorf("parsePubSubTransport(%s) = (%q, %v), want (%q, %v)", tc.body, got, state, tc.want, tc.state)
 			}
 		})
+	}
+}
+
+// fakeWakeEnabler records EnableWake calls and fails until allowed to succeed.
+type fakeWakeEnabler struct {
+	mu       sync.Mutex
+	calls    []string
+	failWith error
+}
+
+func (f *fakeWakeEnabler) EnableWake(_ context.Context, channel string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, channel)
+	return f.failWith
+}
+
+func (f *fakeWakeEnabler) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.calls)
+}
+
+// TestArmWakeAfterWebSocket_ArmsOnceTheRetryLands is the partial-fix guard: a
+// late WebSocket connect goes through Connect, not reconnect, so OnReconnect
+// callbacks never fire and push-wake would stay off forever on a node that
+// started during a control-plane blip -- while `citadel status` reported a
+// healthy "websocket" transport.
+func TestArmWakeAfterWebSocket_ArmsOnceTheRetryLands(t *testing.T) {
+	wsRetry := make(chan struct{})
+	src := &fakeWakeEnabler{}
+	logs := &logCollector{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	armWakeAfterWebSocket(ctx, wsRetry, src, "node:wake:42", logs.logf)
+
+	if got := src.callCount(); got != 0 {
+		t.Fatalf("EnableWake called %d time(s) before the WebSocket landed, want 0", got)
+	}
+
+	close(wsRetry)
+
+	if !waitFor(t, 2*time.Second, func() bool { return src.callCount() == 1 }) {
+		t.Fatalf("push-wake was never re-armed after the WebSocket retry landed (calls=%d)", src.callCount())
+	}
+	if !waitFor(t, 2*time.Second, func() bool { return logs.contains("armed after WebSocket recovery") }) {
+		t.Error("re-arm was not logged")
+	}
+}
+
+// TestArmWakeAfterWebSocket_NoopWhenRetryAlreadyFinished: the caller already
+// invoked EnableWake against the final state, so there is nothing to wait for.
+func TestArmWakeAfterWebSocket_NoopWhenRetryAlreadyFinished(t *testing.T) {
+	wsRetry := make(chan struct{})
+	close(wsRetry)
+	src := &fakeWakeEnabler{}
+
+	armWakeAfterWebSocket(context.Background(), wsRetry, src, "node:wake:42", func(string, string, ...any) {})
+
+	time.Sleep(30 * time.Millisecond)
+	if got := src.callCount(); got != 0 {
+		t.Errorf("EnableWake called %d time(s), want 0 (retry had already finished)", got)
+	}
+}
+
+// TestArmWakeAfterWebSocket_StopsOnShutdown: a cancelled context must not leave
+// a goroutine waiting on a channel that will never close.
+func TestArmWakeAfterWebSocket_StopsOnShutdown(t *testing.T) {
+	wsRetry := make(chan struct{})
+	src := &fakeWakeEnabler{}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	armWakeAfterWebSocket(ctx, wsRetry, src, "node:wake:42", func(string, string, ...any) {})
+	cancel()
+
+	time.Sleep(50 * time.Millisecond)
+	if got := src.callCount(); got != 0 {
+		t.Errorf("EnableWake called %d time(s) after shutdown, want 0", got)
 	}
 }

--- a/cmd/ws_pubsub_test.go
+++ b/cmd/ws_pubsub_test.go
@@ -1,0 +1,291 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aceteam-ai/citadel-cli/internal/redisapi"
+)
+
+// recordingConnector fails a fixed number of times then succeeds, recording the
+// wall-clock time of every attempt so a test can assert the loop backs off
+// rather than hot-looping.
+type recordingConnector struct {
+	mu        sync.Mutex
+	failures  int
+	attemptAt []time.Time
+	err       error
+}
+
+func (r *recordingConnector) Connect(_ context.Context) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.attemptAt = append(r.attemptAt, time.Now())
+	if len(r.attemptAt) <= r.failures {
+		if r.err != nil {
+			return r.err
+		}
+		return errors.New("WebSocket connection failed: connection refused")
+	}
+	return nil
+}
+
+func (r *recordingConnector) attempts() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.attemptAt)
+}
+
+func (r *recordingConnector) gaps() []time.Duration {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []time.Duration
+	for i := 1; i < len(r.attemptAt); i++ {
+		out = append(out, r.attemptAt[i].Sub(r.attemptAt[i-1]))
+	}
+	return out
+}
+
+// logCollector captures the messages enableWebSocketWithRetry emits, so a test
+// can assert the failure and the recovery are BOTH visible. The pre-fix code
+// logged the failure at Debug only, which is why a node in this state produced
+// no evidence at default verbosity (issue #723).
+type logCollector struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (l *logCollector) logf(format string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.lines = append(l.lines, fmt.Sprintf(format, args...))
+}
+
+func (l *logCollector) contains(sub string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, ln := range l.lines {
+		if strings.Contains(ln, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return cond()
+}
+
+// TestEnableWebSocketWithRetry_FirstConnectFailsThenSucceeds is the core
+// regression for #723: a failed startup connect must not be terminal.
+func TestEnableWebSocketWithRetry_FirstConnectFailsThenSucceeds(t *testing.T) {
+	withFastBackoff(t)
+
+	conn := &recordingConnector{failures: 1}
+	logs := &logCollector{}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	returned := make(chan (<-chan struct{}), 1)
+	go func() { returned <- enableWebSocketWithRetry(ctx, conn, logs.logf) }()
+
+	var done <-chan struct{}
+	select {
+	case done = <-returned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("enableWebSocketWithRetry blocked; it must return immediately and retry in the background")
+	}
+	defer func() { <-done }()
+
+	if !waitFor(t, 3*time.Second, func() bool { return conn.attempts() >= 2 }) {
+		t.Fatalf("connector attempted %d time(s); the failed first connect was never retried (#723)", conn.attempts())
+	}
+
+	if !waitFor(t, 3*time.Second, func() bool { return logs.contains("connected on retry") }) {
+		t.Error("recovery was never logged; a node that self-heals must say so")
+	}
+	if !logs.contains("falling back to HTTP") {
+		t.Error("the initial failure was not logged at Log level; the degraded state stays invisible")
+	}
+
+	// Once connected the loop must stop attempting: no steady-state dialing.
+	settled := conn.attempts()
+	time.Sleep(50 * time.Millisecond)
+	if got := conn.attempts(); got != settled {
+		t.Errorf("connector still being dialed after success (%d -> %d); the retry loop must exit", settled, got)
+	}
+}
+
+// TestEnableWebSocketWithRetry_SucceedsFirstTry proves the healthy path is
+// unchanged: one synchronous attempt, no goroutine, no log noise.
+func TestEnableWebSocketWithRetry_SucceedsFirstTry(t *testing.T) {
+	withFastBackoff(t)
+
+	conn := &recordingConnector{failures: 0}
+	logs := &logCollector{}
+
+	done := enableWebSocketWithRetry(context.Background(), conn, logs.logf)
+	select {
+	case <-done:
+	default:
+		t.Fatal("healthy path started a background retry loop")
+	}
+
+	if got := conn.attempts(); got != 1 {
+		t.Errorf("attempts = %d, want exactly 1 on the healthy path", got)
+	}
+	time.Sleep(20 * time.Millisecond)
+	if got := conn.attempts(); got != 1 {
+		t.Errorf("attempts = %d after settling, want 1 (no background loop should have started)", got)
+	}
+	if len(logs.lines) != 0 {
+		t.Errorf("healthy path logged %v, want silence", logs.lines)
+	}
+}
+
+// TestEnableWebSocketWithRetry_BacksOffRatherThanHotLooping is the #443 guard:
+// the retry must not become a tight dial loop that burns the node's daily
+// Redis-API quota and self-DoSes the node it is trying to reconnect.
+func TestEnableWebSocketWithRetry_BacksOffRatherThanHotLooping(t *testing.T) {
+	// Deliberately NOT withFastBackoff: this test asserts on growth, so it needs
+	// bounds it controls precisely.
+	origInitial, origMax := connectBackoffInitial, connectBackoffMax
+	connectBackoffInitial = 20 * time.Millisecond
+	connectBackoffMax = time.Second
+	t.Cleanup(func() { connectBackoffInitial, connectBackoffMax = origInitial, origMax })
+
+	conn := &recordingConnector{failures: 1 << 30} // never succeeds
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := enableWebSocketWithRetry(ctx, conn, func(string, ...any) {})
+	defer func() { <-done }()
+
+	// Attempt 1 is the synchronous one; the background loop then attempts
+	// immediately and sleeps 20/40/80ms (+/-20% jitter) between its own tries.
+	// Five attempts is ~140ms of sleeping.
+	if !waitFor(t, 3*time.Second, func() bool { return conn.attempts() >= 5 }) {
+		t.Fatalf("only %d attempts; the retry loop is not running", conn.attempts())
+	}
+	cancel()
+
+	gaps := conn.gaps()
+	if len(gaps) < 4 {
+		t.Fatalf("recorded %d gaps, want >= 4", len(gaps))
+	}
+
+	// gaps[0] spans the synchronous attempt to the loop's first attempt (no
+	// sleep by design). Every gap after that must be at least the jittered floor
+	// of its nominal backoff (jitter is +/-20%, so 0.8x). A hot loop shows gaps
+	// near zero throughout.
+	nominal := connectBackoffInitial
+	for i := 1; i <= 3; i++ {
+		floor := time.Duration(float64(nominal) * 0.8)
+		if gaps[i] < floor {
+			t.Errorf("gap %d = %s, want >= %s (hot loop: backoff is not being applied)", i, gaps[i], floor)
+		}
+		nominal *= 2
+	}
+
+	// And the backoff must actually GROW, not stay flat at the initial value.
+	if gaps[3] <= gaps[1] {
+		t.Errorf("backoff is not growing: gap 1 = %s, gap 3 = %s", gaps[1], gaps[3])
+	}
+}
+
+// TestEnableWebSocketWithRetry_HonorsRateLimitRetryAfter proves the 429 hint
+// reaches the retry policy: a server asking for a long wait must not be polled
+// tighter than it asked (#443), and the wait must still yield to shutdown.
+func TestEnableWebSocketWithRetry_HonorsRateLimitRetryAfter(t *testing.T) {
+	origInitial, origMax, origChunk := connectBackoffInitial, connectBackoffMax, connectRateLimitChunk
+	connectBackoffInitial = time.Millisecond
+	connectBackoffMax = 5 * time.Millisecond
+	connectRateLimitChunk = 10 * time.Millisecond
+	t.Cleanup(func() {
+		connectBackoffInitial, connectBackoffMax, connectRateLimitChunk = origInitial, origMax, origChunk
+	})
+
+	conn := &recordingConnector{
+		failures: 1 << 30,
+		err:      &redisapi.RateLimitError{StatusCode: 429, RetryAfter: time.Hour},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := enableWebSocketWithRetry(ctx, conn, func(string, ...any) {})
+	defer func() { <-done }()
+
+	// One attempt happens synchronously, one more from the loop's first pass;
+	// after that the 1h retry_after must hold it. Nothing near a hot loop.
+	time.Sleep(200 * time.Millisecond)
+	if got := conn.attempts(); got > 2 {
+		t.Errorf("attempts = %d within 200ms against a 1h retry_after; the server backoff is being ignored", got)
+	}
+	cancel()
+}
+
+// TestEnableWebSocketWithRetry_StopsOnContextCancel: a cancelled context is a
+// clean shutdown, not a reason to keep dialing.
+func TestEnableWebSocketWithRetry_StopsOnContextCancel(t *testing.T) {
+	withFastBackoff(t)
+
+	conn := &recordingConnector{failures: 1 << 30}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := enableWebSocketWithRetry(ctx, conn, func(string, ...any) {})
+	waitFor(t, time.Second, func() bool { return conn.attempts() >= 2 })
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("retry loop did not exit after cancellation")
+	}
+
+	settled := conn.attempts()
+	time.Sleep(50 * time.Millisecond)
+	if got := conn.attempts(); got != settled {
+		t.Errorf("retry loop kept dialing after cancellation (%d -> %d)", settled, got)
+	}
+}
+
+// TestParsePubSubTransport covers what `citadel status` reads off the running
+// worker. The "absent" cases must report unknown rather than default to a
+// transport: claiming "http" when the field simply was not there (older worker,
+// direct-Redis mode, no worker at all) would invent an outage.
+func TestParsePubSubTransport(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+		ok   bool
+	}{
+		{"websocket", `{"worker":{"consuming":true,"pubsub_transport":"websocket"}}`, "websocket", true},
+		{"http fallback", `{"worker":{"consuming":true,"pubsub_transport":"http"}}`, "http", true},
+		{"no worker section", `{"version":"v1"}`, "", false},
+		{"older worker, field absent", `{"worker":{"consuming":true}}`, "", false},
+		{"malformed", `not json`, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parsePubSubTransport([]byte(tc.body))
+			if got != tc.want || ok != tc.ok {
+				t.Errorf("parsePubSubTransport(%s) = (%q, %v), want (%q, %v)", tc.body, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}

--- a/internal/redisapi/client.go
+++ b/internal/redisapi/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -21,8 +22,24 @@ type Client struct {
 	httpClient *http.Client
 	workerID   string
 
-	// WebSocket client for real-time pub/sub (optional)
+	// wsClient is the WebSocket client for real-time pub/sub. It is built once
+	// in NewClient and NEVER reassigned or nil'd afterwards.
+	//
+	// It used to be created lazily by EnableWebSocket and set back to nil when
+	// the connect failed, which is what made a single failed connect permanent:
+	// with no object left there was nothing to retry (issue #723). Owning it for
+	// the Client's whole life means EnableWebSocket is a safe, idempotent
+	// "connect if not connected" that a background retry loop can call, and the
+	// field is immutable so readers (Publish) need no lock.
+	//
+	// Connected-ness, not existence, is the gate everywhere: a non-nil wsClient
+	// that has never dialed reports IsConnected()==false and Publish falls back
+	// to HTTP exactly as before.
 	wsClient *WSClient
+
+	// closed is set by Close so a retry loop that is still in flight cannot
+	// resurrect the WebSocket after shutdown has begun.
+	closed atomic.Bool
 
 	// Debug callback (optional)
 	debugFunc func(format string, args ...any)
@@ -58,7 +75,7 @@ func NewClient(cfg ClientConfig) *Client {
 		cfg.Timeout = 30 * time.Second
 	}
 
-	return &Client{
+	c := &Client{
 		baseURL: cfg.BaseURL,
 		token:   cfg.Token,
 		httpClient: &http.Client{
@@ -67,6 +84,18 @@ func NewClient(cfg ClientConfig) *Client {
 		workerID:  fmt.Sprintf("citadel-%s", uuid.New().String()[:8]),
 		debugFunc: cfg.DebugFunc,
 	}
+
+	// Build the WebSocket client up front (it does not dial until Connect).
+	// See the wsClient field comment: owning it for the Client's lifetime is
+	// what makes a failed connect retryable instead of terminal (issue #723).
+	c.wsClient = NewWSClient(WSClientConfig{
+		BaseURL:          cfg.BaseURL,
+		Token:            cfg.Token,
+		ReconnectEnabled: true,
+		DebugFunc:        cfg.DebugFunc,
+	})
+
+	return c
 }
 
 // debug logs a message if debug function is configured
@@ -125,33 +154,66 @@ func (c *Client) Ping(ctx context.Context) error {
 
 // Close closes the HTTP client and WebSocket if connected.
 func (c *Client) Close() error {
+	c.closed.Store(true)
 	if c.wsClient != nil {
 		return c.wsClient.Close()
 	}
 	return nil
 }
 
+// ErrClientClosed is returned by EnableWebSocket once Close has run, so a
+// background retry loop that outlives shutdown cannot re-dial a closed client.
+var ErrClientClosed = errors.New("redis API client is closed")
+
 // EnableWebSocket connects the WebSocket client for real-time pub/sub.
 // This allows Publish calls to use WebSocket instead of HTTP when connected.
+//
+// It is idempotent and safe to call repeatedly: when already connected it is a
+// no-op, and when not connected it makes exactly one dial attempt and reports
+// the outcome. That is deliberate -- the caller owns the retry policy (see
+// cmd/work.go's enableWebSocketWithRetry, issue #723) so a failed connect backs
+// off instead of hot-looping and never leaves the client permanently HTTP-only.
+//
+// On failure the WebSocket client is retained (not nil'd), so the very next
+// call can succeed.
 func (c *Client) EnableWebSocket(ctx context.Context) error {
-	if c.wsClient != nil && c.wsClient.IsConnected() {
+	if c.closed.Load() {
+		return ErrClientClosed
+	}
+	if c.wsClient == nil {
+		return fmt.Errorf("WebSocket client not initialized")
+	}
+	if c.wsClient.IsConnected() {
 		return nil
 	}
 
-	c.wsClient = NewWSClient(WSClientConfig{
-		BaseURL:          c.baseURL,
-		Token:            c.token,
-		ReconnectEnabled: true,
-		DebugFunc:        c.debugFunc,
-	})
-
 	if err := c.wsClient.Connect(ctx); err != nil {
-		c.wsClient = nil
 		return fmt.Errorf("failed to connect WebSocket: %w", err)
 	}
 
 	c.debug("WebSocket enabled for real-time pub/sub")
 	return nil
+}
+
+// Pub/sub transport names reported by PubSubTransport.
+const (
+	PubSubTransportWebSocket = "websocket"
+	PubSubTransportHTTP      = "http"
+)
+
+// PubSubTransport reports which transport Publish will currently use:
+// "websocket" when the real-time connection is up, "http" when it is not and
+// publishes fall back to the REST route.
+//
+// This exists so the degraded state is visible without a debugger: a node whose
+// startup WebSocket connect failed used to be indistinguishable from a healthy
+// one at default log level (issue #723). Surfaced through the worker liveness
+// payload and `citadel status`.
+func (c *Client) PubSubTransport() string {
+	if c.IsWebSocketConnected() {
+		return PubSubTransportWebSocket
+	}
+	return PubSubTransportHTTP
 }
 
 // WebSocket returns the WebSocket client if enabled, nil otherwise.

--- a/internal/redisapi/errors.go
+++ b/internal/redisapi/errors.go
@@ -4,6 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -96,6 +100,56 @@ func parseRateLimitError(statusCode int, body string) *RateLimitError {
 	}
 
 	return e
+}
+
+// rateLimitFromUpgrade builds a RateLimitError from a rejected WebSocket
+// upgrade response (HTTP 429).
+//
+// The dial path is not doRequest, so without this a rate-limited handshake came
+// back as an untyped fmt.Errorf and AsRateLimitError could never match it --
+// meaning a retry loop would ignore retry_after and poll far tighter than the
+// server asked (issue #723, the #443 failure mode). It prefers the JSON body
+// (the shape the Redis-API routes emit) and falls back to the standard
+// Retry-After header, which an edge proxy may send with no body at all.
+func rateLimitFromUpgrade(resp *http.Response) *RateLimitError {
+	body := ""
+	if resp.Body != nil {
+		// Bounded read: an upgrade rejection body is small, and we must not
+		// block startup on a hostile/slow one.
+		if b, err := io.ReadAll(io.LimitReader(resp.Body, 8192)); err == nil {
+			body = string(b)
+		}
+		resp.Body.Close()
+	}
+
+	e := parseRateLimitError(resp.StatusCode, body)
+	if e.RetryAfter <= 0 && e.ResetAt.IsZero() {
+		if d, ok := parseRetryAfterHeader(resp.Header.Get("Retry-After"), time.Now()); ok {
+			e.RetryAfter = d
+		}
+	}
+	return e
+}
+
+// parseRetryAfterHeader parses an RFC 7231 Retry-After value, which is either
+// delta-seconds or an HTTP-date. Returns ok=false when absent or unparseable.
+func parseRetryAfterHeader(v string, now time.Time) (time.Duration, bool) {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return 0, false
+	}
+	if secs, err := strconv.ParseInt(v, 10, 64); err == nil {
+		if secs <= 0 {
+			return 0, false
+		}
+		return time.Duration(secs) * time.Second, true
+	}
+	if t, err := http.ParseTime(v); err == nil {
+		if d := t.Sub(now); d > 0 {
+			return d, true
+		}
+	}
+	return 0, false
 }
 
 // AsRateLimitError extracts a *RateLimitError from an error chain, if present.

--- a/internal/redisapi/websocket.go
+++ b/internal/redisapi/websocket.go
@@ -151,6 +151,14 @@ func (c *WSClient) connectLocked(ctx context.Context) error {
 	conn, resp, err := dialer.DialContext(ctx, wsURL, headers)
 	if err != nil {
 		if resp != nil {
+			// A rejected upgrade carries the same rate-limit hint the REST
+			// routes do. Return it TYPED so callers that retry (issue #723) can
+			// honor retry_after instead of falling into a generic 2s..2min
+			// backoff and polling tighter than the server asked -- the tight
+			// loop that burned the daily quota in #443.
+			if resp.StatusCode == http.StatusTooManyRequests {
+				return fmt.Errorf("WebSocket connection failed: %w", rateLimitFromUpgrade(resp))
+			}
 			return fmt.Errorf("WebSocket connection failed with status %d: %w", resp.StatusCode, err)
 		}
 		return fmt.Errorf("WebSocket connection failed: %w", err)

--- a/internal/redisapi/websocket_retry_test.go
+++ b/internal/redisapi/websocket_retry_test.go
@@ -1,0 +1,196 @@
+package redisapi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// wsUpgradeServer serves the WebSocket route, rejecting the first `failures`
+// upgrade attempts before accepting. reject is the status written on a rejected
+// attempt; rejectBody/rejectHeader let a test shape a 429.
+type wsUpgradeServer struct {
+	failures      int32
+	attempts      int32
+	rejectStatus  int
+	rejectBody    string
+	rejectHeaders map[string]string
+}
+
+func (s *wsUpgradeServer) handler() http.HandlerFunc {
+	upgrader := websocket.Upgrader{}
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/fabric/redis/ws" {
+			http.NotFound(w, r)
+			return
+		}
+		n := atomic.AddInt32(&s.attempts, 1)
+		if n <= atomic.LoadInt32(&s.failures) {
+			for k, v := range s.rejectHeaders {
+				w.Header().Set(k, v)
+			}
+			status := s.rejectStatus
+			if status == 0 {
+				status = http.StatusBadGateway
+			}
+			w.WriteHeader(status)
+			if s.rejectBody != "" {
+				_, _ = w.Write([]byte(s.rejectBody))
+			}
+			return
+		}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		// Hold the connection open; the client only needs it to be established.
+		go func() {
+			for {
+				if _, _, err := conn.ReadMessage(); err != nil {
+					conn.Close()
+					return
+				}
+			}
+		}()
+	}
+}
+
+// TestEnableWebSocketRetryableAfterFailedFirstConnect is the regression test for
+// issue #723: a failed FIRST connect used to nil out the WebSocket client, so
+// there was nothing left to retry and the process stayed on the (broken) HTTP
+// publish fallback forever. A second call must be able to succeed.
+func TestEnableWebSocketRetryableAfterFailedFirstConnect(t *testing.T) {
+	ws := &wsUpgradeServer{failures: 1}
+	srv := httptest.NewServer(ws.handler())
+	defer srv.Close()
+
+	c := NewClient(ClientConfig{BaseURL: srv.URL, Token: "t"})
+	defer c.Close()
+
+	ctx := context.Background()
+
+	if err := c.EnableWebSocket(ctx); err == nil {
+		t.Fatal("first EnableWebSocket succeeded, want failure (server rejects attempt 1)")
+	}
+	if c.WebSocket() == nil {
+		t.Fatal("WebSocket client was discarded after a failed connect; nothing is left to retry (#723)")
+	}
+	if got := c.PubSubTransport(); got != PubSubTransportHTTP {
+		t.Errorf("PubSubTransport after failure = %q, want %q", got, PubSubTransportHTTP)
+	}
+
+	if err := c.EnableWebSocket(ctx); err != nil {
+		t.Fatalf("second EnableWebSocket failed, want success on retry: %v", err)
+	}
+	if got := c.PubSubTransport(); got != PubSubTransportWebSocket {
+		t.Errorf("PubSubTransport after successful retry = %q, want %q", got, PubSubTransportWebSocket)
+	}
+	if !c.IsWebSocketConnected() {
+		t.Error("IsWebSocketConnected() = false after a successful retry")
+	}
+}
+
+// TestEnableWebSocketIdempotentWhenConnected proves a repeated call on a live
+// connection is a cheap no-op rather than a second dial. The background retry
+// loop calls this in a loop, so a non-idempotent version would re-dial (and
+// start a second read loop) on every tick.
+func TestEnableWebSocketIdempotentWhenConnected(t *testing.T) {
+	ws := &wsUpgradeServer{}
+	srv := httptest.NewServer(ws.handler())
+	defer srv.Close()
+
+	c := NewClient(ClientConfig{BaseURL: srv.URL, Token: "t"})
+	defer c.Close()
+
+	if err := c.EnableWebSocket(context.Background()); err != nil {
+		t.Fatalf("EnableWebSocket: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		if err := c.EnableWebSocket(context.Background()); err != nil {
+			t.Fatalf("repeat EnableWebSocket: %v", err)
+		}
+	}
+	if got := atomic.LoadInt32(&ws.attempts); got != 1 {
+		t.Errorf("upgrade attempts = %d, want 1 (repeat calls must not re-dial)", got)
+	}
+}
+
+// TestEnableWebSocketRefusedAfterClose keeps a still-running retry loop from
+// resurrecting the transport after shutdown has begun.
+func TestEnableWebSocketRefusedAfterClose(t *testing.T) {
+	ws := &wsUpgradeServer{}
+	srv := httptest.NewServer(ws.handler())
+	defer srv.Close()
+
+	c := NewClient(ClientConfig{BaseURL: srv.URL, Token: "t"})
+	_ = c.Close()
+
+	if err := c.EnableWebSocket(context.Background()); err == nil {
+		t.Fatal("EnableWebSocket succeeded after Close, want refusal")
+	}
+	if atomic.LoadInt32(&ws.attempts) != 0 {
+		t.Error("EnableWebSocket dialed after Close")
+	}
+}
+
+// TestWebSocketUpgrade429IsTypedRateLimit is what makes the retry honor the
+// server's backoff. The dial path is not doRequest, so without explicit typing a
+// rate-limited handshake comes back untyped and a retry loop falls into its
+// generic backoff -- polling far tighter than retry_after asked, which is the
+// quota-burning behaviour of #443.
+func TestWebSocketUpgrade429IsTypedRateLimit(t *testing.T) {
+	ws := &wsUpgradeServer{
+		failures:     1,
+		rejectStatus: http.StatusTooManyRequests,
+		rejectBody:   `{"error":"Rate limit exceeded","limit":50000,"window":"day","retry_after":86400}`,
+	}
+	srv := httptest.NewServer(ws.handler())
+	defer srv.Close()
+
+	c := NewClient(ClientConfig{BaseURL: srv.URL, Token: "t"})
+	defer c.Close()
+
+	err := c.EnableWebSocket(context.Background())
+	if err == nil {
+		t.Fatal("EnableWebSocket succeeded, want a 429 failure")
+	}
+	rle, ok := AsRateLimitError(err)
+	if !ok {
+		t.Fatalf("429 upgrade rejection is not a *RateLimitError: %v", err)
+	}
+	if got := rle.Wait(time.Now()); got != 24*time.Hour {
+		t.Errorf("Wait() = %s, want 24h from retry_after", got)
+	}
+	if rle.Limit != 50000 || rle.Window != "day" {
+		t.Errorf("limit/window = %d/%q, want 50000/day", rle.Limit, rle.Window)
+	}
+}
+
+// TestWebSocketUpgrade429UsesRetryAfterHeader covers the edge-proxy case: a 429
+// with no JSON body at all, only the standard header.
+func TestWebSocketUpgrade429UsesRetryAfterHeader(t *testing.T) {
+	ws := &wsUpgradeServer{
+		failures:      1,
+		rejectStatus:  http.StatusTooManyRequests,
+		rejectHeaders: map[string]string{"Retry-After": "120"},
+	}
+	srv := httptest.NewServer(ws.handler())
+	defer srv.Close()
+
+	c := NewClient(ClientConfig{BaseURL: srv.URL, Token: "t"})
+	defer c.Close()
+
+	err := c.EnableWebSocket(context.Background())
+	rle, ok := AsRateLimitError(err)
+	if !ok {
+		t.Fatalf("429 upgrade rejection is not a *RateLimitError: %v", err)
+	}
+	if got := rle.Wait(time.Now()); got != 2*time.Minute {
+		t.Errorf("Wait() = %s, want 2m from the Retry-After header", got)
+	}
+}

--- a/internal/status/types.go
+++ b/internal/status/types.go
@@ -81,6 +81,17 @@ type WorkerLiveness struct {
 	// and on the /agent snapshot it is `omitempty`, so its absence cannot
 	// distinguish a degraded node from an older payload.
 	IdentityUnresolved bool `json:"identity_unresolved,omitempty"`
+
+	// PubSubTransport is the transport the node's pub/sub publishes currently
+	// use: "websocket" (real-time, healthy) or "http" (the fallback). Empty on
+	// nodes with no API-mode client and on legacy builds.
+	//
+	// It is here because "http" is a FAILURE, not a mode: the HTTP publish
+	// fallback misreads the route's ack and always reports failure
+	// (citadel-cli#721), so a node on it publishes no durable heartbeat and the
+	// platform reads it as offline while every other field above looks healthy.
+	// Nothing else distinguishes that node from a working one (issue #723).
+	PubSubTransport string `json:"pubsub_transport,omitempty"`
 }
 
 // AppInfo contains information about an installed catalog app.


### PR DESCRIPTION
## Context

Closes #723. A node went dark for twelve hours: it restarted at 23:39 while the
control plane was mid-deploy, the startup `EnableWebSocket` failed into a Debug
log line, and the process never tried again.

## Premise check

The issue's claim held up, with three corrections worth recording.

**Confirmed.** `EnableWebSocket` was called exactly once at `cmd/work.go:732`,
set `c.wsClient = nil` on failure, and logged at Debug. `ReconnectEnabled: true`
only governs `handleDisconnect -> reconnect`, which is reachable solely from the
read loop, and the read loop only starts after a *successful* `Connect`. A failed
first connect therefore left nothing to reconnect, permanently.

**Correction 1 - "re-arm after a lost connection" was already implemented.**
`WSClient.reconnect` retries a dropped connection indefinitely (1s..60s) and
restores subscriptions. I deliberately did **not** add a supervisor that re-calls
`EnableWebSocket` after a drop: `handleDisconnect` leaves the original read loop
spinning, so a second successful `Connect` would start a *second* `go readLoop()`
on the same gorilla connection - two concurrent readers, duplicated job delivery.
That would be a worse bug than the one being fixed. Only the first connect is
retried here, and the loop exits on first success.

**Correction 1b - retrying the connect alone was NOT enough.** A late connect
goes through `Connect`, not `reconnect`, and `OnReconnect` callbacks explicitly
do not fire on the initial connect. `APISource.EnableWake` (push-wake, #7270) is
one-shot post-connect setup - it registers a `"message"` handler and subscribes
to the node's wake channel - and it refuses when the WebSocket is not connected.
That check previously could only ever see the startup verdict, because the
verdict was permanent. With the retry in place, a node that started during a blip
would recover its heartbeat (visible) and stay poll-only forever (invisible, and
reported as a healthy `websocket` transport) - the same silent-partial-failure
shape as #723 itself. `armWakeAfterWebSocket` waits on the retry and re-runs
`EnableWake`.

**Correction 2 - only two of the four call sites share the defect.**

| Call site | Defective? |
|---|---|
| `cmd/work.go:732` | Yes - the production failure. Fixed. |
| `cmd/controlcenter.go:1780` | Yes - same swallow-and-forget shape. Fixed. |
| `internal/worker/ws_source.go:113` | No - propagates the error, and `NewWSSource` has only test callers, so it is not on a live path. |
| `internal/chat/client.go:121` | No - propagates to a foreground interactive command, so the failure is visible and the user can retry. Not the silent-permanent class. |

**Correction 3 - reusing `connectWithBackoff` alone would not have honored 429.**
`AsRateLimitError` matches a `*RateLimitError`, which only `doRequest` produced.
The dial path returned a plain `fmt.Errorf`, so a rate-limited *upgrade* would
have fallen into the generic 2s..2min backoff and polled tighter than the server
asked - the exact quota-burning behaviour of #443. Typing it was a prerequisite,
not a nicety.

## Changes

- **`internal/redisapi/client.go`** - the `WSClient` is built once in `NewClient`
  and never reassigned or nil'd. `EnableWebSocket` is now idempotent (no-op when
  connected, one dial otherwise) and retains the client on failure, so the next
  call can succeed. A `closed` flag makes it refuse after `Close`, so a retry
  loop cannot outlive shutdown. Adds `PubSubTransport()`.
  Because the field is now immutable after construction, `Publish`'s
  `c.wsClient != nil && IsConnected()` check keeps identical semantics with **no
  lock and no change to `pubsub.go`**.
- **`cmd/ws_pubsub.go`** (new) - `enableWebSocketWithRetry`: one synchronous
  attempt (healthy path unchanged), and on failure a background loop driving the
  existing `connectWithBackoff` policy. Exits on first success or ctx cancel.
- **`cmd/work.go`** - `armWakeAfterWebSocket` wired into the per-node wake setup.
  `connectWithBackoff` now delegates to
  `connectWithBackoffLabeled` so the log lines name the right subject; existing
  behaviour and existing tests are untouched. Call site rewired; the failure and
  the recovery both log at `Log`, not `Debug`.
- **`cmd/controlcenter.go`** - same helper. The log callback now carries a level
  so a recovery renders as `info`, not `warning`, in the TUI.
- **`internal/redisapi/errors.go`** - `rateLimitFromUpgrade` builds a typed
  `RateLimitError` from a rejected upgrade, preferring the JSON body and falling
  back to the standard `Retry-After` header (an edge proxy may send no body).
- **`internal/redisapi/websocket.go`** - four lines in `connectLocked` to use it.
- **`internal/status/types.go` / `cmd/status.go`** - `WorkerLiveness.pubsub_transport`,
  read live off the client (not mirrored through `WorkerState`, since it can flip
  at any moment), and rendered by `citadel status` as a Pub/Sub line. "Status
  server unreachable" and "worker reported no transport" are distinct messages,
  so the line never implies a verdict it did not obtain.

## Why this cannot recreate #443

The retry is in-process (no systemd restart storm), backs off 2s..2min with
+/-20% jitter, sleeps a 429's full `retry_after` in ctx-aware chunks, and stops
permanently on first success. Steady-state dialing during an outage is unchanged
from today, since `WSClient.reconnect` already owns the post-drop path and this
loop exits before that path is ever reachable.

## Merge sequencing (concurrent work)

Three files overlap other in-flight work. All three are small and in different
functions, but flagging them:

- **`internal/redisapi/websocket.go`** - #720 (write mutex). My change is 4 lines
  inside `connectLocked`; #720 is in `sendMessage`. Should merge cleanly.
- **`internal/status/types.go`** - PR #702 touches this file. My change appends
  one field to `WorkerLiveness`; #702 is elsewhere in the file.
- **`cmd/work.go`** - PR #521 touches it. My changes are in `connectWithBackoff`
  and the API-mode source block.

`internal/redisapi/pubsub.go` (#721) and `internal/heartbeat/api.go` (#722) are
**untouched**.

## Tests

`internal/redisapi/websocket_retry_test.go` runs a real gorilla upgrade server
that rejects the first attempt:

- `TestEnableWebSocketRetryableAfterFailedFirstConnect` - the #723 regression:
  the client survives a failed connect and the second call succeeds.
- `TestEnableWebSocketIdempotentWhenConnected` - repeat calls do not re-dial.
- `TestEnableWebSocketRefusedAfterClose`
- `TestWebSocketUpgrade429IsTypedRateLimit` / `...UsesRetryAfterHeader`

`cmd/ws_pubsub_test.go`:

- `..._FirstConnectFailsThenSucceeds` - returns immediately, retries, logs both
  the degrade and the recovery, and stops dialing once connected.
- `..._SucceedsFirstTry` - healthy path: one attempt, no goroutine, silent.
- `..._BacksOffRatherThanHotLooping` - asserts each inter-attempt gap clears the
  jittered floor of its nominal backoff and that the backoff grows.
- `..._HonorsRateLimitRetryAfter` - a 1h `retry_after` is not polled through.
- `..._StopsOnContextCancel`, `TestParsePubSubTransport`.
- `TestArmWakeAfterWebSocket_ArmsOnceTheRetryLands` / `..._NoopWhenRetryAlreadyFinished`
  / `..._StopsOnShutdown`.

The backoff test asserts on the durations the loop **requests**, not the gaps it
achieves (`backoffSleep` is now an overridable package var). Wall-clock gaps were
flaky in the dangerous direction: under full-suite load a 20ms sleep overshot to
87ms, indistinguishable from a correct 80ms backoff, so a hot-loop regression
could have passed.

### Mutation testing

No mutation framework in the repo, so eight mutants by hand. Seven caught:

| Mutant | Result | Caught by |
|---|---|---|
| Remove the background retry goroutine | CAUGHT | `..._FirstConnectFailsThenSucceeds`, `..._BacksOffRatherThanHotLooping` |
| `backoff *= 2` -> `backoff *= 1` | CAUGHT | `..._BacksOffRatherThanHotLooping` |
| Restore `c.wsClient = nil` on failure (the original bug) | CAUGHT | `TestEnableWebSocketRetryableAfterFailedFirstConnect` |
| Leave the 429 upgrade untyped | CAUGHT | both `TestWebSocketUpgrade429*` |
| `PubSubTransport` always returns `websocket` | CAUGHT | `TestEnableWebSocketRetryableAfterFailedFirstConnect` |
| Drop the initial failure log | CAUGHT | `..._FirstConnectFailsThenSucceeds` |
| Never re-arm push-wake after a late connect | CAUGHT | `TestArmWakeAfterWebSocket_ArmsOnceTheRetryLands` |
| Drop `EnableWebSocket`'s connected-guard | **SURVIVED** | - |

The survivor is honest and worth keeping: `WSClient.Connect` has its own
`if c.connected { return nil }`, so the invariant is defended twice and removing
either guard alone changes nothing. Removing **both** is caught by
`TestEnableWebSocketIdempotentWhenConnected` (verified: `upgrade attempts = 4, want 1`).

`go test ./...` and `go vet ./...` pass. The new packages also pass under
`-race` (CI does not run `-race`).

## Manual verification owed

`citadel status`'s Pub/Sub line reads the worker's own `/status` over loopback,
and that server is **opt-in** (`--status-port` / `--gateway`). On a plain
`citadel work` the line honestly reads `unknown (worker status server not
reachable on loopback)` rather than guessing a transport. Worth a live check on a
gateway-enabled node. `citadel status --json` and `-i` go through
`gatherStatusData` -> `dashboard.StatusData` and do not carry the field; the
default text output does, which is what the issue asked for. Noting the omission
rather than expanding scope.

Also verified by inspection, not runtime: `Client.closed` is now permanent, where
previously `EnableWebSocket` rebuilt a fresh `WSClient` on every call and so
silently repaired a closed client. The control center is the only place that
stops and restarts a worker in-process, and each start calls
`worker.NewAPISource` -> `APISource.Connect` -> a **new** `redisapi.NewClient`,
so a restart never reuses a closed client.

## Two bugs found, not fixed here

1. **`WSClient.reconnect` reads and writes `c.reconnectBackoff` without holding
   `connMu`**, while `connectLocked` writes it under the lock. A real data race
   on the reconnect path. Belongs with #720.
2. **No ping/pong keepalive or read deadline on the WebSocket.** A half-open
   connection leaves `connected == true` indefinitely: `Publish` succeeds into
   the void, and the new status line would report `websocket` when nothing is
   flowing. This bounds the observability claim of this PR and is the natural
   next issue.
