### PR TITLE
cli: ssh and connect default to a plain shell, --tmux opts into tmux

### DIFF
--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -45,10 +45,19 @@ BARE TARGET (no port):
 
   The terminal endpoint is started by 'citadel work' by default (disable
   with --no-terminal). No token is needed there: the node trusts your
-  verified mesh-peer identity over the VPN (citadel #585). Repeated connects
-  re-attach to the same live tmux-backed shell. A --token (or
+  verified mesh-peer identity over the VPN (citadel #585). A --token (or
   CITADEL_TERMINAL_TOKEN) is still accepted for the platform terminal path or
   when the target disables mesh trust.
+
+  This CLI path gives you a PLAIN shell by default: no tmux, nothing
+  persists once you disconnect. Pass --tmux to opt into a persistent,
+  reconnect-resilient session instead, a repeated connect (or a reconnect
+  after a drop) re-attaches to the same live shell, running command and
+  scrollback intact. If the target has no tmux binary, it is installed on
+  the node automatically; if that install fails, you get a plain shell with
+  a warning instead of a failed connection. --no-tmux is accepted for
+  symmetry but is already the default. (The web console's own connections
+  are unaffected either way and stay persistent by default.)
 
   --raw (alias --via-sshd) skips straight to the OpenSSH path.
   --mesh (alias --terminal) forces the terminal-endpoint path only, with no
@@ -80,6 +89,9 @@ that system networking cannot.`,
 
   # Force the terminal-endpoint path only, no OpenSSH fallback
   citadel connect gpu-node-1 --mesh
+
+  # Opt into a persistent, reconnect-resilient tmux-backed session
+  citadel connect gpu-node-1 --tmux
 
   # Raw TCP: connect to a PostgreSQL server
   citadel connect gpu-node-1:5432
@@ -318,4 +330,6 @@ func init() {
 	connectCmd.Flags().BoolVar(&viaMesh, "mesh", false, "Force the terminal-endpoint path only, no raw sshd fallback (bare-target mode)")
 	connectCmd.Flags().BoolVar(&viaMesh, "terminal", false, "Alias of --mesh")
 	connectCmd.Flags().StringVar(&shellPasscode, "passcode", "", "Node passcode for the terminal endpoint (or CITADEL_TERMINAL_PASSCODE); prompted interactively if required and omitted")
+	connectCmd.Flags().BoolVar(&wantTmuxSession, "tmux", false, "Opt into a persistent, reconnect-resilient tmux-backed session (bare-target mode; default is a plain shell)")
+	connectCmd.Flags().BoolVar(&wantNoTmuxSession, "no-tmux", false, "Explicit bare shell (the default); accepted for symmetry with --tmux")
 }

--- a/cmd/connect_dispatch.go
+++ b/cmd/connect_dispatch.go
@@ -35,6 +35,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aceteam-ai/citadel-cli/internal/terminal"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -53,11 +54,27 @@ var (
 	// CITADEL_TERMINAL_PASSCODE, then an interactive no-echo prompt on a
 	// 401. Never logged, never placed on any subprocess argv.
 	shellPasscode string
+	// wantTmuxSession is set by --tmux: opt into a persistent, reconnect-
+	// resilient tmux-backed session instead of the CLI's bare-shell default
+	// (citadel #759).
+	wantTmuxSession bool
+	// wantNoTmuxSession is set by --no-tmux: explicit symmetry with --tmux.
+	// It never changes behavior on its own (a bare shell is already the
+	// default); it exists so operators can say what they mean and so
+	// --tmux/--no-tmux together is a detectable, rejected conflict.
+	wantNoTmuxSession bool
 )
 
 // maxPasscodeAttempts bounds the interactive retry loop so a mistyped
 // passcode does not prompt forever, while still tolerating a typo.
 const maxPasscodeAttempts = 3
+
+// bareSessionOverride is the session-query value the terminal server
+// (internal/terminal/server.go) reads as "force a bare, non-persistent
+// shell regardless of the node's own default" (citadel #759). It is the
+// CLI's default override, sent on every connect/ssh unless --tmux asks for
+// a persistent session instead.
+const bareSessionOverride = "none"
 
 // rawFallbackNotice is printed right before falling back to the legacy raw
 // sshd path. The guidance has to be up front, not appended after the fact:
@@ -72,8 +89,8 @@ const rawFallbackNotice = "Terminal endpoint unreachable on the mesh; falling ba
 	"start 'citadel work' on it, or re-run with --mesh to see the terminal-endpoint error directly."
 
 // terminalAttemptFn performs one attempt to open the ts-net terminal shell
-// against target with the given passcode. Package var so tests can
-// substitute a fake without a live mesh/terminal server.
+// against target with the given passcode and session override. Package var
+// so tests can substitute a fake without a live mesh/terminal server.
 var terminalAttemptFn = runRemoteShell
 
 // legacySSHFn execs the real ssh(1) binary against target via the raw-TCP
@@ -109,6 +126,9 @@ func connectToNode(cmd *cobra.Command, target string) error {
 	if portOrUserGiven && viaMesh {
 		return fmt.Errorf("--user/--port select the raw sshd path, which conflicts with --mesh/--terminal (ts-net only, no sshd)")
 	}
+	if wantTmuxSession && wantNoTmuxSession {
+		return fmt.Errorf("--tmux and --no-tmux are mutually exclusive")
+	}
 
 	if viaRaw || portOrUserGiven {
 		return legacySSHFn(target)
@@ -119,8 +139,22 @@ func connectToNode(cmd *cobra.Command, target string) error {
 		passcode = os.Getenv("CITADEL_TERMINAL_PASSCODE")
 	}
 
+	// citadel #759: the CLI connect path always sends an explicit session
+	// override, which is what makes 'citadel ssh'/'citadel connect' default
+	// to a bare shell regardless of the node's own CITADEL_TERMINAL_SESSION
+	// default (tmux ON by default, citadel #585); that default keeps
+	// governing every OTHER caller (namely the web console), which never
+	// sends this override at all. "none" forces a bare shell (the CLI
+	// default, and also what --no-tmux asks for explicitly); --tmux instead
+	// requests the node's standard persistent session name, so a reconnect
+	// (with or without --tmux again) re-attaches to the same live shell.
+	session := bareSessionOverride
+	if wantTmuxSession {
+		session = terminal.DefaultSessionName
+	}
+
 	for attempt := 1; attempt <= maxPasscodeAttempts; attempt++ {
-		err := terminalAttemptFn(target, passcode)
+		err := terminalAttemptFn(target, passcode, session)
 		if err == nil {
 			return nil
 		}

--- a/cmd/connect_dispatch_test.go
+++ b/cmd/connect_dispatch_test.go
@@ -18,6 +18,7 @@ import (
 func resetDispatchState(t *testing.T) {
 	t.Helper()
 	origViaRaw, origViaMesh, origPasscode := viaRaw, viaMesh, shellPasscode
+	origWantTmux, origWantNoTmux := wantTmuxSession, wantNoTmuxSession
 	origSSHUser, origSSHPort := sshUser, sshPort
 	origTerminalAttempt := terminalAttemptFn
 	origLegacySSH := legacySSHFn
@@ -26,6 +27,7 @@ func resetDispatchState(t *testing.T) {
 
 	t.Cleanup(func() {
 		viaRaw, viaMesh, shellPasscode = origViaRaw, origViaMesh, origPasscode
+		wantTmuxSession, wantNoTmuxSession = origWantTmux, origWantNoTmux
 		sshUser, sshPort = origSSHUser, origSSHPort
 		terminalAttemptFn = origTerminalAttempt
 		legacySSHFn = origLegacySSH
@@ -34,6 +36,7 @@ func resetDispatchState(t *testing.T) {
 	})
 
 	viaRaw, viaMesh, shellPasscode = false, false, ""
+	wantTmuxSession, wantNoTmuxSession = false, false
 	sshUser, sshPort = "", ""
 	ensureNetworkConnectedFn = func(context.Context) error { return nil }
 }
@@ -60,7 +63,7 @@ func TestConnectToNode_TsNetSuccess(t *testing.T) {
 
 	var gotTarget, gotPasscode string
 	var calls int
-	terminalAttemptFn = func(target, passcode string) error {
+	terminalAttemptFn = func(target, passcode, session string) error {
 		calls++
 		gotTarget, gotPasscode = target, passcode
 		return nil
@@ -87,7 +90,7 @@ func TestConnectToNode_TsNetSuccess(t *testing.T) {
 func TestConnectToNode_UnreachableFallsBackToRawSSHD(t *testing.T) {
 	resetDispatchState(t)
 
-	terminalAttemptFn = func(target, passcode string) error {
+	terminalAttemptFn = func(target, passcode, session string) error {
 		return &terminalDialError{kind: terminalDialErrUnreachable, err: errors.New("connection refused")}
 	}
 	var legacyCalls int
@@ -130,7 +133,7 @@ func TestConnectToNode_MeshOnly_NoFallbackOnUnreachable(t *testing.T) {
 	viaMesh = true
 
 	wantErr := &terminalDialError{kind: terminalDialErrUnreachable, err: errors.New("connection refused")}
-	terminalAttemptFn = func(target, passcode string) error { return wantErr }
+	terminalAttemptFn = func(target, passcode, session string) error { return wantErr }
 	legacySSHFn = func(string) error {
 		t.Fatal("legacySSHFn must not be called with --mesh forcing ts-net only")
 		return nil
@@ -147,7 +150,7 @@ func TestConnectToNode_PasscodePromptAndRetry(t *testing.T) {
 	resetDispatchState(t)
 
 	var attempts []string // passcodes seen by terminalAttemptFn, in order
-	terminalAttemptFn = func(target, passcode string) error {
+	terminalAttemptFn = func(target, passcode, session string) error {
 		attempts = append(attempts, passcode)
 		if passcode == "correct-horse" {
 			return nil
@@ -185,7 +188,7 @@ func TestConnectToNode_PasscodeRejectedExhausted_NeverFallsBack(t *testing.T) {
 	resetDispatchState(t)
 
 	var attempts int
-	terminalAttemptFn = func(target, passcode string) error {
+	terminalAttemptFn = func(target, passcode, session string) error {
 		attempts++
 		return &terminalDialError{kind: terminalDialErrPasscode, err: errors.New("node passcode required")}
 	}
@@ -216,7 +219,7 @@ func TestConnectToNode_PasscodeFromEnv(t *testing.T) {
 	t.Setenv("CITADEL_TERMINAL_PASSCODE", "env-secret")
 
 	var gotPasscode string
-	terminalAttemptFn = func(target, passcode string) error {
+	terminalAttemptFn = func(target, passcode, session string) error {
 		gotPasscode = passcode
 		return nil
 	}
@@ -234,7 +237,7 @@ func TestConnectToNode_RawSkipsTsNet(t *testing.T) {
 	resetDispatchState(t)
 	viaRaw = true
 
-	terminalAttemptFn = func(string, string) error {
+	terminalAttemptFn = func(string, string, string) error {
 		t.Fatal("terminalAttemptFn must not be called with --raw")
 		return nil
 	}
@@ -253,7 +256,7 @@ func TestConnectToNode_RawAndMeshConflict(t *testing.T) {
 	resetDispatchState(t)
 	viaRaw, viaMesh = true, true
 
-	terminalAttemptFn = func(string, string) error { t.Fatal("unexpected call"); return nil }
+	terminalAttemptFn = func(string, string, string) error { t.Fatal("unexpected call"); return nil }
 	legacySSHFn = func(string) error { t.Fatal("unexpected call"); return nil }
 
 	err := connectToNode(cmdWithChangedFlags(nil), "gpu-node-1")
@@ -267,7 +270,7 @@ func TestConnectToNode_PortOrUserImpliesRaw(t *testing.T) {
 		t.Run(flag, func(t *testing.T) {
 			resetDispatchState(t)
 
-			terminalAttemptFn = func(string, string) error {
+			terminalAttemptFn = func(string, string, string) error {
 				t.Fatal("terminalAttemptFn must not be called when -p/-u was given")
 				return nil
 			}
@@ -288,7 +291,7 @@ func TestConnectToNode_PortOrUserConflictsWithMesh(t *testing.T) {
 	resetDispatchState(t)
 	viaMesh = true
 
-	terminalAttemptFn = func(string, string) error { t.Fatal("unexpected call"); return nil }
+	terminalAttemptFn = func(string, string, string) error { t.Fatal("unexpected call"); return nil }
 	legacySSHFn = func(string) error { t.Fatal("unexpected call"); return nil }
 
 	err := connectToNode(cmdWithChangedFlags([]string{"port"}), "gpu-node-1")
@@ -301,7 +304,7 @@ func TestConnectToNode_OtherErrorSurfacedDirectly(t *testing.T) {
 	resetDispatchState(t)
 
 	wantErr := fmt.Errorf("terminal handshake with node failed (HTTP 503)")
-	terminalAttemptFn = func(string, string) error { return wantErr }
+	terminalAttemptFn = func(string, string, string) error { return wantErr }
 	legacySSHFn = func(string) error {
 		t.Fatal("legacySSHFn must not be called for a non-passcode, non-refused error")
 		return nil

--- a/cmd/connect_shell.go
+++ b/cmd/connect_shell.go
@@ -40,12 +40,17 @@ import (
 // creates duplicate node state — each invocation is an independent view, and on
 // exit the terminal is always restored and the socket closed cleanly. Stateful
 // re-attach (reconnecting to the *same* live shell with its running command and
-// scrollback after a dropped connection) is now the default: the node-side
-// terminal server backs sessions with a persistent per-user tmux session by
-// default (citadel #585, DefaultSessionName="citadel"), so a repeated connect —
-// or a reconnect after a drop — re-attaches to the same live shell. Operators
-// can force a bare shell with CITADEL_TERMINAL_SESSION=none.
-func runRemoteShell(target, passcode string) error {
+// scrollback after a dropped connection) is opt-in from the CLI (citadel #759):
+// a plain `citadel ssh`/`citadel connect` requests a bare shell by default,
+// and `--tmux` opts back into a persistent per-user tmux session. The node's
+// own CITADEL_TERMINAL_SESSION default (tmux ON, DefaultSessionName="citadel")
+// only governs connections that send no override at all, i.e. the web console.
+//
+// session carries that per-connection override: "" leaves the node default
+// alone (unused by this CLI path, which always sets one, see connectToNode),
+// "none" forces a bare shell, and any other value names the persistent
+// session's base to request (see terminalWSURL).
+func runRemoteShell(target, passcode, session string) error {
 	// Ensure the mesh is up before resolving/dialing.
 	netCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
@@ -72,7 +77,7 @@ func runRemoteShell(target, passcode string) error {
 	}
 
 	addr := net.JoinHostPort(ip, fmt.Sprintf("%d", connectTerminalPort))
-	wsURL := terminalWSURL(addr, token, passcode)
+	wsURL := terminalWSURL(addr, token, passcode, session)
 
 	display := hostname
 	if display == "" {
@@ -102,20 +107,28 @@ func runRemoteShell(target, passcode string) error {
 }
 
 // terminalWSURL builds the terminal endpoint's WebSocket upgrade URL for
-// addr (host:port), forwarding token and/or passcode as query parameters the
-// same way the server reads them (internal/terminal/server.go:
-// r.URL.Query().Get("token") / .Get("passcode")). Each is set ONLY when
-// non-empty, so a node with neither configured sees the exact same request
-// it always has, and a node passcode (citadel#753) is never appended when
-// none was supplied. Pure and side-effect-free so the exact query string
-// (notably, the "passcode" key's presence) can be pinned by a test.
-func terminalWSURL(addr, token, passcode string) url.URL {
+// addr (host:port), forwarding token, passcode, and session as query
+// parameters the same way the server reads them (internal/terminal/server.go:
+// r.URL.Query().Get("token") / .Get("passcode") / .Get("session")). token and
+// passcode are set ONLY when non-empty, so a node with neither configured
+// sees the exact same request it always has, and a node passcode
+// (citadel#753) is never appended when none was supplied. session (citadel
+// #759) is set whenever the caller supplies one; connectToNode always does,
+// since it is what makes the CLI path default to a bare shell regardless of
+// the node's own tmux default; only a caller that explicitly passes "" (none
+// today) leaves it off the query string entirely, which is what keeps a
+// hypothetical non-CLI caller's request byte-identical to before #759. Pure
+// and side-effect-free so the exact query string can be pinned by a test.
+func terminalWSURL(addr, token, passcode, session string) url.URL {
 	query := url.Values{}
 	if token != "" {
 		query.Set("token", token)
 	}
 	if passcode != "" {
 		query.Set("passcode", passcode)
+	}
+	if session != "" {
+		query.Set("session", session)
 	}
 	return url.URL{
 		Scheme:   "ws",

--- a/cmd/connect_tmux_test.go
+++ b/cmd/connect_tmux_test.go
@@ -1,0 +1,105 @@
+// cmd/connect_tmux_test.go
+//
+// Pins the citadel #759 CLI-side contract: 'citadel ssh'/'citadel connect'
+// request a bare shell by DEFAULT, and --tmux is what opts a single
+// connection into the node's persistent, reconnect-resilient session. Both
+// are exercised through connectToNode -> terminalAttemptFn, the same seam
+// cmd/connect_dispatch_test.go already uses, so these tests need no live
+// mesh or terminal server.
+package cmd
+
+import (
+	"testing"
+
+	"github.com/aceteam-ai/citadel-cli/internal/terminal"
+)
+
+func TestConnectToNode_DefaultSendsBareSessionOverride(t *testing.T) {
+	resetDispatchState(t)
+
+	var gotSession string
+	terminalAttemptFn = func(target, passcode, session string) error {
+		gotSession = session
+		return nil
+	}
+
+	if err := connectToNode(cmdWithChangedFlags(nil), "gpu-node-1"); err != nil {
+		t.Fatalf("connectToNode() error = %v, want nil", err)
+	}
+	if gotSession != bareSessionOverride {
+		t.Errorf("session = %q, want %q (bare by default)", gotSession, bareSessionOverride)
+	}
+}
+
+func TestConnectToNode_NoTmuxSendsBareSessionOverride(t *testing.T) {
+	resetDispatchState(t)
+	wantNoTmuxSession = true
+
+	var gotSession string
+	terminalAttemptFn = func(target, passcode, session string) error {
+		gotSession = session
+		return nil
+	}
+
+	if err := connectToNode(cmdWithChangedFlags(nil), "gpu-node-1"); err != nil {
+		t.Fatalf("connectToNode() error = %v, want nil", err)
+	}
+	if gotSession != bareSessionOverride {
+		t.Errorf("session = %q, want %q (--no-tmux is explicit bare)", gotSession, bareSessionOverride)
+	}
+}
+
+func TestConnectToNode_TmuxSendsNamedSessionOverride(t *testing.T) {
+	resetDispatchState(t)
+	wantTmuxSession = true
+
+	var gotSession string
+	terminalAttemptFn = func(target, passcode, session string) error {
+		gotSession = session
+		return nil
+	}
+
+	if err := connectToNode(cmdWithChangedFlags(nil), "gpu-node-1"); err != nil {
+		t.Fatalf("connectToNode() error = %v, want nil", err)
+	}
+	if gotSession != terminal.DefaultSessionName {
+		t.Errorf("session = %q, want %q (--tmux requests the node's persistent session name)", gotSession, terminal.DefaultSessionName)
+	}
+	if gotSession == bareSessionOverride {
+		t.Fatalf("session = %q, must not equal the bare override %q when --tmux is set", gotSession, bareSessionOverride)
+	}
+}
+
+func TestConnectToNode_TmuxAndNoTmuxConflict(t *testing.T) {
+	resetDispatchState(t)
+	wantTmuxSession, wantNoTmuxSession = true, true
+
+	terminalAttemptFn = func(string, string, string) error {
+		t.Fatal("terminalAttemptFn must not be called when --tmux and --no-tmux conflict")
+		return nil
+	}
+	legacySSHFn = func(string) error {
+		t.Fatal("legacySSHFn must not be called when --tmux and --no-tmux conflict")
+		return nil
+	}
+
+	err := connectToNode(cmdWithChangedFlags(nil), "gpu-node-1")
+	if err == nil {
+		t.Fatal("connectToNode() error = nil, want a mutually-exclusive-flags error")
+	}
+}
+
+// TestSSHConnectTmuxFlagsRegistered pins that both 'citadel ssh' and
+// 'citadel connect' register --tmux/--no-tmux (the alias contract every
+// other shared flag in this package already gets, see
+// cmd/ssh_connect_alias_test.go's TestSSHConnectSharedFlagsPresent).
+func TestSSHConnectTmuxFlagsRegistered(t *testing.T) {
+	for _, name := range []string{"tmux", "no-tmux"} {
+		if sshCmd.Flags().Lookup(name) == nil {
+			t.Errorf("sshCmd missing --%s", name)
+		}
+		if connectCmd.Flags().Lookup(name) == nil {
+			t.Errorf("connectCmd missing --%s", name)
+		}
+	}
+}

--- a/cmd/passcode_dial_test.go
+++ b/cmd/passcode_dial_test.go
@@ -128,30 +128,36 @@ func TestRemoteShellDialError_OtherTransportFailureNotClassifiedAsUnreachable(t 
 	}
 }
 
-// TestTerminalWSURL pins the #754 wire-level requirement: the passcode is
-// forwarded as a "?passcode=" query parameter on the terminal WebSocket
-// upgrade URL, present ONLY when non-empty. The empty case matters as much
-// as the present case: a node with no passcode configured must see a
-// byte-identical request to before #754, or internal/terminal/server.go's
-// gate (only active when config.PasscodeVerifier != nil, independent of the
-// query string) would still work, but a regression here would be invisible
-// to every routing test in this package (they all stub terminalAttemptFn).
+// TestTerminalWSURL pins the #754/#759 wire-level requirements: the passcode
+// is forwarded as a "?passcode=" query parameter, and the session override
+// (#759) as "?session=", each present ONLY when non-empty. The empty case
+// matters as much as the present case: a node with no passcode configured
+// must see a byte-identical request to before #754 (independent of the
+// session param), or internal/terminal/server.go's gate (only active when
+// config.PasscodeVerifier != nil, independent of the query string) would
+// still work, but a regression here would be invisible to every routing test
+// in this package (they all stub terminalAttemptFn).
 func TestTerminalWSURL(t *testing.T) {
 	cases := []struct {
-		name            string
-		token, passcode string
-		wantHasPasscode bool
-		wantPasscodeVal string
-		wantHasToken    bool
+		name                     string
+		token, passcode, session string
+		wantHasPasscode          bool
+		wantPasscodeVal          string
+		wantHasToken             bool
+		wantHasSession           bool
+		wantSessionVal           string
 	}{
 		{name: "neither set", token: "", passcode: "", wantHasPasscode: false, wantHasToken: false},
 		{name: "passcode only", token: "", passcode: "hunter2", wantHasPasscode: true, wantPasscodeVal: "hunter2", wantHasToken: false},
 		{name: "token only", token: "tok_abc", passcode: "", wantHasPasscode: false, wantHasToken: true},
 		{name: "both set", token: "tok_abc", passcode: "hunter2", wantHasPasscode: true, wantPasscodeVal: "hunter2", wantHasToken: true},
+		{name: "bare session override", session: "none", wantHasSession: true, wantSessionVal: "none"},
+		{name: "named session override", session: "citadel", wantHasSession: true, wantSessionVal: "citadel"},
+		{name: "no session override", session: "", wantHasSession: false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			u := terminalWSURL("100.64.0.5:7860", c.token, c.passcode)
+			u := terminalWSURL("100.64.0.5:7860", c.token, c.passcode, c.session)
 			q := u.Query()
 
 			if _, has := q["passcode"]; has != c.wantHasPasscode {
@@ -162,6 +168,12 @@ func TestTerminalWSURL(t *testing.T) {
 			}
 			if _, has := q["token"]; has != c.wantHasToken {
 				t.Errorf("token key present = %v, want %v (query=%q)", has, c.wantHasToken, u.RawQuery)
+			}
+			if _, has := q["session"]; has != c.wantHasSession {
+				t.Errorf("session key present = %v, want %v (query=%q)", has, c.wantHasSession, u.RawQuery)
+			}
+			if c.wantHasSession && q.Get("session") != c.wantSessionVal {
+				t.Errorf("session value = %q, want %q", q.Get("session"), c.wantSessionVal)
 			}
 			if u.Scheme != "ws" || u.Host != "100.64.0.5:7860" || u.Path != "/terminal" {
 				t.Errorf("URL = %+v, want scheme=ws host=100.64.0.5:7860 path=/terminal", u)

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -44,6 +44,15 @@ HOW IT WORKS:
   to a real OpenSSH connection, tunneled through the mesh to the peer's sshd
   (port 22 by default).
 
+  The terminal endpoint gives you a PLAIN shell by default: no tmux, nothing
+  persists once you disconnect. Pass --tmux to opt into a persistent,
+  reconnect-resilient session instead, a repeated connect (or a reconnect
+  after a drop) re-attaches to the same live shell, running command and
+  scrollback intact. If the target has no tmux binary, it is installed on
+  the node automatically; if that install fails, you get a plain shell with
+  a warning instead of a failed connection. --no-tmux is accepted for
+  symmetry but is already the default.
+
   --raw (alias --via-sshd) skips straight to the OpenSSH path, no terminal
   endpoint attempt at all.
   --mesh (alias --terminal) forces the terminal-endpoint path only, with no
@@ -69,6 +78,9 @@ REQUIREMENTS:
 
   # Force the terminal-endpoint path only, no OpenSSH fallback
   citadel ssh gpu-node-1 --mesh
+
+  # Opt into a persistent, reconnect-resilient tmux-backed session
+  citadel ssh gpu-node-1 --tmux
 
   # Supply a node passcode up front instead of being prompted
   citadel ssh gpu-node-1 --passcode 123456`,
@@ -246,4 +258,6 @@ func init() {
 	sshCmd.Flags().BoolVar(&viaMesh, "mesh", false, "Force the terminal-endpoint path only, no raw sshd fallback")
 	sshCmd.Flags().BoolVar(&viaMesh, "terminal", false, "Alias of --mesh")
 	sshCmd.Flags().StringVar(&shellPasscode, "passcode", "", "Node passcode for the terminal endpoint (or CITADEL_TERMINAL_PASSCODE); prompted interactively if required and omitted")
+	sshCmd.Flags().BoolVar(&wantTmuxSession, "tmux", false, "Opt into a persistent, reconnect-resilient tmux-backed session (terminal-endpoint path only; default is a plain shell)")
+	sshCmd.Flags().BoolVar(&wantNoTmuxSession, "no-tmux", false, "Explicit bare shell (the default); accepted for symmetry with --tmux")
 }

--- a/cmd/ssh_connect_alias_test.go
+++ b/cmd/ssh_connect_alias_test.go
@@ -17,7 +17,7 @@ import (
 // one via either command name has the same effect). -u/-p/-v are
 // deliberately asymmetric (sshCmd only); see TestConnectCmdHasNoRawSSHDFlags.
 func TestSSHConnectSharedFlagsPresent(t *testing.T) {
-	shared := []string{"raw", "via-sshd", "mesh", "terminal", "passcode"}
+	shared := []string{"raw", "via-sshd", "mesh", "terminal", "passcode", "tmux", "no-tmux"}
 	for _, name := range shared {
 		if sshCmd.Flags().Lookup(name) == nil {
 			t.Errorf("sshCmd missing shared flag --%s", name)
@@ -72,7 +72,7 @@ func TestSSHAndConnectRouteBareTargetIdentically(t *testing.T) {
 	const target = "100.64.0.9" // valid IP -> resolvePeer's isValidIP fast path, no network call
 
 	var calls []string
-	terminalAttemptFn = func(gotTarget, passcode string) error {
+	terminalAttemptFn = func(gotTarget, passcode, session string) error {
 		calls = append(calls, gotTarget)
 		return nil
 	}

--- a/internal/terminal/server.go
+++ b/internal/terminal/server.go
@@ -573,17 +573,28 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	// derived per-user from the configured base name so a reconnecting client
 	// re-attaches to its own live session (running command, scrollback, cwd all
 	// preserved by the tmux server) while staying isolated from other users.
-	var tmuxCommand []string
-	if !sessionDisabled(s.config.SessionName) {
-		tmuxSessionName := sessionNameForUser(s.config.SessionName, tokenInfo.UserID)
-		tmuxCommand = sessionCommand(tmuxSessionName, s.config.Shell)
+	//
+	// citadel #759: a per-connection "session" query override, when present,
+	// wins over the node's own CITADEL_TERMINAL_SESSION default: "none"
+	// forces a bare shell, any other value requests a persistent session by
+	// that base name. Only the CLI connect/ssh path ever sends this (the web
+	// console does not), so an absent override reproduces the exact prior
+	// behavior. See resolveSessionCommand for the full contract, including
+	// the on-demand tmux install that only fires for an override-requested
+	// session.
+	sessionOverride := r.URL.Query().Get("session")
+	tmuxCommand, tmuxSessionName, wantedSession := resolveSessionCommand(
+		s.config.SessionName, sessionOverride, tokenInfo.UserID, s.config.Shell, ensureTmuxInstalledFn)
+	if wantedSession {
 		if tmuxCommand != nil {
 			s.logger.Debugf("backing session %s with persistent tmux session %q", sessionID, tmuxSessionName)
 		} else {
-			// tmux backing is wanted (citadel #585 defaults it ON) but no usable
-			// tmux binary resolved. Fall back to a bare, non-persistent shell:
-			// the connection still succeeds, it just won't survive a reconnect.
-			// Warn (not silent) so the missing re-attach is diagnosable.
+			// tmux backing is wanted (either the node default, citadel #585, or
+			// an explicit --tmux override) but no usable tmux binary resolved,
+			// and (for an override) an on-node install attempt also failed.
+			// Fall back to a bare, non-persistent shell: the connection still
+			// succeeds, it just won't survive a reconnect. Warn (not silent) so
+			// the missing re-attach is diagnosable.
 			s.logger.Printf("tmux unavailable; session %s falls back to a bare (non-persistent) shell — reconnect re-attach disabled (install tmux, or set CITADEL_TERMINAL_SESSION=none to silence)", sessionID)
 		}
 	}

--- a/internal/terminal/session_override_test.go
+++ b/internal/terminal/session_override_test.go
@@ -1,0 +1,203 @@
+// internal/terminal/session_override_test.go
+//
+// Pins the citadel #759 server-side contract: a per-connection "session"
+// query override (sent only by the CLI connect/ssh path) forces a bare shell
+// ("none") or a named persistent session, overriding the node's own
+// CITADEL_TERMINAL_SESSION default; an ABSENT override (the web console, and
+// every pre-#759 caller) reproduces the exact prior behavior. Also pins the
+// on-demand tmux install: it fires only when an override explicitly asked
+// for a persistent session that tmux.Resolve can't currently satisfy.
+package terminal
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestResolveSessionOverride(t *testing.T) {
+	cases := []struct {
+		name                   string
+		configDefault, request string
+		wantBase               string
+		wantOverridden         bool
+	}{
+		{name: "no override: node default wins unchanged", configDefault: "citadel", request: "", wantBase: "citadel", wantOverridden: false},
+		{name: "no override, node default off: stays off", configDefault: "none", request: "", wantBase: "none", wantOverridden: false},
+		{name: "override forces bare even when node default is a name", configDefault: "citadel", request: "none", wantBase: "none", wantOverridden: true},
+		{name: "override forces a named session even when node default is off", configDefault: "none", request: "citadel", wantBase: "citadel", wantOverridden: true},
+		{name: "override with the same name as the default is still an override", configDefault: "citadel", request: "citadel", wantBase: "citadel", wantOverridden: true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			base, overridden := resolveSessionOverride(c.configDefault, c.request)
+			if base != c.wantBase || overridden != c.wantOverridden {
+				t.Errorf("resolveSessionOverride(%q, %q) = (%q, %v), want (%q, %v)",
+					c.configDefault, c.request, base, overridden, c.wantBase, c.wantOverridden)
+			}
+		})
+	}
+}
+
+// TestResolveSessionCommand_NoOverridePreservesDefault locks in that an
+// absent override (web console, or any caller predating #759) drives
+// exactly the same tmux-or-bare decision the server made before this
+// feature existed: tmux backing when the node default names a session and
+// tmux resolves, bare otherwise, and never triggers the on-demand
+// install (that install is scoped to an EXPLICIT override, see the next
+// test), so a node whose own default wants tmux but has none installed
+// still just falls back exactly as before.
+func TestResolveSessionCommand_NoOverridePreservesDefault(t *testing.T) {
+	t.Run("tmux available, node default names a session", func(t *testing.T) {
+		bin := makeFakeTmux(t)
+		installCalled := false
+		cmd, name, wanted := resolveSessionCommand("citadel", "", "alice", "/bin/bash", func() bool {
+			installCalled = true
+			return true
+		})
+		if !wanted {
+			t.Fatal("wantedSession = false, want true (node default names a session)")
+		}
+		want := []string{bin, "new-session", "-A", "-s", name, "/bin/bash"}
+		if !reflect.DeepEqual(cmd, want) {
+			t.Errorf("command = %v, want %v", cmd, want)
+		}
+		if installCalled {
+			t.Error("on-demand install must not run when tmux already resolves")
+		}
+	})
+
+	t.Run("tmux unavailable, node default names a session: bare fallback, no install attempt", func(t *testing.T) {
+		t.Setenv("CITADEL_TMUX_BIN", filepath.Join(t.TempDir(), "missing"))
+		installCalled := false
+		cmd, _, wanted := resolveSessionCommand("citadel", "", "alice", "/bin/bash", func() bool {
+			installCalled = true
+			return true
+		})
+		if !wanted {
+			t.Fatal("wantedSession = false, want true (node default names a session)")
+		}
+		if cmd != nil {
+			t.Errorf("command = %v, want nil (bare fallback)", cmd)
+		}
+		if installCalled {
+			t.Error("on-demand install must only fire for an explicit override (citadel #759), not the plain node default")
+		}
+	})
+
+	t.Run("node default off", func(t *testing.T) {
+		makeFakeTmux(t)
+		cmd, _, wanted := resolveSessionCommand("none", "", "alice", "/bin/bash", nil)
+		if wanted {
+			t.Error("wantedSession = true, want false (node default is off)")
+		}
+		if cmd != nil {
+			t.Errorf("command = %v, want nil", cmd)
+		}
+	})
+}
+
+// TestResolveSessionCommand_OverrideBareForcesBare locks in that a "none"
+// override always wins, even when the node's own configured default names a
+// persistent session; this is the actual #759 fix: the CLI path defaults
+// to a bare shell regardless of the node's tmux-on-by-default posture.
+func TestResolveSessionCommand_OverrideBareForcesBare(t *testing.T) {
+	makeFakeTmux(t) // tmux IS available; the override must still force bare.
+	cmd, name, wanted := resolveSessionCommand("citadel", "none", "alice", "/bin/bash", nil)
+	if wanted {
+		t.Error("wantedSession = true, want false (override forces bare)")
+	}
+	if cmd != nil {
+		t.Errorf("command = %v, want nil (bare override)", cmd)
+	}
+	if name != "" {
+		t.Errorf("sessionName = %q, want empty", name)
+	}
+}
+
+// TestResolveSessionCommand_OverrideNamedRequestsTmux locks in --tmux's
+// effect end to end: an override naming a session gets a real
+// tmux-attach-or-create command when tmux resolves, even though the node's
+// own default is "none" (an operator who disabled the persistent default
+// can still have their OWN connection opt back in via --tmux).
+func TestResolveSessionCommand_OverrideNamedRequestsTmux(t *testing.T) {
+	bin := makeFakeTmux(t)
+	cmd, name, wanted := resolveSessionCommand("none", "citadel", "alice", "/bin/bash", nil)
+	if !wanted {
+		t.Fatal("wantedSession = false, want true (override names a session)")
+	}
+	want := []string{bin, "new-session", "-A", "-s", name, "/bin/bash"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Errorf("command = %v, want %v", cmd, want)
+	}
+}
+
+// TestResolveSessionCommand_OverrideTriggersInstallOnMissingTmux is the
+// tmux-absent path: an override explicitly asking for a persistent session
+// with no tmux binary resolvable attempts an on-node install (mirroring
+// 'citadel tmux install') before falling back. A successful install must be
+// picked up immediately (the fake makes tmux resolve as a side effect,
+// simulating a real install landing a binary at the resolved path).
+func TestResolveSessionCommand_OverrideTriggersInstallOnMissingTmux(t *testing.T) {
+	t.Setenv("CITADEL_TMUX_BIN", filepath.Join(t.TempDir(), "missing"))
+
+	var installCalls int
+	installedBin := makeFakeTmuxPath(t)
+	ensureInstall := func() bool {
+		installCalls++
+		// Simulate a successful install landing a binary CITADEL_TMUX_BIN can
+		// now resolve.
+		t.Setenv("CITADEL_TMUX_BIN", installedBin)
+		return true
+	}
+
+	cmd, name, wanted := resolveSessionCommand("none", "citadel", "alice", "/bin/bash", ensureInstall)
+	if !wanted {
+		t.Fatal("wantedSession = false, want true (override names a session)")
+	}
+	if installCalls != 1 {
+		t.Fatalf("ensureInstall called %d times, want 1", installCalls)
+	}
+	want := []string{installedBin, "new-session", "-A", "-s", name, "/bin/bash"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Errorf("command = %v, want %v (should resolve via the newly installed binary)", cmd, want)
+	}
+}
+
+// TestResolveSessionCommand_OverrideInstallFailsFallsBackToBare pins the
+// documented fallback: when the on-demand install ALSO fails (or the
+// platform is gated/unsupported), the connection still succeeds as a bare
+// shell rather than erroring out.
+func TestResolveSessionCommand_OverrideInstallFailsFallsBackToBare(t *testing.T) {
+	t.Setenv("CITADEL_TMUX_BIN", filepath.Join(t.TempDir(), "missing"))
+
+	var installCalls int
+	ensureInstall := func() bool {
+		installCalls++
+		return false // install attempted and failed
+	}
+
+	cmd, _, wanted := resolveSessionCommand("none", "citadel", "alice", "/bin/bash", ensureInstall)
+	if !wanted {
+		t.Fatal("wantedSession = false, want true (override names a session)")
+	}
+	if installCalls != 1 {
+		t.Fatalf("ensureInstall called %d times, want 1", installCalls)
+	}
+	if cmd != nil {
+		t.Errorf("command = %v, want nil (bare fallback after a failed install)", cmd)
+	}
+}
+
+// makeFakeTmuxPath writes an executable tmux stub and returns its path
+// WITHOUT pointing CITADEL_TMUX_BIN at it (unlike makeFakeTmux), so callers
+// can simulate an install landing this exact binary at a controlled moment.
+func makeFakeTmuxPath(t *testing.T) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "tmux-installed")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("setup fake tmux: %v", err)
+	}
+	return bin
+}

--- a/internal/terminal/session_override_wire_test.go
+++ b/internal/terminal/session_override_wire_test.go
@@ -1,0 +1,126 @@
+// internal/terminal/session_override_wire_test.go
+//go:build !windows
+
+// End-to-end check that handleWebSocket actually reads the "session" query
+// parameter and threads it into resolveSessionCommand (citadel #759): every
+// other test in session_override_test.go calls resolveSessionCommand
+// directly, which would stay green even if the query-param read in
+// handleWebSocket were ever dropped. This dials a real WebSocket (real PTY,
+// bare shell via SessionName="citadel" with tmux forced unresolvable) so the
+// only way to tell the two dials apart is the "tmux unavailable" warning the
+// no-override path is expected to log and the "?session=none" path is not.
+package terminal
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// captureLogger records every Printf line so a test can assert on server-side
+// log output without depending on stderr, mirroring the Logger seam SetSilent
+// already proves is swappable.
+type captureLogger struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (c *captureLogger) Printf(format string, v ...interface{}) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.lines = append(c.lines, fmt.Sprintf(format, v...))
+}
+
+func (c *captureLogger) Debugf(format string, v ...interface{}) {}
+
+func (c *captureLogger) contains(substr string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, l := range c.lines {
+		if strings.Contains(l, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *captureLogger) reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.lines = nil
+}
+
+func TestHandleWebSocket_SessionQueryParamWiring(t *testing.T) {
+	// tmux never resolves, so whether the "tmux unavailable" warning fires
+	// depends ENTIRELY on whether a session was wanted, i.e. on how the
+	// "session" query param was (or wasn't) read.
+	t.Setenv("CITADEL_TMUX_BIN", filepath.Join(t.TempDir(), "missing"))
+
+	const port = 17880
+	cfg := &Config{
+		Host:           "127.0.0.1",
+		Port:           port,
+		MaxConnections: 10,
+		IdleTimeout:    30 * time.Minute,
+		OrgID:          "org-1",
+		Shell:          "/bin/sh",
+		SessionName:    "citadel", // node default WANTS a persistent session
+		RateLimitRPS:   100,
+		RateLimitBurst: 100,
+	}
+	auth := NewMockTokenValidator()
+	auth.AddValidToken("tok_test", &TokenInfo{UserID: "alice", OrgID: "org-1"})
+
+	s := NewServer(cfg, auth)
+	logger := &captureLogger{}
+	s.logger = logger // same package: internal field access is deliberate here
+
+	if err := s.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer s.Stop(context.Background())
+	time.Sleep(100 * time.Millisecond)
+
+	dial := func(sessionQS string) {
+		u := fmt.Sprintf("ws://127.0.0.1:%d/terminal?token=tok_test", port)
+		if sessionQS != "" {
+			u += "&session=" + sessionQS
+		}
+		conn, resp, err := websocket.DefaultDialer.Dial(u, nil)
+		if err != nil {
+			t.Fatalf("dial(%q): %v", sessionQS, err)
+		}
+		if resp != nil {
+			resp.Body.Close()
+		}
+		conn.Close()
+		// Give the server goroutine time to run the session decision and log
+		// (it runs synchronously right after the upgrade, before the PTY
+		// read/write loop that the client's immediate Close() tears down).
+		time.Sleep(150 * time.Millisecond)
+	}
+
+	// No override: the node default (SessionName="citadel") wants a
+	// persistent session; tmux is forced unresolvable -> the fallback
+	// warning must fire.
+	dial("")
+	if !logger.contains("tmux unavailable") {
+		t.Error(`expected a "tmux unavailable" warning with no override (node default wants tmux)`)
+	}
+
+	logger.reset()
+
+	// "?session=none": the override must force a bare shell, overriding the
+	// node's own persistent default -> no fallback warning, because no
+	// session was wanted in the first place.
+	dial("none")
+	if logger.contains("tmux unavailable") {
+		t.Error(`unexpected "tmux unavailable" warning with "?session=none" (override should force a bare shell with nothing to fall back FROM)`)
+	}
+}

--- a/internal/terminal/tmux.go
+++ b/internal/terminal/tmux.go
@@ -4,9 +4,12 @@ package terminal
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"net/http"
 	"strings"
+	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/tmux"
+	"github.com/aceteam-ai/citadel-cli/internal/tmuxinstall"
 )
 
 // disableSentinels are case-insensitive values of CITADEL_TERMINAL_SESSION (or
@@ -108,4 +111,73 @@ func sessionCommand(sessionName, shell string) []string {
 		return nil
 	}
 	return append([]string{bin}, tmux.AttachOrCreateArgs(sessionName, shell)...)
+}
+
+// resolveSessionOverride decides the effective session BASE name for a single
+// connection (citadel #759): configDefault is the node's own configured
+// default (Config.SessionName); requestOverride is read from the connection
+// request's "session" query parameter, sent only by the CLI connect/ssh path
+// ("none" for a bare shell, or a session name for --tmux). The web console
+// and any other caller that sends no override at all get configDefault
+// completely unchanged: that is what keeps this additive rather than a
+// behavior change for existing callers. A present override, even "none",
+// always wins over configDefault: only the CLI sends one, so honoring it can
+// never surprise a browser connection.
+func resolveSessionOverride(configDefault, requestOverride string) (base string, overridden bool) {
+	if requestOverride == "" {
+		return configDefault, false
+	}
+	return requestOverride, true
+}
+
+// resolveSessionCommand is handleWebSocket's full session decision, factored
+// out so it is unit-testable without a live WebSocket/PTY: it applies the
+// per-connection override over the node default (resolveSessionOverride),
+// derives the per-user session name, and, ONLY when an override explicitly
+// asked for a persistent session that isn't currently backed by a resolvable
+// tmux binary, attempts an on-node install via ensureInstall before falling
+// back to a bare shell (citadel #759). The plain (non-overridden) default
+// path is untouched: a node whose own CITADEL_TERMINAL_SESSION wants tmux but
+// has none installed still just falls back, exactly as before this change.
+//
+// command is nil for a bare shell. wantedSession reports whether a
+// persistent session was asked for at all (by the override or the node
+// default), which is what the caller needs to decide whether the "tmux
+// unavailable" warning applies.
+func resolveSessionCommand(configDefault, requestOverride, userID, shell string, ensureInstall func() bool) (command []string, sessionName string, wantedSession bool) {
+	base, overridden := resolveSessionOverride(configDefault, requestOverride)
+	if sessionDisabled(base) {
+		return nil, "", false
+	}
+
+	sessionName = sessionNameForUser(base, userID)
+	command = sessionCommand(sessionName, shell)
+	if command == nil && overridden && ensureInstall != nil {
+		if ensureInstall() {
+			command = sessionCommand(sessionName, shell)
+		}
+	}
+	return command, sessionName, true
+}
+
+// tmuxInstallTimeout bounds the on-demand install attempt (below) well under
+// the terminal server's http.Server WriteTimeout (15s, see Start in
+// server.go): a slow or stalled download must degrade to the bare-shell
+// fallback rather than trip the server's own write deadline and kill the
+// WebSocket upgrade outright.
+const tmuxInstallTimeout = 10 * time.Second
+
+// ensureTmuxInstalledFn attempts an on-node install of a Citadel-managed tmux
+// binary (mirrors 'citadel tmux install', cmd/tmux.go, both built on
+// internal/tmuxinstall) when a per-connection override explicitly requests a
+// persistent session but no tmux binary resolves (citadel #759), so
+// '--tmux' works without the operator installing tmux by hand. Package var so
+// tests can substitute a fake without a live network fetch. Returns true when
+// a tmux binary is now present (already installed counts).
+var ensureTmuxInstalledFn = defaultEnsureTmuxInstalled
+
+func defaultEnsureTmuxInstalled() bool {
+	inst := tmuxinstall.New(tmuxinstall.WithHTTPClient(&http.Client{Timeout: tmuxInstallTimeout}))
+	installed, err := inst.Ensure()
+	return err == nil && installed
 }

--- a/internal/terminal/tmux_test.go
+++ b/internal/terminal/tmux_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aceteam-ai/citadel-cli/internal/tmux"
 )
@@ -20,6 +21,22 @@ func makeFakeTmux(t *testing.T) string {
 	}
 	t.Setenv("CITADEL_TMUX_BIN", bin)
 	return bin
+}
+
+// TestTmuxInstallTimeoutUnderServerWriteTimeout pins the constraint that
+// makes the on-demand tmux install (citadel #759) safe to run synchronously
+// inside handleWebSocket: it must finish well before the terminal server's
+// own http.Server.WriteTimeout (15s, see Start in server.go) would tear down
+// the not-yet-upgraded connection out from under it. If this ever regresses
+// (e.g. someone raises tmuxInstallTimeout to "be more generous"), the
+// failure mode is a dead WebSocket upgrade on a slow/stalled install, not a
+// clean bare-shell fallback, so it is worth a hard assertion, not just a
+// comment.
+func TestTmuxInstallTimeoutUnderServerWriteTimeout(t *testing.T) {
+	const serverWriteTimeout = 15 * time.Second // internal/terminal/server.go Start()
+	if tmuxInstallTimeout >= serverWriteTimeout {
+		t.Fatalf("tmuxInstallTimeout = %v, want strictly less than the server's WriteTimeout (%v)", tmuxInstallTimeout, serverWriteTimeout)
+	}
 }
 
 func TestSessionCommand_NoSessionName(t *testing.T) {


### PR DESCRIPTION
## Context

citadel ssh and citadel connect always backed the connection with the
node's persistent tmux session (CITADEL_TERMINAL_SESSION defaults to
"citadel", tmux on). The CLI had no per-connection control over this.
Issue #759 asks for the opposite default from the CLI: a plain shell
unless the operator opts in.

## Changes

Client (cmd/connect_shell.go, cmd/connect_dispatch.go, cmd/ssh.go,
cmd/connect.go):
- terminalWSURL now sends a `session` query parameter on the terminal
  WebSocket URL: `none` for a bare shell, or the node's persistent
  session name for `--tmux`.
- connectToNode (shared by ssh and connect) always sends `none` by
  default, and sends the persistent session name when `--tmux` is
  passed. `--no-tmux` is accepted for symmetry; it is a no-op since
  bare is already the default. `--tmux` and `--no-tmux` together is
  rejected as a conflict.

Server (internal/terminal/server.go, internal/terminal/tmux.go):
- handleWebSocket reads the `session` query parameter and, when
  present, overrides the node's own CITADEL_TERMINAL_SESSION default
  for that connection only. Absent (the web console never sends it),
  behavior is unchanged.
- When an override explicitly asks for a persistent session and no
  tmux binary resolves, the server attempts an on-node install
  (internal/tmuxinstall, the same package `citadel tmux install`
  uses) before falling back to a bare shell with a warning. The
  install is bounded to 10s, under the server's 15s HTTP write
  timeout, so a slow or stalled download degrades to the fallback
  instead of killing the WebSocket upgrade.
- The decision logic is factored into two pure, unit-tested
  functions (resolveSessionOverride, resolveSessionCommand) so the
  override precedence and the install-on-miss path are testable
  without a live WebSocket or PTY.

## Premise check

Two things worth calling out explicitly, since the task asked to
flag anything that could make an existing invariant worse:

- Cross-user session access: not possible. The final tmux session
  name is always the override base plus the authenticated user's ID
  (sessionNameForUser), so a client cannot choose a name that lands
  on another user's session regardless of what override string it
  sends.
- Injection into the tmux command: not possible. sessionCommand
  re-validates the derived name with tmux.ValidateSessionName and
  returns nil (bare fallback) on failure, so a malformed override
  degrades safely instead of reaching argv.
- One real behavior change worth naming: a node operator who sets
  CITADEL_TERMINAL_SESSION=none specifically to disable persistence
  can still have a single connection request tmux via --tmux, since
  the per-connection override wins over the node default in both
  directions. This is what the issue asks for explicitly ("overriding
  the node's CITADEL_TERMINAL_SESSION default"), so it is implemented
  as specified, but it does turn a node-level opt-out into something
  the CLI caller can override for their own connection.

## Testing

```
cpuslot go build ./...
cpuslot go vet ./...
cpuslot go test ./...
```

All green (68 packages). New tests:
- cmd/connect_tmux_test.go: default sends `none`, `--tmux` sends the
  named override, `--no-tmux` sends `none`, `--tmux`+`--no-tmux`
  conflict, both commands register the flags.
- cmd/passcode_dial_test.go: terminalWSURL session query cases.
- internal/terminal/session_override_test.go: resolveSessionOverride
  and resolveSessionCommand precedence, install-on-miss, install
  failure falls back to bare.
- internal/terminal/session_override_wire_test.go: end to end dial
  against handleWebSocket proving the query param is actually read
  and wired through (not just exercised via the pure functions).
- internal/terminal/tmux_test.go: pins the on-demand install timeout
  staying under the server's write timeout.

Every new test was mutation tested: reverted the corresponding
production line, confirmed the named test fails, restored, confirmed
green again.
