### PR TITLE
reconcile: never-managed nodes should not trip the full-wipe guard forever (#733)

### DIFF
--- a/internal/reconcile/fullwipe_test.go
+++ b/internal/reconcile/fullwipe_test.go
@@ -129,6 +129,92 @@ func TestRefuseFullWipeSurfacesReportFailure(t *testing.T) {
 	}
 }
 
+// TestRefuseFullWipeSkipsNeverManagedNode is the #733 root-cause regression: a
+// node the control plane has NEVER assigned any desired state to (Revision ==
+// "0", the zero value the control plane serves when it holds no
+// fabric_node_module_desired row for this node at all) must not be treated as
+// "misconfigured". Before this fix EVERY node hit this path forever, because
+// nothing writes that durable store yet — the guard fired and errored on every
+// single pass (4574+ times over 5+ days, observed on node 1297). It must now
+// succeed as a no-op converge (nothing installed, nothing uninstalled) while
+// still reporting the observed actual state, exactly like a legitimate
+// converged pass.
+func TestRefuseFullWipeSkipsNeverManagedNode(t *testing.T) {
+	ops := newFakeOps(
+		InstalledModule{Name: "a", Source: "src-a", Health: HealthRunning},
+		InstalledModule{Name: "b", Source: "src-b", Health: HealthRunning},
+	)
+	provider := &FakeProvider{Desired: DesiredState{Revision: "0"}} // never managed
+	rec := NewReconciler(provider, ops, "node-1297")
+	rec.RefuseFullWipe = true
+
+	plan, _, err := rec.ReconcileOnce(context.Background())
+	if err != nil {
+		t.Fatalf("never-managed node with modules installed must succeed as a no-op, got: %v", err)
+	}
+	if !plan.IsEmpty() {
+		t.Errorf("want empty plan (nothing to converge to), got %+v", plan.Steps)
+	}
+	for _, c := range ops.calls {
+		if strings.HasPrefix(c, "uninstall:") {
+			t.Fatalf("a never-managed node must not uninstall anything, saw %q", c)
+		}
+	}
+	if len(provider.Reported) != 1 {
+		t.Fatalf("want exactly 1 report, got %d", len(provider.Reported))
+	}
+	report := provider.Reported[0]
+	if len(report.Modules) != 2 {
+		t.Fatalf("want 2 reported modules, got %d (%+v)", len(report.Modules), report.Modules)
+	}
+	// Unlike the refused-and-errored path, this IS a (no-op) converge, so the
+	// revision handshake stamps normally.
+	if report.AppliedRevision != "0" {
+		t.Errorf("AppliedRevision = %q, want %q (echoed like any other converge)", report.AppliedRevision, "0")
+	}
+}
+
+// TestRefuseFullWipeSkipsNeverManagedNodeEmptyRevision confirms the same
+// no-op behavior when Revision is the empty string, not just the literal "0"
+// — both are DesiredState.NeverManaged().
+func TestRefuseFullWipeSkipsNeverManagedNodeEmptyRevision(t *testing.T) {
+	ops := newFakeOps(InstalledModule{Name: "a", Source: "src-a", Health: HealthRunning})
+	provider := &FakeProvider{Desired: DesiredState{Revision: ""}}
+	rec := NewReconciler(provider, ops, "node")
+	rec.RefuseFullWipe = true
+
+	plan, _, err := rec.ReconcileOnce(context.Background())
+	if err != nil {
+		t.Fatalf("never-managed node (empty revision) must succeed as a no-op, got: %v", err)
+	}
+	if !plan.IsEmpty() {
+		t.Errorf("want empty plan, got %+v", plan.Steps)
+	}
+}
+
+// TestDesiredStateNeverManaged pins the predicate directly: only the true
+// zero-history values ("" and "0") count as never-managed; any other revision
+// — including a non-numeric opaque token, which is all the wire contract
+// promises — means the control plane has a history for this node.
+func TestDesiredStateNeverManaged(t *testing.T) {
+	cases := []struct {
+		revision string
+		want     bool
+	}{
+		{"", true},
+		{"0", true},
+		{"1", false},
+		{"rev-42", false},
+		{"1784231386757", false},
+	}
+	for _, c := range cases {
+		got := DesiredState{Revision: c.revision}.NeverManaged()
+		if got != c.want {
+			t.Errorf("DesiredState{Revision: %q}.NeverManaged() = %v, want %v", c.revision, got, c.want)
+		}
+	}
+}
+
 // TestRefuseFullWipeAllowsEmptyDesiredWhenNothingInstalled confirms the guard is
 // scoped: an empty desired set on an empty node is a legitimate no-op converge.
 func TestRefuseFullWipeAllowsEmptyDesiredWhenNothingInstalled(t *testing.T) {

--- a/internal/reconcile/fullwipe_test.go
+++ b/internal/reconcile/fullwipe_test.go
@@ -134,7 +134,7 @@ func TestRefuseFullWipeSurfacesReportFailure(t *testing.T) {
 // "0", the zero value the control plane serves when it holds no
 // fabric_node_module_desired row for this node at all) must not be treated as
 // "misconfigured". Before this fix EVERY node hit this path forever, because
-// nothing writes that durable store yet — the guard fired and errored on every
+// nothing writes that durable store yet: the guard fired and errored on every
 // single pass (4574+ times over 5+ days, observed on node 1297). It must now
 // succeed as a no-op converge (nothing installed, nothing uninstalled) while
 // still reporting the observed actual state, exactly like a legitimate
@@ -175,8 +175,8 @@ func TestRefuseFullWipeSkipsNeverManagedNode(t *testing.T) {
 }
 
 // TestRefuseFullWipeSkipsNeverManagedNodeEmptyRevision confirms the same
-// no-op behavior when Revision is the empty string, not just the literal "0"
-// — both are DesiredState.NeverManaged().
+// no-op behavior when Revision is the empty string, not just the literal "0":
+// both are DesiredState.NeverManaged().
 func TestRefuseFullWipeSkipsNeverManagedNodeEmptyRevision(t *testing.T) {
 	ops := newFakeOps(InstalledModule{Name: "a", Source: "src-a", Health: HealthRunning})
 	provider := &FakeProvider{Desired: DesiredState{Revision: ""}}
@@ -193,9 +193,9 @@ func TestRefuseFullWipeSkipsNeverManagedNodeEmptyRevision(t *testing.T) {
 }
 
 // TestDesiredStateNeverManaged pins the predicate directly: only the true
-// zero-history values ("" and "0") count as never-managed; any other revision
-// — including a non-numeric opaque token, which is all the wire contract
-// promises — means the control plane has a history for this node.
+// zero-history values ("" and "0") count as never-managed; any other revision,
+// including a non-numeric opaque token (which is all the wire contract
+// promises), means the control plane has a history for this node.
 func TestDesiredStateNeverManaged(t *testing.T) {
 	cases := []struct {
 		revision string

--- a/internal/reconcile/loop.go
+++ b/internal/reconcile/loop.go
@@ -96,13 +96,31 @@ func (r *Reconciler) ReconcileOnce(ctx context.Context) (Plan, ApplyResult, erro
 	// are installed (likely an empty/misconfigured control plane), rather than
 	// uninstalling everything the node runs.
 	//
-	// Refusing to APPLY is not a reason to stop OBSERVING (#733). The guard used
-	// to return here, before the report at the bottom of this function, so a node
-	// that tripped it never told the control plane what it had installed. The
-	// destructive path stays refused; the observability path still runs, so an
-	// operator can see the installed set against the empty desired set instead of
-	// only a log line repeating every pass.
-	if r.RefuseFullWipe && len(desired.Modules) == 0 && len(actual) > 0 {
+	// An empty desired set with modules installed splits into two situations
+	// that must NOT be treated the same way (#733 root cause):
+	//
+	//   - UNMANAGED: the control plane has never assigned this node ANY desired
+	//     state (DesiredState.NeverManaged — see its doc: Revision is the zero
+	//     value the control plane serves only when it holds no
+	//     fabric_node_module_desired row for this node at all, live or
+	//     soft-deleted). There is nothing to refuse: the node was never told to
+	//     converge to anything, so this is not a misconfiguration, it is a node
+	//     that is simply not under declarative module management yet — true of
+	//     essentially every node today, since nothing yet writes that durable
+	//     store (aceteam#4273's deferred follow-up; see PR description). Treating
+	//     this as an error made the guard trip every single pass forever (4574+
+	//     times over 5+ days on node 1297, which was never assigned anything).
+	//   - MANAGED: the control plane DOES have a revision history for this node
+	//     (it was assigned modules at some point) and is now serving zero. That
+	//     is the genuine "empty/misconfigured control plane" foot-gun this guard
+	//     exists for — refuse and error, exactly as before.
+	//
+	// Both situations still refuse to APPLY: neither calls Reconcile/Apply below,
+	// so neither can produce an uninstall plan. Only whether the refusal is
+	// logged as an error differs. Refusing to APPLY is also not a reason to stop
+	// OBSERVING (#733): both situations still report the observed actual state.
+	emptyWithModulesInstalled := r.RefuseFullWipe && len(desired.Modules) == 0 && len(actual) > 0
+	if emptyWithModulesInstalled && !desired.NeverManaged() {
 		guardErr := fmt.Errorf(
 			"reconcile: refusing empty desired state with %d module(s) installed (possible control-plane misconfiguration)", len(actual))
 		// Report the state the guard OBSERVED (no re-listing: `actual` is that
@@ -118,15 +136,22 @@ func (r *Reconciler) ReconcileOnce(ctx context.Context) (Plan, ApplyResult, erro
 		return Plan{}, ApplyResult{}, errors.Join(guardErr, reportErr)
 	}
 
-	plan, err := Reconcile(ctx, desired, actual)
-	if err != nil {
-		return Plan{}, ApplyResult{}, err
+	var plan Plan
+	var applyRes ApplyResult
+	if !emptyWithModulesInstalled {
+		plan, err = Reconcile(ctx, desired, actual)
+		if err != nil {
+			return Plan{}, ApplyResult{}, err
+		}
+		applyRes, err = Apply(ctx, r.Ops, plan)
+		if err != nil {
+			return plan, applyRes, err
+		}
 	}
-
-	applyRes, err := Apply(ctx, r.Ops, plan)
-	if err != nil {
-		return plan, applyRes, err
-	}
+	// else: an unmanaged node with modules installed. Nothing was ever assigned,
+	// so there is nothing to converge — plan/applyRes stay zero-valued (an
+	// empty, successful pass) and execution falls through to report the observed
+	// actual state below, same as any other converged pass.
 
 	// Report actual state back (best-effort: a report failure does not undo a
 	// successful converge, but it IS surfaced to the caller).
@@ -134,9 +159,11 @@ func (r *Reconciler) ReconcileOnce(ctx context.Context) (Plan, ApplyResult, erro
 	if err != nil {
 		return plan, applyRes, err
 	}
-	// Revision handshake: echo the desired revision the node just converged to.
-	// Set unconditionally (even on partial per-module failure) — the node HAS
-	// processed this revision; failures surface per-module as Health == HealthError.
+	// Revision handshake: echo the desired revision the node just converged to
+	// (or, for the unmanaged no-op above, the "never managed" revision it
+	// correctly did nothing with). Set unconditionally (even on partial
+	// per-module failure) — the node HAS processed this revision; failures
+	// surface per-module as Health == HealthError.
 	report.AppliedRevision = desired.Revision
 	if err := r.Provider.Report(ctx, report); err != nil {
 		return plan, applyRes, err

--- a/internal/reconcile/loop.go
+++ b/internal/reconcile/loop.go
@@ -100,12 +100,12 @@ func (r *Reconciler) ReconcileOnce(ctx context.Context) (Plan, ApplyResult, erro
 	// that must NOT be treated the same way (#733 root cause):
 	//
 	//   - UNMANAGED: the control plane has never assigned this node ANY desired
-	//     state (DesiredState.NeverManaged — see its doc: Revision is the zero
+	//     state (DesiredState.NeverManaged, see its doc: Revision is the zero
 	//     value the control plane serves only when it holds no
 	//     fabric_node_module_desired row for this node at all, live or
 	//     soft-deleted). There is nothing to refuse: the node was never told to
 	//     converge to anything, so this is not a misconfiguration, it is a node
-	//     that is simply not under declarative module management yet — true of
+	//     that is simply not under declarative module management yet, true of
 	//     essentially every node today, since nothing yet writes that durable
 	//     store (aceteam#4273's deferred follow-up; see PR description). Treating
 	//     this as an error made the guard trip every single pass forever (4574+
@@ -113,7 +113,7 @@ func (r *Reconciler) ReconcileOnce(ctx context.Context) (Plan, ApplyResult, erro
 	//   - MANAGED: the control plane DOES have a revision history for this node
 	//     (it was assigned modules at some point) and is now serving zero. That
 	//     is the genuine "empty/misconfigured control plane" foot-gun this guard
-	//     exists for — refuse and error, exactly as before.
+	//     exists for, so refuse and error, exactly as before.
 	//
 	// Both situations still refuse to APPLY: neither calls Reconcile/Apply below,
 	// so neither can produce an uninstall plan. Only whether the refusal is
@@ -149,7 +149,7 @@ func (r *Reconciler) ReconcileOnce(ctx context.Context) (Plan, ApplyResult, erro
 		}
 	}
 	// else: an unmanaged node with modules installed. Nothing was ever assigned,
-	// so there is nothing to converge — plan/applyRes stay zero-valued (an
+	// so there is nothing to converge: plan/applyRes stay zero-valued (an
 	// empty, successful pass) and execution falls through to report the observed
 	// actual state below, same as any other converged pass.
 
@@ -162,7 +162,7 @@ func (r *Reconciler) ReconcileOnce(ctx context.Context) (Plan, ApplyResult, erro
 	// Revision handshake: echo the desired revision the node just converged to
 	// (or, for the unmanaged no-op above, the "never managed" revision it
 	// correctly did nothing with). Set unconditionally (even on partial
-	// per-module failure) — the node HAS processed this revision; failures
+	// per-module failure): the node HAS processed this revision; failures
 	// surface per-module as Health == HealthError.
 	report.AppliedRevision = desired.Revision
 	if err := r.Provider.Report(ctx, report); err != nil {

--- a/internal/reconcile/proto_provider_test.go
+++ b/internal/reconcile/proto_provider_test.go
@@ -3,6 +3,7 @@ package reconcile
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	fabricpb "github.com/aceteam-ai/fabric-protocol/gen/go/aceteam/fabric/v1"
@@ -167,6 +168,47 @@ func TestProtoProviderRevisionHandshakeThroughReconcileOnce(t *testing.T) {
 	}
 	if got.GetAppliedRevision() != "rev-100" {
 		t.Fatalf("handshake broken: applied_revision = %q, want rev-100", got.GetAppliedRevision())
+	}
+}
+
+// TestNeverManagedThroughRealProtoWireNoUninstall is the end-to-end proof for
+// #733/#752: TestRefuseFullWipeSkipsNeverManagedNode (fullwipe_test.go)
+// exercises DesiredState.NeverManaged() by constructing the internal type
+// directly, which never proves Revision actually survives the real wire path
+// (marshal -> HTTP body -> unmarshal -> adaptDesiredState). This test drives
+// that whole path: a real fabricpb.DesiredState with Revision "0" (the
+// control-plane zero value for "no fabric_node_module_desired row for this
+// node, ever") and zero modules, through ProtoProvider.Fetch, into a
+// Reconciler that already has two modules installed. If adaptDesiredState
+// ever stopped copying Revision through, this would start failing with an
+// uninstall plan instead of a no-op.
+func TestNeverManagedThroughRealProtoWireNoUninstall(t *testing.T) {
+	tr := &fakeTransport{desired: &fabricpb.DesiredState{
+		Revision: "0",
+		Modules:  nil,
+	}}
+	provider := NewProtoProvider(tr, tr, "node-1297", "v1")
+	ops := newFakeOps(
+		InstalledModule{Name: "a", Source: "a", Health: HealthRunning},
+		InstalledModule{Name: "b", Source: "b", Health: HealthRunning},
+	)
+	rec := NewReconciler(provider, ops, "node-1297")
+	rec.RefuseFullWipe = true
+
+	plan, _, err := rec.ReconcileOnce(context.Background())
+	if err != nil {
+		t.Fatalf("never-managed node over the real proto wire must succeed as a no-op, got: %v", err)
+	}
+	if !plan.IsEmpty() {
+		t.Errorf("want empty plan, got %+v", plan.Steps)
+	}
+	for _, c := range ops.calls {
+		if strings.HasPrefix(c, "uninstall:") {
+			t.Fatalf("a never-managed node must not uninstall anything, saw %q", c)
+		}
+	}
+	if tr.posts != 1 {
+		t.Fatalf("want the observed actual state still reported, got %d posts", tr.posts)
 	}
 }
 

--- a/internal/reconcile/types.go
+++ b/internal/reconcile/types.go
@@ -128,7 +128,7 @@ type DesiredState struct {
 }
 
 // NeverManaged reports whether the control plane has never assigned this node
-// ANY desired state — not even a since-removed one. Revision is "" or "0" only
+// ANY desired state, not even a since-removed one. Revision is "" or "0" only
 // when the control plane holds no fabric_node_module_desired row for this node
 // at all (live or soft-deleted); the moment a row has ever existed, Revision
 // carries that row's (or the max historical row's) value and stays non-zero
@@ -138,7 +138,7 @@ type DesiredState struct {
 //   - never managed (this): the node was never told to converge to anything,
 //     so an empty desired set is not a misconfiguration.
 //   - explicitly emptied (NeverManaged() == false, Modules empty): the node
-//     WAS assigned modules and the control plane is now serving zero — the
+//     WAS assigned modules and the control plane is now serving zero, the
 //     genuine foot-gun Reconciler.RefuseFullWipe exists to catch.
 //
 // See internal/reconcile/loop.go's full-wipe guard, the only caller (#733).

--- a/internal/reconcile/types.go
+++ b/internal/reconcile/types.go
@@ -127,6 +127,25 @@ type DesiredState struct {
 	Modules []ModuleAssignment `json:"modules"`
 }
 
+// NeverManaged reports whether the control plane has never assigned this node
+// ANY desired state — not even a since-removed one. Revision is "" or "0" only
+// when the control plane holds no fabric_node_module_desired row for this node
+// at all (live or soft-deleted); the moment a row has ever existed, Revision
+// carries that row's (or the max historical row's) value and stays non-zero
+// even after the live set is emptied.
+//
+// This distinguishes two situations that both serve an empty Modules list:
+//   - never managed (this): the node was never told to converge to anything,
+//     so an empty desired set is not a misconfiguration.
+//   - explicitly emptied (NeverManaged() == false, Modules empty): the node
+//     WAS assigned modules and the control plane is now serving zero — the
+//     genuine foot-gun Reconciler.RefuseFullWipe exists to catch.
+//
+// See internal/reconcile/loop.go's full-wipe guard, the only caller (#733).
+func (d DesiredState) NeverManaged() bool {
+	return d.Revision == "" || d.Revision == "0"
+}
+
 // ----------------------------------------------------------------------------
 // Actual-state report (node -> control plane)
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
## Context

Node 1297 (and effectively every fabric node today) trips
`internal/reconcile/loop.go`'s full-wipe guard every single reconcile pass,
forever: `reconcile: refusing empty desired state with N module(s) installed
(possible control-plane misconfiguration)`. PR #737 already fixed the
observability half (a refused pass still reports its observed actual state).
This PR is the deeper defect that #737 exposed but didn't fix: the guard
itself cannot tell "this node was never assigned anything" apart from "this
node was assigned modules and the control plane is now serving zero", and it
treats both as an error, forever.

## Root cause

Traced the full data flow end to end:

- `internal/reconcile/loop.go` fetches desired state via `DesiredStateProvider`
  then `ProtoProvider` then `redisapi.Client.GetDesiredState`, which calls
  `GET /api/fabric/nodes/{id}/desired-state`.
- On the aceteam side, `python-backend/routes/fabric_desired_state.py` serves
  that endpoint by reading the `fabric_node_module_desired` table.
- **Nothing writes that table.** Confirmed by grep across the whole aceteam
  repo: only two files even reference `fabric_node_module_desired` (the read
  endpoint and a docstring). The intended writer, `fabric_node_module_set`
  (the MCP tool for setting a node's desired module state), explicitly does
  NOT persist, by its own docstring: *"it does NOT persist the desired
  state server-side... Durable desired-state storage
  (`fabric_node_module_desired`)... remains a follow-up (aceteam #4273)"*.
- Confirmed empirically against the live DB: the table exists (schema already
  matches what the read endpoint expects) and has exactly 5 rows total, all
  for one other node, all inserted at the same timestamp (a manual seed, not
  a live writer). Zero rows for node 1297.
- So `desired.Modules` is permanently `[]` for every real node, `RefuseFullWipe`
  fires on every pass that has any actual module installed, and it logs/errors
  forever with no way to converge.

## Why the fix is scoped the way it is (and why the "obvious" fix is unsafe)

The obvious-looking fix, having `fabric_node_module_set` actually write to
`fabric_node_module_desired`, is a genuine architecture fork, not a
mechanical bug, and I did **not** implement it here. Filed separately (and
already open, unassigned) as **#739**: the reconcile engine is fully
declarative once `desired.Modules` is non-empty, and `liveModuleOps.
ListInstalled` enumerates every `citadel.yaml` service, not just modules the
module system installed. So the FIRST desired row ever written for a
never-managed node with N other manifest services running (vllm, ollama,
transcribe, gotenberg, bonsai, ...) would uninstall the other N-1 the very
next pass, turning a merely-noisy bug into a genuinely destructive one. #739
lays out three real options (scope reconcile authority to lockfile-tracked
modules only / cap the uninstall blast radius / require explicit node opt-in)
and none of them are mine to pick.

**What I built instead** is safe regardless of how #739 resolves, because it
never touches the write path or the diff/apply logic at all:

`DesiredState.NeverManaged()` (`internal/reconcile/types.go`) reports whether
the control plane has ever assigned this node anything: `Revision == ""` or
`"0"`, which the wire-level revision handshake already carries and which the
control plane serves only when it holds no `fabric_node_module_desired` row
for this node at all (paired aceteam-side change makes this true even across
a soft-deleted history, see that PR).

`ReconcileOnce` (`internal/reconcile/loop.go`) now splits the "empty desired
with modules installed" case in two:
- **Never managed** (`NeverManaged() == true`): nothing was ever assigned, so
  there is nothing to refuse. Skip `Reconcile`/`Apply` (an empty, successful
  plan, identical safety to today: nothing is ever uninstalled) and fall
  through to the normal report tail, revision handshake included. No error,
  no per-pass log noise, and the node's actual state gets reported like any
  other converged pass.
- **Actually managed and now empty** (`NeverManaged() == false`): unchanged,
  refuse, error, report-without-revision-stamp, exactly as PR #737 shipped it.

Neither branch ever calls `Reconcile`/`Apply`, so this cannot produce an
uninstall plan in either case; it only changes whether the (still-refused)
pass is treated as an error.

## Companion aceteam-side change

A small paired PR in `aceteam-ai/aceteam` makes `revision` survive a
soft-deleted history (queries the row watermark ignoring `delete_on`) so a
node that WAS managed and later had everything explicitly removed still
reports a non-zero revision, keeping the managed/never-managed distinction
correct even after #739 unblocks real writes. Not required for today's bug
(nothing writes/deletes yet), included as defense-in-depth so it isn't
forgotten later. Linked in that PR's description.

## Schema changes

None. `fabric_node_module_desired` already exists with the exact shape the
read endpoint uses; this PR does not write to it.

## Architecture fork for Jason (not decided here)

**citadel#739** (already filed, unassigned): once desired-state persistence
is added, the reconcile engine treats "the control plane assigned zero
modules" as authoritative and uninstalls everything else on the node's
manifest that isn't in that set. Options laid out there:
1. Scope reconcile authority to modules the module system actually installed
   (lockfile entries), not every manifest service.
2. Keep full enumeration, but cap any single pass's uninstall blast radius.
3. Require an explicit per-node opt-in before the pull loop may uninstall
   anything.

My read: option 1 fits the package's own stated model best (`internal/
reconcile`'s doc already describes modules, not "everything in citadel.yaml",
as the unit), but it's a real product/semantics call, not mine to make.

## Testing

`go test ./...`: full suite green, no regressions.

New tests in `internal/reconcile/fullwipe_test.go`:
- `TestDesiredStateNeverManaged`: pins the predicate (`""`/`"0"` -> true,
  anything else, including an opaque non-numeric revision token, -> false).
- `TestRefuseFullWipeSkipsNeverManagedNode` / `...EmptyRevision`: a
  never-managed node with modules installed converges as a no-op: no error,
  no uninstall calls, and the observed actual state IS still reported (with
  the revision handshake stamped, unlike the still-refused/errored path).

New test in `internal/reconcile/proto_provider_test.go`:
- `TestNeverManagedThroughRealProtoWireNoUninstall`: the tests above construct
  the internal `DesiredState` directly, which never exercises the real wire
  path (marshal, HTTP body, unmarshal, `adaptDesiredState`). This one drives a
  real `fabricpb.DesiredState{Revision: "0"}` through `ProtoProvider.Fetch`
  into a `Reconciler` with two already-installed modules, asserting no error,
  no uninstall calls, and the actual state still reported.

Mutation-tested: reverted `loop.go`/`types.go` to `origin/main` (via
`git checkout origin/main -- <files>`, not stash: this repo's shared-stash
gotcha), confirmed the new tests fail (compile error, since `NeverManaged`
no longer exists), restored via a saved patch, reran; green again. Existing
tests (`TestRefuseFullWipeBlocksEmptyDesiredWithInstalled` and friends, which
use non-zero opaque revisions like `"rev-empty"`) were unaffected, confirming
the managed/error path is unchanged. Separately mutation-tested
`TestNeverManagedThroughRealProtoWireNoUninstall` by corrupting
`adaptDesiredState`'s revision copy to a nonzero sentinel (`Revision:
"corrupted-nonzero"`): the test failed with the guard error, confirming it
actually exercises the proto decode path; restored and reran green.

## Draft

Leaving this in draft: it touches reconcile/dispatch control flow and should
get a look before merge, per this repo's CLAUDE.md.

