### PR TITLE
fix(redisapi): websocket ping/pong keepalive and read deadline (#734)

### DIFF
--- a/internal/redisapi/websocket.go
+++ b/internal/redisapi/websocket.go
@@ -3,7 +3,9 @@ package redisapi
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -42,6 +44,13 @@ type WSClient struct {
 	// Overridden in tests; see defaultWriteTimeout for the value rationale.
 	writeTimeout time.Duration
 
+	// pingInterval and pongWait drive the keepalive (#734). pongWait is the
+	// read deadline: nothing arriving within it means the socket is dead.
+	// pingInterval is how often we send a ping to provoke traffic. Both are
+	// overridden in tests; see defaultPongWait for the value rationale.
+	pingInterval time.Duration
+	pongWait     time.Duration
+
 	// Message handlers
 	handlers   map[string]func(WSMessage)
 	handlersMu sync.RWMutex
@@ -53,6 +62,14 @@ type WSClient struct {
 	// Control channels
 	done     chan struct{}
 	stopOnce sync.Once
+
+	// loopsOnce guards the background goroutines. readLoop and pingLoop are
+	// deliberately long-lived: they re-read c.conn every iteration, so they
+	// survive a reconnect and must NOT be started per connection. Connect is
+	// callable again whenever connected is false (the #723 retry loop does
+	// exactly that), and without this a second Connect would start a second
+	// reader -- gorilla permits exactly one concurrent reader.
+	loopsOnce sync.Once
 
 	// Reconnection settings
 	reconnectEnabled bool
@@ -120,6 +137,8 @@ func NewWSClient(cfg WSClientConfig) *WSClient {
 		reconnectBackoff: time.Second,
 		maxBackoff:       time.Minute,
 		writeTimeout:     defaultWriteTimeout,
+		pingInterval:     defaultPingInterval,
+		pongWait:         defaultPongWait,
 		debugFunc:        cfg.DebugFunc,
 	}
 }
@@ -144,8 +163,11 @@ func (c *WSClient) Connect(ctx context.Context) error {
 		return err
 	}
 
-	// Start read loop
-	go c.readLoop()
+	// Both loops outlive any single connection; see loopsOnce.
+	c.loopsOnce.Do(func() {
+		go c.readLoop()
+		go c.pingLoop()
+	})
 
 	return nil
 }
@@ -184,6 +206,15 @@ func (c *WSClient) connectLocked(ctx context.Context) error {
 		}
 		return fmt.Errorf("WebSocket connection failed: %w", err)
 	}
+
+	// Arm the keepalive BEFORE publishing the connection (#734).
+	//
+	// SetReadDeadline, SetPongHandler and SetPingHandler are gorilla READ
+	// methods, so they must not run concurrently with ReadMessage. Doing this
+	// while conn is still private -- readLoop cannot see it until c.conn is
+	// assigned under connMu -- is what makes that safe. The handlers only ever
+	// fire from inside ReadMessage afterwards, i.e. on the read goroutine.
+	c.armKeepalive(conn)
 
 	c.conn = conn
 	c.connected = true
@@ -254,10 +285,25 @@ func (c *WSClient) readLoop() {
 
 		_, message, err := conn.ReadMessage()
 		if err != nil {
-			c.debug("ws: read error: %v", err)
+			var netErr net.Error
+			if errors.As(err, &netErr) && netErr.Timeout() {
+				// The read deadline expired: nothing at all arrived for
+				// pongWait, not even a pong for our pings. Before #734 this
+				// case did not exist and the loop simply blocked forever, so a
+				// half-open socket stayed "connected" while nothing flowed.
+				c.debug("ws: no traffic for %v, treating connection as dead", c.pongWait)
+			} else {
+				c.debug("ws: read error: %v", err)
+			}
 			c.handleDisconnect(conn)
 			continue
 		}
+
+		// Any inbound frame is evidence the peer is alive, so extend the
+		// deadline on data too, not just on pongs. That matters if a proxy or
+		// server ever stops honoring ping frames: a busy connection then still
+		// stays up on its own traffic.
+		_ = conn.SetReadDeadline(time.Now().Add(c.pongWait))
 
 		var msg WSMessage
 		if err := json.Unmarshal(message, &msg); err != nil {
@@ -283,6 +329,82 @@ func (c *WSClient) readLoop() {
 
 		if ok {
 			wildcardHandler(msg)
+		}
+	}
+}
+
+// armKeepalive installs the read deadline and the control-frame handlers on a
+// freshly dialed connection. Caller must not have published conn yet: these are
+// gorilla read methods and cannot race ReadMessage.
+func (c *WSClient) armKeepalive(conn *websocket.Conn) {
+	_ = conn.SetReadDeadline(time.Now().Add(c.pongWait))
+
+	conn.SetPongHandler(func(string) error {
+		// Our ping came back, so the round trip is intact. Runs on the read
+		// goroutine, from inside ReadMessage.
+		return conn.SetReadDeadline(time.Now().Add(c.pongWait))
+	})
+
+	conn.SetPingHandler(func(appData string) error {
+		// A server-side keepalive counts as liveness too. We still have to
+		// answer it, which gorilla's default handler would have done for us,
+		// so replicate that here including its error swallowing: a peer that
+		// has already gone away must not turn into a read error from the pong.
+		_ = conn.SetReadDeadline(time.Now().Add(c.pongWait))
+		err := conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(pingWriteWait))
+		if err == websocket.ErrCloseSent {
+			return nil
+		}
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			return nil
+		}
+		return err
+	})
+}
+
+// pingLoop sends a ping every pingInterval so an idle connection still proves
+// itself. It is long-lived and re-reads c.conn each tick, so it spans
+// reconnects; see loopsOnce.
+//
+// The ping is written with WriteControl, which does NOT need writeMu. Verified
+// against the vendored gorilla source rather than taken on faith: WriteControl
+// takes gorilla's own single-writer semaphore (c.mu) for the duration of the
+// frame, reads writeErr under writeErrMu, and sets the deadline directly on the
+// underlying net.Conn (goroutine-safe) instead of touching the c.writeDeadline
+// field that writeMu exists to guard. The package docs say the same thing in
+// one line: "The Close and WriteControl methods can be called concurrently with
+// all other methods."
+func (c *WSClient) pingLoop() {
+	ticker := time.NewTicker(c.pingInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-c.done:
+			return
+		case <-ticker.C:
+		}
+
+		c.connMu.RLock()
+		conn := c.conn
+		connected := c.connected
+		c.connMu.RUnlock()
+
+		if !connected || conn == nil {
+			continue
+		}
+
+		if err := conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(pingWriteWait)); err != nil {
+			// Deliberately advisory: the read deadline is the single authority
+			// on liveness. A ping can fail simply because a large WriteMessage
+			// is holding gorilla's write semaphore, and tearing down a healthy
+			// connection because a control frame queued too long would be a
+			// self-inflicted outage. A genuinely fatal failure is not lost:
+			// gorilla latches it in writeErr, so the next publish tears the
+			// connection down, and no pongs will arrive either way, so the
+			// read deadline fires within pongWait regardless.
+			c.debug("ws: ping failed: %v", err)
 		}
 	}
 }
@@ -497,6 +619,32 @@ const closeWriteWait = 2 * time.Second
 // so it should never fire in normal operation, and well under the worker
 // self-heal stall timer (600s) that would otherwise be the only backstop.
 const defaultWriteTimeout = 15 * time.Second
+
+// Keepalive intervals (#734).
+//
+// defaultPongWait is the read deadline. Nothing arriving on the socket within
+// it -- not a message, not a pong for our own pings -- means the connection is
+// declared dead and torn down. It is sized against the platform's 120s offline
+// sweep, not against network latency: detection has to happen with room to
+// spare, or the node is already marked offline (and refused for targeted
+// dispatch) by the time it notices. 45s detection plus ~1s of reconnect backoff
+// leaves better than 2x margin, and lands inside two 30s heartbeat intervals.
+//
+// defaultPingInterval is one third of it on purpose, so three pings go
+// unanswered before we act. That absorbs a single dropped pong and scheduler
+// jitter on a GPU-saturated node without pushing detection past the sweep.
+// Tightening these buys little (the sweep, not us, sets the deadline that
+// matters) and costs false-positive teardowns of working connections.
+const (
+	defaultPingInterval = 15 * time.Second
+	defaultPongWait     = 45 * time.Second
+)
+
+// pingWriteWait bounds the ping control frame itself. WriteControl blocks until
+// it can take gorilla's write semaphore, which an in-flight WriteMessage holds
+// for up to defaultWriteTimeout, so this is a bound on how long a ping may wait
+// rather than a liveness signal. Failing here is advisory; see pingLoop.
+const pingWriteWait = 10 * time.Second
 
 // tryLockWrite acquires writeMu, giving up after d. Close must not block
 // forever behind a wedged writer (see the deadline note in Close), so it needs

--- a/internal/redisapi/websocket.go
+++ b/internal/redisapi/websocket.go
@@ -348,10 +348,19 @@ func (c *WSClient) armKeepalive(conn *websocket.Conn) {
 	conn.SetPingHandler(func(appData string) error {
 		// A server-side keepalive counts as liveness too. We still have to
 		// answer it, which gorilla's default handler would have done for us,
-		// so replicate that here including its error swallowing: a peer that
-		// has already gone away must not turn into a read error from the pong.
+		// so replicate that here including its one-second bound and its error
+		// swallowing: a peer that has already gone away must not turn into a
+		// read error from the pong.
+		//
+		// The short bound is the point. This runs on the read goroutine, and
+		// WriteControl waits on gorilla's write semaphore, which an in-flight
+		// WriteMessage can hold for defaultWriteTimeout. A longer deadline here
+		// would park the ONLY reader behind write congestion, processing no
+		// inbound messages while it waited. Skipping a pong is cheaper: the
+		// timeout is swallowed below, we keep reading, and if the peer really
+		// does give up on us the read deadline notices within pongWait.
 		_ = conn.SetReadDeadline(time.Now().Add(c.pongWait))
-		err := conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(pingWriteWait))
+		err := conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(pongReplyWait))
 		if err == websocket.ErrCloseSent {
 			return nil
 		}
@@ -645,6 +654,11 @@ const (
 // for up to defaultWriteTimeout, so this is a bound on how long a ping may wait
 // rather than a liveness signal. Failing here is advisory; see pingLoop.
 const pingWriteWait = 10 * time.Second
+
+// pongReplyWait bounds the pong we send in answer to a server ping. It is much
+// shorter than pingWriteWait because that reply runs on the read goroutine; see
+// the ping handler in armKeepalive. It matches gorilla's own default handler.
+const pongReplyWait = time.Second
 
 // tryLockWrite acquires writeMu, giving up after d. Close must not block
 // forever behind a wedged writer (see the deadline note in Close), so it needs

--- a/internal/redisapi/websocket_keepalive_test.go
+++ b/internal/redisapi/websocket_keepalive_test.go
@@ -53,11 +53,16 @@ func waitFor(cond func() bool, budget time.Duration) bool {
 
 // newKeepaliveTestClient builds a client with the keepalive scaled down so a
 // test does not have to wait out the production 45s read deadline.
+//
+// The scaling keeps production's 1:4 ping-to-deadline ratio but stays coarse on
+// purpose. CI runs these on a shared, heavily contended runner under -race, and
+// a sub-second budget would turn an ordinary scheduling hiccup into a red build
+// that gets rerun rather than diagnosed.
 func newKeepaliveTestClient(srv *httptest.Server) *WSClient {
 	c := NewWSClient(WSClientConfig{BaseURL: srv.URL, Token: "test-token"})
 	c.reconnectEnabled = false
-	c.pingInterval = 100 * time.Millisecond
-	c.pongWait = 400 * time.Millisecond
+	c.pingInterval = 250 * time.Millisecond
+	c.pongWait = time.Second
 	return c
 }
 
@@ -151,7 +156,7 @@ func TestPingsReachTheServer(t *testing.T) {
 	}
 	defer func() { _ = c.Close() }()
 
-	// pingInterval is 100ms, so three pings is a very slack budget.
+	// pingInterval is 250ms, so a 5s budget for three pings is very slack.
 	if !waitFor(func() bool { return pings.Load() >= 3 }, 5*time.Second) {
 		t.Fatalf("server saw %d pings, want at least 3: the ping ticker is not running", pings.Load())
 	}
@@ -187,8 +192,8 @@ func TestReadDeadlineDisconnectTriggersReconnect(t *testing.T) {
 	t.Cleanup(func() { close(release) })
 
 	c := NewWSClient(WSClientConfig{BaseURL: srv.URL, Token: "test-token"})
-	c.pingInterval = 100 * time.Millisecond
-	c.pongWait = 400 * time.Millisecond
+	c.pingInterval = 250 * time.Millisecond
+	c.pongWait = time.Second
 	// reconnectEnabled defaults on for a configured BaseURL; make it explicit,
 	// since the whole subject of this test is the reconnect.
 	c.reconnectEnabled = true
@@ -252,8 +257,8 @@ func TestKeepaliveIsRearmedOnEveryReconnect(t *testing.T) {
 	t.Cleanup(func() { close(release) })
 
 	c := NewWSClient(WSClientConfig{BaseURL: srv.URL, Token: "test-token"})
-	c.pingInterval = 100 * time.Millisecond
-	c.pongWait = 400 * time.Millisecond
+	c.pingInterval = 250 * time.Millisecond
+	c.pongWait = time.Second
 	c.reconnectEnabled = true
 	c.reconnectBackoff = 50 * time.Millisecond
 

--- a/internal/redisapi/websocket_keepalive_test.go
+++ b/internal/redisapi/websocket_keepalive_test.go
@@ -1,0 +1,255 @@
+package redisapi
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// newSilentWSServer upgrades the connection and then does nothing at all: it
+// never sends a message and, because it never calls ReadMessage, it never
+// answers a ping either. From the client's side that is indistinguishable from
+// a peer that vanished without a FIN reaching us, which is the half-open case
+// #734 is about.
+func newSilentWSServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	upgrader := websocket.Upgrader{}
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		<-release
+	}))
+	// LIFO: release the parked handler before shutting the server down,
+	// otherwise srv.Close() waits on it forever.
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(release) })
+	return srv
+}
+
+// waitFor polls cond until it holds or the budget runs out.
+func waitFor(cond func() bool, budget time.Duration) bool {
+	deadline := time.Now().Add(budget)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return cond()
+}
+
+// newKeepaliveTestClient builds a client with the keepalive scaled down so a
+// test does not have to wait out the production 45s read deadline.
+func newKeepaliveTestClient(srv *httptest.Server) *WSClient {
+	c := NewWSClient(WSClientConfig{BaseURL: srv.URL, Token: "test-token"})
+	c.reconnectEnabled = false
+	c.pingInterval = 100 * time.Millisecond
+	c.pongWait = 400 * time.Millisecond
+	return c
+}
+
+// TestReadDeadlineTearsDownASilentConnection is the core #734 regression.
+//
+// Without a read deadline, readLoop blocks in ReadMessage forever against a
+// peer that has gone away without a FIN. connected stays true, Publish writes
+// into a dead socket and reports success, handleDisconnect never fires, and
+// citadel status happily reports pubsub_transport: websocket while nothing is
+// flowing. The client must notice on its own.
+func TestReadDeadlineTearsDownASilentConnection(t *testing.T) {
+	srv := newSilentWSServer(t)
+	c := newKeepaliveTestClient(srv)
+
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	if !c.IsConnected() {
+		t.Fatal("IsConnected() = false right after a successful connect")
+	}
+
+	if !waitFor(func() bool { return !c.IsConnected() }, 5*time.Second) {
+		t.Fatal("still reporting connected against a silent peer: the read deadline never fired (#734)")
+	}
+
+	// The whole point of tearing down is that the caller falls back to HTTP
+	// instead of publishing into a dead socket and being told it worked.
+	if err := c.Publish(context.Background(), "chan", map[string]any{"a": 1}); err == nil {
+		t.Fatal("Publish succeeded on a torn-down connection; the silent-success bug is still reachable")
+	}
+}
+
+// TestKeepaliveHoldsAQuietButHealthyConnection is the counterweight. A
+// connection with no application traffic at all must stay up indefinitely,
+// because our own pings are answered. It fails if the ping ticker does not run
+// or if the pong handler does not push the read deadline out, which is the
+// obvious way to "fix" #734 and end up with a node that reconnects every 45s.
+func TestKeepaliveHoldsAQuietButHealthyConnection(t *testing.T) {
+	// A draining server sits in ReadMessage, so gorilla's default ping handler
+	// answers our pings. No application messages are ever exchanged.
+	srv := newDrainingWSServer(t)
+	c := newKeepaliveTestClient(srv)
+
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	// Five times the read deadline with nothing but keepalive traffic.
+	deadline := time.Now().Add(5 * c.pongWait)
+	for time.Now().Before(deadline) {
+		if !c.IsConnected() {
+			t.Fatal("healthy but idle connection was torn down: keepalive is not extending the read deadline")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// TestPingsReachTheServer pins the ping ticker itself. The previous test would
+// also pass if the server happened to be chatty; this one asserts the frames
+// are actually on the wire at roughly the configured cadence.
+func TestPingsReachTheServer(t *testing.T) {
+	var pings atomic.Int64
+
+	upgrader := websocket.Upgrader{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		// Overriding the handler replaces gorilla's automatic pong, so answer
+		// by hand; otherwise the client would rightly declare us dead.
+		conn.SetPingHandler(func(appData string) error {
+			pings.Add(1)
+			return conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(time.Second))
+		})
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newKeepaliveTestClient(srv)
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	// pingInterval is 100ms, so three pings is a very slack budget.
+	if !waitFor(func() bool { return pings.Load() >= 3 }, 5*time.Second) {
+		t.Fatalf("server saw %d pings, want at least 3: the ping ticker is not running", pings.Load())
+	}
+}
+
+// TestReadDeadlineDisconnectTriggersReconnect closes the loop: detecting death
+// is only useful if it feeds the existing reconnect path. A node that notices
+// and then sits there is no better off than one that never noticed.
+func TestReadDeadlineDisconnectTriggersReconnect(t *testing.T) {
+	var attempts atomic.Int64
+	upgrader := websocket.Upgrader{}
+	release := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		if attempts.Add(1) == 1 {
+			// First connection goes silent: never reads, so never pongs.
+			<-release
+			return
+		}
+		// Every later connection behaves, answering pings from ReadMessage.
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(release) })
+
+	c := NewWSClient(WSClientConfig{BaseURL: srv.URL, Token: "test-token"})
+	c.pingInterval = 100 * time.Millisecond
+	c.pongWait = 400 * time.Millisecond
+	// reconnectEnabled defaults on for a configured BaseURL; make it explicit,
+	// since the whole subject of this test is the reconnect.
+	c.reconnectEnabled = true
+	c.reconnectBackoff = 50 * time.Millisecond
+
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	if !waitFor(func() bool { return attempts.Load() >= 2 && c.IsConnected() }, 15*time.Second) {
+		t.Fatalf("no reconnect after a read-deadline disconnect: attempts=%d connected=%v",
+			attempts.Load(), c.IsConnected())
+	}
+}
+
+// TestPingsAreSafeAlongsideConcurrentWrites checks the load-bearing claim that
+// the ping needs no writeMu.
+//
+// gorilla permits ONE concurrent writer and panics from flushFrame otherwise,
+// taking the worker process with it (#720). WriteControl is documented safe
+// alongside other methods and the vendored source backs that up, but the claim
+// is worth an actual test: a ping every millisecond against 50 publishers
+// pushing 8KB frames. Running the fix with WriteMessage(PingMessage) in place
+// of WriteControl panics here.
+func TestPingsAreSafeAlongsideConcurrentWrites(t *testing.T) {
+	srv := newDrainingWSServer(t)
+
+	c := NewWSClient(WSClientConfig{BaseURL: srv.URL, Token: "test-token"})
+	c.reconnectEnabled = false
+	c.pingInterval = time.Millisecond
+	// Long enough that the read deadline is not what ends this test.
+	c.pongWait = time.Minute
+
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+
+	payload := map[string]any{"blob": strings.Repeat("p", 8192)}
+
+	const (
+		writers   = 50
+		perWriter = 50
+	)
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := range writers {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			for range perWriter {
+				_ = c.Publish(context.Background(), fmt.Sprintf("ping-race-%d", i), payload)
+			}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	if err := c.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}

--- a/internal/redisapi/websocket_keepalive_test.go
+++ b/internal/redisapi/websocket_keepalive_test.go
@@ -203,6 +203,70 @@ func TestReadDeadlineDisconnectTriggersReconnect(t *testing.T) {
 		t.Fatalf("no reconnect after a read-deadline disconnect: attempts=%d connected=%v",
 			attempts.Load(), c.IsConnected())
 	}
+
+	// The reconnected socket must be armed too. Without this the test would
+	// pass on a connection that merely happened to be up at the instant we
+	// looked: connectLocked, not Connect, is what has to arm the keepalive,
+	// because reconnect never goes through Connect. An unarmed connection has
+	// no read deadline and no pings, which is the original bug restored on
+	// every socket after the first.
+	settled := attempts.Load()
+	deadline := time.Now().Add(3 * c.pongWait)
+	for time.Now().Before(deadline) {
+		if !c.IsConnected() {
+			t.Fatal("reconnected connection dropped again: it is not being kept alive")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if got := attempts.Load(); got != settled {
+		t.Fatalf("dial attempts kept climbing (%d -> %d) against a healthy peer: reconnect is flapping", settled, got)
+	}
+}
+
+// TestKeepaliveIsRearmedOnEveryReconnect pins that connectLocked, not Connect,
+// owns the arming.
+//
+// Reconnect never goes through Connect, so arming there would leave every
+// socket after the first with no read deadline and no handlers. That is the
+// original bug restored one connection later, and it is invisible to a test
+// that only checks the reconnected socket stays up: an unarmed connection is
+// MORE stable, not less, because nothing can ever declare it dead. The
+// observable difference is whether the client keeps noticing. Here every
+// connection the server accepts goes silent, so a correctly armed client
+// detects and redials over and over; an armed-once client stalls at two.
+func TestKeepaliveIsRearmedOnEveryReconnect(t *testing.T) {
+	var attempts atomic.Int64
+	upgrader := websocket.Upgrader{}
+	release := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		attempts.Add(1)
+		<-release
+	}))
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(release) })
+
+	c := NewWSClient(WSClientConfig{BaseURL: srv.URL, Token: "test-token"})
+	c.pingInterval = 100 * time.Millisecond
+	c.pongWait = 400 * time.Millisecond
+	c.reconnectEnabled = true
+	c.reconnectBackoff = 50 * time.Millisecond
+
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	// Three accepted connections means the SECOND one was detected as dead too,
+	// which can only happen if the reconnect path armed it.
+	if !waitFor(func() bool { return attempts.Load() >= 3 }, 25*time.Second) {
+		t.Fatalf("server accepted %d connections, want at least 3: the keepalive is not re-armed after a reconnect", attempts.Load())
+	}
 }
 
 // TestPingsAreSafeAlongsideConcurrentWrites checks the load-bearing claim that


### PR DESCRIPTION
## Context

Closes #734.

The pub/sub WebSocket client had no keepalive and no read deadline, so `readLoop`
blocked in `ReadMessage` forever. A peer that went away without a FIN reaching us
(NAT or LB dropping idle state, a partition, a Railway instance replaced
mid-flight) delivered no read error, so `connected` stayed `true`, `Publish`
wrote into a dead socket and reported success, and `handleDisconnect` never
fired, so reconnect never happened.

Node 1297 now reports `pubsub_transport: websocket` in `citadel status`
(v2.103.0). Without this, that line can read `websocket` while nothing is
flowing, which is the same shape as the twelve-hour outage behind #720-#723:
telemetry broken while reporting itself fine.

## The real payoff: an honest `IsConnected()`

`Client.Publish` already branches on `wsClient.IsConnected()` and falls back to
HTTP when it is false. The fallback exists; what was missing was any way for
`IsConnected()` to become false. That makes the two error directions very
asymmetric:

- **False positive** (tear down a live connection): publishes degrade to HTTP for
  ~1s and the client redials. Cheap, bounded, self-correcting.
- **False negative** (miss a dead connection): `connected` stays true, the
  fallback never engages, and every publish is silently lost forever.

That asymmetry is what licenses erring toward detection. This PR is less "detect
inside 120s" than "make `IsConnected()` honest so the fallback that already
exists can engage".

## Changes

`internal/redisapi/websocket.go`:

- `armKeepalive` sets a read deadline on a freshly dialed connection and installs
  pong and ping handlers that push it out. Called from `connectLocked`, so it
  covers reconnects, not just the first `Connect`.
- `readLoop` extends the deadline after every successful read, so ordinary
  application traffic counts as liveness and not only pongs, and reports a
  deadline expiry distinctly from an ordinary read error.
- `pingLoop` sends a ping every `pingInterval`. It is long-lived and re-reads
  `c.conn` each tick, so it spans reconnects.
- A read timeout routes through the existing `handleDisconnect` -> `reconnect`
  path; no new teardown mechanism.
- The pong we send in answer to a server ping is bounded at one second, matching
  gorilla's default handler. That reply runs on the read goroutine and
  `WriteControl` waits on gorilla's write semaphore, which an in-flight
  `WriteMessage` can hold for `defaultWriteTimeout`, so a longer bound there
  would park the only reader behind write congestion. Skipping a pong is
  cheaper: the timeout is already swallowed, so we keep reading.
- `loopsOnce` guards both background goroutines. They were already designed to
  outlive a single connection, but `Connect` is callable again whenever
  `connected` is false (#723's background retry loop does exactly that), and a
  second `Connect` would have started a second reader. gorilla permits one
  concurrent reader.

## Intervals: 15s ping, 45s read deadline

Sized against the platform's 120s offline sweep rather than network latency. If
detection is slower than the sweep the node is already marked offline (and
refused for targeted dispatch, #722) by the time it notices, which defeats the
point. 45s detection plus ~1s reconnect backoff leaves better than 2x margin and
lands inside two 30s heartbeat intervals.

The ping is one third of the deadline on purpose, so three pings go unanswered
before we act. That absorbs a dropped pong and scheduler jitter on a
GPU-saturated node. Tightening further buys little (the sweep, not us, sets the
deadline that matters) and costs false-positive teardowns.

## Why the ping does not take `writeMu`

Verified against the vendored `gorilla/websocket` source rather than taken on
faith, since #720 was a panic from exactly this class of mistake and #725's mutex
is now load-bearing. `WriteControl`:

- takes gorilla's own single-writer semaphore `c.mu` for the duration of the
  frame, so it cannot interleave with a `WriteMessage` frame,
- reads and latches `writeErr` under `writeErrMu`,
- calls `c.conn.SetWriteDeadline` on the underlying `net.Conn` (goroutine-safe)
  instead of touching the `c.writeDeadline` field that `writeMu` exists to guard.

`doc.go` says the same in one line: "The Close and WriteControl methods can be
called concurrently with all other methods." There is a test that would catch a
regression here rather than relying on the reading (see the mutation table).

## What this makes WORSE

1. **#728 becomes substantially more reachable.** Before this change
   `handleDisconnect` almost never fired, which was the bug. Now it fires on
   every deadline expiry, so `go c.reconnect()` runs far more often.
   `reconnect()` does `c.reconnectBackoff *= 2` with no `connMu` while
   `connectLocked` writes `c.reconnectBackoff = time.Second` under
   `connMu.Lock`. Not fixed here to keep this PR to one subject, but this PR is
   what makes that race worth prioritising. Note the new tests do not prove it is
   absent: in them both writes happen on the same goroutine, so `-race` is clean
   for the wrong reason.
2. **A new false-positive class, and it flaps rather than fails.** A peer that is
   alive but never answers a ping (a proxy that strips control frames, a server
   that stops ponging while otherwise fine) is now torn down every 45s. Because
   `connectLocked` resets the backoff to 1s on every successful dial, that is a
   redial roughly every 46s per node, forever, against an endpoint that returns
   429 (typed by #723) and fleet-synchronized with no jitter. Previously those
   nodes sat quiet. Mitigated by counting any inbound frame as liveness, and the
   fabric route is served by `ws`, which answers pings automatically, but the
   failure mode is real and belongs on the record.
3. **The ping is a real writer.** Even with `WriteControl`, a ping can block up
   to its own 10s deadline behind a large in-flight `WriteMessage`, and a hard
   failure inside `WriteControl` latches `writeErr` for the whole connection, so
   a ping can kill a connection that would otherwise have kept serving reads.
   This is why a failed ping is advisory (logged, no teardown): the read deadline
   is the single authority on liveness, a queued ping must not be able to cause
   an outage, and a genuinely fatal failure is not lost (the next publish tears
   down, and no pongs arrive either way).
4. **One control frame per node per 15s**, four times the heartbeat rate on the
   fabric ws endpoint. Tiny per node, nonzero at fleet scale.
5. **The read deadline bounds a single inbound message, not just idle time.**
   Frames on this route are small JSON, so this is theoretical, but a read taking
   more than 45s would now be cut.

The one diagnostic that matters here (`ws: no traffic for 45s, treating
connection as dead`) does reach the log on the real path: `cmd/work.go` passes
`DebugFunc: Debug` into the API source, which passes it to `redisapi.NewClient`,
and `Debug` writes to `latest.log` unconditionally. `internal/chat` does not pass
one, so a chat-client flap stays silent there.

## Testing

`cpuslot go test -race ./internal/redisapi/...` is clean, as is `go vet ./...`
and the full `go test ./...`. (`TestNullSinkRecorder_CapturesAudio` in
`internal/platform` flaked once under a parallel run and passes repeatedly on
its own; it captures from PulseAudio and is unrelated to this package.)

The keepalive tests run at a 250ms ping and a 1s read deadline: production's 1:4
ratio, but coarse on purpose. CI runs on a shared, contended runner under
`-race`, and a sub-second budget would turn an ordinary scheduling hiccup into a
red build that gets rerun rather than diagnosed.

Every new test was mutation-tested: the fix was deliberately broken and each test
confirmed to fail. Per test:

| Mutation | Caught by |
|---|---|
| M1: drop the initial `SetReadDeadline` in `armKeepalive` | `TestReadDeadlineTearsDownASilentConnection` (uniquely), `TestReadDeadlineDisconnectTriggersReconnect`, `TestKeepaliveIsRearmedOnEveryReconnect` |
| M2: pong handler returns nil instead of extending the deadline | `TestKeepaliveHoldsAQuietButHealthyConnection`, `TestReadDeadlineDisconnectTriggersReconnect` |
| M3: never start `pingLoop` | `TestPingsReachTheServer` (uniquely), `TestKeepaliveHoldsAQuietButHealthyConnection`, `TestReadDeadlineDisconnectTriggersReconnect` |
| M4: ping via `SetWriteDeadline` + `WriteMessage` instead of `WriteControl` | `TestPingsAreSafeAlongsideConcurrentWrites` (uniquely; panics `concurrent write to websocket connection` from `flushFrame`, which is #720) |
| M5: `handleDisconnect` never schedules a reconnect | `TestReadDeadlineDisconnectTriggersReconnect` (uniquely) |
| M6: arm the keepalive in `Connect` instead of `connectLocked` | `TestKeepaliveIsRearmedOnEveryReconnect` (uniquely) |

The trailing flap check in `TestReadDeadlineDisconnectTriggersReconnect` (stay
connected for `3 * pongWait` after recovery, and no further dials) catches M2 and
M3 but nothing uniquely; it is a guard, not a demonstrated tripwire.

M6 is worth calling out: the obvious assertion (reconnect, then check the new
socket stays up) does NOT catch it, because an unarmed connection is more stable,
not less. Nothing can declare it dead. The test had to be rewritten to face a
permanently silent server and assert the client keeps detecting and redialing.

Not covered by an automated test, and deliberately so: whether Railway's proxy
and the `ws`-based fabric route pass control frames end to end in production.
That is what worse-item 2 hangs on. Worth watching node 1297's log for
`ws: no traffic for` after this ships; a steady 46s cadence there means the
premise is wrong and the intervals need revisiting.
