### PR TITLE
passcode: add citadel passcode set/clear and reject reason codes (#753)

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -592,6 +592,11 @@ func startTerminalServer(orgID string, activityFn func(level, msg string)) error
 	termCfg.PasscodeVerifier = func(pin string) bool {
 		return config.LoadPermissions(platform.ConfigDir()).VerifyPasscode(pin)
 	}
+	// Lets the reject response distinguish passcode_not_set from
+	// passcode_invalid (citadel#753); see terminal.Config.PasscodeHasPasscode.
+	termCfg.PasscodeHasPasscode = func() bool {
+		return config.LoadPermissions(platform.ConfigDir()).HasPasscode()
+	}
 
 	// Create the caching token validator
 	apiToken := ""

--- a/cmd/passcode.go
+++ b/cmd/passcode.go
@@ -1,0 +1,202 @@
+// cmd/passcode.go
+//
+// citadel#753: before this command existed, the only ways to set the per-node
+// passcode that gates Console/Desktop/Files (aceteam#6524) were an
+// APPLY_DEVICE_CONFIG push from the platform or the Control Center TUI. A node
+// that enabled one of those surfaces any other way (e.g. by hand-editing
+// permissions.yaml, or on a headless box with no Control Center session) had
+// no CLI path to set the passcode those surfaces require, so they stayed
+// unreachable while doctor/heartbeat kept reporting healthy.
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/aceteam-ai/citadel-cli/internal/config"
+	"github.com/aceteam-ai/citadel-cli/internal/platform"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+var passcodeCmd = &cobra.Command{
+	Use:   "passcode",
+	Short: "Manage the node passcode that gates Console/Desktop/Files access",
+	Long: `The node passcode (aceteam#6524) gates the sensitive remote-access surfaces
+(Console/terminal, Desktop/VNC/screen, and Files) once an operator has
+enabled them. Enabling a surface is not enough by itself: without a passcode
+set, that surface fails closed (access denied) even though it is enabled.
+
+Use 'citadel passcode set' to set or change it, and 'citadel passcode clear'
+to remove it (which re-locks every enabled sensitive surface).`,
+}
+
+var passcodeSetCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Set or change the node passcode",
+	Long: `Sets the per-node passcode that gates Console/Desktop/Files remote access
+(aceteam#6524). This is what a client (e.g. 'citadel connect') must present,
+in addition to a valid token or verified mesh-peer identity, before an
+enabled sensitive surface will actually respond.
+
+Takes effect immediately, without restarting the worker: every gate
+(terminal server, gateway, SHELL_COMMAND handler) reloads permissions.yaml on
+each connection, so a running 'citadel work' picks up the new passcode on its
+very next request.
+
+The PIN is read from a no-echo interactive prompt (with a confirmation
+re-entry), or piped in on stdin when stdin is not a terminal. It is never
+accepted as a command-line argument, so it can't land in shell history or be
+visible to other users on the machine via 'ps'.`,
+	Example: `  # Interactive (prompts twice, no echo)
+  citadel passcode set
+
+  # Piped (e.g. from a secrets manager); no confirmation re-prompt
+  echo -n "1234" | citadel passcode set`,
+	Args: cobra.NoArgs,
+	RunE: runPasscodeSet,
+}
+
+var passcodeClearCmd = &cobra.Command{
+	Use:   "clear",
+	Short: "Clear the node passcode",
+	Long: `Clears the per-node passcode. This FAILS CLOSED: with no passcode set, every
+sensitive remote-access surface (Console/Desktop/Files) stays denied even if
+it is enabled, until 'citadel passcode set' is run again.
+
+Takes effect immediately, without restarting the worker.`,
+	Args: cobra.NoArgs,
+	RunE: runPasscodeClear,
+}
+
+func init() {
+	rootCmd.AddCommand(passcodeCmd)
+	passcodeCmd.AddCommand(passcodeSetCmd)
+	passcodeCmd.AddCommand(passcodeClearCmd)
+}
+
+func runPasscodeSet(cmd *cobra.Command, args []string) error {
+	pin, err := readPasscodeInput(os.Stdin, term.IsTerminal(int(os.Stdin.Fd())))
+	if err != nil {
+		return err
+	}
+
+	perms, err := setNodePasscode(platform.ConfigDir(), pin)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Node passcode set.")
+	fmt.Println("Takes effect immediately, no worker restart needed (the gate reloads permissions.yaml per connection).")
+	if !(perms.Console || perms.Desktop || perms.Files) {
+		fmt.Println("Note: Console, Desktop, and Files are all currently disabled, so this passcode has nothing to gate yet.")
+	}
+	return nil
+}
+
+func runPasscodeClear(cmd *cobra.Command, args []string) error {
+	perms, err := clearNodePasscode(platform.ConfigDir())
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Node passcode cleared.")
+	if perms.Console || perms.Desktop || perms.Files {
+		fmt.Println("Console, Desktop, and/or Files are enabled; they now fail closed (access denied) until a new passcode is set.")
+	}
+	fmt.Println("Takes effect immediately, no worker restart needed.")
+	return nil
+}
+
+// setNodePasscode loads permissions from configDir, hashes and stores pin,
+// and persists the result. It refuses an empty/whitespace-only pin ('citadel
+// passcode clear' is the explicit way to remove a passcode, so 'set' with
+// nothing typed is far more likely a mistake than an intent to lock the
+// node). Returns the updated permissions so callers can report follow-on
+// state (e.g. whether any sensitive surface is actually enabled) without a
+// second load.
+func setNodePasscode(configDir, pin string) (*config.Permissions, error) {
+	if strings.TrimSpace(pin) == "" {
+		return nil, fmt.Errorf("passcode must not be empty (use 'citadel passcode clear' to remove it)")
+	}
+
+	perms := config.LoadPermissions(configDir)
+	if err := perms.SetPasscode(pin); err != nil {
+		return nil, fmt.Errorf("set passcode: %w", err)
+	}
+	if err := config.SavePermissions(configDir, perms); err != nil {
+		return nil, fmt.Errorf("save permissions: %w", err)
+	}
+	return perms, nil
+}
+
+// clearNodePasscode loads permissions from configDir, clears the passcode
+// hash, and persists the result.
+func clearNodePasscode(configDir string) (*config.Permissions, error) {
+	perms := config.LoadPermissions(configDir)
+	_ = perms.SetPasscode("") // empty pin only clears; SetPasscode never errors on this path
+	if err := config.SavePermissions(configDir, perms); err != nil {
+		return nil, fmt.Errorf("save permissions: %w", err)
+	}
+	return perms, nil
+}
+
+// readPasscodeInput reads the PIN for 'citadel passcode set'. When stdin is
+// not a terminal (piped/redirected), it reads a single trimmed line with no
+// confirmation re-prompt (there is nothing to re-prompt on a non-interactive
+// stream). When stdin IS a terminal, it prompts twice with no echo
+// (golang.org/x/term.ReadPassword) and requires the two entries to match, so
+// an interactive typo does not silently lock the node behind a passcode the
+// operator never actually typed.
+func readPasscodeInput(stdin *os.File, isTerminal bool) (string, error) {
+	if !isTerminal {
+		return readPasscodeFromReader(stdin)
+	}
+
+	fd := int(stdin.Fd())
+	fmt.Fprint(os.Stderr, "Node passcode: ")
+	first, err := term.ReadPassword(fd)
+	fmt.Fprintln(os.Stderr)
+	if err != nil {
+		return "", fmt.Errorf("read passcode: %w", err)
+	}
+
+	fmt.Fprint(os.Stderr, "Confirm passcode: ")
+	second, err := term.ReadPassword(fd)
+	fmt.Fprintln(os.Stderr)
+	if err != nil {
+		return "", fmt.Errorf("read passcode confirmation: %w", err)
+	}
+
+	pin := strings.TrimSpace(string(first))
+	confirm := strings.TrimSpace(string(second))
+	if err := matchPasscodeConfirmation(pin, confirm); err != nil {
+		return "", err
+	}
+	return pin, nil
+}
+
+// readPasscodeFromReader reads and trims a single line from r. Used for the
+// non-interactive (piped stdin) path.
+func readPasscodeFromReader(r io.Reader) (string, error) {
+	scanner := bufio.NewScanner(r)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return "", fmt.Errorf("read passcode from stdin: %w", err)
+		}
+		return "", fmt.Errorf("no passcode provided on stdin")
+	}
+	return strings.TrimSpace(scanner.Text()), nil
+}
+
+// matchPasscodeConfirmation reports an error when the two interactive entries
+// differ.
+func matchPasscodeConfirmation(pin, confirm string) error {
+	if pin != confirm {
+		return fmt.Errorf("passcodes did not match")
+	}
+	return nil
+}

--- a/cmd/passcode_test.go
+++ b/cmd/passcode_test.go
@@ -1,0 +1,115 @@
+// cmd/passcode_test.go
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/config"
+)
+
+// TestSetNodePasscodePersists confirms 'citadel passcode set' actually
+// persists a passcode that VerifyPasscode subsequently accepts (citadel#753).
+func TestSetNodePasscodePersists(t *testing.T) {
+	dir := t.TempDir()
+
+	perms, err := setNodePasscode(dir, "1234")
+	if err != nil {
+		t.Fatalf("setNodePasscode: %v", err)
+	}
+	if !perms.HasPasscode() {
+		t.Fatal("expected HasPasscode() true after set")
+	}
+
+	// Reload from disk: setNodePasscode must have persisted, not just mutated
+	// the in-memory struct.
+	reloaded := config.LoadPermissions(dir)
+	if !reloaded.HasPasscode() {
+		t.Fatal("passcode was not persisted to disk")
+	}
+	if !reloaded.VerifyPasscode("1234") {
+		t.Error("reloaded permissions do not verify the passcode that was set")
+	}
+	if reloaded.VerifyPasscode("wrong") {
+		t.Error("reloaded permissions verified an incorrect passcode")
+	}
+}
+
+// TestSetNodePasscodeRejectsEmpty confirms an empty/whitespace pin is refused
+// (the explicit removal path is 'citadel passcode clear', not an empty set).
+func TestSetNodePasscodeRejectsEmpty(t *testing.T) {
+	dir := t.TempDir()
+
+	if _, err := setNodePasscode(dir, ""); err == nil {
+		t.Error("expected error for empty passcode, got nil")
+	}
+	if _, err := setNodePasscode(dir, "   "); err == nil {
+		t.Error("expected error for whitespace-only passcode, got nil")
+	}
+
+	// Nothing should have been persisted.
+	perms := config.LoadPermissions(dir)
+	if perms.HasPasscode() {
+		t.Error("a rejected empty passcode must not be persisted")
+	}
+}
+
+// TestClearNodePasscodeLocksSurface confirms 'citadel passcode clear' removes
+// a previously-set passcode so VerifyPasscode fails closed afterward.
+func TestClearNodePasscodeLocksSurface(t *testing.T) {
+	dir := t.TempDir()
+
+	if _, err := setNodePasscode(dir, "5678"); err != nil {
+		t.Fatalf("setNodePasscode: %v", err)
+	}
+	if !config.LoadPermissions(dir).HasPasscode() {
+		t.Fatal("setup: passcode should be set before clearing")
+	}
+
+	perms, err := clearNodePasscode(dir)
+	if err != nil {
+		t.Fatalf("clearNodePasscode: %v", err)
+	}
+	if perms.HasPasscode() {
+		t.Error("expected HasPasscode() false after clear")
+	}
+
+	reloaded := config.LoadPermissions(dir)
+	if reloaded.HasPasscode() {
+		t.Error("passcode clear was not persisted to disk")
+	}
+	if reloaded.VerifyPasscode("5678") {
+		t.Error("cleared passcode must not still verify the old pin")
+	}
+}
+
+// TestReadPasscodeFromReaderTrims confirms the piped-stdin path reads a
+// single line and trims surrounding whitespace/newline.
+func TestReadPasscodeFromReaderTrims(t *testing.T) {
+	pin, err := readPasscodeFromReader(strings.NewReader("  9999  \nignored second line\n"))
+	if err != nil {
+		t.Fatalf("readPasscodeFromReader: %v", err)
+	}
+	if pin != "9999" {
+		t.Errorf("pin = %q, want %q", pin, "9999")
+	}
+}
+
+// TestReadPasscodeFromReaderEmptyInput confirms an empty stdin stream is
+// reported as an error, not a silently-empty passcode.
+func TestReadPasscodeFromReaderEmptyInput(t *testing.T) {
+	if _, err := readPasscodeFromReader(strings.NewReader("")); err == nil {
+		t.Error("expected error for empty stdin, got nil")
+	}
+}
+
+// TestMatchPasscodeConfirmation covers both branches of the interactive
+// double-entry confirmation check.
+func TestMatchPasscodeConfirmation(t *testing.T) {
+	if err := matchPasscodeConfirmation("1234", "1234"); err != nil {
+		t.Errorf("matching entries should not error, got %v", err)
+	}
+	if err := matchPasscodeConfirmation("1234", "5678"); err == nil {
+		t.Error("mismatched entries should error, got nil")
+	}
+}

--- a/cmd/work.go
+++ b/cmd/work.go
@@ -421,6 +421,17 @@ func runWork(cmd *cobra.Command, args []string) {
 		workTerminal = false
 	}
 
+	// Surface the citadel#753 gap locally: a sensitive surface (console/
+	// desktop/files) enabled with no node passcode set fails closed (access
+	// denied) rather than opening, but doctor/heartbeat stay green because the
+	// probe path is exempt from the passcode gate -- the only prior signal was
+	// a single node log line per rejected connection. One line at startup, not
+	// buried per-connection, so an operator who enabled a surface without also
+	// setting a passcode sees it immediately.
+	if warning := sensitiveCapabilityPasscodeWarning(config.LoadPermissions(platform.ConfigDir())); warning != "" {
+		fmt.Fprintln(os.Stderr, warning)
+	}
+
 	// Setup signal handling. The first signal cancels the root context so every
 	// subsystem (worker runner, status/terminal/gateway servers, heartbeat,
 	// auto-updater, usage syncer) observes cancellation and unwinds. As a
@@ -1780,6 +1791,11 @@ func runWork(cmd *cobra.Command, args []string) {
 				termConfig.PasscodeVerifier = func(pin string) bool {
 					return config.LoadPermissions(platform.ConfigDir()).VerifyPasscode(pin)
 				}
+				// Lets the reject response distinguish passcode_not_set from
+				// passcode_invalid (citadel#753); see terminal.Config.PasscodeHasPasscode.
+				termConfig.PasscodeHasPasscode = func() bool {
+					return config.LoadPermissions(platform.ConfigDir()).HasPasscode()
+				}
 
 				// Best-effort: provision a Citadel-managed tmux binary so persistent
 				// terminal sessions "just work" on nodes without a system tmux. This
@@ -2382,6 +2398,36 @@ func resolveEnergySampling() bool {
 		return update.IsTruthy(raw)
 	}
 	return config.LoadEnergy(platform.ConfigDir()).SamplingEnabled
+}
+
+// sensitiveCapabilityPasscodeWarning returns a single warning line when a
+// passcode-gated remote-access surface (console/desktop/files, aceteam#6524)
+// is enabled but no node passcode is configured, or "" when there is nothing
+// to warn about. Every one of these surfaces already fails closed without a
+// passcode (config.Permissions.VerifyPasscode), so this is not itself a
+// functional bug -- but a surface that is enabled, unreachable, and reports
+// no local signal is exactly the "broken while reporting green" failure mode
+// citadel#753 exists to close. Kept pure (permissions in, string out) so it
+// is testable without starting a worker.
+func sensitiveCapabilityPasscodeWarning(perms *config.Permissions) string {
+	if perms == nil || perms.HasPasscode() {
+		return ""
+	}
+	var enabled []string
+	if perms.Console {
+		enabled = append(enabled, "Console")
+	}
+	if perms.Desktop {
+		enabled = append(enabled, "Desktop")
+	}
+	if perms.Files {
+		enabled = append(enabled, "Files")
+	}
+	if len(enabled) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("   - ⚠️ %s enabled but no node passcode is set: remote access stays blocked until one is set (run 'citadel passcode set')",
+		strings.Join(enabled, "/"))
 }
 
 // stopManagedServices tears down services this worker started, mirroring the

--- a/cmd/work_passcode_warning_test.go
+++ b/cmd/work_passcode_warning_test.go
@@ -1,0 +1,70 @@
+// cmd/work_passcode_warning_test.go
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/config"
+)
+
+// TestSensitiveCapabilityPasscodeWarning_NoneEnabled confirms no warning is
+// produced when console/desktop/files are all disabled, even with no
+// passcode set (the default-deny posture for a fresh node).
+func TestSensitiveCapabilityPasscodeWarning_NoneEnabled(t *testing.T) {
+	perms := &config.Permissions{}
+	if got := sensitiveCapabilityPasscodeWarning(perms); got != "" {
+		t.Errorf("expected no warning, got %q", got)
+	}
+}
+
+// TestSensitiveCapabilityPasscodeWarning_EnabledWithPasscode confirms no
+// warning is produced when a sensitive surface is enabled AND a passcode is
+// set (the working, unlocked configuration).
+func TestSensitiveCapabilityPasscodeWarning_EnabledWithPasscode(t *testing.T) {
+	perms := &config.Permissions{Console: true}
+	if err := perms.SetPasscode("1234"); err != nil {
+		t.Fatalf("SetPasscode: %v", err)
+	}
+	if got := sensitiveCapabilityPasscodeWarning(perms); got != "" {
+		t.Errorf("expected no warning when a passcode is set, got %q", got)
+	}
+}
+
+// TestSensitiveCapabilityPasscodeWarning_EnabledNoPasscode is the citadel#753
+// case this warning exists for: a sensitive surface enabled with no passcode
+// stays unreachable, and this is the only local, at-a-glance signal.
+func TestSensitiveCapabilityPasscodeWarning_EnabledNoPasscode(t *testing.T) {
+	perms := &config.Permissions{Console: true}
+	got := sensitiveCapabilityPasscodeWarning(perms)
+	if got == "" {
+		t.Fatal("expected a warning when Console is enabled with no passcode set")
+	}
+	if !strings.Contains(got, "Console") {
+		t.Errorf("warning should name the enabled surface, got %q", got)
+	}
+	if !strings.Contains(got, "citadel passcode set") {
+		t.Errorf("warning should point at the fix, got %q", got)
+	}
+}
+
+// TestSensitiveCapabilityPasscodeWarning_ListsAllEnabled confirms multiple
+// enabled surfaces are all named, not just the first.
+func TestSensitiveCapabilityPasscodeWarning_ListsAllEnabled(t *testing.T) {
+	perms := &config.Permissions{Console: true, Desktop: true, Files: true}
+	got := sensitiveCapabilityPasscodeWarning(perms)
+	for _, want := range []string{"Console", "Desktop", "Files"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("warning %q should mention %q", got, want)
+		}
+	}
+}
+
+// TestSensitiveCapabilityPasscodeWarning_NilPermissions is a defensive check:
+// a nil Permissions must never panic and must produce no warning (fail quiet,
+// not fail loud on a nil-pointer crash at worker startup).
+func TestSensitiveCapabilityPasscodeWarning_NilPermissions(t *testing.T) {
+	if got := sensitiveCapabilityPasscodeWarning(nil); got != "" {
+		t.Errorf("expected no warning for nil permissions, got %q", got)
+	}
+}

--- a/internal/terminal/config.go
+++ b/internal/terminal/config.go
@@ -106,6 +106,19 @@ type Config struct {
 	// nil (e.g. the localhost test server), no passcode is required and behavior
 	// is unchanged. The verifier fails closed (see config.Permissions.VerifyPasscode).
 	PasscodeVerifier func(pin string) bool
+
+	// PasscodeHasPasscode, when non-nil, reports whether a node passcode is
+	// configured at all (WITHOUT leaking it). It lets a PasscodeVerifier
+	// rejection distinguish ReasonPasscodeNotSet ("nothing to check against;
+	// the operator must set one") from ReasonPasscodeInvalid ("a passcode is
+	// set but what was presented is wrong or missing"), a distinction
+	// PasscodeVerifier's bool result alone cannot carry, mirroring
+	// internal/jobs/shell_command.go's HasPasscode/VerifyPasscode split
+	// (aceteam#6524, citadel#753). Optional: when nil, the reject response
+	// omits the "reason" field entirely (unchanged pre-#753 behavior), so
+	// existing callers that only wire PasscodeVerifier keep working. Wire it
+	// from config.LoadPermissions(...).HasPasscode alongside PasscodeVerifier.
+	PasscodeHasPasscode func() bool
 }
 
 // DefaultConfig returns a Config with sensible defaults

--- a/internal/terminal/errors.go
+++ b/internal/terminal/errors.go
@@ -86,3 +86,24 @@ var (
 	// ErrServerAlreadyRunning indicates the server is already running
 	ErrServerAlreadyRunning = errors.New("server is already running")
 )
+
+// Passcode gate reason codes (aceteam#6524, citadel#753). handleWebSocket's
+// reject response carries one of these in its "reason" field so a client can
+// distinguish "no passcode configured at all" from "wrong passcode presented"
+// instead of string-matching the "error" text. Mirrors the
+// ReasonPasscodeNotSet / ReasonPasscodeInvalid pair in
+// internal/jobs/shell_command.go, which gates SHELL_COMMAND the same way; kept
+// as separate constants here (rather than imported) to avoid coupling the
+// terminal package to internal/jobs for two string literals.
+const (
+	// ReasonPasscodeNotSet means the node has no passcode configured at all
+	// (the underlying config.Permissions.PasscodeHash is empty). Nothing was
+	// presented for VerifyPasscode to check against; the operator must set a
+	// passcode (citadel passcode set) before this surface is reachable.
+	ReasonPasscodeNotSet = "passcode_not_set"
+
+	// ReasonPasscodeInvalid means a passcode IS configured but the one
+	// presented on the connection (?passcode= query param or the
+	// X-Citadel-Passcode header) was absent or did not match.
+	ReasonPasscodeInvalid = "passcode_invalid"
+)

--- a/internal/terminal/passcode_reason_test.go
+++ b/internal/terminal/passcode_reason_test.go
@@ -1,0 +1,153 @@
+// internal/terminal/passcode_reason_test.go
+//
+// Covers citadel#753: the passcode-gate reject response must distinguish
+// ReasonPasscodeNotSet (no node passcode configured at all) from
+// ReasonPasscodeInvalid (a passcode is configured but the wrong one, or none,
+// was presented), so a client can show actionable text instead of a generic
+// "node passcode required". See internal/jobs/shell_command.go for the
+// mirrored SHELL_COMMAND behavior this pattern is modeled on.
+package terminal
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// passcodeRejectBody is the shape written by writeJSONErrorWithReason.
+type passcodeRejectBody struct {
+	Error  string `json:"error"`
+	Status int    `json:"status"`
+	Reason string `json:"reason"`
+}
+
+// startPasscodeTestServer builds and starts a terminal server with a token
+// validator, a PasscodeVerifier that only accepts "correct-pin", and the
+// given hasPasscode signal. Returns the port and a teardown func.
+func startPasscodeTestServer(t *testing.T, port int, hasPasscode func() bool) (int, func()) {
+	t.Helper()
+	auth := NewMockTokenValidator()
+	auth.AddValidToken("tok-1", &TokenInfo{UserID: "alice", OrgID: "org-1"})
+
+	cfg := &Config{
+		Host:           "127.0.0.1",
+		Port:           port,
+		MaxConnections: 10,
+		IdleTimeout:    30 * time.Minute,
+		OrgID:          "org-1",
+		Shell:          "/bin/sh",
+		RateLimitRPS:   100,
+		RateLimitBurst: 100,
+		PasscodeVerifier: func(pin string) bool {
+			return pin == "correct-pin"
+		},
+	}
+	if hasPasscode != nil {
+		cfg.PasscodeHasPasscode = hasPasscode
+	}
+
+	s := NewServer(cfg, auth)
+	if err := s.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	return port, func() { _ = s.Stop(context.Background()) }
+}
+
+func fetchPasscodeReject(t *testing.T, port int, passcode string) passcodeRejectBody {
+	t.Helper()
+	url := fmt.Sprintf("http://127.0.0.1:%d/terminal?token=tok-1&passcode=%s", port, passcode)
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+	var body passcodeRejectBody
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode reject body: %v", err)
+	}
+	return body
+}
+
+// TestPasscodeReject_NotSet confirms that when PasscodeHasPasscode reports no
+// passcode configured, the reject carries ReasonPasscodeNotSet regardless of
+// what was presented.
+func TestPasscodeReject_NotSet(t *testing.T) {
+	port, stop := startPasscodeTestServer(t, 17901, func() bool { return false })
+	defer stop()
+
+	body := fetchPasscodeReject(t, port, "anything")
+	if body.Reason != ReasonPasscodeNotSet {
+		t.Errorf("reason = %q, want %q", body.Reason, ReasonPasscodeNotSet)
+	}
+}
+
+// TestPasscodeReject_Invalid confirms that when a passcode IS configured but
+// the wrong one is presented, the reject carries ReasonPasscodeInvalid.
+func TestPasscodeReject_Invalid(t *testing.T) {
+	port, stop := startPasscodeTestServer(t, 17902, func() bool { return true })
+	defer stop()
+
+	body := fetchPasscodeReject(t, port, "wrong-pin")
+	if body.Reason != ReasonPasscodeInvalid {
+		t.Errorf("reason = %q, want %q", body.Reason, ReasonPasscodeInvalid)
+	}
+}
+
+// TestPasscodeReject_NoHasPasscodeWired confirms the pre-#753 fallback: when
+// PasscodeHasPasscode is not wired at all (nil), the reject response omits
+// the reason field rather than guessing, so callers that only wire
+// PasscodeVerifier (e.g. any config predating this field) see unchanged
+// behavior.
+func TestPasscodeReject_NoHasPasscodeWired(t *testing.T) {
+	port, stop := startPasscodeTestServer(t, 17903, nil)
+	defer stop()
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/terminal?token=tok-1&passcode=wrong", port)
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+	var raw map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		t.Fatalf("decode reject body: %v", err)
+	}
+	if _, present := raw["reason"]; present {
+		t.Errorf("reason field present (%v) when PasscodeHasPasscode is nil; want omitted", raw["reason"])
+	}
+}
+
+// TestPasscodeReject_CorrectPinSucceeds is a control: presenting the correct
+// pin must not be rejected by the passcode gate at all (the test asserts the
+// request proceeds past the gate to the WS upgrade, which fails this plain
+// http.Get for lack of upgrade headers, a different status than the 401 the
+// passcode gate would have produced, confirming the gate itself passed).
+func TestPasscodeReject_CorrectPinSucceeds(t *testing.T) {
+	port, stop := startPasscodeTestServer(t, 17904, func() bool { return true })
+	defer stop()
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/terminal?token=tok-1&passcode=correct-pin", port)
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+
+	// A non-WS GET past the passcode gate fails the Upgrade() call itself,
+	// which is not the 401 the passcode gate would have produced. This
+	// confirms the gate let it through.
+	if resp.StatusCode == http.StatusUnauthorized {
+		t.Fatalf("correct passcode was still rejected with 401")
+	}
+}

--- a/internal/terminal/server.go
+++ b/internal/terminal/server.go
@@ -352,6 +352,20 @@ func writeJSONError(w http.ResponseWriter, message string, status int) {
 	fmt.Fprintf(w, `{"error":"%s","status":%d}`, message, status)
 }
 
+// writeJSONErrorWithReason writes a JSON-formatted error response carrying an
+// additional machine-readable "reason" field alongside the existing "error"
+// and "status" fields (citadel#753), so a client can branch on Reason instead
+// of string-matching the human-readable message, mirroring the
+// {"reason":"<code>","message":"<human>"} shape internal/jobs/shell_command.go
+// uses for SHELL_COMMAND refusals. The HTTP status and body shape for every
+// existing writeJSONError caller are unchanged; this is a purely additive
+// sibling used only where a reason code is available.
+func writeJSONErrorWithReason(w http.ResponseWriter, message string, status int, reason string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	fmt.Fprintf(w, `{"error":"%s","status":%d,"reason":"%s"}`, message, status, reason)
+}
+
 // handleRoot handles requests to the root endpoint
 func (s *Server) handleRoot(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
@@ -502,8 +516,24 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 			passcode = r.Header.Get("X-Citadel-Passcode")
 		}
 		if !s.config.PasscodeVerifier(passcode) {
-			s.logger.Printf("passcode gate rejected connection from %s (user %s, via %s)", ip, tokenInfo.UserID, authVia)
+			// Distinguish "no passcode configured at all" (ReasonPasscodeNotSet:
+			// the operator must set one) from "a passcode is set but the wrong
+			// one was presented" (ReasonPasscodeInvalid), mirroring
+			// internal/jobs/shell_command.go (citadel#753). When
+			// PasscodeHasPasscode is not wired, the distinction is unavailable
+			// and the reject falls back to the pre-#753 reason-less response
+			// (writeJSONError) rather than guessing.
 			atomic.AddInt64(&s.failedConnections, 1)
+			if s.config.PasscodeHasPasscode != nil {
+				reason := ReasonPasscodeInvalid
+				if !s.config.PasscodeHasPasscode() {
+					reason = ReasonPasscodeNotSet
+				}
+				s.logger.Printf("passcode gate rejected connection from %s (user %s, via %s, reason=%s)", ip, tokenInfo.UserID, authVia, reason)
+				writeJSONErrorWithReason(w, "node passcode required", http.StatusUnauthorized, reason)
+				return
+			}
+			s.logger.Printf("passcode gate rejected connection from %s (user %s, via %s)", ip, tokenInfo.UserID, authVia)
 			writeJSONError(w, "node passcode required", http.StatusUnauthorized)
 			return
 		}


### PR DESCRIPTION
## Summary

This is the node side of #753. A node with `console: true` (Web Terminal) requires a per-node passcode (aceteam#6524), but there was no CLI to set that passcode, and the terminal server's reject response gave no way to tell "no passcode configured" apart from "wrong passcode presented". This PR closes both gaps and adds a local warning when a sensitive surface is enabled with no passcode set.

Client side passcode forwarding (`citadel connect` / `citadel ssh`, prompting on a 401) is a separate PR against #754, owned by another agent. This PR is self contained and does not depend on it.

- Adds `citadel passcode set` and `citadel passcode clear`. `set` reads the PIN from a no echo interactive prompt (with confirmation re entry) or from piped stdin, never from a command line argument, so it can't land in shell history or be visible via `ps`. Both commands note they take effect immediately, no worker restart needed, since every gate reloads `permissions.yaml` per connection.
- `internal/terminal/server.go`'s passcode gate reject now carries a `reason` field, `passcode_not_set` or `passcode_invalid`, mirroring the existing pattern in `internal/jobs/shell_command.go`. This is additive: the HTTP status and fail closed behavior are unchanged, and when the new `Config.PasscodeHasPasscode` hook isn't wired the reject is identical to before (no reason field).
- `citadel work` now logs one warning line at startup when Console, Desktop, or Files is enabled but no node passcode is set, since that surface fails closed silently while doctor and heartbeat stay green.

## Security review

This touches an auth path (the passcode gate that sits after token/mesh-identity auth on the terminal server). Opening as draft; please do not merge before security review. No fail closed behavior was weakened; the reason field is purely additive and falls back to the pre-existing response shape when not wired.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/terminal/... ./internal/config/... ./cmd/...`
- [x] Full `go test ./...` (no regressions)
- [x] New tests for each new behavior (passcode set/clear persistence and rejection of empty pins, stdin reading, confirmation matching, the passcode_not_set/passcode_invalid split, and the startup warning), each mutation tested by reverting the specific fix and confirming the matching test fails, then restoring
