### PR TITLE
fix(work): already-running worklock is a benign exit-0 no-op, not a crash-loop (#736)

### DIFF
--- a/cmd/work.go
+++ b/cmd/work.go
@@ -361,6 +361,9 @@ func runWork(cmd *cobra.Command, args []string) {
 					if action == actionBanner {
 						renderWorkAttach(network.GetStateDir(), running)
 					} else {
+						// stderr (not stdout like the banner): this path is the
+						// non-interactive/systemd default, and a diagnostic notice
+						// belongs on stderr so journald records it as a log line.
 						fmt.Fprintln(os.Stderr, noOpAlreadyRunningMessage(running))
 					}
 					os.Exit(0)

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -344,19 +344,36 @@ func runWork(cmd *cobra.Command, args []string) {
 		if lockErr != nil {
 			var running *worklock.ErrAlreadyRunning
 			if errors.As(lockErr, &running) {
-				// Discover-and-attach (issue #524, increment 1): on an interactive
-				// TTY, print the running worker's status instead of a bare error
-				// (docker-daemon style). Non-TTY (systemd, scripts) keeps today's
-				// exit-1 refusal UNCHANGED so a misconfigured double systemd unit
-				// still fails visibly. --attach / --no-attach override the heuristic.
-				if decideAttach(stdoutIsTTY(), workAttach, workNoAttach) {
-					renderWorkAttach(network.GetStateDir(), running)
+				// An ErrAlreadyRunning means the OS advisory lock is CONTENDED — a
+				// live process genuinely holds it (the kernel frees flock on death).
+				// Confirm it is a live *citadel* worker via IsHeld (flock-contended +
+				// live citadel PID, the same gate Acquire refuses on) before treating
+				// this as a benign duplicate, so a rare "flock held by something else"
+				// case is never mistaken for "a worker is serving this node".
+				liveHolder, _ := worklock.IsHeld(network.GetStateDir())
+				action := decideAlreadyRunning(stdoutIsTTY(), workAttach, workNoAttach)
+				if liveHolder && action != actionStrictRefuse {
+					// Discover-and-attach (issue #524): render the running worker's
+					// status on a TTY, else a concise no-op notice (issue #736). ONE
+					// worker IS serving this node, so this invocation is a no-op: exit
+					// 0. A duplicate Restart=on-failure unit therefore settles to
+					// inactive(dead) instead of crash-looping forever (the #736 bug).
+					if action == actionBanner {
+						renderWorkAttach(network.GetStateDir(), running)
+					} else {
+						fmt.Fprintln(os.Stderr, noOpAlreadyRunningMessage(running))
+					}
 					os.Exit(0)
 				}
+				// Strict refusal (opt-in --no-attach) or a non-live holder: keep the
+				// visible non-zero refusal so a genuinely-wrong double-start still
+				// fails loudly and a "should be running but isn't" case is never masked.
 				fmt.Fprintf(os.Stderr, "Error: %v\n", running)
 				fmt.Fprintln(os.Stderr, "\nAnother 'citadel work' is already serving this node.")
 				fmt.Fprintln(os.Stderr, "Stop it first (e.g. 'systemctl --user stop citadel' or kill the PID above),")
 				fmt.Fprintln(os.Stderr, "or pass --no-single-instance to run a second worker intentionally.")
+				// Reached only for the strict --no-attach refusal or a non-live holder;
+				// both are a visible failure (exit 1), never the benign no-op exit 0.
 				os.Exit(1)
 			}
 			// Non-contention lock error (e.g. unwritable dir): warn but do not block
@@ -2894,8 +2911,8 @@ func init() {
 	workCmd.Flags().BoolVar(&workNoUpdate, "no-update", false, "(Deprecated) No longer has any effect - use 'citadel update disable' instead")
 	workCmd.Flags().BoolVar(&workNoFootprint, "no-footprint", false, "Disable the background resource-footprint sampler")
 	workCmd.Flags().BoolVar(&workNoSingleInstance, "no-single-instance", false, "Allow a second worker to run for this node (skips the single-instance lock)")
-	workCmd.Flags().BoolVar(&workAttach, "attach", false, "When a worker is already running, print its status banner instead of refusing (default: only on an interactive terminal)")
-	workCmd.Flags().BoolVar(&workNoAttach, "no-attach", false, "When a worker is already running, refuse with exit 1 instead of printing the status banner")
+	workCmd.Flags().BoolVar(&workAttach, "attach", false, "When a worker is already running, print its full status banner and exit 0 (default: banner on an interactive terminal, a concise no-op notice otherwise)")
+	workCmd.Flags().BoolVar(&workNoAttach, "no-attach", false, "When a worker is already running, refuse with exit 1 instead of the exit-0 no-op notice/banner")
 	workCmd.Flags().BoolVar(&workNoKeyRenew, "no-key-renew", false, "Disable the background Headscale node-key renewer (renews the key before expiry while online)")
 	workCmd.Flags().MarkDeprecated("no-update", "use 'citadel update disable' to disable auto-update checks")
 

--- a/cmd/work_attach.go
+++ b/cmd/work_attach.go
@@ -11,7 +11,13 @@
 //
 // Deliberately additive and zero-daemon-change: no new endpoint, no lock
 // mutation. The banner is a read-only HTTP client of the already-running worker.
-// TTY-gated so systemd / scripts keep today's exit-1 refusal (see decideAttach).
+//
+// Response policy (see decideAlreadyRunning): an interactive TTY renders the full
+// banner; a non-interactive invocation (systemd, journald, scripts) prints a
+// concise no-op notice. BOTH exit 0 — a live worker already serves this node, so a
+// second invocation is a benign no-op, and a duplicate Restart=on-failure unit
+// therefore settles to inactive(dead) instead of crash-looping forever (issue
+// #736). Only --no-attach opts back into the strict exit-1 refusal.
 package cmd
 
 import (
@@ -44,23 +50,70 @@ type attachStatus struct {
 	Health string
 }
 
-// decideAttach reports whether to render the friendly discover-and-attach banner
-// (true) versus the legacy exit-1 refusal (false). Pure so the TTY/flag policy is
-// unit tested without a terminal.
+// alreadyRunningAction is how `citadel work` responds when the single-instance
+// lock is already held by a live worker (issues #524 / #736).
+type alreadyRunningAction int
+
+const (
+	// actionBanner: render the full discover-and-attach status banner, exit 0.
+	actionBanner alreadyRunningAction = iota
+	// actionNoOpNotice: print a concise one-line "already running, no-op" notice,
+	// exit 0. This is the DEFAULT for a non-interactive invocation (systemd,
+	// journald, scripts) — the #736 fix that stops a duplicate Restart=on-failure
+	// unit from crash-looping. Before #736 the non-TTY default was actionStrictRefuse.
+	actionNoOpNotice
+	// actionStrictRefuse: print the refusal and exit 1. Opt-in via --no-attach for a
+	// caller that wants a double-start to fail loudly. No unit file passes it, so it
+	// cannot reintroduce the #736 crash-loop.
+	actionStrictRefuse
+)
+
+// exitCode maps an action to the process exit code: 0 for the two benign no-op
+// paths (a live worker already serves the node), 1 only for the strict refusal.
+func (a alreadyRunningAction) exitCode() int {
+	if a == actionStrictRefuse {
+		return 1
+	}
+	return 0
+}
+
+// decideAlreadyRunning chooses how to respond when another live worker already
+// holds this node's single-instance lock. Pure so the policy (and its exit codes)
+// are unit tested without a terminal or a running daemon.
 //
-//   - --no-attach forces the legacy refusal (scripts that want the old behavior).
-//   - --attach forces the banner (e.g. capturing it from a non-TTY).
-//   - otherwise the banner is shown only on an interactive TTY. Non-TTY (systemd,
-//     journald, pipelines) keeps the exit-1 refusal so a misconfigured double
-//     systemd unit still fails visibly instead of "succeeding" as an attach.
-func decideAttach(isTTY, attachFlag, noAttachFlag bool) bool {
+//   - --no-attach forces actionStrictRefuse (exit 1): the documented escape hatch
+//     for a caller that wants a double-start to fail loudly.
+//   - --attach, or an interactive TTY, renders the full status banner (exit 0).
+//   - otherwise (the systemd/non-TTY default) a concise no-op notice (exit 0), so a
+//     redundant Restart=on-failure unit settles to inactive(dead) instead of
+//     crash-looping forever (#736). Before #736 this default was exit 1.
+func decideAlreadyRunning(isTTY, attachFlag, noAttachFlag bool) alreadyRunningAction {
 	if noAttachFlag {
-		return false
+		return actionStrictRefuse
 	}
-	if attachFlag {
-		return true
+	if attachFlag || isTTY {
+		return actionBanner
 	}
-	return isTTY
+	return actionNoOpNotice
+}
+
+// noOpAlreadyRunningMessage is the concise one-line notice printed when a
+// non-interactive `citadel work` finds a live worker already serving this node
+// (issue #736). It names the holder and points at the two real next steps, and
+// accompanies the exit-0 no-op so journald shows an intelligible line instead of a
+// crash-loop. Pure (no IO) so its wording is unit tested.
+func noOpAlreadyRunningMessage(running *worklock.ErrAlreadyRunning) string {
+	who := "citadel worker already running"
+	if running.PID > 0 {
+		who += fmt.Sprintf(" (PID %d", running.PID)
+		if !running.StartTime.IsZero() {
+			who += ", started " + running.StartTime.Format(time.RFC3339)
+		}
+		who += ")"
+	}
+	return who + "; this instance is a no-op. " +
+		"Pass --no-single-instance to force a second worker, " +
+		"or follow the running one with `citadel logs -f` (or `journalctl -u <citadel unit> -f`)."
 }
 
 // resolveStatusPort returns the plaintext status server port to probe for attach
@@ -219,8 +272,8 @@ func humanizeUptime(d time.Duration) string {
 // renderWorkAttach prints the discover-and-attach banner for a refused
 // `citadel work`, reading the holder metadata and probing the local status
 // server. It writes to stdout (this is informational success for an interactive
-// user, not an error) and is only reached after decideAttach approved the banner.
-// stateDir is the resolved node state dir the lock is keyed to.
+// user, not an error) and is only reached after decideAlreadyRunning chose the
+// banner. stateDir is the resolved node state dir the lock is keyed to.
 func renderWorkAttach(stateDir string, running *worklock.ErrAlreadyRunning) {
 	holder, ok := worklock.ReadHolder(stateDir)
 	if !ok {

--- a/cmd/work_attach_test.go
+++ b/cmd/work_attach_test.go
@@ -11,27 +11,68 @@ import (
 	"github.com/aceteam-ai/citadel-cli/internal/worklock"
 )
 
-func TestDecideAttach(t *testing.T) {
+func TestDecideAlreadyRunning(t *testing.T) {
 	cases := []struct {
 		name         string
 		isTTY        bool
 		attachFlag   bool
 		noAttachFlag bool
-		want         bool
+		want         alreadyRunningAction
+		wantExit     int
 	}{
-		{"tty shows banner", true, false, false, true},
-		{"non-tty refuses (systemd)", false, false, false, false},
-		{"attach flag forces banner off tty", false, true, false, true},
-		{"no-attach flag forces refusal on tty", true, false, true, false},
-		{"no-attach beats attach", true, true, true, false},
+		// TTY (or --attach) -> full banner, exit 0.
+		{"tty shows banner", true, false, false, actionBanner, 0},
+		{"attach flag forces banner off tty", false, true, false, actionBanner, 0},
+		// The #736 fix: a non-TTY (systemd) invocation is now a concise no-op that
+		// exits 0 instead of the pre-#736 exit-1 refusal, so a duplicate
+		// Restart=on-failure unit stops crash-looping.
+		{"non-tty is a no-op notice (systemd)", false, false, false, actionNoOpNotice, 0},
+		// --no-attach is the strict escape hatch: exit 1 even on a TTY, and it beats
+		// --attach. No unit file passes it, so it cannot reintroduce the crash-loop.
+		{"no-attach forces strict refusal on tty", true, false, true, actionStrictRefuse, 1},
+		{"no-attach forces strict refusal off tty", false, false, true, actionStrictRefuse, 1},
+		{"no-attach beats attach", true, true, true, actionStrictRefuse, 1},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := decideAttach(tc.isTTY, tc.attachFlag, tc.noAttachFlag); got != tc.want {
-				t.Fatalf("decideAttach(tty=%v, attach=%v, noAttach=%v) = %v, want %v",
+			got := decideAlreadyRunning(tc.isTTY, tc.attachFlag, tc.noAttachFlag)
+			if got != tc.want {
+				t.Fatalf("decideAlreadyRunning(tty=%v, attach=%v, noAttach=%v) = %v, want %v",
 					tc.isTTY, tc.attachFlag, tc.noAttachFlag, got, tc.want)
 			}
+			if ec := got.exitCode(); ec != tc.wantExit {
+				t.Fatalf("exitCode() = %d, want %d (action %v)", ec, tc.wantExit, got)
+			}
 		})
+	}
+}
+
+func TestNoOpAlreadyRunningMessage(t *testing.T) {
+	// Full record: PID + start time both surface, plus the two actionable next steps.
+	start := time.Date(2026, 7, 15, 9, 12, 44, 0, time.UTC)
+	msg := noOpAlreadyRunningMessage(&worklock.ErrAlreadyRunning{PID: 41372, StartTime: start})
+	for _, want := range []string{
+		"citadel worker already running",
+		"PID 41372",
+		start.Format(time.RFC3339),
+		"no-op",
+		"--no-single-instance",
+		"citadel logs -f",
+		"journalctl",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("no-op message missing %q\n---\n%s", want, msg)
+		}
+	}
+
+	// Legacy lock record with no PID/start: the notice degrades gracefully to the
+	// bare "already running" line without inventing a "(PID 0)".
+	bare := noOpAlreadyRunningMessage(&worklock.ErrAlreadyRunning{})
+	if strings.Contains(bare, "PID") {
+		t.Errorf("no-op message should omit PID when unknown\n---\n%s", bare)
+	}
+	if !strings.Contains(bare, "no-op") {
+		t.Errorf("no-op message missing no-op clause\n---\n%s", bare)
 	}
 }
 

--- a/docs/man/citadel-work.1
+++ b/docs/man/citadel-work.1
@@ -60,7 +60,7 @@ Examples:
 
 .PP
 \fB--attach\fP[=false]
-	When a worker is already running, print its status banner instead of refusing (default: only on an interactive terminal)
+	When a worker is already running, print its full status banner and exit 0 (default: banner on an interactive terminal, a concise no-op notice otherwise)
 
 .PP
 \fB--auto-detect\fP=false
@@ -132,7 +132,7 @@ Examples:
 
 .PP
 \fB--no-attach\fP[=false]
-	When a worker is already running, refuse with exit 1 instead of printing the status banner
+	When a worker is already running, refuse with exit 1 instead of the exit-0 no-op notice/banner
 
 .PP
 \fB--no-footprint\fP[=false]


### PR DESCRIPTION
## Context
Part of #736. On node 1276 two ENABLED systemd units competed, running `citadel work` on two different binaries. `worklock` correctly refused the second instance, but the refused unit **crash-looped forever** under `Restart=on-failure` (exit 1 → restart every 5s). Single-instance protection works; the UX around it was poor.

This PR fixes the **worklock "already-running" UX**: instead of exiting non-zero (which a duplicate `Restart=on-failure` unit turns into an endless crash-loop), a refused `citadel work` now exits **0** with a clear notice, because a live worker already serves this node — a second invocation is a benign no-op.

## Root Cause
`cmd/work.go` handled `worklock.ErrAlreadyRunning` by rendering an attach banner on a TTY (exit 0, #524) but falling through to a bare `Error: … refusing …` **exit 1** on non-TTY (systemd/journald). All shipped units are `Type=simple` (`install.sh`, `services/citadel-worker.service`, `packer/scripts/04-citadel.sh` — verified), for which `Restart=on-failure` restarts on exit 1 but NOT on exit 0.

Key invariant that makes exit-0 safe: `worklock.Acquire` returns `ErrAlreadyRunning` **only** when the OS advisory lock is genuinely contended — the `flock` `EWOULDBLOCK` branch on Unix (`internal/worklock/worklock_unix.go`), and the equivalent `LockFileEx` `ERROR_LOCK_VIOLATION` branch on Windows (`worklock_windows.go`, verified). There is no record-only path that could report "already running" while nothing runs (the kernel/OS releases the lock on process death). As defense-in-depth we additionally confirm the holder is a live **citadel** process via `worklock.IsHeld` (also a non-blocking probe on both platforms) before choosing the no-op.

## Changes
- `cmd/work.go`: on `ErrAlreadyRunning`, gate on `worklock.IsHeld` (live citadel holder) and a new 3-way decider; the benign case exits 0 (banner on TTY, concise notice on stderr otherwise). A non-live/anomalous holder OR `--no-attach` keeps the visible **exit 1** refusal.
- `cmd/work_attach.go`: replace `decideAttach` (bool) with pure `decideAlreadyRunning → {actionBanner, actionNoOpNotice, actionStrictRefuse}` + `exitCode()`, and add `noOpAlreadyRunningMessage`.
- `cmd/work_attach_test.go`: `TestDecideAlreadyRunning` (action + exit-code table) and `TestNoOpAlreadyRunningMessage`.
- Flag help for `--attach` / `--no-attach` and the generated `docs/man/citadel-work.1`.

Unchanged: the non-contention lock-error path (unwritable dir, etc.) still warns and continues — a genuinely-failed acquire is never turned into a silent exit-0.

## New behavior
| Invocation | Before | After |
|---|---|---|
| Interactive TTY | banner, exit 0 | banner, exit 0 (unchanged) |
| Non-TTY / systemd (default) | refusal, **exit 1** → crash-loop | concise no-op notice, **exit 0** |
| `--no-attach` | refusal, exit 1 | refusal, exit 1 (unchanged escape hatch) |
| Lock held by non-citadel / racey holder | — | visible refusal, exit 1 |

Notice text (non-TTY, stderr): `citadel worker already running (PID N, started …); this instance is a no-op. Pass --no-single-instance to force a second worker, or follow the running one with 'citadel logs -f' (or 'journalctl -u <citadel unit> -f').`

## Testing
```
go build ./... && go vet ./... && go test ./internal/worklock/... ./cmd/...   # pass
```
- New: `TestDecideAlreadyRunning`, `TestNoOpAlreadyRunningMessage`.
- Existing worklock coverage relied on: `TestAcquireSecondIsRejected` (live holder → refused), `TestStaleLockReclaimed` + `TestReusedPIDReclaimed` (stale lock → acquires), `TestIsHeldLiveWorker`.
- Pre-existing env-only failure `internal/worker` `TestDocumentRasterizeRendersRealPagesWithPoppler` (pdftoppm/GLIBC) is unrelated (#715).

## Risks
- **systemd exit-0 implication (intended):** a redundant `Type=simple` unit now goes `inactive (dead)` cleanly instead of crash-looping. This does not mask a real "should be running but isn't" case — the exit-0 path only fires when `IsHeld` confirms a live citadel worker holds the lock; anything else exits 1.
- **`Restart=always` units:** the fix stops the loop for `Restart=on-failure` units (`install.sh`, `services/citadel-worker.service` — the exact offending unit type in #736). A `Restart=always` unit (`packer/scripts/04-citadel.sh`) would still restart on a clean exit; that unit is the primary provisioned worker, not a duplicate, and the real cure for competing units is the install-hygiene follow-up below.
- **Non-Linux reused-PID:** `processIsCitadel` is a best-effort no-op returning true on macOS/Windows (no `/proc`), so a reused-PID false positive there is now a silent exit-0 no-op rather than a loud exit-1. The OS advisory lock remains the authoritative singleton on those platforms, and there is no systemd crash-loop to fix there.

## Explicit follow-ups (NOT in this PR)
- **Install hygiene:** `citadel init`/installer must not leave two competing units (system `citadel-work` + user `citadel-worker`, different binary paths); detect and adopt an existing unit.
- **Wedged-old-node remote-update gap:** `dispatch_node_update` needs the worker to consume `AGENT_UPDATE`, so a wedged old node can't be remotely updated — document the SSH path or add a control-path update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)