### PR TITLE
control center: Enter connects to peer in Network Peers modal

### DIFF
--- a/cmd/controlcenter.go
+++ b/cmd/controlcenter.go
@@ -47,6 +47,7 @@ import (
 	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/shirou/gopsutil/v3/disk"
 	"github.com/shirou/gopsutil/v3/mem"
+	"github.com/spf13/cobra"
 )
 
 // Worker state for TUI management
@@ -242,7 +243,8 @@ func runControlCenter() {
 				return config.SavePermissions(platform.ConfigDir(), p)
 			},
 		},
-		OnConnect: ccOnNetworkConnect,
+		OnConnect:       ccOnNetworkConnect,
+		ConnectToPeerFn: ccConnectToPeer,
 		// Chat is seeded with the snapshot resolvable at startup, but a node that
 		// completes device authorization in-TUI persists its credentials only
 		// afterward. ChatConfigProvider lets the ChatPage re-resolve them lazily
@@ -505,6 +507,20 @@ func stopDemoServer() {
 	if ccDemoServer != nil {
 		_ = ccDemoServer.Stop()
 	}
+}
+
+// ccConnectToPeer opens an interactive shell on the given peer IP, wired into
+// the Control Center's Network Peers modal (issue #761, Enter=connect) via
+// controlcenter.Config.ConnectToPeerFn. Reuses the exact same bare-target
+// routing `citadel connect <peer>` uses (#754/PR #756): the ts-net terminal
+// endpoint first (with an interactive node-passcode prompt on the gate), and
+// the legacy raw-sshd path only when the terminal endpoint itself is
+// unreachable. A throwaway *cobra.Command carries no --user/--port/--raw/
+// --mesh flags, so connectToNode always takes the default (ts-net-first,
+// fallback-on-unreachable) route here, the same default a bare `citadel
+// connect <peer>` gets from the CLI.
+func ccConnectToPeer(ip string) error {
+	return connectToNode(&cobra.Command{}, ip)
 }
 
 // ccOnNetworkConnect starts terminal server, VNC server, and worker after VPN connects.

--- a/internal/tui/controlcenter/actions.go
+++ b/internal/tui/controlcenter/actions.go
@@ -1799,7 +1799,33 @@ func (cc *ControlCenter) stopWorker() {
 	}()
 }
 
-// showPeerDetailModal shows a modal with peer details and ping option
+// peerModalKeyHandler builds the input-capture callback for the Network Peers
+// modal table. Extracted from showPeerDetailModal (issue #761) so the
+// Enter=connect / p=ping / Esc=close routing is a plain function of a key
+// event and three callbacks, independent of tview widget state, live mesh
+// connectivity, or a running event loop: a test can supply fake
+// connect/ping/close callbacks and assert which one a given key fires,
+// without a live tview screen or mesh.
+func (cc *ControlCenter) peerModalKeyHandler(connectSelected, pingSelected, closeModal func()) func(event *tcell.EventKey) *tcell.EventKey {
+	return func(event *tcell.EventKey) *tcell.EventKey {
+		switch event.Key() {
+		case tcell.KeyEsc:
+			closeModal()
+			return nil
+		case tcell.KeyEnter:
+			connectSelected()
+			return nil
+		case tcell.KeyRune:
+			if event.Rune() == 'p' || event.Rune() == 'P' {
+				pingSelected()
+				return nil
+			}
+		}
+		return event
+	}
+}
+
+// showPeerDetailModal shows a modal with peer details, connect, and ping options.
 func (cc *ControlCenter) showPeerDetailModal() {
 	if !cc.data.Connected || len(cc.data.Peers) == 0 {
 		cc.AddActivity("info", "No peers available")
@@ -1818,7 +1844,7 @@ func (cc *ControlCenter) showPeerDetailModal() {
 		SetBorders(false).
 		SetSelectable(true, false).
 		SetFixed(1, 0)
-	table.SetBorder(true).SetTitle(" Network Peers (p=ping, Enter=ping, Esc=close) ")
+	table.SetBorder(true).SetTitle(" Network Peers (Enter=connect, p=ping, Esc=close) ")
 
 	// Header
 	headers := []string{" ", "HOSTNAME", "IP", "STATUS", "LATENCY"}
@@ -1890,24 +1916,67 @@ func (cc *ControlCenter) showPeerDetailModal() {
 		}()
 	}
 
-	table.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
-		switch event.Key() {
-		case tcell.KeyEsc:
-			cc.inModal = false
-			cc.app.SetRoot(cc.rootView, true)
-			cc.updatePaneFocus()
-			return nil
-		case tcell.KeyEnter:
-			pingSelected()
-			return nil
-		case tcell.KeyRune:
-			if event.Rune() == 'p' || event.Rune() == 'P' {
-				pingSelected()
-				return nil
-			}
+	// Connect function: opens an interactive shell on the selected peer
+	// (issue #761). Enter used to be bound to ping, which was redundant with
+	// 'p'; the natural action on a selected peer is to connect to it.
+	//
+	// Reuses the same connect path as `citadel connect <peer>` (#754/PR #756)
+	// via cc.connectToPeerFn: ts-net terminal endpoint first, node-passcode
+	// prompt on the gate, raw-sshd fallback only when unreachable. That path
+	// takes over stdin/stdout directly (raw terminal mode, blocking read/write
+	// loop) to drive the remote shell, which would otherwise fight tview's own
+	// terminal-mode screen for the same TTY. cc.app.Suspend() is tview's
+	// documented mechanism for exactly this: it exits terminal UI mode
+	// (restoring the TTY to normal/cooked mode), runs the given function
+	// synchronously, and re-enters terminal UI mode (redrawing the TUI) only
+	// after that function returns, so the connect session gets the terminal
+	// to itself and the Control Center is guaranteed to be restored afterward,
+	// including on error or a non-zero remote exit.
+	connectSelected := func() {
+		selectedRow, _ := table.GetSelection()
+		if selectedRow < 1 || selectedRow > len(cc.data.Peers) {
+			return
 		}
-		return event
-	})
+		selectedPeer := cc.data.Peers[selectedRow-1]
+		if selectedPeer.IP == "" {
+			cc.AddActivity("warning", fmt.Sprintf("No IP for %s", selectedPeer.Hostname))
+			return
+		}
+		if cc.connectToPeerFn == nil {
+			cc.AddActivity("warning", "Connect is not available")
+			return
+		}
+
+		var connectErr error
+		suspended := cc.app.Suspend(func() {
+			connectErr = cc.connectToPeerFn(selectedPeer.IP)
+		})
+		if !suspended {
+			// Suspend() returns false without calling the given function when
+			// the screen is already gone (e.g. the Control Center is mid-exit).
+			// Report this explicitly rather than falling through to the
+			// success message below with connectErr still nil, which would be
+			// a silent no-op reported as a normal disconnect.
+			cc.AddActivity("error", fmt.Sprintf("Could not suspend the TUI to connect to %s", selectedPeer.Hostname))
+			return
+		}
+		if connectErr != nil {
+			// Surfaced whether the terminal endpoint was unreachable, the
+			// passcode was rejected, or anything else connectToNode returns:
+			// never a silent no-op.
+			cc.AddActivity("error", fmt.Sprintf("Connect to %s failed: %v", selectedPeer.Hostname, connectErr))
+		} else {
+			cc.AddActivity("info", fmt.Sprintf("Disconnected from %s", selectedPeer.Hostname))
+		}
+	}
+
+	closeModal := func() {
+		cc.inModal = false
+		cc.app.SetRoot(cc.rootView, true)
+		cc.updatePaneFocus()
+	}
+
+	table.SetInputCapture(cc.peerModalKeyHandler(connectSelected, pingSelected, closeModal))
 
 	cc.app.SetRoot(table, true)
 	cc.app.SetFocus(table)

--- a/internal/tui/controlcenter/actions_peer_modal_test.go
+++ b/internal/tui/controlcenter/actions_peer_modal_test.go
@@ -1,0 +1,200 @@
+package controlcenter
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+// TestPeerModalKeyHandler_EnterConnects pins issue #761: Enter on the Network
+// Peers modal must route to connect, not ping. peerModalKeyHandler is the
+// exact function wired into the modal table's SetInputCapture in
+// showPeerDetailModal, so this exercises the real routing decision without a
+// live tview screen or mesh connection: the connect/ping/close callbacks are
+// fakes.
+func TestPeerModalKeyHandler_EnterConnects(t *testing.T) {
+	var connectCalled, pingCalled, closeCalled bool
+	cc := &ControlCenter{}
+	handler := cc.peerModalKeyHandler(
+		func() { connectCalled = true },
+		func() { pingCalled = true },
+		func() { closeCalled = true },
+	)
+
+	result := handler(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone))
+
+	if !connectCalled {
+		t.Error("Enter did not call connectSelected")
+	}
+	if pingCalled {
+		t.Error("Enter called pingSelected, it should route to connect only (issue #761)")
+	}
+	if closeCalled {
+		t.Error("Enter called closeModal unexpectedly")
+	}
+	if result != nil {
+		t.Error("Enter should consume the event (return nil)")
+	}
+}
+
+// TestPeerModalKeyHandler_PStillPings pins that 'p' and 'P' remain bound to
+// ping and do not also trigger connect, unchanged by issue #761.
+func TestPeerModalKeyHandler_PStillPings(t *testing.T) {
+	for _, r := range []rune{'p', 'P'} {
+		r := r
+		t.Run(string(r), func(t *testing.T) {
+			var connectCalled, pingCalled, closeCalled bool
+			cc := &ControlCenter{}
+			handler := cc.peerModalKeyHandler(
+				func() { connectCalled = true },
+				func() { pingCalled = true },
+				func() { closeCalled = true },
+			)
+
+			result := handler(tcell.NewEventKey(tcell.KeyRune, r, tcell.ModNone))
+
+			if !pingCalled {
+				t.Errorf("%q did not call pingSelected", r)
+			}
+			if connectCalled {
+				t.Errorf("%q called connectSelected, only Enter should", r)
+			}
+			if closeCalled {
+				t.Errorf("%q called closeModal unexpectedly", r)
+			}
+			if result != nil {
+				t.Errorf("%q should consume the event (return nil)", r)
+			}
+		})
+	}
+}
+
+// TestPeerModalKeyHandler_EscCloses pins that Esc still closes the modal and
+// does not connect or ping.
+func TestPeerModalKeyHandler_EscCloses(t *testing.T) {
+	var connectCalled, pingCalled, closeCalled bool
+	cc := &ControlCenter{}
+	handler := cc.peerModalKeyHandler(
+		func() { connectCalled = true },
+		func() { pingCalled = true },
+		func() { closeCalled = true },
+	)
+
+	result := handler(tcell.NewEventKey(tcell.KeyEsc, 0, tcell.ModNone))
+
+	if !closeCalled {
+		t.Error("Esc did not call closeModal")
+	}
+	if connectCalled || pingCalled {
+		t.Error("Esc should not connect or ping")
+	}
+	if result != nil {
+		t.Error("Esc should consume the event (return nil)")
+	}
+}
+
+// TestPeerModalKeyHandler_OtherKeyPassesThrough pins that a key with no
+// binding (e.g. an arrow key, used for table navigation) is passed through
+// unconsumed rather than triggering any action.
+func TestPeerModalKeyHandler_OtherKeyPassesThrough(t *testing.T) {
+	var connectCalled, pingCalled, closeCalled bool
+	cc := &ControlCenter{}
+	handler := cc.peerModalKeyHandler(
+		func() { connectCalled = true },
+		func() { pingCalled = true },
+		func() { closeCalled = true },
+	)
+
+	event := tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone)
+	result := handler(event)
+
+	if connectCalled || pingCalled || closeCalled {
+		t.Error("an unbound key should not trigger connect, ping, or close")
+	}
+	if result != event {
+		t.Error("an unbound key should be passed through unchanged so table navigation keeps working")
+	}
+}
+
+// TestShowPeerDetailModal_EnterInvokesConnectToPeerFn is the higher-fidelity
+// companion to the peerModalKeyHandler tests above: it builds the real modal
+// via showPeerDetailModal (not a hand-rolled handler) and presses Enter
+// through the table's actual installed SetInputCapture, proving the
+// production wiring, not just the extracted routing function, calls
+// connectToPeerFn with the selected peer's IP and never touches network
+// ping. Uses a tcell simulation screen (no real terminal) and a fake
+// connectToPeerFn (no live mesh), following the pattern already used by
+// TestWhatsAppDoDeployRunsWorkOffGoroutine for driving a real tview event
+// loop in tests.
+func TestShowPeerDetailModal_EnterInvokesConnectToPeerFn(t *testing.T) {
+	var mu sync.Mutex
+	var gotIP string
+	var connectCalls int
+
+	app := tview.NewApplication()
+	app.SetScreen(tcell.NewSimulationScreen(""))
+
+	cc := &ControlCenter{
+		app:      app,
+		rootView: tview.NewBox(),
+		data: StatusData{
+			Connected: true,
+			Peers: []PeerInfo{
+				{Hostname: "node-a", IP: "100.64.0.10", Online: true},
+			},
+		},
+		peersView: tview.NewTable(),
+		connectToPeerFn: func(ip string) error {
+			mu.Lock()
+			gotIP = ip
+			connectCalls++
+			mu.Unlock()
+			return nil
+		},
+	}
+	cc.peersView.Select(1, 0)
+
+	appDone := make(chan struct{})
+	go func() { _ = app.Run(); close(appDone) }()
+	defer func() { app.Stop(); <-appDone }()
+
+	// Build the modal and press Enter inside a single QueueUpdate so both run
+	// on the tview event-loop goroutine, exactly like a real keypress would
+	// (see TestWhatsAppDoDeployRunsWorkOffGoroutine for why this matters:
+	// touching tview widgets from a second goroutine while Run() is active
+	// races with its internal draw/event handling).
+	done := make(chan struct{})
+	app.QueueUpdate(func() {
+		defer close(done)
+		cc.showPeerDetailModal()
+		table, ok := cc.app.GetFocus().(*tview.Table)
+		if !ok {
+			return
+		}
+		capture := table.GetInputCapture()
+		if capture == nil {
+			return
+		}
+		capture(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone))
+	})
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("modal build + Enter press did not complete within 2s")
+	}
+
+	mu.Lock()
+	ip, calls := gotIP, connectCalls
+	mu.Unlock()
+
+	if calls != 1 {
+		t.Fatalf("connectToPeerFn called %d times, want 1", calls)
+	}
+	if ip != "100.64.0.10" {
+		t.Fatalf("connectToPeerFn called with IP %q, want %q", ip, "100.64.0.10")
+	}
+}

--- a/internal/tui/controlcenter/controlcenter.go
+++ b/internal/tui/controlcenter/controlcenter.go
@@ -516,6 +516,7 @@ type ControlCenter struct {
 	worker             WorkerCallbacks                          // Worker management callbacks
 	permissions        PermissionsCallbacks                     // Gateway permissions callbacks
 	onConnect          func(activityFn func(level, msg string)) // Post-VPN-connect hook
+	connectToPeerFn    func(ip string) error                    // Opens an interactive shell on a peer (issue #761)
 	authServiceURL     string                                   // URL for device auth service
 	nexusURL           string                                   // URL for headscale/nexus coordination server
 
@@ -661,6 +662,7 @@ type Config struct {
 	Worker             WorkerCallbacks                          // Worker management callbacks
 	Permissions        PermissionsCallbacks                     // Gateway permissions callbacks
 	OnConnect          func(activityFn func(level, msg string)) // Called after VPN connects (starts terminal/VNC servers)
+	ConnectToPeerFn    func(ip string) error                    // Opens an interactive shell on a peer, e.g. from the Network Peers modal (issue #761)
 	Chat               ChatPageConfig                           // Chat page configuration (initial snapshot; may be empty pre-auth)
 	ChatConfigProvider func() ChatPageConfig                    // Lazy re-resolver for chat credentials (picks up post-startup device auth)
 
@@ -727,6 +729,7 @@ func New(cfg Config) *ControlCenter {
 		worker:              cfg.Worker,
 		permissions:         cfg.Permissions,
 		onConnect:           cfg.OnConnect,
+		connectToPeerFn:     cfg.ConnectToPeerFn,
 		authServiceURL:      cfg.AuthServiceURL,
 		nexusURL:            cfg.NexusURL,
 		chatConfig:          cfg.Chat,
@@ -1822,7 +1825,7 @@ func (cc *ControlCenter) showHelpModal() {
 [yellow]Navigation (nothing to memorize):[-]
   [white::b]Tab[-:-:-] / [white::b]Shift+Tab[-:-:-]  Move through panes, then on to the next/prev tab
   [white::b]↑/↓[-:-:-] or [white::b]j/k[-:-:-]   Navigate within the focused pane
-  [white::b]Enter[-:-:-]         Details / toggle service / ping peer
+  [white::b]Enter[-:-:-]         Details / toggle service / connect to peer
   [white::b]Alt+1..N[-:-:-]      Jump straight to a tab (optional shortcut)
 
 [yellow]Services Pane:[-]


### PR DESCRIPTION
## Summary

In the Control Center's Network Peers modal, Enter was bound to ping, which
was redundant with `p`. This rebinds Enter to open an interactive shell on
the selected peer instead.

- Enter connects to the selected peer's terminal shell.
- `p` still pings (unchanged).
- Esc still closes (unchanged).
- Title/help updated to `(Enter=connect, p=ping, Esc=close)`.
- The `?` help modal's summary line for Enter now says "connect to peer"
  instead of "ping peer".

## Implementation

- Reuses the connect path from #754 / PR #756 (`connectToNode` /
  `runRemoteShell` in `cmd/connect_dispatch.go` / `cmd/connect_shell.go`):
  ts-net terminal endpoint first, node-passcode prompt on the gate, raw-sshd
  fallback only when the terminal endpoint is unreachable.
- `internal/tui/controlcenter` cannot import `cmd` (the reverse import
  already exists: `cmd` builds the Control Center), so the connect function
  is injected the same way every other Control Center action is:
  `Config.ConnectToPeerFn` in `internal/tui/controlcenter/controlcenter.go`,
  wired to a new `cmd.ccConnectToPeer` in `cmd/controlcenter.go` that calls
  `connectToNode(&cobra.Command{}, ip)` (a throwaway command with no
  `--user`/`--port`/`--raw`/`--mesh` flags, so it always takes the same
  default route a bare `citadel connect <peer>` gets from the CLI).
- Connecting takes over stdin/stdout directly (raw terminal mode, blocking
  read loop), which would otherwise fight tview's own terminal-mode screen.
  `showPeerDetailModal`'s new `connectSelected` closure wraps the call in
  `cc.app.Suspend(...)`, tview's documented mechanism for exactly this: it
  exits terminal UI mode, runs the function, and re-enters terminal UI mode
  when it returns, restoring the Control Center whether the connect
  succeeded, failed, or the remote shell exited normally. `Suspend`'s bool
  return is checked; if it returns false (the TUI is already unsuspended,
  screen gone), that's reported as an explicit activity error rather than
  silently skipping to a false "Disconnected" message.
- A missing/failed connection is surfaced as an activity entry
  (`cc.AddActivity("error", ...)`), not a silent no-op, using
  `connectToNode`'s existing descriptive errors (unreachable terminal
  endpoint, rejected passcode, etc.).

## Premise checked: is suspend/resume around a raw PTY takeover safe here?

Yes, verified by reading the vendored tcell patch rather than assuming from
upstream docs. `tview.Application.Suspend` calls `screen.Suspend()`, which on
the real terminal backend is `tScreen.disengage()`
(`patches/tcell/v2/tscreen.go`). That function closes tcell's internal
`stopQ`, then calls `t.wg.Wait()` before doing any terminal cleanup, so
tcell's own input-reading goroutine is guaranteed to have exited before
`disengage()` proceeds. It then resets terminal modes and calls
`tty.Stop()`, which restores the saved termios (`term.Restore`) and waits on
its own goroutines. Only after all of that does `screen.Suspend()` (and
therefore `Application.Suspend`'s call to `f()`) proceed, so by the time the
connect code calls `term.MakeRaw(stdinFd)` and starts its own
`os.Stdin.Read()` loop, tcell is no longer reading stdin and the terminal is
back in cooked mode. No two readers splitting keystrokes, no fighting over
the TTY.

## Testing

Extracted the modal's key routing into `peerModalKeyHandler` (issue #761),
a plain function of a key event and three callbacks, so it is unit-testable
without a live tview screen or mesh. New tests in
`internal/tui/controlcenter/actions_peer_modal_test.go`:

- `TestPeerModalKeyHandler_EnterConnects`: Enter calls the connect
  callback, not ping or close.
- `TestPeerModalKeyHandler_PStillPings`: `p` and `P` call the ping
  callback, not connect or close.
- `TestPeerModalKeyHandler_EscCloses`: Esc calls close, not connect or
  ping.
- `TestPeerModalKeyHandler_OtherKeyPassesThrough`: an unbound key (e.g. an
  arrow key) is passed through unconsumed so table navigation still works.
- `TestShowPeerDetailModal_EnterInvokesConnectToPeerFn`: higher-fidelity
  companion that builds the real modal via `showPeerDetailModal` (not a
  hand-rolled handler) and presses Enter through the table's actual
  installed `SetInputCapture`, on a real tview event loop driven by a tcell
  simulation screen (same pattern as the existing
  `TestWhatsAppDoDeployRunsWorkOffGoroutine`). Proves the production wiring
  calls `connectToPeerFn` with the selected peer's IP, using a fake
  `connectToPeerFn` (no live mesh).

Each new test was mutation-tested by hand: swapping the Enter/`p` case
bodies in `peerModalKeyHandler`, and changing the connect call to pass
`Hostname` instead of `IP`, made the corresponding test(s) fail as expected;
reverting made them pass again.

Commands run (all green):

```
cpuslot go build ./...
cpuslot go vet ./...
cpuslot go test ./...
cpuslot go test -race ./internal/tui/controlcenter/... -run "TestPeerModalKeyHandler|TestShowPeerDetailModal"
```

## Test plan

- [x] `cpuslot go build ./...`
- [x] `cpuslot go vet ./...`
- [x] `cpuslot go test ./...`
- [x] `cpuslot go test -race ./internal/tui/controlcenter/...` on the new tests
- [ ] Manual: open Control Center on a node with online peers, press Enter
      in the Network Peers modal, confirm it opens a shell on the peer (or
      prompts for a node passcode / shows an actionable error if
      unreachable), and confirm the Control Center redraws correctly after
      exiting the shell
