### PR TITLE
fix(redisapi): integrate the backoff-race and keepalive fixes, and jitter the reconnect (#728, #734, #740, #741)

### DIFF
--- a/cmd/ws_pubsub.go
+++ b/cmd/ws_pubsub.go
@@ -62,8 +62,14 @@ func (w wsConnector) Connect(ctx context.Context) error {
 //
 // Re-arming after a LOST connection is already handled one layer down by
 // WSClient.handleDisconnect -> reconnect, which retries indefinitely and
-// restores subscriptions. This function deliberately does not duplicate that:
-// a second connect path could start a second readLoop on the same connection.
+// restores subscriptions. This function deliberately does not duplicate that.
+//
+// It used to be unsafe as well as redundant: a second connect path could start a
+// second readLoop on the same gorilla Conn, which permits exactly one concurrent
+// reader (#740). That is fixed (WSClient.loopsOnce starts the loops once for the
+// client's whole life), so the reason to keep a single re-arm path is now purely
+// that two of them would dial twice and leave one of the connections orphaned
+// (#748), not that they would corrupt the reader.
 // The returned channel closes when the retry loop has finished (immediately
 // when no loop was needed). Production callers ignore it; it exists so a test
 // can join the goroutine instead of sleeping and guessing.

--- a/internal/redisapi/websocket.go
+++ b/internal/redisapi/websocket.go
@@ -54,7 +54,17 @@ type WSClient struct {
 	done     chan struct{}
 	stopOnce sync.Once
 
-	// Reconnection settings
+	// Reconnection settings.
+	//
+	// reconnectBackoff is guarded by connMu (#728). It is written by
+	// connectLocked, whose caller already holds connMu for write, and it is
+	// advanced by nextReconnectDelay, which takes connMu for the whole
+	// read-modify-write and releases it before the caller sleeps. Nothing may
+	// touch it unlocked: reconnect used to, and a torn or stale read there
+	// shortens a backoff.
+	//
+	// reconnectEnabled and maxBackoff are set once in NewWSClient and never
+	// written again, so they need no guard.
 	reconnectEnabled bool
 	reconnectBackoff time.Duration
 	maxBackoff       time.Duration
@@ -102,6 +112,11 @@ type WSMessage struct {
 	Data      map[string]string `json:"data,omitempty"`      // Job data fields from stream
 }
 
+// initialReconnectBackoff is the delay before the first reconnect attempt, and
+// the value the schedule returns to after any successful connect. It lives in
+// one place so the constructor and the reset in connectLocked cannot drift.
+const initialReconnectBackoff = time.Second
+
 // NewWSClient creates a new WebSocket client.
 func NewWSClient(cfg WSClientConfig) *WSClient {
 	reconnectEnabled := cfg.ReconnectEnabled
@@ -117,7 +132,7 @@ func NewWSClient(cfg WSClientConfig) *WSClient {
 		subscriptions:    make(map[string]bool),
 		done:             make(chan struct{}),
 		reconnectEnabled: reconnectEnabled,
-		reconnectBackoff: time.Second,
+		reconnectBackoff: initialReconnectBackoff,
 		maxBackoff:       time.Minute,
 		writeTimeout:     defaultWriteTimeout,
 		debugFunc:        cfg.DebugFunc,
@@ -187,7 +202,10 @@ func (c *WSClient) connectLocked(ctx context.Context) error {
 
 	c.conn = conn
 	c.connected = true
-	c.reconnectBackoff = time.Second // Reset backoff on successful connection
+	// Reset the backoff schedule on a successful connection. The caller holds
+	// connMu for write, which is what makes this assignment safe against
+	// nextReconnectDelay running in a reconnect goroutine (#728).
+	c.reconnectBackoff = initialReconnectBackoff
 
 	c.debug("ws: connected successfully")
 
@@ -314,6 +332,39 @@ func (c *WSClient) handleDisconnect(conn *websocket.Conn) {
 	go c.reconnect()
 }
 
+// nextReconnectDelay returns how long the caller should wait before its next
+// reconnect attempt, and advances the schedule for the attempt after that.
+//
+// The read, the doubling and the clamp all happen in ONE critical section under
+// connMu, and the caller sleeps on the returned value instead of re-reading the
+// field. reconnect used to do all of it with no lock at all, racing the reset in
+// connectLocked, which runs under connMu (#728). It also read the field twice,
+// once to log the delay and once to sleep it, so a reset landing between the two
+// made the node retry sooner than it had just announced.
+//
+// Both defects point the same way, and it is the way that hurts: anything that
+// silently shortens a backoff moves toward the #443 restart storm referenced
+// above connectWithBackoff in cmd/work.go, where tight retries burned the node's
+// daily Redis-API quota and locked it out for about a day.
+//
+// connMu is reused deliberately rather than adding a third mutex to this file.
+// The reset has to live in connectLocked, which is the only place that knows a
+// dial succeeded and whose caller already holds connMu, so connMu costs no extra
+// lock and no nested acquire. connMu is NOT held across the sleep.
+func (c *WSClient) nextReconnectDelay() time.Duration {
+	c.connMu.Lock()
+	defer c.connMu.Unlock()
+
+	delay := c.reconnectBackoff
+
+	c.reconnectBackoff *= 2
+	if c.reconnectBackoff > c.maxBackoff {
+		c.reconnectBackoff = c.maxBackoff
+	}
+
+	return delay
+}
+
 // reconnect attempts to reconnect with exponential backoff
 func (c *WSClient) reconnect() {
 	for {
@@ -331,14 +382,9 @@ func (c *WSClient) reconnect() {
 			return
 		}
 
-		c.debug("ws: attempting reconnect in %v", c.reconnectBackoff)
-		time.Sleep(c.reconnectBackoff)
-
-		// Increase backoff for next attempt
-		c.reconnectBackoff *= 2
-		if c.reconnectBackoff > c.maxBackoff {
-			c.reconnectBackoff = c.maxBackoff
-		}
+		delay := c.nextReconnectDelay()
+		c.debug("ws: attempting reconnect in %v", delay)
+		time.Sleep(delay)
 
 		c.connMu.Lock()
 		err := c.connectLocked(context.Background())

--- a/internal/redisapi/websocket.go
+++ b/internal/redisapi/websocket.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"net/url"
@@ -91,6 +92,13 @@ type WSClient struct {
 	reconnectBackoff time.Duration
 	maxBackoff       time.Duration
 
+	// jitterFrac draws the randomness nextReconnectDelay adds on top of the
+	// schedule. It is a field rather than a package var so a test can make the
+	// delay deterministic without mutating shared state that a previous test's
+	// still-running reconnect goroutine might be reading. Set once in
+	// NewWSClient, before any goroutine exists. Must return [0,1).
+	jitterFrac func() float64
+
 	// Reconnect callbacks fired after a successful reconnection
 	reconnectCallbacks   []func()
 	reconnectCallbacksMu sync.RWMutex
@@ -139,6 +147,56 @@ type WSMessage struct {
 // one place so the constructor and the reset in connectLocked cannot drift.
 const initialReconnectBackoff = time.Second
 
+// Reconnect jitter.
+//
+// The schedule used to be exactly 1, 2, 4, ... 60 seconds on every node, with no
+// randomness anywhere in this file. Whenever the control plane blips, every node
+// in the fleet is disconnected at nearly the same instant and then redials in
+// lockstep, against an endpoint that answers 429 (typed by rateLimitFromUpgrade
+// above). That is a self-inflicted thundering herd, and the keepalive in #734
+// makes it worse rather than better: handleDisconnect now fires on every
+// read-deadline expiry instead of almost never, so this path runs routinely.
+//
+// The scheme is ADDITIVE and UPWARD-ONLY: the sleep is drawn uniformly from
+// [base, 2*base), where base is the deterministic step. The two textbook
+// alternatives were both rejected for the same reason, which is the only
+// property this package cannot trade away:
+//
+//   - Full jitter, rand(0, base), has a floor of zero. A node that has just been
+//     told 429 could redial milliseconds later, and the mean delay is HALF the
+//     current schedule, so fleet-wide retry pressure doubles. That is the shape
+//     of #443, where tight retries burned the node's daily Redis-API quota and
+//     locked it out for about a day, and it is the direction #728 calls out as
+//     the one that matters. cmd/work.go's rate-limit path already refuses to
+//     "poll tighter than retry_after" for the same reason.
+//   - Decorrelated jitter, min(cap, rand(base, prev*3)), can also return to base
+//     repeatedly, so a long outage can sit near one second indefinitely. It also
+//     wants the previous SLEEP as its state, which would collide with
+//     reconnectBackoff holding the deterministic schedule that connectLocked
+//     resets on a successful dial.
+//
+// Additive jitter is never shorter than what shipped before, and its spread is
+// the full width of the current step, which is exactly enough to decorrelate a
+// fleet whose nodes all hold the same step after a shared blip.
+//
+// The jittered sleep is deliberately NOT clamped to maxBackoff. maxBackoff caps
+// the SCHEDULE, not the sleep. Clamping the result would collapse the spread to
+// zero at the ceiling, which is precisely the worst case: a long control-plane
+// outage puts every node at the cap, and they would all dial together again.
+// The cost is a worst-case sleep of two minutes rather than one, reached only
+// after roughly seven consecutive failed dials, and publishes fall back to HTTP
+// throughout (see Client.Publish).
+//
+// Note what this does NOT fix, so nobody reads more into it than is there: the
+// flap in #734's own "what this makes worse" (a peer that is alive but never
+// pongs, torn down every pongWait, reconnecting at one second, forever) has a
+// period dominated by pongWait, not by the backoff. One second of jitter per
+// 46-second cycle random-walks those phases apart far too slowly to matter. Two
+// things would actually address it, both filed rather than done here: not
+// resetting the schedule for a connection that never proved itself, and honoring
+// the typed rate-limit hint that connectLocked already builds and reconnect
+// currently discards.
+
 // NewWSClient creates a new WebSocket client.
 func NewWSClient(cfg WSClientConfig) *WSClient {
 	reconnectEnabled := cfg.ReconnectEnabled
@@ -159,6 +217,7 @@ func NewWSClient(cfg WSClientConfig) *WSClient {
 		writeTimeout:     defaultWriteTimeout,
 		pingInterval:     defaultPingInterval,
 		pongWait:         defaultPongWait,
+		jitterFrac:       rand.Float64,
 		debugFunc:        cfg.DebugFunc,
 	}
 }
@@ -487,18 +546,79 @@ func (c *WSClient) handleDisconnect(conn *websocket.Conn) {
 // The reset has to live in connectLocked, which is the only place that knows a
 // dial succeeded and whose caller already holds connMu, so connMu costs no extra
 // lock and no nested acquire. connMu is NOT held across the sleep.
+//
+// The returned delay is JITTERED; the stored schedule is not. See the jitter
+// note above initialReconnectBackoff for why it is additive and upward-only,
+// and why the returned sleep is deliberately allowed to exceed maxBackoff.
 func (c *WSClient) nextReconnectDelay() time.Duration {
 	c.connMu.Lock()
 	defer c.connMu.Unlock()
 
-	delay := c.reconnectBackoff
+	base := c.reconnectBackoff
 
 	c.reconnectBackoff *= 2
 	if c.reconnectBackoff > c.maxBackoff {
 		c.reconnectBackoff = c.maxBackoff
 	}
 
-	return delay
+	return c.jitteredLocked(base)
+}
+
+// jitteredLocked spreads base over [base, 2*base). Caller holds connMu.
+//
+// Only the RETURNED sleep is randomized. c.reconnectBackoff keeps holding the
+// clean doubling, so the schedule stays predictable, connectLocked's reset still
+// means exactly "back to one second", and nothing accumulates randomness across
+// attempts.
+func (c *WSClient) jitteredLocked(base time.Duration) time.Duration {
+	if base <= 0 {
+		return base
+	}
+	frac := rand.Float64
+	if c.jitterFrac != nil {
+		frac = c.jitterFrac
+	}
+	return base + time.Duration(frac()*float64(base))
+}
+
+// sleepUnlessDone waits for d, returning false if Close happened first (#741).
+//
+// The bare time.Sleep this replaces was not cancellable and, worse, reconnect
+// did not re-check c.done afterwards, so a Close landing during a backoff still
+// let the loop dial and then mark a closed client connected: IsConnected()
+// reported true after Close returned, and the socket it opened was left dangling
+// until the next iteration noticed done and returned without closing it.
+//
+// The window is the whole remaining sleep, so it was widest exactly when the
+// control plane was unhealthy and the schedule had grown to a minute. The
+// keepalive (#734) is what turns this from rare into ordinary: reconnect used to
+// run almost never and now runs on every read-deadline expiry. Jitter can push
+// the sleep to two minutes, which widens the same window again.
+//
+// Not addressed here, and deliberately: connectLocked is still called with
+// context.Background(), so the dial itself is bound only by the 10s handshake
+// timeout rather than by the caller's lifetime. Giving the client a real context
+// is a larger change than this loop.
+func (c *WSClient) sleepUnlessDone(d time.Duration) bool {
+	if d <= 0 {
+		// Still honour a Close that has already happened.
+		select {
+		case <-c.done:
+			return false
+		default:
+			return true
+		}
+	}
+
+	t := time.NewTimer(d)
+	defer t.Stop()
+
+	select {
+	case <-c.done:
+		return false
+	case <-t.C:
+		return true
+	}
 }
 
 // reconnect attempts to reconnect with exponential backoff
@@ -520,7 +640,9 @@ func (c *WSClient) reconnect() {
 
 		delay := c.nextReconnectDelay()
 		c.debug("ws: attempting reconnect in %v", delay)
-		time.Sleep(delay)
+		if !c.sleepUnlessDone(delay) {
+			return
+		}
 
 		c.connMu.Lock()
 		err := c.connectLocked(context.Background())

--- a/internal/redisapi/websocket.go
+++ b/internal/redisapi/websocket.go
@@ -3,7 +3,9 @@ package redisapi
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -42,6 +44,13 @@ type WSClient struct {
 	// Overridden in tests; see defaultWriteTimeout for the value rationale.
 	writeTimeout time.Duration
 
+	// pingInterval and pongWait drive the keepalive (#734). pongWait is the
+	// read deadline: nothing arriving within it means the socket is dead.
+	// pingInterval is how often we send a ping to provoke traffic. Both are
+	// overridden in tests; see defaultPongWait for the value rationale.
+	pingInterval time.Duration
+	pongWait     time.Duration
+
 	// Message handlers
 	handlers   map[string]func(WSMessage)
 	handlersMu sync.RWMutex
@@ -53,6 +62,14 @@ type WSClient struct {
 	// Control channels
 	done     chan struct{}
 	stopOnce sync.Once
+
+	// loopsOnce guards the background goroutines. readLoop and pingLoop are
+	// deliberately long-lived: they re-read c.conn every iteration, so they
+	// survive a reconnect and must NOT be started per connection. Connect is
+	// callable again whenever connected is false (the #723 retry loop does
+	// exactly that), and without this a second Connect would start a second
+	// reader -- gorilla permits exactly one concurrent reader.
+	loopsOnce sync.Once
 
 	// Reconnection settings
 	reconnectEnabled bool
@@ -120,6 +137,8 @@ func NewWSClient(cfg WSClientConfig) *WSClient {
 		reconnectBackoff: time.Second,
 		maxBackoff:       time.Minute,
 		writeTimeout:     defaultWriteTimeout,
+		pingInterval:     defaultPingInterval,
+		pongWait:         defaultPongWait,
 		debugFunc:        cfg.DebugFunc,
 	}
 }
@@ -144,8 +163,11 @@ func (c *WSClient) Connect(ctx context.Context) error {
 		return err
 	}
 
-	// Start read loop
-	go c.readLoop()
+	// Both loops outlive any single connection; see loopsOnce.
+	c.loopsOnce.Do(func() {
+		go c.readLoop()
+		go c.pingLoop()
+	})
 
 	return nil
 }
@@ -184,6 +206,15 @@ func (c *WSClient) connectLocked(ctx context.Context) error {
 		}
 		return fmt.Errorf("WebSocket connection failed: %w", err)
 	}
+
+	// Arm the keepalive BEFORE publishing the connection (#734).
+	//
+	// SetReadDeadline, SetPongHandler and SetPingHandler are gorilla READ
+	// methods, so they must not run concurrently with ReadMessage. Doing this
+	// while conn is still private -- readLoop cannot see it until c.conn is
+	// assigned under connMu -- is what makes that safe. The handlers only ever
+	// fire from inside ReadMessage afterwards, i.e. on the read goroutine.
+	c.armKeepalive(conn)
 
 	c.conn = conn
 	c.connected = true
@@ -254,10 +285,25 @@ func (c *WSClient) readLoop() {
 
 		_, message, err := conn.ReadMessage()
 		if err != nil {
-			c.debug("ws: read error: %v", err)
+			var netErr net.Error
+			if errors.As(err, &netErr) && netErr.Timeout() {
+				// The read deadline expired: nothing at all arrived for
+				// pongWait, not even a pong for our pings. Before #734 this
+				// case did not exist and the loop simply blocked forever, so a
+				// half-open socket stayed "connected" while nothing flowed.
+				c.debug("ws: no traffic for %v, treating connection as dead", c.pongWait)
+			} else {
+				c.debug("ws: read error: %v", err)
+			}
 			c.handleDisconnect(conn)
 			continue
 		}
+
+		// Any inbound frame is evidence the peer is alive, so extend the
+		// deadline on data too, not just on pongs. That matters if a proxy or
+		// server ever stops honoring ping frames: a busy connection then still
+		// stays up on its own traffic.
+		_ = conn.SetReadDeadline(time.Now().Add(c.pongWait))
 
 		var msg WSMessage
 		if err := json.Unmarshal(message, &msg); err != nil {
@@ -283,6 +329,82 @@ func (c *WSClient) readLoop() {
 
 		if ok {
 			wildcardHandler(msg)
+		}
+	}
+}
+
+// armKeepalive installs the read deadline and the control-frame handlers on a
+// freshly dialed connection. Caller must not have published conn yet: these are
+// gorilla read methods and cannot race ReadMessage.
+func (c *WSClient) armKeepalive(conn *websocket.Conn) {
+	_ = conn.SetReadDeadline(time.Now().Add(c.pongWait))
+
+	conn.SetPongHandler(func(string) error {
+		// Our ping came back, so the round trip is intact. Runs on the read
+		// goroutine, from inside ReadMessage.
+		return conn.SetReadDeadline(time.Now().Add(c.pongWait))
+	})
+
+	conn.SetPingHandler(func(appData string) error {
+		// A server-side keepalive counts as liveness too. We still have to
+		// answer it, which gorilla's default handler would have done for us,
+		// so replicate that here including its error swallowing: a peer that
+		// has already gone away must not turn into a read error from the pong.
+		_ = conn.SetReadDeadline(time.Now().Add(c.pongWait))
+		err := conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(pingWriteWait))
+		if err == websocket.ErrCloseSent {
+			return nil
+		}
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			return nil
+		}
+		return err
+	})
+}
+
+// pingLoop sends a ping every pingInterval so an idle connection still proves
+// itself. It is long-lived and re-reads c.conn each tick, so it spans
+// reconnects; see loopsOnce.
+//
+// The ping is written with WriteControl, which does NOT need writeMu. Verified
+// against the vendored gorilla source rather than taken on faith: WriteControl
+// takes gorilla's own single-writer semaphore (c.mu) for the duration of the
+// frame, reads writeErr under writeErrMu, and sets the deadline directly on the
+// underlying net.Conn (goroutine-safe) instead of touching the c.writeDeadline
+// field that writeMu exists to guard. The package docs say the same thing in
+// one line: "The Close and WriteControl methods can be called concurrently with
+// all other methods."
+func (c *WSClient) pingLoop() {
+	ticker := time.NewTicker(c.pingInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-c.done:
+			return
+		case <-ticker.C:
+		}
+
+		c.connMu.RLock()
+		conn := c.conn
+		connected := c.connected
+		c.connMu.RUnlock()
+
+		if !connected || conn == nil {
+			continue
+		}
+
+		if err := conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(pingWriteWait)); err != nil {
+			// Deliberately advisory: the read deadline is the single authority
+			// on liveness. A ping can fail simply because a large WriteMessage
+			// is holding gorilla's write semaphore, and tearing down a healthy
+			// connection because a control frame queued too long would be a
+			// self-inflicted outage. A genuinely fatal failure is not lost:
+			// gorilla latches it in writeErr, so the next publish tears the
+			// connection down, and no pongs will arrive either way, so the
+			// read deadline fires within pongWait regardless.
+			c.debug("ws: ping failed: %v", err)
 		}
 	}
 }
@@ -497,6 +619,32 @@ const closeWriteWait = 2 * time.Second
 // so it should never fire in normal operation, and well under the worker
 // self-heal stall timer (600s) that would otherwise be the only backstop.
 const defaultWriteTimeout = 15 * time.Second
+
+// Keepalive intervals (#734).
+//
+// defaultPongWait is the read deadline. Nothing arriving on the socket within
+// it -- not a message, not a pong for our own pings -- means the connection is
+// declared dead and torn down. It is sized against the platform's 120s offline
+// sweep, not against network latency: detection has to happen with room to
+// spare, or the node is already marked offline (and refused for targeted
+// dispatch) by the time it notices. 45s detection plus ~1s of reconnect backoff
+// leaves better than 2x margin, and lands inside two 30s heartbeat intervals.
+//
+// defaultPingInterval is one third of it on purpose, so three pings go
+// unanswered before we act. That absorbs a single dropped pong and scheduler
+// jitter on a GPU-saturated node without pushing detection past the sweep.
+// Tightening these buys little (the sweep, not us, sets the deadline that
+// matters) and costs false-positive teardowns of working connections.
+const (
+	defaultPingInterval = 15 * time.Second
+	defaultPongWait     = 45 * time.Second
+)
+
+// pingWriteWait bounds the ping control frame itself. WriteControl blocks until
+// it can take gorilla's write semaphore, which an in-flight WriteMessage holds
+// for up to defaultWriteTimeout, so this is a bound on how long a ping may wait
+// rather than a liveness signal. Failing here is advisory; see pingLoop.
+const pingWriteWait = 10 * time.Second
 
 // tryLockWrite acquires writeMu, giving up after d. Close must not block
 // forever behind a wedged writer (see the deadline note in Close), so it needs

--- a/internal/redisapi/websocket.go
+++ b/internal/redisapi/websocket.go
@@ -192,10 +192,12 @@ const initialReconnectBackoff = time.Second
 // pongs, torn down every pongWait, reconnecting at one second, forever) has a
 // period dominated by pongWait, not by the backoff. One second of jitter per
 // 46-second cycle random-walks those phases apart far too slowly to matter. Two
-// things would actually address it, both filed rather than done here: not
-// resetting the schedule for a connection that never proved itself, and honoring
-// the typed rate-limit hint that connectLocked already builds and reconnect
-// currently discards.
+// things would actually address it, both filed rather than done here: #746, not
+// resetting the schedule for a connection that never proved itself, and #747,
+// honoring the typed rate-limit hint that connectLocked already builds and
+// reconnect currently discards. #747 outranks this jitter for a 429ing endpoint,
+// because it uses the interval the server actually sent rather than one we
+// invented.
 
 // NewWSClient creates a new WebSocket client.
 func NewWSClient(cfg WSClientConfig) *WSClient {

--- a/internal/redisapi/websocket.go
+++ b/internal/redisapi/websocket.go
@@ -348,10 +348,19 @@ func (c *WSClient) armKeepalive(conn *websocket.Conn) {
 	conn.SetPingHandler(func(appData string) error {
 		// A server-side keepalive counts as liveness too. We still have to
 		// answer it, which gorilla's default handler would have done for us,
-		// so replicate that here including its error swallowing: a peer that
-		// has already gone away must not turn into a read error from the pong.
+		// so replicate that here including its one-second bound and its error
+		// swallowing: a peer that has already gone away must not turn into a
+		// read error from the pong.
+		//
+		// The short bound is the point. This runs on the read goroutine, and
+		// WriteControl waits on gorilla's write semaphore, which an in-flight
+		// WriteMessage can hold for defaultWriteTimeout. A longer deadline here
+		// would park the ONLY reader behind write congestion, processing no
+		// inbound messages while it waited. Skipping a pong is cheaper: the
+		// timeout is swallowed below, we keep reading, and if the peer really
+		// does give up on us the read deadline notices within pongWait.
 		_ = conn.SetReadDeadline(time.Now().Add(c.pongWait))
-		err := conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(pingWriteWait))
+		err := conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(pongReplyWait))
 		if err == websocket.ErrCloseSent {
 			return nil
 		}
@@ -645,6 +654,11 @@ const (
 // for up to defaultWriteTimeout, so this is a bound on how long a ping may wait
 // rather than a liveness signal. Failing here is advisory; see pingLoop.
 const pingWriteWait = 10 * time.Second
+
+// pongReplyWait bounds the pong we send in answer to a server ping. It is much
+// shorter than pingWriteWait because that reply runs on the read goroutine; see
+// the ping handler in armKeepalive. It matches gorilla's own default handler.
+const pongReplyWait = time.Second
 
 // tryLockWrite acquires writeMu, giving up after d. Close must not block
 // forever behind a wedged writer (see the deadline note in Close), so it needs

--- a/internal/redisapi/websocket_backoff_test.go
+++ b/internal/redisapi/websocket_backoff_test.go
@@ -28,12 +28,17 @@ import (
 // between them is single-goroutine.
 //
 // The racing goroutine calls connectLocked under connMu, which is exactly what
-// Connect does minus its `go c.readLoop()`. Calling the exported Connect here
-// instead would start a second read loop on the same gorilla Conn, and gorilla
-// permits one concurrent reader just as it permits one concurrent writer. That
-// is a real and separate bug (citadel-cli#740), reachable by the same
-// Connect-during-reconnect overlap; including it would make this test fail for
-// a reason #728 does not fix.
+// Connect does minus its loop startup. That was originally a workaround: on the
+// #728 branch alone, calling the exported Connect here would have started a
+// SECOND read loop on the same gorilla Conn (citadel-cli#740), and the test
+// would have failed for a reason #728 does not fix.
+//
+// #740 is fixed now (loopsOnce), so that constraint is gone and the exported
+// Connect is safe to race. This test is deliberately kept at the accessor level
+// anyway: it is the narrow, fast check that the read-modify-write itself is
+// guarded. TestConnectRacesKeepaliveTeardownOnTheBackoffSchedule in
+// websocket_reconnect_test.go is the wider one, driving the exported Connect
+// against a reconnect that a real read-deadline expiry started.
 func TestReconnectBackoffAccessIsSynchronized(t *testing.T) {
 	srv := newDrainingWSServer(t)
 

--- a/internal/redisapi/websocket_backoff_test.go
+++ b/internal/redisapi/websocket_backoff_test.go
@@ -1,0 +1,183 @@
+package redisapi
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestReconnectBackoffAccessIsSynchronized is the regression test for issue
+// #728: reconnect() read and advanced reconnectBackoff with no lock at all,
+// while connectLocked wrote the same field under connMu.
+//
+// The colliding pair is Connect() versus an in-flight reconnect(), not two
+// reconnects: handleDisconnect's connection-pointer guard means a second caller
+// failing on the SAME connection returns before it can spawn a second reconnect
+// goroutine, because c.conn is already nil by then. Issue
+// #723 made that pair ordinary rather than exotic: enableWebSocketWithRetry
+// keeps calling Client.EnableWebSocket in the background, EnableWebSocket
+// forwards to Connect whenever IsConnected() is false, and IsConnected() is
+// false for the whole reconnect window (up to maxBackoff).
+//
+// The test drives that pair directly. Each round starts disconnected with a
+// short schedule so reconnect takes its read-modify-write path, then races one
+// reconnect against one connect. The two goroutines are deliberately unordered:
+// any channel or lock used to sequence them would establish a happens-before
+// edge and hide the very race being asserted. Rounds are joined, so the setup
+// between them is single-goroutine.
+//
+// The racing goroutine calls connectLocked under connMu, which is exactly what
+// Connect does minus its `go c.readLoop()`. Calling the exported Connect here
+// instead would start a second read loop on the same gorilla Conn, and gorilla
+// permits one concurrent reader just as it permits one concurrent writer. That
+// is a real and separate bug (citadel-cli#740), reachable by the same
+// Connect-during-reconnect overlap; including it would make this test fail for
+// a reason #728 does not fix.
+func TestReconnectBackoffAccessIsSynchronized(t *testing.T) {
+	srv := newDrainingWSServer(t)
+
+	c := NewWSClient(WSClientConfig{BaseURL: srv.URL, Token: "test-token"})
+	t.Cleanup(func() { _ = c.Close() })
+
+	ctx := context.Background()
+
+	const rounds = 40
+	for i := 0; i < rounds; i++ {
+		c.connMu.Lock()
+		if c.conn != nil {
+			_ = c.conn.Close()
+			c.conn = nil
+		}
+		c.connected = false
+		c.reconnectBackoff = time.Millisecond
+		c.maxBackoff = time.Millisecond
+		c.connMu.Unlock()
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			c.reconnect()
+		}()
+		go func() {
+			defer wg.Done()
+			c.connMu.Lock()
+			err := c.connectLocked(ctx)
+			c.connMu.Unlock()
+			if err != nil {
+				t.Errorf("connect: %v", err)
+			}
+		}()
+		wg.Wait()
+	}
+}
+
+// TestNextReconnectDelayAdvancesAndClamps pins the schedule itself: each call
+// returns the current delay and leaves the next one doubled, until maxBackoff
+// caps it.
+//
+// It asserts on returned values, never on elapsed time. An earlier backoff test
+// elsewhere in this codebase asserted on the wall clock and was flaky in the
+// dangerous direction: an overshoot was indistinguishable from a correct wait,
+// so the failure this whole area is about (a backoff that is too SHORT) is
+// exactly the one such a test cannot see.
+func TestNextReconnectDelayAdvancesAndClamps(t *testing.T) {
+	c := NewWSClient(WSClientConfig{BaseURL: "https://example.invalid", Token: "t"})
+	c.reconnectBackoff = 100 * time.Millisecond
+	c.maxBackoff = 400 * time.Millisecond
+
+	want := []time.Duration{
+		100 * time.Millisecond,
+		200 * time.Millisecond,
+		400 * time.Millisecond,
+		400 * time.Millisecond,
+		400 * time.Millisecond,
+	}
+	for i, w := range want {
+		if got := c.nextReconnectDelay(); got != w {
+			t.Fatalf("call %d: nextReconnectDelay() = %v, want %v", i+1, got, w)
+		}
+	}
+}
+
+// TestNextReconnectDelayAdvancesAtomically checks that the read, the doubling
+// and the clamp are one indivisible step.
+//
+// handleDisconnect's connection-pointer guard means one disconnect event cannot
+// spawn two reconnect goroutines: the second caller sees c.conn already nil and
+// returns. Two can still coexist, but only if a Connect lands in the reconnect
+// window and the connection it establishes then fails, which is the same #723
+// precondition as the race above.
+//
+// So this is mostly about the accessor's own contract. If it were built out of a
+// separate load and store, two callers could read the same value and store the
+// same doubled one, losing a doubling and making the schedule quietly tighter
+// than it looks. Distinct return values rule that out, and the assertion is on
+// the set of values, not on order or on time.
+func TestNextReconnectDelayAdvancesAtomically(t *testing.T) {
+	const (
+		callers = 8
+		rounds  = 300
+	)
+
+	c := NewWSClient(WSClientConfig{BaseURL: "https://example.invalid", Token: "t"})
+	// Above the largest expected delay (128ms), so nothing clamps and every
+	// caller in a round must come away with a different value.
+	c.maxBackoff = time.Second
+
+	// A lost doubling needs the two callers to interleave, so one round proves
+	// little. Repeat: rounds are joined, so each one is an independent trial and
+	// the assertion stays on values rather than on timing.
+	got := make([]time.Duration, callers)
+	for r := 0; r < rounds; r++ {
+		// Under connMu, which is the field's guard, even though the previous
+		// round is already joined.
+		c.connMu.Lock()
+		c.reconnectBackoff = time.Millisecond
+		c.connMu.Unlock()
+
+		var wg sync.WaitGroup
+		for i := 0; i < callers; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				got[i] = c.nextReconnectDelay()
+			}(i)
+		}
+		wg.Wait()
+
+		seen := make(map[time.Duration]int, callers)
+		for _, d := range got {
+			seen[d]++
+		}
+		for i := 0; i < callers; i++ {
+			want := time.Duration(1<<uint(i)) * time.Millisecond
+			if seen[want] != 1 {
+				t.Fatalf("round %d: delay %v handed out %d times, want exactly 1 (all delays: %v)",
+					r, want, seen[want], got)
+			}
+		}
+	}
+}
+
+// TestSuccessfulConnectResetsReconnectBackoff pins the other half of the
+// schedule: a connection that comes back returns the node to the initial delay,
+// so a later blip does not start out already backed off to a minute.
+func TestSuccessfulConnectResetsReconnectBackoff(t *testing.T) {
+	srv := newDrainingWSServer(t)
+
+	c := NewWSClient(WSClientConfig{BaseURL: srv.URL, Token: "test-token"})
+	c.reconnectEnabled = false
+	t.Cleanup(func() { _ = c.Close() })
+
+	c.reconnectBackoff = 42 * time.Second
+
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+
+	if got := c.nextReconnectDelay(); got != initialReconnectBackoff {
+		t.Fatalf("delay after a successful connect = %v, want %v", got, initialReconnectBackoff)
+	}
+}

--- a/internal/redisapi/websocket_backoff_test.go
+++ b/internal/redisapi/websocket_backoff_test.go
@@ -82,10 +82,14 @@ func TestReconnectBackoffAccessIsSynchronized(t *testing.T) {
 // dangerous direction: an overshoot was indistinguishable from a correct wait,
 // so the failure this whole area is about (a backoff that is too SHORT) is
 // exactly the one such a test cannot see.
+// The jitter is stubbed to its zero draw so this keeps pinning the SCHEDULE,
+// which is what it is about. The jitter that sits on top of the schedule has
+// its own tests in websocket_reconnect_test.go.
 func TestNextReconnectDelayAdvancesAndClamps(t *testing.T) {
 	c := NewWSClient(WSClientConfig{BaseURL: "https://example.invalid", Token: "t"})
 	c.reconnectBackoff = 100 * time.Millisecond
 	c.maxBackoff = 400 * time.Millisecond
+	c.jitterFrac = func() float64 { return 0 }
 
 	want := []time.Duration{
 		100 * time.Millisecond,
@@ -125,6 +129,9 @@ func TestNextReconnectDelayAdvancesAtomically(t *testing.T) {
 	// Above the largest expected delay (128ms), so nothing clamps and every
 	// caller in a round must come away with a different value.
 	c.maxBackoff = time.Second
+	// Zero draw: the subject here is the read-modify-write, not the jitter, and
+	// a random addend would blur the distinct-values assertion below.
+	c.jitterFrac = func() float64 { return 0 }
 
 	// A lost doubling needs the two callers to interleave, so one round proves
 	// little. Repeat: rounds are joined, so each one is an independent trial and
@@ -172,6 +179,8 @@ func TestSuccessfulConnectResetsReconnectBackoff(t *testing.T) {
 	t.Cleanup(func() { _ = c.Close() })
 
 	c.reconnectBackoff = 42 * time.Second
+	// Zero draw, so the assertion below is on the reset value itself.
+	c.jitterFrac = func() float64 { return 0 }
 
 	if err := c.Connect(context.Background()); err != nil {
 		t.Fatalf("connect: %v", err)

--- a/internal/redisapi/websocket_keepalive_test.go
+++ b/internal/redisapi/websocket_keepalive_test.go
@@ -53,11 +53,16 @@ func waitFor(cond func() bool, budget time.Duration) bool {
 
 // newKeepaliveTestClient builds a client with the keepalive scaled down so a
 // test does not have to wait out the production 45s read deadline.
+//
+// The scaling keeps production's 1:4 ping-to-deadline ratio but stays coarse on
+// purpose. CI runs these on a shared, heavily contended runner under -race, and
+// a sub-second budget would turn an ordinary scheduling hiccup into a red build
+// that gets rerun rather than diagnosed.
 func newKeepaliveTestClient(srv *httptest.Server) *WSClient {
 	c := NewWSClient(WSClientConfig{BaseURL: srv.URL, Token: "test-token"})
 	c.reconnectEnabled = false
-	c.pingInterval = 100 * time.Millisecond
-	c.pongWait = 400 * time.Millisecond
+	c.pingInterval = 250 * time.Millisecond
+	c.pongWait = time.Second
 	return c
 }
 
@@ -151,7 +156,7 @@ func TestPingsReachTheServer(t *testing.T) {
 	}
 	defer func() { _ = c.Close() }()
 
-	// pingInterval is 100ms, so three pings is a very slack budget.
+	// pingInterval is 250ms, so a 5s budget for three pings is very slack.
 	if !waitFor(func() bool { return pings.Load() >= 3 }, 5*time.Second) {
 		t.Fatalf("server saw %d pings, want at least 3: the ping ticker is not running", pings.Load())
 	}
@@ -187,8 +192,8 @@ func TestReadDeadlineDisconnectTriggersReconnect(t *testing.T) {
 	t.Cleanup(func() { close(release) })
 
 	c := NewWSClient(WSClientConfig{BaseURL: srv.URL, Token: "test-token"})
-	c.pingInterval = 100 * time.Millisecond
-	c.pongWait = 400 * time.Millisecond
+	c.pingInterval = 250 * time.Millisecond
+	c.pongWait = time.Second
 	// reconnectEnabled defaults on for a configured BaseURL; make it explicit,
 	// since the whole subject of this test is the reconnect.
 	c.reconnectEnabled = true
@@ -252,8 +257,8 @@ func TestKeepaliveIsRearmedOnEveryReconnect(t *testing.T) {
 	t.Cleanup(func() { close(release) })
 
 	c := NewWSClient(WSClientConfig{BaseURL: srv.URL, Token: "test-token"})
-	c.pingInterval = 100 * time.Millisecond
-	c.pongWait = 400 * time.Millisecond
+	c.pingInterval = 250 * time.Millisecond
+	c.pongWait = time.Second
 	c.reconnectEnabled = true
 	c.reconnectBackoff = 50 * time.Millisecond
 

--- a/internal/redisapi/websocket_keepalive_test.go
+++ b/internal/redisapi/websocket_keepalive_test.go
@@ -1,0 +1,255 @@
+package redisapi
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// newSilentWSServer upgrades the connection and then does nothing at all: it
+// never sends a message and, because it never calls ReadMessage, it never
+// answers a ping either. From the client's side that is indistinguishable from
+// a peer that vanished without a FIN reaching us, which is the half-open case
+// #734 is about.
+func newSilentWSServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	upgrader := websocket.Upgrader{}
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		<-release
+	}))
+	// LIFO: release the parked handler before shutting the server down,
+	// otherwise srv.Close() waits on it forever.
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(release) })
+	return srv
+}
+
+// waitFor polls cond until it holds or the budget runs out.
+func waitFor(cond func() bool, budget time.Duration) bool {
+	deadline := time.Now().Add(budget)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return cond()
+}
+
+// newKeepaliveTestClient builds a client with the keepalive scaled down so a
+// test does not have to wait out the production 45s read deadline.
+func newKeepaliveTestClient(srv *httptest.Server) *WSClient {
+	c := NewWSClient(WSClientConfig{BaseURL: srv.URL, Token: "test-token"})
+	c.reconnectEnabled = false
+	c.pingInterval = 100 * time.Millisecond
+	c.pongWait = 400 * time.Millisecond
+	return c
+}
+
+// TestReadDeadlineTearsDownASilentConnection is the core #734 regression.
+//
+// Without a read deadline, readLoop blocks in ReadMessage forever against a
+// peer that has gone away without a FIN. connected stays true, Publish writes
+// into a dead socket and reports success, handleDisconnect never fires, and
+// citadel status happily reports pubsub_transport: websocket while nothing is
+// flowing. The client must notice on its own.
+func TestReadDeadlineTearsDownASilentConnection(t *testing.T) {
+	srv := newSilentWSServer(t)
+	c := newKeepaliveTestClient(srv)
+
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	if !c.IsConnected() {
+		t.Fatal("IsConnected() = false right after a successful connect")
+	}
+
+	if !waitFor(func() bool { return !c.IsConnected() }, 5*time.Second) {
+		t.Fatal("still reporting connected against a silent peer: the read deadline never fired (#734)")
+	}
+
+	// The whole point of tearing down is that the caller falls back to HTTP
+	// instead of publishing into a dead socket and being told it worked.
+	if err := c.Publish(context.Background(), "chan", map[string]any{"a": 1}); err == nil {
+		t.Fatal("Publish succeeded on a torn-down connection; the silent-success bug is still reachable")
+	}
+}
+
+// TestKeepaliveHoldsAQuietButHealthyConnection is the counterweight. A
+// connection with no application traffic at all must stay up indefinitely,
+// because our own pings are answered. It fails if the ping ticker does not run
+// or if the pong handler does not push the read deadline out, which is the
+// obvious way to "fix" #734 and end up with a node that reconnects every 45s.
+func TestKeepaliveHoldsAQuietButHealthyConnection(t *testing.T) {
+	// A draining server sits in ReadMessage, so gorilla's default ping handler
+	// answers our pings. No application messages are ever exchanged.
+	srv := newDrainingWSServer(t)
+	c := newKeepaliveTestClient(srv)
+
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	// Five times the read deadline with nothing but keepalive traffic.
+	deadline := time.Now().Add(5 * c.pongWait)
+	for time.Now().Before(deadline) {
+		if !c.IsConnected() {
+			t.Fatal("healthy but idle connection was torn down: keepalive is not extending the read deadline")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// TestPingsReachTheServer pins the ping ticker itself. The previous test would
+// also pass if the server happened to be chatty; this one asserts the frames
+// are actually on the wire at roughly the configured cadence.
+func TestPingsReachTheServer(t *testing.T) {
+	var pings atomic.Int64
+
+	upgrader := websocket.Upgrader{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		// Overriding the handler replaces gorilla's automatic pong, so answer
+		// by hand; otherwise the client would rightly declare us dead.
+		conn.SetPingHandler(func(appData string) error {
+			pings.Add(1)
+			return conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(time.Second))
+		})
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newKeepaliveTestClient(srv)
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	// pingInterval is 100ms, so three pings is a very slack budget.
+	if !waitFor(func() bool { return pings.Load() >= 3 }, 5*time.Second) {
+		t.Fatalf("server saw %d pings, want at least 3: the ping ticker is not running", pings.Load())
+	}
+}
+
+// TestReadDeadlineDisconnectTriggersReconnect closes the loop: detecting death
+// is only useful if it feeds the existing reconnect path. A node that notices
+// and then sits there is no better off than one that never noticed.
+func TestReadDeadlineDisconnectTriggersReconnect(t *testing.T) {
+	var attempts atomic.Int64
+	upgrader := websocket.Upgrader{}
+	release := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		if attempts.Add(1) == 1 {
+			// First connection goes silent: never reads, so never pongs.
+			<-release
+			return
+		}
+		// Every later connection behaves, answering pings from ReadMessage.
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(release) })
+
+	c := NewWSClient(WSClientConfig{BaseURL: srv.URL, Token: "test-token"})
+	c.pingInterval = 100 * time.Millisecond
+	c.pongWait = 400 * time.Millisecond
+	// reconnectEnabled defaults on for a configured BaseURL; make it explicit,
+	// since the whole subject of this test is the reconnect.
+	c.reconnectEnabled = true
+	c.reconnectBackoff = 50 * time.Millisecond
+
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	if !waitFor(func() bool { return attempts.Load() >= 2 && c.IsConnected() }, 15*time.Second) {
+		t.Fatalf("no reconnect after a read-deadline disconnect: attempts=%d connected=%v",
+			attempts.Load(), c.IsConnected())
+	}
+}
+
+// TestPingsAreSafeAlongsideConcurrentWrites checks the load-bearing claim that
+// the ping needs no writeMu.
+//
+// gorilla permits ONE concurrent writer and panics from flushFrame otherwise,
+// taking the worker process with it (#720). WriteControl is documented safe
+// alongside other methods and the vendored source backs that up, but the claim
+// is worth an actual test: a ping every millisecond against 50 publishers
+// pushing 8KB frames. Running the fix with WriteMessage(PingMessage) in place
+// of WriteControl panics here.
+func TestPingsAreSafeAlongsideConcurrentWrites(t *testing.T) {
+	srv := newDrainingWSServer(t)
+
+	c := NewWSClient(WSClientConfig{BaseURL: srv.URL, Token: "test-token"})
+	c.reconnectEnabled = false
+	c.pingInterval = time.Millisecond
+	// Long enough that the read deadline is not what ends this test.
+	c.pongWait = time.Minute
+
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+
+	payload := map[string]any{"blob": strings.Repeat("p", 8192)}
+
+	const (
+		writers   = 50
+		perWriter = 50
+	)
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := range writers {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			for range perWriter {
+				_ = c.Publish(context.Background(), fmt.Sprintf("ping-race-%d", i), payload)
+			}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	if err := c.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}

--- a/internal/redisapi/websocket_keepalive_test.go
+++ b/internal/redisapi/websocket_keepalive_test.go
@@ -203,6 +203,70 @@ func TestReadDeadlineDisconnectTriggersReconnect(t *testing.T) {
 		t.Fatalf("no reconnect after a read-deadline disconnect: attempts=%d connected=%v",
 			attempts.Load(), c.IsConnected())
 	}
+
+	// The reconnected socket must be armed too. Without this the test would
+	// pass on a connection that merely happened to be up at the instant we
+	// looked: connectLocked, not Connect, is what has to arm the keepalive,
+	// because reconnect never goes through Connect. An unarmed connection has
+	// no read deadline and no pings, which is the original bug restored on
+	// every socket after the first.
+	settled := attempts.Load()
+	deadline := time.Now().Add(3 * c.pongWait)
+	for time.Now().Before(deadline) {
+		if !c.IsConnected() {
+			t.Fatal("reconnected connection dropped again: it is not being kept alive")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if got := attempts.Load(); got != settled {
+		t.Fatalf("dial attempts kept climbing (%d -> %d) against a healthy peer: reconnect is flapping", settled, got)
+	}
+}
+
+// TestKeepaliveIsRearmedOnEveryReconnect pins that connectLocked, not Connect,
+// owns the arming.
+//
+// Reconnect never goes through Connect, so arming there would leave every
+// socket after the first with no read deadline and no handlers. That is the
+// original bug restored one connection later, and it is invisible to a test
+// that only checks the reconnected socket stays up: an unarmed connection is
+// MORE stable, not less, because nothing can ever declare it dead. The
+// observable difference is whether the client keeps noticing. Here every
+// connection the server accepts goes silent, so a correctly armed client
+// detects and redials over and over; an armed-once client stalls at two.
+func TestKeepaliveIsRearmedOnEveryReconnect(t *testing.T) {
+	var attempts atomic.Int64
+	upgrader := websocket.Upgrader{}
+	release := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		attempts.Add(1)
+		<-release
+	}))
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(release) })
+
+	c := NewWSClient(WSClientConfig{BaseURL: srv.URL, Token: "test-token"})
+	c.pingInterval = 100 * time.Millisecond
+	c.pongWait = 400 * time.Millisecond
+	c.reconnectEnabled = true
+	c.reconnectBackoff = 50 * time.Millisecond
+
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	// Three accepted connections means the SECOND one was detected as dead too,
+	// which can only happen if the reconnect path armed it.
+	if !waitFor(func() bool { return attempts.Load() >= 3 }, 25*time.Second) {
+		t.Fatalf("server accepted %d connections, want at least 3: the keepalive is not re-armed after a reconnect", attempts.Load())
+	}
 }
 
 // TestPingsAreSafeAlongsideConcurrentWrites checks the load-bearing claim that

--- a/internal/redisapi/websocket_reconnect_test.go
+++ b/internal/redisapi/websocket_reconnect_test.go
@@ -50,6 +50,13 @@ import (
 // used to sequence them would establish the happens-before edge that hides the
 // race being asserted. The test therefore asserts nothing itself; the race
 // detector is the assertion.
+//
+// It is ALSO the regression test for #740, which is why it is worth driving the
+// exported Connect rather than connectLocked. Restoring the pre-loopsOnce bare
+// `go c.readLoop()` in Connect makes this test report the exact trace #740 was
+// filed with: two readLoop goroutines inside gorilla's NextReader on the same
+// Conn. Without that, #740 would be closed here with no coverage at all, and a
+// later refactor that dropped loopsOnce would reintroduce it silently.
 func TestConnectRacesKeepaliveTeardownOnTheBackoffSchedule(t *testing.T) {
 	srv := newSilentWSServer(t)
 

--- a/internal/redisapi/websocket_reconnect_test.go
+++ b/internal/redisapi/websocket_reconnect_test.go
@@ -1,0 +1,275 @@
+package redisapi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// No test in this file measures elapsed time. Wall-clock assertions on a
+// contended CI runner under -race are flaky in the direction that HIDES a
+// regression: an overloaded machine overshoots a short sleep enough that it
+// looks like a long one, so a backoff that has collapsed to nothing still
+// passes. The same reasoning is written out above backoffSleep in cmd/work.go,
+// which exists because that mistake was already shipped here once.
+//
+// So the jitter tests assert on the value nextReconnectDelay RETURNS, with the
+// randomness injected, and the Close test asserts on a dial COUNT with a budget
+// several times the backoff rather than on when the dial happened.
+
+// TestConnectRacesKeepaliveTeardownOnTheBackoffSchedule is the test that
+// integrating #728 and #734 actually requires, and that neither PR had.
+//
+// #743's race test deliberately called connectLocked under connMu instead of the
+// exported Connect, because on that branch a Connect landing inside a reconnect
+// window would start a SECOND readLoop on the same gorilla Conn (#740) and the
+// test would fail for a reason #728 does not fix. #745's loopsOnce removes that
+// obstacle, so this can drive the real path.
+//
+// #745's own keepalive tests do not prove #728 absent either: in them both
+// writes to reconnectBackoff land on the same goroutine, so -race is clean for
+// the wrong reason.
+//
+// Here the two writes are on genuinely different goroutines, reached the way
+// production reaches them:
+//
+//   - Every connection the server accepts goes silent, so every one dies at the
+//     read deadline. That is the #734 path, and it runs handleDisconnect ->
+//     go reconnect() -> nextReconnectDelay. Before #734 this fired almost never.
+//   - A background loop calls the exported Connect whenever IsConnected() is
+//     false, which is the exact shape of Client.EnableWebSocket under #723's
+//     background retry. Connect -> connectLocked writes the same field.
+//
+// Nothing orders those two goroutines against each other. Any channel or mutex
+// used to sequence them would establish the happens-before edge that hides the
+// race being asserted. The test therefore asserts nothing itself; the race
+// detector is the assertion.
+func TestConnectRacesKeepaliveTeardownOnTheBackoffSchedule(t *testing.T) {
+	srv := newSilentWSServer(t)
+
+	c := NewWSClient(WSClientConfig{BaseURL: srv.URL, Token: "test-token"})
+	c.pingInterval = 20 * time.Millisecond
+	c.pongWait = 100 * time.Millisecond
+	c.reconnectEnabled = true
+	c.reconnectBackoff = time.Millisecond
+	c.maxBackoff = 2 * time.Millisecond
+	t.Cleanup(func() { _ = c.Close() })
+
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if !c.IsConnected() {
+				// Errors are uninteresting: a losing dial is a normal outcome
+				// of racing a reconnect, and the subject is the field access.
+				_ = c.Connect(context.Background())
+			}
+			time.Sleep(200 * time.Microsecond)
+		}
+	}()
+
+	// The budget only decides how many teardown cycles the detector gets to
+	// look at (pongWait is 100ms, so this is roughly twenty). Nothing is
+	// asserted about how long anything took.
+	time.Sleep(2 * time.Second)
+
+	close(stop)
+	wg.Wait()
+}
+
+// TestReconnectDelayIsNeverShorterThanTheSchedule is the property that decided
+// the jitter scheme.
+//
+// The delay is drawn from [base, 2*base): additive and upward-only. Full jitter,
+// rand(0, base), was rejected precisely because it fails this: its floor is zero
+// and its mean is half the schedule, so a node that has just been answered 429
+// could redial immediately and fleet-wide retry pressure doubles. That is the
+// #443 shape, and #728 names too-aggressive as the direction that matters.
+func TestReconnectDelayIsNeverShorterThanTheSchedule(t *testing.T) {
+	// The extremes of the draw bracket the whole window.
+	for name, frac := range map[string]float64{"lowest draw": 0, "highest draw": 0.999999} {
+		t.Run(name, func(t *testing.T) {
+			c := NewWSClient(WSClientConfig{BaseURL: "https://example.invalid", Token: "t"})
+			c.reconnectBackoff = 100 * time.Millisecond
+			c.maxBackoff = 400 * time.Millisecond
+			c.jitterFrac = func() float64 { return frac }
+
+			// The schedule the delays must bracket, including the clamp.
+			bases := []time.Duration{
+				100 * time.Millisecond,
+				200 * time.Millisecond,
+				400 * time.Millisecond,
+				400 * time.Millisecond,
+				400 * time.Millisecond,
+			}
+			for i, base := range bases {
+				got := c.nextReconnectDelay()
+				if got < base {
+					t.Fatalf("attempt %d: delay %v is SHORTER than the schedule step %v; jitter must never make a retry more aggressive than it was before", i+1, got, base)
+				}
+				if got >= 2*base {
+					t.Fatalf("attempt %d: delay %v is outside the [%v, %v) window", i+1, got, base, 2*base)
+				}
+			}
+		})
+	}
+}
+
+// TestReconnectDelaySpreadSurvivesAtTheMaximumBackoff pins the case that made
+// the "do not clamp the jittered result to maxBackoff" decision.
+//
+// A long control-plane outage puts every node in the fleet at the ceiling, which
+// is exactly when a lockstep redial is most damaging against a rate-limited
+// endpoint. Clamping the jittered delay to maxBackoff would make every node at
+// the ceiling sleep exactly maxBackoff, collapsing the spread to zero in the
+// worst case. maxBackoff therefore caps the SCHEDULE, not the sleep.
+func TestReconnectDelaySpreadSurvivesAtTheMaximumBackoff(t *testing.T) {
+	c := NewWSClient(WSClientConfig{BaseURL: "https://example.invalid", Token: "t"})
+	c.maxBackoff = time.Minute
+	// Pinned at the ceiling: nextReconnectDelay leaves it there.
+	c.reconnectBackoff = c.maxBackoff
+
+	ceiling := c.maxBackoff
+	const draws = 200
+	var sawLow, sawHigh bool
+	for i := 0; i < draws; i++ {
+		d := c.nextReconnectDelay()
+		if d < ceiling {
+			t.Fatalf("draw %d: delay %v is shorter than the ceiling %v", i, d, ceiling)
+		}
+		if d >= 2*ceiling {
+			t.Fatalf("draw %d: delay %v is outside the [%v, %v) window", i, d, ceiling, 2*ceiling)
+		}
+		if d < ceiling+ceiling/4 {
+			sawLow = true
+		}
+		if d > ceiling+3*ceiling/4 {
+			sawHigh = true
+		}
+	}
+	// With 200 uniform draws, missing either quarter is a ~1e-25 event, so this
+	// is a statement about the code and not about luck.
+	if !sawLow || !sawHigh {
+		t.Fatalf("delays at the ceiling did not spread across the window (saw a low draw: %v, saw a high draw: %v); every node pinned at maxBackoff would redial in lockstep", sawLow, sawHigh)
+	}
+}
+
+// TestJitterDoesNotContaminateTheStoredSchedule keeps the randomness in the
+// returned sleep and out of the state.
+//
+// If the jittered value were stored back, randomness would compound across
+// attempts, connectLocked's reset would no longer mean exactly "back to one
+// second", and the schedule would stop being something a reader can predict from
+// the constants. Only the sleep is random.
+func TestJitterDoesNotContaminateTheStoredSchedule(t *testing.T) {
+	c := NewWSClient(WSClientConfig{BaseURL: "https://example.invalid", Token: "t"})
+	c.reconnectBackoff = 100 * time.Millisecond
+	c.maxBackoff = 400 * time.Millisecond
+	// A mid-window draw, so a contaminated schedule diverges immediately.
+	c.jitterFrac = func() float64 { return 0.5 }
+
+	want := []time.Duration{
+		200 * time.Millisecond,
+		400 * time.Millisecond,
+		400 * time.Millisecond,
+		400 * time.Millisecond,
+	}
+	for i, w := range want {
+		_ = c.nextReconnectDelay()
+		c.connMu.RLock()
+		got := c.reconnectBackoff
+		c.connMu.RUnlock()
+		if got != w {
+			t.Fatalf("after call %d the stored schedule = %v, want %v: the jitter is leaking into the state", i+1, got, w)
+		}
+	}
+}
+
+// TestCloseDuringTheBackoffPreventsAFurtherDial is the #741 regression.
+//
+// reconnect checked c.done at the top of the loop and then slept for the whole
+// backoff without re-checking it, so a Close landing inside that sleep still let
+// the loop dial afterwards. On success it set connected = true and c.conn on a
+// client the caller had already closed, so IsConnected() reported true after
+// Close returned and the socket it opened was left dangling.
+//
+// It is fixed here rather than filed because the keepalive changes its odds: the
+// window used to open almost never and now opens on every read-deadline expiry,
+// and the jitter above lengthens the sleep it lives in.
+//
+// The assertion is a dial count under a budget several times the backoff, never
+// an elapsed-time comparison. A broken implementation reaches the second dial at
+// about one second; a correct one never reaches it at all.
+func TestCloseDuringTheBackoffPreventsAFurtherDial(t *testing.T) {
+	var dials atomic.Int64
+	upgrader := websocket.Upgrader{}
+	release := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		dials.Add(1)
+		<-release
+	}))
+	// LIFO: release the parked handlers before the server shuts down.
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(release) })
+
+	c := NewWSClient(WSClientConfig{BaseURL: srv.URL, Token: "test-token"})
+	c.reconnectEnabled = true
+	// The read deadline must not be what ends this test.
+	c.pingInterval = time.Second
+	c.pongWait = time.Minute
+	// One second of backoff, entered deterministically: Close lands about a
+	// hundredth of the way into it, and the check below waits five times it.
+	c.reconnectBackoff = time.Second
+	c.maxBackoff = time.Second
+	c.jitterFrac = func() float64 { return 0 }
+
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if got := dials.Load(); got != 1 {
+		t.Fatalf("dials after the first connect = %d, want 1", got)
+	}
+
+	// Tear the connection down the way a read error would, which schedules the
+	// reconnect and starts its backoff sleep.
+	c.connMu.RLock()
+	conn := c.conn
+	c.connMu.RUnlock()
+	c.handleDisconnect(conn)
+
+	// Close well inside the backoff window.
+	time.Sleep(10 * time.Millisecond)
+	if err := c.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if waitFor(func() bool { return dials.Load() >= 2 }, 5*time.Second) {
+		t.Fatalf("reconnect dialed after Close (%d dials): done is not re-checked after the backoff sleep (#741)", dials.Load())
+	}
+	if c.IsConnected() {
+		t.Fatal("IsConnected() is true after Close: a reconnect marked a closed client connected")
+	}
+}

--- a/internal/redisapi/websocket_write_test.go
+++ b/internal/redisapi/websocket_write_test.go
@@ -63,10 +63,14 @@ func newWedgedWSServer(t *testing.T) *httptest.Server {
 
 // newTestWSClient connects a WSClient to srv with reconnection disabled.
 //
-// Reconnect is off on purpose: reconnect() mutates reconnectBackoff without
-// holding connMu, which is a separate (real, unfixed) data race in this file.
-// Letting it run would make -race report something unrelated to the write path
-// under test.
+// Reconnect is off on purpose, so that a test which deliberately wedges or
+// breaks a write exercises only the write path. Several of these tests trigger
+// handleDisconnect, and letting it schedule reconnects would add dial attempts,
+// a second connection and its own goroutines to the picture under test.
+//
+// This used to say reconnect was excluded because it mutated reconnectBackoff
+// unsynchronized. That was true and is now fixed (#728); the field is guarded by
+// connMu and advanced through nextReconnectDelay.
 func newTestWSClient(t *testing.T, srv *httptest.Server) *WSClient {
 	t.Helper()
 


### PR DESCRIPTION
## Context

Integration branch for PR #743 (#728, `reconnectBackoff` synchronization) and PR
#745 (#734, ping/pong keepalive and read deadline), plus the jitter and the #741
fix that integrating them makes necessary. Opened as a draft for a human to
merge; #743 and #745 should be closed in favour of this rather than merged
alongside it, since both restructure the same function.

**They are not independent, and #745 must not ship without #743.** #745's own
author says so: before the keepalive, `handleDisconnect` almost never fired, so
`reconnect`'s unsynchronized `reconnectBackoff *= 2` almost never ran against
`connectLocked`'s `reconnectBackoff = time.Second` under `connMu`. After the
keepalive it fires on every read-deadline expiry. #745 turns a latent data race
into a routine one. Shipping it alone would be the third consecutive change to
this file that fixed one thing and made the next thing worse.

## How the conflict was resolved

One textual conflict, in the `WSClient` struct field block: both PRs inserted
above `// Reconnection settings`. Both sides kept, `loopsOnce` first.

Everything else auto-merged, and the two overlaps that matter were verified by
hand rather than trusted:

- **`connectLocked`.** #745 inserts `c.armKeepalive(conn)` immediately before
  `c.conn = conn`; #743 replaces the `c.reconnectBackoff = time.Second` line two
  lines later with `initialReconnectBackoff` plus a comment naming its guard.
  Both survive, in that order. The ordering is load-bearing on #745's side (the
  keepalive must be armed while `conn` is still private, because
  `SetReadDeadline` / `SetPongHandler` / `SetPingHandler` are gorilla READ
  methods and must not race `ReadMessage`), and on #743's side (the reset is
  safe because the caller holds `connMu`). Pinned by a mutation below.
- **`reconnect`'s sleep.** #745 does not touch it; #743 replaces the double read
  of the field with `nextReconnectDelay()`. #743's shape is kept, and it is the
  line the jitter and the #741 fix then modify.

No behaviour from either PR was dropped. Commits are ordered so a reviewer can
read the two merges separately from the new work.

## Jitter: additive and upward-only, `[base, 2*base)`

There was no randomness anywhere in this file. Every node ran exactly
1, 2, 4, ... 60 seconds, so a control-plane blip disconnects the whole fleet at
once and it redials in lockstep against an endpoint that answers 429. #734 makes
this worse rather than better, because the path now runs routinely.

The scheme is `delay = base + rand[0, base)`, where `base` is the deterministic
step. `nextReconnectDelay` returns the jittered value; `reconnectBackoff` keeps
storing the clean doubling, so nothing accumulates randomness and
`connectLocked`'s reset still means exactly "back to one second".

**Full jitter, `rand(0, base)`, was rejected** because its floor is zero: a node
just answered 429 could redial milliseconds later, and its mean delay is half the
current schedule, so fleet-wide retry pressure doubles. That is the #443 shape
(tight retries burned a node's daily Redis-API quota and locked it out for about
a day), and #728 explicitly names too-aggressive as the direction that matters.
`cmd/work.go` already refuses to "poll tighter than retry_after" for the same
reason; a client-side scheme that halves the mean would contradict it.

**Decorrelated jitter, `min(cap, rand(base, prev*3))`, was rejected** for a
weaker version of the same reason (it can return to `base` repeatedly, so a long
outage can sit near one second), and because its state is the previous SLEEP,
which collides with `reconnectBackoff` holding the deterministic schedule that
`connectLocked` resets.

Additive jitter is never shorter than what ships today, and its spread is the
full width of the current step, which is exactly what decorrelates a fleet whose
nodes all hold the same step after a shared blip.

**The jittered sleep is deliberately not clamped to `maxBackoff`.** `maxBackoff`
caps the schedule, not the sleep. Clamping the result would collapse the spread
to zero at the ceiling, which is precisely the worst case: a long outage puts
every node at the cap and they would all dial together again. This has its own
test and its own mutation.

### What the jitter does NOT fix

The failure #745 documented (a peer that is alive but never pongs, torn down
every `pongWait`, redialing at one second, forever, fleet-synchronized) is **not
fixed by jitter**, and the PR should not be read as claiming it is. That cycle's
period is dominated by `pongWait` (45s), not by the backoff (1s), so one second
of jitter per 46-second cycle random-walks the phases apart far too slowly to
matter at fleet scale. Jitter fixes the mass-disconnect herd, which is the
genuinely dangerous one against a rate-limited endpoint.

Two things would actually address the flap, both filed rather than done here:

- #746, the schedule resets on a connection that never proved itself.
- #747, `reconnect` discards the typed 429 `retry_after` that `connectLocked`
  goes out of its way to build. **For a 429ing endpoint this outranks the
  jitter**, because it uses the number the server actually sent instead of one we
  invented.

## #740: fixed, with a regression test. Mechanism.

`loopsOnce` makes a second reader structurally impossible, and the reason is
narrower than "one goroutine":

1. `readLoop` is started inside `c.loopsOnce.Do` in `Connect`, so at most one
   `readLoop` goroutine exists for the client's whole life.
2. It has exactly one `return`, the `<-c.done` case, so it cannot exit early and
   leave `loopsOnce` spent with no reader. (Verified: one `return` in the
   function.)
3. It is the only caller of `ReadMessage` in the package. `pingLoop` writes with
   `WriteControl`; the pong and ping handlers installed by `armKeepalive` run
   from inside `ReadMessage`, i.e. on the read goroutine.
4. The swap window does not create a second reader either, and this is the part
   the goroutine count alone does not cover. `Connect` dials only when
   `c.connected` is false, and `connected` goes false only in `handleDisconnect`
   (or `Close`), which under `connMu` closes the connection and nils `c.conn`
   BEFORE releasing the lock. So there is never a moment where `Connect` dials a
   second connection while `readLoop` is blocked on a live current one: the one
   it is blocked on has already been closed, gorilla documents `Close` as safe
   alongside any other method, so the blocked `ReadMessage` returns promptly,
   and `handleDisconnect`'s connection-pointer guard then makes that stale error
   a no-op against the new connection.

Also checked, because it is the "IsConnected() stays true and nothing flows"
shape: `reconnect -> connectLocked` never touches `loopsOnce`, so a client whose
first successful dial came via reconnect would be connected with no reader. That
is unreachable. `connectLocked` has exactly two callers (`Connect`, `reconnect`);
`reconnect` is spawned only from `handleDisconnect`; `handleDisconnect` is called
only from `readLoop` and `sendMessage`, and both require a prior successful
`Connect`. `Connect` runs `loopsOnce.Do` while still holding `connMu`, so the
loops are running before any other goroutine can observe `connected == true`.

That is the argument. The tripwire is mutation K below: restoring the
pre-`loopsOnce` bare `go c.readLoop()` in `Connect` makes
`TestConnectRacesKeepaliveTeardownOnTheBackoffSchedule` report the exact trace
#740 was filed with, two `readLoop` goroutines inside gorilla's `NextReader` on
the same `Conn`. So #740 is closed with coverage rather than with reasoning, and
a later refactor that drops `loopsOnce` cannot reintroduce it silently.

A comment with this mechanism has been posted on #740.

## #741: fixed here

Small, and squarely in scope: the keepalive changes its odds from rare to
routine (the window opens on every read-deadline expiry rather than almost
never), and the jitter lengthens the sleep the window lives in, up to two
minutes. `time.Sleep` is replaced by `sleepUnlessDone`, a select on a timer and
`c.done`, so `Close` during a backoff neither waits out the backoff nor lets a
dial happen afterwards.

The `context.Background()` sub-item of #741 is deliberately left: giving the
client a real context is a larger change than this loop, and it is noted in the
code.

## What the integrated result makes WORSE

1. **`connMu` contention on the reconnect path goes from exotic to routine.**
   #743 flagged `nextReconnectDelay` as "a new place the reconnect goroutine can
   park", because `Connect` holds `connMu` across a whole dial (bounded only by
   the 10s `HandshakeTimeout`). Integration is what makes that frequent: this
   path now runs on every read-deadline expiry per node. It is benign in
   direction (the effect is a longer wait, never a shorter one) but it is real.
2. **The worst-case pub/sub gap doubles, from one minute to two.** That is the
   price of keeping the spread alive at the ceiling. It is reached only after
   roughly seven consecutive failed dials, i.e. when the control plane is
   already down, and `Client.Publish` falls back to HTTP throughout. Stated
   plainly because it is a real regression in a number someone may be relying on.
3. **The next dial is no longer predictable from the log line.** `ws: attempting
   reconnect in %v` still reports the exact sleep, but two nodes at the same step
   no longer wait the same time, so "all nodes retry at t+4s" stops being a thing
   you can assume when reading logs across the fleet.
4. **The flap herd remains** (see above), and this PR adds the jitter that a
   future reader might mistake for a fix for it. That is why it is written out
   here and in the code, and why #746 and #747 exist.
5. **An orphaned-connection leak becomes more frequent, and is not fixed**
   (#748). `reconnect` re-checks `c.done` after the sleep now, but not
   `c.connected`, so a `Connect` that wins the race leaves the reconnect
   goroutine to dial a second connection that overwrites `c.conn` without
   closing the first. The keepalive multiplies the windows. It is not fixed here
   because the obvious one-line re-check would skip the `OnReconnect` callbacks
   that consumers use to re-arm, which is the "connected but nothing flows"
   failure this whole area exists to prevent. That decision deserves its own
   change.
6. **`reconnect` now looks even more finished than it is.** #743 made this point
   about itself; it is more true now. Three real defects remain in that function
   (#746, #747, #748) behind a body that reads as fully synchronized,
   cancellable and jittered.

## Testing

```
cpuslot go build ./... && cpuslot go vet ./...          clean
cpuslot go test ./...                                    all pass
cpuslot go test -race ./internal/redisapi/... ./internal/heartbeat/...
                                                         clean, run 3 times
```

No test asserts on elapsed wall-clock time. The jitter tests assert on the value
`nextReconnectDelay` returns with the randomness injected through a
`jitterFrac` field; the `Close` test asserts on a dial COUNT under a budget five
times the backoff. This is the failure mode `backoffSleep` in `cmd/work.go`
already documents: a timing assertion on a contended runner is flaky in the
direction that HIDES a regression, because an overloaded machine overshoots a
short sleep enough to make a collapsed backoff look correct.

`jitterFrac` is a field rather than a package var on purpose: a package var
mutated by one test can be read concurrently by a previous test's still-running
reconnect goroutine, which is a `-race` failure of the test harness's own making.

### Mutation results, per test

Every new or changed test was mutation-tested by breaking the specific thing it
covers and confirming that test fails. "uniquely" means no other test in the
package caught it.

| Mutation | Tests that FAIL |
|---|---|
| A: drop the `connMu` acquire from `nextReconnectDelay` (the pre-#743 shape) | `TestConnectRacesKeepaliveTeardownOnTheBackoffSchedule` (DATA RACE under `-race`), `TestReconnectBackoffAccessIsSynchronized`, `TestNextReconnectDelayAdvancesAtomically` |
| B: full jitter, `rand(0, base)` instead of `base + rand(0, base)` | `TestReconnectDelayIsNeverShorterThanTheSchedule` (both subtests), plus `TestReconnectDelaySpreadSurvivesAtTheMaximumBackoff`, `TestNextReconnectDelayAdvancesAndClamps`, `TestSuccessfulConnectResetsReconnectBackoff`, `TestCloseDuringTheBackoffPreventsAFurtherDial` |
| C: clamp the jittered delay at `maxBackoff` | `TestReconnectDelaySpreadSurvivesAtTheMaximumBackoff` (uniquely) |
| D: store the jittered value back into `reconnectBackoff` | `TestJitterDoesNotContaminateTheStoredSchedule` (uniquely among the schedule tests), `TestReconnectDelayIsNeverShorterThanTheSchedule/highest_draw` |
| E: revert `sleepUnlessDone` to a bare `time.Sleep` (the pre-#741 shape) | `TestCloseDuringTheBackoffPreventsAFurtherDial` (uniquely) |
| F: remove the `maxBackoff` clamp from the schedule | `TestNextReconnectDelayAdvancesAndClamps`, plus all three jitter tests |
| G: remove the backoff reset in `connectLocked` | `TestSuccessfulConnectResetsReconnectBackoff` (uniquely) |
| H: split `nextReconnectDelay` into a locked load and a separate locked store | `TestNextReconnectDelayAdvancesAtomically` (uniquely) |
| I: arm the keepalive in `Connect` instead of `connectLocked` (#745's M6) | `TestKeepaliveIsRearmedOnEveryReconnect` (uniquely) |
| K: remove `loopsOnce`, restore the bare `go c.readLoop()` in `Connect` (the pre-#745 shape, i.e. #740) | `TestConnectRacesKeepaliveTeardownOnTheBackoffSchedule` (uniquely; DATA RACE with two `readLoop` goroutines in `NextReader`, matching the trace in #740's body) |
| J: never start `pingLoop` (#745's M3) | `TestPingsReachTheServer`, `TestKeepaliveHoldsAQuietButHealthyConnection`, `TestReadDeadlineDisconnectTriggersReconnect` |

I and J are merge-integrity checks rather than new coverage: they target the
`connectLocked` and `Connect` regions the merge touched, and confirm #745's own
tripwires still fire after the conflict resolution. K is what earns the
"closes #740" above.

Mutation A is the one that justifies the new test. #743's race test deliberately
called `connectLocked` under `connMu` instead of the exported `Connect`, because
on that branch a `Connect` inside a reconnect window would trip #740 and fail
for the wrong reason. #745's tests put both writes on the SAME goroutine, so
`-race` was clean for the wrong reason there too. With `loopsOnce` in, the new
test drives the real path: every connection the server accepts goes silent, so
every one dies at the read deadline (`handleDisconnect -> go reconnect() ->
nextReconnectDelay`), while a background loop calls the exported `Connect`
whenever `IsConnected()` is false, which is the exact shape of
`EnableWebSocket` under #723's retry. Two writes, two goroutines, nothing
ordering them.

Not covered by an automated test, and deliberately: whether Railway's proxy and
the `ws` fabric route pass control frames end to end in production. That is what
#746 hangs on. Watch node 1297's log for `ws: no traffic for`; a steady cadence
at roughly `pongWait` means the premise is wrong and the intervals need
revisiting.

## Related

Closes #728, closes #734, closes #740, closes #741.
Follow-ups filed: #746, #747, #748.
Supersedes #743 and #745.
