### PR TITLE
fix(cli): citadel ssh and connect try the terminal endpoint before raw sshd

### DIFF
--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -23,29 +23,46 @@ var (
 
 var connectCmd = &cobra.Command{
 	Use:   "connect [peer|peer:port]",
-	Short: "Open a remote shell on another node, or pipe a raw TCP service",
+	Short: "Open a shell on another node, or pipe a raw TCP service",
 	Long: `Two modes, selected by whether you give a port:
 
-  citadel connect <node-name | ip>          Open an interactive remote shell
+  citadel connect <node-name | ip>          Open a shell on the target
   citadel connect <node-name | ip>:<port>   Pipe a raw TCP service (stdin/stdout)
 
-REMOTE SHELL (no port):
-  Drops you into an interactive shell on the target node over the AceTeam
-  Network mesh — collapsing the old multi-hop SSH chain
-  (ssh a -> ssh b -> tmux) into a single command from any machine on the mesh.
-  No host SSH config, no '.local' mDNS, no manual hops.
+BARE TARGET (no port):
+  This is an alias of 'citadel ssh <peer>' (see 'citadel ssh --help'): both
+  commands route a bare target through the exact same logic (issue #754).
 
-  The target node must be running its terminal endpoint, which 'citadel work'
-  starts by default (disable with --no-terminal). No token is needed: the node
-  trusts your verified mesh-peer identity over the VPN (citadel #585). Repeated
-  connects re-attach to the same live tmux-backed shell. A --token (or
+  By default this tries the AceTeam Network terminal endpoint first,
+  collapsing the old multi-hop SSH chain (ssh a -> ssh b -> tmux) into a
+  single command from any machine on the mesh, no host SSH config, no
+  '.local' mDNS, no manual hops, and it works even on nodes whose host sshd
+  is not exposed on the mesh. A node passcode challenge is NOT treated as a
+  failure to fall back on: you are prompted for it interactively instead.
+  Only when the terminal endpoint itself is unreachable does this fall back
+  to a real OpenSSH connection (tunneled through the mesh to the peer's
+  sshd, port 22 by default), the pre-#754 behavior of 'citadel ssh'.
+
+  The terminal endpoint is started by 'citadel work' by default (disable
+  with --no-terminal). No token is needed there: the node trusts your
+  verified mesh-peer identity over the VPN (citadel #585). Repeated connects
+  re-attach to the same live tmux-backed shell. A --token (or
   CITADEL_TERMINAL_TOKEN) is still accepted for the platform terminal path or
   when the target disables mesh trust.
 
+  --raw (alias --via-sshd) skips straight to the OpenSSH path.
+  --mesh (alias --terminal) forces the terminal-endpoint path only, with no
+  OpenSSH fallback.
+  A node passcode (when the operator has set one) is supplied via --passcode
+  or CITADEL_TERMINAL_PASSCODE, or prompted for interactively. -u/--user and
+  -p/--port for the OpenSSH path are only on 'citadel ssh'.
+
 RAW TCP (with port):
   Establishes a raw TCP connection to a service on the target and pipes
-  stdin/stdout to it. Used internally by 'citadel ssh' as a ProxyCommand,
-  and useful for testing connectivity or piping data through the network.
+  stdin/stdout to it. Used internally by the OpenSSH fallback as a
+  ProxyCommand, and useful for testing connectivity or piping data through
+  the network. Unaffected by any of the above: always a direct dial, no
+  terminal-endpoint attempt, no passcode prompt.
 
 PEER IDENTIFICATION (both modes):
   - By hostname:  citadel connect gpu-node-1
@@ -54,12 +71,15 @@ PEER IDENTIFICATION (both modes):
 
 The connection uses the tsnet userspace network, so it can reach peers
 that system networking cannot.`,
-	Example: `  # Open an interactive remote shell (by name or mesh IP)
+	Example: `  # Open a shell (by name or mesh IP; tries the terminal endpoint, falls back to sshd)
   citadel connect gpu-node-1
   citadel connect 100.64.0.25
 
-  # Remote shell with an explicit terminal token / port
+  # Shell with an explicit terminal token / port
   citadel connect gpu-node-1 --token tok_... --terminal-port 7860
+
+  # Force the terminal-endpoint path only, no OpenSSH fallback
+  citadel connect gpu-node-1 --mesh
 
   # Raw TCP: connect to a PostgreSQL server
   citadel connect gpu-node-1:5432
@@ -71,11 +91,13 @@ that system networking cannot.`,
   citadel connect`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		// Remote-shell mode: a single bare target (name or IP) with no :port.
-		// A port (host:port) always routes to the existing raw-TCP path, which
-		// keeps 'citadel ssh's ProxyCommand (always ip:port) unchanged.
+		// Bare-target mode: a single target (name or IP) with no :port,
+		// shared with 'citadel ssh' via connectToNode (#754). A port
+		// (host:port) always routes to the existing raw-TCP path below,
+		// which keeps the OpenSSH fallback's ProxyCommand (always ip:port)
+		// unchanged.
 		if len(args) == 1 && connectIsShellTarget(args[0]) {
-			if err := runRemoteShell(args[0]); err != nil {
+			if err := connectToNode(cmd, args[0]); err != nil {
 				badColor.Printf("Error: %v\n", err)
 				os.Exit(1)
 			}
@@ -283,6 +305,17 @@ func connectIsShellTarget(arg string) bool {
 func init() {
 	rootCmd.AddCommand(connectCmd)
 	connectCmd.Flags().IntVar(&connectTimeout, "timeout", 0, "Connection timeout in seconds (0 = no timeout, raw-TCP mode)")
-	connectCmd.Flags().IntVar(&connectTerminalPort, "terminal-port", 7860, "Terminal endpoint port on the target (remote-shell mode)")
-	connectCmd.Flags().StringVar(&connectToken, "token", "", "Terminal auth token (remote-shell mode; OPTIONAL — mesh identity is trusted by default; or set CITADEL_TERMINAL_TOKEN)")
+	connectCmd.Flags().IntVar(&connectTerminalPort, "terminal-port", 7860, "Terminal endpoint port on the target (bare-target mode)")
+	connectCmd.Flags().StringVar(&connectToken, "token", "", "Terminal auth token (bare-target mode; OPTIONAL, mesh identity is trusted by default; or set CITADEL_TERMINAL_TOKEN)")
+
+	// Shared with 'citadel ssh' (same package vars, cmd/ssh.go, cmd/connect_dispatch.go)
+	// so a bare target behaves identically regardless of which command name
+	// was used (#754). -u/--user and -p/--port for the OpenSSH fallback are
+	// deliberately NOT mirrored here: they only make sense against a real
+	// sshd, and 'citadel ssh -u/-p' remains the way to set them.
+	connectCmd.Flags().BoolVar(&viaRaw, "raw", false, "Force the raw sshd path, skipping the terminal endpoint entirely (bare-target mode)")
+	connectCmd.Flags().BoolVar(&viaRaw, "via-sshd", false, "Alias of --raw")
+	connectCmd.Flags().BoolVar(&viaMesh, "mesh", false, "Force the terminal-endpoint path only, no raw sshd fallback (bare-target mode)")
+	connectCmd.Flags().BoolVar(&viaMesh, "terminal", false, "Alias of --mesh")
+	connectCmd.Flags().StringVar(&shellPasscode, "passcode", "", "Node passcode for the terminal endpoint (or CITADEL_TERMINAL_PASSCODE); prompted interactively if required and omitted")
 }

--- a/cmd/connect_dispatch.go
+++ b/cmd/connect_dispatch.go
@@ -1,0 +1,183 @@
+// cmd/connect_dispatch.go
+//
+// Shared bare-target dispatcher for `citadel ssh <node>` and
+// `citadel connect <node>` (issue #754). A bare target (no :port) used to
+// route straight through OpenSSH via a raw-TCP ProxyCommand to the peer's
+// port 22, which embedded-tsnet nodes never expose on the mesh (only ports
+// citadel explicitly ListenVPNs, namely 7860 terminal, 8080 status, 8444
+// gateway, answer inbound; see cmd/mesh.go), so the dial was refused and
+// ssh printed the opaque "Connection closed by UNKNOWN port 65535".
+//
+// Both commands now route a bare target through connectToNode, which:
+//  1. tries the ts-net terminal endpoint first (runRemoteShell, :7860, the
+//     path that already works on embedded-tsnet, since it rides a port
+//     citadel does ListenVPN);
+//  2. on a 401 that is specifically the terminal endpoint's optional
+//     passcode gate (aceteam#6524/citadel#753), prompts interactively (no
+//     echo) and retries ts-net. A passcode challenge means the endpoint IS
+//     reachable, so it must never trigger the fallback below;
+//  3. falls back to the legacy raw-sshd path (OpenSSH via
+//     'citadel connect <ip>:22' as ProxyCommand) ONLY when the ts-net
+//     endpoint itself is unreachable (connection refused / not listening).
+//
+// `citadel connect <node>:<port>` (an explicit port) is a separate,
+// unchanged raw-TCP piping mode; see cmd/connect.go. It is never touched by
+// any of this.
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+var (
+	// viaRaw forces the legacy raw-sshd path (OpenSSH via
+	// 'citadel connect <ip>:22' as ProxyCommand), skipping the ts-net
+	// terminal endpoint entirely. --via-sshd is an alias.
+	viaRaw bool
+	// viaMesh forces the ts-net terminal-endpoint path only: never falls
+	// back to raw sshd even if the endpoint is unreachable. --terminal is an
+	// alias.
+	viaMesh bool
+	// shellPasscode is the node passcode for the ts-net terminal endpoint's
+	// optional passcode gate (aceteam#6524/citadel#753). Falls back to
+	// CITADEL_TERMINAL_PASSCODE, then an interactive no-echo prompt on a
+	// 401. Never logged, never placed on any subprocess argv.
+	shellPasscode string
+)
+
+// maxPasscodeAttempts bounds the interactive retry loop so a mistyped
+// passcode does not prompt forever, while still tolerating a typo.
+const maxPasscodeAttempts = 3
+
+// rawFallbackNotice is printed right before falling back to the legacy raw
+// sshd path. The guidance has to be up front, not appended after the fact:
+// runLegacySSH calls os.Exit directly on an ssh(1) failure (preserving its
+// exit code), so nothing printed after that point would ever be seen. If the
+// node is embedded-tsnet with no host sshd exposed on the mesh (#754's
+// original report), this fallback will ALSO fail, and the operator would
+// otherwise be left with only OpenSSH's own opaque
+// "Connection closed by UNKNOWN port 65535".
+const rawFallbackNotice = "Terminal endpoint unreachable on the mesh; falling back to raw sshd (port 22). " +
+	"If that also fails, this node likely does not expose host sshd on the mesh: " +
+	"start 'citadel work' on it, or re-run with --mesh to see the terminal-endpoint error directly."
+
+// terminalAttemptFn performs one attempt to open the ts-net terminal shell
+// against target with the given passcode. Package var so tests can
+// substitute a fake without a live mesh/terminal server.
+var terminalAttemptFn = runRemoteShell
+
+// legacySSHFn execs the real ssh(1) binary against target via the raw-TCP
+// ProxyCommand fallback. Package var so tests can substitute a fake without
+// spawning a real ssh process.
+var legacySSHFn = runLegacySSH
+
+// promptPasscodeFn reads a node passcode from the terminal. Package var so
+// tests can substitute a fixed answer without a TTY.
+var promptPasscodeFn = promptPasscode
+
+// connectToNode implements the shared bare-target routing for both
+// `citadel ssh <node>` and `citadel connect <node>` (#754): both commands'
+// Run functions call this with the raw target string, so they behave
+// identically for the same target and flags.
+func connectToNode(cmd *cobra.Command, target string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := ensureNetworkConnectedFn(ctx); err != nil {
+		return err
+	}
+
+	// -u/--user and -p/--port only make sense against a real sshd, so naming
+	// either implies the raw path: silently ignoring them on the ts-net path
+	// would be a silent behavior regression for existing 'citadel ssh -p ...'
+	// users. Only registered on sshCmd (see cmd/ssh.go), so this is always
+	// false for a connectCmd invocation.
+	portOrUserGiven := cmd.Flags().Changed("user") || cmd.Flags().Changed("port")
+
+	if viaRaw && viaMesh {
+		return fmt.Errorf("--raw/--via-sshd and --mesh/--terminal are mutually exclusive")
+	}
+	if portOrUserGiven && viaMesh {
+		return fmt.Errorf("--user/--port select the raw sshd path, which conflicts with --mesh/--terminal (ts-net only, no sshd)")
+	}
+
+	if viaRaw || portOrUserGiven {
+		return legacySSHFn(target)
+	}
+
+	passcode := shellPasscode
+	if passcode == "" {
+		passcode = os.Getenv("CITADEL_TERMINAL_PASSCODE")
+	}
+
+	for attempt := 1; attempt <= maxPasscodeAttempts; attempt++ {
+		err := terminalAttemptFn(target, passcode)
+		if err == nil {
+			return nil
+		}
+
+		var tdErr *terminalDialError
+		if errors.As(err, &tdErr) {
+			switch tdErr.kind {
+			case terminalDialErrPasscode:
+				// A 401 from the passcode gate means the endpoint IS
+				// reachable: never a fallback trigger (#754). Prompt for a
+				// passcode and retry ts-net instead.
+				if attempt == maxPasscodeAttempts {
+					return fmt.Errorf("passcode rejected after %d attempt(s)", attempt)
+				}
+				warnColor.Fprintln(os.Stderr, "This node requires a passcode.")
+				pc, perr := promptPasscodeFn("Passcode: ")
+				if perr != nil {
+					return fmt.Errorf("failed to read passcode: %w", perr)
+				}
+				passcode = pc
+				continue
+			case terminalDialErrUnreachable:
+				if viaMesh {
+					return err
+				}
+				warnColor.Fprintln(os.Stderr, rawFallbackNotice)
+				return legacySSHFn(target)
+			}
+		}
+		// Every other error (auth-rejected-but-not-passcode, 503, malformed
+		// handshake, ...) is surfaced as-is: not a passcode-retry trigger,
+		// not a fallback trigger.
+		return err
+	}
+	return fmt.Errorf("passcode retry limit reached")
+}
+
+// promptPasscode reads a node passcode with terminal echo disabled where
+// possible, so it never appears on screen, in shell history, or in any
+// process argv.
+func promptPasscode(prompt string) (string, error) {
+	fmt.Fprint(os.Stderr, prompt)
+	stdinFd := int(os.Stdin.Fd())
+	if term.IsTerminal(stdinFd) {
+		b, err := term.ReadPassword(stdinFd)
+		fmt.Fprintln(os.Stderr)
+		if err != nil {
+			return "", err
+		}
+		return string(b), nil
+	}
+	// Non-interactive fallback (piped stdin, tests): there is no terminal to
+	// suppress echo on anyway.
+	reader := bufio.NewReader(os.Stdin)
+	line, err := reader.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+	return strings.TrimRight(line, "\r\n"), nil
+}

--- a/cmd/connect_dispatch_test.go
+++ b/cmd/connect_dispatch_test.go
@@ -1,0 +1,342 @@
+// cmd/connect_dispatch_test.go
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// resetDispatchState saves and restores every package var connectToNode's
+// routing depends on, plus the injectable function vars. The cmd package's
+// tests share one binary, so an unrestored override in one test would leak
+// into every test that runs after it.
+func resetDispatchState(t *testing.T) {
+	t.Helper()
+	origViaRaw, origViaMesh, origPasscode := viaRaw, viaMesh, shellPasscode
+	origSSHUser, origSSHPort := sshUser, sshPort
+	origTerminalAttempt := terminalAttemptFn
+	origLegacySSH := legacySSHFn
+	origPromptPasscode := promptPasscodeFn
+	origEnsureNetwork := ensureNetworkConnectedFn
+
+	t.Cleanup(func() {
+		viaRaw, viaMesh, shellPasscode = origViaRaw, origViaMesh, origPasscode
+		sshUser, sshPort = origSSHUser, origSSHPort
+		terminalAttemptFn = origTerminalAttempt
+		legacySSHFn = origLegacySSH
+		promptPasscodeFn = origPromptPasscode
+		ensureNetworkConnectedFn = origEnsureNetwork
+	})
+
+	viaRaw, viaMesh, shellPasscode = false, false, ""
+	sshUser, sshPort = "", ""
+	ensureNetworkConnectedFn = func(context.Context) error { return nil }
+}
+
+// cmdWithChangedFlags returns a throwaway *cobra.Command carrying the same
+// "user"/"port" flags sshCmd registers, with the named ones marked as
+// explicitly set (pflag's Set() marks Changed=true), so connectToNode's
+// cmd.Flags().Changed("user"/"port") check can be driven without touching
+// the real sshCmd/connectCmd singletons (which every other test in this
+// package also uses).
+func cmdWithChangedFlags(changed []string) *cobra.Command {
+	c := &cobra.Command{Use: "test"}
+	var u, p string
+	c.Flags().StringVarP(&u, "user", "u", "", "")
+	c.Flags().StringVarP(&p, "port", "p", "", "")
+	for _, name := range changed {
+		_ = c.Flags().Set(name, "x")
+	}
+	return c
+}
+
+func TestConnectToNode_TsNetSuccess(t *testing.T) {
+	resetDispatchState(t)
+
+	var gotTarget, gotPasscode string
+	var calls int
+	terminalAttemptFn = func(target, passcode string) error {
+		calls++
+		gotTarget, gotPasscode = target, passcode
+		return nil
+	}
+	legacySSHFn = func(string) error {
+		t.Fatal("legacySSHFn must not be called on ts-net success")
+		return nil
+	}
+
+	if err := connectToNode(cmdWithChangedFlags(nil), "gpu-node-1"); err != nil {
+		t.Fatalf("connectToNode() error = %v, want nil", err)
+	}
+	if calls != 1 {
+		t.Fatalf("terminalAttemptFn called %d times, want 1", calls)
+	}
+	if gotTarget != "gpu-node-1" {
+		t.Errorf("target = %q, want %q", gotTarget, "gpu-node-1")
+	}
+	if gotPasscode != "" {
+		t.Errorf("passcode = %q, want empty (none configured)", gotPasscode)
+	}
+}
+
+func TestConnectToNode_UnreachableFallsBackToRawSSHD(t *testing.T) {
+	resetDispatchState(t)
+
+	terminalAttemptFn = func(target, passcode string) error {
+		return &terminalDialError{kind: terminalDialErrUnreachable, err: errors.New("connection refused")}
+	}
+	var legacyCalls int
+	var legacyTarget string
+	legacySSHFn = func(target string) error {
+		legacyCalls++
+		legacyTarget = target
+		return nil
+	}
+
+	if err := connectToNode(cmdWithChangedFlags(nil), "gpu-node-1"); err != nil {
+		t.Fatalf("connectToNode() error = %v, want nil", err)
+	}
+	if legacyCalls != 1 {
+		t.Fatalf("legacySSHFn called %d times, want 1 (fallback on unreachable)", legacyCalls)
+	}
+	if legacyTarget != "gpu-node-1" {
+		t.Errorf("legacySSHFn target = %q, want %q", legacyTarget, "gpu-node-1")
+	}
+}
+
+// TestRawFallbackNoticeIsActionable pins the substance of the message
+// printed right before falling back to raw sshd. This has to carry the real
+// guidance up front: runLegacySSH calls os.Exit directly on an ssh(1)
+// failure, so if the raw-sshd fallback ALSO fails (the exact #754 report:
+// an embedded-tsnet node with no host sshd exposed on the mesh), nothing
+// printed afterward would ever be seen, and the operator is left staring at
+// OpenSSH's own opaque "Connection closed by UNKNOWN port 65535" with no
+// citadel-authored guidance at all.
+func TestRawFallbackNoticeIsActionable(t *testing.T) {
+	for _, want := range []string{"raw sshd", "citadel work", "--mesh"} {
+		if !strings.Contains(rawFallbackNotice, want) {
+			t.Errorf("rawFallbackNotice = %q, want it to mention %q", rawFallbackNotice, want)
+		}
+	}
+}
+
+func TestConnectToNode_MeshOnly_NoFallbackOnUnreachable(t *testing.T) {
+	resetDispatchState(t)
+	viaMesh = true
+
+	wantErr := &terminalDialError{kind: terminalDialErrUnreachable, err: errors.New("connection refused")}
+	terminalAttemptFn = func(target, passcode string) error { return wantErr }
+	legacySSHFn = func(string) error {
+		t.Fatal("legacySSHFn must not be called with --mesh forcing ts-net only")
+		return nil
+	}
+
+	err := connectToNode(cmdWithChangedFlags(nil), "gpu-node-1")
+	var tdErr *terminalDialError
+	if !errors.As(err, &tdErr) || tdErr.kind != terminalDialErrUnreachable {
+		t.Fatalf("connectToNode() error = %v, want the unreachable dial error surfaced directly (no fallback under --mesh)", err)
+	}
+}
+
+func TestConnectToNode_PasscodePromptAndRetry(t *testing.T) {
+	resetDispatchState(t)
+
+	var attempts []string // passcodes seen by terminalAttemptFn, in order
+	terminalAttemptFn = func(target, passcode string) error {
+		attempts = append(attempts, passcode)
+		if passcode == "correct-horse" {
+			return nil
+		}
+		return &terminalDialError{kind: terminalDialErrPasscode, err: errors.New("node passcode required")}
+	}
+	var promptCalls int
+	promptPasscodeFn = func(prompt string) (string, error) {
+		promptCalls++
+		return "correct-horse", nil
+	}
+	legacySSHFn = func(string) error {
+		t.Fatal("legacySSHFn must not be called for a passcode rejection (#754: not a fallback trigger)")
+		return nil
+	}
+
+	if err := connectToNode(cmdWithChangedFlags(nil), "gpu-node-1"); err != nil {
+		t.Fatalf("connectToNode() error = %v, want nil after a successful retry", err)
+	}
+	if promptCalls != 1 {
+		t.Fatalf("promptPasscodeFn called %d times, want 1", promptCalls)
+	}
+	if len(attempts) != 2 {
+		t.Fatalf("terminalAttemptFn called %d times, want 2 (initial + retry)", len(attempts))
+	}
+	if attempts[0] != "" {
+		t.Errorf("first attempt passcode = %q, want empty", attempts[0])
+	}
+	if attempts[1] != "correct-horse" {
+		t.Errorf("retry passcode = %q, want %q", attempts[1], "correct-horse")
+	}
+}
+
+func TestConnectToNode_PasscodeRejectedExhausted_NeverFallsBack(t *testing.T) {
+	resetDispatchState(t)
+
+	var attempts int
+	terminalAttemptFn = func(target, passcode string) error {
+		attempts++
+		return &terminalDialError{kind: terminalDialErrPasscode, err: errors.New("node passcode required")}
+	}
+	var promptCalls int
+	promptPasscodeFn = func(prompt string) (string, error) {
+		promptCalls++
+		return "still-wrong", nil
+	}
+	legacySSHFn = func(string) error {
+		t.Fatal("legacySSHFn must not be called after repeated passcode rejections (#754: not a fallback trigger)")
+		return nil
+	}
+
+	err := connectToNode(cmdWithChangedFlags(nil), "gpu-node-1")
+	if err == nil {
+		t.Fatal("connectToNode() error = nil, want a passcode-rejected error")
+	}
+	if attempts != maxPasscodeAttempts {
+		t.Errorf("terminalAttemptFn called %d times, want %d (maxPasscodeAttempts)", attempts, maxPasscodeAttempts)
+	}
+	if promptCalls != maxPasscodeAttempts-1 {
+		t.Errorf("promptPasscodeFn called %d times, want %d", promptCalls, maxPasscodeAttempts-1)
+	}
+}
+
+func TestConnectToNode_PasscodeFromEnv(t *testing.T) {
+	resetDispatchState(t)
+	t.Setenv("CITADEL_TERMINAL_PASSCODE", "env-secret")
+
+	var gotPasscode string
+	terminalAttemptFn = func(target, passcode string) error {
+		gotPasscode = passcode
+		return nil
+	}
+	legacySSHFn = func(string) error { t.Fatal("unexpected fallback"); return nil }
+
+	if err := connectToNode(cmdWithChangedFlags(nil), "gpu-node-1"); err != nil {
+		t.Fatalf("connectToNode() error = %v", err)
+	}
+	if gotPasscode != "env-secret" {
+		t.Errorf("passcode = %q, want %q (from CITADEL_TERMINAL_PASSCODE)", gotPasscode, "env-secret")
+	}
+}
+
+func TestConnectToNode_RawSkipsTsNet(t *testing.T) {
+	resetDispatchState(t)
+	viaRaw = true
+
+	terminalAttemptFn = func(string, string) error {
+		t.Fatal("terminalAttemptFn must not be called with --raw")
+		return nil
+	}
+	var legacyCalls int
+	legacySSHFn = func(string) error { legacyCalls++; return nil }
+
+	if err := connectToNode(cmdWithChangedFlags(nil), "gpu-node-1"); err != nil {
+		t.Fatalf("connectToNode() error = %v, want nil", err)
+	}
+	if legacyCalls != 1 {
+		t.Fatalf("legacySSHFn called %d times, want 1", legacyCalls)
+	}
+}
+
+func TestConnectToNode_RawAndMeshConflict(t *testing.T) {
+	resetDispatchState(t)
+	viaRaw, viaMesh = true, true
+
+	terminalAttemptFn = func(string, string) error { t.Fatal("unexpected call"); return nil }
+	legacySSHFn = func(string) error { t.Fatal("unexpected call"); return nil }
+
+	err := connectToNode(cmdWithChangedFlags(nil), "gpu-node-1")
+	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("connectToNode() error = %v, want a mutually-exclusive-flags error", err)
+	}
+}
+
+func TestConnectToNode_PortOrUserImpliesRaw(t *testing.T) {
+	for _, flag := range []string{"port", "user"} {
+		t.Run(flag, func(t *testing.T) {
+			resetDispatchState(t)
+
+			terminalAttemptFn = func(string, string) error {
+				t.Fatal("terminalAttemptFn must not be called when -p/-u was given")
+				return nil
+			}
+			var legacyCalls int
+			legacySSHFn = func(string) error { legacyCalls++; return nil }
+
+			if err := connectToNode(cmdWithChangedFlags([]string{flag}), "gpu-node-1"); err != nil {
+				t.Fatalf("connectToNode() error = %v, want nil", err)
+			}
+			if legacyCalls != 1 {
+				t.Fatalf("legacySSHFn called %d times, want 1 (implied by -%s)", legacyCalls, flag)
+			}
+		})
+	}
+}
+
+func TestConnectToNode_PortOrUserConflictsWithMesh(t *testing.T) {
+	resetDispatchState(t)
+	viaMesh = true
+
+	terminalAttemptFn = func(string, string) error { t.Fatal("unexpected call"); return nil }
+	legacySSHFn = func(string) error { t.Fatal("unexpected call"); return nil }
+
+	err := connectToNode(cmdWithChangedFlags([]string{"port"}), "gpu-node-1")
+	if err == nil || !strings.Contains(err.Error(), "conflicts") {
+		t.Fatalf("connectToNode() error = %v, want a conflict error", err)
+	}
+}
+
+func TestConnectToNode_OtherErrorSurfacedDirectly(t *testing.T) {
+	resetDispatchState(t)
+
+	wantErr := fmt.Errorf("terminal handshake with node failed (HTTP 503)")
+	terminalAttemptFn = func(string, string) error { return wantErr }
+	legacySSHFn = func(string) error {
+		t.Fatal("legacySSHFn must not be called for a non-passcode, non-refused error")
+		return nil
+	}
+	promptPasscodeFn = func(string) (string, error) {
+		t.Fatal("promptPasscodeFn must not be called for a non-passcode error")
+		return "", nil
+	}
+
+	err := connectToNode(cmdWithChangedFlags(nil), "gpu-node-1")
+	if err != wantErr {
+		t.Fatalf("connectToNode() error = %v, want %v (surfaced as-is)", err, wantErr)
+	}
+}
+
+// TestBuildSSHArgs_NeverCarriesPasscode pins the security invariant behind
+// "never put the passcode in argv" (#754 PR): buildSSHArgs has no passcode
+// parameter, so it structurally cannot leak one into the ssh(1) argv even if
+// a node passcode is configured (subprocess argv is visible to other users
+// on the same machine via `ps`).
+func TestBuildSSHArgs_NeverCarriesPasscode(t *testing.T) {
+	resetDispatchState(t)
+	shellPasscode = "super-secret-passcode"
+
+	args := buildSSHArgs("/usr/local/bin/citadel", "100.64.0.5", "22", "ubuntu", true)
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, shellPasscode) {
+		t.Fatalf("buildSSHArgs() = %q, must never contain the node passcode", joined)
+	}
+	// Sanity: the function does produce the expected shape, so the
+	// non-containment above is a meaningful assertion and not vacuous.
+	if !strings.Contains(joined, "ProxyCommand=/usr/local/bin/citadel connect 100.64.0.5:22") {
+		t.Fatalf("buildSSHArgs() = %q, missing expected ProxyCommand", joined)
+	}
+	if !strings.Contains(joined, "ubuntu@100.64.0.5") {
+		t.Fatalf("buildSSHArgs() = %q, missing expected user@host target", joined)
+	}
+}

--- a/cmd/connect_shell.go
+++ b/cmd/connect_shell.go
@@ -11,11 +11,14 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -42,11 +45,11 @@ import (
 // default (citadel #585, DefaultSessionName="citadel"), so a repeated connect —
 // or a reconnect after a drop — re-attaches to the same live shell. Operators
 // can force a bare shell with CITADEL_TERMINAL_SESSION=none.
-func runRemoteShell(target string) error {
+func runRemoteShell(target, passcode string) error {
 	// Ensure the mesh is up before resolving/dialing.
 	netCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
-	if err := ensureNetworkConnected(netCtx); err != nil {
+	if err := ensureNetworkConnectedFn(netCtx); err != nil {
 		return err
 	}
 
@@ -69,16 +72,7 @@ func runRemoteShell(target string) error {
 	}
 
 	addr := net.JoinHostPort(ip, fmt.Sprintf("%d", connectTerminalPort))
-	query := url.Values{}
-	if token != "" {
-		query.Set("token", token)
-	}
-	wsURL := url.URL{
-		Scheme:   "ws",
-		Host:     addr,
-		Path:     "/terminal",
-		RawQuery: query.Encode(),
-	}
+	wsURL := terminalWSURL(addr, token, passcode)
 
 	display := hostname
 	if display == "" {
@@ -107,11 +101,113 @@ func runRemoteShell(target string) error {
 	return pumpRemoteShell(conn)
 }
 
+// terminalWSURL builds the terminal endpoint's WebSocket upgrade URL for
+// addr (host:port), forwarding token and/or passcode as query parameters the
+// same way the server reads them (internal/terminal/server.go:
+// r.URL.Query().Get("token") / .Get("passcode")). Each is set ONLY when
+// non-empty, so a node with neither configured sees the exact same request
+// it always has, and a node passcode (citadel#753) is never appended when
+// none was supplied. Pure and side-effect-free so the exact query string
+// (notably, the "passcode" key's presence) can be pinned by a test.
+func terminalWSURL(addr, token, passcode string) url.URL {
+	query := url.Values{}
+	if token != "" {
+		query.Set("token", token)
+	}
+	if passcode != "" {
+		query.Set("passcode", passcode)
+	}
+	return url.URL{
+		Scheme:   "ws",
+		Host:     addr,
+		Path:     "/terminal",
+		RawQuery: query.Encode(),
+	}
+}
+
+// terminalDialErrKind classifies why the ts-net terminal-endpoint dial failed
+// (#754), so connectToNode knows whether to prompt for a passcode and retry,
+// fall back to the legacy raw-sshd path, or just report the error as-is.
+type terminalDialErrKind int
+
+const (
+	// terminalDialErrOther covers every dial failure that is neither a
+	// passcode rejection nor a bare connection-refused: forbidden/not-found
+	// auth rejections, 503, malformed handshake, etc. Never a fallback
+	// trigger and never a passcode-retry trigger, surfaced as-is.
+	terminalDialErrOther terminalDialErrKind = iota
+	// terminalDialErrUnreachable means the ts-net terminal endpoint refused
+	// the TCP connection outright (not listening / 'citadel work' not
+	// running / --no-terminal). Safe to fall back to raw sshd for.
+	terminalDialErrUnreachable
+	// terminalDialErrPasscode means the endpoint IS reachable but rejected
+	// the connection with the terminal passcode gate (HTTP 401, node
+	// passcode required). NOT a fallback trigger: the caller should prompt
+	// for a passcode and retry ts-net.
+	terminalDialErrPasscode
+)
+
+// terminalDialError wraps a ts-net terminal-endpoint dial failure with a
+// classification connectToNode uses to route between prompting for a
+// passcode, falling back to raw sshd, and reporting the error directly.
+type terminalDialError struct {
+	kind terminalDialErrKind
+	err  error
+}
+
+func (e *terminalDialError) Error() string { return e.err.Error() }
+func (e *terminalDialError) Unwrap() error { return e.err }
+
+// terminalErrorBody mirrors the JSON error shape internal/terminal/server.go
+// writes ({"error":...,"status":...}, plus an optional "reason" field added
+// by citadel#753) closely enough to detect the passcode gate, without
+// importing that package: the wire contract, not the Go type, is what a
+// client should couple to (same rationale as isConnRefused's string match).
+type terminalErrorBody struct {
+	Error  string `json:"error"`
+	Reason string `json:"reason"`
+}
+
+// isPasscodeRequiredResponse reports whether a 401 from the terminal
+// endpoint is specifically the passcode gate (node passcode required)
+// rather than a rejected/invalid auth token: both return HTTP 401
+// (internal/terminal/server.go resolveAuth vs. the PasscodeVerifier check),
+// so the response body is the only thing that tells them apart. A
+// malformed/unreadable body is treated as NOT passcode-required (falls
+// through to the existing generic auth-rejected message) rather than
+// guessing. The "reason" field (citadel#753) is read opportunistically when
+// present but never required; the "error" text is the stable contract.
+func isPasscodeRequiredResponse(resp *http.Response) bool {
+	if resp == nil || resp.Body == nil {
+		return false
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if err != nil {
+		return false
+	}
+	var body terminalErrorBody
+	if err := json.Unmarshal(data, &body); err != nil {
+		return false
+	}
+	if strings.HasPrefix(body.Reason, "passcode_") {
+		return true
+	}
+	return body.Error == "node passcode required"
+}
+
 // remoteShellDialError turns a WebSocket dial failure into an actionable message.
 func remoteShellDialError(err error, resp *http.Response, display, addr string) error {
 	if resp != nil {
 		switch resp.StatusCode {
-		case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
+		case http.StatusUnauthorized:
+			if isPasscodeRequiredResponse(resp) {
+				return &terminalDialError{
+					kind: terminalDialErrPasscode,
+					err:  fmt.Errorf("%s requires a node passcode", display),
+				}
+			}
+			return fmt.Errorf("authentication rejected by %s (HTTP %d): mesh-peer identity was not accepted (target may have mesh trust disabled, or we are not a same-owner tailnet peer) and no valid --token was supplied", display, resp.StatusCode)
+		case http.StatusForbidden, http.StatusNotFound:
 			return fmt.Errorf("authentication rejected by %s (HTTP %d): mesh-peer identity was not accepted (target may have mesh trust disabled, or we are not a same-owner tailnet peer) and no valid --token was supplied", display, resp.StatusCode)
 		case http.StatusServiceUnavailable:
 			return fmt.Errorf("%s is at capacity or its auth service is unavailable (HTTP %d)", display, resp.StatusCode)
@@ -120,6 +216,19 @@ func remoteShellDialError(err error, resp *http.Response, display, addr string) 
 		}
 	}
 	// No HTTP response => transport-level failure (refused / unreachable).
+	if isConnRefused(err) {
+		// Reuses the isConnRefused pattern from cmd/mesh.go: a refused dial
+		// means the terminal endpoint isn't listening at all (e.g.
+		// 'citadel work' isn't running, or --no-terminal), which IS safe to
+		// fall back to raw sshd for (#754), unlike the passcode case above.
+		return &terminalDialError{
+			kind: terminalDialErrUnreachable,
+			err: fmt.Errorf("could not reach a terminal endpoint on %s (%s): %w\n"+
+				"  The target may not be running 'citadel work' (its terminal endpoint is\n"+
+				"  enabled by default), may have it disabled (--no-terminal), or may be\n"+
+				"  offline / not yet reachable on the mesh.", display, addr, err),
+		}
+	}
 	return fmt.Errorf("could not reach a terminal endpoint on %s (%s): %w\n"+
 		"  The target may not be running 'citadel work' (its terminal endpoint is\n"+
 		"  enabled by default), may have it disabled (--no-terminal), or may be\n"+

--- a/cmd/passcode_dial_test.go
+++ b/cmd/passcode_dial_test.go
@@ -1,0 +1,171 @@
+// cmd/passcode_dial_test.go
+//
+// Pins the #754 discrimination between the terminal endpoint's two distinct
+// HTTP 401 causes (internal/terminal/server.go): a rejected/invalid auth
+// token (resolveAuth) vs. the passcode gate (PasscodeVerifier). Both return
+// status 401, so the response body is the only signal. See
+// isPasscodeRequiredResponse in cmd/connect_shell.go. Getting this wrong in
+// either direction is a real regression: treating every 401 as
+// passcode-required would turn a bad --token into three passcode prompts and
+// a misleading "passcode rejected" error; treating the real passcode gate as
+// a generic auth failure would send an operator to check their token instead
+// of prompting for the passcode #754 actually needs.
+package cmd
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func jsonResp(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func TestIsPasscodeRequiredResponse(t *testing.T) {
+	cases := []struct {
+		name string
+		resp *http.Response
+		want bool
+	}{
+		{
+			name: "passcode gate by error text (pre-#753 shape, current main)",
+			resp: jsonResp(401, `{"error":"node passcode required","status":401}`),
+			want: true,
+		},
+		{
+			name: "passcode gate with reason field (citadel#753)",
+			resp: jsonResp(401, `{"error":"node passcode required","status":401,"reason":"passcode_invalid"}`),
+			want: true,
+		},
+		{
+			name: "passcode_not_set reason still recognized even if error text ever drifts",
+			resp: jsonResp(401, `{"error":"something else","status":401,"reason":"passcode_not_set"}`),
+			want: true,
+		},
+		{
+			name: "rejected auth token is NOT passcode-required",
+			resp: jsonResp(401, `{"error":"invalid token","status":401}`),
+			want: false,
+		},
+		{
+			name: "generic authentication failed is NOT passcode-required",
+			resp: jsonResp(401, `{"error":"authentication failed","status":401}`),
+			want: false,
+		},
+		{
+			name: "malformed body treated as not-passcode-required, not a crash",
+			resp: jsonResp(401, `not json`),
+			want: false,
+		},
+		{
+			name: "nil response",
+			resp: nil,
+			want: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isPasscodeRequiredResponse(c.resp); got != c.want {
+				t.Errorf("isPasscodeRequiredResponse() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestRemoteShellDialError_PasscodeGateClassifiedForRetry(t *testing.T) {
+	resp := jsonResp(401, `{"error":"node passcode required","status":401}`)
+	err := remoteShellDialError(errors.New("bad handshake"), resp, "gpu-node-1", "100.64.0.5:7860")
+
+	var tdErr *terminalDialError
+	if !errors.As(err, &tdErr) {
+		t.Fatalf("remoteShellDialError() = %v, want a *terminalDialError", err)
+	}
+	if tdErr.kind != terminalDialErrPasscode {
+		t.Errorf("kind = %v, want terminalDialErrPasscode", tdErr.kind)
+	}
+}
+
+func TestRemoteShellDialError_RejectedTokenNotClassifiedAsPasscode(t *testing.T) {
+	resp := jsonResp(401, `{"error":"invalid token","status":401}`)
+	err := remoteShellDialError(errors.New("bad handshake"), resp, "gpu-node-1", "100.64.0.5:7860")
+
+	var tdErr *terminalDialError
+	if errors.As(err, &tdErr) {
+		t.Fatalf("remoteShellDialError() = %v, want a plain (non-terminalDialError) auth-rejected error, not classified as passcode or unreachable", err)
+	}
+	if err == nil {
+		t.Fatal("remoteShellDialError() = nil, want an error")
+	}
+}
+
+func TestRemoteShellDialError_ConnRefusedClassifiedForFallback(t *testing.T) {
+	err := remoteShellDialError(errors.New("dial tcp 100.64.0.5:7860: connect: connection refused"), nil, "gpu-node-1", "100.64.0.5:7860")
+
+	var tdErr *terminalDialError
+	if !errors.As(err, &tdErr) {
+		t.Fatalf("remoteShellDialError() = %v, want a *terminalDialError", err)
+	}
+	if tdErr.kind != terminalDialErrUnreachable {
+		t.Errorf("kind = %v, want terminalDialErrUnreachable", tdErr.kind)
+	}
+}
+
+func TestRemoteShellDialError_OtherTransportFailureNotClassifiedAsUnreachable(t *testing.T) {
+	err := remoteShellDialError(errors.New("dial tcp 100.64.0.5:7860: i/o timeout"), nil, "gpu-node-1", "100.64.0.5:7860")
+
+	var tdErr *terminalDialError
+	if errors.As(err, &tdErr) {
+		t.Fatalf("remoteShellDialError() = %v, want a plain error (not a fallback trigger) for a non-refused transport failure", err)
+	}
+	if err == nil {
+		t.Fatal("remoteShellDialError() = nil, want an error")
+	}
+}
+
+// TestTerminalWSURL pins the #754 wire-level requirement: the passcode is
+// forwarded as a "?passcode=" query parameter on the terminal WebSocket
+// upgrade URL, present ONLY when non-empty. The empty case matters as much
+// as the present case: a node with no passcode configured must see a
+// byte-identical request to before #754, or internal/terminal/server.go's
+// gate (only active when config.PasscodeVerifier != nil, independent of the
+// query string) would still work, but a regression here would be invisible
+// to every routing test in this package (they all stub terminalAttemptFn).
+func TestTerminalWSURL(t *testing.T) {
+	cases := []struct {
+		name            string
+		token, passcode string
+		wantHasPasscode bool
+		wantPasscodeVal string
+		wantHasToken    bool
+	}{
+		{name: "neither set", token: "", passcode: "", wantHasPasscode: false, wantHasToken: false},
+		{name: "passcode only", token: "", passcode: "hunter2", wantHasPasscode: true, wantPasscodeVal: "hunter2", wantHasToken: false},
+		{name: "token only", token: "tok_abc", passcode: "", wantHasPasscode: false, wantHasToken: true},
+		{name: "both set", token: "tok_abc", passcode: "hunter2", wantHasPasscode: true, wantPasscodeVal: "hunter2", wantHasToken: true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			u := terminalWSURL("100.64.0.5:7860", c.token, c.passcode)
+			q := u.Query()
+
+			if _, has := q["passcode"]; has != c.wantHasPasscode {
+				t.Errorf("passcode key present = %v, want %v (query=%q)", has, c.wantHasPasscode, u.RawQuery)
+			}
+			if c.wantHasPasscode && q.Get("passcode") != c.wantPasscodeVal {
+				t.Errorf("passcode value = %q, want %q", q.Get("passcode"), c.wantPasscodeVal)
+			}
+			if _, has := q["token"]; has != c.wantHasToken {
+				t.Errorf("token key present = %v, want %v (query=%q)", has, c.wantHasToken, u.RawQuery)
+			}
+			if u.Scheme != "ws" || u.Host != "100.64.0.5:7860" || u.Path != "/terminal" {
+				t.Errorf("URL = %+v, want scheme=ws host=100.64.0.5:7860 path=/terminal", u)
+			}
+		})
+	}
+}

--- a/cmd/peer_helpers.go
+++ b/cmd/peer_helpers.go
@@ -59,6 +59,11 @@ func isValidIP(s string) bool {
 	return err == nil
 }
 
+// ensureNetworkConnectedFn indirects ensureNetworkConnected so tests (e.g.
+// connectToNode's routing tests, #754) can stub it without a live mesh.
+// Mirrors the listenVPNFn pattern in cmd/controlcenter.go.
+var ensureNetworkConnectedFn = ensureNetworkConnected
+
 // ensureNetworkConnected verifies the network connection and reconnects if needed.
 // Returns an error if the network cannot be established.
 func ensureNetworkConnected(ctx context.Context) error {

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -21,8 +21,13 @@ var (
 
 var sshCmd = &cobra.Command{
 	Use:   "ssh [peer]",
-	Short: "SSH to another node on the AceTeam Network",
-	Long: `Establishes an SSH connection to another node on the AceTeam Network.
+	Short: "Open a shell on another node on the AceTeam Network",
+	Long: `Opens a shell on another node on the AceTeam Network.
+
+This command is an alias of 'citadel connect <peer>' (see
+'citadel connect --help'): a bare peer target routes through the exact same
+logic on both commands, so 'citadel ssh <node>' and 'citadel connect <node>'
+behave identically (issue #754).
 
 PEER IDENTIFICATION:
   You can specify the peer in multiple ways:
@@ -31,38 +36,50 @@ PEER IDENTIFICATION:
   - Interactive:  citadel ssh  (shows a list of online peers to choose from)
 
 HOW IT WORKS:
-  This command tunnels SSH through the AceTeam Network's secure mesh.
-  It works even when system tools (ping, ssh) can't reach the peer directly,
-  because it uses the internal tsnet userspace network.
+  By default this tries the AceTeam Network terminal endpoint first (works on
+  every node, including nodes whose host sshd is not exposed on the mesh, no
+  host SSH config required). A node passcode challenge is NOT treated as
+  a failure to fall back on: you are prompted for it interactively instead.
+  Only when the terminal endpoint itself is unreachable does this fall back
+  to a real OpenSSH connection, tunneled through the mesh to the peer's sshd
+  (port 22 by default).
+
+  --raw (alias --via-sshd) skips straight to the OpenSSH path, no terminal
+  endpoint attempt at all.
+  --mesh (alias --terminal) forces the terminal-endpoint path only, with no
+  OpenSSH fallback.
+  -u/--user and -p/--port select the OpenSSH path implicitly, since they only
+  make sense against a real sshd.
 
 REQUIREMENTS:
   - Both machines must be registered to the same AceTeam Network
-  - The target peer must have SSH enabled (port 22 or custom port)
-  - You must have valid SSH credentials for the target machine`,
+  - For the OpenSSH path: the target peer must have SSH enabled (port 22 or
+    a custom port) and you must have valid SSH credentials for it`,
 	Example: `  # Interactive mode - select from available peers
   citadel ssh
 
-  # Connect by hostname
+  # Connect by hostname (tries the terminal endpoint, falls back to sshd)
   citadel ssh gpu-node-1
 
   # Connect by network IP address
   citadel ssh 100.64.0.25
 
-  # Specify SSH username
-  citadel ssh gpu-node-1 -u ubuntu
+  # Force the OpenSSH path with a specific user and port
+  citadel ssh gpu-node-1 -u ubuntu -p 2222
 
-  # Specify custom SSH port
-  citadel ssh gpu-node-1 -p 2222
+  # Force the terminal-endpoint path only, no OpenSSH fallback
+  citadel ssh gpu-node-1 --mesh
 
-  # Combine options
-  citadel ssh gpu-node-1 -u admin -p 2222 -v`,
+  # Supply a node passcode up front instead of being prompted
+  citadel ssh gpu-node-1 --passcode 123456`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		// Ensure network connection
+		// Ensure network connection (also needed for the interactive picker
+		// below, before connectToNode gets a chance to ensure it itself).
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
-		if err := ensureNetworkConnected(ctx); err != nil {
+		if err := ensureNetworkConnectedFn(ctx); err != nil {
 			badColor.Println(err)
 			os.Exit(1)
 		}
@@ -81,85 +98,100 @@ REQUIREMENTS:
 			peer = args[0]
 		}
 
-		// Resolve peer to IP
-		ip, hostname, err := resolvePeer(peer)
-		if err != nil {
-			badColor.Printf("Could not resolve peer '%s': %v\n", peer, err)
-			suggestAvailablePeers()
-			os.Exit(1)
-		}
-
-		// Determine SSH port
-		port := "22"
-		if sshPort != "" {
-			port = sshPort
-		}
-
-		// Get the path to the current citadel executable for ProxyCommand
-		citadelPath, err := os.Executable()
-		if err != nil {
-			badColor.Printf("Could not determine citadel path: %v\n", err)
-			os.Exit(1)
-		}
-
-		// Build SSH command arguments
-		// Use ProxyCommand to tunnel through tsnet via 'citadel connect'
-		proxyCmd := fmt.Sprintf("%s connect %s:%s", citadelPath, ip, port)
-		sshArgs := []string{
-			"-o", fmt.Sprintf("ProxyCommand=%s", proxyCmd),
-			"-o", "StrictHostKeyChecking=accept-new", // Auto-accept new host keys (user can override)
-		}
-
-		// Add verbose flag if requested
-		if sshVerbose {
-			sshArgs = append(sshArgs, "-v")
-		}
-
-		// Build target - use a placeholder hostname since ProxyCommand handles the actual connection
-		// SSH needs a target but ProxyCommand bypasses normal resolution
-		target := ip
-		if sshUser != "" {
-			target = sshUser + "@" + ip
-		}
-		sshArgs = append(sshArgs, target)
-
-		// Display connection info
-		displayName := hostname
-		if displayName == "" {
-			displayName = ip
-		}
-		fmt.Printf("Connecting to %s via AceTeam Network...\n", displayName)
-		if hostname != "" && hostname != ip {
-			fmt.Printf("  Peer: %s (%s)\n", hostname, ip)
-		}
-		if sshUser != "" {
-			fmt.Printf("  User: %s\n", sshUser)
-		}
-		if port != "22" {
-			fmt.Printf("  Port: %s\n", port)
-		}
-		fmt.Println()
-
-		// Execute SSH
-		sshPath, err := exec.LookPath("ssh")
-		if err != nil {
-			badColor.Println("Error: ssh command not found. Please install OpenSSH.")
-			os.Exit(1)
-		}
-
-		sshExec := exec.Command(sshPath, sshArgs...)
-		sshExec.Stdin = os.Stdin
-		sshExec.Stdout = os.Stdout
-		sshExec.Stderr = os.Stderr
-
-		if err := sshExec.Run(); err != nil {
-			if exitErr, ok := err.(*exec.ExitError); ok {
-				os.Exit(exitErr.ExitCode())
-			}
-			badColor.Printf("SSH error: %v\n", err)
+		if err := connectToNode(cmd, peer); err != nil {
+			badColor.Printf("Error: %v\n", err)
 			os.Exit(1)
 		}
 	},
+}
+
+// runLegacySSH execs the real ssh(1) binary against peer, tunneled through
+// the mesh via 'citadel connect <ip>:<port>' as ProxyCommand. This predates
+// #754's ts-net-first routing and is now: the fallback path when the ts-net
+// terminal endpoint is unreachable, and the explicit path for
+// --raw/--via-sshd (or naming -u/-p, which only make sense against a real
+// sshd).
+func runLegacySSH(peer string) error {
+	ip, hostname, err := resolvePeer(peer)
+	if err != nil {
+		suggestAvailablePeers()
+		return fmt.Errorf("could not resolve peer '%s': %w", peer, err)
+	}
+
+	// Determine SSH port
+	port := "22"
+	if sshPort != "" {
+		port = sshPort
+	}
+
+	// Get the path to the current citadel executable for ProxyCommand
+	citadelPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("could not determine citadel path: %w", err)
+	}
+
+	sshArgs := buildSSHArgs(citadelPath, ip, port, sshUser, sshVerbose)
+
+	// Display connection info
+	displayName := hostname
+	if displayName == "" {
+		displayName = ip
+	}
+	fmt.Printf("Connecting to %s via AceTeam Network (raw sshd)...\n", displayName)
+	if hostname != "" && hostname != ip {
+		fmt.Printf("  Peer: %s (%s)\n", hostname, ip)
+	}
+	if sshUser != "" {
+		fmt.Printf("  User: %s\n", sshUser)
+	}
+	if port != "22" {
+		fmt.Printf("  Port: %s\n", port)
+	}
+	fmt.Println()
+
+	// Execute SSH
+	sshPath, err := exec.LookPath("ssh")
+	if err != nil {
+		return fmt.Errorf("ssh command not found. Please install OpenSSH")
+	}
+
+	sshExec := exec.Command(sshPath, sshArgs...)
+	sshExec.Stdin = os.Stdin
+	sshExec.Stdout = os.Stdout
+	sshExec.Stderr = os.Stderr
+
+	if err := sshExec.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			os.Exit(exitErr.ExitCode())
+		}
+		return fmt.Errorf("ssh error: %w", err)
+	}
+	return nil
+}
+
+// buildSSHArgs constructs the argv passed to the ssh(1) binary for the raw
+// sshd path (#754's fallback / --raw path). Factored out for testability: it
+// takes only the exact values that end up in argv, so a test can pin exactly
+// what ssh(1) sees. Notably it has no passcode parameter at all: the node
+// passcode (citadel#753) belongs to the terminal-endpoint auth path, which
+// this raw-sshd path never touches, and it must never appear in a
+// subprocess argv (visible to other users on the same machine via `ps`).
+func buildSSHArgs(citadelPath, ip, port, user string, verbose bool) []string {
+	proxyCmd := fmt.Sprintf("%s connect %s:%s", citadelPath, ip, port)
+	args := []string{
+		"-o", fmt.Sprintf("ProxyCommand=%s", proxyCmd),
+		"-o", "StrictHostKeyChecking=accept-new", // Auto-accept new host keys (user can override)
+	}
+	if verbose {
+		args = append(args, "-v")
+	}
+	// Build target - use a placeholder hostname since ProxyCommand handles the actual connection
+	// SSH needs a target but ProxyCommand bypasses normal resolution
+	target := ip
+	if user != "" {
+		target = user + "@" + ip
+	}
+	return append(args, target)
 }
 
 // selectPeerInteractive shows a list of online peers and lets the user select one.
@@ -206,7 +238,12 @@ func selectPeerInteractive(ctx context.Context) (string, error) {
 
 func init() {
 	rootCmd.AddCommand(sshCmd)
-	sshCmd.Flags().StringVarP(&sshUser, "user", "u", "", "SSH username (defaults to current user)")
-	sshCmd.Flags().StringVarP(&sshPort, "port", "p", "", "SSH port (defaults to 22)")
-	sshCmd.Flags().BoolVarP(&sshVerbose, "verbose", "v", false, "Enable verbose SSH output")
+	sshCmd.Flags().StringVarP(&sshUser, "user", "u", "", "SSH username for the raw sshd path (implies --raw)")
+	sshCmd.Flags().StringVarP(&sshPort, "port", "p", "", "sshd port for the raw sshd path, default 22 (implies --raw)")
+	sshCmd.Flags().BoolVarP(&sshVerbose, "verbose", "v", false, "Enable verbose OpenSSH output (raw sshd path only)")
+	sshCmd.Flags().BoolVar(&viaRaw, "raw", false, "Force the raw sshd path, skipping the terminal endpoint entirely")
+	sshCmd.Flags().BoolVar(&viaRaw, "via-sshd", false, "Alias of --raw")
+	sshCmd.Flags().BoolVar(&viaMesh, "mesh", false, "Force the terminal-endpoint path only, no raw sshd fallback")
+	sshCmd.Flags().BoolVar(&viaMesh, "terminal", false, "Alias of --mesh")
+	sshCmd.Flags().StringVar(&shellPasscode, "passcode", "", "Node passcode for the terminal endpoint (or CITADEL_TERMINAL_PASSCODE); prompted interactively if required and omitted")
 }

--- a/cmd/ssh_connect_alias_test.go
+++ b/cmd/ssh_connect_alias_test.go
@@ -1,0 +1,111 @@
+// cmd/ssh_connect_alias_test.go
+//
+// Pins the #754 "mutual alias" contract between `citadel ssh` and
+// `citadel connect`: same shared flags, each command's help names the
+// other, and (the part that actually matters) identical routing behavior
+// for the same bare target regardless of which command name was invoked.
+package cmd
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestSSHConnectSharedFlagsPresent asserts sshCmd and connectCmd register
+// the same #754 override flags (bound to the same package vars, so setting
+// one via either command name has the same effect). -u/-p/-v are
+// deliberately asymmetric (sshCmd only); see TestConnectCmdHasNoRawSSHDFlags.
+func TestSSHConnectSharedFlagsPresent(t *testing.T) {
+	shared := []string{"raw", "via-sshd", "mesh", "terminal", "passcode"}
+	for _, name := range shared {
+		if sshCmd.Flags().Lookup(name) == nil {
+			t.Errorf("sshCmd missing shared flag --%s", name)
+		}
+		if connectCmd.Flags().Lookup(name) == nil {
+			t.Errorf("connectCmd missing shared flag --%s", name)
+		}
+	}
+}
+
+// TestConnectCmdHasNoRawSSHDFlags documents the deliberate scope decision
+// (see PR description): -u/--user, -p/--port, -v/--verbose for the raw-sshd
+// fallback stay ssh-only. They control a real OpenSSH invocation's identity
+// and port, which only 'citadel ssh' builds; 'citadel connect' does not gain
+// them just to claim full flag parity.
+func TestConnectCmdHasNoRawSSHDFlags(t *testing.T) {
+	for _, name := range []string{"user", "port", "verbose"} {
+		if connectCmd.Flags().Lookup(name) != nil {
+			t.Errorf("connectCmd unexpectedly has --%s (deliberately ssh-only)", name)
+		}
+	}
+	for _, name := range []string{"user", "port", "verbose"} {
+		if sshCmd.Flags().Lookup(name) == nil {
+			t.Errorf("sshCmd missing --%s", name)
+		}
+	}
+}
+
+// TestSSHConnectHelpNameEachOther asserts each command's Long help text
+// documents the alias relationship, so a user reading either --help learns
+// about the other command.
+func TestSSHConnectHelpNameEachOther(t *testing.T) {
+	if !strings.Contains(sshCmd.Long, "citadel connect") {
+		t.Error("sshCmd.Long does not mention 'citadel connect'")
+	}
+	if !strings.Contains(connectCmd.Long, "citadel ssh") {
+		t.Error("connectCmd.Long does not mention 'citadel ssh'")
+	}
+}
+
+// TestSSHAndConnectRouteBareTargetIdentically drives both commands' real Run
+// functions with the same bare target and asserts they exercise the exact
+// same shared routing (connectToNode -> terminalAttemptFn) with the same
+// target: the behavioral proof that they are aliases, not just two
+// commands that happen to look similar. Network connectivity and peer
+// resolution are stubbed out (ensureNetworkConnectedFn, and an IP target so
+// resolvePeer's fast path never touches the network) so this runs without a
+// live mesh.
+func TestSSHAndConnectRouteBareTargetIdentically(t *testing.T) {
+	resetDispatchState(t)
+
+	const target = "100.64.0.9" // valid IP -> resolvePeer's isValidIP fast path, no network call
+
+	var calls []string
+	terminalAttemptFn = func(gotTarget, passcode string) error {
+		calls = append(calls, gotTarget)
+		return nil
+	}
+	legacySSHFn = func(string) error {
+		t.Fatal("legacySSHFn must not be called on ts-net success")
+		return nil
+	}
+
+	sshCmd.Run(sshCmd, []string{target})
+	connectCmd.Run(connectCmd, []string{target})
+
+	if len(calls) != 2 {
+		t.Fatalf("terminalAttemptFn called %d times, want 2 (once per command)", len(calls))
+	}
+	if calls[0] != target || calls[1] != target {
+		t.Fatalf("calls = %v, want both %q", calls, target)
+	}
+}
+
+// ensureNetworkConnectedFn is stubbed to nil-out; sanity-check that helper
+// exists and behaves (guards against a future refactor silently dropping the
+// injection point that makes the test above possible without a live mesh).
+func TestEnsureNetworkConnectedFnIsInjectable(t *testing.T) {
+	resetDispatchState(t)
+	called := false
+	ensureNetworkConnectedFn = func(context.Context) error {
+		called = true
+		return nil
+	}
+	if err := ensureNetworkConnectedFn(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatal("stub was not invoked")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #754.

`citadel ssh <node>` always proxied raw TCP to the peer's port 22. On an
embedded-tsnet node that port is never exposed on the mesh (only ports
citadel explicitly `ListenVPN`s answer inbound), so the dial was refused and
ssh printed the opaque `Connection closed by UNKNOWN port 65535` with no hint
that `citadel connect <node>` (the terminal endpoint) already worked.

`citadel ssh` and `citadel connect` are now mutual aliases for a bare target
(no `:port`): both route through the same `connectToNode` dispatcher, so
`citadel ssh <node>` and `citadel connect <node>` behave identically.

- Tries the ts-net terminal endpoint first (`:7860`, the path that already
  works on embedded-tsnet).
- On the terminal endpoint's optional passcode gate (aceteam#6524,
  citadel#753), prompts interactively with no echo and retries the terminal
  endpoint. A passcode challenge means the endpoint is reachable, so it is
  never treated as a fallback trigger.
- Falls back to the legacy raw sshd path (OpenSSH via
  `citadel connect <ip>:22` as ProxyCommand) only when the terminal endpoint
  itself is unreachable (connection refused, reusing the `isConnRefused`
  pattern already in `cmd/mesh.go`).
- `--raw` (alias `--via-sshd`) forces the raw sshd path only.
- `--mesh` (alias `--terminal`) forces the terminal endpoint path only, no
  fallback.
- `--passcode` / `CITADEL_TERMINAL_PASSCODE` supply a node passcode up front
  instead of the interactive prompt. Never logged, never placed on any
  subprocess argv (pinned by `TestBuildSSHArgs_NeverCarriesPasscode`).

`citadel connect <node>:<port>` (explicit port, raw TCP piping, used
internally by the sshd fallback's ProxyCommand) is unchanged.

## Security review needed

This touches an auth-adjacent path (the terminal endpoint's passcode gate,
citadel#753) and forwards a user-supplied secret over a query parameter.
Please give this a security pass before it leaves draft: the passcode
forwarding contract (`?passcode=` on the WebSocket upgrade URL), the 401
discrimination between a rejected token and the passcode gate (both return
HTTP 401 from `internal/terminal/server.go`, distinguished only by response
body), and that the passcode never reaches process argv or logs.

## Deliberate scope decisions

- `-u/--user`, `-p/--port`, `-v/--verbose` (controlling the OpenSSH
  invocation identity/port/verbosity) stay `citadel ssh`-only rather than
  being mirrored onto `citadel connect`. They only make sense against a real
  sshd, and `citadel connect` gaining a `-p`/`--port` flag that means
  something entirely different from its existing `peer:port` positional
  syntax seemed more confusing than useful. Pinned by
  `TestConnectCmdHasNoRawSSHDFlags`.
- Naming `-u`/`-p` on `citadel ssh` implies the raw sshd path (skips the
  terminal endpoint entirely), since they only make sense against a real
  sshd and silently ignoring them would be a behavior regression for
  existing `citadel ssh -p ...` users. Pinned by
  `TestConnectToNode_PortOrUserImpliesRaw`.
- Server-side reason codes (`passcode_not_set` vs `passcode_invalid` in
  `internal/terminal/server.go`) and a `citadel passcode set`/`clear` command
  are out of scope here, owned by a separate PR. This PR reads a `reason`
  field opportunistically when present but does not depend on it; the stable
  discriminator is the `"error":"node passcode required"` response body,
  which already exists on `main`.

## Test plan

- `go build -o citadel ./cmd/citadel`
- `cpuslot go vet ./...` and `cpuslot go test ./...` (full repo, all green)
- New tests in `cmd/connect_dispatch_test.go`, `cmd/ssh_connect_alias_test.go`,
  `cmd/passcode_dial_test.go` cover: alias flag parity and help cross-links,
  behavioral routing equivalence between `citadel ssh` and `citadel connect`
  for the same bare target, the ts-net-first/passcode-retry/raw-fallback
  state machine, the `--raw`/`--mesh` override flags and their conflict with
  `-u`/`-p`, the `?passcode=` wire forwarding (present only when non-empty),
  the 401 passcode-gate vs rejected-token discrimination, and that the
  passcode never appears in the raw sshd path's argv.
- Every new behavior was mutation-tested by hand: reverted the specific
  fix, confirmed the corresponding test failed, restored it.
- Empirically verified against this machine's own live AceTeam Network
  connection (read-only client dials only, the running worker was not
  touched or restarted): `citadel ssh <bogus-ip> --mesh` correctly dials
  `:7860` (not `:0`), and `--terminal`/`--terminal-port` coexist without a
  flag-parsing conflict.
