### PR TITLE
controlcenter: add TUI control to set, rotate, and clear the node passcode

### DIFF
--- a/internal/tui/controlcenter/actions.go
+++ b/internal/tui/controlcenter/actions.go
@@ -2014,6 +2014,17 @@ func (cc *ControlCenter) showBuiltinServicesModal() {
 	renderRows()
 	table.Select(0, 0)
 
+	// passcodeStatusLine renders the current node-passcode state (citadel#760).
+	// Re-read on every render (not cached) so a set/rotate/clear performed via
+	// the P hotkey is reflected the moment this modal regains focus.
+	passcodeStatusLine := func() string {
+		status := "[red]NOT SET[-]"
+		if cc.permissions.Load != nil && cc.permissions.Load().HasPasscode() {
+			status = "[green]SET[-]"
+		}
+		return fmt.Sprintf("[yellow::b]Node Passcode:[-:-:-] %s   [gray](gates Console/Desktop/Files, press[-] [yellow::b]P[-:-:-] [gray]to manage)[-]", status)
+	}
+
 	updateDetail := func(row int) {
 		if row < 0 || row >= len(services) {
 			return
@@ -2024,8 +2035,8 @@ func (cc *ControlCenter) showBuiltinServicesModal() {
 			statusLine = "[green]ENABLED[-]"
 		}
 		detailView.SetText(fmt.Sprintf(
-			"[yellow::b]%s[-:-:-]  %s\n\n[gray]%s[-]\n\n%s\n\n[gray]Space/Enter[-] toggle  [gray]+[-] add Docker service  [gray]Esc[-] close",
-			svc.name, statusLine, svc.desc, svc.detail,
+			"[yellow::b]%s[-:-:-]  %s\n\n[gray]%s[-]\n\n%s\n\n%s\n\n[gray]Space/Enter[-] toggle  [gray]+[-] add Docker service  [gray]P[-] passcode  [gray]Esc[-] close",
+			svc.name, statusLine, svc.desc, svc.detail, passcodeStatusLine(),
 		))
 	}
 	updateDetail(0)
@@ -2085,6 +2096,11 @@ func (cc *ControlCenter) showBuiltinServicesModal() {
 				cc.inModal = false
 				cc.app.SetRoot(cc.rootView, true)
 				cc.showAddServiceModal()
+				return nil
+			case 'p', 'P':
+				cc.inModal = false
+				cc.app.SetRoot(cc.rootView, true)
+				cc.showPasscodeModal()
 				return nil
 			}
 		}

--- a/internal/tui/controlcenter/actions.go
+++ b/internal/tui/controlcenter/actions.go
@@ -2015,8 +2015,9 @@ func (cc *ControlCenter) showBuiltinServicesModal() {
 	table.Select(0, 0)
 
 	// passcodeStatusLine renders the current node-passcode state (citadel#760).
-	// Re-read on every render (not cached) so a set/rotate/clear performed via
-	// the P hotkey is reflected the moment this modal regains focus.
+	// It calls Load() fresh on every render instead of reusing the outer
+	// perms snapshot, so re-opening this modal after a set/rotate/clear (which
+	// tears down and rebuilds it) always shows the current on-disk state.
 	passcodeStatusLine := func() string {
 		status := "[red]NOT SET[-]"
 		if cc.permissions.Load != nil && cc.permissions.Load().HasPasscode() {

--- a/internal/tui/controlcenter/controlcenter.go
+++ b/internal/tui/controlcenter/controlcenter.go
@@ -1900,14 +1900,7 @@ func (cc *ControlCenter) getActions() []actionDef {
 
 	svcDesc := "[gray]Built-in + add[-]"
 	if cc.permissions.Load != nil {
-		perms := cc.permissions.Load()
-		enabled := 0
-		for _, e := range []bool{perms.Console, perms.Desktop, perms.Files, perms.Services, perms.SSH} {
-			if e {
-				enabled++
-			}
-		}
-		svcDesc = fmt.Sprintf("[gray]%d/5 enabled[-]", enabled)
+		svcDesc = builtinServicesActionDesc(cc.permissions.Load())
 	}
 
 	return []actionDef{

--- a/internal/tui/controlcenter/passcode.go
+++ b/internal/tui/controlcenter/passcode.go
@@ -1,0 +1,311 @@
+// Package controlcenter: node-passcode set/rotate/clear controls (citadel#760).
+//
+// Before this file, the Control Center could only WARN when a sensitive
+// remote-access surface (Console/Desktop/Files) was enabled with no node
+// passcode set (see the "enabled but no node passcode is set" line in
+// actions.go's showBuiltinServicesModal) and pointed the operator elsewhere
+// (the web console, APPLY_DEVICE_CONFIG, or 'citadel passcode set' at a
+// shell). This file gives the TUI itself the ability to fix it, reusing the
+// same config.Permissions helpers citadel#753/#755 shipped for the CLI
+// ('citadel passcode set'/'clear', cmd/passcode.go): SetPasscode + bcrypt
+// hashing, HasPasscode, and SavePermissions. No worker restart is needed:
+// every gate (terminal server, gateway, SHELL_COMMAND handler) reloads
+// permissions.yaml per connection/request.
+package controlcenter
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+
+	"github.com/aceteam-ai/citadel-cli/internal/config"
+)
+
+// validatePasscodeInput checks a set/rotate passcode entry pair before it is
+// persisted. Mirrors 'citadel passcode set's confirmation rule
+// (cmd/passcode.go's matchPasscodeConfirmation + empty-pin guard): neither
+// entry may be empty/whitespace-only, and the two entries must match exactly,
+// so an interactive typo does not silently lock the node behind a passcode
+// the operator never actually typed. Pure and side-effect free so it can be
+// unit-tested without a running TUI.
+func validatePasscodeInput(pin, confirm string) error {
+	pin = strings.TrimSpace(pin)
+	confirm = strings.TrimSpace(confirm)
+	if pin == "" {
+		return fmt.Errorf("passcode must not be empty")
+	}
+	if pin != confirm {
+		return fmt.Errorf("passcodes did not match")
+	}
+	return nil
+}
+
+// setNodePasscode hashes and persists pin as the node's passcode via the
+// PermissionsCallbacks Load/Save pair (the same permissions.yaml the CLI's
+// 'citadel passcode set' and an APPLY_DEVICE_CONFIG push write). Returns the
+// updated permissions so callers can report follow-on state (e.g. whether any
+// sensitive surface is actually enabled) without a second load. Never logs or
+// otherwise persists pin itself; only the bcrypt hash is written to disk.
+func (cc *ControlCenter) setNodePasscode(pin string) (*config.Permissions, error) {
+	if cc.permissions.Load == nil || cc.permissions.Save == nil {
+		return nil, fmt.Errorf("permissions not configured")
+	}
+	perms := cc.permissions.Load()
+	if err := perms.SetPasscode(pin); err != nil {
+		return nil, fmt.Errorf("set passcode: %w", err)
+	}
+	if err := cc.permissions.Save(perms); err != nil {
+		return nil, fmt.Errorf("save permissions: %w", err)
+	}
+	return perms, nil
+}
+
+// clearNodePasscode removes the node passcode via the PermissionsCallbacks
+// Load/Save pair. Clearing re-locks every enabled sensitive surface
+// (Console/Desktop/Files): config.Permissions.VerifyPasscode fails CLOSED with
+// no hash stored, so an enabled-but-ungated surface is never a possible state.
+func (cc *ControlCenter) clearNodePasscode() (*config.Permissions, error) {
+	if cc.permissions.Load == nil || cc.permissions.Save == nil {
+		return nil, fmt.Errorf("permissions not configured")
+	}
+	perms := cc.permissions.Load()
+	_ = perms.SetPasscode("") // empty pin only clears; SetPasscode never errors on this path
+	if err := cc.permissions.Save(perms); err != nil {
+		return nil, fmt.Errorf("save permissions: %w", err)
+	}
+	return perms, nil
+}
+
+// showPasscodeModal shows the current node-passcode status and offers to set,
+// rotate, or clear it. Reachable from the Built-in Services modal (the same
+// place that shows the "enabled but no node passcode is set" warning) via the
+// P hotkey, so the surface that flags the problem can also fix it.
+func (cc *ControlCenter) showPasscodeModal() {
+	if cc.permissions.Load == nil || cc.permissions.Save == nil {
+		cc.AddActivity("warning", "Permissions not configured")
+		return
+	}
+
+	cc.inModal = true
+	perms := cc.permissions.Load()
+
+	var statusLine, body string
+	buttons := []string{"Cancel"}
+	if perms.HasPasscode() {
+		statusLine = "[green::b]Set[-:-:-]"
+		body = "Rotating replaces it immediately; every sensitive surface keeps\n" +
+			"working, gated by the new passcode. Clearing removes it and\n" +
+			"re-locks every enabled sensitive surface until a new one is set."
+		buttons = append(buttons, "Rotate", "Clear")
+	} else {
+		statusLine = "[red::b]Not set[-:-:-]"
+		body = "No node passcode is set. Console, Desktop, and Files fail CLOSED\n" +
+			"(access denied) even when enabled, until you set one here."
+		buttons = append(buttons, "Set")
+	}
+
+	modal := tview.NewModal().
+		SetText(fmt.Sprintf("[yellow::b]Node Passcode[-:-:-]\n\nStatus: %s\n\n%s", statusLine, body)).
+		AddButtons(buttons).
+		SetDoneFunc(func(buttonIndex int, buttonLabel string) {
+			cc.inModal = false
+			switch buttonLabel {
+			case "Set", "Rotate":
+				cc.app.SetRoot(cc.rootView, true)
+				cc.showPasscodeInputModal(buttonLabel == "Rotate")
+			case "Clear":
+				cc.app.SetRoot(cc.rootView, true)
+				cc.showPasscodeClearConfirmModal()
+			default:
+				cc.app.SetRoot(cc.rootView, true)
+				cc.updatePaneFocus()
+			}
+		})
+
+	cc.app.SetRoot(modal, true)
+	cc.app.SetFocus(modal)
+}
+
+// showPasscodeInputModal prompts for a new node passcode with echo disabled
+// (tview's InputField mask character, matching 'citadel passcode set's
+// term.ReadPassword no-echo prompt) and a required matching confirmation
+// entry, then persists it. The typed PIN lives only in the two InputFields'
+// in-memory buffers and this function's local variables. It is cleared from
+// both fields immediately after use, and it is never written to the activity
+// feed, never logged, and never passed as a command-line argument (this is a
+// pure in-process config write via setNodePasscode, not a subprocess call).
+func (cc *ControlCenter) showPasscodeInputModal(rotate bool) {
+	cc.inModal = true
+
+	title := "Set Node Passcode"
+	if rotate {
+		title = "Rotate Node Passcode"
+	}
+
+	pinInput := tview.NewInputField().
+		SetLabel("New Passcode: ").
+		SetFieldWidth(20).
+		SetMaskCharacter('*')
+	confirmInput := tview.NewInputField().
+		SetLabel("Confirm:      ").
+		SetFieldWidth(20).
+		SetMaskCharacter('*')
+
+	errView := tview.NewTextView().SetDynamicColors(true)
+
+	formFlex := tview.NewFlex().SetDirection(tview.FlexRow).
+		AddItem(nil, 1, 0, false).
+		AddItem(pinInput, 1, 0, true).
+		AddItem(nil, 1, 0, false).
+		AddItem(confirmInput, 1, 0, false).
+		AddItem(nil, 1, 0, false).
+		AddItem(errView, 1, 0, false).
+		AddItem(nil, 1, 0, false).
+		AddItem(tview.NewTextView().SetText("[yellow]Tab[-] switch field  [yellow]Enter[-] save  [yellow]Esc[-] cancel").SetDynamicColors(true).SetTextAlign(tview.AlignCenter), 1, 0, false)
+
+	formFlex.SetBorder(true).SetTitle(" " + title + " ")
+
+	centered := tview.NewFlex().
+		AddItem(nil, 0, 1, false).
+		AddItem(tview.NewFlex().SetDirection(tview.FlexRow).
+			AddItem(nil, 0, 1, false).
+			AddItem(formFlex, 12, 0, true).
+			AddItem(nil, 0, 1, false), 50, 0, true).
+		AddItem(nil, 0, 1, false)
+
+	currentField := 0 // 0 = pin, 1 = confirm
+
+	// wipeFields clears both InputFields' text so the plaintext PIN does not
+	// linger in the widget buffers after we're done with them (cancel or
+	// successful save).
+	wipeFields := func() {
+		pinInput.SetText("")
+		confirmInput.SetText("")
+	}
+
+	closeModal := func() {
+		wipeFields()
+		cc.inModal = false
+		cc.app.SetRoot(cc.rootView, true)
+		cc.updatePaneFocus()
+	}
+
+	submit := func() {
+		pin := pinInput.GetText()
+		confirm := confirmInput.GetText()
+		if err := validatePasscodeInput(pin, confirm); err != nil {
+			wipeFields()
+			cc.app.SetFocus(pinInput)
+			currentField = 0
+			errView.SetText(fmt.Sprintf("[red]%s[-]", err))
+			return
+		}
+
+		perms, err := cc.setNodePasscode(pin)
+		wipeFields()
+		if err != nil {
+			errView.SetText(fmt.Sprintf("[red]Failed to save: %v[-]", err))
+			return
+		}
+
+		closeModal()
+		verb := "set"
+		if rotate {
+			verb = "updated"
+		}
+		cc.AddActivity("success", fmt.Sprintf("Node passcode %s.", verb))
+		if !(perms.Console || perms.Desktop || perms.Files) {
+			cc.AddActivity("info", "Console, Desktop, and Files are all currently disabled, so this passcode has nothing to gate yet.")
+		}
+	}
+
+	handleInput := func(event *tcell.EventKey) *tcell.EventKey {
+		switch event.Key() {
+		case tcell.KeyEsc:
+			closeModal()
+			return nil
+		case tcell.KeyEnter:
+			submit()
+			return nil
+		case tcell.KeyTab, tcell.KeyDown:
+			if currentField == 0 {
+				currentField = 1
+				cc.app.SetFocus(confirmInput)
+			} else {
+				currentField = 0
+				cc.app.SetFocus(pinInput)
+			}
+			return nil
+		case tcell.KeyBacktab, tcell.KeyUp:
+			if currentField == 1 {
+				currentField = 0
+				cc.app.SetFocus(pinInput)
+			} else {
+				currentField = 1
+				cc.app.SetFocus(confirmInput)
+			}
+			return nil
+		}
+		return event
+	}
+
+	pinInput.SetInputCapture(handleInput)
+	confirmInput.SetInputCapture(handleInput)
+
+	cc.app.SetRoot(centered, true)
+	cc.app.SetFocus(pinInput)
+}
+
+// showPasscodeClearConfirmModal confirms before clearing the node passcode,
+// which re-locks every enabled sensitive surface (Console/Desktop/Files).
+func (cc *ControlCenter) showPasscodeClearConfirmModal() {
+	cc.inModal = true
+
+	modal := tview.NewModal().
+		SetText("[red::b]Clear node passcode?[-:-:-]\n\n" +
+			"Console, Desktop, and Files (if enabled) will fail closed\n" +
+			"immediately (no worker restart needed) until a new\n" +
+			"passcode is set.\n\nAre you sure?").
+		AddButtons([]string{"Cancel", "Clear"}).
+		SetDoneFunc(func(buttonIndex int, buttonLabel string) {
+			cc.inModal = false
+			cc.app.SetRoot(cc.rootView, true)
+			if buttonLabel == "Clear" {
+				cc.doClearNodePasscode()
+			} else {
+				cc.updatePaneFocus()
+			}
+		})
+
+	cc.app.SetRoot(modal, true)
+	cc.app.SetFocus(modal)
+}
+
+// passcodeClearNeedsWarning reports whether clearing the passcode leaves any
+// sensitive remote-access surface (Console/Desktop/Files) enabled but now
+// unreachable, so the "enabled but no node passcode is set" warning
+// (actions.go's showBuiltinServicesModal toggle handler) applies again. Pure
+// so the "refresh the warning state" behavior is unit-testable without a
+// running TUI.
+func passcodeClearNeedsWarning(perms *config.Permissions) bool {
+	return perms.Console || perms.Desktop || perms.Files
+}
+
+// doClearNodePasscode performs the passcode clear and reports the resulting
+// state, including re-surfacing the "enabled but no node passcode is set"
+// warning (matching 'citadel passcode clear's copy) when a sensitive surface
+// is still enabled, since clearing just re-locked it.
+func (cc *ControlCenter) doClearNodePasscode() {
+	perms, err := cc.clearNodePasscode()
+	if err != nil {
+		cc.AddActivity("error", fmt.Sprintf("Failed to clear passcode: %v", err))
+		return
+	}
+	cc.AddActivity("success", "Node passcode cleared.")
+	if passcodeClearNeedsWarning(perms) {
+		cc.AddActivity("warning", "Console, Desktop, and/or Files are enabled; they now fail closed (access denied) until a new passcode is set.")
+	}
+	cc.updatePaneFocus()
+}

--- a/internal/tui/controlcenter/passcode.go
+++ b/internal/tui/controlcenter/passcode.go
@@ -289,8 +289,37 @@ func (cc *ControlCenter) showPasscodeClearConfirmModal() {
 // (actions.go's showBuiltinServicesModal toggle handler) applies again. Pure
 // so the "refresh the warning state" behavior is unit-testable without a
 // running TUI.
+//
+// Deliberately matches the existing toggle-warning's surface set (Console,
+// Desktop, Files) and 'citadel passcode clear's own message
+// (cmd/passcode.go's runPasscodeClear), not config.Permissions.Shell, even
+// though Shell is also passcode-gated in enforcement
+// (internal/jobs/shell_command.go calls VerifyPasscode). Extending the
+// warning to Shell is a real gap, but it is a pre-existing one shared by both
+// of those call sites, out of scope for citadel#760's ask (give the TUI a way
+// to set/rotate/clear), and tracked separately (citadel#763) rather than
+// fixed as a side effect here.
 func passcodeClearNeedsWarning(perms *config.Permissions) bool {
 	return perms.Console || perms.Desktop || perms.Files
+}
+
+// builtinServicesActionDesc renders the Actions-panel description for the
+// Built-in Services row (key 1). It appends a passcode warning when a
+// sensitive surface is enabled but no passcode is set, so an operator who
+// never opens the modal still sees the gap on the always-visible action
+// panel, not only inside showBuiltinServicesModal's detail pane.
+func builtinServicesActionDesc(perms *config.Permissions) string {
+	enabled := 0
+	for _, e := range []bool{perms.Console, perms.Desktop, perms.Files, perms.Services, perms.SSH} {
+		if e {
+			enabled++
+		}
+	}
+	desc := fmt.Sprintf("[gray]%d/5 enabled[-]", enabled)
+	if passcodeClearNeedsWarning(perms) && !perms.HasPasscode() {
+		desc += "  [red]no passcode[-]"
+	}
+	return desc
 }
 
 // doClearNodePasscode performs the passcode clear and reports the resulting

--- a/internal/tui/controlcenter/passcode_test.go
+++ b/internal/tui/controlcenter/passcode_test.go
@@ -2,6 +2,7 @@ package controlcenter
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/aceteam-ai/citadel-cli/internal/config"
@@ -180,6 +181,35 @@ func TestPasscodeClearNeedsWarning(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := passcodeClearNeedsWarning(tc.perms); got != tc.want {
 				t.Errorf("passcodeClearNeedsWarning(%+v) = %v, want %v", tc.perms, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuiltinServicesActionDesc(t *testing.T) {
+	cases := []struct {
+		name        string
+		perms       *config.Permissions
+		wantCount   string
+		wantWarning bool
+	}{
+		{"all off", &config.Permissions{}, "0/5 enabled", false},
+		{"non-sensitive only, no warning", &config.Permissions{Services: true, SSH: true}, "2/5 enabled", false},
+		{"sensitive enabled with passcode set, no warning", &config.Permissions{Console: true, PasscodeHash: "x"}, "1/5 enabled", false},
+		{"sensitive enabled without passcode, warns", &config.Permissions{Console: true}, "1/5 enabled", true},
+		{"desktop enabled without passcode, warns", &config.Permissions{Desktop: true}, "1/5 enabled", true},
+		{"all five on without passcode, warns", &config.Permissions{Console: true, Desktop: true, Files: true, Services: true, SSH: true}, "5/5 enabled", true},
+		{"shell alone does not count toward N/5 or warn (citadel#763)", &config.Permissions{Shell: true}, "0/5 enabled", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := builtinServicesActionDesc(tc.perms)
+			if !strings.Contains(got, tc.wantCount) {
+				t.Errorf("builtinServicesActionDesc(%+v) = %q, want it to contain %q", tc.perms, got, tc.wantCount)
+			}
+			hasWarning := strings.Contains(got, "no passcode")
+			if hasWarning != tc.wantWarning {
+				t.Errorf("builtinServicesActionDesc(%+v) = %q, wantWarning=%v", tc.perms, got, tc.wantWarning)
 			}
 		})
 	}

--- a/internal/tui/controlcenter/passcode_test.go
+++ b/internal/tui/controlcenter/passcode_test.go
@@ -1,0 +1,186 @@
+package controlcenter
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/config"
+)
+
+// newTestControlCenterWithPermissions wires a ControlCenter to an in-memory
+// permissions store, mirroring newTestSettings in settings_page_test.go so
+// the passcode logic can be exercised without a running tview app.
+func newTestControlCenterWithPermissions() (*ControlCenter, *config.Permissions) {
+	store := config.DefaultPermissions()
+	cfg := Config{
+		Version: "1.0.0",
+		Permissions: PermissionsCallbacks{
+			Load: func() *config.Permissions {
+				cp := *store
+				return &cp
+			},
+			Save: func(p *config.Permissions) error {
+				*store = *p
+				return nil
+			},
+		},
+	}
+	cc := New(cfg)
+	return cc, store
+}
+
+func TestSetNodePasscode_PersistsHashNotPlaintext(t *testing.T) {
+	cc, store := newTestControlCenterWithPermissions()
+
+	if store.HasPasscode() {
+		t.Fatalf("expected no passcode set by default, got %+v", store)
+	}
+
+	perms, err := cc.setNodePasscode("123456")
+	if err != nil {
+		t.Fatalf("setNodePasscode returned error: %v", err)
+	}
+	if !perms.HasPasscode() {
+		t.Error("returned permissions should report HasPasscode true after set")
+	}
+	if !store.HasPasscode() {
+		t.Error("persisted store should have a passcode set")
+	}
+	if store.PasscodeHash == "123456" {
+		t.Error("plaintext passcode must never be persisted verbatim")
+	}
+	if !store.VerifyPasscode("123456") {
+		t.Error("stored hash should verify against the passcode that was set")
+	}
+	if store.VerifyPasscode("000000") {
+		t.Error("stored hash should not verify against a wrong passcode")
+	}
+}
+
+func TestSetNodePasscode_RotateReplacesPrevious(t *testing.T) {
+	cc, store := newTestControlCenterWithPermissions()
+
+	if _, err := cc.setNodePasscode("111111"); err != nil {
+		t.Fatalf("initial set failed: %v", err)
+	}
+	if !store.VerifyPasscode("111111") {
+		t.Fatal("expected first passcode to verify before rotation")
+	}
+
+	if _, err := cc.setNodePasscode("222222"); err != nil {
+		t.Fatalf("rotate failed: %v", err)
+	}
+	if store.VerifyPasscode("111111") {
+		t.Error("old passcode should no longer verify after rotation")
+	}
+	if !store.VerifyPasscode("222222") {
+		t.Error("new passcode should verify after rotation")
+	}
+}
+
+func TestClearNodePasscode_RemovesHashAndFailsClosed(t *testing.T) {
+	cc, store := newTestControlCenterWithPermissions()
+
+	if _, err := cc.setNodePasscode("654321"); err != nil {
+		t.Fatalf("initial set failed: %v", err)
+	}
+	if !store.HasPasscode() {
+		t.Fatal("expected passcode set before clearing")
+	}
+
+	perms, err := cc.clearNodePasscode()
+	if err != nil {
+		t.Fatalf("clearNodePasscode returned error: %v", err)
+	}
+	if perms.HasPasscode() {
+		t.Error("returned permissions should report HasPasscode false after clear")
+	}
+	if store.HasPasscode() {
+		t.Error("persisted store should have no passcode after clear")
+	}
+	if store.VerifyPasscode("654321") {
+		t.Error("cleared passcode must fail closed: old PIN must not verify")
+	}
+	if store.VerifyPasscode("") {
+		t.Error("cleared passcode must fail closed: empty PIN must not verify")
+	}
+}
+
+func TestSetNodePasscode_NotConfigured(t *testing.T) {
+	cc := New(Config{Version: "1.0.0"}) // Permissions callbacks left nil
+
+	if _, err := cc.setNodePasscode("123456"); err == nil {
+		t.Error("expected an error when permissions callbacks are not configured")
+	}
+	if _, err := cc.clearNodePasscode(); err == nil {
+		t.Error("expected an error when permissions callbacks are not configured")
+	}
+}
+
+func TestSetNodePasscode_SaveErrorPropagates(t *testing.T) {
+	saveErr := errors.New("disk full")
+	cfg := Config{
+		Version: "1.0.0",
+		Permissions: PermissionsCallbacks{
+			Load: config.DefaultPermissions,
+			Save: func(*config.Permissions) error { return saveErr },
+		},
+	}
+	cc := New(cfg)
+
+	if _, err := cc.setNodePasscode("123456"); err == nil {
+		t.Error("expected setNodePasscode to propagate the save error")
+	}
+	if _, err := cc.clearNodePasscode(); err == nil {
+		t.Error("expected clearNodePasscode to propagate the save error")
+	}
+}
+
+func TestValidatePasscodeInput(t *testing.T) {
+	cases := []struct {
+		name    string
+		pin     string
+		confirm string
+		wantErr bool
+	}{
+		{"matching", "123456", "123456", false},
+		{"matching with surrounding whitespace", "  123456  ", "123456", false},
+		{"empty pin", "", "123456", true},
+		{"whitespace-only pin", "   ", "123456", true},
+		{"mismatch", "123456", "654321", true},
+		{"empty confirm", "123456", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validatePasscodeInput(tc.pin, tc.confirm)
+			if tc.wantErr && err == nil {
+				t.Errorf("validatePasscodeInput(%q, %q) = nil, want error", tc.pin, tc.confirm)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("validatePasscodeInput(%q, %q) = %v, want nil", tc.pin, tc.confirm, err)
+			}
+		})
+	}
+}
+
+func TestPasscodeClearNeedsWarning(t *testing.T) {
+	cases := []struct {
+		name  string
+		perms *config.Permissions
+		want  bool
+	}{
+		{"nothing sensitive enabled", &config.Permissions{}, false},
+		{"console enabled", &config.Permissions{Console: true}, true},
+		{"desktop enabled", &config.Permissions{Desktop: true}, true},
+		{"files enabled", &config.Permissions{Files: true}, true},
+		{"non-sensitive surfaces only", &config.Permissions{Services: true, SSH: true, Provision: true}, false},
+		{"mixed sensitive and non-sensitive", &config.Permissions{Console: true, Services: true}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := passcodeClearNeedsWarning(tc.perms); got != tc.want {
+				t.Errorf("passcodeClearNeedsWarning(%+v) = %v, want %v", tc.perms, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Context

Closes #760

The Control Center TUI already warns when Console, Desktop, or Files is
enabled with no node passcode set (`internal/tui/controlcenter/actions.go`,
the "enabled but no node passcode is set" activity line), but it had no way
to actually set the passcode. The warning pointed the operator to the web
console or `APPLY_DEVICE_CONFIG` instead.

## Changes

- New `internal/tui/controlcenter/passcode.go`:
  - `showPasscodeModal` shows whether a passcode is currently set
    (`config.Permissions.HasPasscode`) and offers Set (when unset) or
    Rotate/Clear (when set).
  - `showPasscodeInputModal` prompts for the new passcode with echo disabled
    (tview `SetMaskCharacter`) and a required matching confirmation entry,
    then persists it via `setNodePasscode` (`SetPasscode` + `SavePermissions`,
    the same helpers `citadel passcode set` uses). Both input fields are
    wiped immediately after use.
  - `showPasscodeClearConfirmModal` confirms before clearing
    (`clearNodePasscode`), which re-locks every enabled sensitive surface.
  - `doClearNodePasscode` re-surfaces the "enabled but no passcode" warning
    after a clear if Console/Desktop/Files is still enabled, matching the
    existing warning copy and `citadel passcode clear`'s own message.
  - `builtinServicesActionDesc` extends the always-visible Actions panel
    ("1 Services  N/5 enabled") with a "no passcode" flag when a sensitive
    surface is enabled but ungated, so the gap is visible without opening the
    modal.
- `internal/tui/controlcenter/actions.go`: the Built-in Services modal (key
  `1`) now shows the current passcode status in its detail pane and adds a
  `P` hotkey that opens the passcode control.

No worker restart is required: the terminal server, gateway, and
`SHELL_COMMAND` handler all reload `permissions.yaml` per connection, so the
change takes effect on the next request.

## Decisions worth flagging for review

- **Rotate does not re-verify the old passcode.** `setNodePasscode` matches
  `cmd/passcode.go`'s CLI behavior exactly: it does not call `VerifyPasscode`
  against the existing PIN before overwriting it. This is deliberate, not an
  oversight: the operator driving this TUI already has local write access to
  `permissions.yaml` (same trust boundary as the CLI), so gating a local
  rotate on the old PIN would be theater, not a real control.
- **Placement: an in-modal hotkey, not a Settings page row.** The issue
  suggested "Settings page or a dedicated action." I put it inside the
  existing Built-in Services modal (`P` hotkey) rather than the Settings
  page, because that modal is exactly where the "enabled but no passcode"
  warning already fires, and its `cc.permissions` Load/Save plumbing was
  already wired there. To avoid the tradeoff of "an operator who never opens
  that modal never sees the gap," I also added the warning to the
  always-visible Actions panel description (`builtinServicesActionDesc`).
- **Filed #763 for a related gap, not fixed here.** `internal/jobs/
  shell_command.go` enforces the passcode gate on Shell too (it calls
  `VerifyPasscode`), but none of the three existing "no passcode" warning
  call sites (the TUI toggle handler, `citadel passcode clear`, and this PR's
  `passcodeClearNeedsWarning`) mention Shell, only Console/Desktop/Files.
  I matched the existing (narrower) set for consistency rather than widening
  scope inside this PR; #763 tracks fixing the underlying gap.

## Security notes

- The typed PIN lives only in the two input fields' in-memory buffers and
  local variables inside `showPasscodeInputModal`; it is never written to the
  activity feed, never logged, and never passed as a command-line argument
  (this is a direct config write, not a subprocess call).
- Only the bcrypt hash (via `config.Permissions.SetPasscode`) is persisted to
  `permissions.yaml`.
- Clearing fails closed: `VerifyPasscode` rejects every check once the hash is
  removed, so an enabled-but-ungated surface can't happen.

## Testing

```
cpuslot go build ./...
cpuslot go vet ./...
cpuslot go test ./...
```

All green. New tests in `internal/tui/controlcenter/passcode_test.go` cover
`setNodePasscode`, `clearNodePasscode`, `validatePasscodeInput`,
`passcodeClearNeedsWarning`, and `builtinServicesActionDesc` against an
in-memory permissions store (same pattern as `settings_page_test.go`),
including save-error propagation and the not-configured case. Each new test
was mutation-tested (revert the fix under test, confirm the test fails,
restore) before opening this PR.

Marking as draft since the TUI wiring (modal navigation, masked input,
tab/focus handling) is best verified by running the actual TUI on a node,
which I have not done in this environment.
