### PR TITLE
fix(redisapi): guard reconnectBackoff with connMu (#728)

### DIFF
--- a/internal/redisapi/websocket.go
+++ b/internal/redisapi/websocket.go
@@ -54,7 +54,17 @@ type WSClient struct {
 	done     chan struct{}
 	stopOnce sync.Once
 
-	// Reconnection settings
+	// Reconnection settings.
+	//
+	// reconnectBackoff is guarded by connMu (#728). It is written by
+	// connectLocked, whose caller already holds connMu for write, and it is
+	// advanced by nextReconnectDelay, which takes connMu for the whole
+	// read-modify-write and releases it before the caller sleeps. Nothing may
+	// touch it unlocked: reconnect used to, and a torn or stale read there
+	// shortens a backoff.
+	//
+	// reconnectEnabled and maxBackoff are set once in NewWSClient and never
+	// written again, so they need no guard.
 	reconnectEnabled bool
 	reconnectBackoff time.Duration
 	maxBackoff       time.Duration
@@ -102,6 +112,11 @@ type WSMessage struct {
 	Data      map[string]string `json:"data,omitempty"`      // Job data fields from stream
 }
 
+// initialReconnectBackoff is the delay before the first reconnect attempt, and
+// the value the schedule returns to after any successful connect. It lives in
+// one place so the constructor and the reset in connectLocked cannot drift.
+const initialReconnectBackoff = time.Second
+
 // NewWSClient creates a new WebSocket client.
 func NewWSClient(cfg WSClientConfig) *WSClient {
 	reconnectEnabled := cfg.ReconnectEnabled
@@ -117,7 +132,7 @@ func NewWSClient(cfg WSClientConfig) *WSClient {
 		subscriptions:    make(map[string]bool),
 		done:             make(chan struct{}),
 		reconnectEnabled: reconnectEnabled,
-		reconnectBackoff: time.Second,
+		reconnectBackoff: initialReconnectBackoff,
 		maxBackoff:       time.Minute,
 		writeTimeout:     defaultWriteTimeout,
 		debugFunc:        cfg.DebugFunc,
@@ -187,7 +202,10 @@ func (c *WSClient) connectLocked(ctx context.Context) error {
 
 	c.conn = conn
 	c.connected = true
-	c.reconnectBackoff = time.Second // Reset backoff on successful connection
+	// Reset the backoff schedule on a successful connection. The caller holds
+	// connMu for write, which is what makes this assignment safe against
+	// nextReconnectDelay running in a reconnect goroutine (#728).
+	c.reconnectBackoff = initialReconnectBackoff
 
 	c.debug("ws: connected successfully")
 
@@ -314,6 +332,39 @@ func (c *WSClient) handleDisconnect(conn *websocket.Conn) {
 	go c.reconnect()
 }
 
+// nextReconnectDelay returns how long the caller should wait before its next
+// reconnect attempt, and advances the schedule for the attempt after that.
+//
+// The read, the doubling and the clamp all happen in ONE critical section under
+// connMu, and the caller sleeps on the returned value instead of re-reading the
+// field. reconnect used to do all of it with no lock at all, racing the reset in
+// connectLocked, which runs under connMu (#728). It also read the field twice,
+// once to log the delay and once to sleep it, so a reset landing between the two
+// made the node retry sooner than it had just announced.
+//
+// Both defects point the same way, and it is the way that hurts: anything that
+// silently shortens a backoff moves toward the #443 restart storm referenced
+// above connectWithBackoff in cmd/work.go, where tight retries burned the node's
+// daily Redis-API quota and locked it out for about a day.
+//
+// connMu is reused deliberately rather than adding a third mutex to this file.
+// The reset has to live in connectLocked, which is the only place that knows a
+// dial succeeded and whose caller already holds connMu, so connMu costs no extra
+// lock and no nested acquire. connMu is NOT held across the sleep.
+func (c *WSClient) nextReconnectDelay() time.Duration {
+	c.connMu.Lock()
+	defer c.connMu.Unlock()
+
+	delay := c.reconnectBackoff
+
+	c.reconnectBackoff *= 2
+	if c.reconnectBackoff > c.maxBackoff {
+		c.reconnectBackoff = c.maxBackoff
+	}
+
+	return delay
+}
+
 // reconnect attempts to reconnect with exponential backoff
 func (c *WSClient) reconnect() {
 	for {
@@ -331,14 +382,9 @@ func (c *WSClient) reconnect() {
 			return
 		}
 
-		c.debug("ws: attempting reconnect in %v", c.reconnectBackoff)
-		time.Sleep(c.reconnectBackoff)
-
-		// Increase backoff for next attempt
-		c.reconnectBackoff *= 2
-		if c.reconnectBackoff > c.maxBackoff {
-			c.reconnectBackoff = c.maxBackoff
-		}
+		delay := c.nextReconnectDelay()
+		c.debug("ws: attempting reconnect in %v", delay)
+		time.Sleep(delay)
 
 		c.connMu.Lock()
 		err := c.connectLocked(context.Background())

--- a/internal/redisapi/websocket_backoff_test.go
+++ b/internal/redisapi/websocket_backoff_test.go
@@ -1,0 +1,183 @@
+package redisapi
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestReconnectBackoffAccessIsSynchronized is the regression test for issue
+// #728: reconnect() read and advanced reconnectBackoff with no lock at all,
+// while connectLocked wrote the same field under connMu.
+//
+// The colliding pair is Connect() versus an in-flight reconnect(), not two
+// reconnects: handleDisconnect's connection-pointer guard means a second caller
+// failing on the SAME connection returns before it can spawn a second reconnect
+// goroutine, because c.conn is already nil by then. Issue
+// #723 made that pair ordinary rather than exotic: enableWebSocketWithRetry
+// keeps calling Client.EnableWebSocket in the background, EnableWebSocket
+// forwards to Connect whenever IsConnected() is false, and IsConnected() is
+// false for the whole reconnect window (up to maxBackoff).
+//
+// The test drives that pair directly. Each round starts disconnected with a
+// short schedule so reconnect takes its read-modify-write path, then races one
+// reconnect against one connect. The two goroutines are deliberately unordered:
+// any channel or lock used to sequence them would establish a happens-before
+// edge and hide the very race being asserted. Rounds are joined, so the setup
+// between them is single-goroutine.
+//
+// The racing goroutine calls connectLocked under connMu, which is exactly what
+// Connect does minus its `go c.readLoop()`. Calling the exported Connect here
+// instead would start a second read loop on the same gorilla Conn, and gorilla
+// permits one concurrent reader just as it permits one concurrent writer. That
+// is a real and separate bug (citadel-cli#740), reachable by the same
+// Connect-during-reconnect overlap; including it would make this test fail for
+// a reason #728 does not fix.
+func TestReconnectBackoffAccessIsSynchronized(t *testing.T) {
+	srv := newDrainingWSServer(t)
+
+	c := NewWSClient(WSClientConfig{BaseURL: srv.URL, Token: "test-token"})
+	t.Cleanup(func() { _ = c.Close() })
+
+	ctx := context.Background()
+
+	const rounds = 40
+	for i := 0; i < rounds; i++ {
+		c.connMu.Lock()
+		if c.conn != nil {
+			_ = c.conn.Close()
+			c.conn = nil
+		}
+		c.connected = false
+		c.reconnectBackoff = time.Millisecond
+		c.maxBackoff = time.Millisecond
+		c.connMu.Unlock()
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			c.reconnect()
+		}()
+		go func() {
+			defer wg.Done()
+			c.connMu.Lock()
+			err := c.connectLocked(ctx)
+			c.connMu.Unlock()
+			if err != nil {
+				t.Errorf("connect: %v", err)
+			}
+		}()
+		wg.Wait()
+	}
+}
+
+// TestNextReconnectDelayAdvancesAndClamps pins the schedule itself: each call
+// returns the current delay and leaves the next one doubled, until maxBackoff
+// caps it.
+//
+// It asserts on returned values, never on elapsed time. An earlier backoff test
+// elsewhere in this codebase asserted on the wall clock and was flaky in the
+// dangerous direction: an overshoot was indistinguishable from a correct wait,
+// so the failure this whole area is about (a backoff that is too SHORT) is
+// exactly the one such a test cannot see.
+func TestNextReconnectDelayAdvancesAndClamps(t *testing.T) {
+	c := NewWSClient(WSClientConfig{BaseURL: "https://example.invalid", Token: "t"})
+	c.reconnectBackoff = 100 * time.Millisecond
+	c.maxBackoff = 400 * time.Millisecond
+
+	want := []time.Duration{
+		100 * time.Millisecond,
+		200 * time.Millisecond,
+		400 * time.Millisecond,
+		400 * time.Millisecond,
+		400 * time.Millisecond,
+	}
+	for i, w := range want {
+		if got := c.nextReconnectDelay(); got != w {
+			t.Fatalf("call %d: nextReconnectDelay() = %v, want %v", i+1, got, w)
+		}
+	}
+}
+
+// TestNextReconnectDelayAdvancesAtomically checks that the read, the doubling
+// and the clamp are one indivisible step.
+//
+// handleDisconnect's connection-pointer guard means one disconnect event cannot
+// spawn two reconnect goroutines: the second caller sees c.conn already nil and
+// returns. Two can still coexist, but only if a Connect lands in the reconnect
+// window and the connection it establishes then fails, which is the same #723
+// precondition as the race above.
+//
+// So this is mostly about the accessor's own contract. If it were built out of a
+// separate load and store, two callers could read the same value and store the
+// same doubled one, losing a doubling and making the schedule quietly tighter
+// than it looks. Distinct return values rule that out, and the assertion is on
+// the set of values, not on order or on time.
+func TestNextReconnectDelayAdvancesAtomically(t *testing.T) {
+	const (
+		callers = 8
+		rounds  = 300
+	)
+
+	c := NewWSClient(WSClientConfig{BaseURL: "https://example.invalid", Token: "t"})
+	// Above the largest expected delay (128ms), so nothing clamps and every
+	// caller in a round must come away with a different value.
+	c.maxBackoff = time.Second
+
+	// A lost doubling needs the two callers to interleave, so one round proves
+	// little. Repeat: rounds are joined, so each one is an independent trial and
+	// the assertion stays on values rather than on timing.
+	got := make([]time.Duration, callers)
+	for r := 0; r < rounds; r++ {
+		// Under connMu, which is the field's guard, even though the previous
+		// round is already joined.
+		c.connMu.Lock()
+		c.reconnectBackoff = time.Millisecond
+		c.connMu.Unlock()
+
+		var wg sync.WaitGroup
+		for i := 0; i < callers; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				got[i] = c.nextReconnectDelay()
+			}(i)
+		}
+		wg.Wait()
+
+		seen := make(map[time.Duration]int, callers)
+		for _, d := range got {
+			seen[d]++
+		}
+		for i := 0; i < callers; i++ {
+			want := time.Duration(1<<uint(i)) * time.Millisecond
+			if seen[want] != 1 {
+				t.Fatalf("round %d: delay %v handed out %d times, want exactly 1 (all delays: %v)",
+					r, want, seen[want], got)
+			}
+		}
+	}
+}
+
+// TestSuccessfulConnectResetsReconnectBackoff pins the other half of the
+// schedule: a connection that comes back returns the node to the initial delay,
+// so a later blip does not start out already backed off to a minute.
+func TestSuccessfulConnectResetsReconnectBackoff(t *testing.T) {
+	srv := newDrainingWSServer(t)
+
+	c := NewWSClient(WSClientConfig{BaseURL: srv.URL, Token: "test-token"})
+	c.reconnectEnabled = false
+	t.Cleanup(func() { _ = c.Close() })
+
+	c.reconnectBackoff = 42 * time.Second
+
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+
+	if got := c.nextReconnectDelay(); got != initialReconnectBackoff {
+		t.Fatalf("delay after a successful connect = %v, want %v", got, initialReconnectBackoff)
+	}
+}

--- a/internal/redisapi/websocket_write_test.go
+++ b/internal/redisapi/websocket_write_test.go
@@ -63,10 +63,14 @@ func newWedgedWSServer(t *testing.T) *httptest.Server {
 
 // newTestWSClient connects a WSClient to srv with reconnection disabled.
 //
-// Reconnect is off on purpose: reconnect() mutates reconnectBackoff without
-// holding connMu, which is a separate (real, unfixed) data race in this file.
-// Letting it run would make -race report something unrelated to the write path
-// under test.
+// Reconnect is off on purpose, so that a test which deliberately wedges or
+// breaks a write exercises only the write path. Several of these tests trigger
+// handleDisconnect, and letting it schedule reconnects would add dial attempts,
+// a second connection and its own goroutines to the picture under test.
+//
+// This used to say reconnect was excluded because it mutated reconnectBackoff
+// unsynchronized. That was true and is now fixed (#728); the field is guarded by
+// connMu and advanced through nextReconnectDelay.
 func newTestWSClient(t *testing.T, srv *httptest.Server) *WSClient {
 	t.Helper()
 


### PR DESCRIPTION
## Context

Closes #728. `reconnectBackoff` was written under `connMu` in `connectLocked`
and read and advanced with no lock at all in `reconnect`.

The race is real on current `main`, and it reproduces under `-race`. It does not
reproduce the way the issue thread describes, so the mechanism is worth
correcting before the fix.

## The race as described, versus the race that is there

The escalation comment on #728 says PR #725 lets the read path and the write
path start two `reconnect()` goroutines concurrently, and that the second one
"bails at `alreadyConnected`". On current `main` the second caller never reaches
`go c.reconnect()` at all. `handleDisconnect` takes `connMu`, the first caller
sets `c.conn = nil`, and the second caller then fails the connection-pointer
guard (`conn != nil && c.conn != conn`) and returns one layer earlier.

So a single disconnect event cannot spawn two reconnects, which is what the
read-path/write-path pair in #725 would produce. Two reconnects can still
coexist, but only by a longer route: reconnect#1 is sleeping, a `Connect()`
lands in that window and succeeds, the connection it established then fails, and
`handleDisconnect` spawns reconnect#2 while #1 is still alive. That route needs a
`Connect()` inside the reconnect window, which is the #723 precondition below,
not anything #725 introduced.

The pair that actually collides is `Connect()` versus an in-flight `reconnect()`:

- `connectLocked` writes `reconnectBackoff` at websocket.go:190 under `connMu`
- `reconnect` reads and advances it at websocket.go:334-341 under nothing

What makes that pair ordinary rather than exotic is #723 / PR #732, not #725.
`Client.EnableWebSocket` is documented as idempotent and safe to call
repeatedly; it returns early only when `IsConnected()` is true, and
`IsConnected()` is false for the entire reconnect window, which is up to
`maxBackoff` (one minute). `enableWebSocketWithRetry` now keeps calling it in the
background on a schedule until it succeeds, and `worker/ws_source.go`,
`chat/client.go` and `controlcenter.go` call it too. Any of those landing inside
a reconnect window forwards straight to `Connect`.

The consequence is the one #728 flags: a stale read of the backoff shortens the
retry schedule, which is the direction that produced the #443 restart storm.

## Reproduction

`TestReconnectBackoffAccessIsSynchronized` fails under `-race` on `main`:

```
WARNING: DATA RACE
Write at 0x00c00018a2b0 by goroutine 16:
  ...redisapi.(*WSClient).connectLocked()
      internal/redisapi/websocket.go:190
Previous write at 0x00c00018a2b0 by goroutine 15:
  ...redisapi.(*WSClient).reconnect()
      internal/redisapi/websocket.go:338
```

Corroborating evidence that this was already known to fire: `newTestWSClient` in
`websocket_write_test.go` disables reconnect with a comment saying reconnect's
unsynchronized mutation "would make `-race` report something unrelated to the
write path under test". That comment is updated here, since it now describes a
fixed bug and this repo has a documented history of stale comments costing time.

## Changes

- `internal/redisapi/websocket.go`
  - `nextReconnectDelay()` does the read, the doubling and the clamp in one
    critical section under `connMu`, and returns the delay. `connMu` is not held
    across the sleep.
  - `reconnect` sleeps on the returned value instead of re-reading the field.
    It used to read the field twice, once to log and once to sleep, so a reset
    landing between them made the node retry sooner than it had just announced.
  - `initialReconnectBackoff` replaces the two `time.Second` literals so the
    constructor and the reset in `connectLocked` cannot drift.
  - The field comment now names its guard.
- `internal/redisapi/websocket_backoff_test.go` (new), three tests.
- `internal/redisapi/websocket_write_test.go`, corrected the stale comment.

`connMu` is reused rather than adding a third mutex. The reset has to live in
`connectLocked`, whose caller already holds `connMu`, so this costs no new lock
and no nested acquire in a file whose lock discipline is already load-bearing.

## What this makes worse

- It widens `connMu`'s remit past "guards the conn pointer", which is how the
  existing comment describes it. A future reader has one more field to keep in
  mind, and `reconnect` now takes `connMu` twice per iteration (once shared for
  the connected check, once exclusive to advance the schedule) where it used to
  take it once.
- It adds a blocking point that did not exist. `Connect` holds `connMu` across
  the whole dial, bounded only by the 10s `HandshakeTimeout`, so
  `nextReconnectDelay` can now stall behind an in-flight dial where the old
  unlocked advance never blocked. It is benign in both directions that matter:
  the effect is a longer wait, never a shorter one, and `reconnect` already
  blocked the same way at its own `connMu.Lock()` a few lines later. It is still
  a new place the reconnect goroutine can park.
- Capturing the delay in a local is a behaviour change, not just a lock. Today a
  `Connect()` that succeeds between the log line and the sleep shortens that one
  sleep. After this it does not. The new behaviour is the more conservative of
  the two and matches what was logged, but it is a change.
- The advance now happens before the attempt rather than after it, so during a
  sleep the field holds the *next* delay rather than the current one. The
  sequence of sleeps is unchanged and nothing else reads the field, so this only
  matters to a future debugger.
- Most importantly: `reconnect` now looks fully synchronized while two real bugs
  in the same function are untouched, so it invites over-trust. Both are filed
  rather than fixed here, because #725 and #723 were deliberately sequenced one
  concern at a time and this is the third pass over the same lines:
  - #740, a `Connect()` during a reconnect starts a **second** `readLoop` on the
    same gorilla `Conn`. gorilla permits one concurrent reader just as it permits
    one concurrent writer, so this is the read-side twin of #720. It was observed
    under `-race` while building the test here, which is why the racing goroutine
    in that test calls `connectLocked` under `connMu` rather than `Connect`.
  - #741, `reconnect` checks `c.done` at the top of the loop but not after the
    sleep, so `Close` during a backoff still lets it dial and mark the client
    connected afterwards.

## Testing

`cpuslot go test -race ./internal/redisapi/...` passes, run five times. Full
`go test ./...` and `go vet ./...` pass.

No test asserts on wall-clock elapsed time. The schedule tests assert on returned
values; the race test asserts nothing and relies on the detector.

Mutation results, one deliberate break per test:

| Mutation | Effect |
| --- | --- |
| Drop the `connMu` acquire from `nextReconnectDelay` (the pre-fix shape) | `TestReconnectBackoffAccessIsSynchronized` FAILS under `-race`, and `TestNextReconnectDelayAdvancesAtomically` FAILS |
| Remove the `maxBackoff` clamp | `TestNextReconnectDelayAdvancesAndClamps` FAILS |
| Split the accessor into a locked load and a separate locked store | `TestNextReconnectDelayAdvancesAtomically` FAILS (duplicate delays handed out, so a doubling was lost) |
| Remove the reset in `connectLocked` | `TestSuccessfulConnectResetsReconnectBackoff` FAILS with `delay after a successful connect = 42s, want 1s` |

The split load/store mutation initially survived a single-round version of the
atomicity test, so that test now repeats the trial 300 times and kills it on
every run.
