### PR TITLE
fix(status): read pub/sub transport from a cheap /worker endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1131,6 +1131,17 @@ Unit tests focus on manifest parsing and utility functions. Most command logic i
 
 **Version Injection**: The `build.sh` script injects version via linker flags: `-ldflags="-X '${MODULE_PATH}/cmd.Version=${VERSION}'"`. Version is set as global var in `cmd/version.go`.
 
+**Reading one field off the running worker**: use `GET /worker`, not `GET /status`.
+`/status` runs a full collection (docker stats per running service plus
+`nvidia-smi`), which on a busy gateway node takes seconds; `/worker` serves the
+same `worker` envelope from an in-memory snapshot and shells out to nothing. A 404
+on `/worker` means the *serving* worker predates it (the probing binary is
+whatever `citadel status` you just ran; the serving one is a long-lived `citadel
+work`), so callers fall back to `/status`. See `probeWorkerPubSubTransport`
+(#735). Related: `httpGetBodyErr` (`cmd/work_attach.go`) derives its deadline from
+the caller's `client.Timeout`; it used to impose its own constant instead, so
+raising a caller's timeout was a silent no-op.
+
 **Mock Mode**:
 - The Nexus client in `internal/nexus/client.go` has a mock mode using `mock_jobs.json` for local testing
 - Device auth client has mock server in `internal/nexus/deviceauth_mock.go` for testing without backend

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -220,6 +220,9 @@ func runServe(cmd *cobra.Command, args []string) error {
 	// These route to the status server started by 'citadel work --status-port'
 	gw.AddUpstream("/health", &gateway.Upstream{Address: statusAddr})
 	gw.AddUpstream("/status", &gateway.Upstream{Address: statusAddr})
+	// /worker is the cheap liveness read (#735). Routed alongside /status so a
+	// 404 here can only mean "this build predates the route", never "no upstream".
+	gw.AddUpstream("/worker", &gateway.Upstream{Address: statusAddr})
 	gw.AddUpstream("/ping", &gateway.Upstream{Address: statusAddr})
 	gw.AddUpstream("/services", &gateway.Upstream{Address: statusAddr})
 	gw.AddUpstream("/api/screenshot", &gateway.Upstream{Address: statusAddr})

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -268,7 +268,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	listenAddr := fmt.Sprintf("%s:%d", serveBind, servePort)
 	fmt.Printf("   - Gateway: %s://%s\n", scheme, listenAddr)
 	fmt.Println("   - Routes:")
-	fmt.Printf("     /health, /status, /ping  -> %s (status server)\n", statusAddr)
+	fmt.Printf("     /health, /status, /worker, /ping -> %s (status server)\n", statusAddr)
 	fmt.Printf("     /api/screenshot, /api/actions -> %s\n", statusAddr)
 	fmt.Printf("     /ssh/authorized-keys     -> %s (SSH key deploy)\n", statusAddr)
 	fmt.Printf("     /v1/embeddings           -> %s (TEI embeddings)\n", embeddingAddr)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -279,9 +279,9 @@ func probeWorkerPubSubTransport() (string, pubSubProbeState) {
 	// has no /worker route": internal/status.Server.buildMux registers no "/"
 	// catch-all, so an unregistered path is answered by net/http itself. Every
 	// other outcome is either a transport failure that will repeat on /status, or
-	// a server that answered and simply could not serve this — and paying for a
-	// full collection on either buys nothing but the sweep's latency, which is
-	// the cost this whole change exists to avoid.
+	// a server that answered and simply could not serve this. Paying for a full
+	// collection on either buys nothing but the sweep's latency, which is the
+	// cost this whole change exists to avoid.
 	var statusErr *httpStatusError
 	if !errors.As(err, &statusErr) || statusErr.StatusCode != http.StatusNotFound {
 		return "", classifyProbeError(err)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -192,6 +192,10 @@ func printPubSubInfo(w io.Writer) {
 	case state == pubSubProbeMalformed:
 		fmt.Fprintf(w, "  %s\t%s\n", label,
 			faintColor.Sprint("unknown (the worker status server answered with a payload this build could not parse)"))
+	case state == pubSubProbeBadStatus:
+		fmt.Fprintf(w, "  %s\t%s\n", label,
+			faintColor.Sprint("unknown (the worker status server answered with an error status: it IS running, "+
+				"so check its logs rather than the --status-port/--gateway setting)"))
 	case state == pubSubProbeNotReported:
 		fmt.Fprintf(w, "  %s\t%s\n", label,
 			faintColor.Sprint("unknown (worker reports no pub/sub transport: not API mode, or an older build)"))
@@ -229,6 +233,12 @@ const (
 	// and reporting it as one would send the operator to enable something that is
 	// already running.
 	pubSubProbeMalformed
+	// pubSubProbeBadStatus: the server answered with a non-2xx we cannot use (and
+	// that is not the 404 meaning "no such route"). Same reason as the two above
+	// for not folding it into Unreachable: an HTTP status is proof something
+	// answered, so "enable --status-port/--gateway" would be advice to change a
+	// setting that is not the problem.
+	pubSubProbeBadStatus
 )
 
 // Probe bounds. Package vars so tests can shrink them rather than sleep.
@@ -265,10 +275,15 @@ func probeWorkerPubSubTransport() (string, pubSubProbeState) {
 	if err == nil {
 		return parsePubSubTransport(body)
 	}
-	// A transport-level failure (refused, timed out) will repeat on /status and
-	// only doubles the operator's wait, so report it rather than retry.
+	// Only a 404 earns the fallback. 404 is the one status that means "this build
+	// has no /worker route": internal/status.Server.buildMux registers no "/"
+	// catch-all, so an unregistered path is answered by net/http itself. Every
+	// other outcome is either a transport failure that will repeat on /status, or
+	// a server that answered and simply could not serve this — and paying for a
+	// full collection on either buys nothing but the sweep's latency, which is
+	// the cost this whole change exists to avoid.
 	var statusErr *httpStatusError
-	if !errors.As(err, &statusErr) {
+	if !errors.As(err, &statusErr) || statusErr.StatusCode != http.StatusNotFound {
 		return "", classifyProbeError(err)
 	}
 
@@ -282,11 +297,18 @@ func probeWorkerPubSubTransport() (string, pubSubProbeState) {
 	return parsePubSubTransport(body)
 }
 
-// classifyProbeError separates "took too long" from "nothing there", because
-// they are different operator actions and used to print the same string.
+// classifyProbeError maps a probe failure onto the state whose message names the
+// right operator action. Only a failure to reach anything at all may return
+// Unreachable: that is the one state whose message says "enable the status
+// server", and saying it to someone whose server just answered is the exact
+// conflation citadel-cli#735 is about.
 func classifyProbeError(err error) pubSubProbeState {
 	if isTimeoutError(err) {
 		return pubSubProbeTimedOut
+	}
+	var statusErr *httpStatusError
+	if errors.As(err, &statusErr) {
+		return pubSubProbeBadStatus
 	}
 	return pubSubProbeUnreachable
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -4,8 +4,10 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -181,8 +183,15 @@ func printPubSubInfo(w io.Writer) {
 	switch {
 	case state == pubSubProbeUnreachable:
 		fmt.Fprintf(w, "  %s\t%s\n", label,
-			faintColor.Sprint("unknown (worker status server not reachable on loopback; "+
-				"enable it with --status-port or --gateway)"))
+			faintColor.Sprint("unknown (nothing is listening on the worker status server's loopback port; "+
+				"it is opt-in, so enable it with --status-port or --gateway)"))
+	case state == pubSubProbeTimedOut:
+		fmt.Fprintf(w, "  %s\t%s\n", label,
+			faintColor.Sprint("unknown (the worker status server IS enabled but did not answer in time: "+
+				"the node is busy or the server is wedged, so re-running --status-port/--gateway will not help)"))
+	case state == pubSubProbeMalformed:
+		fmt.Fprintf(w, "  %s\t%s\n", label,
+			faintColor.Sprint("unknown (the worker status server answered with a payload this build could not parse)"))
 	case state == pubSubProbeNotReported:
 		fmt.Fprintf(w, "  %s\t%s\n", label,
 			faintColor.Sprint("unknown (worker reports no pub/sub transport: not API mode, or an older build)"))
@@ -202,27 +211,96 @@ type pubSubProbeState int
 
 const (
 	pubSubProbeOK pubSubProbeState = iota
-	// pubSubProbeUnreachable: no answer on loopback. The worker's status server
-	// is opt-in (--status-port / --gateway), so this is the common case.
+	// pubSubProbeUnreachable: nothing is listening (connection refused, no
+	// route to the port). The worker's status server is opt-in (--status-port /
+	// --gateway), so this is the common case, and the operator action is to
+	// enable it.
 	pubSubProbeUnreachable
+	// pubSubProbeTimedOut: something IS listening but did not answer inside the
+	// probe's bound. The operator action is the OPPOSITE of the above: the
+	// server is already enabled, so telling them to enable it sends them to fix
+	// a setting that is not the problem (citadel-cli#735).
+	pubSubProbeTimedOut
 	// pubSubProbeNotReported: the server answered but carried no transport --
 	// direct-Redis mode (no WebSocket/HTTP split) or a pre-#723 build.
 	pubSubProbeNotReported
+	// pubSubProbeMalformed: the server answered with a body we could not decode.
+	// Distinct from Unreachable: a reply we cannot parse is not an absent server,
+	// and reporting it as one would send the operator to enable something that is
+	// already running.
+	pubSubProbeMalformed
 )
 
-// probeWorkerPubSubTransport GETs the running worker's /status over loopback and
-// returns worker.pubsub_transport.
+// Probe bounds. Package vars so tests can shrink them rather than sleep.
+var (
+	// pubSubProbeCheapTimeout bounds the /worker probe. /worker reads a cached
+	// field and shells out to nothing, so anything slower than this is a wedged
+	// server, not a busy one.
+	pubSubProbeCheapTimeout = 2 * time.Second
+	// pubSubProbeFullTimeout bounds the /status fallback used against a worker
+	// too old to serve /worker. /status runs a full collection (docker stats per
+	// running service plus nvidia-smi), measured at 1.98-2.67s on a gateway node,
+	// so this must sit well above a realistic sweep. It is a compatibility path:
+	// on a worker that serves /worker it is never reached.
+	pubSubProbeFullTimeout = 10 * time.Second
+)
+
+// probeWorkerPubSubTransport reads worker.pubsub_transport off the running
+// worker over loopback.
+//
+// It asks /worker first. The transport is a single cached field, and coupling it
+// to /status's full collection made the answer a coin flip on exactly the busy
+// gateway nodes the line was written for (citadel-cli#735). /status remains the
+// fallback for a worker predating /worker. Version skew is normal here, since
+// the probing binary is whatever `citadel status` the operator just ran while
+// the serving binary is a long-lived `citadel work` nobody has restarted.
 func probeWorkerPubSubTransport() (string, pubSubProbeState) {
 	port := resolveStatusPort()
 	if port <= 0 {
 		return "", pubSubProbeUnreachable
 	}
-	body, ok := httpGetBody(&http.Client{Timeout: 2 * time.Second},
+
+	body, err := httpGetBodyErr(&http.Client{Timeout: pubSubProbeCheapTimeout},
+		fmt.Sprintf("http://127.0.0.1:%d/worker", port))
+	if err == nil {
+		return parsePubSubTransport(body)
+	}
+	// A transport-level failure (refused, timed out) will repeat on /status and
+	// only doubles the operator's wait, so report it rather than retry.
+	var statusErr *httpStatusError
+	if !errors.As(err, &statusErr) {
+		return "", classifyProbeError(err)
+	}
+
+	// The server answered but has no /worker route: an older worker. Pay for the
+	// full collection, with a bound above a realistic sweep this time.
+	body, err = httpGetBodyErr(&http.Client{Timeout: pubSubProbeFullTimeout},
 		fmt.Sprintf("http://127.0.0.1:%d/status", port))
-	if !ok {
-		return "", pubSubProbeUnreachable
+	if err != nil {
+		return "", classifyProbeError(err)
 	}
 	return parsePubSubTransport(body)
+}
+
+// classifyProbeError separates "took too long" from "nothing there", because
+// they are different operator actions and used to print the same string.
+func classifyProbeError(err error) pubSubProbeState {
+	if isTimeoutError(err) {
+		return pubSubProbeTimedOut
+	}
+	return pubSubProbeUnreachable
+}
+
+// isTimeoutError reports whether err is a deadline/timeout rather than a
+// connection failure. http.Client.Timeout surfaces as a *url.Error whose
+// Timeout() is true; the context check is a belt for the deadline propagated
+// into the request.
+func isTimeoutError(err error) bool {
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	return errors.Is(err, context.DeadlineExceeded)
 }
 
 // parsePubSubTransport extracts worker.pubsub_transport from a /status payload.
@@ -235,7 +313,7 @@ func parsePubSubTransport(body []byte) (string, pubSubProbeState) {
 		} `json:"worker"`
 	}
 	if err := json.Unmarshal(body, &payload); err != nil {
-		return "", pubSubProbeUnreachable
+		return "", pubSubProbeMalformed
 	}
 	if payload.Worker == nil || payload.Worker.PubSubTransport == "" {
 		return "", pubSubProbeNotReported

--- a/cmd/status_probe_test.go
+++ b/cmd/status_probe_test.go
@@ -1,0 +1,206 @@
+// cmd/status_probe_test.go
+//
+// Regression tests for the `citadel status` Pub/Sub probe (citadel-cli#735).
+//
+// The bug: the probe read worker.pubsub_transport off /status, which runs a full
+// collection (docker stats per running service plus nvidia-smi). On a gateway
+// node that collection measured 1.98-2.67s against a 2s probe bound, so the line
+// degraded to "unknown" on 9 of 10 runs on a node whose status server was
+// enabled and answering 200 -- and the "unknown" text told the operator to
+// enable a feature that was already on.
+//
+// These tests pin both halves: the transport is readable while /status is slow,
+// and a timeout no longer reports as an absent server.
+package cmd
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// pointProbeAtServer makes probeWorkerPubSubTransport() (which dials 127.0.0.1
+// at the recorded status port) reach the given test server.
+func pointProbeAtServer(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	_, portStr, err := net.SplitHostPort(srv.Listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pointProbeAtPort(t, port)
+}
+
+func pointProbeAtPort(t *testing.T, port int) {
+	t.Helper()
+	prev := provisionedStateDirOverride
+	t.Cleanup(func() { provisionedStateDirOverride = prev })
+	dir := t.TempDir()
+	provisionedStateDirOverride = dir
+	writeFactsFile(t, dir, gatewayFacts{Port: 8443, UseTLS: true, StatusPort: port})
+}
+
+// TestProbeWorkerPubSubTransportSurvivesSlowStatus is the #735 regression test.
+//
+// It models the reported node exactly: a worker too old to serve /worker (404),
+// whose /status takes longer than the old 2s bound. The probe must still report
+// the transport rather than "unknown".
+//
+// This is also the test that pins the real defect. The old code passed
+// `&http.Client{Timeout: 2 * time.Second}`, but httpGetBody ALSO applied its own
+// hardcoded 2s context deadline, so raising the client timeout alone changed
+// nothing. Reinstating that inner constant must fail this test.
+func TestProbeWorkerPubSubTransportSurvivesSlowStatus(t *testing.T) {
+	var statusHits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/worker":
+			// Pre-#735 worker: no such route.
+			http.NotFound(w, r)
+		case "/status":
+			statusHits++
+			// Straddles the old 2s bound the way the measured collection did.
+			time.Sleep(3 * time.Second)
+			fmt.Fprint(w, `{"worker":{"consuming":true,"pubsub_transport":"websocket"}}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	pointProbeAtServer(t, srv)
+
+	transport, state := probeWorkerPubSubTransport()
+	if state != pubSubProbeOK || transport != "websocket" {
+		t.Fatalf("probeWorkerPubSubTransport() = (%q, %v), want (\"websocket\", pubSubProbeOK): "+
+			"a slow /status must not read as an unreachable status server", transport, state)
+	}
+	if statusHits != 1 {
+		t.Errorf("/status hits = %d, want 1 (the 404 on /worker must fall back exactly once)", statusHits)
+	}
+}
+
+// TestProbeWorkerPubSubTransportPrefersCheapEndpoint pins the decoupling: on a
+// worker that serves /worker, the probe must not touch /status at all, so the
+// answer no longer depends on how long a docker/nvidia sweep takes.
+func TestProbeWorkerPubSubTransportPrefersCheapEndpoint(t *testing.T) {
+	var statusHits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/worker":
+			fmt.Fprint(w, `{"worker":{"consuming":true,"pubsub_transport":"http"}}`)
+		case "/status":
+			statusHits++
+			time.Sleep(5 * time.Second)
+			fmt.Fprint(w, `{"worker":{"consuming":true,"pubsub_transport":"websocket"}}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	pointProbeAtServer(t, srv)
+
+	start := time.Now()
+	transport, state := probeWorkerPubSubTransport()
+	elapsed := time.Since(start)
+
+	if state != pubSubProbeOK || transport != "http" {
+		t.Fatalf("probeWorkerPubSubTransport() = (%q, %v), want (\"http\", pubSubProbeOK)", transport, state)
+	}
+	if statusHits != 0 {
+		t.Errorf("/status was collected %d time(s); the cheap endpoint must make the full sweep unnecessary", statusHits)
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("probe took %s; it must not wait on the full collection", elapsed)
+	}
+}
+
+// TestProbeWorkerPubSubTransportDistinguishesTimeoutFromAbsent covers the second
+// half of #735: "timed out" and "not enabled" are different operator actions and
+// used to print the same string.
+func TestProbeWorkerPubSubTransportDistinguishesTimeoutFromAbsent(t *testing.T) {
+	t.Run("nothing listening reads as unreachable", func(t *testing.T) {
+		// Bind and immediately release a port so the dial is refused rather than
+		// filtered (a filtered port would hang, which is a different verdict).
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, portStr, _ := net.SplitHostPort(ln.Addr().String())
+		port, _ := strconv.Atoi(portStr)
+		ln.Close()
+		pointProbeAtPort(t, port)
+
+		if _, state := probeWorkerPubSubTransport(); state != pubSubProbeUnreachable {
+			t.Fatalf("probe state = %v, want pubSubProbeUnreachable", state)
+		}
+	})
+
+	t.Run("listening but wedged reads as timed out", func(t *testing.T) {
+		release := make(chan struct{})
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			<-release
+		}))
+		// Cleanups run last-registered-first: unblock the handler before Close,
+		// which waits on outstanding requests.
+		t.Cleanup(srv.Close)
+		t.Cleanup(func() { close(release) })
+		pointProbeAtServer(t, srv)
+
+		// Shrink the bounds so the test does not sit out the production ones.
+		prevCheap, prevFull := pubSubProbeCheapTimeout, pubSubProbeFullTimeout
+		t.Cleanup(func() { pubSubProbeCheapTimeout, pubSubProbeFullTimeout = prevCheap, prevFull })
+		pubSubProbeCheapTimeout, pubSubProbeFullTimeout = 150*time.Millisecond, 150*time.Millisecond
+
+		if _, state := probeWorkerPubSubTransport(); state != pubSubProbeTimedOut {
+			t.Fatalf("probe state = %v, want pubSubProbeTimedOut: a server that IS listening must not be "+
+				"reported as one the operator still needs to enable", state)
+		}
+	})
+}
+
+// TestHTTPGetBodyHonorsClientTimeout pins the fix at its source: the inner
+// deadline must come from the caller's client, not a constant. A caller that
+// asks for longer than 2s and does not get it is the #735 defect in miniature.
+func TestHTTPGetBodyHonorsClientTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2500 * time.Millisecond)
+		fmt.Fprint(w, "ok")
+	}))
+	defer srv.Close()
+
+	body, err := httpGetBodyErr(&http.Client{Timeout: 8 * time.Second}, srv.URL)
+	if err != nil {
+		t.Fatalf("httpGetBodyErr with an 8s client timeout failed after ~2.5s: %v", err)
+	}
+	if string(body) != "ok" {
+		t.Errorf("body = %q, want %q", body, "ok")
+	}
+}
+
+// TestHTTPGetBodyErrReportsStatus pins the 404 signal the version-skew fallback
+// depends on: a non-2xx must be distinguishable from a transport failure.
+func TestHTTPGetBodyErrReportsStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	_, err := httpGetBodyErr(&http.Client{Timeout: time.Second}, srv.URL)
+	statusErr, ok := err.(*httpStatusError)
+	if !ok {
+		t.Fatalf("err = %T (%v), want *httpStatusError", err, err)
+	}
+	if statusErr.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode = %d, want 404", statusErr.StatusCode)
+	}
+	if isTimeoutError(err) {
+		t.Error("a 404 must not classify as a timeout")
+	}
+}

--- a/cmd/status_probe_test.go
+++ b/cmd/status_probe_test.go
@@ -122,6 +122,51 @@ func TestProbeWorkerPubSubTransportPrefersCheapEndpoint(t *testing.T) {
 	}
 }
 
+// TestProbeWorkerPubSubTransportDoesNotFallBackOnNon404 pins the OTHER half of
+// the version-skew branch: only a 404 buys the expensive fallback.
+//
+// 404 is the one status that means "this build has no /worker route" (the status
+// server's mux registers no "/" catch-all, so net/http answers it). Any other
+// status came from a server that answered, and re-asking that server for a full
+// collection would pay the 10s sweep this change exists to avoid, on a node that
+// is already unhealthy.
+//
+// It also pins the message: a server that answered must not be reported as one
+// the operator still needs to enable.
+func TestProbeWorkerPubSubTransportDoesNotFallBackOnNon404(t *testing.T) {
+	for _, code := range []int{http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable} {
+		t.Run(strconv.Itoa(code), func(t *testing.T) {
+			var statusHits int
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/worker":
+					http.Error(w, "upstream unavailable", code)
+				case "/status":
+					statusHits++
+					fmt.Fprint(w, `{"worker":{"consuming":true,"pubsub_transport":"websocket"}}`)
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer srv.Close()
+			pointProbeAtServer(t, srv)
+
+			_, state := probeWorkerPubSubTransport()
+			if statusHits != 0 {
+				t.Errorf("/status was collected %d time(s) after a %d on /worker; only a 404 means "+
+					"\"no such route\", and the full sweep is exactly the cost being avoided", statusHits, code)
+			}
+			if state == pubSubProbeUnreachable {
+				t.Errorf("probe state = pubSubProbeUnreachable after a %d; the server ANSWERED, so telling the "+
+					"operator to enable --status-port/--gateway points at a setting that is not the problem", code)
+			}
+			if state != pubSubProbeBadStatus {
+				t.Errorf("probe state = %v, want pubSubProbeBadStatus", state)
+			}
+		})
+	}
+}
+
 // TestProbeWorkerPubSubTransportDistinguishesTimeoutFromAbsent covers the second
 // half of #735: "timed out" and "not enabled" are different operator actions and
 // used to print the same string.

--- a/cmd/status_probe_test.go
+++ b/cmd/status_probe_test.go
@@ -6,7 +6,7 @@
 // collection (docker stats per running service plus nvidia-smi). On a gateway
 // node that collection measured 1.98-2.67s against a 2s probe bound, so the line
 // degraded to "unknown" on 9 of 10 runs on a node whose status server was
-// enabled and answering 200 -- and the "unknown" text told the operator to
+// enabled and answering 200, and the "unknown" text told the operator to
 // enable a feature that was already on.
 //
 // These tests pin both halves: the transport is readable while /status is slow,
@@ -14,6 +14,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -193,8 +194,11 @@ func TestHTTPGetBodyErrReportsStatus(t *testing.T) {
 	defer srv.Close()
 
 	_, err := httpGetBodyErr(&http.Client{Timeout: time.Second}, srv.URL)
-	statusErr, ok := err.(*httpStatusError)
-	if !ok {
+	// errors.As, matching the predicate the /status fallback actually branches
+	// on. A bare type assertion would pass here and still let a future wrap break
+	// the fallback silently.
+	var statusErr *httpStatusError
+	if !errors.As(err, &statusErr) {
 		t.Fatalf("err = %T (%v), want *httpStatusError", err, err)
 	}
 	if statusErr.StatusCode != http.StatusNotFound {

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -1946,6 +1946,7 @@ func runWork(cmd *cobra.Command, args []string) {
 		// Register upstreams (same routes as cmd/serve.go)
 		gw.AddUpstream("/health", &gateway.Upstream{Address: statusAddr})
 		gw.AddUpstream("/status", &gateway.Upstream{Address: statusAddr})
+		gw.AddUpstream("/worker", &gateway.Upstream{Address: statusAddr})
 		gw.AddUpstream("/ping", &gateway.Upstream{Address: statusAddr})
 		gw.AddUpstream("/services", &gateway.Upstream{Address: statusAddr})
 		gw.AddUpstream("/api/screenshot", &gateway.Upstream{Address: statusAddr})

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -2040,7 +2040,7 @@ func runWork(cmd *cobra.Command, args []string) {
 		listenAddr := fmt.Sprintf("%s:%d", workGatewayBind, workGatewayPort)
 		fmt.Printf("   - Gateway: %s://%s\n", scheme, listenAddr)
 		fmt.Println("   - Routes:")
-		fmt.Printf("     /health, /status, /ping  -> %s (status server)\n", statusAddr)
+		fmt.Printf("     /health, /status, /worker, /ping -> %s (status server)\n", statusAddr)
 		fmt.Printf("     /api/screenshot, /api/actions -> %s\n", statusAddr)
 		fmt.Printf("     /ssh/authorized-keys     -> %s (SSH key deploy)\n", statusAddr)
 		fmt.Printf("     /workflow/...             -> %s (workflow API)\n", statusAddr)

--- a/cmd/work_attach.go
+++ b/cmd/work_attach.go
@@ -129,28 +129,59 @@ func fetchHealth(client *http.Client, port int) string {
 	return payload.Status
 }
 
+// defaultHTTPGetTimeout bounds a probe whose client carries no Timeout of its
+// own.
+const defaultHTTPGetTimeout = 2 * time.Second
+
+// httpStatusError is returned by httpGetBodyErr when the server answered but
+// with a non-2xx. Callers that treat "no such route" (404, an older worker)
+// differently from a transport failure need to tell the two apart (#735).
+type httpStatusError struct{ StatusCode int }
+
+func (e *httpStatusError) Error() string { return fmt.Sprintf("http status %d", e.StatusCode) }
+
 // httpGetBody performs a bounded GET and returns the body on a 2xx, else ok=false.
 func httpGetBody(client *http.Client, url string) ([]byte, bool) {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	body, err := httpGetBodyErr(client, url)
+	return body, err == nil
+}
+
+// httpGetBodyErr is httpGetBody with the failure reason preserved.
+//
+// The bound is the CALLER's client.Timeout (defaultHTTPGetTimeout when the
+// client sets none). This used to be a hardcoded 2s context deadline that
+// silently overrode every caller's Timeout, so a caller that needed longer
+// could not have it and would not be told: raising client.Timeout was a no-op,
+// which is what made citadel-cli#735 look like a timeout that had already been
+// widened. Any new caller here must set client.Timeout, not assume 2s.
+func httpGetBodyErr(client *http.Client, url string) ([]byte, error) {
+	if client == nil {
+		client = &http.Client{}
+	}
+	timeout := client.Timeout
+	if timeout <= 0 {
+		timeout = defaultHTTPGetTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return nil, false
+		return nil, err
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, false
+		return nil, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
-		return nil, false
+		return nil, &httpStatusError{StatusCode: resp.StatusCode}
 	}
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
-		return nil, false
+		return nil, err
 	}
-	return body, true
+	return body, nil
 }
 
 // buildAttachBanner renders the discover-and-attach banner. Pure (no IO) so it is

--- a/cmd/ws_pubsub_test.go
+++ b/cmd/ws_pubsub_test.go
@@ -295,7 +295,9 @@ func TestParsePubSubTransport(t *testing.T) {
 		{"http fallback", `{"worker":{"consuming":true,"pubsub_transport":"http"}}`, "http", pubSubProbeOK},
 		{"no worker section", `{"version":"v1"}`, "", pubSubProbeNotReported},
 		{"older worker, field absent", `{"worker":{"consuming":true}}`, "", pubSubProbeNotReported},
-		{"malformed", `not json`, "", pubSubProbeUnreachable},
+		// A reply we cannot decode is NOT an absent server: reporting it as one
+		// would tell the operator to enable something already running (#735).
+		{"malformed", `not json`, "", pubSubProbeMalformed},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/status/collector.go
+++ b/internal/status/collector.go
@@ -237,6 +237,19 @@ func (c *Collector) Collect() (*NodeStatus, error) {
 	return status, nil
 }
 
+// WorkerLivenessSnapshot returns the live worker consume-loop liveness WITHOUT
+// running a collection. Collect() gathers docker stats and nvidia-smi output;
+// this block needs neither (it is an in-memory snapshot plus a live read off the
+// API client), so a caller that only wants liveness must not pay for the sweep
+// (citadel-cli#735). Returns nil when no provider was wired: a status server
+// with no consume loop behind it, not an error.
+func (c *Collector) WorkerLivenessSnapshot() *WorkerLiveness {
+	if c.workerLiveness == nil {
+		return nil
+	}
+	return c.workerLiveness()
+}
+
 // populateServices sets AvailableServices to the sorted list of serving
 // services this build knows how to deploy (the embedded services.ServiceMap
 // keys). It advertises what the binary CAN run, not what is currently

--- a/internal/status/server.go
+++ b/internal/status/server.go
@@ -418,10 +418,14 @@ type WorkerEnvelope struct {
 // body is a strict SUBSET of what /status already serves unauthenticated here,
 // so this adds a route, not an exposure.
 //
-// A worker that supplies no liveness provider (e.g. `citadel serve`, which runs
-// a status server with no consume loop) answers 200 with the block absent, NOT
-// 404. 404 must keep meaning "this build has no /worker route" so a newer CLI
-// can use it to detect an older worker.
+// A 404 from this route is load-bearing elsewhere: it is what a newer
+// `citadel status` branches on to detect a worker predating the route (see
+// probeWorkerPubSubTransport in cmd/status.go), so this handler must never emit
+// 404 for any other reason. A server built without a liveness provider therefore
+// answers 200 with the block absent. No production path reaches that: the only
+// status.NewServer call site is in cmd/work.go, and both collector constructions
+// there pass the worker liveness closure. It is a guarantee for constructions
+// that wire no provider, not a case that fires today.
 func (s *Server) handleWorker(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)

--- a/internal/status/server.go
+++ b/internal/status/server.go
@@ -232,6 +232,7 @@ func (s *Server) buildMux() *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ping", s.handlePing)
 	mux.HandleFunc("/status", s.handleStatus)
+	mux.HandleFunc("/worker", s.handleWorker)
 	mux.HandleFunc("/health", s.handleHealth)
 	mux.HandleFunc("/services", s.handleServices)
 	mux.HandleFunc("/resources", s.handleResources)
@@ -392,6 +393,48 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(status)
+}
+
+// WorkerEnvelope is the /worker response body. It deliberately reuses the field
+// name and shape /status uses for the same block, so one parser reads either
+// endpoint and a caller can fall back from /worker to /status without a second
+// decoder.
+type WorkerEnvelope struct {
+	Worker *WorkerLiveness `json:"worker,omitempty"`
+}
+
+// handleWorker returns ONLY the worker liveness block.
+// GET /worker
+//
+// It exists because /status runs a full collection (docker stats across every
+// running service, plus nvidia-smi), which on a busy gateway node takes about as
+// long as any caller's patience. Reading a single cached field should not be
+// coupled to that sweep: `citadel status` was reporting the pub/sub transport as
+// "unknown" on healthy nodes because its probe raced the collection
+// (citadel-cli#735). The liveness block is assembled from an in-memory snapshot
+// and a live accessor on the API client, so this handler shells out to nothing.
+//
+// Auth posture is the same as /status on this listener: unauthenticated. The
+// body is a strict SUBSET of what /status already serves unauthenticated here,
+// so this adds a route, not an exposure.
+//
+// A worker that supplies no liveness provider (e.g. `citadel serve`, which runs
+// a status server with no consume loop) answers 200 with the block absent, NOT
+// 404. 404 must keep meaning "this build has no /worker route" so a newer CLI
+// can use it to detect an older worker.
+func (s *Server) handleWorker(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var live *WorkerLiveness
+	if s.collector != nil {
+		live = s.collector.WorkerLivenessSnapshot()
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(WorkerEnvelope{Worker: live})
 }
 
 // handleHealth returns a simple health check response.

--- a/internal/status/server_test.go
+++ b/internal/status/server_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 	"time"
 
@@ -459,11 +461,12 @@ func TestServerWorkerEndpoint(t *testing.T) {
 	}
 }
 
-// TestServerWorkerEndpointNoProvider: a status server with no consume loop
-// behind it (e.g. `citadel serve`) must answer 200 with the block absent, not
-// 404. A newer CLI uses 404 to mean "this build predates /worker" and falls back
-// to /status; returning it here would send that caller down the slow path
-// forever.
+// TestServerWorkerEndpointNoProvider: a server built with no liveness provider
+// must answer 200 with the block absent, not 404. A newer CLI uses 404 to mean
+// "this build predates /worker" and falls back to /status; returning it here
+// would send that caller down the slow path forever. No production path
+// constructs the server that way today (cmd/work.go always passes the closure),
+// so this pins a protocol guarantee rather than a live case.
 func TestServerWorkerEndpointNoProvider(t *testing.T) {
 	server := NewServer(ServerConfig{}, NewCollector(CollectorConfig{NodeName: "test-node"}))
 
@@ -481,6 +484,91 @@ func TestServerWorkerEndpointNoProvider(t *testing.T) {
 	if env.Worker != nil {
 		t.Errorf("worker = %+v, want absent", env.Worker)
 	}
+}
+
+// TestServerWorkerEndpointServesNoMoreThanStatus pins the route's SIZE, not just
+// its contents. /worker is unauthenticated on a listener that is also reachable
+// over the mesh, and the argument for that is entirely "it serves a subset of
+// what /status already serves there". Nothing else in this file would fail if
+// /worker grew: the other tests assert the worker block is PRESENT and say
+// nothing about what else is absent, so a later `node_name` or `version` added
+// for a caller's convenience would widen an ungated route silently.
+//
+// The top-level assertion is the load-bearing half. The inner comparison is a
+// weaker guard by construction: both endpoints marshal the same *WorkerLiveness,
+// so a field added THERE appears in both and cannot diverge. What can diverge is
+// WorkerEnvelope, which only /worker uses.
+//
+// Every WorkerLiveness field is populated non-zero on purpose: most are
+// omitempty, so a zero value would drop the key and leave this asserting almost
+// nothing.
+func TestServerWorkerEndpointServesNoMoreThanStatus(t *testing.T) {
+	now := time.Now().UTC()
+	collector := NewCollector(CollectorConfig{
+		NodeName: "test-node",
+		WorkerLiveness: func() *WorkerLiveness {
+			return &WorkerLiveness{
+				Consuming:          true,
+				LastJobConsumedAt:  &now,
+				LastPollAt:         &now,
+				InFlight:           1,
+				Processed:          2,
+				Failed:             3,
+				IdentityUnresolved: true,
+				PubSubTransport:    "websocket",
+			}
+		},
+	})
+	server := NewServer(ServerConfig{}, collector)
+
+	workerBody := decodeJSONMap(t, func() *httptest.ResponseRecorder {
+		w := httptest.NewRecorder()
+		server.handleWorker(w, httptest.NewRequest(http.MethodGet, "/worker", nil))
+		return w
+	}())
+
+	topLevel := slices.Sorted(maps.Keys(workerBody))
+	if !slices.Equal(topLevel, []string{"worker"}) {
+		t.Fatalf("/worker top-level keys = %v, want exactly [worker]: this route is unauthenticated, so "+
+			"anything added to WorkerEnvelope widens what an unauthenticated caller can read", topLevel)
+	}
+
+	workerBlock, ok := workerBody["worker"].(map[string]any)
+	if !ok {
+		t.Fatalf("/worker `worker` = %T, want an object", workerBody["worker"])
+	}
+
+	statusBody := decodeJSONMap(t, func() *httptest.ResponseRecorder {
+		w := httptest.NewRecorder()
+		server.handleStatus(w, httptest.NewRequest(http.MethodGet, "/status", nil))
+		return w
+	}())
+	statusWorker, ok := statusBody["worker"].(map[string]any)
+	if !ok {
+		t.Fatalf("/status `worker` = %T, want an object", statusBody["worker"])
+	}
+
+	for _, key := range slices.Sorted(maps.Keys(workerBlock)) {
+		if _, present := statusWorker[key]; !present {
+			t.Errorf("/worker serves worker.%s and /status does not; the subset claim that justifies "+
+				"leaving this route ungated no longer holds", key)
+		}
+	}
+}
+
+// decodeJSONMap decodes a recorded response into an untyped map, so a test can
+// assert on the keys actually on the wire rather than on the ones its own struct
+// happens to know about.
+func decodeJSONMap(t *testing.T, w *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	if w.Code != http.StatusOK {
+		t.Fatalf("StatusCode = %v, want %v", w.Code, http.StatusOK)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(w.Result().Body).Decode(&body); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	return body
 }
 
 func TestServerWorkerEndpointRejectsNonGET(t *testing.T) {

--- a/internal/status/server_test.go
+++ b/internal/status/server_test.go
@@ -420,3 +420,77 @@ func TestExistingEndpointsUnaffectedByDesktopConfig(t *testing.T) {
 		})
 	}
 }
+
+// TestServerWorkerEndpoint pins the cheap liveness route added for
+// citadel-cli#735: it must serve the same `worker` envelope /status uses (so one
+// parser reads either), and it must reach the provider directly rather than via
+// a collection.
+func TestServerWorkerEndpoint(t *testing.T) {
+	calls := 0
+	collector := NewCollector(CollectorConfig{
+		NodeName: "test-node",
+		WorkerLiveness: func() *WorkerLiveness {
+			calls++
+			return &WorkerLiveness{Consuming: true, PubSubTransport: "websocket"}
+		},
+	})
+	server := NewServer(ServerConfig{}, collector)
+
+	req := httptest.NewRequest(http.MethodGet, "/worker", nil)
+	w := httptest.NewRecorder()
+	server.handleWorker(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("StatusCode = %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+	var env WorkerEnvelope
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	if env.Worker == nil {
+		t.Fatal("worker block absent; the whole point of the route is to serve it")
+	}
+	if env.Worker.PubSubTransport != "websocket" {
+		t.Errorf("PubSubTransport = %q, want websocket", env.Worker.PubSubTransport)
+	}
+	if calls != 1 {
+		t.Errorf("liveness provider called %d times, want 1", calls)
+	}
+}
+
+// TestServerWorkerEndpointNoProvider: a status server with no consume loop
+// behind it (e.g. `citadel serve`) must answer 200 with the block absent, not
+// 404. A newer CLI uses 404 to mean "this build predates /worker" and falls back
+// to /status; returning it here would send that caller down the slow path
+// forever.
+func TestServerWorkerEndpointNoProvider(t *testing.T) {
+	server := NewServer(ServerConfig{}, NewCollector(CollectorConfig{NodeName: "test-node"}))
+
+	req := httptest.NewRequest(http.MethodGet, "/worker", nil)
+	w := httptest.NewRecorder()
+	server.handleWorker(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("StatusCode = %v, want %v", w.Code, http.StatusOK)
+	}
+	var env WorkerEnvelope
+	if err := json.NewDecoder(w.Result().Body).Decode(&env); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	if env.Worker != nil {
+		t.Errorf("worker = %+v, want absent", env.Worker)
+	}
+}
+
+func TestServerWorkerEndpointRejectsNonGET(t *testing.T) {
+	server := NewServer(ServerConfig{}, NewCollector(CollectorConfig{NodeName: "test-node"}))
+
+	req := httptest.NewRequest(http.MethodPost, "/worker", nil)
+	w := httptest.NewRecorder()
+	server.handleWorker(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("StatusCode = %v, want %v", w.Code, http.StatusMethodNotAllowed)
+	}
+}


### PR DESCRIPTION
## Context

Fixes #735. `citadel status` printed

```
Pub/Sub:  unknown (worker status server not reachable on loopback; enable it with --status-port or --gateway)
```

on a gateway node whose status server was enabled and answering 200 on every request. Reported as 9 of 10 invocations at v2.103.0.

## Root cause, and one correction to the issue

The issue attributes this to "a hardcoded 2s client timeout" in `probeWorkerPubSubTransport`. That client timeout exists, but it was never the binding constraint. `httpGetBody` (`cmd/work_attach.go`) applied its **own** hardcoded 2s `context.WithTimeout` on top of whatever the caller passed:

```go
ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
```

So the issue's first suggested remedy, raising the client timeout to 5-10s, would have been a **silent no-op**: the inner context still fires at 2s and the probe still loses the race. Worth knowing because that helper is shared, and any future caller that "sets a longer timeout" gets 2s regardless.

The rest of the diagnosis holds. `/status` runs a full collection (docker stats across running services plus `nvidia-smi`), and the transport is a single cached field that needs none of it.

## Changes

**Decouple, per the issue's preferred direction.** New `GET /worker` on the status server (`internal/status/server.go`) serves only the worker liveness block, assembled from the in-memory snapshot plus a live read off the API client. It shells out to nothing. It emits the *same* `worker` envelope `/status` uses, so one parser reads either endpoint.

- `Collector.WorkerLivenessSnapshot()` reaches the provider without `Collect()`.
- A server built with no liveness provider answers 200 with the block absent, **not** 404, so 404 keeps meaning exactly one thing: this build predates the route.

**`cmd/status.go`** probes `/worker` first. It falls back to `/status` on a **404 only**, with a bound above a realistic sweep. Any other outcome is reported rather than retried: a transport failure would fail the same way on `/status` and only doubles the operator's wait, and a non-404 status came from a server that answered, so the full collection would buy nothing but its own latency.

**Gateway upstream.** `/worker` is registered alongside `/status` in both `cmd/serve.go` and `cmd/work.go`, and added to the route list each prints. The loopback probe does not traverse the gateway, so `citadel status` did not need this, but without it a caller reaching the node through the gateway gets a 404 that means "no upstream" rather than "this build predates the route". `/worker` matches none of `categoryForPath`'s gated prefixes, so it falls through to the always-allowed bucket, same as `/status`.

**`httpGetBodyErr`** derives its deadline from the caller's `client.Timeout` and returns the error so callers can classify it. `httpGetBody` stays as the bool wrapper.

**Distinguish the failure modes**, as asked. Four unknowns now, and the rule is that only a failure to reach anything at all may print "enable it":

| State | Message | Action |
|---|---|---|
| `Unreachable` | nothing listening on the loopback port, it is opt-in | enable `--status-port` / `--gateway` |
| `TimedOut` | server IS enabled but did not answer in time | look at load or a wedged server, not config |
| `BadStatus` | answered with an error status | read the server's logs, it is running |
| `Malformed` | answered with a payload this build could not parse | version mismatch |

`parsePubSubTransport` previously returned `Unreachable` on a JSON decode failure. That was the same conflation in miniature: a reply we cannot parse is not an absent server.

## Review conditions applied

A security review returned approve-with-conditions. Three follow-ups, all in the second commit:

1. **The fallback fired on any non-2xx, not just 404.** Only 404 carries the "this build predates the route" meaning the design depends on: the status server's mux registers no `/` catch-all, so an unregistered path is answered by `net/http` itself. A 500/502/503 would have paid the 10s full-collection sweep this change exists to avoid. Narrowed, with a test that a non-404 does not fall back and does not touch `/status`.

   Narrowing this unmasked a second bug the old broad branch had been hiding: a non-404 fell through `classifyProbeError` onto `Unreachable`, whose message tells the operator to enable a status server that had just answered them. That is the exact conflation this PR exists to remove, so a non-404 now gets its own state and its own message.

2. **The subset argument was not pinned by anything.** The case for leaving `/worker` ungated is that its body is a strict subset of what `/status` already serves on the same listener. Nothing tested that: the existing tests assert the worker block is present and say nothing about what else is absent, so a later `node_name` or `version` added for a caller's convenience would widen the route silently. `TestServerWorkerEndpointServesNoMoreThanStatus` decodes `/worker` into an untyped map, asserts the top-level key set is exactly `{worker}`, and asserts its inner keys all appear in the `worker` block `/status` returns.

3. **The comment justifying "200 with the block absent, not 404" was wrong.** It cited `citadel serve` as a status server with no consume loop. `cmd/serve.go` starts no status server at all; it proxies to `127.0.0.1:<status-port>` served by `citadel work`. The only production `status.NewServer` call site is in `cmd/work.go`, and both collector constructions there pass the worker liveness closure, so no production path serves `/worker` with a nil provider. The behaviour is unchanged and still correct; the rationale is now the real one: 404 on this route is the version-skew signal a newer CLI branches on, so the handler must never emit it for another reason, and the absent-block answer is a guarantee for constructions that wire no provider rather than a case that fires today.

## Version skew: this does not fix a running node until its worker restarts

The probing binary is whatever `citadel status` the operator just ran. The **serving** binary is a long-lived `citadel work` nobody has restarted. So `/worker` is absent on exactly the busy production nodes that motivated this issue until their worker process restarts. Until then those nodes take the `/status` fallback, which is why the widened fallback bound is load-bearing rather than decorative. The narrowing to 404 does not touch this path: an old status server answers an unregistered route with exactly 404, and a mutation reverting the narrowing leaves the version-skew test passing and fails only the new one.

## What this makes worse

- **A wedged status server now costs `citadel status` up to the fallback bound instead of failing at 2s.** Slower CLI on precisely the unhealthy node. Judged worth it: a wrong answer in 2s is worse than a right one in 5.
- **A non-404 status now reports without the sweep, so the answer is less complete than it used to be.** Before the narrowing, a server that 500'd on `/worker` but still served `/status` would have produced the real transport after a 10s wait. Now it prints an unknown. Deliberate: a status server erroring on its cheapest route is a node to look at, not a node to wait on, and the 10s sweep is the cost this change exists to remove.
- **Four probe states instead of two.** The `printPubSubInfo` switch has no exhaustiveness check, so a fifth state added without a case degrades silently to printing a bare transport string.
- **One more unauthenticated route** on the plaintext listener, which is also reachable over the mesh. It serves a strict subset of what unauthenticated `/status` already serves on that listener, and the new key-set test is what keeps that true, but it is one more route to keep in mind.
- **Two probe paths instead of one.** A version-skew branch to maintain until old workers age out.
- **The 2s bound on the `citadel work` attach banner (`probeLocalStatus`) is unchanged** and still races the same collection on the same nodes. Same class of bug, out of scope here; the banner degrades gracefully to lock-record-only info.

## Interaction with #734

This makes the line *reachable*, not *meaningful*. `websocket` still means only "the client believes a socket is open"; until keepalive lands that is not evidence bytes are flowing.

## Testing

`cpuslot go build ./... && cpuslot go vet ./... && cpuslot go test ./...` green.

Mutation-tested, each mutation killed its test:

| Mutation | Result |
|---|---|
| Restore the hardcoded 2s context deadline inside `httpGetBodyErr` | FAIL `TestProbeWorkerPubSubTransportSurvivesSlowStatus`, `TestHTTPGetBodyHonorsClientTimeout` |
| Collapse `classifyProbeError` back to always-`Unreachable` | FAIL `TestProbeWorkerPubSubTransportDistinguishesTimeoutFromAbsent/listening_but_wedged`, `TestProbeWorkerPubSubTransportDoesNotFallBackOnNon404` (all 3 statuses) |
| Probe `/status` instead of `/worker` on the first hop | FAIL `TestProbeWorkerPubSubTransportPrefersCheapEndpoint` |
| Widen the fallback back to any non-2xx (drop the 404 check) | FAIL `TestProbeWorkerPubSubTransportDoesNotFallBackOnNon404` only; the version-skew and slow-`/status` tests still pass, which is the point |
| Add a field to `WorkerEnvelope` | FAIL `TestServerWorkerEndpointServesNoMoreThanStatus` |
| Add a field to `WorkerLiveness` (control) | PASSES, and must: both endpoints marshal the same type, so a field added there appears in both and cannot diverge. `WorkerEnvelope` is the only place the two payloads can drift apart, which is why the top-level assertion is the load-bearing half |

The first mutation is the one that matters for the original bug: mutating only the `http.Client{Timeout:}` literal in `probeWorkerPubSubTransport` leaves the tests passing, because that literal was never what bounded the request.

**Manual verification still owed** (hence draft): confirm on a real gateway node, after its worker restarts onto this build, that `citadel status` reports the transport rather than `unknown`. No production worker was restarted as part of this work.
