### PR TITLE
fix(reconcile): keep reporting actual state when the full-wipe guard refuses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -713,6 +713,31 @@ current directory, and it does not look for `/etc/citadel/citadel.yaml` directly
 Read the function for the exact order; do not re-copy it here. A restated
 algorithm is what went stale before.
 
+### Two ActualState reporters, two different module sets (#733)
+
+A node ships `ActualState` to the control plane from TWO independent paths, and
+they do not enumerate the same thing. Both are wired in `cmd/work.go`:
+
+- `nodestate.BuildActualState` decides the report the 60s `nodestate.Emitter`
+  sends. Its authority for "what is installed" is the **lockfile**
+  (`catalog.LoadLockfile`). No lockfile means it returns early with an EMPTY
+  module list, and the control plane's ingest writes zero module rows.
+- `liveModuleOps.ListInstalled` (`cmd/module_ops.go`) decides the report the
+  reconcile loop sends, and its authority is the **manifest** `services:` list.
+  Every embedded/catalog service in `citadel.yaml` counts, whether or not the
+  module system ever installed it.
+
+**The consequence that bites:** a node running services with no lockfile entries
+reports fine and still shows up as "has not reported any modules" upstream, so
+that message says nothing about whether the node is healthy or reporting. Check
+which path you expect to carry the data before concluding a node is silent. It
+also means the reconcile engine's authority is WIDER than "modules": see #739.
+
+Reporting is on the observability path, never the apply path. The full-wipe
+guard in `internal/reconcile/loop.go` refuses the destructive converge and still
+reports, deliberately leaving `AppliedRevision` empty because nothing was
+applied. `TestRefuseFullWipeReportOmitsAppliedRevision` pins that.
+
 ### GPU Detection
 Status command detects NVIDIA GPUs using:
 1. `nvidia-smi` command output parsing

--- a/internal/reconcile/fullwipe_test.go
+++ b/internal/reconcile/fullwipe_test.go
@@ -30,8 +30,102 @@ func TestRefuseFullWipeBlocksEmptyDesiredWithInstalled(t *testing.T) {
 			t.Fatalf("full-wipe guard must not uninstall anything, saw %q", c)
 		}
 	}
-	if len(provider.Reported) != 0 {
-		t.Errorf("guard must abort before reporting, got %d reports", len(provider.Reported))
+	// The guard blocks the APPLY, not the report (#733). Reporting is the
+	// observability path: suppressing it left the control plane unable to see the
+	// installed set it was refusing to wipe. Exactly one report per refused pass.
+	if len(provider.Reported) != 1 {
+		t.Fatalf("guard must still report actual state, got %d reports", len(provider.Reported))
+	}
+}
+
+// TestRefuseFullWipeStillReportsActualState is the #733 regression: a refused
+// pass must still tell the control plane what the node has installed. Before the
+// fix the guard returned before BuildActualState/Report, so a node that tripped
+// it reported nothing about its modules for as long as the condition held.
+func TestRefuseFullWipeStillReportsActualState(t *testing.T) {
+	ops := newFakeOps(
+		InstalledModule{Name: "a", Source: "src-a", Health: HealthRunning},
+		InstalledModule{Name: "b", Source: "src-b", Health: HealthStopped},
+	)
+	provider := &FakeProvider{Desired: DesiredState{Revision: "rev-empty"}} // zero modules
+	rec := NewReconciler(provider, ops, "node-7")
+	rec.RefuseFullWipe = true
+
+	if _, _, err := rec.ReconcileOnce(context.Background()); err == nil {
+		t.Fatal("expected refusal error for empty desired with modules installed")
+	}
+
+	if len(provider.Reported) != 1 {
+		t.Fatalf("want exactly 1 report from the refused pass, got %d", len(provider.Reported))
+	}
+	report := provider.Reported[0]
+	if report.Node != "node-7" {
+		t.Errorf("report node = %q, want %q", report.Node, "node-7")
+	}
+	if len(report.Modules) != 2 {
+		t.Fatalf("want 2 reported modules, got %d (%+v)", len(report.Modules), report.Modules)
+	}
+	got := map[string]InstalledModule{}
+	for _, m := range report.Modules {
+		got[m.Name] = m
+	}
+	if m, ok := got["a"]; !ok || m.Source != "src-a" || m.Health != HealthRunning {
+		t.Errorf("module a reported as %+v, want source src-a health running", m)
+	}
+	if m, ok := got["b"]; !ok || m.Source != "src-b" || m.Health != HealthStopped {
+		t.Errorf("module b reported as %+v, want source src-b health stopped", m)
+	}
+}
+
+// TestRefuseFullWipeReportOmitsAppliedRevision pins the handshake half of the
+// fix: a refused pass must NOT claim it applied the revision it refused. The
+// converge path stamps AppliedRevision; the guard path deliberately does not, or
+// the control plane would record a convergence that never happened.
+func TestRefuseFullWipeReportOmitsAppliedRevision(t *testing.T) {
+	ops := newFakeOps(InstalledModule{Name: "a", Source: "src-a", Health: HealthRunning})
+	provider := &FakeProvider{Desired: DesiredState{Revision: "rev-42"}} // zero modules
+	rec := NewReconciler(provider, ops, "node-7")
+	rec.RefuseFullWipe = true
+
+	if _, _, err := rec.ReconcileOnce(context.Background()); err == nil {
+		t.Fatal("expected refusal error")
+	}
+	if len(provider.Reported) != 1 {
+		t.Fatalf("want exactly 1 report, got %d", len(provider.Reported))
+	}
+	if rev := provider.Reported[0].AppliedRevision; rev != "" {
+		t.Errorf("refused pass reported AppliedRevision %q, want empty (nothing was applied)", rev)
+	}
+}
+
+// TestRefuseFullWipeSurfacesReportFailure confirms a failed report on the guard
+// path does not swallow either error: the refusal stays visible (it is the
+// operator-actionable one) and the report failure is surfaced alongside it, so a
+// node that is refusing AND unable to report is not mistaken for one that is
+// merely refusing.
+func TestRefuseFullWipeSurfacesReportFailure(t *testing.T) {
+	ops := newFakeOps(InstalledModule{Name: "a", Source: "src-a", Health: HealthRunning})
+	provider := &FakeProvider{
+		Desired:   DesiredState{Revision: "rev-empty"},
+		ReportErr: errf("post node-state: 503"),
+	}
+	rec := NewReconciler(provider, ops, "node-7")
+	rec.RefuseFullWipe = true
+
+	_, _, err := rec.ReconcileOnce(context.Background())
+	if err == nil {
+		t.Fatal("expected an error when both the guard trips and the report fails")
+	}
+	if !strings.Contains(err.Error(), "refusing empty desired state") {
+		t.Errorf("refusal must stay visible, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "post node-state: 503") {
+		t.Errorf("report failure must be surfaced, got: %v", err)
+	}
+	for _, c := range ops.calls {
+		if strings.HasPrefix(c, "uninstall:") {
+			t.Fatalf("a failed report must not unblock the apply, saw %q", c)
+		}
 	}
 }
 

--- a/internal/reconcile/loop.go
+++ b/internal/reconcile/loop.go
@@ -2,6 +2,7 @@ package reconcile
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -62,6 +63,8 @@ type Reconciler struct {
 	// plane. When true, a SUCCESSFUL fetch that yields ZERO desired modules while
 	// the node still has installed modules is REFUSED (the pass errors and applies
 	// nothing) instead of letting the authoritative engine uninstall every module.
+	// A refused pass STILL reports its observed actual state (#733): the guard
+	// blocks the destructive apply, not the report.
 	// A fetch FAILURE is already safe (it aborts before the diff); this guards the
 	// distinct "empty backend storage returns 200 with no modules" foot-gun. The
 	// live wiring sets it true; it is off in the zero value so existing engine
@@ -92,9 +95,27 @@ func (r *Reconciler) ReconcileOnce(ctx context.Context) (Plan, ApplyResult, erro
 	// Full-wipe guard: refuse to converge to an empty desired set while modules
 	// are installed (likely an empty/misconfigured control plane), rather than
 	// uninstalling everything the node runs.
+	//
+	// Refusing to APPLY is not a reason to stop OBSERVING (#733). The guard used
+	// to return here, before the report at the bottom of this function, so a node
+	// that tripped it never told the control plane what it had installed. The
+	// destructive path stays refused; the observability path still runs, so an
+	// operator can see the installed set against the empty desired set instead of
+	// only a log line repeating every pass.
 	if r.RefuseFullWipe && len(desired.Modules) == 0 && len(actual) > 0 {
-		return Plan{}, ApplyResult{}, fmt.Errorf(
+		guardErr := fmt.Errorf(
 			"reconcile: refusing empty desired state with %d module(s) installed (possible control-plane misconfiguration)", len(actual))
+		// Report the state the guard OBSERVED (no re-listing: `actual` is that
+		// state, and a re-list would repeat a per-module container inspection
+		// sweep on every refused pass).
+		//
+		// AppliedRevision is deliberately LEFT EMPTY here, unlike the converge
+		// path below: the node did not apply this revision, it refused it.
+		// Stamping it would report a convergence that never happened.
+		reportErr := r.Provider.Report(ctx, ActualState{Node: r.Node, Modules: actual})
+		// The guard error comes first so the refusal stays the headline; a report
+		// failure is additive, never a reason to hide the refusal.
+		return Plan{}, ApplyResult{}, errors.Join(guardErr, reportErr)
 	}
 
 	plan, err := Reconcile(ctx, desired, actual)


### PR DESCRIPTION
## Context

Closes #733.

`Reconciler.ReconcileOnce` returned from the full-wipe guard before
`BuildActualState` and `Provider.Report`, so a node that refused an empty
desired state never reported the modules it had installed. The guard is right
to refuse the apply; suppressing the report as well conflates two concerns.

Live example: node `1297` has logged
`reconcile: refusing empty desired state with 11 module(s) installed` every 5
minutes for days (36 occurrences in a 3 hour window on v2.103.0), and its
reconcile loop has therefore never reported a single module.

## Premise correction (what the issue got wrong)

The issue describes a self-sustaining deadlock: the node cannot report, so the
control plane cannot populate desired state, so the guard keeps tripping.
Two parts of that are not accurate, and the PR should not claim a fix it does
not deliver.

1. **The guard is not the only reason the module list is empty, and it is not
   the only reporter.** A second, independent path
   (`internal/nodestate.Emitter`, wired in `cmd/work.go`) posts an `ActualState`
   report to the same device authed endpoint every 60s, unaffected by the guard.
   It reports zero modules on this node regardless: `nodestate.BuildActualState`
   enumerates the **lockfile** (`modules.lock`), node 1297 has no lockfile, and
   the builder returns early with an empty module list, which upstream upserts
   as zero rows. The node's 11 "modules" are manifest **services** (vllm,
   ollama, llamacpp, transcribe, gotenberg, meeting, kokoro, tei-embeddings,
   unlimited-ocr, bonsai, tei), and only the reconcile path's `ListInstalled`
   enumerates those. So the guard suppresses the one report that would have
   carried them, which is what this PR fixes, while the emitter would have
   reported nothing useful either way.

2. **Reporting does not unblock desired state.** Nothing writes
   `fabric_node_module_desired` yet (stated in the aceteam MCP module tool's own
   docstring), so desired state is empty for every node by construction. This
   fix will not stop the guard from firing. It will keep firing every 5 minutes
   until durable desired state persistence lands upstream.

What remains true, and is what this PR fixes: refusing to apply should not
suppress the report. The reconcile path is the only one that sees manifest
services, so with this change a refused pass finally surfaces the installed set
the guard is protecting.

## Is reporting on this path safe?

Checked before writing the fix, because a report that could trigger a wipe would
change the answer. As implemented today the ingest side is observational only:
the node state worker decodes `ActualState`, upserts `node_module_state` rows
keyed `(node_id, source)`, and updates `agent_version` on `fabric_node_status`.
There is no path from a reported actual state to `fabric_node_module_desired`,
and no delete. That is a fact about the current upstream implementation, not an
invariant this repo can enforce.

Both report writers resolve to the same row set: the emitter reports the
Headscale hostname, the reconcile loop reports the numeric node id, and
`get_node_info` accepts either and returns the same `headscale_node_id`.

## Changes

- `internal/reconcile/loop.go`: the guard branch now reports the module list it
  already observed, then returns. Two deliberate details:
  - It reuses the `actual` slice instead of calling `BuildActualState`, which
    would repeat a per module container inspection sweep on every refused pass
    (11 `docker inspect` calls every 5 minutes on node 1297).
  - It leaves `AppliedRevision` empty. The converge path stamps it a few lines
    below; doing that here would report a convergence the node explicitly
    refused, and `applied_revision` is written straight into every
    `node_module_state` row upstream.
  - A report failure is joined onto the guard error rather than replacing or
    hiding it, so "refusing and cannot report" is distinguishable from
    "refusing".
- `CLAUDE.md`: documents the two independent ActualState reporters and the
  different module sets they enumerate, which is the fact that made this bug
  hard to read from the outside.
- `internal/reconcile/fullwipe_test.go`: the existing assertion that the guard
  "must abort before reporting" is inverted on purpose. It asserted the bug.
  Refusing to apply and refusing to observe are separate concerns. Everything
  else about that test (refusal error, nothing uninstalled) is unchanged.

Blast radius is one call site: `RefuseFullWipe` is set only in
`cmd/module_ops.go:newReconcileLoop`. `internal/worker/module_set.go` uses a
scoped engine and `HandleReconcileJob` runs with the flag defaulted false.

## What this makes worse

- `fabric_node_modules_list` for node 1297 goes from "nothing reported" to an
  11 row table listing `vllm`, `ollama`, `bonsai`, `tei` and friends as
  "modules". Those are manifest services the control plane never installed and
  cannot uninstall through the module path, so the tool's output now mixes two
  concepts. The converge path already had this behaviour; this change is what
  first makes it reachable.
- `node_module_state` rows upsert and are never deleted, so a service removed
  from the manifest leaves a stale row until someone cleans it up. Same
  provenance: pre-existing on the converge path, newly reachable here.
- One extra POST per node every 5 minutes on refused passes, on top of the
  existing 60s emitter. The emitter's zero module reports do not flap these rows
  (the upsert returns early on an empty module list), so the two writers do not
  fight.
- The refusal error is now a joined error, so a caller that string matched the
  message exactly would see extra text appended when the report also fails.
  Current callers print it (`cmd/work.go` onPass) or return it (`job.go`); none
  match on it.

## Testing

```
cpuslot go build ./... && cpuslot go vet ./... && cpuslot go test ./...
```
All green.

Mutation tested, each mutation applied to the fix and reverted after:

| Mutation | Result |
|---|---|
| Guard branch reverted to a bare `return Plan{}, ApplyResult{}, err` | all 4 guard tests FAIL, including `TestRefuseFullWipeStillReportsActualState` |
| `AppliedRevision: desired.Revision` stamped on the guard report | `TestRefuseFullWipeReportOmitsAppliedRevision` FAILS, others pass |
| `errors.Join` dropped, only the guard error returned | `TestRefuseFullWipeSurfacesReportFailure` FAILS, others pass |
| Guard condition deleted entirely | all 4 FAIL, and the no uninstall assertion catches `uninstall:a` |

No test survived all four.

## Follow-ups (not in this PR)

- The guard covers only the empty desired set. A single desired row for a node
  like 1297 would make the authoritative engine uninstall the other 10 manifest
  services, because `ListInstalled` enumerates all of them. The aceteam side
  already flags the same hazard ("so a lone desired row cannot make the eventual
  pull loop uninstall every other module"). Tracked in #739.
- A node stuck in the refused state deserves a distinct health signal rather
  than an identical warning every 5 minutes, as #733 notes. Tracked in #742.
